### PR TITLE
Fix URL in docs image

### DIFF
--- a/docs/javascript/init_kapa_widget.js
+++ b/docs/javascript/init_kapa_widget.js
@@ -4,7 +4,7 @@ document.addEventListener("DOMContentLoaded", function () {
     script.setAttribute("data-website-id", "e83c5c60-2968-410b-a2da-08fb104f23df");
     script.setAttribute("data-project-name", "Roboflow");
     script.setAttribute("data-project-color", "#6405C9");
-    script.setAttribute("data-project-logo", "https:/media.roboflow.com/chat.png");
+    script.setAttribute("data-project-logo", "https://media.roboflow.com/chat.png");
     script.async = true;
     document.head.appendChild(script);
 });


### PR DESCRIPTION
# Description

This PR fixes a typo in the URL of the image used in our new docs bot, Kapa.

## Type of change

-   [X] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

This change was tested by running `mkdocs serve`, opening `localhost:8000`, and checking that the "Ask AI" bot in the bottom right corner has the correct image.

## Any specific deployment considerations

N/A

## Docs

N/A
