### PR TITLE
Deprecate `get_roboflow_model`

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@ You can [train and deploy your own custom model](https://github.com/roboflow/not
 [fine-tuned models shared by the community](https://universe.roboflow.com).
 
 There are three primary `inference` interfaces:
-* A Python-native package (`pip install inference`)
-* A self-hosted inference server (`inference server start`)
-* A [fully-managed, auto-scaling API](https://docs.roboflow.com).
+
+- A Python-native package (`pip install inference`)
+- A self-hosted inference server (`inference server start`)
+- A [fully-managed, auto-scaling API](https://docs.roboflow.com).
 
 You can run Inference on an edge device like an NVIDIA Jetson, or on cloud computing platforms like AWS, GCP, and Azure.
 
@@ -65,14 +66,14 @@ inference.Stream(
 
     output_channel_order="BGR",
     use_main_thread=True, # for opencv display
-    
+
     on_prediction=lambda predictions, image: (
         print(predictions), # now hold up your hand: 🪨 📄 ✂️
-        
+
         cv2.imshow(
-            "Prediction", 
+            "Prediction",
             annotator.annotate(
-                scene=image, 
+                scene=image,
                 detections=sv.Detections.from_inference(predictions)
             )
         ),
@@ -208,9 +209,9 @@ a `model` and using the `infer` method (don't forget to setup your
 `ROBOFLOW_API_KEY` environment variable or `.env` file):
 
 ```python
-from inference.models.utils import get_roboflow_model
+from inference.models.utils import get_model
 
-model = get_roboflow_model(
+model = get_model(
     model_id="soccer-players-5fuqs/1"
 )
 
@@ -301,6 +302,7 @@ The Roboflow Inference code is distributed under an [Apache 2.0 license](https:/
 | `inference/models/yolov8` |                              [AGPL-3.0](https://github.com/ultralytics/ultralytics/blob/master/LICENSE)                               |
 
 ## Inference CLI
+
 We've created a CLI tool with useful commands to make the `inference` usage easier. Check out [docs](./inference_cli/README.md).
 
 ## 🚀 Enterprise

--- a/docs/quickstart/configure_api_key.md
+++ b/docs/quickstart/configure_api_key.md
@@ -25,14 +25,14 @@ Then, any command you run within that same terminal session will have access to 
 When using Inference within python, your Roboflow API key can be set via keyword arguments
 
 ```python
-from inference.models.utils import get_roboflow_model
+from inference.models.utils import get_model
 
-model = get_roboflow_model(model_id="...", api_key="YOUR ROBOFLOW API KEY")
+model = get_model(model_id="...", api_key="YOUR ROBOFLOW API KEY")
 ```
 
 !!! Hint
 
-    If you set your API key in your environment, you do not have to pass it as a keyword argument: `model = get_roboflow_model(model_id="...")`
+    If you set your API key in your environment, you do not have to pass it as a keyword argument: `model = get_model(model_id="...")`
 
 ### HTTP Request Payload
 

--- a/docs/quickstart/explore_models.md
+++ b/docs/quickstart/explore_models.md
@@ -41,7 +41,7 @@ Create a new Python file and add the following code:
 
 ```python
 # import a utility function for loading Roboflow models
-from inference import get_roboflow_model
+from inference import get_model
 # import supervision to visualize our results
 import supervision as sv
 # import cv2 to helo load our image
@@ -52,7 +52,7 @@ image_file = "people-walking.jpg"
 image = cv2.imread(image_file)
 
 # load a pre-trained yolov8n model
-model = get_roboflow_model(model_id="yolov8n-640")
+model = get_model(model_id="yolov8n-640")
 
 # run inference on our chosen image, image can be a url, a numpy array, a PIL image, etc.
 results = model.infer(image)
@@ -108,7 +108,7 @@ Then, create a new Python file and add the following code:
 
 ```python
 # import a utility function for loading Roboflow models
-from inference import get_roboflow_model
+from inference import get_model
 # import supervision to visualize our results
 import supervision as sv
 # import cv2 to helo load our image
@@ -119,7 +119,7 @@ image_file = "taylor-swift-album-1989.jpeg"
 image = cv2.imread(image_file)
 
 # load a pre-trained yolov8n model
-model = get_roboflow_model(model_id="taylor-swift-records/3")
+model = get_model(model_id="taylor-swift-records/3")
 
 # run inference on our chosen image, image can be a url, a numpy array, a PIL image, etc.
 results = model.infer(image)

--- a/docs/quickstart/run_a_model.md
+++ b/docs/quickstart/run_a_model.md
@@ -18,13 +18,13 @@ Create a new Python file called `app.py` and add the following code:
 
 ```python
 # import a utility function for loading Roboflow models
-from inference import get_roboflow_model
+from inference import get_model
 
 # define the image url to use for inference
 image = "https://media.roboflow.com/inference/people-walking.jpg"
 
 # load a pre-trained yolov8n model
-model = get_roboflow_model(model_id="yolov8n-640")
+model = get_model(model_id="yolov8n-640")
 
 # run inference on our chosen image, image can be a url, a numpy array, a PIL image, etc.
 results = model.infer(image)
@@ -42,7 +42,7 @@ Running inference is fun but it's not much to look at. Let's add some code to vi
 
 ```python
 # import a utility function for loading Roboflow models
-from inference import get_roboflow_model
+from inference import get_model
 # import supervision to visualize our results
 import supervision as sv
 # import cv2 to helo load our image
@@ -53,7 +53,7 @@ image_file = "people-walking.jpg"
 image = cv2.imread(image_file)
 
 # load a pre-trained yolov8n model
-model = get_roboflow_model(model_id="yolov8n-640")
+model = get_model(model_id="yolov8n-640")
 
 # run inference on our chosen image, image can be a url, a numpy array, a PIL image, etc.
 results = model.infer(image)

--- a/docs/quickstart/what_is_inference.md
+++ b/docs/quickstart/what_is_inference.md
@@ -18,10 +18,10 @@ Then, use it to infer on an image with a public computer vision model:
 
 ```python
 # import utility function for loading roboflow models
-from inference import get_roboflow_model
+from inference import get_model
 
 # load a yolov8x model pre-trained on coco with input size 1280x1280
-model = get_roboflow_model(model_id="yolov8x-1280")
+model = get_model(model_id="yolov8x-1280")
 
 # use the model's infer(...) method to get predictions
 results = model.infer("people-walking.jpg")
@@ -31,11 +31,11 @@ results = model.infer("people-walking.jpg")
 
 Let's break our example down step by step:
 
-**`from inference import get_roboflow_model`**
+**`from inference import get_model`**
 
 First, we import a utility function which will help us load a computer vision model from Roboflow.
 
-**`model = get_roboflow_model(model_id="yolov8x-1280")`**
+**`model = get_model(model_id="yolov8x-1280")`**
 
 Next, we load a model by referencing its `model_id`. For Roboflow models, the model ID is a combination of a project name and a version number `f"{project_name}/{version_number}"`. You can find your models project name and version number <a href="https://docs.roboflow.com/api-reference/workspace-and-project-ids" target="_blank">in the Roboflow App</a>. You can also browse public models that are ready to use on <a href="https://universe.roboflow.com/" target="_blank">Roboflow Universe</a>. In this example, we are using a special model ID that is an alias of <a href="https://universe.roboflow.com/microsoft/coco/model/13" target="_blank">a COCO pretrained model on Roboflow Universe</a>. You can see the list of model aliases [here](../../reference_pages/model_aliases).
 

--- a/docs/using_inference/native_python_api.md
+++ b/docs/using_inference/native_python_api.md
@@ -11,12 +11,12 @@ This example shows how to load a model, run inference, then display the results.
 Next, import a model:
 
 ```python
-from inference import get_roboflow_model
+from inference import get_model
 
-model = get_roboflow_model(model_id="yolov8x-1280")
+model = get_model(model_id="yolov8x-1280")
 ```
 
-The `get_roboflow_model` method is a utility function which will help us load a computer vision model from Roboflow. We load a model by referencing its `model_id`. For Roboflow models, the model ID is a combination of a project name and a version number `f"{project_name}/{version_number}"`.
+The `get_model` method is a utility function which will help us load a computer vision model from Roboflow. We load a model by referencing its `model_id`. For Roboflow models, the model ID is a combination of a project name and a version number `f"{project_name}/{version_number}"`.
 
 !!! Hint
 
@@ -25,9 +25,9 @@ The `get_roboflow_model` method is a utility function which will help us load a 
 Next, we can run inference with our model by providing an input image:
 
 ```python
-from inference import get_roboflow_model
+from inference import get_model
 
-model = get_roboflow_model(model_id="yolov8x-1280")
+model = get_model(model_id="yolov8x-1280")
 
 results = model.infer("people-walking.jpg") # replace with path to your image
 ```
@@ -37,12 +37,12 @@ The results object is an [inference response object](../../docs/reference/infere
 Now, lets visualize the results using <a href="https://supervision.roboflow.com" target="_blank">Supervision</a>:
 
 ```python
-from inference import get_roboflow_model
+from inference import get_model
 import supervision as sv
 import cv2
 
 #Load model
-model = get_roboflow_model(model_id="yolov8x-1280")
+model = get_model(model_id="yolov8x-1280")
 
 #Load image with cv2
 image = cv2.imread("people-walking.jpg")
@@ -83,12 +83,12 @@ cv2.imwrite("people-walking-annotated.jpg", annotated_image)
 In the previous example, we saw that we can provide different image types to the `infer(...)` method. The `infer(...)` method accepts images in many forms including PIL images, OpenCV images (Numpy arrays), paths to local images, image URLs, and more. Under the hood, models use the `load_image(...)` method in the [`image_utils` module](../../docs/reference/inference/core/utils/image_utils/).
 
 ```python
-from inference import get_roboflow_model
+from inference import get_model
 
 import cv2
 from PIL import Image
 
-model = get_roboflow_model(model_id="yolov8x-1280")
+model = get_model(model_id="yolov8x-1280")
 
 image_url = "https://media.roboflow.com/inference/people-walking.jpg"
 local_image_file = "people-walking.jpg"
@@ -106,9 +106,9 @@ results = model.infer(image_url)
 The `infer(...)` method accepts [keyword arguments to set inference parameters](../../docs/reference/inference/core/models/object_detection_base/#inference.core.models.object_detection_base.ObjectDetectionBaseOnnxRoboflowInferenceModel.infer). The example below shows setting the confidence threshold and the IoU threshold.
 
 ```python
-from inference import get_roboflow_model
+from inference import get_model
 
-model = get_roboflow_model(model_id="yolov8x-1280")
+model = get_model(model_id="yolov8x-1280")
 
 results = model.infer("people-walking.jpg", confidence=0.75, iou_threshold=0.5)
 ```

--- a/examples/notebooks/quickstart.ipynb
+++ b/examples/notebooks/quickstart.ipynb
@@ -105,13 +105,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from inference.models.utils import get_roboflow_model\n",
+    "from inference.models.utils import get_model\n",
     "\n",
     "image_url = (\n",
     "    \"https://storage.googleapis.com/com-roboflow-marketing/inference/soccer2.jpg\"\n",
     ")\n",
     "\n",
-    "model = get_roboflow_model(\n",
+    "model = get_model(\n",
     "    model_id=\"soccer-players-5fuqs/1\",\n",
     "    api_key=api_key\n",
     ")"

--- a/inference/__init__.py
+++ b/inference/__init__.py
@@ -1,3 +1,3 @@
 from inference.core.interfaces.stream.stream import Stream  # isort:skip
 from inference.core.interfaces.stream.inference_pipeline import InferencePipeline
-from inference.models.utils import get_roboflow_model
+from inference.models.utils import get_model, get_roboflow_model

--- a/inference/core/interfaces/stream/inference_pipeline.py
+++ b/inference/core/interfaces/stream/inference_pipeline.py
@@ -42,7 +42,7 @@ from inference.core.interfaces.stream.watchdog import (
     PipelineWatchDog,
 )
 from inference.core.models.roboflow import OnnxRoboflowInferenceModel
-from inference.models.utils import get_roboflow_model
+from inference.models.utils import get_model
 
 INFERENCE_PIPELINE_CONTEXT = "inference_pipeline"
 SOURCE_CONNECTION_ATTEMPT_FAILED_EVENT = "SOURCE_CONNECTION_ATTEMPT_FAILED"
@@ -164,7 +164,7 @@ class InferencePipeline:
             mask_decode_mode=mask_decode_mode,
             tradeoff_factor=tradeoff_factor,
         )
-        model = get_roboflow_model(model_id=model_id, api_key=api_key)
+        model = get_model(model_id=model_id, api_key=api_key)
         if watchdog is None:
             watchdog = NullPipelineWatchdog()
         status_update_handlers.append(watchdog.on_status_update)

--- a/inference/core/interfaces/stream/stream.py
+++ b/inference/core/interfaces/stream/stream.py
@@ -34,7 +34,7 @@ from inference.core.interfaces.base import BaseInterface
 from inference.core.interfaces.camera.camera import WebcamStream
 from inference.core.logger import logger
 from inference.core.registries.roboflow import get_model_type
-from inference.models.utils import get_roboflow_model
+from inference.models.utils import get_model
 
 
 class Stream(BaseInterface):
@@ -103,7 +103,7 @@ class Stream(BaseInterface):
 
         self.active_learning_middleware = NullActiveLearningMiddleware()
         if isinstance(model, str):
-            self.model = get_roboflow_model(model, self.api_key)
+            self.model = get_model(model, self.api_key)
             if ACTIVE_LEARNING_ENABLED:
                 self.active_learning_middleware = (
                     ThreadingActiveLearningMiddleware.init(

--- a/inference/core/interfaces/udp/udp_stream.py
+++ b/inference/core/interfaces/udp/udp_stream.py
@@ -37,7 +37,7 @@ from inference.core.interfaces.camera.camera import WebcamStream
 from inference.core.logger import logger
 from inference.core.registries.roboflow import get_model_type
 from inference.core.version import __version__
-from inference.models.utils import get_roboflow_model
+from inference.models.utils import get_model
 
 
 class UdpStream(BaseInterface):
@@ -104,7 +104,7 @@ class UdpStream(BaseInterface):
                 f"the key."
             )
 
-        self.model = get_roboflow_model(self.model_id, self.api_key)
+        self.model = get_model(self.model_id, self.api_key)
         self.task_type = get_model_type(model_id=self.model_id, api_key=self.api_key)[0]
         self.active_learning_middleware = NullActiveLearningMiddleware()
         if ACTIVE_LEARNING_ENABLED:

--- a/inference/core/utils/function.py
+++ b/inference/core/utils/function.py
@@ -1,0 +1,17 @@
+import functools
+
+from inference.core import logger
+
+
+def deprecated(reason: str):
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            logger.warn(
+                f"{func.__name__} is deprecated: {reason}",
+            )
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/inference/landing/src/app/components/Examples.tsx
+++ b/inference/landing/src/app/components/Examples.tsx
@@ -1,20 +1,20 @@
 "use client";
 
-import React from "react"
-import { Tab } from '@headlessui/react'
+import React from "react";
+import { Tab } from "@headlessui/react";
 
-import { Light as SyntaxHighlighter } from "react-syntax-highlighter"
-import python from "react-syntax-highlighter/dist/esm/languages/hljs/python"
-import docco from "react-syntax-highlighter/dist/esm/styles/hljs/docco"
+import { Light as SyntaxHighlighter } from "react-syntax-highlighter";
+import python from "react-syntax-highlighter/dist/esm/languages/hljs/python";
+import docco from "react-syntax-highlighter/dist/esm/styles/hljs/docco";
 
 SyntaxHighlighter.registerLanguage("python", python);
 
 export default function Examples() {
-    return (
-        <div className="text-gray-800">
-            <Quickstart />
-        </div>
-    )
+  return (
+    <div className="text-gray-800">
+      <Quickstart />
+    </div>
+  );
 }
 
 const dockerCode = `import requests
@@ -36,11 +36,11 @@ params = {
 
 res = requests.post(url, params=params)
 print(res.json())
-`
+`;
 
-const pipCode = `from inference.models.utils import get_roboflow_model
+const pipCode = `from inference.models.utils import get_model
 
-model = get_roboflow_model(
+model = get_model(
     model_id="soccer-players-5fuqs/1",
     # Replace ROBOFLOW_API_KEY with your Roboflow API Key
     api_key="ROBOFLOW_API_KEY"
@@ -53,7 +53,7 @@ results = model.infer(
 )
 
 print(results)
-`
+`;
 
 const clipCode = `from inference.models import Clip
 
@@ -67,7 +67,7 @@ image_url = "https://source.roboflow.com/7fLqS2r1SV8mm0YzyI0c/yy6hjtPUFFkq4yAvhk
 embeddings = model.embed_image(image_url)
 
 print(embeddings)
-`
+`;
 
 const samCode = `from inference.models import SegmentAnything
 
@@ -81,61 +81,65 @@ image_url = "https://source.roboflow.com/7fLqS2r1SV8mm0YzyI0c/yy6hjtPUFFkq4yAvhk
 embeddings = model.embed_image(image_url)
 
 print(embeddings)
-`
+`;
 
-const tabClasses = "py-3 px-4 text-sm ui-selected:border-b-2 border-b ui-selected:border-purple-600 border-white focus:outline-none ui-selected:text-purple-600 text-gray-800 hover:text-purple-600"
+const tabClasses =
+  "py-3 px-4 text-sm ui-selected:border-b-2 border-b ui-selected:border-purple-600 border-white focus:outline-none ui-selected:text-purple-600 text-gray-800 hover:text-purple-600";
 
 function Quickstart() {
-    return (
-        <div className="w-100">
-            <Tab.Group>
-                <Tab.List className="flex text-gray-800 mb-3 font-medium">
-                    <Tab className={tabClasses}>Docker</Tab>
-                    <Tab className={tabClasses}>CLIP</Tab>
-                    <Tab className={tabClasses}>SAM</Tab>
-                    <Tab className={tabClasses}>pip</Tab>
-                </Tab.List>
-                <Tab.Panels>
-                    <Tab.Panel>
-                        <Code code={dockerCode} />
-                    </Tab.Panel>
-                    <Tab.Panel>
-                        <Code code={clipCode} />
-                    </Tab.Panel>
-                    <Tab.Panel>
-                        <Code code={samCode} />
-                    </Tab.Panel>
-                    <Tab.Panel>
-                        <Code code={pipCode} />
-                    </Tab.Panel>
-                </Tab.Panels>
-            </Tab.Group>
-        </div>
-    )
+  return (
+    <div className="w-100">
+      <Tab.Group>
+        <Tab.List className="flex text-gray-800 mb-3 font-medium">
+          <Tab className={tabClasses}>Docker</Tab>
+          <Tab className={tabClasses}>CLIP</Tab>
+          <Tab className={tabClasses}>SAM</Tab>
+          <Tab className={tabClasses}>pip</Tab>
+        </Tab.List>
+        <Tab.Panels>
+          <Tab.Panel>
+            <Code code={dockerCode} />
+          </Tab.Panel>
+          <Tab.Panel>
+            <Code code={clipCode} />
+          </Tab.Panel>
+          <Tab.Panel>
+            <Code code={samCode} />
+          </Tab.Panel>
+          <Tab.Panel>
+            <Code code={pipCode} />
+          </Tab.Panel>
+        </Tab.Panels>
+      </Tab.Group>
+    </div>
+  );
 }
-
 
 type CodeProps = {
-    code: string
-}
+  code: string;
+};
 
 function Code({ code }: CodeProps) {
-    function copyToClipboard() {
-        navigator.clipboard.writeText(code)
-    }
+  function copyToClipboard() {
+    navigator.clipboard.writeText(code);
+  }
 
-    return (
-        <div className="rounded p-8 bg-[#f8f8ff] relative">
-            <SyntaxHighlighter className="rounded p-8" language="python" style={docco}>
-                {code}
-            </SyntaxHighlighter>
-            <div
-                className="text-gray-700 absolute w-24 h-8 top-2 right-2 bg-white text-sm flex items-center justify-center border rounded-tr-md rounded-bl-md cursor-pointer select-none hover:bg-gray-100"
-                onClick={copyToClipboard}
-            >
-                <i className="far fa-copy h-4 w-4 mr-1 text-sm" />
-                Copy
-            </div>
-        </div>
-    )
+  return (
+    <div className="rounded p-8 bg-[#f8f8ff] relative">
+      <SyntaxHighlighter
+        className="rounded p-8"
+        language="python"
+        style={docco}
+      >
+        {code}
+      </SyntaxHighlighter>
+      <div
+        className="text-gray-700 absolute w-24 h-8 top-2 right-2 bg-white text-sm flex items-center justify-center border rounded-tr-md rounded-bl-md cursor-pointer select-none hover:bg-gray-100"
+        onClick={copyToClipboard}
+      >
+        <i className="far fa-copy h-4 w-4 mr-1 text-sm" />
+        Copy
+      </div>
+    </div>
+  );
 }

--- a/inference/models/utils.py
+++ b/inference/models/utils.py
@@ -192,8 +192,5 @@ def get_model(model_id, api_key=API_KEY, **kwargs):
     return ROBOFLOW_MODEL_TYPES[(task, model)](model_id, api_key=api_key, **kwargs)
 
 
-@deprecated(
-    "`get_roboflow_model` is deprecated and will be removed in `inference-1.0.0`, use `get_model` instead."
-)
 def get_roboflow_model(*args, **kwargs):
     return get_model(*args, **kwargs)

--- a/inference/models/utils.py
+++ b/inference/models/utils.py
@@ -7,6 +7,7 @@ from inference.core.models.stubs import (
     ObjectDetectionModelStub,
 )
 from inference.core.registries.roboflow import get_model_type
+from inference.core.utils.function import deprecated
 from inference.models import (
     YOLACT,
     VitClassification,
@@ -186,6 +187,13 @@ except:
     pass
 
 
-def get_roboflow_model(model_id, api_key=API_KEY, **kwargs):
+def get_model(model_id, api_key=API_KEY, **kwargs):
     task, model = get_model_type(model_id, api_key=api_key)
     return ROBOFLOW_MODEL_TYPES[(task, model)](model_id, api_key=api_key, **kwargs)
+
+
+@deprecated(
+    "`get_roboflow_model` is deprecated and will be removed in `inference-1.0.0`, use `get_model` instead."
+)
+def get_roboflow_model(*args, **kwargs):
+    return get_model(*args, **kwargs)

--- a/inference_cli/lib/benchmark/python_package_speed.py
+++ b/inference_cli/lib/benchmark/python_package_speed.py
@@ -11,7 +11,7 @@ from inference_cli.lib.benchmark.results_gathering import ResultsCollector
 from inference_cli.lib.exceptions import InferencePackageMissingError
 
 try:
-    from inference import get_roboflow_model
+    from inference import get_model
     from inference.core.models.base import Model
     from inference.core.registries.roboflow import get_model_type
 except Exception as error:
@@ -49,7 +49,7 @@ def run_python_package_speed_benchmark(
         f"Inference will be executed with the following parameters: {inference_configuration}"
     )
     model_type = get_model_type(model_id, api_key=api_key)
-    model = get_roboflow_model(model_id=model_id, api_key=api_key)
+    model = get_model(model_id=model_id, api_key=api_key)
     model_batch_size = getattr(model, "batch_size", None)
     input_height = getattr(model, "img_size_h", None)
     input_width = getattr(model, "img_size_w", None)


### PR DESCRIPTION
# Description

Changed name of `get_roboflow_model` to `get_model` and added deprecation warning.

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [X] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update
