### PR TITLE
Add --version option to CLI

### DIFF
--- a/inference_cli/main.py
+++ b/inference_cli/main.py
@@ -14,6 +14,32 @@ app.add_typer(cloud_app, name="cloud")
 app.add_typer(benchmark_app, name="benchmark")
 
 
+def version_callback(value: bool):
+    if value:
+        from importlib.metadata import version, PackageNotFoundError
+
+        version_msg = ""
+        for package in ['inference', 'inference-sdk', 'inference-cli']:
+            try:
+                package_version = version(package)
+                version_msg += f"{package} version: v{package_version}\n"
+            except PackageNotFoundError:
+                if package == 'inference':
+                    version_msg = f"{package} version: using local install"
+                    break
+        
+        typer.echo(version_msg)
+            
+        raise typer.Exit()
+
+@app.callback()
+def version(
+    version: Annotated[
+        Optional[bool], typer.Option("--version", callback=version_callback, is_eager=True)
+    ] = None,
+):
+    return
+
 @app.command()
 def infer(
     input_reference: Annotated[


### PR DESCRIPTION
# Description

Taking a shot at https://github.com/roboflow/inference/issues/338. It's a little tricky to test locally, since there's nothing I could find that tracks the version locally. Therefore, looking for package metadata can cause issues. When I tested the `version()` function with the latest release it returned the version correctly, so I opted to just catch the exception and let the user know it's a local install.

List any dependencies that are required for this change.

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Try running `inference --version`. I also tested the `version()` function on an actual release and it returned the correct version.

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
