### PR TITLE
API Key Not Required by Methods

### DIFF
--- a/inference/core/interfaces/stream/inference_pipeline.py
+++ b/inference/core/interfaces/stream/inference_pipeline.py
@@ -142,13 +142,6 @@ class InferencePipeline:
         """
         if api_key is None:
             api_key = API_KEY
-        if api_key is None:
-            raise MissingApiKeyError(
-                "Could not initialise InferencePipeline, as API key is missing either in initializer parameters "
-                f"or in one one of allowed env variables: {API_KEY_ENV_NAMES}. "
-                f"Visit https://docs.roboflow.com/api-reference/authentication#retrieve-an-api-key to learn how to "
-                f"retrieve one."
-            )
         if status_update_handlers is None:
             status_update_handlers = []
         inference_config = ObjectDetectionInferenceConfig.init(

--- a/inference/core/interfaces/stream/stream.py
+++ b/inference/core/interfaces/stream/stream.py
@@ -100,13 +100,6 @@ class Stream(BaseInterface):
         if not self.model_id:
             raise ValueError("MODEL_ID is not defined")
         self.api_key = api_key
-        if not self.api_key:
-            raise ValueError(
-                f"API key is missing. Either pass it explicitly to constructor, or use one of env variables: "
-                f"{API_KEY_ENV_NAMES}. Visit "
-                f"https://docs.roboflow.com/api-reference/authentication#retrieve-an-api-key to learn how to generate "
-                f"the key."
-            )
 
         self.active_learning_middleware = NullActiveLearningMiddleware()
         if isinstance(model, str):

--- a/inference/core/models/roboflow.py
+++ b/inference/core/models/roboflow.py
@@ -121,15 +121,6 @@ class RoboflowInferenceModel(Model):
         self.load_weights = load_weights
         self.metrics = {"num_inferences": 0, "avg_inference_time": 0.0}
         self.api_key = api_key if api_key else API_KEY
-        if not self.api_key and not (
-            AWS_SECRET_ACCESS_KEY and AWS_ACCESS_KEY_ID and LAMBDA
-        ):
-            raise MissingApiKeyError(
-                "No API Key Found, must provide an API Key in each request or as an environment "
-                f"variable on server startup. Supported variables: {API_KEY_ENV_NAMES}. "
-                f"Visit https://docs.roboflow.com/api-reference/authentication#retrieve-an-api-key to learn how to "
-                f"retrieve the key."
-            )
         model_id = resolve_roboflow_model_alias(model_id=model_id)
         self.dataset_id, self.version_id = model_id.split("/")
         self.endpoint = model_id

--- a/inference/core/registries/roboflow.py
+++ b/inference/core/registries/roboflow.py
@@ -5,7 +5,11 @@ from inference.core.cache import cache
 from inference.core.devices.utils import GLOBAL_DEVICE_ID
 from inference.core.entities.types import DatasetID, ModelType, TaskType, VersionID
 from inference.core.env import MODEL_CACHE_DIR
-from inference.core.exceptions import MissingApiKeyError, ModelNotRecognisedError
+from inference.core.exceptions import (
+    MissingApiKeyError,
+    ModelArtefactError,
+    ModelNotRecognisedError,
+)
 from inference.core.logger import logger
 from inference.core.models.base import Model
 from inference.core.registries.base import ModelRegistry
@@ -108,8 +112,12 @@ def get_model_type(
         endpoint_type=ModelEndpointType.ORT,
         device_id=GLOBAL_DEVICE_ID,
     ).get("ort")
+    if api_data is None:
+        raise ModelArtefactError("Error loading model artifacts from Roboflow API.")
     project_task_type = api_data.get("type", "object-detection")
     model_type = api_data.get("modelType")
+    if model_type is None or project_task_type is None:
+        raise ModelArtefactError("Error loading model artifacts from Roboflow API.")
     save_model_metadata_in_cache(
         dataset_id=dataset_id,
         version_id=version_id,

--- a/inference/core/registries/roboflow.py
+++ b/inference/core/registries/roboflow.py
@@ -5,7 +5,7 @@ from inference.core.cache import cache
 from inference.core.devices.utils import GLOBAL_DEVICE_ID
 from inference.core.entities.types import DatasetID, ModelType, TaskType, VersionID
 from inference.core.env import MODEL_CACHE_DIR
-from inference.core.exceptions import ModelNotRecognisedError
+from inference.core.exceptions import MissingApiKeyError, ModelNotRecognisedError
 from inference.core.logger import logger
 from inference.core.models.base import Model
 from inference.core.registries.base import ModelRegistry
@@ -13,7 +13,9 @@ from inference.core.roboflow_api import (
     MODEL_TYPE_KEY,
     PROJECT_TASK_TYPE_KEY,
     ModelEndpointType,
+    get_roboflow_dataset_type,
     get_roboflow_model_data,
+    get_roboflow_workspace,
 )
 from inference.core.utils.file_system import dump_json, read_json
 from inference.core.utils.roboflow import get_model_id_chunks
@@ -83,7 +85,23 @@ def get_model_type(
     )
     if cached_metadata is not None:
         return cached_metadata[0], cached_metadata[1]
-
+    if version_id == STUB_VERSION_ID:
+        if api_key is None:
+            raise MissingApiKeyError(
+                "Stub model version provided but no API key was provided. API key is required to load stub models."
+            )
+        workspace_id = get_roboflow_workspace(api_key=api_key)
+        project_task_type = get_roboflow_dataset_type(
+            api_key=api_key, workspace_id=workspace_id, dataset_id=dataset_id
+        )
+        model_type = "stub"
+        save_model_metadata_in_cache(
+            dataset_id=dataset_id,
+            version_id=version_id,
+            project_task_type=project_task_type,
+            model_type=model_type,
+        )
+        return project_task_type, model_type
     api_data = get_roboflow_model_data(
         api_key=api_key,
         model_id=model_id,
@@ -92,6 +110,12 @@ def get_model_type(
     ).get("ort")
     project_task_type = api_data.get("type", "object-detection")
     model_type = api_data.get("modelType")
+    save_model_metadata_in_cache(
+        dataset_id=dataset_id,
+        version_id=version_id,
+        project_task_type=project_task_type,
+        model_type=model_type,
+    )
 
     return project_task_type, model_type
 

--- a/inference/core/roboflow_api.py
+++ b/inference/core/roboflow_api.py
@@ -8,6 +8,7 @@ from requests import Response
 from requests_toolbelt import MultipartEncoder
 
 from inference.core import logger
+from inference.core.cache import cache
 from inference.core.entities.types import (
     DatasetID,
     ModelType,
@@ -183,16 +184,33 @@ def get_roboflow_model_data(
     endpoint_type: ModelEndpointType,
     device_id: str,
 ) -> dict:
-    api_url = _add_params_to_url(
-        url=f"{API_BASE_URL}/{endpoint_type.value}/{model_id}",
-        params=[
-            ("api_key", api_key),
+    api_data_cache_key = f"roboflow_api_data:{endpoint_type.value}:{model_id}"
+    api_data = cache.get(api_data_cache_key)
+    if api_data is not None:
+        logger.debug(f"Loaded model data from cache with key: {api_data_cache_key}.")
+        return api_data
+    else:
+        params = [
             ("nocache", "true"),
             ("device", device_id),
             ("dynamic", "true"),
-        ],
-    )
-    return _get_from_url(url=api_url)
+        ]
+        if api_key is not None:
+            params.append(("api_key", api_key))
+        api_url = _add_params_to_url(
+            url=f"{API_BASE_URL}/{endpoint_type.value}/{model_id}",
+            params=params,
+        )
+        api_data = _get_from_url(url=api_url)
+        cache.set(
+            api_data_cache_key,
+            api_data,
+            expire=60,
+        )
+        logger.debug(
+            f"Loaded model data from Roboflow API and saved to cache with key: {api_data_cache_key}."
+        )
+        return api_data
 
 
 @wrap_roboflow_api_errors()

--- a/inference/core/roboflow_api.py
+++ b/inference/core/roboflow_api.py
@@ -205,7 +205,7 @@ def get_roboflow_model_data(
         cache.set(
             api_data_cache_key,
             api_data,
-            expire=60,
+            expire=10,
         )
         logger.debug(
             f"Loaded model data from Roboflow API and saved to cache with key: {api_data_cache_key}."

--- a/inference/models/utils.py
+++ b/inference/models/utils.py
@@ -169,12 +169,5 @@ except:
 
 
 def get_roboflow_model(model_id, api_key=API_KEY, **kwargs):
-    if not api_key:
-        raise MissingApiKeyError(
-            "No API Key Found, must provide an API Key via key word argument 'api_key' or as an "
-            f"environment variable on server startup. Supported variables: {API_KEY_ENV_NAMES}. "
-            f"Visit https://docs.roboflow.com/api-reference/authentication#retrieve-an-api-key to learn how to "
-            f"retrieve the key."
-        )
     task, model = get_model_type(model_id, api_key=api_key)
     return ROBOFLOW_MODEL_TYPES[(task, model)](model_id, api_key=api_key, **kwargs)

--- a/tests/inference/unit_tests/core/test_roboflow_api.py
+++ b/tests/inference/unit_tests/core/test_roboflow_api.py
@@ -564,10 +564,9 @@ def test_get_roboflow_model_data_when_wrong_api_key_used(requests_mock: Mocker) 
         )
 
     # then
-    assert (
-        requests_mock.last_request.query
-        == "api_key=my_api_key&nocache=true&device=some&dynamic=true"
-    )
+    params = ["api_key=my_api_key", "nocache=true", "device=some", "dynamic=true"]
+    for param in params:
+        assert param in requests_mock.last_request.query
 
 
 def test_get_roboflow_model_data_when_wrong_model_used(requests_mock: Mocker) -> None:
@@ -587,10 +586,9 @@ def test_get_roboflow_model_data_when_wrong_model_used(requests_mock: Mocker) ->
         )
 
     # then
-    assert (
-        requests_mock.last_request.query
-        == "api_key=my_api_key&nocache=true&device=some&dynamic=true"
-    )
+    params = ["api_key=my_api_key", "nocache=true", "device=some", "dynamic=true"]
+    for param in params:
+        assert param in requests_mock.last_request.query
 
 
 def test_get_roboflow_model_data_when_http_error_occurs(requests_mock: Mocker) -> None:
@@ -610,10 +608,9 @@ def test_get_roboflow_model_data_when_http_error_occurs(requests_mock: Mocker) -
         )
 
     # then
-    assert (
-        requests_mock.last_request.query
-        == "api_key=my_api_key&nocache=true&device=some&dynamic=true"
-    )
+    params = ["api_key=my_api_key", "nocache=true", "device=some", "dynamic=true"]
+    for param in params:
+        assert param in requests_mock.last_request.query
 
 
 def test_get_roboflow_model_data_when_response_parsing_error_occurs(
@@ -635,10 +632,9 @@ def test_get_roboflow_model_data_when_response_parsing_error_occurs(
         )
 
     # then
-    assert (
-        requests_mock.last_request.query
-        == "api_key=my_api_key&nocache=true&device=some&dynamic=true"
-    )
+    params = ["api_key=my_api_key", "nocache=true", "device=some", "dynamic=true"]
+    for param in params:
+        assert param in requests_mock.last_request.query
 
 
 def test_get_roboflow_model_data_when_valid_response_expected(
@@ -673,10 +669,10 @@ def test_get_roboflow_model_data_when_valid_response_expected(
     )
 
     # then
-    assert (
-        requests_mock.last_request.query
-        == "api_key=my_api_key&nocache=true&device=some&dynamic=true"
-    )
+    params = ["api_key=my_api_key", "nocache=true", "device=some", "dynamic=true"]
+    for param in params:
+        assert param in requests_mock.last_request.query
+
     assert result == expected_response
 
 


### PR DESCRIPTION
# Description

Updated api logic so that an api key is not required by `inference` methods. Instead, when an api key is required by a Roboflow API but not provided, an exception will be raised. This accommodates the new public coco models that do not require an api key.

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [X] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Local dev scripts and automated GH actions
