### PR TITLE
Skip to latest frame of camera stream by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,12 @@ export PYTHONPATH = .
 check_dirs := inference inference_sdk
 
 style:
-	black  $(check_dirs)
-	isort --profile black $(check_dirs)
+	python3 -m black  $(check_dirs)
+	python3 -m isort --profile black $(check_dirs)
 
 check_code_quality:
-	black --check $(check_dirs)
-	isort --check-only --profile black $(check_dirs)
+	python3 -m black --check $(check_dirs)
+	python3 -m isort --check-only --profile black $(check_dirs)
 	# stop the build if there are Python syntax errors or undefined names
 	flake8 $(check_dirs) --count --select=E9,F63,F7,F82 --show-source --statistics
 	# exit-zero treats all errors as warnings. E203 for black, E501 for docstring, W503 for line breaks before logical operators 

--- a/inference/core/interfaces/camera/camera.py
+++ b/inference/core/interfaces/camera/camera.py
@@ -88,12 +88,14 @@ class WebcamStream:
                     logger.debug("[Exiting] Frame not available for read")
                     self.stopped = True
                     break
-                logger.debug(f"retrieved frame {frame_id}, effective FPS: {frame_id / (t1 - t0):.2f}")
+                logger.debug(
+                    f"retrieved frame {frame_id}, effective FPS: {frame_id / (t1 - t0):.2f}"
+                )
                 self.frame_id = frame_id
                 self.frame = frame
                 while self.file_mode and self.enforce_fps and self.max_fps is None:
                     # sleep until we have processed the first frame and we know what our FPS should be
-                    time.sleep(.01)
+                    time.sleep(0.01)
                 if self.max_fps is None:
                     self.max_fps = 30
                 next_frame_time = t1 + (1 / self.max_fps) + 0.02

