### PR TITLE
Add YOLO-World model documentation

### DIFF
--- a/docs/foundation/grounding_dino.md
+++ b/docs/foundation/grounding_dino.md
@@ -1,7 +1,3 @@
-!!! warning
-
-    This model is not yet available in Inference. Check back later for updates.
-
 <a href="https://github.com/IDEA-Research/GroundingDINO" target="_blank">Grounding DINO</a> is a zero-shot object detection model.
 
 You can use Grounding DINO to identify objects in images and videos using arbitrary text prompts.
@@ -17,7 +13,21 @@ To use Grounding DINO effectively, we recommend experimenting with the model to 
 Create a new Python file called `app.py` and add the following code:
 
 ```python
+from inference.models.grounding_dino import GroundingDINO
 
+model = GroundingDINO(api_key="")
+
+results = model.infer(
+    {
+        "image": {
+            "type": "url",
+            "value": "https://media.roboflow.com/fruit.png",
+        },
+        "text": ["apple"]
+    }
+)
+
+print(results.json())
 ```
 
 In this code, we load Grounding DINO, run Grounding DINO on an image, and annotate the image with the predictions from the model.
@@ -39,6 +49,4 @@ Then, run the Python script you have created:
 python app.py
 ```
 
-The results of Grounding DINO model will be displayed in a new window:
-
-![]()
+The predictions from your model will be printed to the console.

--- a/docs/foundation/yolo_world.md
+++ b/docs/foundation/yolo_world.md
@@ -1,0 +1,61 @@
+<a href="https://www.yoloworld.cc/" target="_blank">YOLO-World</a> is a zero-shot object detection model.
+
+You can use YOLO-World to identify objects in images and videos using arbitrary text prompts.
+
+To use YOLO-World effectively, we recommend experimenting with the model to understand which text prompts help achieve the desired results.
+
+YOLO World is faster than many other zero-shot object detection models like YOLO-World. On powerful hardware like a V100 GPU, YOLO World can run in real-time.
+
+!!! note
+
+    YOLO-World, like most state-of-the-art zero-shot detection models, is most effective at identifying common objects (i.e. cars, people, dogs, etc.). It is less effective at identifying uncommon objects (i.e. a specific type of car, a specific person, a specific dog, etc.).
+
+### How to Use YOLO-World
+
+Create a new Python file called `app.py` and add the following code:
+
+```python
+import cv2
+import supervision as sv
+
+from inference.models.yolo_world.yolo_world import YOLOWorld
+
+image = cv2.imread("image.jpeg")
+
+model = YOLOWorld(model_id="yolo_world/l")
+classes = ["person", "backpack", "dog", "eye", "nose", "ear", "tongue"]
+results = model.infer("image.jpeg", text=classes, confidence=0.03)
+
+detections = sv.Detections.from_inference(results)
+
+bounding_box_annotator = sv.BoundingBoxAnnotator()
+label_annotator = sv.LabelAnnotator()
+
+labels = [classes[class_id] for class_id in detections.class_id]
+
+annotated_image = bounding_box_annotator.annotate(
+    scene=image, detections=detections
+)
+annotated_image = label_annotator.annotate(
+    scene=annotated_image, detections=detections, labels=labels
+)
+
+sv.plot_image(annotated_image)
+```
+
+In this code, we load YOLO-World, run YOLO-World on an image, and annotate the image with the predictions from the model.
+
+Above, replace:
+
+1. `["person", "backpack", "dog", "eye", "nose", "ear", "tongue"]` with the objects you want to detect.
+2. `image.jpeg` with the path to the image in which you want to detect objects.
+
+Then, run the Python script you have created:
+
+```
+python app.py
+```
+
+The result from YOLO-World will be displayed in a new window.
+
+![YOLO-World results](https://media.roboflow.com/yolo-world-dog.png)

--- a/docs/foundation/yolo_world.md
+++ b/docs/foundation/yolo_world.md
@@ -34,7 +34,7 @@ YOLO World is faster than many other zero-shot object detection models like YOLO
     classes = ["person", "backpack", "dog", "eye", "nose", "ear", "tongue"]
     results = model.infer("image.jpeg", text=classes, confidence=0.03)
 
-    detections = sv.Detections.from_inference(results)
+    detections = sv.Detections.from_inference(results[0])
 
     bounding_box_annotator = sv.BoundingBoxAnnotator()
     label_annotator = sv.LabelAnnotator()

--- a/docs/foundation/yolo_world.md
+++ b/docs/foundation/yolo_world.md
@@ -89,7 +89,7 @@ YOLO World is faster than many other zero-shot object detection models like YOLO
         confidence=0.1,
     )
 
-    detections = sv.Detections.from_inference(results)
+    detections = sv.Detections.from_inference(results[0])
 
     bounding_box_annotator = sv.BoundingBoxAnnotator()
     label_annotator = sv.LabelAnnotator()

--- a/docs/foundation/yolo_world.md
+++ b/docs/foundation/yolo_world.md
@@ -14,34 +14,80 @@ YOLO World is faster than many other zero-shot object detection models like YOLO
 
 Create a new Python file called `app.py` and add the following code:
 
-```python
-import cv2
-import supervision as sv
+=== "Inference Python Library"
 
