### PR TITLE
Add support for stubs in InferencePipeline

### DIFF
--- a/development/stream_interface/inference_pipeline_on_camera.py
+++ b/development/stream_interface/inference_pipeline_on_camera.py
@@ -1,0 +1,84 @@
+import argparse
+import os
+import subprocess
+from datetime import datetime
+from functools import partial
+from threading import Thread
+from typing import Optional, Union
+
+import cv2
+import numpy as np
+import supervision as sv
+
+from inference.core.interfaces.camera.entities import VideoFrame
+from inference.core.interfaces.stream.inference_pipeline import InferencePipeline
+from inference.core.interfaces.stream.sinks import render_boxes, display_image, UDPSink, multi_sink
+from inference.core.interfaces.stream.watchdog import (
+    BasePipelineWatchDog,
+    PipelineWatchDog,
+)
+from inference.core.utils.environment import str2bool
+from inference.core.utils.preprocess import letterbox_image
+
+STOP = False
+
+
+def main(
+    model_id: str,
+    stream_id: int,
+) -> None:
+    global STOP
+    watchdog = BasePipelineWatchDog()
+    on_prediction = partial(
+        render_boxes,
+        display_statistics=True,
+    )
+    pipeline = InferencePipeline.init(
+        model_id=model_id,
+        video_reference=stream_id,
+        on_prediction=on_prediction,
+        watchdog=watchdog,
+    )
+    control_thread = Thread(target=command_thread, args=(pipeline, watchdog))
+    control_thread.start()
+    pipeline.start()
+    STOP = True
+    pipeline.join()
+
+
+def command_thread(pipeline: InferencePipeline, watchdog: PipelineWatchDog) -> None:
+    global STOP
+    while not STOP:
+        key = input()
+        if key == "i":
+            print(watchdog.get_report())
+        if key == "t":
+            pipeline.terminate()
+            STOP = True
+        elif key == "p":
+            pipeline.pause_stream()
+        elif key == "m":
+            pipeline.mute_stream()
+        elif key == "r":
+            pipeline.resume_stream()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser("Inference pipeline demo")
+    parser.add_argument(
+        "--model_id",
+        required=True,
+        type=str,
+    )
+    parser.add_argument(
+        "--stream_id",
+        help=f"Id of a stream",
+        required=False,
+        type=int,
+        default=0,
+    )
+    args = parser.parse_args()
+    main(
+        model_id=args.model_id,
+        stream_id=args.stream_id,
+    )

--- a/inference/core/interfaces/stream/entities.py
+++ b/inference/core/interfaces/stream/entities.py
@@ -21,12 +21,14 @@ ObjectDetectionPrediction = dict
 
 
 @dataclass(frozen=True)
-class ObjectDetectionInferenceConfig:
+class ModelConfig:
     class_agnostic_nms: Optional[bool]
     confidence: Optional[float]
     iou_threshold: Optional[float]
     max_candidates: Optional[int]
     max_detections: Optional[int]
+    mask_decode_mode: Optional[str]
+    tradeoff_factor: Optional[float]
 
     @classmethod
     def init(
@@ -36,7 +38,9 @@ class ObjectDetectionInferenceConfig:
         iou_threshold: Optional[float] = None,
         max_candidates: Optional[int] = None,
         max_detections: Optional[int] = None,
-    ) -> "ObjectDetectionInferenceConfig":
+        mask_decode_mode: Optional[str] = None,
+        tradeoff_factor: Optional[float] = None,
+    ) -> "ModelConfig":
         if class_agnostic_nms is None:
             class_agnostic_nms = safe_env_to_type(
                 variable_name=CLASS_AGNOSTIC_NMS_ENV,
@@ -67,12 +71,14 @@ class ObjectDetectionInferenceConfig:
                 default_value=DEFAULT_MAX_DETECTIONS,
                 type_constructor=int,
             )
