### PR TITLE
Fix/ CLI readme by removing errant bash line

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -33,11 +33,9 @@ Starts a local inference server. It optionally takes a port number (default is 9
 
 It will automatically detect the device you are running on and pull the appropriate Docker image.
 
-````bash
-
 ```bash
 inference server start --port 9001
-````
+```
 
 ### inference server status
 


### PR DESCRIPTION
# Description

Removes the ```bash line:

<img width="982" alt="image" src="https://github.com/roboflow/inference/assets/6319317/dafa861b-62ff-4c00-9b05-dcba81aea197">
