### PR TITLE
revert accidental change to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,12 @@ export PYTHONPATH = .
 check_dirs := inference inference_sdk
 
 style:
-	python3 -m black  $(check_dirs)
-	python3 -m isort --profile black $(check_dirs)
+	black  $(check_dirs)
+	isort --profile black $(check_dirs)
 
 check_code_quality:
-	python3 -m black --check $(check_dirs)
-	python3 -m isort --check-only --profile black $(check_dirs)
+	black --check $(check_dirs)
+	isort --check-only --profile black $(check_dirs)
 	# stop the build if there are Python syntax errors or undefined names
 	flake8 $(check_dirs) --count --select=E9,F63,F7,F82 --show-source --statistics
 	# exit-zero treats all errors as warnings. E203 for black, E501 for docstring, W503 for line breaks before logical operators 


### PR DESCRIPTION
Reverts [this change](https://github.com/roboflow/inference/pull/120/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R7-R8) I made in #120 which was not needed as part of the PR.