### PR TITLE
Add 404 page

### DIFF
--- a/custom_theme/404.html
+++ b/custom_theme/404.html
@@ -1,0 +1,7 @@
+{% extends "main.html" %} 
+
+{% block content %}
+    <h1>Page Not Found</h1> 
+    <p>The page you have requested was not found.</p>
+    <p><a href="/">Go back to the documentation home</a>.</p>
+{% endblock %} 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -70,6 +70,7 @@ theme:
   font:
     text: Roboto
     code: Roboto Mono
+  custom_dir: 'custom_theme'
 
 plugins:
   - mkdocstrings


### PR DESCRIPTION
This PR adds a 404 page so that broken URLs don't return a page that looks like this:

<img width="1386" alt="Screenshot 2023-10-16 at 09 01 42" src="https://github.com/roboflow/inference/assets/37276661/35e5c80f-2751-4750-bedf-197443793d46">
