### PR TITLE
Add documentation build step workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,17 @@
+name: Docs Workflow
+
+on:
+  push:
+    branches:
+      - main
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.x
+      - run: pip install mkdocs-material
+      - run: pip install "mkdocstrings[python]"
+      - run: mkdocs gh-deploy --force


### PR DESCRIPTION
This PR ensures that our documentation is built and published any time a commit is merged into `main`.