### PR TITLE
Add API parameter preventing AL feature to capture data for single request

### DIFF
--- a/docs/inference_sdk/http_client.md
+++ b/docs/inference_sdk/http_client.md
@@ -364,6 +364,8 @@ based on model confidence
 * `service_secret`
 * `disable_preproc_auto_orientation`, `disable_preproc_contrast`, `disable_preproc_grayscale`, 
 `disable_preproc_static_crop` to alter server-side pre-processing
+* `disable_active_learning` to prevent Active Learning feature from registering the datapoint (can be useful for 
+instance while testing model)
 
 
 ### Classification model in `v1` mode:
@@ -372,6 +374,8 @@ based on model confidence
 * `stroke_width`: width of stroke in visualisation
 * `disable_preproc_auto_orientation`, `disable_preproc_contrast`, `disable_preproc_grayscale`, 
 `disable_preproc_static_crop` to alter server-side pre-processing
+* `disable_active_learning` to prevent Active Learning feature from registering the datapoint (can be useful for 
+instance while testing model)
 
 
 ### Object detection model in `v1` mode:
@@ -387,7 +391,8 @@ based on model confidence
 * `max_candidates`: max candidates to post-processing from model
 * `disable_preproc_auto_orientation`, `disable_preproc_contrast`, `disable_preproc_grayscale`, 
 `disable_preproc_static_crop` to alter server-side pre-processing
-
+* `disable_active_learning` to prevent Active Learning feature from registering the datapoint (can be useful for 
+instance while testing model)
 
 ### Keypoints detection model in `v1` mode:
 * `visualize_predictions`: flag to enable / disable visualisation
@@ -404,7 +409,8 @@ based on model confidence
 * `max_candidates`: max candidates to post-processing from model
 * `disable_preproc_auto_orientation`, `disable_preproc_contrast`, `disable_preproc_grayscale`, 
 `disable_preproc_static_crop` to alter server-side pre-processing
-
+* `disable_active_learning` to prevent Active Learning feature from registering the datapoint (can be useful for 
+instance while testing model)
 
 ### Instance segmentation model in `v1` mode:
 * `visualize_predictions`: flag to enable / disable visualisation
@@ -421,6 +427,9 @@ based on model confidence
 `disable_preproc_static_crop` to alter server-side pre-processing
 * `mask_decode_mode`
 * `tradeoff_factor`
+* `disable_active_learning` to prevent Active Learning feature from registering the datapoint (can be useful for 
+instance while testing model)
+
 
 ### Configuration of client
 * `output_visualisation_format`: one of (`VisualisationResponseFormat.BASE64`, `VisualisationResponseFormat.NUMPY`, 

--- a/inference/core/entities/requests/inference.py
+++ b/inference/core/entities/requests/inference.py
@@ -145,6 +145,11 @@ class ObjectDetectionInferenceRequest(CVInferenceRequest):
         example=False,
         description="If true, the predictions will be drawn on the original image and returned as a base64 string",
     )
+    disable_active_learning: Optional[bool] = Field(
+        default=False,
+        example=False,
+        description="If true, the predictions will be prevented from registration by Active Learning (if the functionality is enabled)",
+    )
 
 
 class KeypointsDetectionInferenceRequest(ObjectDetectionInferenceRequest):
@@ -198,6 +203,11 @@ class ClassificationInferenceRequest(CVInferenceRequest):
         default=False,
         example=False,
         description="If true, the predictions will be drawn on the original image and returned as a base64 string",
+    )
+    disable_active_learning: Optional[bool] = Field(
+        default=False,
+        example=False,
+        description="If true, the predictions will be prevented from registration by Active Learning (if the functionality is enabled)",
     )
 
 

--- a/inference/core/interfaces/http/http_api.py
+++ b/inference/core/interfaces/http/http_api.py
@@ -1042,6 +1042,10 @@ class HttpInterface(BaseInterface):
                 disable_preproc_static_crop: Optional[bool] = Query(
                     False, description="If true, disables automatic static crop"
                 ),
