### PR TITLE
Change the default value for 'only_top_classes' option of close-to-threshold sampling strategy of AL

### DIFF
--- a/docs/enterprise/active-learning/close_to_threshold_sampling.md
+++ b/docs/enterprise/active-learning/close_to_threshold_sampling.md
@@ -30,7 +30,7 @@ selected classes must be close to the threshold to accept the datapoint. If give
 (Optional - with default to `1`)
 * `only_top_classes`: (used for classification predictions only) Flag to decide whether only the `top` or 
 `predicted_classes` (for multi-class/multi-label cases, respectively) should be considered. This helps avoid sampling 
-based on non-leading classes in predictions.
+based on non-leading classes in predictions. Default: `True`.
 * `tags`: list of tags (each contains 1-64 characters from range `a-z, A-Z, 0-9, and -_:/.[]<>{}@`) (optional)
 
 ## Example

--- a/inference/core/active_learning/README.md
+++ b/inference/core/active_learning/README.md
@@ -133,7 +133,7 @@ selected classes must be close to the threshold to accept the datapoint. If give
 (Optional - with default to `1`)
 * `only_top_classes`: (used for classification predictions only) Flag to decide whether only the `top` or 
 `predicted_classes` (for multi-class/multi-label cases, respectively) should be considered. This helps avoid sampling 
-based on non-leading classes in predictions.
+based on non-leading classes in predictions. Default: `True`.
 * `tags`: list of tags (each contains 1-64 characters from range `a-z, A-Z, 0-9, and -_:/.[]<>{}@`) (optional)
 
 #### Configuration example

--- a/inference/core/active_learning/samplers/close_to_threshold.py
+++ b/inference/core/active_learning/samplers/close_to_threshold.py
@@ -37,7 +37,7 @@ def initialize_close_to_threshold_sampling(
             selected_class_names=selected_class_names,
             threshold=strategy_config["threshold"],
             epsilon=strategy_config["epsilon"],
-            only_top_classes=strategy_config.get("only_top_classes", False),
+            only_top_classes=strategy_config.get("only_top_classes", True),
             minimum_objects_close_to_threshold=strategy_config.get(
                 "minimum_objects_close_to_threshold",
                 1,

--- a/tests/inference/unit_tests/core/active_learning/samplers/test_close_to_threshold.py
+++ b/tests/inference/unit_tests/core/active_learning/samplers/test_close_to_threshold.py
@@ -684,7 +684,7 @@ def test_initialize_close_to_threshold_sampling_when_classes_not_selected(
         selected_class_names=None,
         threshold=0.75,
         epsilon=0.25,
-        only_top_classes=False,
+        only_top_classes=True,
         minimum_objects_close_to_threshold=1,
         probability=0.6,
     )
@@ -712,7 +712,7 @@ def test_initialize_close_to_threshold_sampling_when_classes_selected(
         selected_class_names={"Ambulance", "Helicopter"},
         threshold=0.75,
         epsilon=0.25,
-        only_top_classes=False,
+        only_top_classes=True,
         minimum_objects_close_to_threshold=1,
         probability=0.6,
     )
@@ -729,7 +729,7 @@ def test_initialize_close_to_threshold_sampling_when_only_top_classes_mode_enabl
         "threshold": 0.75,
         "epsilon": 0.25,
         "probability": 0.6,
-        "only_top_classes": True,
+        "only_top_classes": False,
     }
 
     # when
@@ -741,7 +741,7 @@ def test_initialize_close_to_threshold_sampling_when_only_top_classes_mode_enabl
         selected_class_names={"Ambulance"},
         threshold=0.75,
         epsilon=0.25,
-        only_top_classes=True,
+        only_top_classes=False,
         minimum_objects_close_to_threshold=1,
         probability=0.6,
     )
@@ -770,7 +770,7 @@ def test_initialize_close_to_threshold_sampling_when_objects_close_to_threshold_
         selected_class_names={"Ambulance"},
         threshold=0.75,
         epsilon=0.25,
-        only_top_classes=False,
+        only_top_classes=True,
         minimum_objects_close_to_threshold=6,
         probability=0.6,
     )


### PR DESCRIPTION
# Description

As discussed with @robiscoding - default for close-to-threshold strategy should be `only_top_classes=True` for classification tasks.

List any dependencies that are required for this change.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [x] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

YOUR_ANSWER

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [x] Docs updated? What were the changes:
