### PR TITLE
Add inference_id to batches created by AL

### DIFF
--- a/inference/core/active_learning/core.py
+++ b/inference/core/active_learning/core.py
@@ -53,7 +53,7 @@ def execute_datapoint_registration(
     configuration: ActiveLearningConfiguration,
     api_key: str,
     batch_name: str,
-    inference_id=None,
+    inference_id: Optional[str] = None,
 ) -> None:
     local_image_id = str(uuid4())
     encoded_image, scaling_factor = prepare_image_to_registration(

--- a/inference/core/active_learning/core.py
+++ b/inference/core/active_learning/core.py
@@ -53,6 +53,7 @@ def execute_datapoint_registration(
     configuration: ActiveLearningConfiguration,
     api_key: str,
     batch_name: str,
+    inference_id=None,
 ) -> None:
     local_image_id = str(uuid4())
     encoded_image, scaling_factor = prepare_image_to_registration(
@@ -88,6 +89,7 @@ def execute_datapoint_registration(
         configuration=configuration,
         api_key=api_key,
         batch_name=batch_name,
+        inference_id=inference_id,
     )
 
 
@@ -120,6 +122,7 @@ def register_datapoint_at_roboflow(
     configuration: ActiveLearningConfiguration,
     api_key: str,
     batch_name: str,
+    inference_id: Optional[str],
 ) -> None:
     tags = collect_tags(
         configuration=configuration,
@@ -134,6 +137,7 @@ def register_datapoint_at_roboflow(
         api_key=api_key,
         batch_name=batch_name,
         tags=tags,
+        inference_id=inference_id,
     )
     if is_prediction_registration_forbidden(
         prediction=prediction,
@@ -176,6 +180,7 @@ def safe_register_image_at_roboflow(
     api_key: str,
     batch_name: str,
     tags: List[str],
+    inference_id: Optional[str],
 ) -> Optional[str]:
     credit_to_be_returned = False
     try:
@@ -186,6 +191,7 @@ def safe_register_image_at_roboflow(
             image_bytes=encoded_image,
             batch_name=batch_name,
             tags=tags,
+            inference_id=inference_id,
         )
         image_duplicated = registration_response.get("duplicate", False)
         if image_duplicated:

--- a/inference/core/active_learning/middlewares.py
+++ b/inference/core/active_learning/middlewares.py
@@ -104,6 +104,7 @@ class ActiveLearningMiddleware:
         predictions: List[Prediction],
         prediction_type: PredictionType,
         disable_preproc_auto_orient: bool = False,
+        inference_id=None,
     ) -> None:
         for inference_input, prediction in zip(inference_inputs, predictions):
             self.register(
@@ -111,6 +112,7 @@ class ActiveLearningMiddleware:
                 prediction=prediction,
                 prediction_type=prediction_type,
                 disable_preproc_auto_orient=disable_preproc_auto_orient,
+                inference_id=inference_id,
             )
 
     def register(
@@ -119,12 +121,14 @@ class ActiveLearningMiddleware:
         prediction: dict,
         prediction_type: PredictionType,
         disable_preproc_auto_orient: bool = False,
+        inference_id=None,
     ) -> None:
         self._execute_registration(
             inference_input=inference_input,
             prediction=prediction,
             prediction_type=prediction_type,
             disable_preproc_auto_orient=disable_preproc_auto_orient,
+            inference_id=inference_id,
         )
 
     def _execute_registration(
@@ -133,6 +137,7 @@ class ActiveLearningMiddleware:
         prediction: dict,
         prediction_type: PredictionType,
         disable_preproc_auto_orient: bool = False,
+        inference_id=None,
     ) -> None:
         if self._configuration is None:
             return None
@@ -169,6 +174,7 @@ class ActiveLearningMiddleware:
             configuration=self._configuration,
             api_key=self._api_key,
             batch_name=batch_name,
+            inference_id=inference_id,
         )
 
 

--- a/inference/core/active_learning/middlewares.py
+++ b/inference/core/active_learning/middlewares.py
@@ -239,6 +239,7 @@ class ThreadingActiveLearningMiddleware(ActiveLearningMiddleware):
         prediction: dict,
         prediction_type: PredictionType,
         disable_preproc_auto_orient: bool = False,
+        inference_id=None,
     ) -> None:
         logger.debug(f"Putting registration task into queue")
         try:

--- a/inference/core/managers/active_learning.py
+++ b/inference/core/managers/active_learning.py
@@ -107,6 +107,7 @@ class ActiveLearningManager(ModelManager):
             predictions=results_dicts,
             prediction_type=prediction_type,
             disable_preproc_auto_orient=disable_preproc_auto_orient,
+            inference_id=request.id,
         )
         end = time.perf_counter()
         logger.debug(f"Registration: {(end - start) * 1000} ms")

--- a/inference/core/roboflow_api.py
+++ b/inference/core/roboflow_api.py
@@ -228,12 +228,15 @@ def register_image_at_roboflow(
     image_bytes: bytes,
     batch_name: str,
     tags: Optional[List[str]] = None,
+    inference_id=None,
 ) -> dict:
     url = f"{API_BASE_URL}/dataset/{dataset_id}/upload"
     params = [
         ("api_key", api_key),
         ("batch", batch_name),
     ]
+    if inference_id is not None:
+        params.append(("inference_id", inference_id))
     tags = tags if tags is not None else []
     for tag in tags:
         params.append(("tag", tag))

--- a/tests/inference/unit_tests/core/active_learning/test_core.py
+++ b/tests/inference/unit_tests/core/active_learning/test_core.py
@@ -324,6 +324,7 @@ def test_safe_register_image_at_roboflow_when_registration_detects_duplicate(
         api_key="api-key",
         batch_name="some-batch",
         tags=[],
+        inference_id=None,
     )
 
     # then
