### PR TITLE
Fix/ Add inference CLI requirements to inference packages

### DIFF
--- a/.release/pypi/inference.core.setup.py
+++ b/.release/pypi/inference.core.setup.py
@@ -42,7 +42,12 @@ setuptools.setup(
             "inference=inference_cli.main:app",
         ],
     },
-    install_requires=read_requirements("requirements/_requirements.txt"),
+    install_requires=read_requirements(
+        [
+            "requirements/_requirements.txt",
+            "requirements/requirements.cli.txt",
+        ]
+    ),
     extras_require={
         "clip": read_requirements("requirements/requirements.clip.txt"),
         "cpu": read_requirements("requirements/requirements.cpu.txt"),

--- a/.release/pypi/inference.cpu.setup.py
+++ b/.release/pypi/inference.cpu.setup.py
@@ -48,7 +48,11 @@ setuptools.setup(
         ],
     },
     install_requires=read_requirements(
-        ["requirements/_requirements.txt", "requirements/requirements.cpu.txt"]
+        [
+            "requirements/_requirements.txt",
+            "requirements/requirements.cli.txt",
+            "requirements/requirements.cpu.txt",
+        ]
     ),
     extras_require={
         "clip": read_requirements("requirements/requirements.clip.txt"),

--- a/.release/pypi/inference.gpu.setup.py
+++ b/.release/pypi/inference.gpu.setup.py
@@ -31,7 +31,11 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/roboflow/inference",
     install_requires=read_requirements(
-        ["requirements/_requirements.txt", "requirements/requirements.gpu.txt"]
+        [
+            "requirements/_requirements.txt",
+            "requirements/requirements.cli.txt",
+            "requirements/requirements.gpu.txt",
+        ]
     ),
     packages=find_packages(
         where=root,

--- a/.release/pypi/inference.setup.py
+++ b/.release/pypi/inference.setup.py
@@ -48,7 +48,11 @@ setuptools.setup(
         ],
     },
     install_requires=read_requirements(
-        ["requirements/_requirements.txt", "requirements/requirements.cpu.txt"]
+        [
+            "requirements/_requirements.txt",
+            "requirements/requirements.cli.txt",
+            "requirements/requirements.cpu.txt",
+        ]
     ),
     extras_require={
         "clip": read_requirements("requirements/requirements.clip.txt"),


### PR DESCRIPTION
# Description

Adds cli requirements file to `inference` pypi package setups, so necessary packages for CLI (`typer`) will be installed with `inference`.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update