### PR TITLE
Add copyable code snippet

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,6 +81,7 @@ theme:
     - navigation.instant.progress
     - navigation.indexes
     - navigation.sections
+    - content.code.copy
 
 plugins:
   - mkdocstrings


### PR DESCRIPTION
# Description

This PR adds a button that enables users to copy code snippets from the `inference` documentation.

## Type of change

Documentation.

## How has this change been tested, please provide a testcase or example of how you tested the change?

This was tested by opening a code snippet and checking for the presence of the copy button in the top right corner of the code box.

## Any specific deployment considerations

N/A

## Docs

N/A