--- a/inference/core/interfaces/camera/camera.py
+++ b/inference/core/interfaces/camera/camera.py
@@ -36,6 +36,12 @@ class WebcamStream:
         self.vcap = cv2.VideoCapture(self.stream_id)
         self.width = int(self.vcap.get(cv2.CAP_PROP_FRAME_WIDTH))
         self.height = int(self.vcap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+        self.file_mode = self.vcap.get(cv2.CAP_PROP_FRAME_COUNT) > 0
+        if self.enforce_fps and not self.file_mode:
+            logger.warn(
+                "Ignoring enforce_fps flag for this stream. It is not compatible with streams and will cause the process to crash"
+            )
+            self.enforce_fps = False
         self.max_fps = 30
         if self.vcap.isOpened() is False:
             logger.debug("[Exiting]: Error accessing webcam stream.")
@@ -61,8 +67,7 @@ class WebcamStream:
     def update(self):
         """Update the frame by reading from the webcam."""
         frame_id = 0
-        skip_seconds = 0
-        last_frame_position = time.perf_counter()
+        next_frame_time = 0
         t0 = time.perf_counter()
         while True:
             t1 = time.perf_counter()
@@ -70,36 +75,28 @@ class WebcamStream:
                 break
 
             self.grabbed = self.vcap.grab()
-            if self.grabbed:
-                frame_id += 1
-                if (
-                    self.enforce_fps != "skip"
-                    or t1 >= last_frame_position + skip_seconds
-                ):
-                    ret, frame = self.vcap.retrieve()
-                    logger.debug("video capture FPS: %s", frame_id / (t1 - t0))
-                    if frame is not None:
-                        last_frame_position = t1
-                        self.frame_id = frame_id
-                        self.frame = frame
-                    else:
-                        logger.debug("[Exiting] Frame not available to retrieve")
-                        self.stopped = True
-                        break
-
             if self.grabbed is False:
                 logger.debug("[Exiting] No more frames to read")
                 self.stopped = True
                 break
-            if self.enforce_fps:
+            frame_id += 1
+            # We can't retrieve each frame on nano and other lower powered devices quickly enough to keep up with the stream.
+            # By default, we will only retrieve frames when we'll be ready process them (determined by self.max_fps).
+            if t1 > next_frame_time or self.enforce_fps:
+                ret, frame = self.vcap.retrieve()
+                if frame is None:
+                    logger.debug("[Exiting] Frame not available for read")
+                    self.stopped = True
+                    break
+                logger.debug(f"video capture effective FPS: {frame_id / (t1 - t0):.2f}")
+                self.frame_id = frame_id
+                self.frame = frame
+                next_frame_time = t1 + (1 / self.max_fps) + 0.02
+            if self.file_mode:
                 t2 = time.perf_counter()
-                next_frame = max(
-                    1 / self.max_fps + 0.02, 1 / self.fps_input_stream - (t2 - t1)
-                )
-                if self.enforce_fps == "skip":
-                    skip_seconds = next_frame
-                else:
-                    time.sleep(next_frame)
+                time_to_sleep = (1 / self.fps_input_stream) - (t2 - t1)
+                if time_to_sleep > 0:
+                    time.sleep(time_to_sleep)
         self.vcap.release()
 
     def read_opencv(self):

--- a/inference/core/interfaces/stream/stream.py
+++ b/inference/core/interfaces/stream/stream.py
@@ -109,7 +109,6 @@ class Stream(BaseInterface):
         self.json_response = json_response
         self.use_main_thread = use_main_thread
         self.output_channel_order = output_channel_order
-        self.simulate_process_delay = simulate_process_delay
 
         self.inference_request_type = (
             inference.core.entities.requests.inference.ObjectDetectionInferenceRequest
@@ -201,7 +200,7 @@ class Stream(BaseInterface):
                     break
                 else:
                     self.frame_cv, frame_id = webcam_stream.read_opencv()
-                    if frame_id != self.frame_id:
+                    if frame_id > 0 and frame_id != self.frame_id:
                         self.frame_id = frame_id
                         self.frame = cv2.cvtColor(self.frame_cv, cv2.COLOR_BGR2RGB)
                         self.preproc_result = self.model.preprocess(self.frame)
@@ -248,9 +247,6 @@ class Stream(BaseInterface):
                     max_candidates=self.max_candidates,
                     max_detections=self.max_detections,
                 )
-
-                if self.simulate_process_delay > 0:
-                    time.sleep(self.simulate_process_delay)
 
                 if self.json_response:
                     predictions = self.model.make_response(

--- a/inference/core/interfaces/stream/stream.py
+++ b/inference/core/interfaces/stream/stream.py
@@ -70,6 +70,7 @@ class Stream(BaseInterface):
         on_prediction: Callable = None,
         on_start: Callable = None,
         on_stop: Callable = None,
+        simulate_process_delay: float = 0,
     ):
         """Initialize the stream with the given parameters.
         Prints the server settings and initializes the inference with a test frame.
@@ -108,6 +109,7 @@ class Stream(BaseInterface):
         self.json_response = json_response
         self.use_main_thread = use_main_thread
         self.output_channel_order = output_channel_order
+        self.simulate_process_delay = simulate_process_delay
 
         self.inference_request_type = (
             inference.core.entities.requests.inference.ObjectDetectionInferenceRequest
@@ -246,6 +248,9 @@ class Stream(BaseInterface):
                     max_candidates=self.max_candidates,
                     max_detections=self.max_detections,
                 )
+
+                if self.simulate_process_delay > 0:
+                    time.sleep(self.simulate_process_delay)
 
                 if self.json_response:
                     predictions = self.model.make_response(

--- a/inference/core/interfaces/stream/stream.py
+++ b/inference/core/interfaces/stream/stream.py
@@ -70,7 +70,6 @@ class Stream(BaseInterface):
         on_prediction: Callable = None,
         on_start: Callable = None,
         on_stop: Callable = None,
-        simulate_process_delay: float = 0,
     ):
         """Initialize the stream with the given parameters.
         Prints the server settings and initializes the inference with a test frame.


### PR DESCRIPTION
This makes the `enforce_fps='skip'` behavior the default.

Additionally, we now will by default grab file streams at their native FPS (`file_mode`), skipping frames until we are ready to infer in the same manner as we would when streaming. `enforce_fps` will additionally ensure that each frame of the file is inferred upon by the model.

We detect whether we are working with a file or a stream based on how many frames are available via `CAP_PROP_FRAME_COUNT` at start of the stream. In my testing, this was reliable for streams vs webcams vs static files on mac as well as on the nano with FFMPEG backend. If we are not working with a file, we do not allow `enforce_fps` as we know it will cause problems when the `VideoCapture` process gets too far behind in the stream.




-   [x] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Locally (webcam, file, and stream). Also tested streaming on my jetson nano.

