### PR TITLE
updated API_KEY to ROBOFLOW_API_KEY for clarity

### DIFF
--- a/docs/foundation/gaze.md
+++ b/docs/foundation/gaze.md
@@ -26,10 +26,10 @@ import requests
 import os
 
 IMG_PATH = "image.jpg"
-API_KEY = os.environ["API_KEY"]
+ROBOFLOW_API_KEY = os.environ["ROBOFLOW_API_KEY"]
 DISTANCE_TO_OBJECT = 1000  # mm
 HEIGHT_OF_HUMAN_FACE = 250  # mm
-GAZE_DETECTION_URL = "http://127.0.0.1:9001/gaze/gaze_detection?api_key=" + API_KEY
+GAZE_DETECTION_URL = "http://127.0.0.1:9001/gaze/gaze_detection?api_key=" + ROBOFLOW_API_KEY
 
 def detect_gazes(frame: np.ndarray):
     img_encode = cv2.imencode(".jpg", frame)[1]
@@ -37,7 +37,7 @@ def detect_gazes(frame: np.ndarray):
     resp = requests.post(
         GAZE_DETECTION_URL,
         json={
-            "api_key": API_KEY,
+            "api_key": ROBOFLOW_API_KEY,
             "image": {"type": "base64", "value": img_base64.decode("utf-8")},
         },
     )

--- a/examples/gaze-detection/README.md
+++ b/examples/gaze-detection/README.md
@@ -13,12 +13,12 @@ git clone https://github.com/roboflow/inference
 cd inference/examples/gaze-detection
 ```
 
-Next, set up a Python environment and install the required project dependencies:
+Next, set up a Python environment and install the required project dependencies (this assumes running these bash commands from the above terminal window install):
 
 ```bash
 python3 -m venv venv
 source venv/bin/activate
-pip install -r requirements.txt
+pip install -r ../../requirements/_requirements.txt
 ```
 
 Next, set up a Roboflow Inference Docker container. This Docker container will manage inference for the gaze detection system. [Learn how to set up an Inference Docker container](https://inference.roboflow.com/quickstart/docker/).

--- a/examples/gaze-detection/gaze.py
+++ b/examples/gaze-detection/gaze.py
@@ -6,10 +6,10 @@ import requests
 import os
 
 IMG_PATH = "image.jpg"
-API_KEY = os.environ["API_KEY"]
+ROBOFLOW_API_KEY = os.environ["ROBOFLOW_API_KEY"]
 DISTANCE_TO_OBJECT = 1000  # mm
 HEIGHT_OF_HUMAN_FACE = 250  # mm
-GAZE_DETECTION_URL = "http://127.0.0.1:9001/gaze/gaze_detection?api_key=" + API_KEY
+GAZE_DETECTION_URL = "http://127.0.0.1:9001/gaze/gaze_detection?api_key=" + ROBOFLOW_API_KEY
 
 
 def detect_gazes(frame: np.ndarray):
@@ -18,7 +18,7 @@ def detect_gazes(frame: np.ndarray):
     resp = requests.post(
         GAZE_DETECTION_URL,
         json={
-            "api_key": API_KEY,
+            "api_key": ROBOFLOW_API_KEY,
             "image": {"type": "base64", "value": img_base64.decode("utf-8")},
         },
     )


### PR DESCRIPTION
# Description

I updated the gaze_detection example such that the API_KEY is named as ROBOFLOW_API_KEY as this is what the examples in the docs (https://inference.roboflow.com/foundation/gaze/#how-to-use-l2cs-net and https://github.com/roboflow/inference/tree/main/examples/gaze-detection) name the environment variable for the Roboflow API key

## Type of change

Please delete options that are not relevant.

-   [ X ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Yes, I've tried this change locally.

## Any specific deployment considerations

None

## Docs

-   [ ] Docs updated? What were the changes:

This change makes the gaze_detection example work with the docs as-is.
