### PR TITLE
Add CLIP and SAM examples, add new docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,30 @@ To standardize the inference process throughout all our models, Roboflow Inferen
 
 <img width="900" alt="inference structure" src="https://github.com/stellasphere/inference/assets/29011058/abf69717-f852-4655-9e6e-dae19fc263dc">
 
+## ✅ Supported Models
+
+### Load from Roboflow
+
+You can use models hosted on Roboflow with the following architectures through Inference:
+
+- YOLOv5 Object Detection
+- YOLOv5 Instance Segmentation
+- YOLOv8 Object Detection
+- YOLOv8 Classification
+- YOLOv8 Segmentation
+- YOLACT Segmentation
+- ViT Classification
+
+### Core Models
+
+Core Models are foundation models and models that have not been fine-tuned on a specific dataset.
+
+The following core models are supported:
+
+1. CLIP
+2. L2CS (Gaze Detection)
+3. Segment Anything (SAM)
+
 ## 📝 license
 
 The Roboflow Inference code is distributed under an [Apache 2.0 license](https://github.com/roboflow/inference/blob/master/LICENSE.md). The models supported by Roboflow Inference have their own licenses. View the licenses for supported models below.

--- a/docs/add_a_model.md
+++ b/docs/add_a_model.md
@@ -1,5 +1,83 @@
 # Add a Model to the Inference Server
 
-The Roboflow Inference Server comes with several state-of-the-art models available for inference out of the box. If your model is not supported by the Inference Server, you can implement support for a custom model architecture.
+The Roboflow Inference Server comes with several state-of-the-art models available for inference out of the box ([see list of available models](https://github.com/roboflow/inference#Supported_Models)). If your model is not supported by the Inference Server, you can implement support for a custom model architecture.
+
+!!! note
+
+    Inference is designed to be extensible so you can add support for new models.
+
+    Before you add a new model, check the [list of supported models](https://inference.roboflow.com/docs/library/models/) to see if your model is already supported.
+    
+    Roboflow may not accept contributions for new models to Inference depending on the model architecture, but you can maintain your own fork that supports your custom model.
+
+    If you are contributing a model to Inference that you want other people to use, please open a [GitHub Issue](https://github.com/roboflow/inference/issues/new) to discuss your contribution.
 
 In this guide, we are going to walk through how to add support for a new model architecture to the Roboflow Inference Server.
+
+## Create Model Structure
+
+To add a model to the inference server, there are a few files you need to create.
+
+First, create a folder called `inference/models/MODEL_NAME`, where `MODEL_NAME` is the name of your model. Then, create the following files:
+
+```
+inference/models/MODEL_NAME/__init__.py
+inference/models/MODEL_NAME/MODEL_NAME_model.py
+inference/models/MODEL_NAME/LICENSE.txt
+```
+
+- `__init__.py` should contain an import to your model API. You can see examples of this in the CLIP and SAM models.
+- `MODEL_NAME_model.py` should contain the implementation of your model API. You can see examples of this in the CLIP and SAM models.
+- `LICENSE.txt` should contain the license for your model. You must include the license of the model you are using.
+
+## Implement Model API
+
+To implement a model, you will need to work across multiple parts of the Inference codebase. Here are the main files with which you will need to work:
+
+- `inference/models/MODEL_NAME/MODEL_NAME_model.py`: This file contains the implementation of your model API. You can see examples of this in the CLIP and SAM models.
+- `inference/core/data_models.py`: This is where you will store your Request and Response objects. These will be consumed by FastAPI for creating a HTTP interface for your model.
+- `inference/core/env.py`: This is where you should declare any configuration variables you want to infer from the environment. These will be available when you import `inference.core.env.VARIABLE`, where `VARIABLE` is the name of the variable with which you want to work.
+
+Inference has support for adding PyTorch and ONNX models.
+
+Every model needs to have:
+
+1. An `__init__` function that loads the model.
+2. A `preprocess_image` function that runs any preprocessing required before inference is run on an image.
+3. An `infer` function through which inference is run.
+
+This code should be written in your `inference/models/MODEL_NAME/MODEL_NAME_model.py` file.
+
+You can implement any other functions needed for your model to work.
+
+### PyTorch Models
+
+TODO
+
+### ONNX Models
+
+TODO
+
+### Request and Response Objects
+
+Every model has a Request and a Response object. These objects are used to define the structure of the input and output that your model API accepts.
+
+You must define these objects in `inference/core/data_models.py`.
+
+TODO
+
+## Write Documentation
+
+All contributions to Roboflow Inference for new models must have documentation.
+
+Create a file in `inference/docs/library/models/MODEL_NAME.md`. This file should contain auto-generated API documentation for your model. You can see an example of how this works in the CLIP documentation.
+
+FastAPI, used to generate the HTTP interfaces for Inference, will automatically create OpenAPI documentation for your model.
+
+Add your model to the `Supported Models` list in the Roboflow Inference `README`. In addition, update the `license` section in the project README to include a link to the model you have implemented, its license, and its location in the Inference codebase.
+
+Next, add a link to your model in the Models section of the `mkdocs.yml` file in the root folder of the Inference project. This will ensure your model is linked in the sidebar of the [official Inference documentation](https://inference.roboflow.com).
+
+## Open a Pull Request
+
+If you want to contribute your model for others to use, open a pull request to the [Roboflow Inference repository](https://github.com/roboflow/inference) with your contribution. Your contribution will be reviewed by a member of the Roboflow team.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,53 @@
+# Changelog
+
+## v0.8.5
+
+### Summary
+
+Contains bug fixes for configurations that use the LICENSE_SERVER setting.
+
+## v0.8.4
+
+### Summary
+
+Image loading is now multi-threaded for batch requests. This should increase total FPS, especially for batch requests that include large images.
+
+The regression test Github action now runs on a Github actions runner.
+
+The extras require has been fixed for the various distribution packages
+
+## v0.8.2
+
+### Summary
+
+Updated the Jetson images so that the default execution provider is CUDA. TensorRT is now an optional configuration via the environment variable ONNXRUNTIME_EXECUTION_PROVIDERS=TensorrtExecutionProvider. The images are also renamed to:
+
+- roboflow/roboflow-inference-server-jetson-4.5.0
+- roboflow/roboflow-inference-server-jetson-4.6.1
+- roboflow/roboflow-inference-server-jetson-5.1.1
+
+## v0.8.1
+
+### Summary
+
+- Optional Byte Track for UDP interface
+- Updated SAM and CLIP requirements and added README quickstarts
+- Bug fix for single channel numpy strings
+
+### Breaking Changes
+
+The output for UDP JSON messages has updated the key class_name to class to match HTTP responses.
+
+## v0.8.0
+
+### Summary
+
+This release includes a bit of an overhaul for the model APIs. As this repository started as an internal tool for hosting inference logic, the APIs were tailored for an HTTP interface. With this release, we have made using inference within your python code much smoother and easier. We also updated imports to be less verbose. See the README and docs for new usage. Additionally, a new interface is provided for consuming video streams, and then broadcasting the results over UDP. This interface is tuned for low latency and is ideal for use cases that need to the most up to date information as possible from a video stream. See https://blog.roboflow.com/udp-inference/ for more details.
+
+### Breaking Changes
+
+The main change was creating new definitions for model infer() functions that now take many keyword arguments instead of a single request argument. To continue inferring using request objects, a new method infer_from_request() is provided.
+
+## v0.7.2
+
+Initial release.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -4,6 +4,10 @@ Thank you for your interest in contributing to the Roboflow Inference Server!
 
 We welcome any contributions to help us improve the quality of `inference-server` and expand the range of supported models.
 
+!!! note
+
+    Interested in adding a new model to Inference? Check out our guide on [how to add a model](https://inference.roboflow.com/add_a_model/).
+
 ## Contribution Guidelines
 
 We welcome contributions to:

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,3 +1,5 @@
+![Roboflow Inference banner](https://github.com/roboflow/inference/blob/main/banner.png?raw=true)
+
 # Inference Examples
 
 This folder contains examples of projects built with Inference.
@@ -7,6 +9,8 @@ This folder contains examples of projects built with Inference.
 - [Inference Client](./inference-client-example/): Quickstart HTTP and UDP clients for use with Inference.
 - [Inference dashboard](./inference-dashboard-example/): Extracts insights from video frames at defined intervals and generates informative visualizations and CSV outputs.
 - [Gaze Detection](./gaze-detection/): Detects the direction in which someone is looking and the point in a frame at which someone is looking.
+- [CLIP Image-to-Image Search Engine](./clip-search-engine): Find images similar to a given image in a dataset with CLIP. Served as a web application.
+- [SAM Client](./sam-client): Use Segment Anything to segment objects in an image. Served as a command line application.
 
 ## Community Examples
 

--- a/examples/clip-search-engine/README.md
+++ b/examples/clip-search-engine/README.md
@@ -1,0 +1,65 @@
+# CLIP Example
+
+## 👋 Hello
+
+This repository shows how to use the [Roboflow Inference](https://github.com/roboflow/inference) CLIP API to build a semantic search engine.
+
+With this project, you can search for related images in a given folder. For example, if you upload a photo of a cat, the dataset you have provided will be searched for photos similar to the cat photo.
+
+## 💻 Getting Started
+
+First, clone this repository and navigate to the project folder:
+
+```bash
+git clone https://github.com/roboflow/inference
+cd inference/examples/clip-client
+```
+
+Next, set up a Python environment and install the required project dependencies:
+
+```bash
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
+
+Next, set up a Roboflow Inference Docker container. This Docker container will manage inference for the gaze detection system. [Learn how to set up an Inference Docker container](https://inference.roboflow.com/quickstart/docker/).
+
+## 🔑 keys
+
+Before running the inference script, ensure that the `API_KEY` is set as an environment variable. This key provides access to the inference API.
+
+- For Unix/Linux:
+
+    ```bash
+    export API_KEY=your_api_key_here
+    ```
+
+- For Windows:
+
+    ```bash
+    set API_KEY=your_api_key_here
+    ```
+  
+Replace `your_api_key_here` with your Roboflow API key. [Learn how to retrieve your Roboflow API key](https://docs.roboflow.com/api-reference/authentication#retrieve-an-api-key).
+
+## 🎬 Run Inference
+
+To use the CLIP search engine, run the following command:
+
+```bash
+python app.py --dataset_path=./images
+```
+
+Replace `./images` with a folder that you want to search.
+
+The first time you run the script, an image database will be created and saved to your system. The amount of time this takes will depend on how many images you want to be able to search. This database will be saved in two files:
+
+- `index.bin`: The database that stores the image embeddings.
+- `database.json`: The database that stores the image paths.
+
+Both of these files are saved in the root folder of the project.
+
+When the database has been built, it will be opened in subsequent runs of the script. If you want to search a new folder of images, delete the `index.bin` and `database.json` files and run the script again.
+
+A web application will be available at `http://localhost:9001` with which you can search for images.

--- a/examples/clip-search-engine/app.py
+++ b/examples/clip-search-engine/app.py
@@ -1,0 +1,110 @@
+import base64
+import os
+from io import BytesIO
+import faiss
+import numpy as np
+import requests
+from PIL import Image
+import argparse
+import json
+
+from flask import Flask, request, render_template, send_from_directory
+
+parser = argparse.ArgumentParser(description="Build a search engine with CLIP")
+
+parser.add_argument(
+    "--dataset_path", type=str, required=True, help="Path to dataset", default="images"
+)
+parser.add_argument(
+    "--inference_endpoint",
+    type=str,
+    required=True,
+    help="Roboflow Inference endpoint URL",
+    default="http://localhost:9001",
+)
+parser.add_argument(
+    "--api_key",
+    type=str,
+    required=True,
+    help="Roboflow API key",
+    default=os.environ.get("ROBOFLOW_API_KEY")
+)
+
+args = parser.parse_args()
+
+app = Flask(__name__)
+
+
+def get_image_embedding(image: str) -> dict:
+    image = image.convert("RGB")
+
+    buffer = BytesIO()
+    image.save(buffer, format="JPEG")
+    image = base64.b64encode(buffer.getvalue()).decode("utf-8")
+
+    payload = {
+        "image": {"type": "base64", "value": image},
+    }
+
+    data = requests.post(
+        args.inference_endpoint + "/clip/embed_image?api_key=" + args.api_key,
+        json=payload,
+    )
+
+    response = data.json()
+
+    embedding = response["embeddings"]
+
+    return embedding
+
+if os.path.exists("index.bin"):
+    index = faiss.read_index("index.bin")
+    with open("database.json", "r") as f:
+        file_names = json.load(f)
+else:
+    index = faiss.IndexFlatL2(512)
+    file_names = []
+
+    TRAIN_IMAGES = os.path.join(args.dataset_path, "train")
+
+    for frame_name in os.listdir(TRAIN_IMAGES):
+        try:
+            frame = Image.open(os.path.join(TRAIN_IMAGES, frame_name))
+        except IOError:
+            print("error computing embedding for", frame_name)
+            continue
+
+        embedding = get_image_embedding(frame)
+
+        index.add(np.array(embedding).astype(np.float32))
+
+        file_names.append(frame_name)
+
+    faiss.write_index(index, "index.bin")
+
+    with open("database.json", "w") as f:
+        json.dump(file_names, f)
+
+
+@app.route("/", methods=["GET", "POST"])
+def search():
+    if request.method == "POST":
+        file = request.files["file"]
+        query = get_image_embedding(Image.open(file))
+
+        _, I = index.search(np.array(query).astype(np.float32), 3)
+
+        images = [os.path.join(TRAIN_IMAGES, file_names[i]) for i in I[0]]
+
+        return render_template("index.html", images=images)
+
+    return render_template("index.html")
+
+
+@app.route("/images/<path:path>")
+def send_image(path):
+    return send_from_directory(args.dataset_path, path)
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/examples/clip-search-engine/requirements.txt
+++ b/examples/clip-search-engine/requirements.txt
@@ -1,0 +1,4 @@
+faiss-cpu
+requests
+PIL
+flask

--- a/examples/clip-search-engine/templates/index.html
+++ b/examples/clip-search-engine/templates/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>Search</title>
+    </head>
+    <body>
+        <h1>Search</h1>
+
+        <p>Search a folder of images.</p>
+
+        <form action="/" method="post" enctype="multipart/form-data">
+            <input type="file" name="image" accept="image/*">
+            <input type="submit" value="Upload">
+        </form>
+    </body>
+</html>

--- a/examples/sam-client/app.py
+++ b/examples/sam-client/app.py
@@ -1,0 +1,44 @@
+from inference.models import SegmentAnything
+import argparse
+import os
+import supervision as sv
+import cv2
+
+parser = argparse.ArgumentParser(description="Segment images with SAM.")
+
+parser.add_argument(
+    "--image_path", type=str, required=True, help="Path to image to segment"
+)
+parser.add_argument(
+    "--text_prompt", type=str, required=True, help="Text prompt for segmentation"
+)
+parser.add_argument(
+    "--inference_endpoint",
+    type=str,
+    required=True,
+    help="Roboflow Inference endpoint URL",
+    default="http://localhost:9001",
+)
+parser.add_argument(
+    "--api_key",
+    type=str,
+    required=True,
+    help="Roboflow API key",
+    default=os.environ.get("ROBOFLOW_API_KEY"),
+)
+
+args = parser.parse_args()
+
+model = SegmentAnything(api_key=args.api_key)
+
+inference_results = model.infer(args.image_path)
+
+masks = inference_results["masks"]
+
+image = cv2.imread(args.image_path)
+
+mask_annotator = sv.MaskAnnotator()
+detections = sv.Detections.from_sam(masks)
+annotated_image = mask_annotator.annotate(image, detections)
+
+sv.plot_image(annotated_image, (4, 4))

--- a/examples/sam-client/requirements.txt
+++ b/examples/sam-client/requirements.txt
@@ -1,0 +1,2 @@
+supervision
+opencv-python

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,6 +31,10 @@ nav:
   - Quickstart:
     - Docker: quickstart/docker.md
     - HTTP Inference: quickstart/http_inference.md
+    - CLIP Example: https://github.com/roboflow/inference/tree/main/examples/clip-search-engine
+    - SAM Example: https://github.com/roboflow/inference/tree/main/examples/sam-client
+    - Gaze Detection Example: https://github.com/roboflow/inference/tree/main/examples/gaze-detection
+    - UDP and Video Examples: https://github.com/roboflow/inference/tree/main/examples/inference-client
   - API Reference: api.md
   - Library Reference:
     - Models:


### PR DESCRIPTION
# Description

This PR adds:

- An example showing how to use CLIP and SAM with Inference;
- A changelog to the main docs, and;
- More content to the Add a Model guide that shows how to add a model to Roboflow Inference.

List any dependencies that are required for this change.

## Type of change

Documentation change.

## How has this change been tested, please provide a testcase or example of how you tested the change?

The examples are being tested manually.

## Any specific deployment considerations

N/A