### PR TITLE
Optionally Disable Inference Caching

### DIFF
--- a/inference/core/env.py
+++ b/inference/core/env.py
@@ -114,6 +114,9 @@ CORE_MODEL_GAZE_ENABLED = bool_env(os.getenv("CORE_MODEL_GAZE_ENABLED", True))
 # ID of host device, default is None
 DEVICE_ID = os.getenv("DEVICE_ID", None)
 
+# Flag to disable inference cache, default is False
+DISABLE_INFERENCE_CACHE = bool_env(os.getenv("DISABLE_INFERENCE_CACHE", False))
+
 # Flag to disable auto-orientation preprocessing, default is False
 DISABLE_PREPROC_AUTO_ORIENT = bool_env(os.getenv("DISABLE_PREPROC_AUTO_ORIENT", False))
 

--- a/inference/core/interfaces/camera/camera.py
+++ b/inference/core/interfaces/camera/camera.py
@@ -4,6 +4,8 @@ from threading import Thread
 import cv2
 from PIL import Image
 
+from inference.core.logger import logger
+
 
 class WebcamStream:
     """Class to handle webcam streaming using a separate thread.
@@ -35,14 +37,16 @@ class WebcamStream:
         self.width = int(self.vcap.get(cv2.CAP_PROP_FRAME_WIDTH))
         self.height = int(self.vcap.get(cv2.CAP_PROP_FRAME_HEIGHT))
         if self.vcap.isOpened() is False:
-            print("[Exiting]: Error accessing webcam stream.")
+            logger.debug("[Exiting]: Error accessing webcam stream.")
             exit(0)
         self.fps_input_stream = int(self.vcap.get(5))
-        print("FPS of webcam hardware/input stream: {}".format(self.fps_input_stream))
+        logger.debug(
+            "FPS of webcam hardware/input stream: {}".format(self.fps_input_stream)
+        )
         self.grabbed, self.frame = self.vcap.read()
         self.pil_image = Image.fromarray(cv2.cvtColor(self.frame, cv2.COLOR_BGR2RGB))
         if self.grabbed is False:
-            print("[Exiting] No more frames to read")
+            logger.debug("[Exiting] No more frames to read")
             exit(0)
         self.stopped = True
         self.t = Thread(target=self.update, args=())
@@ -67,7 +71,7 @@ class WebcamStream:
                 )
 
             if self.grabbed is False:
-                print("[Exiting] No more frames to read")
+                logger.debug("[Exiting] No more frames to read")
                 self.stopped = True
                 break
             if self.enforce_fps:

--- a/inference/core/interfaces/udp/udp_stream.py
+++ b/inference/core/interfaces/udp/udp_stream.py
@@ -26,6 +26,7 @@ from inference.core.env import (
 )
 from inference.core.interfaces.base import BaseInterface
 from inference.core.interfaces.camera.camera import WebcamStream
+from inference.core.logger import logger
 from inference.core.version import __version__
 from inference.models.utils import get_roboflow_model
 
@@ -75,7 +76,7 @@ class UdpStream(BaseInterface):
         """Initialize the UDP stream with the given parameters.
         Prints the server settings and initializes the inference with a test frame.
         """
-        print("Initializing server")
+        logger.info("Initializing server")
 
         self.frame_count = 0
         self.byte_tracker = sv.ByteTrack() if use_bytetrack else None
@@ -115,7 +116,7 @@ class UdpStream(BaseInterface):
         self.webcam_stream = WebcamStream(
             stream_id=self.stream_id, enforce_fps=enforce_fps
         )
-        print(
+        logger.info(
             f"Streaming from device with resolution: {self.webcam_stream.width} x {self.webcam_stream.height}"
         )
 
@@ -129,14 +130,14 @@ class UdpStream(BaseInterface):
         self.frame = None
         self.frame_cv = None
         self.frame_id = None
-        print("Server initialized with settings:")
-        print(f"Stream ID: {self.stream_id}")
-        print(f"Model ID: {self.model_id}")
-        print(f"Confidence: {self.confidence}")
-        print(f"Class Agnostic NMS: {self.class_agnostic_nms}")
-        print(f"IOU Threshold: {self.iou_threshold}")
-        print(f"Max Candidates: {self.max_candidates}")
-        print(f"Max Detections: {self.max_detections}")
+        logger.info("Server initialized with settings:")
+        logger.info(f"Stream ID: {self.stream_id}")
+        logger.info(f"Model ID: {self.model_id}")
+        logger.info(f"Confidence: {self.confidence}")
+        logger.info(f"Class Agnostic NMS: {self.class_agnostic_nms}")
+        logger.info(f"IOU Threshold: {self.iou_threshold}")
+        logger.info(f"Max Candidates: {self.max_candidates}")
+        logger.info(f"Max Detections: {self.max_detections}")
 
     def init_infer(self):
         """Initialize the inference with a test frame.
