### PR TITLE
Fix metrics middleware attr error (num_errors set on wrong model manager)

### DIFF
--- a/inference/core/managers/decorators/base.py
+++ b/inference/core/managers/decorators/base.py
@@ -200,8 +200,7 @@ class ModelManagerDecorator(ModelManager):
     @property
     def num_errors(self):
         return self.model_manager.num_errors
-    
+
     @num_errors.setter
     def num_errors(self, value):
         self.model_manager.num_errors = value
-

--- a/inference/core/managers/decorators/base.py
+++ b/inference/core/managers/decorators/base.py
@@ -196,3 +196,7 @@ class ModelManagerDecorator(ModelManager):
         self, model_id: str, predictions: List[List[float]], *args, **kwargs
     ) -> InferenceResponse:
         return self.model_manager.make_response(model_id, predictions, *args, **kwargs)
+
+    @property
+    def num_errors(self):
+        return self.model_manager.num_errors

--- a/inference/core/managers/decorators/base.py
+++ b/inference/core/managers/decorators/base.py
@@ -200,3 +200,8 @@ class ModelManagerDecorator(ModelManager):
     @property
     def num_errors(self):
         return self.model_manager.num_errors
+    
+    @num_errors.setter
+    def num_errors(self, value):
+        self.model_manager.num_errors = value
+

--- a/tests/inference/unit_tests/core/managers/test_pingback_num_errors.py
+++ b/tests/inference/unit_tests/core/managers/test_pingback_num_errors.py
@@ -1,0 +1,11 @@
+from inference.core.managers.decorators.base import ModelManagerDecorator
+from inference.core.managers.base import ModelManager, ModelRegistry
+
+def test_increment_num_errors():
+    mm = ModelManager(ModelRegistry(dict()))
+    mm_wrapper = ModelManagerDecorator(mm)
+    mm_wrapper.init_pingback()
+    mm_wrapper.num_errors += 1
+    assert mm.num_errors == mm_wrapper.num_errors == 1
+    mm.num_errors += 1
+    assert mm.num_errors == mm_wrapper.num_errors == 2


### PR DESCRIPTION
# Description

There was a problem with init pingback on a model manager decorator because pingback was not being set on the outer wrapper any more.
This fixes the metrics middleware attr error (num_errors set on wrong model manager).

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Unit tests

## Any specific deployment considerations

No

## Docs

-   [ ] Docs updated? What were the changes:
