### PR TITLE
Resolve memory management issue causing ti many models being loaded in lambda

### DIFF
--- a/inference/core/managers/base.py
+++ b/inference/core/managers/base.py
@@ -251,6 +251,7 @@ class ModelManager:
             model_id (str): The identifier of the model.
         """
         try:
+            logger.debug(f"Removing model {model_id} from base model manager")
             self.check_for_model(model_id)
             self._models[model_id].clear_cache()
             del self._models[model_id]

--- a/inference/core/managers/decorators/fixed_size_cache.py
+++ b/inference/core/managers/decorators/fixed_size_cache.py
@@ -47,7 +47,7 @@ class WithFixedSizeCache(ModelManagerDecorator):
             logger.debug(
                 f"Reached maximum capacity of ModelManager. Unloading model {to_remove_model_id}"
             )
-            self.remove(to_remove_model_id)
+            super().remove(to_remove_model_id)
             logger.debug(f"Model {to_remove_model_id} successfully unloaded.")
         logger.debug(f"Marking new model {queue_id} as most recently used.")
         self._key_queue.append(queue_id)

--- a/inference/core/version.py
+++ b/inference/core/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.9.16rc1"
+__version__ = "0.9.16rc2"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description
We had a problem with the model manager loading dozens of model and lambda environments were running out of memory after a while. This change fixes issue with memory management. What was happening - old version of function for reference:
```python
def add_model(
        self, model_id: str, api_key: str, model_id_alias: Optional[str] = None
    ):
        """Adds a model to the manager and evicts the least recently used if the cache is full.

        Args:
            model_id (str): The identifier of the model.
            model (Model): The model instance.
        """
        queue_id = self._resolve_queue_id(
            model_id=model_id, model_id_alias=model_id_alias
        )
        if model_id in self:
            self._key_queue.remove(queue_id)
            self._key_queue.append(queue_id)
            return

        should_pop = len(self) == self.max_size
        if should_pop:
            to_remove_model_id = self._key_queue.popleft()
            self.remove(to_remove_model_id)

        self._key_queue.append(queue_id)
        try:
            return super().add_model(model_id, api_key, model_id_alias=model_id_alias)
        except Exception as error:
            self._key_queue.remove(model_id)
            raise error
```

In lambda (due to aliasing of endpoints), the block:
```python
   if model_id in self:
      self._key_queue.remove(queue_id)
      self._key_queue.append(queue_id)
      return
```
never enter inner state - which means that we were always deciding `if should_pop` - even if model was in registry. We could unload model that was about to be used. Assuming that `self.max_size` > 1 we may end up in the situation when we unload model that already was purged (`len(self) == self.max_size` still holds after `if should_pop: True` block) - in that moment we are loading first illegal model and we will never pop again causing inevitable OOM. 

List any dependencies that are required for this change.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

YOUR_ANSWER

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
