### PR TITLE
add api key fallback for model monitoring

### DIFF
--- a/inference/core/managers/base.py
+++ b/inference/core/managers/base.py
@@ -37,6 +37,8 @@ class ModelManager:
         if METRICS_ENABLED:
             self.pingback = PingbackInfo(self)
             self.pingback.start()
+        else:
+            self.pingback = None
 
     def add_model(
         self, model_id: str, api_key: str, model_id_alias: Optional[str] = None
@@ -91,6 +93,9 @@ class ModelManager:
         logger.debug(
             f"ModelManager - inference from request started for model_id={model_id}."
         )
+        if METRICS_ENABLED and self.pingback:
+            logger.debug("ModelManager - setting pingback fallback api key...")
+            self.pingback.fallback_api_key = request.api_key
         try:
             rtn_val = await self.model_infer(
                 model_id=model_id, request=request, **kwargs

--- a/inference/core/managers/base.py
+++ b/inference/core/managers/base.py
@@ -29,6 +29,7 @@ class ModelManager:
     def __init__(self, model_registry: ModelRegistry, models: Optional[dict] = None):
         self.model_registry = model_registry
         self._models: Dict[str, Model] = models if models is not None else {}
+        self.pingback = None
 
     def init_pingback(self):
         """Initializes pingback mechanism."""
@@ -37,8 +38,6 @@ class ModelManager:
         if METRICS_ENABLED:
             self.pingback = PingbackInfo(self)
             self.pingback.start()
-        else:
-            self.pingback = None
 
     def add_model(
         self, model_id: str, api_key: str, model_id_alias: Optional[str] = None

--- a/inference/core/managers/decorators/base.py
+++ b/inference/core/managers/decorators/base.py
@@ -41,6 +41,13 @@ class ModelManagerDecorator(ModelManager):
         """Initializes the decorator with an instance of a ModelManager."""
         self.model_manager = model_manager
 
+    def init_pingback(self):
+        self.model_manager.init_pingback()
+
+    @property
+    def pingback(self):
+        return self.model_manager.pingback
+
     def add_model(
         self, model_id: str, api_key: str, model_id_alias: Optional[str] = None
     ):

--- a/inference/core/managers/pingback.py
+++ b/inference/core/managers/pingback.py
@@ -60,9 +60,14 @@ class PingbackInfo:
                 "tags": TAGS,
             }
             self.environment_info = context | get_system_info()
+
+            # we will set this from model manager when a new api key is used
+            # to use in case there is no global ENV api key configured
+            self.fallback_api_key = None
+
         except Exception as e:
             logger.debug(
-                "Error sending pingback to Roboflow, if you want to disable this feature unset the ROBOFLOW_ENABLED environment variable. "
+                "Error CCC sending pingback to Roboflow, if you want to disable this feature unset the ROBOFLOW_ENABLED environment variable. "
                 + str(e)
             )
 
@@ -101,6 +106,11 @@ class PingbackInfo:
         """
         all_data = self.environment_info.copy()
         all_data["inference_results"] = []
+
+        # use fallback api key if env didn't have one
+        if self.fallback_api_key and not all_data.get("api_key"):
+            all_data["api_key"] = self.fallback_api_key
+
         try:
             now = time.time()
             start = now - METRICS_INTERVAL

--- a/inference/core/managers/pingback.py
+++ b/inference/core/managers/pingback.py
@@ -67,7 +67,7 @@ class PingbackInfo:
 
         except Exception as e:
             logger.debug(
-                "Error CCC sending pingback to Roboflow, if you want to disable this feature unset the ROBOFLOW_ENABLED environment variable. "
+                "Error sending pingback to Roboflow, if you want to disable this feature unset the ROBOFLOW_ENABLED environment variable. "
                 + str(e)
             )
 


### PR DESCRIPTION
# Description
The model monitoring feature only works if a global API key is provided when the server is started.  This change modifies the model manager to set a fallback api for the pingback when it sees a API key used for inference requests so we can send model monitoring data by default without requiring a separate / global api key to be set

## Type of change
Please delete options that are not relevant.
-   [X] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?
locally running cpu docker container, observing debug logs and sending inference requests via postman

## Any specific deployment considerations
n/a

## Docs
n/a