### PR TITLE
Speed Regression Fix - Remove Numpy Range Validation

### DIFF
--- a/inference/core/utils/image_utils.py
+++ b/inference/core/utils/image_utils.py
@@ -257,11 +257,6 @@ def validate_numpy_image(data: np.ndarray) -> None:
         raise InvalidNumpyInput(
             f"For image given as np.ndarray expected 1 or 3 channels, got {data.shape[-1]} channels."
         )
-    if np.max(data) > 255 or np.min(data) < 0:
-        raise InvalidNumpyInput(
-            f"For image given as np.ndarray expected values between 0 and 255, got values between "
-            f"{np.min(data)} and {np.max(data)}."
-        )
 
 
 def load_image_from_url(

--- a/tests/inference/unit_tests/core/utils/test_image_utils.py
+++ b/tests/inference/unit_tests/core/utils/test_image_utils.py
@@ -165,15 +165,6 @@ def test_load_image_from_numpy_str_when_array_with_non_standard_channels_given()
         _ = load_image_from_numpy_str(value=payload)
 
 
-def test_load_image_from_numpy_str_when_array_with_invalid_values_given() -> None:
-    # given
-    payload = pickle.dumps(1024 * np.ones((128, 128, 3), dtype=np.uint8))
-
-    # when
-    with pytest.raises(InvalidNumpyInput):
-        _ = load_image_from_numpy_str(value=payload)
-
-
 def test_load_image_from_numpy_str_when_valid_image_given(
     image_as_pickled_bytes: bytes,
     image_as_numpy: np.ndarray,


### PR DESCRIPTION
# Description

Removed a numpy validation check that turned out to be very costly for large images. Not worth the loss in performance here.

## Type of change

Please delete options that are not relevant.

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Tested locally and with auto regression tests
