### PR TITLE
Deduce API keys from logs

### DIFF
--- a/inference/core/managers/pingback.py
+++ b/inference/core/managers/pingback.py
@@ -14,6 +14,7 @@ from inference.core.env import (
 )
 from inference.core.logger import logger
 from inference.core.managers.metrics import get_model_metrics, get_system_info
+from inference.core.utils.requests import safe_raise_for_status
 from inference.core.version import __version__
 
 
@@ -129,7 +130,7 @@ class PingbackInfo:
             self.window_start_timestamp = timestamp
             res = requests.post(METRICS_URL, json=all_data)
             try:
-                res.raise_for_status()
+                safe_raise_for_status(response=res)
                 logger.debug(
                     "Sent metrics to Roboflow {} at {}.".format(
                         METRICS_URL, str(all_data)

--- a/inference/core/managers/pingback.py
+++ b/inference/core/managers/pingback.py
@@ -14,7 +14,7 @@ from inference.core.env import (
 )
 from inference.core.logger import logger
 from inference.core.managers.metrics import get_model_metrics, get_system_info
-from inference.core.utils.requests import safe_raise_for_status
+from inference.core.utils.requests import api_key_safe_raise_for_status
 from inference.core.version import __version__
 
 
@@ -130,7 +130,7 @@ class PingbackInfo:
             self.window_start_timestamp = timestamp
             res = requests.post(METRICS_URL, json=all_data)
             try:
-                safe_raise_for_status(response=res)
+                api_key_safe_raise_for_status(response=res)
                 logger.debug(
                     "Sent metrics to Roboflow {} at {}.".format(
                         METRICS_URL, str(all_data)

--- a/inference/core/roboflow_api.py
+++ b/inference/core/roboflow_api.py
@@ -22,6 +22,7 @@ from inference.core.exceptions import (
     RoboflowAPIUnsuccessfulRequestError,
     WorkspaceLoadError,
 )
+from inference.core.utils.requests import safe_raise_for_status
 from inference.core.utils.url_utils import wrap_url
 
 MODEL_TYPE_DEFAULTS = {
@@ -102,7 +103,7 @@ def wrap_roboflow_api_errors(
 def get_roboflow_workspace(api_key: str) -> WorkspaceID:
     api_url = wrap_url("/".join([API_BASE_URL, f"?api_key={api_key}"]))
     api_key_info = requests.get(api_url)
-    api_key_info.raise_for_status()
+    safe_raise_for_status(response=api_key_info)
     workspace_id = api_key_info.json().get("workspace")
     if workspace_id is None:
         raise WorkspaceLoadError(f"Empty workspace encountered, check your API key.")
@@ -119,7 +120,7 @@ def get_roboflow_dataset_type(
         )
     )
     dataset_info = requests.get(api_url)
-    dataset_info.raise_for_status()
+    safe_raise_for_status(response=dataset_info)
     project_task_type = dataset_info.json().get("project", {})
     if "type" not in project_task_type:
         logger.warning(
@@ -157,7 +158,7 @@ def get_roboflow_model_type(
         )
     )
     version_info = requests.get(api_url)
-    version_info.raise_for_status()
+    safe_raise_for_status(response=version_info)
     model_type = version_info.json()["version"]
     if "modelType" not in model_type:
         if project_task_type not in MODEL_TYPE_DEFAULTS:
@@ -186,7 +187,7 @@ def get_roboflow_model_data(
         f"{API_BASE_URL}/{endpoint_type.value}/{model_id}?api_key={api_key}&device={device_id}&nocache=true&dynamic=true"
     )
     model_data = requests.get(api_url)
-    model_data.raise_for_status()
+    safe_raise_for_status(response=model_data)
     return model_data.json()
 
 

--- a/inference/core/roboflow_api.py
+++ b/inference/core/roboflow_api.py
@@ -22,7 +22,7 @@ from inference.core.exceptions import (
     RoboflowAPIUnsuccessfulRequestError,
     WorkspaceLoadError,
 )
-from inference.core.utils.requests import safe_raise_for_status
+from inference.core.utils.requests import api_key_safe_raise_for_status
 from inference.core.utils.url_utils import wrap_url
 
 MODEL_TYPE_DEFAULTS = {
@@ -103,7 +103,7 @@ def wrap_roboflow_api_errors(
 def get_roboflow_workspace(api_key: str) -> WorkspaceID:
     api_url = wrap_url("/".join([API_BASE_URL, f"?api_key={api_key}"]))
     api_key_info = requests.get(api_url)
-    safe_raise_for_status(response=api_key_info)
+    api_key_safe_raise_for_status(response=api_key_info)
     workspace_id = api_key_info.json().get("workspace")
     if workspace_id is None:
         raise WorkspaceLoadError(f"Empty workspace encountered, check your API key.")
@@ -120,7 +120,7 @@ def get_roboflow_dataset_type(
         )
     )
     dataset_info = requests.get(api_url)
-    safe_raise_for_status(response=dataset_info)
+    api_key_safe_raise_for_status(response=dataset_info)
     project_task_type = dataset_info.json().get("project", {})
     if "type" not in project_task_type:
         logger.warning(
@@ -158,7 +158,7 @@ def get_roboflow_model_type(
         )
     )
     version_info = requests.get(api_url)
-    safe_raise_for_status(response=version_info)
+    api_key_safe_raise_for_status(response=version_info)
     model_type = version_info.json()["version"]
     if "modelType" not in model_type:
         if project_task_type not in MODEL_TYPE_DEFAULTS:
@@ -187,7 +187,7 @@ def get_roboflow_model_data(
         f"{API_BASE_URL}/{endpoint_type.value}/{model_id}?api_key={api_key}&device={device_id}&nocache=true&dynamic=true"
     )
     model_data = requests.get(api_url)
-    safe_raise_for_status(response=model_data)
+    api_key_safe_raise_for_status(response=model_data)
     return model_data.json()
 
 

--- a/inference/core/utils/image_utils.py
+++ b/inference/core/utils/image_utils.py
@@ -21,6 +21,7 @@ from inference.core.exceptions import (
     InvalidImageTypeDeclared,
     InvalidNumpyInput,
 )
+from inference.core.utils.requests import safe_raise_for_status
 
 BASE64_DATA_TYPE_PATTERN = re.compile(r"^data:image\/[a-z]+;base64,")
 
@@ -276,7 +277,7 @@ def load_image_from_url(
     """
     try:
         response = requests.get(value, stream=True)
-        response.raise_for_status()
+        safe_raise_for_status(response=response)
         return load_image_from_encoded_bytes(
             value=response.content, cv_imread_flags=cv_imread_flags
         )

--- a/inference/core/utils/image_utils.py
+++ b/inference/core/utils/image_utils.py
@@ -21,7 +21,7 @@ from inference.core.exceptions import (
     InvalidImageTypeDeclared,
     InvalidNumpyInput,
 )
-from inference.core.utils.requests import safe_raise_for_status
+from inference.core.utils.requests import api_key_safe_raise_for_status
 
 BASE64_DATA_TYPE_PATTERN = re.compile(r"^data:image\/[a-z]+;base64,")
 
@@ -277,7 +277,7 @@ def load_image_from_url(
     """
     try:
         response = requests.get(value, stream=True)
-        safe_raise_for_status(response=response)
+        api_key_safe_raise_for_status(response=response)
         return load_image_from_encoded_bytes(
             value=response.content, cv_imread_flags=cv_imread_flags
         )

--- a/inference/core/utils/requests.py
+++ b/inference/core/utils/requests.py
@@ -7,7 +7,7 @@ KEY_VALUE_GROUP = 1
 MIN_KEY_LENGTH_TO_REVEAL_PREFIX = 8
 
 
-def safe_raise_for_status(response: Response) -> None:
+def api_key_safe_raise_for_status(response: Response) -> None:
     request_is_successful = response.status_code < 400
     if request_is_successful:
         return None

--- a/inference/core/utils/requests.py
+++ b/inference/core/utils/requests.py
@@ -1,0 +1,24 @@
+import re
+
+from requests import Response
+
+API_KEY_PATTERN = re.compile(r"api_key=(.[^&]*)")
+KEY_VALUE_GROUP = 1
+MIN_KEY_LENGTH_TO_REVEAL_PREFIX = 8
+
+
+def safe_raise_for_status(response: Response) -> None:
+    request_is_successful = response.status_code < 400
+    if request_is_successful:
+        return None
+    response.url = API_KEY_PATTERN.sub(deduct_api_key, response.url)
+    response.raise_for_status()
+
+
+def deduct_api_key(match: re.Match) -> str:
+    key_value = match.group(KEY_VALUE_GROUP)
+    if len(key_value) < MIN_KEY_LENGTH_TO_REVEAL_PREFIX:
+        return f"api_key=***"
+    key_prefix = key_value[:2]
+    key_postfix = key_value[-2:]
+    return f"api_key={key_prefix}***{key_postfix}"

--- a/inference/enterprise/device_manager/metrics_service.py
+++ b/inference/enterprise/device_manager/metrics_service.py
@@ -6,6 +6,7 @@ from inference.core.devices.utils import GLOBAL_DEVICE_ID
 from inference.core.env import API_KEY, METRICS_INTERVAL, METRICS_URL, TAGS
 from inference.core.logger import logger
 from inference.core.managers.metrics import get_model_metrics, get_system_info
+from inference.core.utils.requests import safe_raise_for_status
 from inference.core.version import __version__
 from inference.enterprise.device_manager.command_handler import handle_command
 from inference.enterprise.device_manager.container_service import (
@@ -128,7 +129,7 @@ def report_metrics_and_handle_commands():
     all_data = aggregate_device_stats()
     logger.info(f"Sending metrics to Roboflow {str(all_data)}.")
     res = requests.post(METRICS_URL, json=all_data)
-    res.raise_for_status()
+    safe_raise_for_status(response=res)
     response = res.json()
     for cmd in response.get("data", []):
         if cmd:

--- a/inference/enterprise/device_manager/metrics_service.py
+++ b/inference/enterprise/device_manager/metrics_service.py
@@ -6,7 +6,7 @@ from inference.core.devices.utils import GLOBAL_DEVICE_ID
 from inference.core.env import API_KEY, METRICS_INTERVAL, METRICS_URL, TAGS
 from inference.core.logger import logger
 from inference.core.managers.metrics import get_model_metrics, get_system_info
-from inference.core.utils.requests import safe_raise_for_status
+from inference.core.utils.requests import api_key_safe_raise_for_status
 from inference.core.version import __version__
 from inference.enterprise.device_manager.command_handler import handle_command
 from inference.enterprise.device_manager.container_service import (
@@ -129,7 +129,7 @@ def report_metrics_and_handle_commands():
     all_data = aggregate_device_stats()
     logger.info(f"Sending metrics to Roboflow {str(all_data)}.")
     res = requests.post(METRICS_URL, json=all_data)
-    safe_raise_for_status(response=res)
+    api_key_safe_raise_for_status(response=res)
     response = res.json()
     for cmd in response.get("data", []):
         if cmd:

--- a/tests/inference/unit_tests/core/utils/test_requests.py
+++ b/tests/inference/unit_tests/core/utils/test_requests.py
@@ -1,0 +1,88 @@
+import pytest
+from requests import Response, HTTPError
+
+from inference.core.utils.requests import (
+    API_KEY_PATTERN,
+    deduct_api_key,
+    safe_raise_for_status,
+)
+
+
+def test_deduce_api_key_when_no_api_key_available() -> None:
+    # given
+    url = "https://some.com/endpoint?param_1=12098xx87s&param_2=2982s8x"
+
+    # when
+    result = API_KEY_PATTERN.sub(deduct_api_key, url)
+
+    # then
+    assert result == url
+
+
+def test_deduce_api_key_when_short_api_key_available() -> None:
+    # given
+    url = "https://some.com/endpoint?api_key=my_key&param_2=some_value"
+
+    # when
+    result = API_KEY_PATTERN.sub(deduct_api_key, url)
+
+    # then
+    assert result == "https://some.com/endpoint?api_key=***&param_2=some_value"
+
+
+def test_deduce_api_key_when_single_long_api_key_available() -> None:
+    # given
+    url = "https://some.com/endpoint?api_key=19xjs9-XSXSAos0s&param_2=some_value"
+
+    # when
+    result = API_KEY_PATTERN.sub(deduct_api_key, url)
+
+    # then
+    assert result == "https://some.com/endpoint?api_key=19***0s&param_2=some_value"
+
+
+def test_deduce_api_key_when_multiple_api_key_available() -> None:
+    # given
+    url = "https://some.com/endpoint?api_key=19xjs9-XSXSAos0s&param_2=some_value&api_key=my_key"
+
+    # when
+    result = API_KEY_PATTERN.sub(deduct_api_key, url)
+
+    # then
+    assert (
+        result
+        == "https://some.com/endpoint?api_key=19***0s&param_2=some_value&api_key=***"
+    )
+
+
+@pytest.mark.parametrize("status_code", [200, 201, 300])
+def test_safe_raise_for_status_when_no_error_occurs(status_code: int) -> None:
+    # given
+    response = Response()
+    response.status_code = status_code
+
+    # when
+    safe_raise_for_status(response=response)
+
+    # then no error happens
+
+
+@pytest.mark.parametrize(
+    "status_code", [400, 401, 402, 403, 404, 500, 501, 502, 503, 504]
+)
+def test_safe_raise_for_status_when_error_occurs(status_code: int) -> None:
+    # given
+    response = Response()
+    response.status_code = status_code
+    response.url = (
+        "https://some.com/endpoint?api_key=19xjs9-XSXSAos0s&param_2=some_value"
+    )
+
+    # when
+    with pytest.raises(HTTPError) as expected_error:
+        safe_raise_for_status(response=response)
+
+    # then
+    assert "https://some.com/endpoint?api_key=19***0s&param_2=some_value" in str(
+        expected_error.value
+    )

--- a/tests/inference/unit_tests/core/utils/test_requests.py
+++ b/tests/inference/unit_tests/core/utils/test_requests.py
@@ -4,7 +4,7 @@ from requests import Response, HTTPError
 from inference.core.utils.requests import (
     API_KEY_PATTERN,
     deduct_api_key,
-    safe_raise_for_status,
+    api_key_safe_raise_for_status,
 )
 
 
@@ -56,13 +56,13 @@ def test_deduce_api_key_when_multiple_api_key_available() -> None:
 
 
 @pytest.mark.parametrize("status_code", [200, 201, 300])
-def test_safe_raise_for_status_when_no_error_occurs(status_code: int) -> None:
+def test_api_key_safe_raise_for_status_when_no_error_occurs(status_code: int) -> None:
     # given
     response = Response()
     response.status_code = status_code
 
     # when
-    safe_raise_for_status(response=response)
+    api_key_safe_raise_for_status(response=response)
 
     # then no error happens
 
@@ -70,7 +70,7 @@ def test_safe_raise_for_status_when_no_error_occurs(status_code: int) -> None:
 @pytest.mark.parametrize(
     "status_code", [400, 401, 402, 403, 404, 500, 501, 502, 503, 504]
 )
-def test_safe_raise_for_status_when_error_occurs(status_code: int) -> None:
+def test_api_keysafe_raise_for_status_when_error_occurs(status_code: int) -> None:
     # given
     response = Response()
     response.status_code = status_code
@@ -80,7 +80,7 @@ def test_safe_raise_for_status_when_error_occurs(status_code: int) -> None:
 
     # when
     with pytest.raises(HTTPError) as expected_error:
-        safe_raise_for_status(response=response)
+        api_key_safe_raise_for_status(response=response)
 
     # then
     assert "https://some.com/endpoint?api_key=19***0s&param_2=some_value" in str(


### PR DESCRIPTION
# Description

In this PR, we deduce API keys previously displayed in open-text at the logging level.

Basically all occurrences of this behaviour were connected to the fact that API key is given in the `param` of REST request - and hence may be visible in error messages and access logs. Solution applied - each occurrence of code producing error logs for Roboflow backend calls is now wrapped with `api_key_safe_raise_for_status(...)` that deducts `api-key` param from URLs reported in logs.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Covered with tests and checked in docker.

We have now:
```
ERROR:inference:HTTP error encountered while requesting Roboflow API response: 500 Server Error: Internal Server Error for url: https://api.roboflow.com/pawel-peczek-private/barbel-detection/37/?api_key=Mr***MR&nocache=true
```

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
