### PR TITLE
UDP Interface Fix

### DIFF
--- a/inference/core/interfaces/udp/udp_stream.py
+++ b/inference/core/interfaces/udp/udp_stream.py
@@ -1,7 +1,4 @@
-import glob
 import json
-import os
-import signal
 import socket
 import sys
 import threading
@@ -25,10 +22,6 @@ from inference.core.env import (
 )
 from inference.core.interfaces.base import BaseInterface
 from inference.core.interfaces.camera.camera import WebcamStream
-from inference.core.interfaces.videoWriter.videoWriter import (
-    ResultHelper,
-    RTSPFrameRecorder,
-)
 from inference.core.managers.base import ModelManager
 from inference.core.registries.roboflow import RoboflowModelRegistry
 from inference.core.version import __version__


### PR DESCRIPTION
# Description

Removed unused import in udp interface and fixed a typo in the __init__ file name.
## Type of change

Please delete options that are not relevant.

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update
