### PR TITLE
Fix Circular Import of inference from inference_sdk

### DIFF
--- a/.release/pypi/inference.cli.setup.py
+++ b/.release/pypi/inference.cli.setup.py
@@ -4,12 +4,12 @@ from setuptools import find_packages
 import sys
 import shutil
 
-root = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
+root = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../inference_cli"))
 sys.path.append(root)
 
 shutil.copyfile(
-    os.path.join(root, "inference/core/version.py"),
-    os.path.join(root, "inference_cli/version.py"),
+    os.path.join(root, "../inference/core/version.py"),
+    os.path.join(root, "../inference_cli/version.py"),
 )
 
 from inference.core.version import __version__

--- a/.release/pypi/inference.sdk.setup.py
+++ b/.release/pypi/inference.sdk.setup.py
@@ -5,12 +5,12 @@ import setuptools
 from setuptools import find_packages
 import sys
 
-root = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
+root = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../inference_sdk"))
 sys.path.append(root)
 
 shutil.copyfile(
-    os.path.join(root, "inference/core/version.py"),
-    os.path.join(root, "inference_sdk/version.py"),
+    os.path.join(root, "../inference/core/version.py"),
+    os.path.join(root, "../inference_sdk/version.py"),
 )
 
 from inference.core.version import __version__


### PR DESCRIPTION
# Description

Still not entirely sure why, but `pip install -e .` was getting `inference` from PyPi vs from local and this fixes it.

I _think_ this was happening for two reasons:
1. `inference_sdk` was including `inference` along with its distribution
2. `inference_cli` has `inference_sdk` in its requirements so it was pulling the version from PyPi vs the local one (which also kept bringing down `inference` even after fixing the inference_sdk `setup.py`)

Repro Docker:
```
FROM ubuntu

WORKDIR /app
RUN apt-get update -y && apt-get install -y python3 pip git ffmpeg libsm6 libxext6 && rm -rf /var/lib/apt/lists/*
RUN git clone https://github.com/roboflow/inference.git
WORKDIR /app/inference
RUN git checkout feature/improve_contributor_experience
RUN pip install -e .
RUN echo 'print("LOCAL CHANGE")' >> inference/__init__.py 
WORKDIR /app
RUN echo "import inference" > app.py
RUN echo 'print("FINISHED")' >> app.py

ENTRYPOINT python3 app.py
```

Save to `Dockerfile` and run via
```
docker build . -t localinference -f Dockerfile && docker run localinference
```

The `LOCAL CHANGE` text will not be printed (though it should be if the package were installed locally).

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Locally in a new `venv` and in a fresh `ubuntu` docker. To try, swap out the git checkout in the Dockerfile above to use this branch, `fix/circular-import`; after rebuilding & running the docker, the `LOCAL CHANGE` text should now be printed.

## Any specific deployment considerations

No

## Docs

- Not needed
