### PR TITLE
Fix wheels creation CI

### DIFF
--- a/.github/workflows/publish.pypi.yml
+++ b/.github/workflows/publish.pypi.yml
@@ -21,9 +21,6 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - name: 🦾 Install dependencies
-        run: |
-          ln -s .release/pypi/inference.core.setup.py setup.py
       - name: 🛞 Create Wheels
         run: |
           make create_wheels


### PR DESCRIPTION
# Description

We've unfortunate symlink creation command in GHA to build and push wheels - as there is one generic setup.py to resolve dev dependencies in repo root. Script for creating wheels, up to my knowledge, should not require that.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)

YOUR_ANSWER

## How has this change been tested, please provide a testcase or example of how you tested the change?
* Automated tests running in GHA CI
* manual verification of command `make create_wheels` without `setup.py` being linked prior to execution

## Any specific deployment considerations
N/A

## Docs

-   [ ] Docs updated? What were the changes: (N/A)
