### PR TITLE
Fix problem with class names sorting

### DIFF
--- a/inference/core/models/roboflow.py
+++ b/inference/core/models/roboflow.py
@@ -810,9 +810,10 @@ def get_class_names_from_environment_file(environment: Optional[dict]) -> List[s
         raise ModelArtefactError(
             f"Missing `CLASS_MAP` in environment or `CLASS_MAP` is not dict."
         )
-    return [
-        environment["CLASS_MAP"][key] for key in sorted(environment["CLASS_MAP"].keys())
-    ]
+    class_names = []
+    for i in range(len(environment["CLASS_MAP"].keys())):
+        class_names.append(environment["CLASS_MAP"][str(i)])
+    return class_names
 
 
 def class_mapping_not_available_in_environment(environment: dict) -> bool:

--- a/inference/core/version.py
+++ b/inference/core/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.9.9rc3"
+__version__ = "0.9.9rc4"
 
 
 if __name__ == "__main__":

--- a/tests/inference/models_predictions_tests/test_vit.py
+++ b/tests/inference/models_predictions_tests/test_vit.py
@@ -75,8 +75,8 @@ def assert_vit_multi_class_prediction_matches_reference(
     prediction: ClassificationInferenceResponse,
 ) -> None:
     assert (
-        prediction.top == "bird"
-    ), "This is assertion for model from random weights, it was checked to be bird while model was created"
+        prediction.top == "train"
+    ), "This is assertion for model from random weights, it was checked to be train while model was created"
     assert (
         abs(prediction.confidence - 0.0386) < 1e-5
     ), "This is assertion for model from random weights, it was checked to be 0.038 while model was created"
@@ -152,16 +152,16 @@ def assert_vit_multi_label_prediction_matches_reference(
 ) -> None:
     assert sorted(prediction.predicted_classes) == sorted(
         [
-            "parking meter",
-            "horse",
-            "giraffe",
-            "backpack",
-            "umbrella",
-            "handbag",
-            "frisbee",
             "airplane",
-            "truck",
-            "boat",
+            "cow",
+            "dog",
+            "frisbee",
+            "handbag",
+            "horse",
+            "sheep",
+            "skis",
+            "traffic light",
+            "zebra",
         ]
     ), "This is assertion for model from random weights, it was checked while model was created"
     assert (

--- a/tests/inference/models_predictions_tests/test_yolov8.py
+++ b/tests/inference/models_predictions_tests/test_yolov8.py
@@ -82,9 +82,7 @@ def assert_yolov8_classification_prediction_matches_reference(
     assert (
         len(prediction.predictions) == 1000
     ), "Example model is expected to predict across 1000 classes"
-    assert (
-        prediction.top == "Egyptian_cat"
-    ), "Egyptian_cat class was predicted by exported model, but here there is probably bug in model post-processing code, see https://github.com/roboflow/inference/issues/201"
+    assert prediction.top == "golden_retriever", "Golden retriever should be predicted"
     assert (
         abs(prediction.confidence - 0.0018) < 1e-5
     ), "Confidence while test creation was 0.0018"

--- a/tests/inference/unit_tests/core/models/test_roboflow.py
+++ b/tests/inference/unit_tests/core/models/test_roboflow.py
@@ -132,8 +132,8 @@ def test_get_color_mapping_from_environment_when_color_mapping_not_in_environmen
     "environment, expected_result",
     [
         ({}, True),
-        ({"CLASS_MAP": json.dumps({"1": "class_a"})}, True),
-        ({"CLASS_MAP": {"1": "class_1"}}, False),
+        ({"CLASS_MAP": json.dumps({"0": "class_a"})}, True),
+        ({"CLASS_MAP": {"0": "class_1"}}, False),
     ],
 )
 def test_class_mapping_not_available_in_environment(
@@ -147,7 +147,7 @@ def test_class_mapping_not_available_in_environment(
 
 
 @pytest.mark.parametrize(
-    "environment", [None, {}, {"CLASS_MAP": json.dumps({"1": "class_a"})}]
+    "environment", [None, {}, {"CLASS_MAP": json.dumps({"0": "class_a"})}]
 )
 def test_get_class_names_from_environment_file_when_procedure_should_fail(
     environment: Optional[dict],
@@ -159,10 +159,28 @@ def test_get_class_names_from_environment_file_when_procedure_should_fail(
 
 def test_get_class_names_from_environment_file() -> None:
     # given
-    environment = {"CLASS_MAP": {"1": "class_a", "2": "class_b", "3": "class_c"}}
+    environment = {
+        "CLASS_MAP": {
+            "0": "class_a",
+            "1": "class_b",
+            "2": "class_c",
+            "3": "class_d",
+            "4": "class_e",
+            "5": "class_f",
+            "6": "class_g",
+            "7": "class_h",
+            "8": "class_i",
+            "9": "class_j",
+            "10": "class_k",
+            "11": "class_l",
+        }
+    }
 
     # when
     result = get_class_names_from_environment_file(environment=environment)
 
     # then
-    assert result == ["class_a", "class_b", "class_c"]
+    assert result == [
+        "class_a", "class_b", "class_c", "class_d", "class_e", "class_f", "class_g", "class_h",
+        "class_i", "class_j", "class_k", "class_l"
+    ]


### PR DESCRIPTION
# Description

I introduced bug with parsing class names if only `environment.json` file is available and no classes in API response.
Previously - sorting keys was applied - but keys are strings, so that lead in: `["1", "10", "2", "3"]` being the sort order 🤦 

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

YOUR_ANSWER

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