@@ -170,7 +171,7 @@ class UdpStream(BaseInterface):
                         self.queue_control = True
 
         except Exception as e:
-            print(e)
+            logger.error(e)
 
     def inference_request_thread(self):
         """Manage the inference requests.
@@ -251,7 +252,7 @@ class UdpStream(BaseInterface):
             try:
                 time.sleep(10)
             except KeyboardInterrupt:
-                print("Stopping server...")
+                logger.info("Stopping server...")
                 self.stop = True
                 time.sleep(3)
                 sys.exit(0)

--- a/inference/core/managers/pingback.py
+++ b/inference/core/managers/pingback.py
@@ -42,7 +42,7 @@ class PingbackInfo:
             self.scheduler = BackgroundScheduler()
             self.model_manager = manager
             self.process_startup_time = str(int(time.time()))
-            logger.info(
+            logger.debug(
                 "UUID: " + self.model_manager.uuid
             )  # To correlate with UI container view
             self.METRICS_URL = METRICS_URL  # Test URL
@@ -50,7 +50,7 @@ class PingbackInfo:
             self.system_info = get_system_info()
             self.window_start_timestamp = str(int(time.time()))
         except Exception as e:
-            logger.error(
+            logger.debug(
                 "Error sending pingback to Roboflow, if you want to disable this feature unset the ROBOFLOW_ENABLED environment variable. "
                 + str(e)
             )
@@ -61,7 +61,7 @@ class PingbackInfo:
         If METRICS_ENABLED is False, a warning is logged, and the method returns without starting the scheduler.
         """
         if METRICS_ENABLED == False:
-            logger.warn(
+            logger.debug(
                 "Metrics reporting to Roboflow is disabled; not sending back stats to Roboflow."
             )
             return
@@ -74,7 +74,7 @@ class PingbackInfo:
             )
             self.scheduler.start()
         except Exception as e:
-            print(e)
+            logger.debug(e)
 
     def stop(self):
         """Stops the scheduler."""
@@ -128,19 +128,26 @@ class PingbackInfo:
             all_data["timestamp"] = timestamp
             self.window_start_timestamp = timestamp
             res = requests.post(METRICS_URL, json=all_data)
-            res.raise_for_status()
-            logger.debug(
-                "Sent metrics to Roboflow {} at {}.".format(METRICS_URL, str(all_data))
-            )
+            try:
+                res.raise_for_status()
+                logger.debug(
+                    "Sent metrics to Roboflow {} at {}.".format(
+                        METRICS_URL, str(all_data)
+                    )
+                )
+            except Exception as e:
+                logger.debug(
+                    f"Error sending metrics to Roboflow, if you want to disable this feature unset the METRICS_ENABLED environment variable."
+                )
 
         except Exception as e:
             try:
