### PR TITLE
Add actual container version

### DIFF
--- a/inference/enterprise/device_manager/container_service.py
+++ b/inference/enterprise/device_manager/container_service.py
@@ -20,6 +20,7 @@ class InferServerContainer:
     port: int
     host: str
     startup_time: float
+    version: str
 
     def __init__(self, docker_container, details):
         self.container = docker_container
@@ -27,6 +28,7 @@ class InferServerContainer:
         self.id = details.get("uuid")
         self.port = details.get("port")
         self.host = details.get("host")
+        self.version = details.get("version")
         t = details.get("startup_time_ts").split(".")[0]
         self.startup_time = (
             datetime.strptime(t, "%Y-%m-%dT%H:%M:%S").timestamp()

--- a/inference/enterprise/device_manager/metrics_service.py
+++ b/inference/enterprise/device_manager/metrics_service.py
@@ -82,6 +82,7 @@ def build_container_stats():
             container_stats = {}
             models = aggregate_model_stats(id)
             container_stats["uuid"] = container.id
+            container_stats["version"] = container.version
             container_stats["startup_time"] = container.startup_time
             container_stats["models"] = models
             if container.status == "running" or container.status == "restarting":


### PR DESCRIPTION
# Description

- Adding the actual version of the container image to the pingback (currently it's using the same version as the device-manager)

## Type of change

Please delete options that are not relevant.

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

- Tested that the pingback sends the correct version on the image tag in the pingback logs

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
