### PR TITLE
Skip encode image as jpeg if no-resize is specified

### DIFF
--- a/inference/core/version.py
+++ b/inference/core/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.9.21rc3"
+__version__ = "0.9.22"
 
 
 if __name__ == "__main__":

--- a/inference_sdk/http/utils/loaders.py
+++ b/inference_sdk/http/utils/loaders.py
@@ -138,6 +138,12 @@ def load_image_from_string(
             url=reference, max_height=max_height, max_width=max_width
         )
     if os.path.exists(reference):
+        if max_height is None or max_width is None:
+            with open(reference, 'rb') as f:
+                img_bytes = f.read()
+                img_base64_str = encode_base_64(payload=img_bytes)
+                return img_base64_str, None
+        
         local_image = cv2.imread(reference)
         if local_image is None:
             raise EncodingError(f"Could not load image from {reference}")

--- a/inference_sdk/http/utils/loaders.py
+++ b/inference_sdk/http/utils/loaders.py
@@ -143,7 +143,6 @@ def load_image_from_string(
                 img_bytes = f.read()
             img_base64_str = encode_base_64(payload=img_bytes)
             return img_base64_str, None
-        
         local_image = cv2.imread(reference)
         if local_image is None:
             raise EncodingError(f"Could not load image from {reference}")

--- a/inference_sdk/http/utils/loaders.py
+++ b/inference_sdk/http/utils/loaders.py
@@ -139,7 +139,7 @@ def load_image_from_string(
         )
     if os.path.exists(reference):
         if max_height is None or max_width is None:
-            with open(reference, 'rb') as f:
+            with open(reference, "rb") as f:
                 img_bytes = f.read()
             img_base64_str = encode_base_64(payload=img_bytes)
             return img_base64_str, None

--- a/inference_sdk/http/utils/loaders.py
+++ b/inference_sdk/http/utils/loaders.py
@@ -141,8 +141,8 @@ def load_image_from_string(
         if max_height is None or max_width is None:
             with open(reference, 'rb') as f:
                 img_bytes = f.read()
-                img_base64_str = encode_base_64(payload=img_bytes)
-                return img_base64_str, None
+            img_base64_str = encode_base_64(payload=img_bytes)
+            return img_base64_str, None
         
         local_image = cv2.imread(reference)
         if local_image is None:


### PR DESCRIPTION
# Description

Inference_sdk will forcibly encode image as jpeg (and then convert to base64 string) before sending request to inference server, this is not necessary and not expected.
We have the requirement from Duolingo that they want to keep the original image quality, but jpeg encoding will degrade image quality and affect the inference results.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Tested locally.
