### PR TITLE
Fix problem with keyless access and Active Learning

### DIFF
--- a/inference/__init__.py
+++ b/inference/__init__.py
@@ -1,3 +1,3 @@
-from inference.core.interfaces.stream.stream import Stream
+from inference.core.interfaces.stream.stream import Stream  # isort:skip
 from inference.core.interfaces.stream.inference_pipeline import InferencePipeline
 from inference.models.utils import get_roboflow_model

--- a/inference/core/interfaces/stream/inference_pipeline.py
+++ b/inference/core/interfaces/stream/inference_pipeline.py
@@ -127,7 +127,9 @@ class InferencePipeline:
             active_learning_enabled (Optional[bool]): Flag to enable / disable Active Learning middleware (setting it
                 true does not guarantee any data to be collected, as data collection is controlled by Roboflow backend -
                 it just enables middleware intercepting predictions). If not given, env variable
-                `ACTIVE_LEARNING_ENABLED` will be used.
+                `ACTIVE_LEARNING_ENABLED` will be used. Please point out that Active Learning will be forcefully
+                disabled in a scenario when Roboflow API key is not given, as Roboflow account is required
+                for this feature to be operational.
 
         Other ENV variables involved in low-level configuration:
         * INFERENCE_PIPELINE_PREDICTIONS_QUEUE_SIZE - size of buffer for predictions that are ready for dispatching
@@ -170,6 +172,11 @@ class InferencePipeline:
                 f"with value: {ACTIVE_LEARNING_ENABLED}"
             )
             active_learning_enabled = ACTIVE_LEARNING_ENABLED
+        if api_key is None:
+            logger.info(
+                f"Roboflow API key not given - Active Learning is forced to be disabled."
+            )
+            active_learning_enabled = False
         if active_learning_enabled is True:
             active_learning_middleware = ThreadingActiveLearningMiddleware.init(
                 api_key=api_key,

--- a/inference/core/managers/active_learning.py
+++ b/inference/core/managers/active_learning.py
@@ -34,7 +34,7 @@ class ActiveLearningManager(ModelManager):
             model_id=model_id, request=request
         )
         active_learning_eligible = kwargs.get(ACTIVE_LEARNING_ELIGIBLE_PARAM, False)
-        if not active_learning_eligible:
+        if not active_learning_eligible or request.api_key is None:
             return prediction
         self.register(prediction=prediction, model_id=model_id, request=request)
         return prediction

--- a/inference/enterprise/stream_management/api/entities.py
+++ b/inference/enterprise/stream_management/api/entities.py
@@ -51,7 +51,7 @@ class PipelineInitialisationRequest(BaseModel):
     sink_configuration: UDPSinkConfiguration = Field(
         description="Configuration of the sink."
     )
-    api_key: str = Field(description="Roboflow API key")
+    api_key: Optional[str] = Field(description="Roboflow API key", default=None)
     max_fps: Optional[Union[float, int]] = Field(
         description="Limit of FPS in video processing.", default=None
     )

--- a/inference/enterprise/stream_management/manager/inference_pipeline_manager.py
+++ b/inference/enterprise/stream_management/manager/inference_pipeline_manager.py
@@ -115,7 +115,7 @@ class InferencePipelineManager(Process):
                 model_id=payload["model_id"],
                 video_reference=payload["video_reference"],
                 on_prediction=sink,
-                api_key=payload["api_key"],
+                api_key=payload.get("api_key"),
                 max_fps=payload.get("max_fps"),
                 watchdog=watchdog,
                 source_buffer_filling_strategy=source_buffer_filling_strategy,

--- a/inference_sdk/http/client.py
+++ b/inference_sdk/http/client.py
@@ -478,7 +478,7 @@ class InferenceHTTPClient:
             )
         payload = self.__initialise_payload()
         payload["subject_type"] = subject_type
