### PR TITLE
fix udp.py

### DIFF
--- a/examples/inference-client/udp.py
+++ b/examples/inference-client/udp.py
@@ -7,7 +7,7 @@ import argparse
 parser = argparse.ArgumentParser(description="Receive stream detections over UDP.")
 
 parser.add_argument(
-    "--port", type=str, required=True, help="Port to listen on.", default=12345
+    "--port", type=int, required=True, help="Port to listen on.", default=12345
 )
 
 arguments = parser.parse_args()


### PR DESCRIPTION
The typing was incorrect. The error "TypeError; integer required" was detected at startup/

# Description

An error in typing ArgumentParser of the '--port' argument has been fixed. Changed from 'str' to 'int'.

List any dependencies that are required for this change.

## Type of change

-   [ ] Bug fix (non-breaking change which fixes an issue)
