### PR TITLE
Update default API key parameter for get_roboflow_model function

### DIFF
--- a/inference/models/utils.py
+++ b/inference/models/utils.py
@@ -1,3 +1,4 @@
+from inference.core.env import API_KEY
 from inference.core.registries.roboflow import get_model_type
 from inference.models import (
     YOLACT,
@@ -10,7 +11,6 @@ from inference.models import (
     YOLOv8ObjectDetection,
 )
 from inference.models.yolov8.yolov8_keypoints_detection import YOLOv8KeypointsDetection
-from inference.core.env import API_KEY
 
 ROBOFLOW_MODEL_TYPES = {
     ("classification", "vit"): VitClassification,

--- a/inference/models/utils.py
+++ b/inference/models/utils.py
@@ -10,6 +10,7 @@ from inference.models import (
     YOLOv8ObjectDetection,
 )
 from inference.models.yolov8.yolov8_keypoints_detection import YOLOv8KeypointsDetection
+from inference.core.env import API_KEY
 
 ROBOFLOW_MODEL_TYPES = {
     ("classification", "vit"): VitClassification,
@@ -149,6 +150,6 @@ except:
     pass
 
 
-def get_roboflow_model(model_id, api_key=None, **kwargs):
+def get_roboflow_model(model_id, api_key=API_KEY, **kwargs):
     task, model = get_model_type(model_id, api_key=api_key)
     return ROBOFLOW_MODEL_TYPES[(task, model)](model_id, api_key=api_key, **kwargs)


### PR DESCRIPTION
# Description

`ROBOFLOW_API_KEY` is used by default when `get_roboflow_model` is being called.