@@ -408,6 +409,7 @@ def test_register_datapoint_at_roboflow_when_predictions_not_to_be_persisted(
         configuration=configuration,
         api_key="api-key",
         batch_name="some-batch",
+        inference_id=None,
     )
 
     # then
@@ -453,6 +455,7 @@ def test_register_datapoint_at_roboflow_when_predictions_to_be_persisted_but_dup
         configuration=configuration,
         api_key="api-key",
         batch_name="some-batch",
+        inference_id="inference-id-123",
     )
 
     # then
@@ -469,6 +472,7 @@ def test_register_datapoint_at_roboflow_when_predictions_to_be_persisted_but_dup
         api_key="api-key",
         batch_name="some-batch",
         tags=["a", "b"],
+        inference_id="inference-id-123",
     )
     annotate_image_at_roboflow_mock.assert_not_called()
 
@@ -498,6 +502,7 @@ def test_register_datapoint_at_roboflow_when_predictions_to_be_persisted(
         configuration=configuration,
         api_key="api-key",
         batch_name="some-batch",
+        inference_id="inference-id-ABC",
     )
 
     # then
@@ -514,6 +519,7 @@ def test_register_datapoint_at_roboflow_when_predictions_to_be_persisted(
         api_key="api-key",
         batch_name="some-batch",
         tags=["a", "b"],
+        inference_id="inference-id-ABC",
     )
     annotate_image_at_roboflow_mock.assert_called_once_with(
         api_key="api-key",
@@ -554,6 +560,7 @@ def test_register_datapoint_at_roboflow_when_image_registration_error_occurs(
             configuration=configuration,
             api_key="api-key",
             batch_name="some-batch",
+            inference_id=None,
         )
 
     # then

--- a/tests/inference/unit_tests/core/active_learning/test_core.py
+++ b/tests/inference/unit_tests/core/active_learning/test_core.py
@@ -280,6 +280,7 @@ def test_safe_register_image_at_roboflow_when_registration_fails(
             api_key="api-key",
             batch_name="some-batch",
             tags=[],
+            inference_id=None,
         )
 
     # then
@@ -290,6 +291,7 @@ def test_safe_register_image_at_roboflow_when_registration_fails(
         image_bytes=b"IMAGE",
         batch_name="some-batch",
         tags=[],
+        inference_id=None,
     )
     return_strategy_credit_mock.assert_called_once_with(
         cache=cache,
@@ -369,6 +371,7 @@ def test_safe_register_image_at_roboflow_when_registration_detects_duplicate(
         api_key="api-key",
         batch_name="some-batch",
         tags=[],
+        inference_id="inference-id-234",
     )
 
     # then
@@ -379,6 +382,7 @@ def test_safe_register_image_at_roboflow_when_registration_detects_duplicate(
         image_bytes=b"IMAGE",
         batch_name="some-batch",
         tags=[],
+        inference_id="inference-id-234",
     )
     return_strategy_credit_mock.assert_not_called()
     assert result == "roboflow-id"
@@ -409,7 +413,7 @@ def test_register_datapoint_at_roboflow_when_predictions_not_to_be_persisted(
         configuration=configuration,
         api_key="api-key",
         batch_name="some-batch",
-        inference_id=None,
+        inference_id="inference-id-987",
     )
 
     # then
@@ -426,6 +430,7 @@ def test_register_datapoint_at_roboflow_when_predictions_not_to_be_persisted(
         api_key="api-key",
         batch_name="some-batch",
         tags=["a", "b"],
+        inference_id="inference-id-987",
     )
     annotate_image_at_roboflow_mock.assert_not_called()
 
@@ -560,7 +565,7 @@ def test_register_datapoint_at_roboflow_when_image_registration_error_occurs(
             configuration=configuration,
             api_key="api-key",
             batch_name="some-batch",
-            inference_id=None,
+            inference_id="inference-id-876",
         )
 
     # then
@@ -577,6 +582,7 @@ def test_register_datapoint_at_roboflow_when_image_registration_error_occurs(
         api_key="api-key",
         batch_name="some-batch",
         tags=["a", "b"],
+        inference_id="inference-id-876",
     )
     annotate_image_at_roboflow_mock.assert_not_called()
 

--- a/tests/inference/unit_tests/core/active_learning/test_middlewares.py
+++ b/tests/inference/unit_tests/core/active_learning/test_middlewares.py
@@ -162,6 +162,7 @@ def test_active_learning_registration_when_datapoint_is_to_be_registered(
         configuration=configuration,
         api_key="api-key",
         batch_name="some-batch",
+        inference_id=None,
     )
 
 
@@ -217,12 +218,14 @@ def test_active_learning_registration_of_batch(
                 prediction={"some": "prediction"},
                 prediction_type="object-detection",
                 disable_preproc_auto_orient=False,
+                inference_id=None,
             ),
             call(
                 inference_input=image_as_numpy,
                 prediction={"other": "prediction"},
                 prediction_type="object-detection",
                 disable_preproc_auto_orient=False,
+                inference_id=None,
             ),
         ]
     )


### PR DESCRIPTION
# Description

In order to display inference images in the model monitoring dashboard, we need to add the inference id to the images created from inference requests via the AL workflow

Relates to: https://github.com/roboflow/roboflow/pull/3080

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [X] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

- Test case for staging: inference_ids are sent as part of batch request (e2e test case will be tested once https://github.com/roboflow/roboflow/pull/3080 is merged)

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
