### PR TITLE
Fix/fix multi detections workflows

### DIFF
--- a/inference/core/version.py
+++ b/inference/core/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.9.14rc1"
+__version__ = "0.9.14rc2"
 
 
 if __name__ == "__main__":

--- a/inference/enterprise/workflows/complier/steps_executors/auxiliary.py
+++ b/inference/enterprise/workflows/complier/steps_executors/auxiliary.py
@@ -140,6 +140,8 @@ def crop_image(
                 ORIGIN_COORDINATES_KEY: {
                     CENTER_X_KEY: detection["x"],
                     CENTER_Y_KEY: detection["y"],
+                    WIDTH_KEY: detection[WIDTH_KEY],
+                    HEIGHT_KEY: detection[HEIGHT_KEY],
                     ORIGIN_SIZE_KEY: origin_size,
                 },
             }

--- a/inference/enterprise/workflows/complier/steps_executors/models.py
+++ b/inference/enterprise/workflows/complier/steps_executors/models.py
@@ -34,9 +34,11 @@ from inference.enterprise.workflows.complier.entities import StepExecutionMode
 from inference.enterprise.workflows.complier.steps_executors.constants import (
     CENTER_X_KEY,
     CENTER_Y_KEY,
+    HEIGHT_KEY,
     ORIGIN_COORDINATES_KEY,
     ORIGIN_SIZE_KEY,
     PARENT_COORDINATES_SUFFIX,
+    WIDTH_KEY,
 )
 from inference.enterprise.workflows.complier.steps_executors.types import (
     NextStepReference,
@@ -804,9 +806,11 @@ def anchor_image_detections_in_parent_coordinates(
         image[ORIGIN_COORDINATES_KEY][CENTER_X_KEY],
         image[ORIGIN_COORDINATES_KEY][CENTER_Y_KEY],
     )
+    parent_left_top_x = round(shift_x - image[ORIGIN_COORDINATES_KEY][WIDTH_KEY] / 2)
+    parent_left_top_y = round(shift_y - image[ORIGIN_COORDINATES_KEY][HEIGHT_KEY] / 2)
     for detection in serialised_result[f"{detections_key}{PARENT_COORDINATES_SUFFIX}"]:
-        detection["x"] += shift_x
-        detection["y"] += shift_y
+        detection["x"] += parent_left_top_x
+        detection["y"] += parent_left_top_y
     serialised_result[f"{image_metadata_key}{PARENT_COORDINATES_SUFFIX}"] = image[
         ORIGIN_COORDINATES_KEY
     ][ORIGIN_SIZE_KEY]

--- a/tests/inference/unit_tests/enterprise/workflows/compiler/steps_executors/test_auxiliary.py
+++ b/tests/inference/unit_tests/enterprise/workflows/compiler/steps_executors/test_auxiliary.py
@@ -74,6 +74,8 @@ def test_crop_image() -> None:
     assert result[0]["origin_coordinates"] == {
         "center_x": 10,
         "center_y": 10,
+        "height": 20,
+        "width": 20,
         "origin_image_size": {"height": 1000, "width": 1000},
     }, "Appropriate origin coordinates must be attached"
     assert (
@@ -88,6 +90,8 @@ def test_crop_image() -> None:
     assert result[1]["origin_coordinates"] == {
         "center_x": 100,
         "center_y": 100,
+        "height": 40,
+        "width": 40,
         "origin_image_size": {"height": 1000, "width": 1000},
     }, "Appropriate origin coordinates must be attached"
     assert (
@@ -102,6 +106,8 @@ def test_crop_image() -> None:
     assert result[2]["origin_coordinates"] == {
         "center_x": 500,
         "center_y": 500,
+        "height": 100,
+        "width": 100,
         "origin_image_size": {"height": 1000, "width": 1000},
     }, "Appropriate origin coordinates must be attached"
 


### PR DESCRIPTION
# Description

There was a bug in translation of nested detection coordinates into parent's coordinate system. What should happen is the shift according to parent detection left_top point, not shift according to center point of parent detection.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

YOUR_ANSWER

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
