### PR TITLE
Wrap pingback url

### DIFF
--- a/inference/core/managers/pingback.py
+++ b/inference/core/managers/pingback.py
@@ -13,6 +13,7 @@ from inference.core.env import (
     TAGS,
 )
 from inference.core.logger import logger
+from inference.core.utils.url_utils import wrap_url
 from inference.core.managers.metrics import get_model_metrics, get_system_info
 from inference.core.utils.requests import api_key_safe_raise_for_status
 from inference.core.version import __version__
@@ -128,7 +129,7 @@ class PingbackInfo:
             timestamp = str(int(time.time()))
             all_data["timestamp"] = timestamp
             self.window_start_timestamp = timestamp
-            res = requests.post(METRICS_URL, json=all_data)
+            res = requests.post(wrap_url(METRICS_URL), json=all_data)
             try:
                 api_key_safe_raise_for_status(response=res)
                 logger.debug(

--- a/inference/core/managers/pingback.py
+++ b/inference/core/managers/pingback.py
@@ -13,9 +13,9 @@ from inference.core.env import (
     TAGS,
 )
 from inference.core.logger import logger
-from inference.core.utils.url_utils import wrap_url
 from inference.core.managers.metrics import get_model_metrics, get_system_info
 from inference.core.utils.requests import api_key_safe_raise_for_status
+from inference.core.utils.url_utils import wrap_url
 from inference.core.version import __version__
 
 


### PR DESCRIPTION
# Description

- Wrapping the metrics_url so that it goes through the proxy server if enabled

## Type of change

Please delete options that are not relevant.

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

- Smoke tested inference server (checked if running, made an inference)

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
