### PR TITLE
Remove Legacy Cache Path

### DIFF
--- a/docs/quickstart/docker.md
+++ b/docs/quickstart/docker.md
@@ -131,7 +131,7 @@ Server in a container.
 
 You may add the flag `-e ROBOFLOW_API_KEY=<YOUR API KEY>` to your `docker run` command so that you do not need to provide a Roboflow API key in your requests. Substitute `<YOUR API KEY>` with your Roboflow API key. Learn how to retrieve your [Roboflow API key here](https://docs.roboflow.com/api-reference/authentication#retrieve-an-api-key).
 
-You may add the flag `-v $(pwd)/cache:/cache` to create a cache folder on your home device so that you do not need to redownload or recompile model artifacts upon inference container reboot. You can also (preferably) store artificats in a [docker volume](https://docs.docker.com/storage/volumes/) named `inference-cache` by adding the flag `-v inference-cache:/cache`.
+You may add the flag `-v $(pwd)/cache:/tmp/cache` to create a cache folder on your home device so that you do not need to redownload or recompile model artifacts upon inference container reboot. You can also (preferably) store artificats in a [docker volume](https://docs.docker.com/storage/volumes/) named `inference-cache` by adding the flag `-v inference-cache:/tmp/cache`.
 
 ### Advanced: Build a Docker Container from Scratch
 

--- a/inference/enterprise/parallel/run.sh
+++ b/inference/enterprise/parallel/run.sh
@@ -2,4 +2,4 @@
 # run from root of inference like ./inference/enterpise/parallel/run.sh
 PORT=${PORT:=9001}
 TAG="latest"
-docker run --rm --network=host --gpus=all --shm-size=8g --name inference-parallel -e NUM_CELERY_WORKERS=24 -e REDIS_HOST=localhost -e PORT=$PORT -v parallel:/cache -it roboflow/roboflow-inference-server-gpu-parallel:$TAG
+docker run --rm --network=host --gpus=all --shm-size=8g --name inference-parallel -e NUM_CELERY_WORKERS=24 -e REDIS_HOST=localhost -e PORT=$PORT -v parallel:/tmp/cache -it roboflow/roboflow-inference-server-gpu-parallel:$TAG

--- a/inference/models/doctr/doctr_model.py
+++ b/inference/models/doctr/doctr_model.py
@@ -37,16 +37,16 @@ class DocTR(RoboflowCoreModel):
         self.det_model = DocTRDet(api_key=kwargs.get("api_key"))
         self.rec_model = DocTRRec(api_key=kwargs.get("api_key"))
 
-        os.makedirs("/tmp/cache/doctr_rec/models/", exist_ok=True)
-        os.makedirs("/tmp/cache/doctr_det/models/", exist_ok=True)
+        os.makedirs(f"{MODEL_CACHE_DIR}/doctr_rec/models/", exist_ok=True)
+        os.makedirs(f"{MODEL_CACHE_DIR}/doctr_det/models/", exist_ok=True)
 
         shutil.copyfile(
-            "/tmp/cache/doctr_det/db_resnet50/model.pt",
-            "/tmp/cache/doctr_det/models/db_resnet50-ac60cadc.pt",
+            f"{MODEL_CACHE_DIR}/doctr_det/db_resnet50/model.pt",
+            f"{MODEL_CACHE_DIR}/doctr_det/models/db_resnet50-ac60cadc.pt",
         )
         shutil.copyfile(
-            "/tmp/cache/doctr_rec/crnn_vgg16_bn/model.pt",
-            "/tmp/cache/doctr_rec/models/crnn_vgg16_bn-9762b0b0.pt",
+            f"{MODEL_CACHE_DIR}/doctr_rec/crnn_vgg16_bn/model.pt",
+            f"{MODEL_CACHE_DIR}/doctr_rec/models/crnn_vgg16_bn-9762b0b0.pt",
         )
 
         self.model = ocr_predictor(

--- a/inference/models/gaze/gaze.py
+++ b/inference/models/gaze/gaze.py
@@ -22,6 +22,7 @@ from inference.core.entities.responses.gaze import (
 from inference.core.entities.responses.inference import FaceDetectionPrediction, Point
 from inference.core.env import (
     GAZE_MAX_BATCH_SIZE,
+    MODEL_CACHE_DIR,
     REQUIRED_ONNX_PROVIDERS,
     TENSORRT_CACHE_PATH,
 )
@@ -338,13 +339,15 @@ class L2C2Wrapper(L2CS):
         return yaw_radian, pitch_radian
 
     def load_L2CS_model(
-        self, file_path="/tmp/cache/gaze/L2CS/L2CSNet_gaze360_resnet50_90bins.pkl"
+        self,
+        file_path=f"{MODEL_CACHE_DIR}/gaze/L2CS/L2CSNet_gaze360_resnet50_90bins.pkl",
     ):
         super().load_state_dict(torch.load(file_path, map_location=self.device))
         super().to(self.device)
 
     def saveas_ONNX_model(
-        self, file_path="/tmp/cache/gaze/L2CS/L2CSNet_gaze360_resnet50_90bins.onnx"
+        self,
+        file_path=f"{MODEL_CACHE_DIR}/gaze/L2CS/L2CSNet_gaze360_resnet50_90bins.onnx",
     ):
         dummy_input = torch.randn(1, 3, 448, 448)
         dynamic_axes = {


### PR DESCRIPTION
# Description

Removed all references to legacy cache path `/cache` and replaced with `/tmp/cache`. Also removed hard coded instances of `/tmp/cache` and replaced with env var `MODEL_CACHE_DIR`.

## Type of change

Please delete options that are not relevant.

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update