-        return ObjectDetectionInferenceConfig(
+        return ModelConfig(
             class_agnostic_nms=class_agnostic_nms,
             confidence=confidence,
             iou_threshold=iou_threshold,
             max_candidates=max_candidates,
             max_detections=max_detections,
+            mask_decode_mode=mask_decode_mode,
+            tradeoff_factor=tradeoff_factor,
         )
 
     def to_postprocessing_params(self) -> Dict[str, Union[bool, float, int]]:
@@ -83,6 +89,8 @@ class ObjectDetectionInferenceConfig:
             "iou_threshold",
             "max_candidates",
             "max_detections",
+            "mask_decode_mode",
+            "tradeoff_factor",
         ]:
             result[field] = getattr(self, field, None)
         return {name: value for name, value in result.items() if value is not None}

--- a/inference/core/interfaces/stream/inference_pipeline.py
+++ b/inference/core/interfaces/stream/inference_pipeline.py
@@ -302,7 +302,10 @@ class InferencePipeline:
                     iou_threshold=self._inference_config.iou_threshold,
                     max_candidates=self._inference_config.max_candidates,
                     max_detections=self._inference_config.max_detections,
-                )[0].dict(
+                )
+                if issubclass(type(predictions), list):
+                    predictions = predictions[0]
+                predictions = predictions.dict(
                     by_alias=True,
                     exclude_none=True,
                 )

--- a/inference/core/interfaces/stream/inference_pipeline.py
+++ b/inference/core/interfaces/stream/inference_pipeline.py
@@ -33,7 +33,7 @@ from inference.core.interfaces.camera.video_source import (
     VideoSource,
 )
 from inference.core.interfaces.stream.entities import (
-    ObjectDetectionInferenceConfig,
+    ModelConfig,
     ObjectDetectionPrediction,
 )
 from inference.core.interfaces.stream.sinks import active_learning_sink, multi_sink
@@ -72,6 +72,8 @@ class InferencePipeline:
         iou_threshold: Optional[float] = None,
         max_candidates: Optional[int] = None,
         max_detections: Optional[int] = None,
