### PR TITLE
Fix inconsistency in class filtering for workflows

### DIFF
--- a/inference/core/version.py
+++ b/inference/core/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.9.16rc2"
+__version__ = "0.9.16rc3"
 
 
 if __name__ == "__main__":

--- a/inference/enterprise/workflows/README.md
+++ b/inference/enterprise/workflows/README.md
@@ -441,8 +441,9 @@ prevent situation when evaluation of condition for multiple images yield differe
 * `name`: must be unique within all steps - used as identifier (required)
 * `left`: left operand of `operator`, can be actual value, reference to input or step output (required)
 * `right`: left operand of `operator`, can be actual value, reference to input or step output (required)
-* `operator`: one of `equal`, `not_equal`, `lower_than`, `greater_than`, `lower_or_equal_than`, `greater_or_equal_than`
-or `in` (required)
+* `operator`: one of `equal`, `not_equal`, `lower_than`, `greater_than`, `lower_or_equal_than`, `greater_or_equal_than`, 
+`in`, `str_starts_with` (meaning `left` ends with `right`), `str_ends_with` (meaning `left` starts with `right`), 
+`str_contains` (meaning `left` contains `right`) (required)
 * `step_if_true`: reference to the step that will be executed if condition is true (required)
 * `step_if_false`: reference to the step that will be executed if condition is false (required)
 
