### PR TITLE
Fix/release 0.10.0 Jetson 4.5 build

### DIFF
--- a/docker/dockerfiles/Dockerfile.onnx.jetson.4.5.0
+++ b/docker/dockerfiles/Dockerfile.onnx.jetson.4.5.0
@@ -33,7 +33,7 @@ COPY requirements/requirements.clip.txt \
 
 RUN python3.8 -m pip install --ignore-installed PyYAML && rm -rf ~/.cache/pip
 
-RUN python3.8 -m pip install --upgrade pip  && python3.8 -m pip install \
+RUN python3.8 -m pip install --upgrade pip "h5py<=3.10.0" && python3.8 -m pip install \
     -r _requirements.txt \
     -r requirements.clip.txt \
     -r requirements.http.txt \

--- a/docker/dockerfiles/Dockerfile.onnx.jetson.4.5.0
+++ b/docker/dockerfiles/Dockerfile.onnx.jetson.4.5.0
@@ -27,6 +27,7 @@ COPY requirements/requirements.clip.txt \
     requirements/requirements.http.txt \
     requirements/requirements.doctr.txt \
     requirements/requirements.groundingdino.txt \
+    requirements/requirements.sdk.http.txt \
     requirements/requirements.yolo_world.txt \
     requirements/_requirements.txt \ 
     ./
@@ -39,6 +40,7 @@ RUN python3.8 -m pip install --upgrade pip wheel Cython && python3.8 -m pip inst
     -r requirements.http.txt \
     -r requirements.doctr.txt \
     -r requirements.groundingdino.txt \
+    -r requirements.sdk.http.txt \
     -r requirements.yolo_world.txt \
     jupyterlab \
     --upgrade \

--- a/docker/dockerfiles/Dockerfile.onnx.jetson.4.5.0
+++ b/docker/dockerfiles/Dockerfile.onnx.jetson.4.5.0
@@ -33,7 +33,7 @@ COPY requirements/requirements.clip.txt \
 
 RUN python3.8 -m pip install --ignore-installed PyYAML && rm -rf ~/.cache/pip
 
-RUN python3.8 -m pip install --upgrade pip "h5py<=3.10.0" && python3.8 -m pip install \
+RUN python3.8 -m pip install --upgrade pip wheel Cython && python3.8 -m pip install --upgrade "h5py<=3.10.0" && python3.8 -m pip install \
     -r _requirements.txt \
     -r requirements.clip.txt \
     -r requirements.http.txt \
@@ -52,6 +52,7 @@ RUN python3.8 -m pip install onnxruntime_gpu-1.11.0-cp38-cp38-linux_aarch64.whl 
 
 WORKDIR /app/
 COPY inference inference
+COPY inference_sdk inference_sdk
 COPY docker/config/gpu_http.py gpu_http.py
 
 ENV VERSION_CHECK_MODE=continuous

--- a/docker/dockerfiles/Dockerfile.onnx.jetson.4.6.1
+++ b/docker/dockerfiles/Dockerfile.onnx.jetson.4.6.1
@@ -49,7 +49,7 @@ COPY requirements/requirements.clip.txt \
 
 RUN python3.9 -m pip install --ignore-installed PyYAML && rm -rf ~/.cache/pip
 
-RUN python3.9 -m pip install --upgrade pip setuptools "h5py<=3.10.0" && python3.9 -m pip install \
+RUN python3.9 -m pip install --upgrade pip cython "h5py<=3.10.0" && python3.9 -m pip install \
     -r _requirements.txt \
     -r requirements.clip.txt \
     -r requirements.http.txt \

--- a/docker/dockerfiles/Dockerfile.onnx.jetson.4.6.1
+++ b/docker/dockerfiles/Dockerfile.onnx.jetson.4.6.1
@@ -49,7 +49,7 @@ COPY requirements/requirements.clip.txt \
 
 RUN python3.9 -m pip install --ignore-installed PyYAML && rm -rf ~/.cache/pip
 
-RUN python3.9 -m pip install --upgrade pip "h5py<=3.10.0" && python3.9 -m pip install \
+RUN python3.9 -m pip install --upgrade pip setuptools "h5py<=3.10.0" && python3.9 -m pip install \
     -r _requirements.txt \
     -r requirements.clip.txt \
     -r requirements.http.txt \

--- a/docker/dockerfiles/Dockerfile.onnx.jetson.4.6.1
+++ b/docker/dockerfiles/Dockerfile.onnx.jetson.4.6.1
@@ -49,7 +49,7 @@ COPY requirements/requirements.clip.txt \
 
 RUN python3.9 -m pip install --ignore-installed PyYAML && rm -rf ~/.cache/pip
 
-RUN python3.9 -m pip install --upgrade pip cython "h5py<=3.10.0" && python3.9 -m pip install \
+RUN python3.9 -m pip install --upgrade pip "h5py<=3.10.0" && python3.9 -m pip install \
     -r _requirements.txt \
     -r requirements.clip.txt \
     -r requirements.http.txt \


### PR DESCRIPTION
# Description

Build for Jetson Jetpack 4.5 was broken - see details [here](https://github.com/roboflow/inference/actions/runs/9079290720)

Fixing build, but I have no way to verify integration tests.

Discussion about sunset of that build: https://github.com/roboflow/inference/issues/394

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

* test build succeeds 
* no way to verify integration tests

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
