### PR TITLE
Remove SAM from Jetson

### DIFF
--- a/docker/dockerfiles/Dockerfile.onnx.jetson.4.5.0
+++ b/docker/dockerfiles/Dockerfile.onnx.jetson.4.5.0
@@ -23,12 +23,7 @@ RUN apt-get update -y && apt-get upgrade -y && apt-get install -y \
     python3-setuptools \
     && rm -rf /var/lib/apt/lists/*
 
-# Manually listed requirements for SAM below due to need for lower rasterio requirment on Jetson images
-COPY rf-segment-anything==1.0 \ 
-    torch<=2.0.1 \
-    torchvision<=0.15.2 \
-    rasterio<=1.2.10 \
-    requirements/requirements.clip.txt \
+COPY requirements/requirements.clip.txt \
     requirements/requirements.http.txt \
     requirements/requirements.doctr.txt \
     requirements/_requirements.txt \ 
@@ -38,7 +33,6 @@ RUN python3.8 -m pip install --ignore-installed PyYAML && rm -rf ~/.cache/pip
 
 RUN python3.8 -m pip install --upgrade pip  && python3.8 -m pip install \
     -r _requirements.txt \
-    -r requirements.sam.txt \
     -r requirements.clip.txt \
     -r requirements.http.txt \
     -r requirements.doctr.txt \

--- a/docker/dockerfiles/Dockerfile.onnx.jetson.4.6.1
+++ b/docker/dockerfiles/Dockerfile.onnx.jetson.4.6.1
@@ -23,12 +23,7 @@ RUN apt-get update -y && apt-get upgrade -y && apt-get install -y \
     python3-setuptools \
     && rm -rf /var/lib/apt/lists/*
 
-# Manually listed requirements for SAM below due to need for lower rasterio requirment on Jetson images
-COPY rf-segment-anything==1.0 \ 
-    torch<=2.0.1 \
-    torchvision<=0.15.2 \
-    rasterio<=1.2.10 \
-    requirements/requirements.clip.txt \
+COPY requirements/requirements.clip.txt \
     requirements/requirements.http.txt \
     requirements/requirements.doctr.txt \
     requirements/_requirements.txt \
@@ -38,7 +33,6 @@ RUN python3.8 -m pip install --ignore-installed PyYAML && rm -rf ~/.cache/pip
 
 RUN python3.8 -m pip install --upgrade pip  && python3.8 -m pip install \
     -r _requirements.txt \
-    -r requirements.sam.txt \
     -r requirements.clip.txt \
     -r requirements.http.txt \
     -r requirements.doctr.txt \

--- a/docker/dockerfiles/Dockerfile.onnx.jetson.5.1.1
+++ b/docker/dockerfiles/Dockerfile.onnx.jetson.5.1.1
@@ -20,12 +20,7 @@ RUN apt-get update -y && apt-get install -y \
     libgdal-dev \
     && rm -rf /var/lib/apt/lists/*
 
-# Manually listed requirements for SAM below due to need for lower rasterio requirment on Jetson images
-COPY rf-segment-anything==1.0 \ 
-    torch<=2.0.1 \
-    torchvision<=0.15.2 \
-    rasterio<=1.2.10 \
-    requirements/requirements.clip.txt \
+COPY requirements/requirements.clip.txt \
     requirements/requirements.http.txt \
     requirements/requirements.doctr.txt \
     requirements/_requirements.txt \
@@ -35,7 +30,6 @@ RUN pip3 install --ignore-installed PyYAML && rm -rf ~/.cache/pip
 
 RUN pip3 install --upgrade pip  && pip3 install \
     -r _requirements.txt \
-    -r requirements.sam.txt \
     -r requirements.clip.txt \
     -r requirements.http.txt \
     -r requirements.doctr.txt \


### PR DESCRIPTION
# Description

Removed sam deps from Jetson images. We had it disabled via env vars already but we failed to remove the deps from being installed. The Jetsons seem to not be powerful enough for SAM to be useful on them for right now. 

## Type of change

Please delete options that are not relevant.

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update
