### PR TITLE
Lower Rasterio for JP4

### DIFF
--- a/docker/dockerfiles/Dockerfile.onnx.jetson.4.5.0
+++ b/docker/dockerfiles/Dockerfile.onnx.jetson.4.5.0
@@ -23,7 +23,11 @@ RUN apt-get update -y && apt-get upgrade -y && apt-get install -y \
     python3-setuptools \
     && rm -rf /var/lib/apt/lists/*
 
-COPY requirements/requirements.sam.txt \
+# Manually listed requirements for SAM below due to need for lower rasterio requirment on Jetson images
+COPY rf-segment-anything==1.0 \ 
+    torch<=2.0.1 \
+    torchvision<=0.15.2 \
+    rasterio<=1.2.10 \
     requirements/requirements.clip.txt \
     requirements/requirements.http.txt \
     requirements/requirements.doctr.txt \

--- a/docker/dockerfiles/Dockerfile.onnx.jetson.4.6.1
+++ b/docker/dockerfiles/Dockerfile.onnx.jetson.4.6.1
@@ -23,7 +23,11 @@ RUN apt-get update -y && apt-get upgrade -y && apt-get install -y \
     python3-setuptools \
     && rm -rf /var/lib/apt/lists/*
 
-COPY requirements/requirements.sam.txt \
+# Manually listed requirements for SAM below due to need for lower rasterio requirment on Jetson images
+COPY rf-segment-anything==1.0 \ 
+    torch<=2.0.1 \
+    torchvision<=0.15.2 \
+    rasterio<=1.2.10 \
     requirements/requirements.clip.txt \
     requirements/requirements.http.txt \
     requirements/requirements.doctr.txt \


### PR DESCRIPTION
# Description
Lowered rasterio dep in jetson dockers to accomodate lower GDAL version in Jetson JP4 images.

## Type of change

Please delete options that are not relevant.

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update
