### PR TITLE
ByteTrack integration to the UDP stream

### DIFF
--- a/inference/core/data_models.py
+++ b/inference/core/data_models.py
@@ -342,6 +342,7 @@ class ObjectDetectionPrediction(BaseModel):
         confidence (float): The detection confidence as a fraction between 0 and 1.
         class_name (str): The predicted class label.
         class_confidence (Union[float, None]): The class label confidence as a fraction between 0 and 1.
+        class_id (int): The class id of the prediction
     """
 
     x: float = Field(description="The center x-axis pixel coordinate of the prediction")
@@ -360,7 +361,8 @@ class ObjectDetectionPrediction(BaseModel):
     class_confidence: Union[float, None] = Field(
         description="The class label confidence as a fraction between 0 and 1"
     )
-    class_id: int = Field(description="The class id of the prediction")
+    class_id: int = Field(description="The class id of the prediction"
+    )
 
 
 class Point(BaseModel):
@@ -387,6 +389,7 @@ class InstanceSegmentationPrediction(BaseModel):
         class_name (str): The predicted class label.
         class_confidence (Union[float, None]): The class label confidence as a fraction between 0 and 1.
         points (List[Point]): The list of points that make up the instance polygon.
+        class_id: int = Field(description="The class id of the prediction")
     """
 
     x: float = Field(description="The center x-axis pixel coordinate of the prediction")
@@ -408,6 +411,8 @@ class InstanceSegmentationPrediction(BaseModel):
     points: List[Point] = Field(
         description="The list of points that make up the instance polygon"
     )
+    class_id: int = Field(description="The class id of the prediction"
+    )
 
 
 class ClassificationPrediction(BaseModel):
@@ -415,10 +420,12 @@ class ClassificationPrediction(BaseModel):
 
     Attributes:
         class_name (str): The predicted class label.
