### PR TITLE
Fix problem with BGR->RGB and RGB->BGR conversions

### DIFF
--- a/inference/core/interfaces/stream/stream.py
+++ b/inference/core/interfaces/stream/stream.py
@@ -202,7 +202,7 @@ class Stream(BaseInterface):
                     if frame_id > 0 and frame_id != self.frame_id:
                         self.frame_id = frame_id
                         self.frame = cv2.cvtColor(self.frame_cv, cv2.COLOR_BGR2RGB)
-                        self.preproc_result = self.model.preprocess(self.frame)
+                        self.preproc_result = self.model.preprocess(self.frame_cv)
                         self.img_in, self.img_dims = self.preproc_result
                         self.queue_control = True
 

--- a/inference/core/interfaces/udp/udp_stream.py
+++ b/inference/core/interfaces/udp/udp_stream.py
@@ -130,7 +130,6 @@ class UdpStream(BaseInterface):
         self.inference_response = None
         self.stop = False
 
-        self.frame = None
         self.frame_cv = None
         self.frame_id = None
         logger.info("Server initialized with settings:")
@@ -169,8 +168,7 @@ class UdpStream(BaseInterface):
                     self.frame_cv, frame_id = webcam_stream.read_opencv()
                     if frame_id != self.frame_id:
                         self.frame_id = frame_id
-                        self.frame = cv2.cvtColor(self.frame_cv, cv2.COLOR_BGR2RGB)
-                        self.preproc_result = self.model.preprocess(self.frame)
+                        self.preproc_result = self.model.preprocess(self.frame_cv)
                         self.img_in, self.img_dims = self.preproc_result
                         self.queue_control = True
 


### PR DESCRIPTION
# Description

Double `BGR->RGB` and `RGB->BGR` conversion happen in streaming interfaces as `preprocess` for yolo models does the thing again. This is quick-fix. As some models may not do `BGR->RGB` conversion - we shall think of providing explicit information about colour mode into the model.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

YOUR_ANSWER

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
