### PR TITLE
improve performance of video capture for streams

### DIFF
--- a/inference/core/interfaces/camera/camera.py
+++ b/inference/core/interfaces/camera/camera.py
@@ -76,11 +76,12 @@ class WebcamStream:
                     self.enforce_fps != "skip"
                     or t1 >= last_frame_position + skip_seconds
                 ):
-                    ret, self.frame = self.vcap.retrieve()
+                    ret, frame = self.vcap.retrieve()
                     logger.debug("video capture FPS: %s", frame_id / (t1 - t0))
-                    if self.frame is not None:
+                    if frame is not None:
                         last_frame_position = t1
                         self.frame_id = frame_id
+                        self.frame = frame
                     else:
                         logger.debug("[Exiting] Frame not available to retrieve")
                         self.stopped = True

--- a/inference/core/interfaces/camera/camera.py
+++ b/inference/core/interfaces/camera/camera.py
@@ -40,7 +40,7 @@ class WebcamStream:
         if self.vcap.isOpened() is False:
             logger.debug("[Exiting]: Error accessing webcam stream.")
             exit(0)
-        self.fps_input_stream = int(self.vcap.get(5))
+        self.fps_input_stream = int(self.vcap.get(cv2.CAP_PROP_FPS))
         logger.debug(
             "FPS of webcam hardware/input stream: {}".format(self.fps_input_stream)
         )
@@ -60,16 +60,31 @@ class WebcamStream:
 
     def update(self):
         """Update the frame by reading from the webcam."""
+        frame_id = 0
+        skip_seconds = 0
+        last_frame_position = time.perf_counter()
+        t0 = time.perf_counter()
         while True:
             t1 = time.perf_counter()
             if self.stopped is True:
                 break
-            self.grabbed, self.frame = self.vcap.read()
-            if self.frame is not None and self.grabbed:
-                self.frame_id += 1
-                self.pil_image = Image.fromarray(
-                    cv2.cvtColor(self.frame, cv2.COLOR_BGR2RGB)
-                )
+
+            self.grabbed = self.vcap.grab()
+            if self.grabbed:
+                frame_id += 1
+                if (
+                    self.enforce_fps != "skip"
+                    or t1 >= last_frame_position + skip_seconds
+                ):
+                    ret, self.frame = self.vcap.retrieve()
+                    logger.debug("video capture FPS: %s", frame_id / (t1 - t0))
+                    if self.frame is not None:
+                        last_frame_position = t1
+                        self.frame_id = frame_id
+                    else:
+                        logger.debug("[Exiting] Frame not available to retrieve")
+                        self.stopped = True
+                        break
 
             if self.grabbed is False:
                 logger.debug("[Exiting] No more frames to read")
@@ -77,18 +92,14 @@ class WebcamStream:
                 break
             if self.enforce_fps:
                 t2 = time.perf_counter()
-                time.sleep(
-                    max(1 / self.max_fps + 0.02, 1 / self.fps_input_stream - (t2 - t1))
+                next_frame = max(
+                    1 / self.max_fps + 0.02, 1 / self.fps_input_stream - (t2 - t1)
                 )
+                if self.enforce_fps == "skip":
+                    skip_seconds = next_frame
+                else:
+                    time.sleep(next_frame)
         self.vcap.release()
-
-    def read(self):
-        """Read the current frame.
-
-        Returns:
-            Image, array, int: The current frame as a PIL image, a NumPy array, and the frame ID.
-        """
-        return self.pil_image, self.frame, self.frame_id
 
     def read_opencv(self):
         """Read the current frame using OpenCV.

--- a/inference/core/interfaces/stream/stream.py
+++ b/inference/core/interfaces/stream/stream.py
@@ -203,9 +203,7 @@ class Stream(BaseInterface):
                     self.frame_cv, frame_id = webcam_stream.read_opencv()
                     if frame_id != self.frame_id:
                         self.frame_id = frame_id
-                        self.frame = Image.fromarray(
-                            cv2.cvtColor(self.frame_cv, cv2.COLOR_BGR2RGB)
-                        )
+                        self.frame = cv2.cvtColor(self.frame_cv, cv2.COLOR_BGR2RGB)
                         self.preproc_result = self.model.preprocess(self.frame)
                         self.img_in, self.img_dims = self.preproc_result
                         self.queue_control = True

--- a/inference/core/interfaces/udp/udp_stream.py
+++ b/inference/core/interfaces/udp/udp_stream.py
@@ -5,6 +5,7 @@ import threading
 import time
 from typing import Union
 
+import cv2
 import supervision as sv
 from PIL import Image
 
@@ -165,9 +166,12 @@ class UdpStream(BaseInterface):
                 if webcam_stream.stopped is True or self.stop:
                     break
                 else:
-                    self.frame, self.frame_cv, frame_id = webcam_stream.read()
+                    self.frame_cv, frame_id = webcam_stream.read_opencv()
                     if frame_id != self.frame_id:
                         self.frame_id = frame_id
+                        self.frame = Image.fromarray(
+                            cv2.cvtColor(self.frame_cv, cv2.COLOR_BGR2RGB)
+                        )
                         self.preproc_result = self.model.preprocess(self.frame)
                         self.img_in, self.img_dims = self.preproc_result
                         self.queue_control = True

--- a/inference/core/interfaces/udp/udp_stream.py
+++ b/inference/core/interfaces/udp/udp_stream.py
@@ -169,9 +169,7 @@ class UdpStream(BaseInterface):
                     self.frame_cv, frame_id = webcam_stream.read_opencv()
                     if frame_id != self.frame_id:
                         self.frame_id = frame_id
-                        self.frame = Image.fromarray(
-                            cv2.cvtColor(self.frame_cv, cv2.COLOR_BGR2RGB)
-                        )
+                        self.frame = cv2.cvtColor(self.frame_cv, cv2.COLOR_BGR2RGB)
                         self.preproc_result = self.model.preprocess(self.frame)
                         self.img_in, self.img_dims = self.preproc_result
                         self.queue_control = True


### PR DESCRIPTION
 * do not convert each frame to PIL Image on the capture thread.
 * when enforce_fps is 'skip':
    - continue to grab frames rather than sleeping for the amount of time. VideoCapture requires streams to be continuously grabbed even if not used.
    - do not `retrieve()` frames we are skipping. This gives a big performance improvement on the nano.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Tested locally with RTSP stream, mp4, and webcam, and on nano with RTSP stream.
