### PR TITLE
Remove TOC from Docs Homepage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,4 @@ inference_sdk/version.py
 !tests/inference/models_predictions_tests/assets/*.jpg
 tests/inference/models_predictions_tests/assets/*.zip
 !inference/enterprise/deployments/assets/*.jpg
+dev.py

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,7 @@
 ---
 hide:
   - navigation
+  - toc
 ---
 
 <style>

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,10 @@ hide:
   .md-content__button {
     display: none;
   }
+  .md-content {
+    padding-left: 10%;
+    padding-right: 10%;
+  }
 </style>
 
 ![Roboflow Inference banner](https://github.com/roboflow/inference/blob/main/banner.png?raw=true)

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,10 +9,10 @@ hide:
   .md-content__button {
     display: none;
   }
-  .md-content {
+  @media screen and (min-width: 800px) {.md-content {
     padding-left: 10%;
     padding-right: 10%;
-  }
+  }}
 </style>
 
 ![Roboflow Inference banner](https://github.com/roboflow/inference/blob/main/banner.png?raw=true)

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,6 +26,11 @@ You can run Inference on an edge device like an NVIDIA Jetson, or on cloud compu
 
 <a href="/quickstart/run_a_model/" class="button">Get started with our "Run your first model" guide</a>
 
+<div class="button-holder">
+<a href="/quickstart/what_is_inference/" class="button half-button">Learn about the various ways you can use Inference</a>
+<a href="/foundation/about/" class="button half-button">See all of the models you can run with Inference</a>
+</div>
+
 <style>
   .button {
     background-color: var(--md-primary-fg-color);

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -7,3 +7,12 @@
 .md-tabs__link {
   font-size: 1rem;
 }
+
+.half-button {
+  width: 49%;
+}
+
+.button-holder {
+  display: flex;
+  justify-content: space-between;
+}


### PR DESCRIPTION
# Description

Removed TOC from homepage and added a couple buttons to help drive users to the top nav links / content.

![Screenshot 2024-01-22 at 7 55 27 AM](https://github.com/roboflow/inference/assets/97041392/09e75a96-1db0-4aff-9ad5-ae8ed3b14bbf)
