### PR TITLE
Upgrade Onnxruntime in CPU Requirements

### DIFF
--- a/requirements/requirements.cpu.txt
+++ b/requirements/requirements.cpu.txt
@@ -1,2 +1,2 @@
-onnxruntime<=1.14.1
+onnxruntime<=1.15.1
 GPUtil==1.4.0


### PR DESCRIPTION
# Description

Updated onnxruntime to <=1.15.1 in cpu requirements to allow Python 3.11 for CPU installs

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [X] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update
