### PR TITLE
Add inference server performance profiling with pyinstrument

### DIFF
--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -1,0 +1,34 @@
+# Profiling API Requests with pyinstrument
+
+The inference server supports detailed performance profiling of API requests using pyinstrument, which offers a deeper insight into the execution time of HTTP requests and models through statistical sampling.
+
+## Enabling profiling
+
+Install the profiling dependencies using pip:
+
+```bash
+pip install -r requirements/requirements.profiling.txt
+```
+
+Then set the environment variable `PYINSTRUMENT_ENABLED` to `true`:
+
+```bash
+export PYINSTRUMENT_ENABLED=true
+```
+
+## Profiling a request
+
+To enable profiling for a specific request, simply append the query parameter `?profile=true` to the URL of any request. For example, to profile a Grounding DINO inference request:
+
+```
+curl -X POST -H "Content-Type: application/json" -d "@/home/user/request-data.json" "https://inference-url/grounding_dino/infer?profile=true"
+```
+
+## Viewing performance profiles
+
+The inference server writes two files when a request is profiled:
+
+- `profile.html:` A detailed HTML report of the profile.
+    - Open in a Web browser.
+- `profile.speedscope.json`: A JSON file containing the raw profile data in the Speedscope format.
+    - Open with https://www.speedscope.app/.

--- a/inference/core/env.py
+++ b/inference/core/env.py
@@ -239,6 +239,9 @@ PORT = int(os.getenv("PORT", 9001))
 # Profile flag, default is False
 PROFILE = str2bool(os.getenv("PROFILE", False))
 
+# Flag to enable pyinstrument profiling, default is False
+PYINSTRUMENT_ENABLED = str2bool(os.getenv("PYINSTRUMENT_ENABLED", False))
+
 # Redis host, default is None
 REDIS_HOST = os.getenv("REDIS_HOST", None)
 

--- a/inference/core/interfaces/http/http_api.py
+++ b/inference/core/interfaces/http/http_api.py
@@ -340,7 +340,6 @@ class HttpInterface(BaseInterface):
 
                 return response
 
-
         self.app = app
         self.model_manager = model_manager
         self.workflows_active_learning_middleware = WorkflowsActiveLearningMiddleware(

--- a/requirements/requirements.profiling.txt
+++ b/requirements/requirements.profiling.txt
@@ -1,0 +1,1 @@
+pyinstrument>=4.6.2


### PR DESCRIPTION
# Description

Adds statistical performance profiling for HTTP requests using pyinstrument. Outputs two formats:
- Speedscope (for flame graphs)
- HTML

Example outputs:

<img width="1511" alt="Screenshot 2024-03-05 at 3 51 54 PM" src="https://github.com/roboflow/inference/assets/6478/9e85f5d1-5544-46bc-8402-5844c6143904">

<img width="1512" alt="Screenshot 2024-03-05 at 3 56 02 PM" src="https://github.com/roboflow/inference/assets/6478/0fb1883f-a724-4ede-a749-3496af8bc0c9">

## Type of change

-   ✅  New feature (non-breaking change which adds functionality)
-   ✅  This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

See `docs/profiling.md` for profiling instructions.

## Docs

-   ✅  Docs updated? What were the changes: `docs/profiling.md`
