### PR TITLE
Clarify Enterprise License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,7 @@
 LICENSE.core (Apache 2.0) applies to all files in this repository
 except for files in or under any directory that contains a superseding
-license file (such as the models located in `inference/models/`).
+license file (such as the models located in `inference/models/`
+which are governed by their own individual licenses and
+the files and folders in the `inference/enterprise/` directory which are
+governed by the Roboflow Enterprise License located at
+`inference/enterprise/LICENSE.txt`).

--- a/inference/enterprise/LICENSE.txt
+++ b/inference/enterprise/LICENSE.txt
@@ -1,0 +1,39 @@
+The Roboflow Enterprise License (the “Enterprise License”)
+Copyright (c) 2023 Roboflow Inc.
+
+With regard to the Roboflow Software:
+
+This software and associated documentation files (the "Software") may only be
+used in production, if you (and any entity that you represent) have accepted
+and are following the terms of a separate Roboflow Enterprise agreement
+that governs how you use the software.
+
+Subject to the foregoing sentence, you are free to modify this Software and publish
+patches to the Software. You agree that Roboflow and/or its licensors (as applicable)
+retain all right, title and interest in and to all such modifications and/or patches,
+and all such modifications and/or patches may only be used, copied, modified,
+displayed, distributed, or otherwise exploited with a valid Roboflow Enterprise
+license for the correct number of seats, devices, inferences, and other 
+usage metrics specified therein.
+
+Notwithstanding the foregoing, you may copy and modify the Software for development
+and testing purposes, without requiring a subscription. You agree that Roboflow and/or
+its licensors (as applicable) retain all right, title and interest in and to all
+such modifications. You are not granted any other rights beyond what is expressly
+stated herein. Subject to the foregoing, it is forbidden to copy, merge, publish,
+distribute, sublicense, and/or sell the Software.
+
+The full text of this Enterprise License shall be included in all copies or
+substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+For all third party components incorporated into the Roboflow Software, those
+components are licensed under the original license provided by the owner of the
+applicable component.


### PR DESCRIPTION
# Description

Clarifies that the `inference/enterprise` directory is governed by the Roboflow Enterprise License (pursuant to a Roboflow enterprise contract).

## Type of change

-   [x] This change is a documentation update
