### PR TITLE
Fixed broken links

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -79,21 +79,21 @@ You can also run any model hosted on Roboflow using the Inference.
 
 ### Classification
 
-- [ViT](https://inference.roboflow.com/models/classification/vit)
-- [YOLOv8](https://inference.roboflow.com/models/classification/yolov8)
-- [CLIP](https://inference.roboflow.com/models/classification/clip)
+- [ViT](https://inference.roboflow.com/library/models/vit_classification)
+- [YOLOv8](https://inference.roboflow.com/library/models/yolov8_classification/)
+- [CLIP](https://inference.roboflow.com/library/models/clip/)
 
 ### Object Detection
 
-- [YOLOv5](https://inference.roboflow.com/models/object-detection/yolov5)
-- [YOLOv8](https://inference.roboflow.com/models/object-detection/yolov8)
+- [YOLOv5](https://inference.roboflow.com/library/models/yolov5/)
+- [YOLOv8](https://inference.roboflow.com/library/models/yolov8/)
 
 ### Segmentation
 
-- [YOLOv7](https://inference.roboflow.com/models/segmentation/yolov7)
+- [YOLOv7](https://inference.roboflow.com/library/models/yolov7_instance_segmentation/)
 - [YOLOv8](https://inference.roboflow.com/models/segmentation/yolov8)
 - [YOLOACT](https://inference.roboflow.com/models/segmentation/yoloact)
-- [Segment Anything](https://inference.roboflow.com/models/segmentation/segment-anything)
+- [Segment Anything](https://inference.roboflow.com/library/models/segment_anything/)
 
 ## Environment Variable Control 🌐
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -91,8 +91,8 @@ You can also run any model hosted on Roboflow using the Inference.
 ### Segmentation
 
 - [YOLOv7](https://inference.roboflow.com/library/models/yolov7_instance_segmentation/)
-- [YOLOv8](https://inference.roboflow.com/models/segmentation/yolov8)
-- [YOLOACT](https://inference.roboflow.com/models/segmentation/yoloact)
+- [YOLOv8](https://inference.roboflow.com/library/models/yolov8_segmentation/)
+- [YOLOACT](https://inference.roboflow.com/library/models/yoloact_segmentation/)
 - [Segment Anything](https://inference.roboflow.com/library/models/segment_anything/)
 
 ## Environment Variable Control 🌐

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,8 +41,8 @@ nav:
       - YOLOv8 Object Detection: library/models/yolov8.md
       - YOLOv8 Classification: library/models/yolov8_classification.md
       - YOLOv7 Instance Segmentation: library/models/yolov7_instance_segmentation.md
-      - YOLOv8 Instance Segmentation: library/models/yolov8_instance_segmentation.md
-      - YOLO-ACT Instance Segmentation: library/models/yoloact_instance_segmentation.md
+      - YOLOv8 Instance Segmentation: library/models/yolov8_segmentation.md
+      - YOLO-ACT Instance Segmentation: library/models/yoloact_segmentation.md
     - Model Managers:
       - Base Manager: library/model_managers/base.md
       - Pingback Manager: library/model_managers/pingback.md


### PR DESCRIPTION
# Description

Fixed broken links on the docs home page in the "Model Support" section and the sidebar menu. 

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?


## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [x] Docs updated? What were the changes:
  - Fixed all of the links in the Home page Model Support section
  - Fixed YOLOv7, YOLOv8 and YOLOACT segmentation links in the sidebar
