### PR TITLE
features/sv-from-roboflow-no-need-class-list-args

### DIFF
--- a/examples/inference-client/image.py
+++ b/examples/inference-client/image.py
@@ -60,7 +60,7 @@ def annotate_image(
     response = requests.post(
         url, headers=headers, params=params, data=encoded_image
     ).json()
-    detections = sv.Detections.from_roboflow(response, class_list=class_list)
+    detections = sv.Detections.from_roboflow(response)
 
     box_annotator = sv.BoxAnnotator()
     labels = [

--- a/examples/inference-client/video.py
+++ b/examples/inference-client/video.py
@@ -60,7 +60,7 @@ def process_and_annotate_frames(
         response = requests.post(
             url, headers=headers, params=params, data=numpy_data
         ).json()
-        detections = sv.Detections.from_roboflow(response, class_list=class_list)
+        detections = sv.Detections.from_roboflow(response)
         labels = [
             f"{class_list[class_id]} {confidence_value:0.2f}"
             for _, _, confidence_value, class_id, _ in detections


### PR DESCRIPTION
The class_list argument is no longer required in the Detections.from_roboflow function within Supervision. Even though the inference-client examples still include this argument, I've removed it as it's unnecessary now.

[def from_roboflow(cls, roboflow_result: dict) -> Detections:](https://github.com/roboflow/supervision/blob/5d19e246a42cc7caf8bb323933237d18e642adec/supervision/detection/core.py#L394)