### PR TITLE
Document source_id parameter of VideoFrame

### DIFF
--- a/docs/quickstart/run_model_on_rtsp_webcam.md
+++ b/docs/quickstart/run_model_on_rtsp_webcam.md
@@ -81,6 +81,7 @@ A VideoFrame object contains:
 - `image`: The video frame as a NumPy array,
 - `frame_id`: The frame ID, and;
 - `frame_timestamp`: The timestamp of the frame.
+- `source_id`: The index of the video_reference element which was passed to InferencePipeline (useful when multiple streams are passed to InferencePipeline).
 
 Let's start by just printing the frame ID to the console.
 

--- a/inference/core/interfaces/camera/entities.py
+++ b/inference/core/interfaces/camera/entities.py
@@ -53,6 +53,7 @@ class VideoFrame:
         image (np.ndarray): The image data of the frame as a NumPy array.
         frame_id (FrameID): A unique identifier for the frame.
         frame_timestamp (FrameTimestamp): The timestamp when the frame was captured.
+        source_id (int): The index of the video_reference element which was passed to InferencePipeline for this frame (useful when multiple streams are passed to InferencePipeline).
     """
 
     image: np.ndarray


### PR DESCRIPTION
# Description

The `source_id` element of `VideoFrame` is not documented and is a useful property when inferring on multiple streams with `SinkMode.SEQUENTIAL`.

w/ @nathan-marraccini

## Type of change

-   [x] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Documentation only

## Any specific deployment considerations

Documentation will need to be deployed

## Docs

-   [x] Docs updated? What were the changes: docs only