+        mask_decode_mode: Optional[str] = "accurate",
+        tradeoff_factor: Optional[float] = 0.0,
         active_learning_enabled: Optional[bool] = None,
     ) -> "InferencePipeline":
         """
@@ -87,6 +89,9 @@ class InferencePipeline:
         are handled by separate threads.
 
         Given that reference to stream is passed and connectivity is lost - it attempts to re-connect with delay.
+
+        Since version 0.9.11 it works not only for object detection models but is also compatible with stubs,
+        classification, instance-segmentation and keypoint-detection models.
 
         Args:
             model_id (str): Name and version of model at Roboflow platform (example: "my-model/3")
@@ -124,6 +129,10 @@ class InferencePipeline:
                 env variable "MAX_CANDIDATES" with default "3000"
             max_detections (Optional[int]): Parameter of model post-processing. If not given - value checked in
                 env variable "MAX_DETECTIONS" with default "300"
+            mask_decode_mode: (Optional[str]): Parameter of model post-processing. If not given - model "accurate" is
+                used. Applicable for instance segmentation models
+            tradeoff_factor (Optional[float]): Parameter of model post-processing. If not 0.0 - model default is used.
+                Applicable for instance segmentation models
             active_learning_enabled (Optional[bool]): Flag to enable / disable Active Learning middleware (setting it
                 true does not guarantee any data to be collected, as data collection is controlled by Roboflow backend -
                 it just enables middleware intercepting predictions). If not given, env variable
@@ -146,12 +155,14 @@ class InferencePipeline:
             api_key = API_KEY
         if status_update_handlers is None:
             status_update_handlers = []
-        inference_config = ObjectDetectionInferenceConfig.init(
+        inference_config = ModelConfig.init(
             class_agnostic_nms=class_agnostic_nms,
             confidence=confidence,
             iou_threshold=iou_threshold,
             max_candidates=max_candidates,
             max_detections=max_detections,
+            mask_decode_mode=mask_decode_mode,
+            tradeoff_factor=tradeoff_factor,
         )
         model = get_roboflow_model(model_id=model_id, api_key=api_key)
         if watchdog is None:
@@ -214,7 +225,7 @@ class InferencePipeline:
         predictions_queue: Queue,
         watchdog: PipelineWatchDog,
         status_update_handlers: List[Callable[[StatusUpdate], None]],
-        inference_config: ObjectDetectionInferenceConfig,
+        inference_config: ModelConfig,
         active_learning_middleware: Union[
             NullActiveLearningMiddleware, ThreadingActiveLearningMiddleware
         ],
@@ -294,21 +305,17 @@ class InferencePipeline:
                     frame_timestamp=video_frame.frame_timestamp,
                     frame_id=video_frame.frame_id,
                 )
+                postprocessing_args = self._inference_config.to_postprocessing_params()
                 predictions = self._model.postprocess(
                     predictions,
                     preprocessing_metadata,
-                    class_agnostic_nms=self._inference_config.class_agnostic_nms,
-                    confidence=self._inference_config.confidence,
-                    iou_threshold=self._inference_config.iou_threshold,
-                    max_candidates=self._inference_config.max_candidates,
-                    max_detections=self._inference_config.max_detections,
+                    **postprocessing_args,
                 )
                 if issubclass(type(predictions), list):
-                    predictions = predictions[0]
-                predictions = predictions.dict(
-                    by_alias=True,
-                    exclude_none=True,
-                )
+                    predictions = predictions[0].dict(
+                        by_alias=True,
+                        exclude_none=True,
+                    )
                 self._watchdog.on_model_prediction_ready(
                     frame_timestamp=video_frame.frame_timestamp,
                     frame_id=video_frame.frame_id,

--- a/inference/core/interfaces/stream/sinks.py
+++ b/inference/core/interfaces/stream/sinks.py
@@ -37,6 +37,9 @@ def render_boxes(
     to draw bounding boxes and resizes prediction to 1280x720 (keeping aspect ratio and adding black padding).
     One may configure default behaviour, for instance to display latency and throughput statistics.
 
+    This sink is only partially compatible with stubs and classification models (it will not fail,
+    although predictions will not be displayed).
+
     Args:
         predictions (dict): Roboflow object detection predictions with Bounding Boxes
         video_frame (VideoFrame): frame of video with its basic metadata emitted by `VideoSource`
@@ -87,9 +90,9 @@ def render_boxes(
         image = annotator.annotate(
             scene=video_frame.image.copy(), detections=detections, labels=labels
         )
-    except KeyError:
+    except (TypeError, KeyError):
         logger.warning(
-            f"Used `render_boxes()` sink, but predictions that were provided do not match the expected format "
+            f"Used `render_boxes(...)` sink, but predictions that were provided do not match the expected format "
             f"of object detection prediction that could be accepted by `supervision.Detection.from_roboflow(...)"
         )
         image = video_frame.image.copy()

--- a/inference/core/interfaces/stream/sinks.py
+++ b/inference/core/interfaces/stream/sinks.py
@@ -81,11 +81,18 @@ def render_boxes(
     if fps_monitor is not None:
         fps_monitor.tick()
         fps_value = fps_monitor()
-    labels = [p["class"] for p in predictions["predictions"]]
-    detections = sv.Detections.from_roboflow(predictions)
-    image = annotator.annotate(
-        scene=video_frame.image.copy(), detections=detections, labels=labels
-    )
+    try:
+        labels = [p["class"] for p in predictions["predictions"]]
+        detections = sv.Detections.from_roboflow(predictions)
+        image = annotator.annotate(
+            scene=video_frame.image.copy(), detections=detections, labels=labels
+        )
+    except KeyError:
+        logger.warning(
+            f"Used `render_boxes()` sink, but predictions that were provided do not match the expected format "
+            f"of object detection prediction that could be accepted by `supervision.Detection.from_roboflow(...)"
+        )
+        image = video_frame.image.copy()
     if display_size is not None:
         image = letterbox_image(image, desired_size=display_size)
     if display_statistics:

--- a/tests/inference/unit_tests/core/interfaces/stream/test_interface_pipeline.py
+++ b/tests/inference/unit_tests/core/interfaces/stream/test_interface_pipeline.py
@@ -24,7 +24,7 @@ from inference.core.interfaces.camera.video_source import (
     VideoSource,
     lock_state_transition,
 )
-from inference.core.interfaces.stream.entities import ObjectDetectionInferenceConfig
+from inference.core.interfaces.stream.entities import ModelConfig
 from inference.core.interfaces.stream.inference_pipeline import InferencePipeline
 from inference.core.interfaces.stream.sinks import active_learning_sink, multi_sink
 from inference.core.interfaces.stream.watchdog import BasePipelineWatchDog
@@ -152,7 +152,7 @@ def test_inference_pipeline_works_correctly_against_video_file(
         predictions.append((video_frame, prediction))
 
     status_update_handlers = [watchdog.on_status_update]
-    inference_config = ObjectDetectionInferenceConfig.init(
+    inference_config = ModelConfig.init(
         confidence=0.5, iou_threshold=0.5
     )
     predictions_queue = Queue(maxsize=512)
@@ -195,7 +195,7 @@ def test_inference_pipeline_works_correctly_against_stream_including_reconnectio
         predictions.append((video_frame, prediction))
 
     status_update_handlers = [watchdog.on_status_update]
-    inference_config = ObjectDetectionInferenceConfig.init(
+    inference_config = ModelConfig.init(
         confidence=0.5, iou_threshold=0.5
     )
     predictions_queue = Queue(maxsize=512)
@@ -242,7 +242,7 @@ def test_inference_pipeline_works_correctly_against_stream_including_dispatching
         raise Exception()
 
     status_update_handlers = [watchdog.on_status_update]
-    inference_config = ObjectDetectionInferenceConfig.init(
+    inference_config = ModelConfig.init(
         confidence=0.5, iou_threshold=0.5
     )
     predictions_queue = Queue(maxsize=512)
@@ -314,7 +314,7 @@ def test_inference_pipeline_works_correctly_against_video_file_with_active_learn
     prediction_handler = partial(multi_sink, sinks=[on_prediction, al_sink])
 
     status_update_handlers = [watchdog.on_status_update]
-    inference_config = ObjectDetectionInferenceConfig.init(
+    inference_config = ModelConfig.init(
         confidence=0.5, iou_threshold=0.5
     )
     predictions_queue = Queue(maxsize=512)

--- a/tests/inference/unit_tests/core/interfaces/stream/test_sinks.py
+++ b/tests/inference/unit_tests/core/interfaces/stream/test_sinks.py
@@ -68,6 +68,37 @@ def test_render_boxes_completes_successfully() -> None:
     ), "capture_image() should be called against resized image dictated by default parameter"
 
 
+def test_render_boxes_completes_successfully_despite_malformed_predictions() -> None:
+    # given
+    video_frame = VideoFrame(
+        image=np.ones((1920, 1920, 3), dtype=np.uint8) * 255,
+        frame_id=1,
+        frame_timestamp=datetime.now(),
+    )
+    predictions = {"top": "cat", "predictions": {"class": "cat", "confidence": 0.8}}
+    captured_images = []
+
+    def capture_image(image: np.ndarray) -> None:
+        captured_images.append(image)
+
+    # when
+    render_boxes(
+        video_frame=video_frame,
+        predictions=predictions,
+        on_frame_rendered=capture_image,
+    )
+
+    # then
+    assert (
+        len(captured_images) == 1
+    ), "One capture_image() side effect expected after rendering"
+    assert captured_images[0].shape == (
+        720,
+        1280,
+        3,
+    ), "capture_image() should be called against resized image dictated by default parameter"
+
+
 def test_udp_sends_data_through_socket() -> None:
     # given
     socket = MagicMock()


### PR DESCRIPTION
# Description

In this PR we make it possible for `InferencePipeline` to work with stubs (`model/0`) and with Roboflow models other than object-detection ones. We adjusted sinks to work with other type of output.

List any dependencies that are required for this change.

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [x] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

YOUR_ANSWER

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [x] Docs updated? Partially (at the docstring level) - @capjamesg if u could post something in high-level docs that would be great.
