### PR TITLE
Updated Requirements.cli.txt

### DIFF
--- a/requirements/requirements.cli.txt
+++ b/requirements/requirements.cli.txt
@@ -10,3 +10,5 @@ opencv-python>=4.6.0
 tqdm>=4.0.0
 GPUtil>=1.4.0
 py-cpuinfo>=9.0.0
+aiohttp>=3.9.0
+backoff>=2.2.0


### PR DESCRIPTION
Issue: #299 
Added `aiohttp` and `backoff` to the `requirements.cli.txt` file. This ensures that these dependencies are installed alongside `inference_cli`, addressing the root cause of the startup failures.

- `aiohttp` and `backoff` are direct dependencies of the `inference_sdk` used by our CLI tool for handling HTTP requests and implementing retry logic, respectively.

- The absence of these packages in the `requirements.cli.txt` file led to an incomplete environment setup for users, resulting in runtime errors.

- By explicitly listing these dependencies, i ensure that the necessary packages are present in the environment, thereby preventing `ModuleNotFoundError` issues during runtime.
