### PR TITLE
🛠️ fix arm64 CPU docker run instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ docker run --network=host --gpus=all roboflow/roboflow-inference-server-gpu:late
 - Run on arm64 CPU:
 
 ```bash
-docker run --net=host roboflow/roboflow-inference-server-arm-cpu:latest
+docker run -p 9001:9001 roboflow/roboflow-inference-server-arm-cpu:latest
 ```
   
 - Run on Nvidia GPU with TensorRT Runtime:

--- a/docs/quickstart/docker.md
+++ b/docs/quickstart/docker.md
@@ -69,7 +69,7 @@ Server in a container.
 
     === "arm64 CPU"
         ```
-        docker run --net=host \
+        docker run -p 9001:9001 \
         roboflow/roboflow-inference-server-arm-cpu:latest
         ```
 


### PR DESCRIPTION
# Description


During testing, it turned out that the commands for the arm64 CPU were incorrect. The PR contains the appropriate changes.