### PR TITLE
Update HTTP inference docs

### DIFF
--- a/docs/quickstart/http_inference.md
+++ b/docs/quickstart/http_inference.md
@@ -14,155 +14,184 @@ To run inference with the server, we will:
 
 ## Step #1: Install the Inference Server
 
+_You can skip this step if you already have Inference installed and running._
+
 The Inference Server runs in Docker. Before we begin, make sure you have installed Docker on your system. To learn how to install Docker, refer to the [official Docker installation guide](https://docs.docker.com/get-docker/).
 
 Once you have Docker installed, you are ready to download Roboflow Inference. The command you need to run depends on what device you are using.
 
-[Run the relevant command for your device](docker.md#run). After you have installed the Inference Server, the Docker container will start running the server at `localhost:9001`.
-
-Now we are ready to run inference!
+Start the server using `inference server start`. After you have installed the Inference Server, the Docker container will start running the server at `localhost:9001`.
 
 ## Step #2: Run Inference
 
-> The easiest way to interact with the `inference` API is using the [`inference-sdk`](../inference_sdk/http_client.md)
+You can send a URL with an image, a NumPy array, or a base64-encoded image to an Inference server. The server will return a JSON response with the predictions.
 
-To run inference on a model, there are two routes we can make an HTTP request to:
+Choose an option below:
 
-```url
-http://localhost:9001/{project_id}/{model_version}
-```
+!!! Run Inference
 
-or
+    === "URL"
+    
+        Create a new Python file and add the following code:
 
-```url
-http://localhost:9001/infer/{task}
-```
+        ```python
+        import requests
 
-where task is one of `object_detection`, `instance_segmentation`, or `classification`, depending on your project type. The former is the route used by our hosted inference. It doesn't require that you know or pass your task type, just your project ID and model version number and it is fully interchangable with Roboflow's hosted inference offerings at `detect.roboflow.com`, `outline.roboflow.com`, and `classify.roboflow.com`. The latter is a newer route within the `inference` API. It assumes you know your task type, and it is more flexible (e.g. batching is possible).
+        project_id = ""
+        model_version = ""
+        image_url = ""
+        confidence = 0.75
+        api_key = ""
+        task = "object_detection"
 
-To find your project ID, model version number, and task type refer to the Roboflow documentation, [Workspace and Project IDs](https://docs.roboflow.com/api-reference/workspace-and-project-ids).
+        infer_payload = {
+            "model_id": f"{project_id}/{model_version}",
+            "image": {
+                "type": "url",
+                "value": image_url,
+            },
+            "confidence": confidence,
+            "iou_threshold": iou_thresh,
+            "api_key": api_key,
+        }
+        res = requests.post(
+            f"http://localhost:9001/infer/{task}",
+            json=infer_payload,
+        )
 
-### via CLI
+        predictions = res.json()
+        ```
 
-First, [Install the CLI](../index.md#cli).
+        Above, specify:
 
-To run inference, use the `inference infer` command:
+        1. `project_id`, `model_version`: Your project ID and model version number. [Learn how to retrieve your project ID and model version number](https://docs.roboflow.com/api-reference/workspace-and-project-ids).
+        2. `image_url`: The URL of the image you want to run inference on.
+        3. `confidence`: The confidence threshold for predictions. Predictions with a confidence score below this threshold will be filtered out.
+        4. `api_key`: Your Roboflow API key. [Learn how to retrieve your Roboflow API key](https://docs.roboflow.com/api-reference/authentication#retrieve-an-api-key).
+        5. `task`: The type of task you want to run. Choose from `object_detection`, `classification`, or `segmentation`.
 
-```bash
-inference infer {image_path} \
-    --project-id {project_id} \
-    --model-version {model_version} \
-    --api-key {api_key}
-```
+        Then, run the Python script:
 
-You can also specify a host option to run inference on the Roboflow Hosted API.
+        ```
+        python app.py
+        ```
 
-```bash
-inference infer {image_path} \
-    --project-id {project_id} \
-    --model-version {model_version} \
-    --api-key {api_key} \
-    --host https://detect.roboflow.com
-```
+    === "NumPy Array"
+    
+        Create a new Python file and add the following code:
 
-{image_path} can be a local path to an image, or a URL to a hosted image.
+        ```python
+        import requests
+        from PIL import Image
 
-E.g. `./image.jpg` or `https://[YOUR_HOSTED_IMAGE_URL]`
+        project_id = ""
+        model_version = ""
+        image_url = ""
+        confidence = 0.75
+        api_key = ""
+        task = "object_detection"
+        file_name = ""
 
-### Python script
+        image = Image.open(file_name)
 
-To run inference, make a HTTP request to the routes:
+        infer_payload = {
+            "model_id": f"{project_id}/{model_version}",
+            "image": {
+                "type": "numpy",
+                "value": image,
+            },
+            "confidence": confidence,
+            "iou_threshold": iou_thresh,
+            "api_key": api_key,
+        }
 
-*V1 Route*
-```python
-import requests
+        res = requests.post(
+            f"http://localhost:9001/infer/{task}",
+            json=infer_payload,
+        )
 
-project_id = ""
-model_version = ""
-image_url = ""
-confidence = 0.75
-api_key = ""
+        predictions = res.json()
+        ```
 
-params = {
-    "image": image_url,
-    "confidence": confidence,
-    "overlap": iou_thresh,
-    "api_key": api_key,
-}
-res = requests.post(
-    f"http://localhost:9001/{project_id}/{model_version}",
-    params=params,
-)
+        Above, specify:
 
-predictions = res.json()
-```
+        1. `project_id`, `model_version`: Your project ID and model version number. [Learn how to retrieve your project ID and model version number](https://docs.roboflow.com/api-reference/workspace-and-project-ids).
+        2. `confidence`: The confidence threshold for predictions. Predictions with a confidence score below this threshold will be filtered out.
+        3. `api_key`: Your Roboflow API key. [Learn how to retrieve your Roboflow API key](https://docs.roboflow.com/api-reference/authentication#retrieve-an-api-key).
+        4. `task`: The type of task you want to run. Choose from `object_detection`, `classification`, or `segmentation`.
+        5. `filename`: The path to the image you want to run inference on.
 
-You can also run using an image you have in memory.
+        Then, run the Python script:
 
-```python
-import base64
-import requests
-from io import BytesIO
-from PIL import Image
+        ```
+        python app.py
+        ```
 
-project_id = ""
-model_version = ""
-confidence = 0.75
-api_key = ""
+    === "Base64 Image"
+    
+        Create a new Python file and add the following code:
 
-params = {
-    "confidence": confidence,
-    "overlap": iou_thresh,
-    "api_key": api_key,
-}
+        ```python
+        import requests
+        import base64
+        from PIL import Image
 
-image = Image.open("/path/to/file.jpg")
-# image = Image.fromarray(numpy_array)
+        project_id = ""
+        model_version = ""
+        image_url = ""
+        confidence = 0.75
+        api_key = ""
+        task = "object_detection"
+        file_name = ""
 
-buffered = BytesIO()
-image.save(buffered, quality=100, format="JPEG")
-img_str = base64.b64encode(buffered.getvalue())
-img_str = img_str.decode("ascii")
+        image = Image.open(file_name)
 
-res = requests.post(
-    f"http://localhost:9001/{project_id}/{model_version}",
-    params=params,
-    data=img_str,
-)
+        buffered = BytesIO()
 
-predictions = res.json()
-```
+        image.save(buffered, quality=100, format="JPEG")
 
-*V2 Route*
-```python
-import requests
+        img_str = base64.b64encode(buffered.getvalue())
 
-project_id = ""
-model_version = ""
-image_url = ""
-confidence = 0.75
-api_key = ""
-task = "object_detection
+        infer_payload = {
+            "model_id": f"{project_id}/{model_version}",
+            "image": {
+                "type": "base64",
+                "value": img_str,
+            },
+            "confidence": confidence,
+            "iou_threshold": iou_thresh,
+            "api_key": api_key,
+        }
 
-infer_payload = {
-    "model_id": f"{project_id}/{model_version}",
-    "image": {
-        "type": "url",
-        "value": image_url,
-    },
-    "confidence": confidence,
-    "iou_threshold": iou_thresh,
-    "api_key": api_key,
-}
-res = requests.post(
-    f"http://localhost:9001/infer/{task}",
-    json=infer_payload,
-)
+        res = requests.post(
+            f"http://localhost:9001/infer/{task}",
+            json=infer_payload,
+        )
 
-predictions = res.json()
-```
+        predictions = res.json()
+        ```
 
-Object detection models trained with Roboflow support batching.
+        Above, specify:
+
+        1. `project_id`, `model_version`: Your project ID and model version number. [Learn how to retrieve your project ID and model version number](https://docs.roboflow.com/api-reference/workspace-and-project-ids).
+        2. `confidence`: The confidence threshold for predictions. Predictions with a confidence score below this threshold will be filtered out.
+        3. `api_key`: Your Roboflow API key. [Learn how to retrieve your Roboflow API key](https://docs.roboflow.com/api-reference/authentication#retrieve-an-api-key).
+        4. `task`: The type of task you want to run. Choose from `object_detection`, `classification`, or `segmentation`.
+        5. `filename`: The path to the image you want to run inference on.
+
+        Then, run the Python script:
+
+        ```
+        python app.py
+        ```
+
+The code snippets above will run inference on a computer vision model. On the first request, the model weights will be downloaded and set up with your local inference server. This request may take some time depending on your network connection and the size of the model. Once your model has downloaded, subsequent requests will be much faster.
+
+The Inference Server comes with a `/docs` route at `localhost:9001/docs` or `localhost:9001/redoc` that provides OpenAPI-powered documentation. You can use this to reference the routes available, and the configuration options for each route.
+
+## Auto Batching Requests
+
+Object detection models trained with Roboflow support batching, which allow you to upload multiple images of any type at once:
 
 ```python
 infer_payload = {
@@ -186,34 +215,3 @@ infer_payload = {
     "api_key": api_key,
 }
 ```
-
-To run with an image in memory:
-
-```python
-image = Image.open("/path/to/file.jpg")
-# image = Image.fromarray(numpy_array)
-
-buffered = BytesIO()
-image.save(buffered, quality=100, format="JPEG")
-img_str = base64.b64encode(buffered.getvalue())
-img_str = img_str.decode("ascii")
-
-infer_payload = {
-    "model_id": f"{project_id}/{model_version}",
-    "image": {
-        "type": "base64",
-        "value": img_str,
-    },
-    "confidence": confidence,
-    "iou_threshold": iou_thresh,
-    "api_key": api_key,
-}
-```
-
-The code snippets above will run inference on a computer vision model. On the first request, the model weights will be downloaded and set up with your local inference server. This request may take some time depending on your network connection and the size of the model. Once your model has downloaded, subsequent requests will be much faster.
-
-Above, set your project ID and model version number. Also configure your confidence and IoU threshold values as needed. If you are using classification, you can omit the IoU threshold value. You will also need to set your Roboflow API key. To learn how to retrieve your Roboflow API key, refer to the Roboflow API documentation, [Authentication - Retrieve an API Key](https://docs.roboflow.com/api-reference/authentication#retrieve-an-api-key).
-
-You can post either a URL, a base64-encoded image, or a pickled NumPy array to the server.
-
-The Inference Server comes with a `/docs` route at `localhost:9001/docs` or `localhost:9001/redoc` that provides OpenAPI-powered documentation. You can use this to reference the routes available, and the configuration options for each route.

--- a/docs/quickstart/run_a_model.md
+++ b/docs/quickstart/run_a_model.md
@@ -1,6 +1,8 @@
 Let's run a fine-tuned computer vision model to play rock paper scissors.
 
-First, we need to install Inference:
+The Inference Server runs in Docker. Before we begin, make sure you have installed Docker on your system. To learn how to install Docker, refer to the [official Docker installation guide](https://docs.docker.com/get-docker/).
+
+Next, we need to install Inference:
 
 ```
 pip install inference

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,7 +35,8 @@ nav:
       - Run Your First Model: quickstart/run_a_model.md
       - Run a Fine-Tuned Model: quickstart/explore_models.md
     - Run a Model:
-      - On an Image: quickstart/run_model_on_image.md
+      - On an Image (Using HTTP): quickstart/http_inference.md
+      - On an Image (Using SDK): quickstart/run_model_on_image.md
       - On a Video, Webcam or RTSP Stream: quickstart/run_model_on_rtsp_webcam.md
       - Over UDP: quickstart/run_model_over_udp.md
     - Use a Foundation Model:
@@ -50,7 +51,6 @@ nav:
       - Model Device Compatability: quickstart/compatability_matrix.md
       - Install Inference with Docker: quickstart/docker.md
       - Docker Configuration Options: quickstart/docker_configuration_options.md
-      - HTTP Inference: quickstart/http_inference.md
       - SDK Reference: inference_sdk/http_client.md
   - HTTP API Reference:
     - API Reference: api.md


### PR DESCRIPTION
# Description

This PR restructures the HTTP interface documentation to make it more user friendly and fixes some code snippets in those docs.

## Type of change

- [ ] Documentation improvement

## How has this change been tested, please provide a testcase or example of how you tested the change?

This change was tested by running `mkdocs serve` and opening http://localhost:8000/quickstart/http_inference/ to ensure the page rendered properly.

## Any specific deployment considerations

N/A

## Docs

N/A