### PR TITLE
Expect Numpy Input To Be RGB

### DIFF
--- a/inference/core/utils/image_utils.py
+++ b/inference/core/utils/image_utils.py
@@ -113,7 +113,11 @@ def load_image_with_known_type(
             f"NumPy image type is not supported in this configuration of `inference`."
         )
     loader = IMAGE_LOADERS[image_type]
-    is_bgr = True if image_type is not ImageType.PILLOW else False
+    is_bgr = (
+        True
+        if image_type is not ImageType.PILLOW and image_type is not ImageType.NUMPY
+        else False
+    )
     image = loader(value, cv_imread_flags)
     return image, is_bgr
 
@@ -135,7 +139,7 @@ def load_image_with_inferred_type(
     """
     if isinstance(value, (np.ndarray, np.generic)):
         validate_numpy_image(data=value)
-        return value, True
+        return value, False
     elif isinstance(value, Image.Image):
         return np.asarray(value.convert("RGB")), False
     elif isinstance(value, str) and (value.startswith("http")):


### PR DESCRIPTION
# Description

Switch numpy loading to expect array is already RGB

## Type of change

Please delete options that are not relevant.

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

With automated actions and local test scripts