+        class_id (int): Numeric ID associated with the class label.
         confidence (float): The class label confidence as a fraction between 0 and 1.
     """
 
     class_name: str = Field(alias="class", description="The predicted class label")
+    class_id: int = Field(description="Numeric ID associated with the class label")
     confidence: float = Field(
         description="The class label confidence as a fraction between 0 and 1"
     )

--- a/inference/core/data_models.py
+++ b/inference/core/data_models.py
@@ -360,6 +360,7 @@ class ObjectDetectionPrediction(BaseModel):
     class_confidence: Union[float, None] = Field(
         description="The class label confidence as a fraction between 0 and 1"
     )
+    class_id: int = Field(description="The class id of the prediction")
 
 
 class Point(BaseModel):

--- a/inference/core/data_models.py
+++ b/inference/core/data_models.py
@@ -361,8 +361,7 @@ class ObjectDetectionPrediction(BaseModel):
     class_confidence: Union[float, None] = Field(
         description="The class label confidence as a fraction between 0 and 1"
     )
-    class_id: int = Field(description="The class id of the prediction"
-    )
+    class_id: int = Field(description="The class id of the prediction")
 
 
 class Point(BaseModel):
@@ -411,8 +410,7 @@ class InstanceSegmentationPrediction(BaseModel):
     points: List[Point] = Field(
         description="The list of points that make up the instance polygon"
     )
-    class_id: int = Field(description="The class id of the prediction"
-    )
+    class_id: int = Field(description="The class id of the prediction")
 
 
 class ClassificationPrediction(BaseModel):

--- a/inference/core/interfaces/udp/udp_stream.py
+++ b/inference/core/interfaces/udp/udp_stream.py
@@ -3,24 +3,16 @@ import socket
 import sys
 import threading
 import time
-import supervision as sv
 
+import supervision as sv
 from PIL import Image
 
 from inference.core import data_models as M
-from inference.core.env import (
-    API_KEY,
-    CLASS_AGNOSTIC_NMS,
-    CONFIDENCE,
-    IOU_THRESHOLD,
-    IP_BROADCAST_ADDR,
-    IP_BROADCAST_PORT,
-    JSON_RESPONSE,
-    MAX_CANDIDATES,
-    MAX_DETECTIONS,
-    MODEL_ID,
-    STREAM_ID,
-)
+from inference.core.env import (API_KEY, CLASS_AGNOSTIC_NMS, CONFIDENCE,
+                                IOU_THRESHOLD, IP_BROADCAST_ADDR,
+                                IP_BROADCAST_PORT, JSON_RESPONSE,
+                                MAX_CANDIDATES, MAX_DETECTIONS, MODEL_ID,
+                                STREAM_ID)
 from inference.core.interfaces.base import BaseInterface
 from inference.core.interfaces.camera.camera import WebcamStream
 from inference.core.managers.base import ModelManager

--- a/inference/core/interfaces/udp/udp_stream.py
+++ b/inference/core/interfaces/udp/udp_stream.py
@@ -238,7 +238,7 @@ class UdpStream(BaseInterface):
                     detections = sv.Detections.from_ultralytics(predictions)
                     detections = self.byte_tracker.update_with_detections(detections)
                     for pred, detect in zip(predictions, detections):
-                        pred['tracker_id'] = detect['tracker_id']
+                        pred["tracker_id"] = detect["tracker_id"]
                 if self.json_response:
                     predictions = self.model_manager.make_response(
                         self.inference_request_obj.model_id,

--- a/inference/core/interfaces/udp/udp_stream.py
+++ b/inference/core/interfaces/udp/udp_stream.py
@@ -8,11 +8,19 @@ import supervision as sv
 from PIL import Image
 
 from inference.core import data_models as M
-from inference.core.env import (API_KEY, CLASS_AGNOSTIC_NMS, CONFIDENCE,
-                                IOU_THRESHOLD, IP_BROADCAST_ADDR,
-                                IP_BROADCAST_PORT, JSON_RESPONSE,
-                                MAX_CANDIDATES, MAX_DETECTIONS, MODEL_ID,
-                                STREAM_ID)
+from inference.core.env import (
+    API_KEY,
+    CLASS_AGNOSTIC_NMS,
+    CONFIDENCE,
+    IOU_THRESHOLD,
+    IP_BROADCAST_ADDR,
+    IP_BROADCAST_PORT,
+    JSON_RESPONSE,
+    MAX_CANDIDATES,
+    MAX_DETECTIONS,
+    MODEL_ID,
+    STREAM_ID,
+)
 from inference.core.interfaces.base import BaseInterface
 from inference.core.interfaces.camera.camera import WebcamStream
 from inference.core.managers.base import ModelManager

--- a/inference/core/models/classification_base.py
+++ b/inference/core/models/classification_base.py
@@ -111,7 +111,7 @@ class ClassificationBaseOnnxRoboflowInferenceModel(
                 for i, o in enumerate(preds):
                     cls_name = self.class_names[i]
                     score = float(o)
-                    results[cls_name] = {"confidence": score}
+                    results[cls_name] = {"confidence": score, "class_id": i}
                     if score > confidence_threshold:
                         predicted_classes.append(cls_name)
                 response = MultiLabelClassificationInferenceResponse(
@@ -128,7 +128,7 @@ class ClassificationBaseOnnxRoboflowInferenceModel(
                 results = []
                 for i, cls_name in enumerate(self.class_names):
                     score = float(preds[i])
-                    pred = {"class": cls_name, "confidence": round(score, 4)}
+                    pred = {"class_id": i, "class": cls_name, "confidence": round(score, 4)}
                     results.append(pred)
                 results = sorted(results, key=lambda x: x["confidence"], reverse=True)
 
@@ -176,7 +176,7 @@ class ClassificationBaseOnnxRoboflowInferenceModel(
                 outline=color,
                 width=inference_request.visualization_stroke_width,
             )
-            text = f"{prediction.class_name} {prediction.confidence:.2f}"
+            text = f"{prediction.class_id} - {prediction.class_name} {prediction.confidence:.2f}"
             text_size = font.getbbox(text)
 
             # set button size + 10px margins
@@ -206,7 +206,7 @@ class ClassificationBaseOnnxRoboflowInferenceModel(
             )
             for i, (cls_name, pred) in enumerate(predictions):
                 color = self.colors.get(cls_name, "#4892EA")
-                text = f"{cls_name} {pred.confidence:.2f}"
+                text = f"{i} - {cls_name} {pred.confidence:.2f}"
                 text_size = font.getbbox(text)
 
                 # set button size + 10px margins

--- a/inference/core/models/classification_base.py
+++ b/inference/core/models/classification_base.py
@@ -128,7 +128,11 @@ class ClassificationBaseOnnxRoboflowInferenceModel(
                 results = []
                 for i, cls_name in enumerate(self.class_names):
                     score = float(preds[i])
-                    pred = {"class_id": i, "class": cls_name, "confidence": round(score, 4)}
+                    pred = {
+                        "class_id": i,
+                        "class": cls_name,
+                        "confidence": round(score, 4),
+                    }
                     results.append(pred)
                 results = sorted(results, key=lambda x: x["confidence"], reverse=True)
 

--- a/inference/core/models/instance_segmentation_base.py
+++ b/inference/core/models/instance_segmentation_base.py
@@ -136,6 +136,7 @@ class InstanceSegmentationBaseOnnxRoboflowInferenceModel(
                             "points": [Point(x=point[0], y=point[1]) for point in mask],
                             "confidence": pred[4],
                             "class": self.class_names[int(pred[6])],
+                            "class_id": int(pred[6]),
                         }
                     )
                     for pred, mask in zip(batch_predictions, batch_masks)

--- a/inference/core/models/object_detection_base.py
+++ b/inference/core/models/object_detection_base.py
@@ -81,6 +81,7 @@ class ObjectDetectionBaseOnnxRoboflowInferenceModel(
         Returns:
             List[ObjectDetectionInferenceResponse]: A list of response objects containing object detection predictions.
         """