-        payload["prompt_type"] = subject_type
+        payload["prompt_type"] = prompt_type
         if subject_type == "image":
             encoded_image = load_static_inference_input(
                 inference_input=subject,

--- a/tests/inference/unit_tests/enterprise/stream_management/api/test_app.py
+++ b/tests/inference/unit_tests/enterprise/stream_management/api/test_app.py
@@ -178,6 +178,44 @@ def test_initialise_pipeline_when_valid_payload_given(
 
 
 @mock.patch.object(app, "STREAM_MANAGER_CLIENT", new_callable=AsyncMock)
+def test_initialise_pipeline_when_valid_payload_given_without_api_key(
+    stream_manager_client: AsyncMock,
+) -> None:
+    # given
+    client = TestClient(app.app)
+    stream_manager_client.initialise_pipeline.return_value = CommandResponse(
+        status="success",
+        context=CommandContext(request_id="my_request", pipeline_id="my_pipeline"),
+    )
+
+    # when
+    response = client.post(
+        "/initialise",
+        json={
+            "model_id": "some/1",
+            "video_reference": "rtsp://some:543",
+            "sink_configuration": {
+                "type": "udp_sink",
+                "host": "127.0.0.1",
+                "port": 9090,
+            },
+            "model_configuration": {"type": "object-detection"},
+            "active_learning_enabled": True,
+        },
+    )
+
+    # then
+    assert response.status_code == 200, "Status code for success must be 200"
+    assert response.json() == {
+        "status": "success",
+        "context": {
+            "request_id": "my_request",
+            "pipeline_id": "my_pipeline",
+        },
+    }, "CommandResponse must be serialised directly to JSON response"
+
+
+@mock.patch.object(app, "STREAM_MANAGER_CLIENT", new_callable=AsyncMock)
 def test_pause_pipeline_when_successful_response_expected(
     stream_manager_client: AsyncMock,
 ) -> None:

--- a/tests/inference/unit_tests/enterprise/stream_management/manager/test_inference_pipeline_manager.py
+++ b/tests/inference/unit_tests/enterprise/stream_management/manager/test_inference_pipeline_manager.py
@@ -60,7 +60,7 @@ def test_inference_pipeline_manager_when_init_pipeline_operation_is_requested(
 
 @pytest.mark.timeout(30)
 @mock.patch.object(inference_pipeline_manager.InferencePipeline, "init")
-def test_inference_pipeline_manager_when_init_pipeline_operation_is_requested_but_invalid_payload_sent(
+def test_inference_pipeline_manager_when_init_pipeline_operation_is_requested_without_api_key(
     pipeline_init_mock: MagicMock,
 ) -> None:
     # given
@@ -70,7 +70,7 @@ def test_inference_pipeline_manager_when_init_pipeline_operation_is_requested_bu
         command_queue=command_queue, responses_queue=responses_queue
     )
     init_payload = assembly_valid_init_payload()
-    del init_payload["model_configuration"]
+    del init_payload["api_key"]
 
     # when
     command_queue.put(("1", init_payload))
@@ -82,24 +82,18 @@ def test_inference_pipeline_manager_when_init_pipeline_operation_is_requested_bu
     status_2 = responses_queue.get()
 
     # then
-    assert (
-        status_1[0] == "1"
-    ), "First request should be reported in responses_queue at first"
-    assert (
-        status_1[1]["status"] == OperationStatus.FAILURE
-    ), "Init operation should fail"
-    assert (
-        status_1[1]["error_type"] == ErrorType.INVALID_PAYLOAD
-    ), "Invalid Payload error is expected"
+    assert status_1 == (
+        "1",
+        {"status": OperationStatus.SUCCESS},
+    ), "Initialisation operation must succeed"
     assert status_2 == (
         "2",
         {"status": OperationStatus.SUCCESS},
-    ), "Termination of pipeline must happen"
-
+    ), "Termination operation must succeed"
 
 @pytest.mark.timeout(30)
 @mock.patch.object(inference_pipeline_manager.InferencePipeline, "init")
-def test_inference_pipeline_manager_when_init_pipeline_operation_is_requested_but_api_key_not_given(
+def test_inference_pipeline_manager_when_init_pipeline_operation_is_requested_but_invalid_payload_sent(
     pipeline_init_mock: MagicMock,
 ) -> None:
     # given
@@ -109,7 +103,7 @@ def test_inference_pipeline_manager_when_init_pipeline_operation_is_requested_bu
         command_queue=command_queue, responses_queue=responses_queue
     )
     init_payload = assembly_valid_init_payload()
-    del init_payload["api_key"]
+    del init_payload["model_configuration"]
 
     # when
     command_queue.put(("1", init_payload))


### PR DESCRIPTION
# Description

* Disable active learning each time api key is not used
* Fix malformed payload in clip compare
* Fix double invocation of AL registration in AL middleware

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

YOUR_ANSWER

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
