### PR TITLE
updated links to cached URL

### DIFF
--- a/docs/quickstart/explore_models.md
+++ b/docs/quickstart/explore_models.md
@@ -74,7 +74,7 @@ annotated_image = label_annotator.annotate(
 sv.plot_image(annotated_image)
 ```
 
-The `people-walking.jpg` file is hosted <a href="https://storage.googleapis.com/com-roboflow-marketing/inference/people-walking.jpg" target="_blank">here</a>.
+The `people-walking.jpg` file is hosted <a href="https://media.roboflow.com/inference/people-walking.jpg" target="_blank">here</a>.
 
 Replace `yolov8n-640` with the model ID you found on Universe, replace `image` with the image of your choosing, and be sure to export your API key:
 

--- a/docs/quickstart/run_a_model.md
+++ b/docs/quickstart/run_a_model.md
@@ -21,7 +21,7 @@ Create a new Python file called `app.py` and add the following code:
 from inference import get_roboflow_model
 
 # define the image url to use for inference
-image = "https://storage.googleapis.com/com-roboflow-marketing/inference/people-walking.jpg"
+image = "https://media.roboflow.com/inference/people-walking.jpg"
 
 # load a pre-trained yolov8n model
 model = get_roboflow_model(model_id="yolov8n-640")
@@ -75,7 +75,7 @@ annotated_image = label_annotator.annotate(
 sv.plot_image(annotated_image)
 ```
 
-The `people-walking.jpg` file is hosted <a href="https://storage.googleapis.com/com-roboflow-marketing/inference/people-walking.jpg" target="_blank">here</a>.
+The `people-walking.jpg` file is hosted <a href="https://media.roboflow.com/inference/people-walking.jpg" target="_blank">here</a>.
 
 ![People Walking Annotated](https://storage.googleapis.com/com-roboflow-marketing/inference/people-walking-annotated.jpg)
 

--- a/docs/quickstart/what_is_inference.md
+++ b/docs/quickstart/what_is_inference.md
@@ -41,7 +41,7 @@ Next, we load a model by referencing its `model_id`. For Roboflow models, the mo
 
 **`results = model.infer("people-walking.jpg")`**
 
-Finally, we run inference on a local image file (<a href="https://storage.googleapis.com/com-roboflow-marketing/inference/people-walking.jpg" target="_blank">hosted here</a>). We used <a href="https://supervision.roboflow.com/how_to/detect_and_annotate/" target="_blank">Supervision</a> to visualize the results.
+Finally, we run inference on a local image file (<a href="https://media.roboflow.com/inference/people-walking.jpg" target="_blank">hosted here</a>). We used <a href="https://supervision.roboflow.com/how_to/detect_and_annotate/" target="_blank">Supervision</a> to visualize the results.
 
 ## Why Inference?
 

--- a/docs/using_inference/native_python_api.md
+++ b/docs/using_inference/native_python_api.md
@@ -90,7 +90,7 @@ from PIL import Image
 
 model = get_roboflow_model(model_id="yolov8x-1280")
 
-image_url = "https://storage.googleapis.com/com-roboflow-marketing/inference/people-walking.jpg"
+image_url = "https://media.roboflow.com/inference/people-walking.jpg"
 local_image_file = "people-walking.jpg"
 pil_image = Image.open(local_image_file)
 numpy_image = cv2.imread(local_image_file)


### PR DESCRIPTION
# Description

Every URL of this type "https://storage.googleapis.com/com-roboflow-marketing/inference/people-walking.jpg" has been updated to a shorter URL that is also faster as the image is cached: https://media.roboflow.com/inference/people-walking.jpg

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ X ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Yes, https://media.roboflow.com/inference/people-walking.jpg loads

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:

Yes, four markdowns with the prior link were updated.