### PR TITLE
Update Jetson Dockers

### DIFF
--- a/.github/workflows/docker.jetson.4.5.0.yml
+++ b/.github/workflows/docker.jetson.4.5.0.yml
@@ -1,4 +1,4 @@
-name: Build and Push Jetson 4.5.1 Container
+name: Build and Push Jetson 4.5.0 Container
 
 on:
   release:
@@ -38,8 +38,8 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           push: true
-          tags: roboflow/roboflow-inference-server-trt-jetson:latest,roboflow/roboflow-inference-server-trt-jetson:${{ env.VERSION}}
-          cache-from: type=registry,ref=roboflow/roboflow-inference-server-trt-jetson:cache
-          cache-to: type=registry,ref=roboflow/roboflow-inference-server-trt-jetson:cache,mode=max
+          tags: roboflow/roboflow-inference-server-jetson-4.5.0:latest,roboflow/roboflow-inference-server-jetson-4.5.0:${{ env.VERSION}}
+          cache-from: type=registry,ref=roboflow/roboflow-inference-server-jetson-4.5.0:cache
+          cache-to: type=registry,ref=roboflow/roboflow-inference-server-jetson-4.5.0:cache,mode=max
           platforms: linux/arm64
-          file: ./docker/dockerfiles/Dockerfile.onnx.jetson
+          file: ./docker/dockerfiles/Dockerfile.onnx.jetson.4.5.0

--- a/.github/workflows/docker.jetson.4.6.1.yml
+++ b/.github/workflows/docker.jetson.4.6.1.yml
@@ -38,8 +38,8 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           push: true
-          tags: roboflow/roboflow-inference-server-trt-jetson-4.6.1:latest,roboflow/roboflow-inference-server-trt-jetson-4.6.1:${{ env.VERSION}}
-          cache-from: type=registry,ref=roboflow/roboflow-inference-server-trt-jetson-4.6.1:cache
-          cache-to: type=registry,ref=roboflow/roboflow-inference-server-trt-jetson-4.6.1:cache,mode=max
+          tags: roboflow/roboflow-inference-server-jetson-4.6.1:latest,roboflow/roboflow-inference-server-jetson-4.6.1:${{ env.VERSION}}
+          cache-from: type=registry,ref=roboflow/roboflow-inference-server-jetson-4.6.1:cache
+          cache-to: type=registry,ref=roboflow/roboflow-inference-server-jetson-4.6.1:cache,mode=max
           platforms: linux/arm64
           file: ./docker/dockerfiles/Dockerfile.onnx.jetson.4.6.1

--- a/.github/workflows/docker.jetson.5.1.1.yml
+++ b/.github/workflows/docker.jetson.5.1.1.yml
@@ -38,8 +38,8 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           push: true
-          tags: roboflow/roboflow-inference-server-trt-jetson-5.1.1:latest,roboflow/roboflow-inference-server-trt-jetson-5.1.1:${{ env.VERSION}}
-          cache-from: type=registry,ref=roboflow/roboflow-inference-server-trt-jetson-5.1.1:cache
-          cache-to: type=registry,ref=roboflow/roboflow-inference-server-trt-jetson-5.1.1:cache,mode=max
+          tags: roboflow/roboflow-inference-server-jetson-5.1.1:latest,roboflow/roboflow-inference-server-jetson-5.1.1:${{ env.VERSION}}
+          cache-from: type=registry,ref=roboflow/roboflow-inference-server-jetson-5.1.1:cache
+          cache-to: type=registry,ref=roboflow/roboflow-inference-server-jetson-5.1.1:cache,mode=max
           platforms: linux/arm64
           file: ./docker/dockerfiles/Dockerfile.onnx.jetson.5.1.1

--- a/README.md
+++ b/README.md
@@ -124,13 +124,13 @@ docker run --network=host --gpus=all roboflow/roboflow-inference-server-trt:late
 - Run on NVIDIA Jetson with JetPack `4.x`:
 
 ```bash
-docker run --privileged --net=host --runtime=nvidia roboflow/roboflow-inference-server-trt-jetson:latest
+docker run --privileged --net=host --runtime=nvidia roboflow/roboflow-inference-server-jetson:latest
 ```
 
 - Run on NVIDIA Jetson with JetPack `5.x`:
 
 ```bash
-docker run --privileged --net=host --runtime=nvidia roboflow/roboflow-inference-server-trt-jetson-5.1.1:latest
+docker run --privileged --net=host --runtime=nvidia roboflow/roboflow-inference-server-jetson-5.1.1:latest
 ```
 
 </details>