+
         responses = [
             ObjectDetectionInferenceResponse(
                 predictions=[
@@ -93,6 +94,7 @@ class ObjectDetectionBaseOnnxRoboflowInferenceModel(
                             "height": pred[3] - pred[1],
                             "confidence": pred[4],
                             "class": self.class_names[int(pred[6])],
+                            "class_id": int(pred[6]),
                         }
                     )
                     for pred in batch_predictions
@@ -102,6 +104,7 @@ class ObjectDetectionBaseOnnxRoboflowInferenceModel(
                 image=InferenceResponseImage(
                     width=img_dims[ind][1], height=img_dims[ind][0]
                 ),
+
             )
             for ind, batch_predictions in enumerate(predictions)
         ]

--- a/inference/core/models/object_detection_base.py
+++ b/inference/core/models/object_detection_base.py
@@ -104,7 +104,6 @@ class ObjectDetectionBaseOnnxRoboflowInferenceModel(
                 image=InferenceResponseImage(
                     width=img_dims[ind][1], height=img_dims[ind][0]
                 ),
-
             )
             for ind, batch_predictions in enumerate(predictions)
         ]

--- a/inference/models/yolact/yolact_instance_segmentation.py
+++ b/inference/models/yolact/yolact_instance_segmentation.py
@@ -116,7 +116,6 @@ class YOLACTInstanceSegmentationOnnxRoboflowInferenceModel(
             box_format="xyxy",
         )
         predictions = np.array(predictions)
-
         batch_preds = []
         for batch_idx, img_dim in zip(range(batch_size), img_dims):
             boxes = predictions[batch_idx, :, :4]
@@ -152,6 +151,7 @@ class YOLACTInstanceSegmentationOnnxRoboflowInferenceModel(
                     "class": class_name,
                     "confidence": round(confidence, 3),
                     "points": points,
+                    "class_id" : int(cls),
                 }
                 if not request.class_filter or class_name in request.class_filter:
                     preds.append(pred)

--- a/inference/models/yolact/yolact_instance_segmentation.py
+++ b/inference/models/yolact/yolact_instance_segmentation.py
@@ -151,7 +151,7 @@ class YOLACTInstanceSegmentationOnnxRoboflowInferenceModel(
                     "class": class_name,
                     "confidence": round(confidence, 3),
                     "points": points,
-                    "class_id" : int(cls),
+                    "class_id": int(cls),
                 }
                 if not request.class_filter or class_name in request.class_filter:
                     preds.append(pred)

--- a/test/clip_test.py
+++ b/test/clip_test.py
@@ -55,7 +55,6 @@ def test_clip(test):
 
 @pytest.fixture(scope="session", autouse=True)
 def setup():
-
     try:
         res = requests.get(f"{base_url}:{port}")
         res.raise_for_status()


### PR DESCRIPTION
# Description

Added optional ByteTrack integration to the UDP stream interface for object tracking.

## Type of change

-   [X] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Not tested due to no host. To verify, initialize `UdpStream` with `use_bytetrack=True` and observe the object tracking via `run_thread`.

## Docs

-   [ ] Update documentation to cover new ByteTrack integration.
