### PR TITLE
Fix doctr deps for jetson

### DIFF
--- a/requirements/requirements.doctr.txt
+++ b/requirements/requirements.doctr.txt
@@ -1,1 +1,2 @@
 python-doctr[torch]
+tf2onnx


### PR DESCRIPTION
# Description

For some envs, tf2onnx needs to be installed manually for DocTR.