### PR TITLE
Apply fix for post-processing of keypoints

### DIFF
--- a/inference/core/interfaces/http/http_api.py
+++ b/inference/core/interfaces/http/http_api.py
@@ -582,8 +582,7 @@ class HttpInterface(BaseInterface):
                 Returns:
                     Union[ClassificationInferenceResponse, MultiLabelClassificationInferenceResponse]: The response containing the inference results.
                 """
-
-                return process_inference_request(inference_request)
+                return await process_inference_request(inference_request)
 
         if CORE_MODELS_ENABLED:
             if CORE_MODEL_CLIP_ENABLED:

--- a/inference/core/models/keypoints_detection_base.py
+++ b/inference/core/models/keypoints_detection_base.py
@@ -142,13 +142,13 @@ class KeypointsDetectionBaseOnnxRoboflowInferenceModel(
                             "width": pred[2] - pred[0],
                             "height": pred[3] - pred[1],
                             "confidence": pred[4],
-                            "class": self.class_names[int(pred[4 + len(self.get_class_names)])],
-                            "class_id": int(pred[4 + len(self.get_class_names)]),
+                            "class": self.class_names[int(pred[6])],
+                            "class_id": int(pred[6]),
                             "keypoints": self._model_keypoints_to_response(
-                                keypoints=pred[
-                                    -(len(pred) - 5 - len(self.get_class_names)) :
-                                ],
-                                predicted_object_class_id=int(pred[4 + len(self.get_class_names)]),
+                                keypoints=pred[7:],
+                                predicted_object_class_id=int(
+                                    pred[4 + len(self.get_class_names)]
+                                ),
                                 keypoint_confidence_threshold=keypoint_confidence_threshold,
                             ),
                         }

--- a/inference/core/models/keypoints_detection_base.py
+++ b/inference/core/models/keypoints_detection_base.py
@@ -126,7 +126,6 @@ class KeypointsDetectionBaseOnnxRoboflowInferenceModel(
         Returns:
             List[KeypointsDetectionInferenceResponse]: A list of response objects containing keypoints detection predictions.
         """
-
         if isinstance(img_dims, dict) and "img_dims" in img_dims:
             img_dims = img_dims["img_dims"]
         keypoint_confidence_threshold = 0.0
@@ -143,13 +142,13 @@ class KeypointsDetectionBaseOnnxRoboflowInferenceModel(
                             "width": pred[2] - pred[0],
                             "height": pred[3] - pred[1],
                             "confidence": pred[4],
-                            "class": self.class_names[int(pred[6])],
-                            "class_id": int(pred[6]),
+                            "class": self.class_names[int(pred[4 + len(self.get_class_names)])],
+                            "class_id": int(pred[4 + len(self.get_class_names)]),
                             "keypoints": self._model_keypoints_to_response(
                                 keypoints=pred[
-                                    -(len(pred) - 6 - len(self.get_class_names)) :
+                                    -(len(pred) - 5 - len(self.get_class_names)) :
                                 ],
-                                predicted_object_class_id=int(pred[6]),
+                                predicted_object_class_id=int(pred[4 + len(self.get_class_names)]),
                                 keypoint_confidence_threshold=keypoint_confidence_threshold,
                             ),
                         }

--- a/inference/core/nms.py
+++ b/inference/core/nms.py
@@ -17,7 +17,8 @@ def w_np_non_max_suppression(
     """Applies non-maximum suppression to predictions.
 
     Args:
-        prediction (np.ndarray): Array of predictions.
+        prediction (np.ndarray): Array of predictions. Format for single prediction is
+            [bbox x 4, max_class_confidence, (confidence) x num_of_classes, additional_element x num_masks]
         conf_thresh (float, optional): Confidence threshold. Defaults to 0.25.
         iou_thresh (float, optional): IOU threshold. Defaults to 0.45.
         class_agnostic (bool, optional): Whether to ignore class labels. Defaults to False.
@@ -28,7 +29,9 @@ def w_np_non_max_suppression(
         box_format (str, optional): Format of bounding boxes. Either 'xywh' or 'xyxy'. Defaults to 'xywh'.
 
     Returns:
-        list: List of filtered predictions after non-maximum suppression.
+        list: List of filtered predictions after non-maximum suppression. Format of a single result is:
+            [bbox x 4, max_class_confidence, max_class_confidence, id_of_class_with_max_confidence,
+            additional_element x num_masks]
     """
     num_classes = prediction.shape[2] - 5 - num_masks
 


### PR DESCRIPTION
# Description

Initially I misunderstood the outputs from pose model. For example, in case of YOLOv8:
* model outputs `[bs, [bbox x 4, cls_confidence x num_classes, (kp_x, kp_y, visibility) * keypoints_number], 8400 (defined at export level]` - visibility is only defined if data.yml defines it, but **we assume it's always the case**
* we change that into `[bs, 8400, [bbox x 4, max_class_confidence, cls_confidence x num_classes, (kp_x, kp_y, visibility) * keypoints_number]]`
* then, while NMS, we do `[bs, qualified_boxes, [bbox x 4, max_class_confidence, max_class_confidence, winning_class_id, (kp_x, kp_y, visibility) * keypoints_number]]`
* effectively, in the post-processing we have
  * bbox coordinates at `predictions[batch][detection][0:4]`
  * bbox confidence at `predictions[batch][detection][4] or predictions[batch][detection][5]`
  * class id at `predictions[batch][detection][6]`
  * keypoints at `predictions[batch][detection][7:]`

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

YOUR_ANSWER

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
