### PR TITLE
Catch CLI Error When Docker Is Not Running

### DIFF
--- a/inference_cli/lib/container_adapter.py
+++ b/inference_cli/lib/container_adapter.py
@@ -8,7 +8,12 @@ from rich.progress import Progress, TaskID
 import docker
 from inference_cli.lib.utils import read_env_file
 
-docker_client = docker.from_env()
+try:
+    docker_client = docker.from_env()
+except docker.errors.DockerException as e:
+    raise (
+        "Error connecting to Docker daemon. Is docker installed and running? See https://www.docker.com/get-started/ for installation instructions."
+    ) from e
 
 
 def ask_user_to_kill_container(container: Container) -> bool:


### PR DESCRIPTION
# Description

Added logic to catch when docker is not installed and point users in the right direction

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [X] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update
