### PR TITLE
Use `from_inference` data loader in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ inference.Stream(
             "Prediction", 
             annotator.annotate(
                 scene=image, 
-                detections=sv.Detections.from_roboflow(predictions)
+                detections=sv.Detections.from_inference(predictions)
             )
         ),
         cv2.waitKey(1)

--- a/docs/quickstart/create_a_custom_inference_pipeline_sink.md
+++ b/docs/quickstart/create_a_custom_inference_pipeline_sink.md
@@ -90,7 +90,7 @@ def my_custom_sink(predictions: dict, video_frame: VideoFrame):
     # get the text labels for each prediction
     labels = [p["class"] for p in predictions["predictions"]]
     # load our predictions into the Supervision Detections api
-    detections = sv.Detections.from_roboflow(predictions)
+    detections = sv.Detections.from_inference(predictions)
     # annotate the frame using our supervision annotator, the video_frame, the predictions (as supervision Detections), and the prediction labels
     image = annotator.annotate(
         scene=video_frame.image.copy(), detections=detections, labels=labels

--- a/docs/quickstart/explore_models.md
+++ b/docs/quickstart/explore_models.md
@@ -58,7 +58,7 @@ model = get_roboflow_model(model_id="yolov8n-640")
 results = model.infer(image)
 
 # load the results into the supervision Detections api
-detections = sv.Detections.from_roboflow(results[0].dict(by_alias=True, exclude_none=True))
+detections = sv.Detections.from_inference(results[0].dict(by_alias=True, exclude_none=True))
 
 # create supervision annotators
 bounding_box_annotator = sv.BoundingBoxAnnotator()
@@ -125,7 +125,7 @@ model = get_roboflow_model(model_id="taylor-swift-records/3")
 results = model.infer(image)
 
 # load the results into the supervision Detections api
-detections = sv.Detections.from_roboflow(results[0].dict(by_alias=True, exclude_none=True))
+detections = sv.Detections.from_inference(results[0].dict(by_alias=True, exclude_none=True))
 
 # create supervision annotators
 bounding_box_annotator = sv.BoundingBoxAnnotator()

--- a/docs/quickstart/run_a_model.md
+++ b/docs/quickstart/run_a_model.md
@@ -59,7 +59,7 @@ model = get_roboflow_model(model_id="yolov8n-640")
 results = model.infer(image)
 
 # load the results into the supervision Detections api
-detections = sv.Detections.from_roboflow(results[0].dict(by_alias=True, exclude_none=True))
+detections = sv.Detections.from_inference(results[0].dict(by_alias=True, exclude_none=True))
 
 # create supervision annotators
 bounding_box_annotator = sv.BoundingBoxAnnotator()

--- a/docs/using_inference/http_api.md
+++ b/docs/using_inference/http_api.md
@@ -63,7 +63,7 @@ client = InferenceHTTPClient(
 results = client.infer(image, model_id=model_id)
 
 #Load results into Supervision Detection API
-detections = sv.Detections.from_roboflow(results[0])
+detections = sv.Detections.from_inference(results[0].dict(by_alias=True, exclude_none=True))
 
 #Create Supervision annotators
 bounding_box_annotator = sv.BoundingBoxAnnotator()

--- a/docs/using_inference/native_python_api.md
+++ b/docs/using_inference/native_python_api.md
@@ -51,7 +51,7 @@ image = cv2.imread("people-walking.jpg")
 results = model.infer(image)
 
 #Load results into Supervision Detection API
-detections = sv.Detections.from_roboflow(
+detections = sv.Detections.from_inference(
     results[0].dict(by_alias=True, exclude_none=True)
 )
 


### PR DESCRIPTION
# Description

This PR replaces `from_roboflow` with `from_inference` in our docs.

## Type of change

- [X] Docs change

## How has this change been tested, please provide a testcase or example of how you tested the change?

Open up any of the changed pages to ensure `from_inference` is used as the data loader in a guide instead of `from_roboflow`.

## Any specific deployment considerations

N/A

## Docs

N/A
