### PR TITLE
Noted that inference stream only supports object detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ inference.Stream(
 )
 ```
 
+> [!NOTE]  
+> Currently, the stream interface only supports object detection
+
 Now let's extend the example to use [Supervision](https://roboflow.com/supervision)
 to visualize the predictions and display them on screen with OpenCV:
 


### PR DESCRIPTION
# Description

Edited the examples in the README to clarify the fact that `inference.Stream` only supports object detection at this time.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?


## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [x] Docs updated? What were the changes:
- Getting started example updated
