### PR TITLE
Fix/ Core inference package updated to read list of requirements

### DIFF
--- a/.release/pypi/inference.core.setup.py
+++ b/.release/pypi/inference.core.setup.py
@@ -12,8 +12,13 @@ with open("README.md", "r") as fh:
 
 
 def read_requirements(path):
-    with open(path) as fh:
-        return [line.strip() for line in fh]
+    if not isinstance(path, list):
+        path = [path]
+    requirements = []
+    for p in path:
+        with open(p) as fh:
+            requirements.extend([line.strip() for line in fh])
+    return requirements
 
 
 setuptools.setup(


### PR DESCRIPTION
# Description

Just a tooling update to correctly read a list of requirements when creating wheels. No deploy needed.