### PR TITLE
Change documentation site URL

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Roboflow Inference
-site_url: https://roboflow.github.io/inference/
+site_url: https://inference.roboflow.com/
 site_author: Roboflow
 site_description: With no prior knowledge of machine learning or device-specific deployment, you can deploy a computer vision model to a range of devices and environments using the Roboflow Inference Server.
 repo_name: roboflow/inference


### PR DESCRIPTION
This PR changes the `inference` site URL parameter in `mkdocs` to `inference.roboflow.com`. 