### PR TITLE
Ensure parity between docs homepage and README, fix git clone

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,137 +1,322 @@
 ![Roboflow Inference banner](https://github.com/roboflow/inference/blob/main/banner.png?raw=true)
 
-# Roboflow Inference 💻
+## Roboflow Inference
 
-[Roboflow](https://roboflow.com) Inference is an opinionated tool for running inference on state-of-the-art computer vision models. With no prior knowledge of machine learning or device-specific deployment, you can deploy a computer vision model to a range of devices and environments.
+[Roboflow](https://roboflow.com) Inference is an opinionated tool for running inference on state-of-the-art computer vision models. With no prior
+knowledge of machine learning or device-specific deployment, you can deploy a computer vision model to a range of devices and environments. Inference supports object detection, classification, and instance segmentation models, and running foundation models (CLIP and SAM).
 
-By using Roboflow Inference, you can:
+## 🎥 Inference in action
 
-1. Write inference logic without having to configure environments or install dependencies.
-2. Deploy models to a range of devices and environments.
-3. Use state-of-the-art models with your own weights.
-4. Query models with HTTP.
-5. Scale up your inference server as your production needs grow with Docker.
+Check out Inference running on a video of a football game:
 
-You can use Inference wherever you can use Docker: on CPUs, GPUs, TRT and more.
+https://github.com/roboflow/inference/assets/37276661/121ab5f4-5970-4e78-8052-4b40f2eec173
 
-You can run inference using the `inference` pip package, or using the HTTP server available by running a Roboflow Inference Docker containers.
+## 👩‍🏫 Examples
 
-## Installation 🛠️
+The [`/examples` directory](./examples/) contains example code for working with and extending `inference`, including HTTP and UDP client code and an insights dashboard, along with community examples (PRs welcome)!
 
-The Roboflow Inference runs in a Docker container. If you do not already have Docker installed on your computer, follow the official Docker installation instructions to install Docker.
+## 💻 Why Inference?
 
-For all installation options, you will need a [free Roboflow account](https://app.roboflow.com) and a Roboflow API key. You can learn how to retrieve your API key in the [Roboflow API documentation](https://docs.roboflow.com/api-reference/authentication#retrieve-an-api-key).
+Inference provides a scalable method through which you can manage inferences for your vision projects.
 
-### Install Using Pip
+Inference is backed by:
 
-To install the Inference using pip, run one of the following commands, depending on the device on which you want to run the Inference:
+- A server, so you don’t have to reimplement things like image processing and prediction visualization on every project.
+
+- Standardized APIs for computer vision tasks, so switching out the model weights and architecture can be done independently of your application code.
+
+- Model architecture implementations, which implement the tensor parsing glue between images and predictions for supervised models that you've fine-tuned to perform custom tasks.
+
+- A model registry, so your code can be independent from your model weights & you don't have to re-build and re-deploy every time you want to iterate on your model weights.
+
+- Data management integrations, so you can collect more images of edge cases to improve your dataset & model the more it sees in the wild.
+
+And more!
+
+### 📌 Install pip vs Docker:
+
+- **pip**: Installs `inference` into your Python environment. Lightweight, good for Python-centric projects.
+- **Docker**: Packages `inference` with its environment. Ensures consistency across setups; ideal for scalable deployments.
+
+## 💻 install
+
+### With ONNX CPU Runtime:
+
+For CPU powered inference:
 
 ```bash
 pip install inference
-pip install inference[gpu]
-pip install inference[arm]
-pip install inference[jetson]
-pip install inference[trt]
 ```
 
-### Install Using Docker
-
-See the [docker quickstart](quickstart/docker.md).
-
-## Quickstart 🚀
-
-API documentation are hosted by a running instance of the inference server at the `/docs` and `/redoc` endpoints. For an inference server running locally, see `https://localhost/docs` or `https://localhost/redoc`.
-
-## Model Support 🖼️
-
-The Roboflow Inference supports the models listed below.
-
-You can also run any model hosted on Roboflow using the Inference.
-
-### Classification
-
-- [ViT](https://inference.roboflow.com/library/models/vit_classification)
-- [YOLOv8](https://inference.roboflow.com/library/models/yolov8_classification/)
-- [CLIP](https://inference.roboflow.com/library/models/clip/)
-
-### Object Detection
-
-- [YOLOv5](https://inference.roboflow.com/library/models/yolov5/)
-- [YOLOv8](https://inference.roboflow.com/library/models/yolov8/)
-
-### Segmentation
-
-- [YOLOv7](https://inference.roboflow.com/library/models/yolov7_instance_segmentation/)
-- [YOLOv8](https://inference.roboflow.com/library/models/yolov8_segmentation/)
-- [YOLOACT](https://inference.roboflow.com/library/models/yoloact_segmentation/)
-- [Segment Anything](https://inference.roboflow.com/library/models/segment_anything/)
-
-## Environment Variable Control 🌐
-
-Use these environment variables to control pingback and to Roboflow as well as other features; if you are running a Docker container, [pass these](https://docs.docker.com/engine/reference/commandline/run/#env) into the docker run command.
-
-| ENV Variable    | Description |
-| -------- | ------- |
-|   PINGBACK_ENABLED  | Default is true; if set to the string "false", pingback messages are not sent back to Roboflow.   |
-|   PINGBACK_URL  | Default is `https://api.roboflow.com/pingback`   |
-| PINGBACK_INTERVAL_SECONDS | Frequency of sending pingback messages, default is 3600 seconds |
-| ROBOFLOW_SERVER_UUID  | If this is set, the ID of the process reported back to Roboflow's UI is the value of this environment variable. Omitting this causes the process (docker container) to generate a new UUID.    |
-| ENABLE_PROMETHEUS | if set to any value, this will cause a /metrics endpoint to be created with some FastAPI metrics for Prometheus to scrape; not applicable to the lambda inference server     |
-
-## Community Resources 📚
-
-- [Roboflow Inference Documentation](https://inference.roboflow.com/)
-
-## Roadmap
-
-- [ ] Add support for more models
-
-## Contributing ⌨️
-
-Thank you for your interest in contributing to the Roboflow Inference! You can learn more about how to start contributing in our [contributing guide](https://github.com/roboflow/roboflow-inference-server/blob/master/CONTRIBUTING.md).
-
-## License 📝
-
-The Roboflow Inference code, enclosed within `inference/core`, as well as the documentation in `docs/`, is licnsed under an [Apache 2.0 license](LICENSE).
-
-The following models, accessible through, Roboflow Inference comes with their own licenses:
-
-- `inference/models/clip`: [MIT](https://github.com/openai/CLIP/blob/main/LICENSE).
-- `inference/models/sam`: [Apache 2.0](https://github.com/facebookresearch/segment-anything/blob/main/LICENSE).
-- `inference/models/yolact`: [MIT](https://github.com/dbolya/yolact/blob/master/README.md).
-- `inference/models/yolov5`: [AGPL-3.0](https://github.com/ultralytics/yolov5/blob/master/LICENSE).
-- `inference/models/yolov7`: [GPL-3.0](https://github.com/WongKinYiu/yolov7/blob/main/README.md).
-- `inference/models/yolov8`: [AGPL-3.0](https://github.com/ultralytics/ultralytics/blob/master/LICENSE).
-
-Roboflow Inference offers more features to Enterprise License holders, including:
-
-1. Running Inference on a cluster of multiple servers
-2. Handling auto-batched inference
-3. Device management
-4. Active learning
-5. Sub-license YOLOv5 and YOLOv8 models for enterprise use
-6. And more.
-
-To learn more about a Roboflow Inference Enterprise License, [contact us](https://roboflow.com/sales).
-
-## Build the Documentation
-
-Roboflow Inference uses `mkdocs` and `mike` to offer versioned documentation. The project documentation is hosted at [https://inference.roboflow.com](https://inference.roboflow.com)
-
-To build the Inference documentation, first install the project development dependencies:
+or
 
 ```bash
-pip install -r requirements/requirements.docs.txt
+pip install inference-cpu
 ```
 
-To run the latest version of the documentation, run:
+### With ONNX GPU Runtime:
+
+If you have an NVIDIA GPU, you can accelerate your inference with:
 
 ```bash
-mkdocs serve
+pip install inference-gpu
 ```
 
-Before a new release is published, a new version of the documentation should be built. To create a new version, run:
+### Without ONNX Runtime:
+
+Roboflow Inference uses Onnxruntime as its core inference engine. Onnxruntime provides an array of different [execution providers](https://onnxruntime.ai/docs/execution-providers/) that can optimize inference on differnt target devices. If you decide to install onnxruntime on your own, install inference with:
 
 ```bash
-mkdocs gh-deploy
+pip install inference-core
 ```
+
+Alternatively, you can take advantage of some advanced execution providers using one of our published docker images.
+
+### Extras:
+
+Some functionality requires extra dependencies. These can be installed by specifying the desired extras during installation of Roboflow Inference.
+| extra | description |
+|:-------|:-------------------------------------------------|
+| `clip` | Ability to use the core `CLIP` model (by OpenAI) |
+| `gaze` | Ability to use the core `Gaze` model |
+| `http` | Ability to run the http interface |
+| `sam`  | Ability to run the core `Segment Anything` model (by Meta AI) |
+
+**_Note:_** Both CLIP and Segment Anything require pytorch to run. These are included in their respective dependencies however pytorch installs can be highly environment dependent. See the [official pytorch install page](https://pytorch.org/get-started/locally/) for instructions specific to your enviornment.
+
+Example install with http dependencies:
+
+```bash
+pip install inference[http]
+```
+
+## 🐋 docker
+
+You can learn more about Roboflow Inference Docker Image build, pull and run in our [documentation](https://roboflow.github.io/inference/quickstart/docker/).
+
+- Run on x86 CPU:
+
+```bash
+docker run --net=host roboflow/roboflow-inference-server-cpu:latest
+```
+
+- Run on NVIDIA GPU:
+
+```bash
+docker run --network=host --gpus=all roboflow/roboflow-inference-server-gpu:latest
+```
+
+<details close>
+<summary>👉 more docker run options</summary>
+
+- Run on arm64 CPU:
+
+```bash
+docker run -p 9001:9001 roboflow/roboflow-inference-server-arm-cpu:latest
+```
+
+- Run on NVIDIA GPU with TensorRT Runtime:
+
+```bash
+docker run --network=host --gpus=all roboflow/roboflow-inference-server-trt:latest
+```
+
+- Run on NVIDIA Jetson with JetPack `4.x`:
+
+```bash
+docker run --privileged --net=host --runtime=nvidia roboflow/roboflow-inference-server-jetson:latest
+```
+
+- Run on NVIDIA Jetson with JetPack `5.x`:
+
+```bash
+docker run --privileged --net=host --runtime=nvidia roboflow/roboflow-inference-server-jetson-5.1.1:latest
+```
+
+</details>
+
+<br/>
+
+## 🔥 quickstart
+
+**Docker Quickstart**:
+
+```python
+import requests
+
+dataset_id = "soccer-players-5fuqs"
+version_id = "1"
+image_url = "https://source.roboflow.com/pwYAXv9BTpqLyFfgQoPZ/u48G0UpWfk8giSw7wrU8/original.jpg"
+#Replace ROBOFLOW_API_KEY with your Roboflow API Key
+api_key = "ROBOFLOW_API_KEY"
+confidence = 0.5
+
+url = f"http://localhost:9001/{dataset_id}/{version_id}"
+
+params = {
+    "api_key": api_key,
+    "confidence": confidence,
+    "image": image_url,
+}
+
+res = requests.post(url, params=params)
+print(res.json())
+```
+
+**pip Quickstart**:
+
+After installing via pip, you can run a simple inference using:
+
+```python
+from inference.models.utils import get_roboflow_model
+
+model = get_roboflow_model(
+    model_id="soccer-players-5fuqs/1", 
+    #Replace ROBOFLOW_API_KEY with your Roboflow API Key
+    api_key="ROBOFLOW_API_KEY"
+)
+
+results = model.infer(image="https://source.roboflow.com/pwYAXv9BTpqLyFfgQoPZ/u48G0UpWfk8giSw7wrU8/original.jpg", confidence=0.5, iou_threshold=0.5)
+
+print(results)
+
+```
+
+**CLIP Quickstart**:
+
+You can run inference with OpenAI's CLIP model using:
+
+```python
+from inference.models import Clip
+
+model = Clip(
+    #Replace ROBOFLOW_API_KEY with your Roboflow API Key
+    api_key = "ROBOFLOW_API_KEY"
+)
+
+image_url = "https://source.roboflow.com/7fLqS2r1SV8mm0YzyI0c/yy6hjtPUFFkq4yAvhkvs/original.jpg"
+
+embeddings = model.embed_image(image_url)
+
+print(embeddings)
+```
+
+**SAM Quickstart**:
+
+You can run inference with Meta's Segment Anything model using:
+
+```python
+from inference.models import SegmentAnything
+
+model = SegmentAnything(
+    #Replace ROBOFLOW_API_KEY with your Roboflow API Key
+    api_key = "ROBOFLOW_API_KEY"
+)
+
+image_url = "https://source.roboflow.com/7fLqS2r1SV8mm0YzyI0c/yy6hjtPUFFkq4yAvhkvs/original.jpg"
+
+embeddings = model.embed_image(image_url)
+
+print(embeddings)
+```
+
+## 🏗️ inference process
+
+To standardize the inference process throughout all our models, Roboflow Inference has a structure for processing inference requests. The specifics can be found on each model's respective page, but overall it works like this for most models:
+
+<img width="900" alt="inference structure" src="https://github.com/stellasphere/inference/assets/29011058/abf69717-f852-4655-9e6e-dae19fc263dc">
+
+## 📝 license
+
+The Roboflow Inference code is distributed under an [Apache 2.0 license](https://github.com/roboflow/inference/blob/master/LICENSE.md). The models supported by Roboflow Inference have their own licenses. View the licenses for supported models below.
+
+| model                     |                                        license                                        |
+| :------------------------ | :-----------------------------------------------------------------------------------: |
+| `inference/models/clip`   |                [MIT](https://github.com/openai/CLIP/blob/main/LICENSE)                |
+|`inference/models/gaze` | [MIT](https://github.com/Ahmednull/L2CS-Net/blob/main/LICENSE), [Apache 2.0](https://github.com/google/mediapipe/blob/master/LICENSE) |
+| `inference/models/sam`    | [Apache 2.0](https://github.com/facebookresearch/segment-anything/blob/main/LICENSE)  |
+| `inference/models/vit`    | [Apache 2.0](https://github.com/roboflow/inference/main/inference/models/vit/LICENSE) |
+| `inference/models/yolact` |             [MIT](https://github.com/dbolya/yolact/blob/master/README.md)             |
+| `inference/models/yolov5` |         [AGPL-3.0](https://github.com/ultralytics/yolov5/blob/master/LICENSE)         |
+| `inference/models/yolov7` |          [GPL-3.0](https://github.com/WongKinYiu/yolov7/blob/main/README.md)          |
+| `inference/models/yolov8` |      [AGPL-3.0](https://github.com/ultralytics/ultralytics/blob/master/LICENSE)       |
+
+## 🚀 enterprise
+
+With a Roboflow Inference Enterprise License, you can access additional Inference features, including:
+
+- Server cluster deployment
+- Device management
+- Active learning
+- YOLOv5 and YOLOv8 model sub-license
+
+To learn more, [contact the Roboflow team](https://roboflow.com/sales).
+
+## 📚 documentation
+
+Visit our [documentation](https://roboflow.github.io/inference) for usage examples and reference for Roboflow Inference.
+
+## 🏆 contribution
+
+We would love your input to improve Roboflow Inference! Please see our [contributing guide](https://github.com/roboflow/inference/blob/master/CONTRIBUTING.md) to get started. Thank you to all of our contributors! 🙏
+
+## 💻 explore more Roboflow open source projects
+
+|Project | Description|
+|:---|:---|
+|[supervision](https://roboflow.com/supervision) | General-purpose utilities for use in computer vision projects, from predictions filtering and display to object tracking to model evaluation.
+|[Autodistill](https://github.com/autodistill/autodistill) | Automatically label images for use in training computer vision models. |
+|[Inference](https://github.com/roboflow/inference) (this project) | An easy-to-use, production-ready inference server for computer vision supporting deployment of many popular model architectures and fine-tuned models.
+|[Notebooks](https://roboflow.com/notebooks) | Tutorials for computer vision tasks, from training state-of-the-art models to tracking objects to counting objects in a zone.
+|[Collect](https://github.com/roboflow/roboflow-collect) | Automated, intelligent data collection powered by CLIP.
+
+<br>
+
+<div align="center">
+
+  <div align="center">
+      <a href="https://youtube.com/roboflow">
+          <img
+            src="https://media.roboflow.com/notebooks/template/icons/purple/youtube.png?ik-sdk-version=javascript-1.4.3&updatedAt=1672949634652"
+            width="3%"
+          />
+      </a>
+      <img src="https://raw.githubusercontent.com/ultralytics/assets/main/social/logo-transparent.png" width="3%"/>
+      <a href="https://roboflow.com">
+          <img
+            src="https://media.roboflow.com/notebooks/template/icons/purple/roboflow-app.png?ik-sdk-version=javascript-1.4.3&updatedAt=1672949746649"
+            width="3%"
+          />
+      </a>
+      <img src="https://raw.githubusercontent.com/ultralytics/assets/main/social/logo-transparent.png" width="3%"/>
+      <a href="https://www.linkedin.com/company/roboflow-ai/">
+          <img
+            src="https://media.roboflow.com/notebooks/template/icons/purple/linkedin.png?ik-sdk-version=javascript-1.4.3&updatedAt=1672949633691"
+            width="3%"
+          />
+      </a>
+      <img src="https://raw.githubusercontent.com/ultralytics/assets/main/social/logo-transparent.png" width="3%"/>
+      <a href="https://docs.roboflow.com">
+          <img
+            src="https://media.roboflow.com/notebooks/template/icons/purple/knowledge.png?ik-sdk-version=javascript-1.4.3&updatedAt=1672949634511"
+            width="3%"
+          />
+      </a>
+      <img src="https://raw.githubusercontent.com/ultralytics/assets/main/social/logo-transparent.png" width="3%"/>
+      <a href="https://disuss.roboflow.com">
+          <img
+            src="https://media.roboflow.com/notebooks/template/icons/purple/forum.png?ik-sdk-version=javascript-1.4.3&updatedAt=1672949633584"
+            width="3%"
+          />
+      <img src="https://raw.githubusercontent.com/ultralytics/assets/main/social/logo-transparent.png" width="3%"/>
+      <a href="https://blog.roboflow.com">
+          <img
+            src="https://media.roboflow.com/notebooks/template/icons/purple/blog.png?ik-sdk-version=javascript-1.4.3&updatedAt=1672949633605"
+            width="3%"
+          />
+      </a>
+      </a>
+  </div>
+
+</div>
+  </div>

--- a/docs/quickstart/docker.md
+++ b/docs/quickstart/docker.md
@@ -23,7 +23,7 @@ hardware configurations.
         Official Roboflow Inference Server Docker Image for ARM CPU Targets.
     
         ```
-        docker pull roboflow/roboflow-inference-server-arm-cpu
+        docker pull roboflow/roboflow-inference-server-cpu
         ```
     
     === "GPU"
@@ -77,7 +77,7 @@ Server in a container.
     === "arm64 CPU"
         ```
         docker run -p 9001:9001 \
-        roboflow/roboflow-inference-server-arm-cpu:latest
+        roboflow/roboflow-inference-server-cpu:latest
         ```
 
     === "GPU"
@@ -138,8 +138,8 @@ Choose a Dockerfile from the following options, depending on the hardware you wa
     === "arm64 CPU"
         ```
         docker build \
-        -f dockerfiles/Dockerfile.onnx.arm.cpu \
-        -t roboflow/roboflow-inference-server-arm-cpu .
+        -f dockerfiles/Dockerfile.onnx.cpu \
+        -t roboflow/roboflow-inference-server-cpu .
         ```
     
     === "GPU"

--- a/docs/quickstart/docker.md
+++ b/docs/quickstart/docker.md
@@ -121,7 +121,7 @@ You may add the flag `-v $(pwd)/cache:/cache` to create a cache folder on your h
 To build a Docker image locally, first clone the Inference Server repository.
 
 ```bash
-git clone git clone https://github.com/roboflow/inference
+git clone https://github.com/roboflow/inference
 ```
 
 Choose a Dockerfile from the following options, depending on the hardware you want to run Inference Server on.

--- a/docs/quickstart/http_inference.md
+++ b/docs/quickstart/http_inference.md
@@ -2,7 +2,7 @@
 
 The Roboflow Inference Server provides a standard API through which to run inference on computer vision models.
 
-In this guide, we walk through how to run inference on object detection, classification, and segmentation models using the Inference Server.
+In this guide, we show how to run inference on object detection, classification, and segmentation models using the Inference Server.
 
 Currently, the server is compatible with models trained on Roboflow, but stay tuned as we actively develop support for bringing your own models.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,8 +60,8 @@ nav:
 
 theme:
   name: 'material'
-  logo: https://media.roboflow.com/laptop-lenny.png
-  favicon: https://media.roboflow.com/laptop-lenny.png
+  logo: https://media.roboflow.com/inference-icon.png
+  favicon: https://media.roboflow.com/nference-icon.png
   font:
     text: Roboto
     code: Roboto Mono


### PR DESCRIPTION
# Description

This PR copies the contents of the README into the docs homepage and fixes an errant `git clone` in the manual Docker build instructions.

## Type of change

Docs change.

## How has this change been tested, please provide a testcase or example of how you tested the change?

N/A

## Any specific deployment considerations

N/A
