### PR TITLE
Padding Logic Bug Fix

### DIFF
--- a/inference/core/models/object_detection_base.py
+++ b/inference/core/models/object_detection_base.py
@@ -236,8 +236,16 @@ class ObjectDetectionBaseOnnxRoboflowInferenceModel(
                 if FIX_BATCH_SIZE or fix_batch_size
                 else 0
             )
-            width_padding = 32 - (img_in.shape[2] % 32)
-            height_padding = 32 - (img_in.shape[3] % 32)
+            width_remainder = img_in.shape[2] % 32
+            height_remainder = img_in.shape[3] % 32
+            if width_remainder > 0:
+                width_padding = 32 - (img_in.shape[2] % 32)
+            else:
+                width_padding = 0
+            if height_remainder > 0:
+                height_padding = 32 - (img_in.shape[3] % 32)
+            else:
+                height_padding = 0
             img_in = np.pad(
                 img_in,
                 ((0, batch_padding), (0, 0), (0, width_padding), (0, height_padding)),

--- a/inference/core/models/roboflow.py
+++ b/inference/core/models/roboflow.py
@@ -502,16 +502,16 @@ class RoboflowInferenceModel(Model):
 
         if self.resize_method == "Stretch to":
             resized = cv2.resize(
-                preprocessed_image, (self.img_size_h, self.img_size_w), cv2.INTER_CUBIC
+                preprocessed_image, (self.img_size_w, self.img_size_h), cv2.INTER_CUBIC
             )
         elif self.resize_method == "Fit (black edges) in":
             resized = self.letterbox_image(
-                preprocessed_image, (self.img_size_h, self.img_size_w)
+                preprocessed_image, (self.img_size_w, self.img_size_h)
             )
         elif self.resize_method == "Fit (white edges) in":
             resized = self.letterbox_image(
                 preprocessed_image,
-                (self.img_size_h, self.img_size_w),
+                (self.img_size_w, self.img_size_h),
                 c=(255, 255, 255),
             )
 

--- a/inference/core/utils/image_utils.py
+++ b/inference/core/utils/image_utils.py
@@ -50,7 +50,7 @@ def load_image(value: Any, disable_preproc_auto_orient=False) -> np.ndarray:
         elif type == "numpy" and ALLOW_NUMPY_INPUT:
             np_image = load_image_numpy_str(value)
         elif type == "pil":
-            np_image = np.asarray(value)
+            np_image = np.asarray(value.convert("RGB"))
             is_bgr = False
         elif type == "url":
             np_image = load_image_url(value, cv_imread_flags=cv_imread_flags)
@@ -89,7 +89,7 @@ def load_image_inferred(value: Any, cv_imread_flags=cv2.IMREAD_COLOR) -> Image.I
     if isinstance(value, (np.ndarray, np.generic)):
         return value, True
     elif isinstance(value, Image.Image):
-        return np.asarray(value), False
+        return np.asarray(value.convert("RGB")), False
     elif isinstance(value, str) and (value.startswith("http")):
         return load_image_url(value, cv_imread_flags=cv_imread_flags), True
     elif isinstance(value, str) and os.path.exists(value):


### PR DESCRIPTION
# Description

Fixed a bug in padding logic causing a minimum of 32 pixels of padding to be applied when the minimum padding should be 0 (in the case that the image dimensions are already a multiple of 32)

## Type of change

Please delete options that are not relevant.

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Tested locally
