### PR TITLE
Remove Old Benchmark Data

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -165,17 +165,3 @@ Before a new release is published, a new version of the documentation should be 
 ```bash
 mike deploy <version-number>
 ```
-
-## Initial Benchmark Speed Results 📈
-
-The Roboflow team has run initial benchmarks on the inference server. Our results are below.
-
-### Legacy TRT 
-
-- Node Benchmark: 50FPS (36 frames in 0.72s)
-- Python Benchmark: 22FPS (93FPS internal)
-
-### ONNX TRT
-
-- Node Benchmark: 63FPS (36 frames in 0.57s)
-- Python Benchmark: 27FPS (53FPS internal)


### PR DESCRIPTION
# Description

Removed old benchmark data from docs

## Type of change

Please delete options that are not relevant.

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update