--- a/docker/dockerfiles/Dockerfile.onnx.jetson.4.5.0
+++ b/docker/dockerfiles/Dockerfile.onnx.jetson.4.5.0
@@ -46,8 +46,6 @@ WORKDIR /app/
 COPY inference inference
 COPY docker/config/trt_http.py trt_http.py
 
-ENV ONNXRUNTIME_EXECUTION_PROVIDERS=TensorrtExecutionProvider
-ENV REQUIRED_ONNX_PROVIDERS=TensorrtExecutionProvider
 ENV PROJECT=roboflow-platform
 ENV ORT_TENSORRT_FP16_ENABLE=1
 ENV ORT_TENSORRT_ENGINE_CACHE_ENABLE=1

--- a/docker/dockerfiles/Dockerfile.onnx.jetson.4.6.1
+++ b/docker/dockerfiles/Dockerfile.onnx.jetson.4.6.1
@@ -49,8 +49,6 @@ WORKDIR /app/
 COPY inference inference
 COPY docker/config/trt_http.py trt_http.py
 
-ENV ONNXRUNTIME_EXECUTION_PROVIDERS=TensorrtExecutionProvider
-ENV REQUIRED_ONNX_PROVIDERS=TensorrtExecutionProvider
 ENV PROJECT=roboflow-platform
 ENV ORT_TENSORRT_FP16_ENABLE=1
 ENV ORT_TENSORRT_ENGINE_CACHE_ENABLE=1

--- a/docker/dockerfiles/Dockerfile.onnx.jetson.5.1.1
+++ b/docker/dockerfiles/Dockerfile.onnx.jetson.5.1.1
@@ -46,8 +46,6 @@ WORKDIR /app/
 COPY inference inference
 COPY docker/config/trt_http.py trt_http.py
 
-ENV ONNXRUNTIME_EXECUTION_PROVIDERS=TensorrtExecutionProvider
-ENV REQUIRED_ONNX_PROVIDERS=TensorrtExecutionProvider
 ENV PROJECT=roboflow-platform
 ENV ORT_TENSORRT_FP16_ENABLE=1
 ENV ORT_TENSORRT_ENGINE_CACHE_ENABLE=1

--- a/docker/publish/jetson_trt_4.4.1_http.sh
+++ b/docker/publish/jetson_trt_4.4.1_http.sh
@@ -1,1 +1,1 @@
-docker/publish/deploy_docker_image.sh roboflow/roboflow-inference-server-trt-jetson-4.4.1 docker/dockerfiles/Dockerfile.onnx.jetson.4.4.1
+docker/publish/deploy_docker_image.sh roboflow/roboflow-inference-server-jetson-4.4.1 docker/dockerfiles/Dockerfile.onnx.jetson.4.4.1

--- a/docker/publish/jetson_trt_http.sh
+++ b/docker/publish/jetson_trt_http.sh
@@ -1,1 +1,1 @@
-docker/publish/deploy_docker_image.sh roboflow/roboflow-inference-server-trt-jetson docker/dockerfiles/Dockerfile.onnx.jetson
+docker/publish/deploy_docker_image.sh roboflow/roboflow-inference-server-jetson docker/dockerfiles/Dockerfile.onnx.jetson

--- a/docker/publish/jetson_trt_http_5.1.1.sh
+++ b/docker/publish/jetson_trt_http_5.1.1.sh
@@ -1,1 +1,1 @@
-docker/publish/deploy_docker_image.sh roboflow/roboflow-inference-server-trt-jetson-5.1.1 docker/dockerfiles/Dockerfile.onnx.jetson.5.1.1
+docker/publish/deploy_docker_image.sh roboflow/roboflow-inference-server-jetson-5.1.1 docker/dockerfiles/Dockerfile.onnx.jetson.5.1.1

--- a/docs/quickstart/docker.md
+++ b/docs/quickstart/docker.md
@@ -40,18 +40,25 @@ hardware configurations.
         docker pull roboflow/roboflow-inference-server-trt
         ```
 
-    === "Jetson 4.x"
-        Official Roboflow Inference Server Docker Image for Nvidia Jetson JetPack 4.x Targets.
+    === "Jetson 4.5.x"
+        Official Roboflow Inference Server Docker Image for Nvidia Jetson JetPack 4.5.x Targets.
 
         ```
-        docker pull roboflow/roboflow-inference-server-trt-jetson
+        docker pull roboflow/roboflow-inference-server-jetson-4.5.0
+        ```
+
+    === "Jetson 4.6.x"
+        Official Roboflow Inference Server Docker Image for Nvidia Jetson JetPack 4.6.x Targets.
+
+        ```
+        docker pull roboflow/roboflow-inference-server-jetson-4.6.1
         ```
 
     === "Jetson 5.x"
         Official Roboflow Inference Server Docker Image for Nvidia Jetson JetPack 5.x Targets.
 
         ```