-                logger.error(
+                logger.debug(
                     f"Error sending metrics to Roboflow, if you want to disable this feature unset the METRICS_ENABLED environment variable. Error was: {e}. Data was: {all_data}"
                 )
                 traceback.print_exc()
 
             except Exception as e2:
-                logger.error(
+                logger.debug(
                     f"Error sending metrics to Roboflow, if you want to disable this feature unset the METRICS_ENABLED environment variable. Error was: {e}."
                 )

--- a/inference/core/models/roboflow.py
+++ b/inference/core/models/roboflow.py
@@ -39,6 +39,7 @@ from inference.core.exceptions import (
     OnnxProviderNotAvailable,
     TensorrtRoboflowAPIError,
 )
+from inference.core.logger import logger
 from inference.core.models.base import Model
 from inference.core.utils.image_utils import load_image, load_image_rgb
 from inference.core.utils.onnx import get_onnxruntime_execution_providers
@@ -277,7 +278,7 @@ class RoboflowInferenceModel(Model):
         else:
             # If AWS keys are available, then we can download model artifacts directly
             if AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY:
-                self.log("Downloading model artifacts from S3")
+                logger.debug("Downloading model artifacts from S3")
                 for f in infer_bucket_files:
                     success = False
                     attempts = 0
@@ -291,7 +292,7 @@ class RoboflowInferenceModel(Model):
                             success = True
                         except Exception as e:
                             attempts += 1
-                            print(
+                            logger.error(
                                 f"Failed to download model artifacts after {attempts} attempts | Infer Bucket = {INFER_BUCKET} | Object Path = {self.endpoint}/{f} | Weights File = {self.weights_file}",
                                 traceback.format_exc(),
                             )
@@ -618,7 +619,7 @@ class RoboflowCoreModel(RoboflowInferenceModel):
                             success = True
                         except Exception as e:
                             attempts += 1
-                            print(
+                            logger.error(
                                 f"Failed to download model artifacts after {attempts} attempts | Infer Bucket = {INFER_BUCKET} | Object Path = {self.endpoint}/{f}",
                                 traceback.format_exc(),
                             )

--- a/inference/core/registries/roboflow.py
+++ b/inference/core/registries/roboflow.py
@@ -5,6 +5,7 @@ import requests
 
 from inference.core.env import API_BASE_URL, MODEL_CACHE_DIR
 from inference.core.exceptions import DatasetLoadError, WorkspaceLoadError
+from inference.core.logger import logger
 from inference.core.models.base import Model
 from inference.core.registries.base import ModelRegistry
 from inference.core.utils.url_utils import ApiUrl
@@ -78,7 +79,7 @@ def get_model_type(model_id: str, api_key: str) -> str:
     try:
         api_key_info.raise_for_status()
     except requests.exceptions.HTTPError as e:
-        print(e)
+        logger.error(e)
         raise WorkspaceLoadError("Could not load workspace, check your API key")
 
     workspace_id = api_key_info.json().get("workspace")
@@ -108,7 +109,7 @@ def get_model_type(model_id: str, api_key: str) -> str:
         dataset_info.raise_for_status()
         version_info.raise_for_status()
     except requests.exceptions.HTTPError as e:
-        print(e)
+        logger.error(e)
         raise DatasetLoadError(
             f"Could not load dataset with ID {dataset_id} and workspace ID {workspace_id} for version ID {version_id}, check your API key"
         )

--- a/inference/core/usage.py
+++ b/inference/core/usage.py
@@ -4,6 +4,7 @@ import elasticache_auto_discovery
 from pymemcache.client.hash import HashClient
 
 from inference.core.env import ELASTICACHE_ENDPOINT
+from inference.core.logger import logger
 
 nodes = elasticache_auto_discovery.discover(ELASTICACHE_ENDPOINT)
 
@@ -58,5 +59,5 @@ def trackUsage(endpoint, actor, n=1):
                 memcache_client.set("ACTOR_KEYS", json.dumps(actor_keys))
 
     except Exception as e:
-        print("WARNING: there was an error in counting this inference")
-        print(e)
+        logger.debug("WARNING: there was an error in counting this inference")
+        logger.debug(e)

--- a/inference/core/version.py
+++ b/inference/core/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.8.8"
+__version__ = "0.8.9"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description
Added ability to disable inference cache. Also made default logging a lot less verbose, especially for pingback.

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [X] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update
