### PR TITLE
fix: 🐞 turn off instant page for load to cookbook page properly

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,7 +5,7 @@ site_description: Scalable, on-device computer vision deployment.
 repo_name: roboflow/inference
 repo_url: https://github.com/roboflow/inference
 edit_uri: https://github.com/roboflow/inference/tree/main/docs
-copyright: Roboflow 2023. All rights reserved.
+copyright: Roboflow 2024. All rights reserved.
 
 extra:
   social:
@@ -100,8 +100,6 @@ theme:
     - navigation.prune
     - navigation.footer
     - navigation.tracking
-    - navigation.instant
-    - navigation.instant.progress
     - navigation.indexes
     - navigation.sections
     - content.code.copy


### PR DESCRIPTION
# Description

Instant nav is make docs SPA and cookbook side doesn't use that side yet so turning off is make sure page load properly