-        docker pull roboflow/roboflow-inference-server-trt-jetson-5.1.1
+        docker pull roboflow/roboflow-inference-server-jetson-5.1.1
         ```
 
 ## Run
@@ -85,17 +92,25 @@ Server in a container.
         roboflow/roboflow-inference-server-trt:latest
         ```
 
-    === "Jetson 4.x"
+    === "Jetson 4.5.x"
         ```
         docker run --privileged --net=host --runtime=nvidia \
-        roboflow/roboflow-inference-server-trt-jetson:latest
+        roboflow/roboflow-inference-server-jetson-4.5.0:latest
+        ```
+
+    === "Jetson 4.6.x"
+        ```
+        docker run --privileged --net=host --runtime=nvidia \
+        roboflow/roboflow-inference-server-jetson-4.6.1:latest
         ```
 
     === "Jetson 5.x"
         ```
         docker run --privileged --net=host --runtime=nvidia \
-        roboflow/roboflow-inference-server-trt-jetson-5.1.1:latest
+        roboflow/roboflow-inference-server-jetson-5.1.1:latest
         ```
+
+    **_Note:_** The Jetson images come with TensorRT dependancies. To use TensorRT acceleration with your model, pass an additional environment variable at runtime `-e ONNXRUNTIME_EXECUTION_PROVIDERS=TensorrtExecutionProvider`. This can improve inference speed, however, this also incurs a costly startup expense when the model is loaded.
 
 ## Build
 
@@ -137,16 +152,23 @@ Choose a Dockerfile from the following options, depending on the hardware you wa
         roboflow/roboflow-inference-server-trt .
         ```
 
-    === "Jetson 4.x"
+    === "Jetson 4.5.x"
         ```
         docker build \
         -f dockerfiles/Dockerfile.onnx.jetson \
-        -t roboflow/roboflow-inference-server-trt-jetson .
+        -t roboflow/roboflow-inference-server-jetson-4.5.0 .
+        ```
+
+    === "Jetson 4.6.x"
+        ```
+        docker build \
+        -f dockerfiles/Dockerfile.onnx.jetson \
+        -t roboflow/roboflow-inference-server-jetson-4.6.1 .
         ```
 
     === "Jetson 5.x"
         ```
         docker build \
         -f dockerfiles/Dockerfile.onnx.jetson.5.1.1 \
-        -t roboflow/roboflow-inference-server-trt-jetson-5.1.1 .
+        -t roboflow/roboflow-inference-server-jetson-5.1.1 .
         ```

--- a/docs/quickstart/http_inference.md
+++ b/docs/quickstart/http_inference.md
@@ -27,7 +27,7 @@ sudo docker run -it --rm -p 9001:9001 roboflow/roboflow-inference-server-arm-cpu
 ### TRT
 
 ```bash
-sudo docker run --privileged --net=host --runtime=nvidia --mount source=roboflow,target=/cache -e NUM_WORKERS=1 roboflow/roboflow-inference-server-trt-jetson:latest
+sudo docker run --privileged --net=host --runtime=nvidia --mount source=roboflow,target=/cache -e NUM_WORKERS=1 roboflow/roboflow-inference-server-jetson:latest
 ```
 
 ### GPU

--- a/examples/inference-client/README.md
+++ b/examples/inference-client/README.md
@@ -74,13 +74,13 @@ docker run --gpus=all --net=host -e STREAM_ID=0 -e MODEL_ID=<> -e API_KEY=<> rob
 - Run on Nvidia Jetson with JetPack `4.x`:
 
   ```bash
-  docker run --privileged --net=host --runtime=nvidia roboflow/roboflow-inference-server-trt-jetson:latest
+  docker run --privileged --net=host --runtime=nvidia roboflow/roboflow-inference-server-jetson:latest
   ```
   
 - Run on Nvidia Jetson with JetPack `5.x`:
 
   ```bash
-  docker run --privileged --net=host --runtime=nvidia roboflow/roboflow-inference-server-trt-jetson-5.1.1:latest
+  docker run --privileged --net=host --runtime=nvidia roboflow/roboflow-inference-server-jetson-5.1.1:latest
   ```
 
 ### UDP

--- a/inference/core/version.py
+++ b/inference/core/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.8.1"
+__version__ = "0.8.2"
 
 if __name__ == "__main__":
     print(__version__)


### PR DESCRIPTION
# Description

Updated jetson dockers, removed `trt` from image names, removed TensorRTExecution provider as default

## Type of change

Please delete options that are not relevant.

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update
