### PR TITLE
Minor docs update, API key in InferenceHTTPClient

### DIFF
--- a/docs/inference_helpers/inference_sdk.md
+++ b/docs/inference_helpers/inference_sdk.md
@@ -502,9 +502,10 @@ CLIENT.unload_all_models()
 ```python
 from inference_sdk import InferenceHTTPClient
 
+# Replace ROBOFLOW_API_KEY with your Roboflow API Key
 CLIENT = InferenceHTTPClient(
-    "http://127.0.0.1:9001",
-    "XXX",
+    api_url="http://localhost:9001",
+    api_key="ROBOFLOW_API_KEY"
 )
 
 # for older versions of server than v0.9.21 use: CLIENT.infer_from_workflow(...) 


### PR DESCRIPTION
# Description

Minor docs improvement. "XXX" -> "ROBOFLOW_API_KEY".

## Type of change

Please delete options that are not relevant.

## How has this change been tested, please provide a testcase or example of how you tested the change?

## Any specific deployment considerations

## Docs

-   [x] Docs updated? What were the changes:

"XXX" -> "ROBOFLOW_API_KEY".
Matched style of other `InferenceHTTPClient` cases.