@@ -487,7 +488,18 @@ or `CompoundDetectionFilterDefinition`
 ```
 
 where `DetectionFilterDefinition` uses binary operator and the left operand is detection field pointed by `field_name`
-and right operand is `reference_value`.
+and right operand is `reference_value`. `"operaror"` can be filled with values:
+* `equal` (field value equal to `reference_value`)
+* `not_equal`
+* `lower_than`
+* `greater_than`
+* `lower_or_equal_than`
+* `greater_or_equal_than`
+* `in` (field value in range of `reference_value`)
+* `str_starts_with` (field value - string - starts from `reference_value`)
+* `str_ends_with` (field value - string - ends with `reference_value`)
+* `str_contains` (field value - string - contains substring pointed in `reference_value`)
+
 In case if `CompoundDetectionFilterDefinition`, logical operators `or`, `and` can be used to combine simple filters.
 This let user define recursive structure of filters.
 

--- a/inference/enterprise/workflows/complier/steps_executors/auxiliary.py
+++ b/inference/enterprise/workflows/complier/steps_executors/auxiliary.py
@@ -55,10 +55,7 @@ from inference.enterprise.workflows.entities.steps import (
     Operator,
     RelativeStaticCrop,
 )
-from inference.enterprise.workflows.entities.validators import (
-    get_last_selector_chunk,
-    is_selector,
-)
+from inference.enterprise.workflows.entities.validators import get_last_selector_chunk
 from inference.enterprise.workflows.errors import ExecutionGraphError
 
 OPERATORS = {
@@ -69,6 +66,9 @@ OPERATORS = {
     Operator.LOWER_OR_EQUAL_THAN: lambda a, b: a <= b,
     Operator.GREATER_OR_EQUAL_THAN: lambda a, b: a >= b,
     Operator.IN: lambda a, b: a in b,
+    Operator.STR_STARTS_WITH: lambda a, b: a.startswith(b),
+    Operator.STR_ENDS_WITH: lambda a, b: a.endswith(b),
+    Operator.STR_CONTAINS: lambda a, b: b in a,
 }
 
 BINARY_OPERATORS = {

--- a/inference/enterprise/workflows/complier/steps_executors/models.py
+++ b/inference/enterprise/workflows/complier/steps_executors/models.py
@@ -131,6 +131,17 @@ async def run_roboflow_model_step(
             image=image, results=serialised_result, nested_key=None
         )
     else:
+        class_filter = resolve_parameter(
+            selector_or_value=step.class_filter,
+            runtime_parameters=runtime_parameters,
+            outputs_lookup=outputs_lookup,
+        )
+        # we need to filter-out classes here, to ensure consistent behaviour of external API usage
+        # as legacy endpoints to not support this functionality
+        serialised_result = filter_out_unwanted_classes(
+            serialised_result=serialised_result,
+            classes_to_accept=class_filter,
+        )
         serialised_result = attach_parent_info(image=image, results=serialised_result)
         serialised_result = anchor_detections_in_parent_coordinates(
             image=image,
@@ -138,6 +149,25 @@ async def run_roboflow_model_step(
         )
     outputs_lookup[construct_step_selector(step_name=step.name)] = serialised_result
     return None, outputs_lookup
+
+
+def filter_out_unwanted_classes(
+    serialised_result: List[Dict[str, Any]],
+    classes_to_accept: Optional[List[str]],
+) -> List[Dict[str, Any]]:
+    if classes_to_accept is None:
+        return serialised_result
+    classes_to_accept = set(classes_to_accept)
+    results = []
+    for image_result in serialised_result:
+        filtered_image_result = deepcopy(image_result)
+        filtered_image_result["predictions"] = []
+        for prediction in image_result["predictions"]:
+            if prediction["class"] not in classes_to_accept:
+                continue
+            filtered_image_result["predictions"].append(prediction)
+        results.append(filtered_image_result)
+    return results
 
 
 async def get_roboflow_model_predictions_locally(

--- a/inference/enterprise/workflows/entities/steps.py
+++ b/inference/enterprise/workflows/entities/steps.py
@@ -562,6 +562,9 @@ class Operator(Enum):
     LOWER_OR_EQUAL_THAN = "lower_or_equal_than"
     GREATER_OR_EQUAL_THAN = "greater_or_equal_than"
     IN = "in"
+    STR_STARTS_WITH = "str_starts_with"
+    STR_ENDS_WITH = "str_ends_with"
+    STR_CONTAINS = "str_contains"
 
 
 class Condition(BaseModel, StepInterface):

--- a/tests/inference/unit_tests/enterprise/workflows/compiler/steps_executors/test_auxiliary.py
+++ b/tests/inference/unit_tests/enterprise/workflows/compiler/steps_executors/test_auxiliary.py
@@ -262,6 +262,186 @@ async def test_run_condition_step_for_outputs_with_not_allowed_batch_size() -> N
 
 
 @pytest.mark.asyncio
+async def test_run_condition_step_when_string_prefix_to_be_matched_correctly() -> None:
+    # given
+    step = Condition(
+        type="Condition",
+        name="step_1",
+        left="$steps.step_0.top",
+        operator=Operator.STR_STARTS_WITH,
+        right="$inputs.some",
+        step_if_true="$steps.step_2",
+        step_if_false="$steps.step_3",
+    )
+
+    # when
+    next_step, outputs_lookup = await run_condition_step(
+        step=step,
+        runtime_parameters={"some": "cat"},
+        outputs_lookup={"$steps.step_0": {"top": "cat_persian"}},
+        model_manager=MagicMock(),
+        api_key=None,
+        step_execution_mode=StepExecutionMode.LOCAL,
+    )
+
+    # then
+    assert outputs_lookup == {
+        "$steps.step_0": {"top": "cat_persian"}
+    }, "Output lookup must not be modified"
+    assert next_step == "$steps.step_2"
+
+
+@pytest.mark.asyncio
+async def test_run_condition_step_when_string_prefix_not_to_be_matched() -> None:
+    # given
+    step = Condition(
+        type="Condition",
+        name="step_1",
+        left="$steps.step_0.top",
+        operator=Operator.STR_STARTS_WITH,
+        right="$inputs.some",
+        step_if_true="$steps.step_2",
+        step_if_false="$steps.step_3",
+    )
+
+    # when
+    next_step, outputs_lookup = await run_condition_step(
+        step=step,
+        runtime_parameters={"some": "dog"},
+        outputs_lookup={"$steps.step_0": {"top": "cat_persian"}},
+        model_manager=MagicMock(),
+        api_key=None,
+        step_execution_mode=StepExecutionMode.LOCAL,
+    )
+
+    # then
+    assert outputs_lookup == {
+        "$steps.step_0": {"top": "cat_persian"}
+    }, "Output lookup must not be modified"
+    assert next_step == "$steps.step_3"
+
+
+@pytest.mark.asyncio
+async def test_run_condition_step_when_string_postfix_to_be_matched_correctly() -> None:
+    # given
+    step = Condition(
+        type="Condition",
+        name="step_1",
+        left="$steps.step_0.top",
+        operator=Operator.STR_ENDS_WITH,
+        right="$inputs.some",
+        step_if_true="$steps.step_2",
+        step_if_false="$steps.step_3",
+    )
+
+    # when
+    next_step, outputs_lookup = await run_condition_step(
+        step=step,
+        runtime_parameters={"some": "persian"},
+        outputs_lookup={"$steps.step_0": {"top": "cat_persian"}},
+        model_manager=MagicMock(),
+        api_key=None,
+        step_execution_mode=StepExecutionMode.LOCAL,
+    )
+
+    # then
+    assert outputs_lookup == {
+        "$steps.step_0": {"top": "cat_persian"}
+    }, "Output lookup must not be modified"
+    assert next_step == "$steps.step_2"
+
+
+@pytest.mark.asyncio
+async def test_run_condition_step_when_string_postfix_not_to_be_matched() -> None:
+    # given
+    step = Condition(
+        type="Condition",
+        name="step_1",
+        left="$steps.step_0.top",
+        operator=Operator.STR_ENDS_WITH,
+        right="$inputs.some",
+        step_if_true="$steps.step_2",
+        step_if_false="$steps.step_3",
+    )
+
+    # when
+    next_step, outputs_lookup = await run_condition_step(
+        step=step,
+        runtime_parameters={"some": "european"},
+        outputs_lookup={"$steps.step_0": {"top": "cat_persian"}},
+        model_manager=MagicMock(),
+        api_key=None,
+        step_execution_mode=StepExecutionMode.LOCAL,
+    )
+
+    # then
+    assert outputs_lookup == {
+        "$steps.step_0": {"top": "cat_persian"}
+    }, "Output lookup must not be modified"
+    assert next_step == "$steps.step_3"
+
+
+@pytest.mark.asyncio
+async def test_run_condition_step_when_string_infix_to_be_matched_correctly() -> None:
+    # given
+    step = Condition(
+        type="Condition",
+        name="step_1",
+        left="$steps.step_0.top",
+        operator=Operator.STR_CONTAINS,
+        right="$inputs.some",
+        step_if_true="$steps.step_2",
+        step_if_false="$steps.step_3",
+    )
+
+    # when
+    next_step, outputs_lookup = await run_condition_step(
+        step=step,
+        runtime_parameters={"some": "t_p"},
+        outputs_lookup={"$steps.step_0": {"top": "cat_persian"}},
+        model_manager=MagicMock(),
+        api_key=None,
+        step_execution_mode=StepExecutionMode.LOCAL,
+    )
+
+    # then
+    assert outputs_lookup == {
+        "$steps.step_0": {"top": "cat_persian"}
+    }, "Output lookup must not be modified"
+    assert next_step == "$steps.step_2"
+
+
+@pytest.mark.asyncio
+async def test_run_condition_step_when_string_infix_not_to_be_matched_correctly() -> None:
+    # given
+    step = Condition(
+        type="Condition",
+        name="step_1",
+        left="$steps.step_0.top",
+        operator=Operator.STR_CONTAINS,
+        right="$inputs.some",
+        step_if_true="$steps.step_2",
+        step_if_false="$steps.step_3",
+    )
+
+    # when
+    next_step, outputs_lookup = await run_condition_step(
+        step=step,
+        runtime_parameters={"some": "t.p"},
+        outputs_lookup={"$steps.step_0": {"top": "cat_persian"}},
+        model_manager=MagicMock(),
+        api_key=None,
+        step_execution_mode=StepExecutionMode.LOCAL,
+    )
+
+    # then
+    assert outputs_lookup == {
+        "$steps.step_0": {"top": "cat_persian"}
+    }, "Output lookup must not be modified"
+    assert next_step == "$steps.step_3"
+
+
+@pytest.mark.asyncio
 async def test_run_detection_filter_step_when_batch_detections_given() -> None:
     # given
     step = DetectionFilter.parse_obj(


### PR DESCRIPTION
# Description

Legacy inference endpoint does not support filtering by class names - fixed.
Also - added possibility to filter detections by pre- / post- fix and substring in `DetectionFilter` and make the same for string fields in `Condition` step (as a requested feature)

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [x] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

YOUR_ANSWER

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [x] Docs updated? What were the changes:
