### PR TITLE
Attempt to re-initialize video stream when no frames read

### DIFF
--- a/inference/core/interfaces/camera/camera.py
+++ b/inference/core/interfaces/camera/camera.py
@@ -34,7 +34,7 @@ class WebcamStream:
         self.enforce_fps = enforce_fps
         self.frame_id = 0
         if not self.init_video():
-          exit(0)
+            exit(0)
         self.stopped = True
         self.t = Thread(target=self.update, args=())
         self.t.daemon = True


### PR DESCRIPTION
We encountered a situation where the cv2 VideoCapture process stops reading frames periodically. Verbose logging of opencv and the FFMPEG backend did not show any errors, and `self.vcap.isOpened()` continued to return `True` even though no frames were read. 

With this PR, we attempt to reinitialize the video stream in this case, and exit if the video stream can't be initialized.



## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Tested locally

