### PR TITLE
track source for remote execution flows

### DIFF
--- a/inference/core/version.py
+++ b/inference/core/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.9.16"
+__version__ = "0.9.17rc2"
 
 
 if __name__ == "__main__":

--- a/inference/enterprise/workflows/complier/steps_executors/models.py
+++ b/inference/enterprise/workflows/complier/steps_executors/models.py
@@ -360,6 +360,7 @@ def construct_http_client_configuration_for_classification_step(
         disable_active_learning=resolve(step.disable_active_learning),
         max_batch_size=WORKFLOWS_REMOTE_EXECUTION_MAX_STEP_BATCH_SIZE,
         max_concurrent_requests=WORKFLOWS_REMOTE_EXECUTION_MAX_STEP_CONCURRENT_REQUESTS,
+        source="workflow-execution",
     )
 
 
@@ -383,6 +384,7 @@ def construct_http_client_configuration_for_detection_step(
         max_candidates=resolve(step.max_candidates),
         max_batch_size=WORKFLOWS_REMOTE_EXECUTION_MAX_STEP_BATCH_SIZE,
         max_concurrent_requests=WORKFLOWS_REMOTE_EXECUTION_MAX_STEP_CONCURRENT_REQUESTS,
+        source="workflow-execution",
     )
 
 
@@ -408,6 +410,7 @@ def construct_http_client_configuration_for_segmentation_step(
         tradeoff_factor=resolve(step.tradeoff_factor),
         max_batch_size=WORKFLOWS_REMOTE_EXECUTION_MAX_STEP_BATCH_SIZE,
         max_concurrent_requests=WORKFLOWS_REMOTE_EXECUTION_MAX_STEP_CONCURRENT_REQUESTS,
+        source="workflow-execution",
     )
 
 
@@ -432,6 +435,7 @@ def construct_http_client_configuration_for_keypoints_detection_step(
         keypoint_confidence_threshold=resolve(step.keypoint_confidence),
         max_batch_size=WORKFLOWS_REMOTE_EXECUTION_MAX_STEP_BATCH_SIZE,
         max_concurrent_requests=WORKFLOWS_REMOTE_EXECUTION_MAX_STEP_CONCURRENT_REQUESTS,
+        source="workflow-execution",
     )
 
 


### PR DESCRIPTION
# Description

Tupling with @PawelPeczek-Roboflow, we realized that #293 needed a few additional changes to make the source parameter be used correctly for hosted inference in addition to local inference.

Now it works and the correct source shows up in core api logs
![image](https://github.com/roboflow/inference/assets/218821/e1080d64-4470-46f1-a00a-0918bc11ac0a)


## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Tested on staging by running a curl command to the hosted workflow
