### PR TITLE
Add deep links to deployment widget, fix broken links

### DIFF
--- a/docs/fine-tuned/yolonas.md
+++ b/docs/fine-tuned/yolonas.md
@@ -17,9 +17,9 @@ Click a link below to see instructions on how to run a YOLO-NAS model on differe
 
 Starting from scratch? Use our Deployment Wizard to get a code snippet tailored to your device and use case.
 
-- [Configure a YOLO-NAS Object Detection Model](/quickstart/configure_yolov8_object_detection/)
-- [Configure a YOLO-NAS Classification Model](/quickstart/configure_yolov8_classification/)
-- [Configure a YOLO-NAS Segmentation Model](/quickstart/configure_yolov8_segmentation/)
+- [Configure a YOLO-NAS Object Detection Model](https://roboflow.github.io/deploy-setup-widget/results.html#Fine-Tuned/Object%20Detection)
+- [Configure a YOLO-NAS Classification Model](https://roboflow.github.io/deploy-setup-widget/results.html#Fine-Tuned/Classification)
+- [Configure a YOLO-NAS Segmentation Model](https://roboflow.github.io/deploy-setup-widget/results.html#Fine-Tuned/Image%20Segmentation)
 
 ## License
 

--- a/docs/fine-tuned/yolov5.md
+++ b/docs/fine-tuned/yolov5.md
@@ -19,9 +19,9 @@ Click a link below to see instructions on how to run a YOLOv5 model on different
 
 Starting from scratch? Use our Deployment Wizard to get a code snippet tailored to your device and use case.
 
-- [Configure a YOLOv5 Object Detection Model](/quickstart/configure_yolov8_object_detection/)
-- [Configure a YOLOv5 Classification Model](/quickstart/configure_yolov8_classification/)
-- [Configure a YOLOv5 Segmentation Model](/quickstart/configure_yolov8_segmentation/)
+- [Configure a YOLOv5 Object Detection Model](https://roboflow.github.io/deploy-setup-widget/results.html#Fine-Tuned/Object%20Detection)
+- [Configure a YOLOv5 Classification Model](https://roboflow.github.io/deploy-setup-widget/results.html#Fine-Tuned/Classification)
+- [Configure a YOLOv5 Segmentation Model](https://roboflow.github.io/deploy-setup-widget/results.html#Fine-Tuned/Image%20Segmentation)
 
 ## License
 

--- a/docs/fine-tuned/yolov7.md
+++ b/docs/fine-tuned/yolov7.md
@@ -15,7 +15,7 @@ Click a link below to see instructions on how to run a YOLOv8 model on different
 
 Starting from scratch? Use our Deployment Wizard to get a code snippet tailored to your device and use case.
 
-- [Deploy a YOLOv7 Segmentation Model](/quickstart/configure_yolov8_segmentation/)
+- [Deploy a YOLOv7 Segmentation Model](https://roboflow.github.io/deploy-setup-widget/results.html#Fine-Tuned/Image%20Segmentation)
 
 ## License
 

--- a/docs/fine-tuned/yolov8.md
+++ b/docs/fine-tuned/yolov8.md
@@ -19,9 +19,9 @@ Click a link below to see instructions on how to run a YOLOv8 model on different
 
 Starting from scratch? Use our Deployment Wizard to get a code snippet tailored to your device and use case.
 
-- [Configure a YOLOv8 Object Detection Model](/quickstart/configure_yolov8_object_detection/)
-- [Configure a YOLOv8 Classification Model](/quickstart/configure_yolov8_classification/)
-- [Configure a YOLOv8 Segmentation Model](/quickstart/configure_yolov8_segmentation/)
+- [Configure a YOLOv8 Object Detection Model](https://roboflow.github.io/deploy-setup-widget/results.html#Fine-Tuned/Object%20Detection)
+- [Configure a YOLOv8 Classification Model](https://roboflow.github.io/deploy-setup-widget/results.html#Fine-Tuned/Classification)
+- [Configure a YOLOv8 Segmentation Model](https://roboflow.github.io/deploy-setup-widget/results.html#Fine-Tuned/Image%20Segmentation)
 
 ## License
 

--- a/docs/fine-tuned/yolov9.md
+++ b/docs/fine-tuned/yolov9.md
@@ -17,7 +17,7 @@ Click a link below to see instructions on how to run a YOLOv8 model on different
 
 Starting from scratch? Use our Deployment Wizard to get a code snippet tailored to your device and use case.
 
-- [Configure a YOLOv8 Object Detection Model](/quickstart/configure_yolov8_object_detection/)
+- [Configure a YOLOv9 Object Detection Model](https://roboflow.github.io/deploy-setup-widget/results.html#Fine-Tuned/Image%20Segmentation)
 
 ## License
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ Explore our [enterprise options](https://roboflow.com/sales) for advanced featur
 <a href="/quickstart/run_a_model/" class="button">Get started with our "Run your first model" guide</a>
 
 <div class="button-holder">
-<a href="/quickstart/what_is_inference/" class="button half-button">Learn about the various ways you can use Inference</a>
+<a href="/quickstart/inference_101/" class="button half-button">Learn about the various ways you can use Inference</a>
 <a href="/foundation/about/" class="button half-button">See all of the models you can run with Inference</a>
 </div>
 

--- a/docs/quickstart/explore_models.md
+++ b/docs/quickstart/explore_models.md
@@ -6,10 +6,6 @@ All models run on your own hardware.
 
 In the first example, we showed how to run a people detection model. This model was hosted on Universe. Let's find another model to try.
 
-!!! Info
-
-    If you haven't already, follow our [Run Your First Model guide](http://127.0.0.1:8000/quickstart/run_a_model/) to install and set up Inference.
-
 Go to the <a href="https://universe.roboflow.com" target="_blank">Roboflow Universe</a> homepage and use the search bar to find a model.
 
 ![Roboflow Universe search bar](https://media.roboflow.com/universe-search.png)
@@ -24,7 +20,13 @@ Browse the search page to find a model.
 
 When you have found a model, click on the model card to learn more. Click the "Model" link in the sidebar to get the information you need to use the model.
 
-Create a new Python file and add the following code:
+Then, install Inference and supervision, which we will use to run our model and handle model predictions, respectively:
+
+```bash
+pip install inference supervision
+```
+
+Next, create a new Python file and add the following code:
 
 ```python
 # import a utility function for loading Roboflow models


### PR DESCRIPTION
# Description

This PR adds deep links to our interactive deployment widget (i.e. https://roboflow.github.io/deploy-setup-widget/results.html#Fine-Tuned/Object%20Detection) to fine-tuned model pages and fixes several broken links.

## Type of change

- Documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

This change can be tested by running the documentation with `mkdocs serve` and checking that the changed links work.

## Any specific deployment considerations

N/A

## Docs

N/A