### PR TITLE
Downgrade transformers to avoid faulty release of that package

### DIFF
--- a/requirements/requirements.cogvlm.txt
+++ b/requirements/requirements.cogvlm.txt
@@ -1,4 +1,4 @@
-transformers>=4.36.0,<=4.38.2
+transformers>=4.36.0,<4.38.0
 sentencepiece<=0.1.99
 einops<=0.7.0
 xformers<=0.0.22

--- a/requirements/requirements.groundingdino.txt
+++ b/requirements/requirements.groundingdino.txt
@@ -1,1 +1,2 @@
+transformers>=4.36.0,<4.38.0
 rf_groundingdino


### PR DESCRIPTION
# Description

As reported in one of our issues (https://github.com/roboflow/inference/issues/355) and as suggested in discussions in `transformers` issues - we shall restrict versions of `transformers` we use to avoid faulty release. The problem is solved in one of newer versions, but defensively I propose to just downgrade max version of transformers a bit.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

* run of CogVLM on new build yo ensure model works e2e

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
