### PR TITLE
Check Lambda Env Var for Artifact Retrieval 

### DIFF
--- a/inference/core/models/roboflow.py
+++ b/inference/core/models/roboflow.py
@@ -29,6 +29,7 @@ from inference.core.env import (
     CORE_MODEL_BUCKET,
     DISABLE_PREPROC_AUTO_ORIENT,
     INFER_BUCKET,
+    LAMBDA,
     MODEL_CACHE_DIR,
     ONNXRUNTIME_EXECUTION_PROVIDERS,
     REQUIRED_ONNX_PROVIDERS,
@@ -102,7 +103,9 @@ class RoboflowInferenceModel(Model):
         super().__init__()
         self.metrics = {"num_inferences": 0, "avg_inference_time": 0.0}
         self.api_key = api_key if api_key else API_KEY
-        if not self.api_key and not (AWS_SECRET_ACCESS_KEY and AWS_ACCESS_KEY_ID):
+        if not self.api_key and not (
+            AWS_SECRET_ACCESS_KEY and AWS_ACCESS_KEY_ID and LAMBDA
+        ):
             raise MissingApiKeyError(
                 "No API Key Found, must provide an API Key in each request or as an environment variable on server startup"
             )
@@ -277,7 +280,7 @@ class RoboflowInferenceModel(Model):
                     i += 1
         else:
             # If AWS keys are available, then we can download model artifacts directly
-            if AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY:
+            if AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY and LAMBDA:
                 logger.debug("Downloading model artifacts from S3")
                 for f in infer_bucket_files:
                     success = False
@@ -594,7 +597,7 @@ class RoboflowCoreModel(RoboflowInferenceModel):
             ]
         ):
             self.log("Downloading model artifacts")
-            if AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY:
+            if AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY and LAMBDA:
                 infer_bucket_files = self.get_infer_bucket_file_list()
                 for f in infer_bucket_files:
                     success = False

--- a/inference/models/vit/vit_classification.py
+++ b/inference/models/vit/vit_classification.py
@@ -1,4 +1,4 @@
-from inference.core.env import AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY
+from inference.core.env import AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, LAMBDA
 from inference.core.models.classification_base import (
     ClassificationBaseOnnxRoboflowInferenceModel,
 )
@@ -36,7 +36,7 @@ class VitClassification(ClassificationBaseOnnxRoboflowInferenceModel):
         Returns:
             str: Path to the weights file.
         """
-        if AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY:
+        if AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY and LAMBDA:
             return "weights.onnx"
         else:
             return "best.onnx"


### PR DESCRIPTION
# Description

Check lambda env var in addition to AWS key vars when choosing where to retrieve artifacts from.

## Type of change

Please delete options that are not relevant.

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

GH actions
