### PR TITLE
Error Handling for Onnx Session Creation

### DIFF
--- a/inference/core/models/roboflow.py
+++ b/inference/core/models/roboflow.py
@@ -658,10 +658,16 @@ class OnnxRoboflowInferenceModel(RoboflowInferenceModel):
             providers = self.onnxruntime_execution_providers
             if not self.load_weights:
                 providers = ["CPUExecutionProvider"]
-            self.onnx_session = onnxruntime.InferenceSession(
-                self.cache_file(self.weights_file),
-                providers=providers,
-            )
+            try:
+                self.onnx_session = onnxruntime.InferenceSession(
+                    self.cache_file(self.weights_file),
+                    providers=providers,
+                )
+            except Exception as e:
+                self.clear_cache()
+                raise ModelArtefactError(
+                    f"Unable to load ONNX session. Cause: {e}"
+                ) from e
             logger.debug(f"Session created in {perf_counter() - t1_session} seconds")
 
             if REQUIRED_ONNX_PROVIDERS:


### PR DESCRIPTION
# Description

Added try/except around onnx session creation. An exception will now cause the model artifacts to be cleared from the cache so that a corrupt model file doesn't continue to cause problems.

This is to mitigate an error we see in production some times where, on model init, we see 
`INVALID_PROTOBUF : Load model from /tmp/cache/<dataset>/<version>/weights.onnx failed:Protobuf parsing failed.`

To test this, I manually deleted a few lines from a valid weights file. This simulates a corruption on download and induces the same protobuf parsing error. With the change in this PR, sending a single request to a model with a corrupted weights file clears the model cache and returns 500. A subsequent request causes the artifacts to be redownloaded, and the request succeeds. 

## Type of change

Please delete options that are not relevant.

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update
