### PR TITLE
Fix/ Correct pingback url and docs params

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -70,13 +70,12 @@ You can also run any model hosted on Roboflow using the Inference.
 
 Use these environment variables to control pingback and to Roboflow as well as other features; if you are running a Docker container, [pass these](https://docs.docker.com/engine/reference/commandline/run/#env) into the docker run command.
 
-| ENV Variable    | Description |
-| -------- | ------- |
-|   PINGBACK_ENABLED  | Default is true; if set to the string "false", pingback messages are not sent back to Roboflow.   |
-|   PINGBACK_URL  | Default is `https://api.roboflow.com/pingback`   |
-| PINGBACK_INTERVAL_SECONDS | Frequency of sending pingback messages, default is 3600 seconds |
-| ROBOFLOW_SERVER_UUID  | If this is set, the ID of the process reported back to Roboflow's UI is the value of this environment variable. Omitting this causes the process (docker container) to generate a new UUID.    |
-| ENABLE_PROMETHEUS | if set to any value, this will cause a /metrics endpoint to be created with some FastAPI metrics for Prometheus to scrape; not applicable to the lambda inference server     |
+| ENV Variable              | Description                                                                                                                                                                                 |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| PINGBACK_ENABLED          | Default is true; if set to the string "false", pingback messages are not sent back to Roboflow.                                                                                             |
+| PINGBACK_INTERVAL_SECONDS | Frequency of sending pingback messages, default is 3600 seconds                                                                                                                             |
+| ROBOFLOW_SERVER_UUID      | If this is set, the ID of the process reported back to Roboflow's UI is the value of this environment variable. Omitting this causes the process (docker container) to generate a new UUID. |
+| ENABLE_PROMETHEUS         | if set to any value, this will cause a /metrics endpoint to be created with some FastAPI metrics for Prometheus to scrape; not applicable to the lambda inference server                    |
 
 ## Community Resources 📚
 

--- a/docs/quickstart/http_inference.md
+++ b/docs/quickstart/http_inference.md
@@ -27,10 +27,10 @@ Now we are ready to run inference!
 To run inference on a model, we will make a HTTP request to:
 
 ```url
-http://localhost:9001/{workspace_id}/{model_id}
+http://localhost:9001/{project_id}/{model_version}
 ```
 
-To find your workspace and model IDs, refer to the Roboflow documentation.
+To find your project ID and model version number, refer to the Roboflow documentation, [Workspace and Project IDs](https://docs.roboflow.com/api-reference/workspace-and-project-ids).
 
 This route works for all supported task types: object detection, classification, and segmentation.
 
@@ -39,8 +39,8 @@ To run inference, make a HTTP request to the route:
 ```python
 import requests
 
-workspace_id = ""
-model_id = ""
+project_id = ""
+model_version = ""
 image_url = ""
 confidence = 0.75
 api_key = ""
@@ -55,7 +55,7 @@ infer_payload = {
     "api_key": api_key,
 }
 res = requests.post(
-    f"http://localhost:9001/{workspace_id}/{model_id}",
+    f"http://localhost:9001/{project_id}/{model_version}",
     json=infer_object_detection_payload,
 )
 
@@ -64,7 +64,7 @@ predictions = res.json()
 
 This code will run inference on a computer vision model. On the first request, the model weights will be downloaded and set up with your local inference server. This request may take some time depending on your network connection and the size of the model. Once your model has downloaded, subsequent requests will be much faster.
 
-Above, set your workspace and model ID. Also configure your confidence and IoU threshold values as needed. If you are using classification, you can omit the IoU threshold value. You will also need to set your Roboflow API key. To learn how to retrieve your Roboflow API key, refer to the Roboflow API documentation.
+Above, set your project ID and model version number. Also configure your confidence and IoU threshold values as needed. If you are using classification, you can omit the IoU threshold value. You will also need to set your Roboflow API key. To learn how to retrieve your Roboflow API key, refer to the Roboflow API documentation, [Authentication - Retrieve an API Key](https://docs.roboflow.com/api-reference/authentication#retrieve-an-api-key).
 
 You can post either a URL, a base64-encoded image, or a pickled NumPy array to the server.
 

--- a/inference/core/env.py
+++ b/inference/core/env.py
@@ -230,9 +230,6 @@ PINGBACK_ENABLED = bool_env(os.getenv("PINGBACK_ENABLED", True))
 if LAMBDA:
     PINGBACK_ENABLED = False
 
-# Pingback URL
-PINGBACK_URL = os.getenv("PINGBACK_URL", "https://api.roboflow.com/pingback")
-
 # Pingback interval in seconds, default is 3600
 PINGBACK_INTERVAL_SECONDS = int(os.getenv("PINGBACK_INTERVAL_SECONDS", 3600))
 

--- a/inference/core/managers/pingback.py
+++ b/inference/core/managers/pingback.py
@@ -14,7 +14,7 @@ from inference.core.env import (
     API_KEY,
     PINGBACK_ENABLED,
     PINGBACK_INTERVAL_SECONDS,
-    PINGBACK_URL,
+    API_BASE_URL,
 )
 from inference.core.logger import logger
 
@@ -52,7 +52,6 @@ class PingbackInfo:
         scheduler (BackgroundScheduler): A scheduler for running jobs in the background.
         model_manager (ModelManager): Reference to the model manager object.
         process_startup_time (str): Unix timestamp indicating when the process started.
-        pingback_url (str): URL to send the pingback data to.
         system_info (dict): Information about the system.
         window_start_timestamp (str): Unix timestamp indicating the start of the current window.
     """
@@ -70,7 +69,6 @@ class PingbackInfo:
             logger.info(
                 "UUID: " + self.model_manager.uuid
             )  # To correlate with UI container view
-            self.pingback_url = PINGBACK_URL  # Test URL
 
             self.system_info = getSystemInfo()
             self.window_start_timestamp = str(int(time.time()))
@@ -159,10 +157,11 @@ class PingbackInfo:
             timestamp = str(int(time.time()))
             all_data["timestamp"] = timestamp
             self.window_start_timestamp = timestamp
-            requests.post(PINGBACK_URL, json=all_data)
+            pingback_url = f"{API_BASE_URL}/device-health"
+            requests.post(pingback_url, json=all_data)
             logger.info(
                 "Sent pingback to Roboflow {} at {}.".format(
-                    PINGBACK_URL, str(all_data)
+                    pingback_url, str(all_data)
                 )
             )
 

--- a/inference/core/managers/pingback.py
+++ b/inference/core/managers/pingback.py
@@ -11,10 +11,10 @@ from apscheduler.schedulers.background import BackgroundScheduler
 
 from inference.core.devices.utils import get_device_id
 from inference.core.env import (
+    API_BASE_URL,
     API_KEY,
     PINGBACK_ENABLED,
     PINGBACK_INTERVAL_SECONDS,
-    API_BASE_URL,
 )
 from inference.core.logger import logger
 


### PR DESCRIPTION
# Description

- Fixes pingback URL to correct path: `{API_BASE_URL}/device-health`, removes unnecessary env var.
- Corrects http interface docs with Roboflow project terminology

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Tested by building local inference docker image and running container with two different models.