### PR TITLE
Fix workflows specification URL and other docs updates

### DIFF
--- a/docs/inference_helpers/inference_sdk.md
+++ b/docs/inference_helpers/inference_sdk.md
@@ -518,6 +518,10 @@ CLIENT.run_workflow(
         ],
         # ...
     },
+    # OR
+    # workspace_name="my_workspace_name",
+    # workflow_id="my_workflow_id",
+
     images={
         "image": "url or your np.array",
     },
@@ -528,9 +532,9 @@ CLIENT.run_workflow(
 ```
 
 Please note that either `specification` is provided with specification of workflow as described
-[here](https://github.com/roboflow/inference/blob/main/inference/enterprise/deployments/README.md) or 
+[here](../workflows/definitions.md) or 
 both `workspace_name` and `workflow_id` are given to use workflow predefined in Roboflow app. `workspace_name`
-can be found in Roboflow APP URL once browser shows the main panel of workspace. 
+can be found in Roboflow APP URL once browser shows the main panel of workspace.
 
 
 ## Details about client configuration

--- a/inference_sdk/http/client.py
+++ b/inference_sdk/http/client.py
@@ -276,7 +276,7 @@ class InferenceHTTPClient:
         model_id_chunks = model_id_to_be_used.split("/")
         if len(model_id_chunks) != 2:
             raise InvalidModelIdentifier(
-                f"Invalid model identifier: {model_id} in use."
+                f"Invalid model id: {model_id}. Expected format: project_id/model_version_id."
             )
         max_height, max_width = _determine_client_downsizing_parameters(
             client_downsizing_disabled=self.__inference_configuration.client_downsizing_disabled,
@@ -335,7 +335,7 @@ class InferenceHTTPClient:
         model_id_chunks = model_id_to_be_used.split("/")
         if len(model_id_chunks) != 2:
             raise InvalidModelIdentifier(
-                f"Invalid model identifier: {model_id} in use."
+                f"Invalid model id: {model_id}. Expected format: project_id/model_version_id."
             )
         max_height, max_width = _determine_client_downsizing_parameters(
             client_downsizing_disabled=self.__inference_configuration.client_downsizing_disabled,


### PR DESCRIPTION
# Description

- update workflow specification URL to non-broken one
- add clarification in example on run_workflow params
- make invalid model id error more descriptive

<img width="688" alt="image" src="https://github.com/roboflow/inference/assets/6319317/259a852f-e2f5-4ef5-b24f-f154a005a6c2">


## How has this change been tested, please provide a testcase or example of how you tested the change?

Just docs and error message text.

## Any specific deployment considerations

Can go out with next release, not urgent.

## Docs

-   [ ] Docs updated? What were the changes:
