### PR TITLE
Allow setting cv2 camera capture props from .env file

### DIFF
--- a/inference/core/__init__.py
+++ b/inference/core/__init__.py
@@ -33,7 +33,7 @@ def check_latest_release_against_current():
     get_latest_release_version()
     if latest_release is not None and latest_release != __version__:
         logger.warning(
-            f"Your inference package version {__version__} is out of date! Please upgrade to version {latest_release} of inference for the latest features and bug fixes by running `pip install --upgrade roboflow-inference`."
+            f"Your inference package version {__version__} is out of date! Please upgrade to version {latest_release} of inference for the latest features and bug fixes by running `pip install --upgrade inference`."
         )
 
 

--- a/inference/core/interfaces/camera/camera.py
+++ b/inference/core/interfaces/camera/camera.py
@@ -1,3 +1,4 @@
+import os
 import time
 from threading import Thread
 
@@ -34,6 +35,18 @@ class WebcamStream:
         self.enforce_fps = enforce_fps
         self.frame_id = 0
         self.vcap = cv2.VideoCapture(self.stream_id)
+
+        for key in os.environ:
+            if key.startswith("CV2_CAP_PROP"):
+                opencv_prop = key[4:]
+                opencv_constant = getattr(cv2, opencv_prop, None)
+                if opencv_constant is not None:
+                    value = int(os.getenv(key))
+                    self.vcap.set(opencv_constant, value)
+                    logger.info(f"set {opencv_prop} to {value}")
+                else:
+                    logger.warn(f"Property {opencv_prop} not found in cv2")
+
         self.width = int(self.vcap.get(cv2.CAP_PROP_FRAME_WIDTH))
         self.height = int(self.vcap.get(cv2.CAP_PROP_FRAME_HEIGHT))
         self.file_mode = self.vcap.get(cv2.CAP_PROP_FRAME_COUNT) > 0


### PR DESCRIPTION
# Description

 * This will allow customization of camera resolutions via .env file for `inference.Stream` and UDP streaming.
 * also fixed an upgrade message telling the user to upgrade the wrong pip package.



## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Tested locally.

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

Do we have documentation of all the ENV variables that can be customized?