+                disable_active_learning: Optional[bool] = Query(
+                    default=False,
+                    description="If true, the predictions will be prevented from registration by Active Learning (if the functionality is enabled)",
+                ),
             ):
                 """
                 Legacy inference endpoint for object detection, instance segmentation, and classification.
@@ -1147,6 +1151,7 @@ class HttpInterface(BaseInterface):
                     disable_preproc_contrast=disable_preproc_contrast,
                     disable_preproc_grayscale=disable_preproc_grayscale,
                     disable_preproc_static_crop=disable_preproc_static_crop,
+                    disable_active_learning=disable_active_learning,
                     **args,
                 )
 

--- a/inference/core/managers/active_learning.py
+++ b/inference/core/managers/active_learning.py
@@ -36,7 +36,7 @@ class ActiveLearningManager(ModelManager):
         )
         active_learning_eligible = kwargs.get(ACTIVE_LEARNING_ELIGIBLE_PARAM, False)
         active_learning_disabled_for_request = kwargs.get(
-            DISABLE_ACTIVE_LEARNING_PARAM, True
+            DISABLE_ACTIVE_LEARNING_PARAM, False
         )
         if (
             not active_learning_eligible
@@ -118,7 +118,7 @@ class BackgroundTaskActiveLearningManager(ActiveLearningManager):
     ) -> InferenceResponse:
         active_learning_eligible = kwargs.get(ACTIVE_LEARNING_ELIGIBLE_PARAM, False)
         active_learning_disabled_for_request = kwargs.get(
-            DISABLE_ACTIVE_LEARNING_PARAM, True
+            DISABLE_ACTIVE_LEARNING_PARAM, False
         )
         kwargs[ACTIVE_LEARNING_ELIGIBLE_PARAM] = False  # disabling AL in super-classes
         prediction = await super().infer_from_request(

--- a/inference_sdk/http/entities.py
+++ b/inference_sdk/http/entities.py
@@ -83,6 +83,7 @@ class InferenceConfiguration:
     )
     client_downsizing_disabled: bool = False
     default_max_input_size: int = DEFAULT_MAX_INPUT_SIZE
+    disable_active_learning: bool = False
 
     @classmethod
     def init_default(cls) -> "InferenceConfiguration":
@@ -126,6 +127,7 @@ class InferenceConfiguration:
             ("visualize_labels", "visualization_labels"),
             ("stroke_width", "visualization_stroke_width"),
             ("visualize_predictions", "visualize_predictions"),
+            ("disable_active_learning", "disable_active_learning"),
         ]
         return get_non_empty_attributes(
             source_object=self,
@@ -151,6 +153,7 @@ class InferenceConfiguration:
             ("confidence_threshold", "confidence"),
             ("visualize_predictions", "visualize_predictions"),
             ("stroke_width", "visualization_stroke_width"),
+            ("disable_active_learning", "disable_active_learning"),
         ]
         return get_non_empty_attributes(
             source_object=self,
@@ -174,6 +177,7 @@ class InferenceConfiguration:
             ("disable_preproc_contrast", "disable_preproc_contrast"),
             ("disable_preproc_grayscale", "disable_preproc_grayscale"),
             ("disable_preproc_static_crop", "disable_preproc_static_crop"),
+            ("disable_active_learning", "disable_active_learning"),
         ]
         return get_non_empty_attributes(
             source_object=self,

--- a/tests/inference_sdk/unit_tests/http/test_client.py
+++ b/tests/inference_sdk/unit_tests/http/test_client.py
@@ -735,8 +735,14 @@ def test_infer_from_api_v0_when_request_succeed_for_object_detection_with_batch_
             ],
         },
     ]
-    assert requests_mock.request_history[0].query == "api_key=my-api-key&confidence=0.5"
-    assert requests_mock.request_history[1].query == "api_key=my-api-key&confidence=0.5"
+    assert (
+        requests_mock.request_history[0].query
+        == "api_key=my-api-key&confidence=0.5&disable_active_learning=false"
+    )
+    assert (
+        requests_mock.request_history[1].query
+        == "api_key=my-api-key&confidence=0.5&disable_active_learning=false"
+    )
 
 
 @mock.patch.object(client, "load_static_inference_input")
@@ -765,7 +771,7 @@ def test_infer_from_api_v0_when_request_succeed_for_object_detection_with_visual
     assert result == {"visualization": base64.b64encode(b"data").decode("utf-8")}
     assert (
         requests_mock.last_request.query
-        == "api_key=my-api-key&confidence=0.5&format=image"
+        == "api_key=my-api-key&confidence=0.5&format=image&disable_active_learning=false"
     )
 
 
@@ -816,7 +822,10 @@ def test_infer_from_api_v0_when_request_succeed_for_object_detection(
             }
         ],
     }
-    assert requests_mock.last_request.query == "api_key=my-api-key&confidence=0.5"
+    assert (
+        requests_mock.last_request.query
+        == "api_key=my-api-key&confidence=0.5&disable_active_learning=false"
+    )
 
 
 def test_infer_from_api_v1_when_model_id_is_not_selected() -> None:
@@ -881,7 +890,9 @@ def test_infer_from_api_v1_when_request_succeed_for_object_detection_with_batch_
         ("base64_image", 0.5),
         ("another_image", None),
     ]
-    configuration = InferenceConfiguration(confidence_threshold=0.5)
+    configuration = InferenceConfiguration(
+        confidence_threshold=0.5, disable_active_learning=True
+    )
     http_client.configure(inference_configuration=configuration)
     requests_mock.post(
         f"{api_url}/infer/object_detection",
@@ -962,6 +973,7 @@ def test_infer_from_api_v1_when_request_succeed_for_object_detection_with_batch_
         "image": {"type": "base64", "value": "base64_image"},
         "visualize_predictions": False,
         "confidence": 0.5,
+        "disable_active_learning": True,
     }
     assert requests_mock.request_history[1].json() == {
         "model_id": "some/1",
@@ -969,6 +981,7 @@ def test_infer_from_api_v1_when_request_succeed_for_object_detection_with_batch_
         "image": {"type": "base64", "value": "another_image"},
         "visualize_predictions": False,
         "confidence": 0.5,
+        "disable_active_learning": True,
     }
 
 
@@ -1036,6 +1049,7 @@ def test_infer_from_api_v1_when_request_succeed_for_object_detection_with_visual
         "image": {"type": "base64", "value": "base64_image"},
         "visualize_predictions": True,
         "confidence": 0.5,
+        "disable_active_learning": False,
     }
 
 
@@ -1569,9 +1583,7 @@ def test_clip_compare_when_mixed_input_is_given(
     # given
     api_url = "http://some.com"
     http_client = InferenceHTTPClient(api_key="my-api-key", api_url=api_url)
-    load_static_inference_input_mock.side_effect = [
-        [("base64_image_1", 0.5)]
-    ]
+    load_static_inference_input_mock.side_effect = [[("base64_image_1", 0.5)]]
     requests_mock.post(
         f"{api_url}/clip/compare",
         json={

--- a/tests/inference_sdk/unit_tests/http/test_entities.py
+++ b/tests/inference_sdk/unit_tests/http/test_entities.py
@@ -27,6 +27,7 @@ REFERENCE_IMAGE_CONFIGURATION = InferenceConfiguration(
     visualize_predictions=False,
     visualize_labels=True,
     iou_threshold=0.7,
+    disable_active_learning=True,
 )
 
 
@@ -76,6 +77,7 @@ def test_to_api_call_parameters_for_api_v0() -> None:
         "disable_preproc_contrast": False,
         "disable_preproc_grayscale": True,
         "disable_preproc_static_crop": False,
+        "disable_active_learning": True,
     }
 
 
@@ -95,6 +97,7 @@ def test_to_api_call_parameters_for_api_v1_classification() -> None:
         "disable_preproc_contrast": False,
         "disable_preproc_grayscale": True,
         "disable_preproc_static_crop": False,
+        "disable_active_learning": True,
     }
 
 
@@ -120,4 +123,5 @@ def test_to_api_call_parameters_for_api_v1_object_detection() -> None:
         "visualization_labels": True,
         "visualize_predictions": False,
         "visualization_stroke_width": 1,
+        "disable_active_learning": True,
     }


### PR DESCRIPTION
# Description
New feature letting us define `disable_active_learning` flag for a single request.

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [x] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

YOUR_ANSWER

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [x] Docs updated? What were the changes:
