### PR TITLE
Add `inference.Stream()` examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -11,6 +11,7 @@ This folder contains examples of projects built with Inference.
 - [Gaze Detection](./gaze-detection/): Detects the direction in which someone is looking and the point in a frame at which someone is looking.
 - [CLIP Image-to-Image Search Engine](./clip-search-engine): Find images similar to a given image in a dataset with CLIP. Served as a web application.
 - [SAM Client](./sam-client): Use Segment Anything to segment objects in an image. Served as a command line application.
+- [Stream Examples](./stream-examples/): Run computer vision models on frames from webcam and RTSP streams. Includes examples using models hosted on Roboflow and deployed locally with Inference and CLIP.
 
 ## Community Examples
 

--- a/examples/stream-examples/README.md
+++ b/examples/stream-examples/README.md
@@ -1,0 +1,11 @@
+# Stream Examples
+
+This folder contains examples that show how to use the `inference.Stream()` method.
+
+## Examples
+
+- `video.py`: Run an object detection model hosted on Roboflow on frames in an `.mp4` video.
+- `webcam.py`: Run an object detection model hosted on Roboflow on frames from a webcam.
+- `rtsp.py`: Run an object detection model hosted on Roboflow on frames from an RTSP stream.
+- `track.py`: Run an object detection model with ByteTrack on frames from a webcam. This example both identifies and tracks objects in a stream.
+- `paintwtf.py`: Use CLIP to identify the similarity between a video frame and a text prompt. Uses a webcam. This project is inspired by [paint.wtf](https://paint.wtf).

--- a/examples/stream-examples/paintwtf.py
+++ b/examples/stream-examples/paintwtf.py
@@ -1,0 +1,42 @@
+import cv2
+import inference
+from inference.core.utils.postprocess import cosine_similarity
+
+from inference.models import Clip
+clip = Clip()
+
+prompt = "an ace of spades playing card"
+text_embedding = clip.embed_text(prompt)
+
+def render(result, image):
+    # get the cosine similarity between the prompt & the image
+    similarity = cosine_similarity(result["embeddings"][0], text_embedding[0])
+
+    # scale the result to 0-100 based on heuristic (~the best & worst values I've observed)
+    range = (0.15, 0.40)
+    similarity = (similarity-range[0])/(range[1]-range[0])
+    similarity = max(min(similarity, 1), 0)*100
+    
+    # print the similarity
+    text = f"{similarity:.1f}%"
+    cv2.putText(image, text, (10, 310), cv2.FONT_HERSHEY_SIMPLEX, 12, (255, 255, 255), 30)
+    cv2.putText(image, text, (10, 310), cv2.FONT_HERSHEY_SIMPLEX, 12, (206, 6, 103), 16)
+
+    # print the prompt
+    cv2.putText(image, prompt, (20, 1050), cv2.FONT_HERSHEY_SIMPLEX, 2, (255, 255, 255), 10)
+    cv2.putText(image, prompt, (20, 1050), cv2.FONT_HERSHEY_SIMPLEX, 2, (206, 6, 103), 5)
+
+    # display the image
+    cv2.imshow("CLIP", image)
+    cv2.waitKey(1)
+
+# start the stream
+inference.Stream(
+    source="webcam",
+    model=clip,
+
+    output_channel_order="BGR",
+    use_main_thread=True,
+    
+    on_prediction=render
+)

--- a/examples/stream-examples/rtsp.py
+++ b/examples/stream-examples/rtsp.py
@@ -1,0 +1,24 @@
+import cv2
+import inference
+import supervision as sv
+
+annotator = sv.BoxAnnotator()
+
+
+def render(predictions, image):
+    print(predictions)
+    image = annotator.annotate(
+        scene=image, detections=sv.Detections.from_roboflow(predictions)
+    )
+
+    cv2.imshow("Prediction", image)
+    cv2.waitKey(1)
+
+# replace with your own RTSP stream
+inference.Stream(
+    source="rtsp://127.0.0.1:8000/test",
+    model="microsoft-coco/9",
+    output_channel_order="BGR",
+    use_main_thread=True,
+    on_prediction=render,
+)

--- a/examples/stream-examples/track.py
+++ b/examples/stream-examples/track.py
@@ -1,0 +1,28 @@
+import cv2
+import inference
+import supervision as sv
+
+box_annotator = sv.BoxAnnotator(color=sv.Color(103, 6, 206))
+trace_annotator = sv.TraceAnnotator(color=sv.Color(163, 81, 251), thickness=6)
+byte_tracker = sv.ByteTrack()
+
+
+def render(detections, image):
+    detections = sv.Detections.from_roboflow(detections)
+    detections = byte_tracker.update_with_detections(detections)
+    if detections.tracker_id is not None and len(detections.tracker_id) > 0:
+        image = trace_annotator.annotate(scene=image, detections=detections)
+    image = box_annotator.annotate(scene=image, detections=detections)
+
+    cv2.imshow("Prediction", image)
+    cv2.waitKey(1)
+
+
+inference.Stream(
+    source="webcam",
+    model="playing-cards-ow27d/1",
+    # model="microsoft-coco/9",
+    output_channel_order="BGR",
+    use_main_thread=True,
+    on_prediction=render,
+)

--- a/examples/stream-examples/video.py
+++ b/examples/stream-examples/video.py
@@ -1,0 +1,26 @@
+import cv2
+import inference
+import supervision as sv
+
+box_annotator = sv.BoxAnnotator(color=sv.Color(103, 6, 206))
+trace_annotator = sv.TraceAnnotator(color=sv.Color(163, 81, 251), thickness=6)
+byte_tracker = sv.ByteTrack()
+
+
+def render(detections, image):
+    detections = sv.Detections.from_roboflow(detections)
+    detections = byte_tracker.update_with_detections(detections)
+    image = trace_annotator.annotate(scene=image, detections=detections)
+    image = box_annotator.annotate(scene=image, detections=detections)
+
+    cv2.imshow("Prediction", image)
+    cv2.waitKey(1)
+
+
+inference.Stream(
+    source="people-walking-bw.mp4",
+    model="microsoft-coco/9",
+    output_channel_order="BGR",
+    use_main_thread=True,
+    on_prediction=render,
+)

--- a/examples/stream-examples/webcam.py
+++ b/examples/stream-examples/webcam.py
@@ -1,0 +1,26 @@
+import cv2
+import inference
+import supervision as sv
+
+annotator = sv.BoxAnnotator()
+
+def render(predictions, image):
+    print(predictions)
+    
+    image = annotator.annotate(
+        scene=image, 
+        detections=sv.Detections.from_roboflow(predictions)
+    )
+
+    cv2.imshow("Prediction", image)
+    cv2.waitKey(1)
+
+inference.Stream(
+    source="webcam",
+    model="rock-paper-scissors-sxsw/11",
+    
+    output_channel_order="BGR",
+    use_main_thread=True,
+
+    on_prediction=render
+)


### PR DESCRIPTION
This PR adds examples showing how to use `inference.Stream()` with `inference`. The code was written by @yeldarby.