-from inference.models.yolo_world.yolo_world import YOLOWorld
+    ```python
+    import cv2
+    import supervision as sv
 
-image = cv2.imread("image.jpeg")
+    from inference.models.yolo_world.yolo_world import YOLOWorld
 
-model = YOLOWorld(model_id="yolo_world/l")
-classes = ["person", "backpack", "dog", "eye", "nose", "ear", "tongue"]
-results = model.infer("image.jpeg", text=classes, confidence=0.03)
+    image = cv2.imread("image.jpeg")
 
-detections = sv.Detections.from_inference(results)
+    model = YOLOWorld(model_id="yolo_world/l")
+    classes = ["person", "backpack", "dog", "eye", "nose", "ear", "tongue"]
+    results = model.infer("image.jpeg", text=classes, confidence=0.03)
 
-bounding_box_annotator = sv.BoundingBoxAnnotator()
-label_annotator = sv.LabelAnnotator()
+    detections = sv.Detections.from_inference(results)
 
-labels = [classes[class_id] for class_id in detections.class_id]
+    bounding_box_annotator = sv.BoundingBoxAnnotator()
+    label_annotator = sv.LabelAnnotator()
 
-annotated_image = bounding_box_annotator.annotate(
-    scene=image, detections=detections
-)
-annotated_image = label_annotator.annotate(
-    scene=annotated_image, detections=detections, labels=labels
-)
+    labels = [classes[class_id] for class_id in detections.class_id]
 
-sv.plot_image(annotated_image)
-```
+    annotated_image = bounding_box_annotator.annotate(
+        scene=image, detections=detections
+    )
+    annotated_image = label_annotator.annotate(
+        scene=annotated_image, detections=detections, labels=labels
+    )
+
+    sv.plot_image(annotated_image)
+    ```
+
+=== "Inference Server API ()"
+
+    ```python
+    import cv2
+    import supervision as sv
+
+    from inference_sdk import InferenceHTTPClient
+
+    client = InferenceHTTPClient(
+        api_url="http://127.0.0.1:9001",
+        api_key="XXX"
+    )
+
+    result = client.infer_from_yolo_world(
+        inference_input=["https://media.roboflow.com/dog.jpeg"],
+        class_names=["person", "backpack", "dog", "eye", "nose", "ear", "tongue"],
+        model_version="l",
+        confidence=0.1,
+    )
+
+    detections = sv.Detections.from_inference(results)
+
+    bounding_box_annotator = sv.BoundingBoxAnnotator()
+    label_annotator = sv.LabelAnnotator()
+
+    labels = [classes[class_id] for class_id in detections.class_id]
+
+    annotated_image = bounding_box_annotator.annotate(
+        scene=image, detections=detections
+    )
+    annotated_image = label_annotator.annotate(
+        scene=annotated_image, detections=detections, labels=labels
+    )
+
+    sv.plot_image(annotated_image)
+    ```
+
+
+    Run the following command to set your API key in your coding environment:
+
+    ```
+    export ROBOFLOW_API_KEY=<your api key>
+    ```
 
 In this code, we load YOLO-World, run YOLO-World on an image, and annotate the image with the predictions from the model.
 

--- a/docs/foundation/yolo_world.md
+++ b/docs/foundation/yolo_world.md
@@ -12,9 +12,15 @@ YOLO World is faster than many other zero-shot object detection models like YOLO
 
 ### How to Use YOLO-World
 
-Create a new Python file called `app.py` and add the following code:
-
 === "Inference Python Library"
+
+    Run the following command to set your API key in your coding environment:
+
+    ```
+    export ROBOFLOW_API_KEY=<your api key>
+    ```
+
+    Then, create a new Python file called `app.py` and add the following code:
 
     ```python
     import cv2
@@ -45,9 +51,27 @@ Create a new Python file called `app.py` and add the following code:
     sv.plot_image(annotated_image)
     ```
 
-=== "Inference Server API ()"
+=== "Inference Server HTTP API"
+
+    Run the following command to set your API key in your coding environment:
+
+    ```
+    export ROBOFLOW_API_KEY=<your api key>
+    ```
+
+    Then, you will need to set up an Inference server to use the YOLO World HTTP API.
+
+    To do this, run:
+
+    ```
+    pip install inference inference-sdk
+    inference server start
+    ```
+
+    Then, create a new Python file called `app.py` and add the following code:
 
     ```python
+    import os
     import cv2
     import supervision as sv
 
@@ -55,7 +79,7 @@ Create a new Python file called `app.py` and add the following code:
 
     client = InferenceHTTPClient(
         api_url="http://127.0.0.1:9001",
-        api_key="XXX"
+        api_key=os.environ["ROBOFLOW_API_KEY"]
     )
 
     result = client.infer_from_yolo_world(
@@ -80,13 +104,6 @@ Create a new Python file called `app.py` and add the following code:
     )
 
     sv.plot_image(annotated_image)
-    ```
-
-
-    Run the following command to set your API key in your coding environment:
-
-    ```
-    export ROBOFLOW_API_KEY=<your api key>
     ```
 
 In this code, we load YOLO-World, run YOLO-World on an image, and annotate the image with the predictions from the model.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,7 +82,7 @@ nav:
       - Grounding DINO (Object Detection): foundation/grounding_dino.md
       - L2CS-Net (Gaze Detection): foundation/gaze.md
       - Segment Anything (Segmentation): foundation/sam.md
-      - YOLO-World: foundation/yolo_world.md
+      - YOLO-World (Object Detection): foundation/yolo_world.md
   - Cookbooks: cookbooks.md
 
 theme:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,6 +82,7 @@ nav:
       - Grounding DINO (Object Detection): foundation/grounding_dino.md
       - L2CS-Net (Gaze Detection): foundation/gaze.md
       - Segment Anything (Segmentation): foundation/sam.md
+      - YOLO-World: foundation/yolo_world.md
   - Cookbooks: cookbooks.md
 
 theme:


### PR DESCRIPTION
# Description

This PR adds instructions on how to use YOLO-World to the Inference documentation.

## Type of change

- [ ] Documentation improvements

## How has this change been tested, please provide a testcase or example of how you tested the change?

You can test this project by navigating to the Models tab, click "YOLO World", and ensure the page opens properly.

## Any specific deployment considerations

N/A

## Docs

N/A