### PR TITLE
Update inference video on docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,10 @@ knowledge of machine learning or device-specific deployment, you can deploy a co
 
 Check out Inference running on a video of a football game:
 
-https://github.com/roboflow/inference/assets/37276661/121ab5f4-5970-4e78-8052-4b40f2eec173
+<video width="320" height="240" controls style="width: 100%">
+  <source src="https://github.com/roboflow/inference/assets/37276661/121ab5f4-5970-4e78-8052-4b40f2eec173" type="video/mp4"> 
+  Your browser does not support the video tag.
+</video>
 
 ## 👩‍🏫 Examples
 


### PR DESCRIPTION
This PR replaces the plain text link to the Inference demo to a HTML tag that embeds the video.

<img width="711" alt="Screenshot 2023-10-03 at 16 11 55" src="https://github.com/roboflow/inference/assets/37276661/ac40af42-26e7-4110-adbb-2d4f72676eae">
