### PR TITLE
Add PaliGemma documentation, update table of contents

### DIFF
--- a/docs/foundation/paligemma.md
+++ b/docs/foundation/paligemma.md
@@ -1,0 +1,140 @@
+<a href="https://github.com/IDEA-Research/GroundingDINO" target="_blank">PaliGemma</a> is a large multimodal model developed by Google Research.
+
+You can use PaliGemma to:
+
+1. Ask questions about images (Visual Question Answering)
+2. Identify the location of objects in an image (object detection)
+3. Identify the precise location of objects in an imageh (image segmentation)
+
+You can deploy PaliGemma object detection models with Inference, and use PaliGemma for objcet detection.
+
+### How to Use PaliGemma (VQA)
+
+Create a new Python file called `app.py` and add the following code:
+
+```python
+import inference
+
+from inference.models.paligemma.paligemma import PaliGemma
+
+pg = PaliGemma(api_key="YOUR ROBOFLOW API KEY")
+
+from PIL import Image
+
+image = Image.open("image.jpeg") # Change to your image
+
+prompt = "How many dogs are in this image?"
+
+result = pg.predict(image,prompt)
+```
+
+In this code, we load PaliGemma run PaliGemma on an image, and annotate the image with the predictions from the model.
+
+Above, replace:
+
+1. `prompt` with the prompt for the model.
+2. `image.jpeg` with the path to the image in which you want to detect objects.
+
+To use PaliGemma with Inference, you will need a Roboflow API key. If you don't already have a Roboflow account, <a href="https://app.roboflow.com" target="_blank">sign up for a free Roboflow account</a>.
+
+Then, run the Python script you have created:
+
+```
+python app.py
+```
+
+The result from your model will be printed to the console.
+
+### How to Use PaliGemma (Object Detection)
+
+Create a new Python file called `app.py` and add the following code:
+
+```python
+import os
+import transformers
+import re
+import numpy as np
+import supervision as sv
+from typing import Tuple, List, Optional
+from PIL import Image
+
+image = Image.open("/content/data/dog.jpeg")
+
+def from_pali_gemma(response: str, resolution_wh: Tuple[int, int], class_list: Optional[List[str]] = None) -> sv.Detections:
+    _SEGMENT_DETECT_RE = re.compile(
+        r'(.*?)' +
+        r'<loc(\d{4})>' * 4 + r'\s*' +
+        '(?:%s)?' % (r'<seg(\d{3})>' * 16) +
+        r'\s*([^;<>]+)? ?(?:; )?',
+    )
+
+    width, height = resolution_wh
+    xyxy_list = []
+    class_name_list = []
+
+    while response:
+        m = _SEGMENT_DETECT_RE.match(response)
+        if not m:
+            break
+
+        gs = list(m.groups())
+        before = gs.pop(0)
+        name = gs.pop()
+        y1, x1, y2, x2 = [int(x) / 1024 for x in gs[:4]]
+        y1, x1, y2, x2 = map(round, (y1*height, x1*width, y2*height, x2*width))
+
+        content = m.group()
+        if before:
+            response = response[len(before):]
+            content = content[len(before):]
+
+        xyxy_list.append([x1, y1, x2, y2])
+        class_name_list.append(name.strip())
+        response = response[len(content):]
+
+    xyxy = np.array(xyxy_list)
+    class_name = np.array(class_name_list)
+
+    if class_list is None:
+        class_id = None
+    else:
+        class_id = np.array([class_list.index(name) for name in class_name])
+
+    return sv.Detections(
+        xyxy=xyxy,
+        class_id=class_id,
+        data={'class_name': class_name}
+    )
+
+prompt = "detect person; car; backpack"
+response = pali_gemma.predict(image, prompt)[0]
+print(response)
+
+detections = from_pali_gemma(response=response, resolution_wh=image.size, class_list=['person', 'car', 'backpack'])
+
+bounding_box_annotator = sv.BoundingBoxAnnotator()
+label_annotator = sv.LabelAnnotator()
+
+annotatrd_image = bounding_box_annotator.annotate(image, detections)
+annotatrd_image = label_annotator.annotate(annotatrd_image, detections)
+sv.plot_image(annotatrd_image)
+```
+
+In this code, we load PaliGemma run PaliGemma on an image, and annotate the image with the predictions from the model.
+
+Above, replace:
+
+1. `prompt` with the prompt for the model.
+2. `image.jpeg` with the path to the image in which you want to detect objects.
+
+To use PaliGemma with Inference, you will need a Roboflow API key. If you don't already have a Roboflow account, <a href="https://app.roboflow.com" target="_blank">sign up for a free Roboflow account</a>.
+
+Then, run the Python script you have created:
+
+```
+python app.py
+```
+
+The result from the model will be displayed:
+
+![PaliGemma results](https://media.roboflow.com/inference/paligemma.png)

--- a/docs/foundation/paligemma.md
+++ b/docs/foundation/paligemma.md
@@ -1,4 +1,4 @@
-<a href="https://github.com/IDEA-Research/GroundingDINO" target="_blank">PaliGemma</a> is a large multimodal model developed by Google Research.
+<a href="https://blog.roboflow.com/paligemma-multimodal-vision/" target="_blank">PaliGemma</a> is a large multimodal model developed by Google Research.
 
 You can use PaliGemma to:
 

--- a/docs/foundation/paligemma.md
+++ b/docs/foundation/paligemma.md
@@ -6,7 +6,7 @@ You can use PaliGemma to:
 2. Identify the location of objects in an image (object detection)
 3. Identify the precise location of objects in an imageh (image segmentation)
 
-You can deploy PaliGemma object detection models with Inference, and use PaliGemma for objcet detection.
+You can deploy PaliGemma object detection models with Inference, and use PaliGemma for object detection.
 
 ### How to Use PaliGemma (VQA)
 

--- a/docs/quickstart/licensing.md
+++ b/docs/quickstart/licensing.md
@@ -1,24 +1,3 @@
 ## Inference Source Code License
 
-The Roboflow Inference code is distributed under an <a href="https://github.com/roboflow/inference/blob/main/LICENSE" target="_blank">Apache 2.0 license</a>.
-
-## Using Models Hosted on Roboflow
-
-To use a model hosted on Roboflow for commercial purposes, you need a Roboflow Enterprise license.
-
-<a href="https://roboflow.com/sales" target="_blank">Contact the Roboflow sales team</a> to inquire about an enterprise license.
-
-## Model Code Licenses
-
-The models supported by Roboflow Inference have their own licenses. View the licenses for supported models below.
-
-| model                     |                                        license                                        |
-| :------------------------ | :-----------------------------------------------------------------------------------: |
-| `inference/models/clip`   |                <a href="https://github.com/openai/CLIP/blob/main/LICENSE" target="_blank">MIT</a>                |
-|`inference/models/gaze` | <a href="https://github.com/Ahmednull/L2CS-Net/blob/main/LICENSE" target="_blank">MIT</a>, <a href="https://github.com/google/mediapipe/blob/master/LICENSE" target="_blank">Apache 2.0</a> |
-| `inference/models/sam`    | <a href="https://github.com/facebookresearch/segment-anything/blob/main/LICENSE" target="_blank">Apache 2.0</a>  |
-| `inference/models/vit`    | <a href="https://github.com/roboflow/inference/main/inference/models/vit/LICENSE" target="_blank">Apache 2.0</a> |
-| `inference/models/yolact` |             <a href="https://github.com/dbolya/yolact/blob/master/LICENSE" target="_blank">MIT</a>             |
-| `inference/models/yolov5` |         <a href="https://github.com/ultralytics/yolov5/blob/master/LICENSE" target="_blank">AGPL-3.0</a>         |
-| `inference/models/yolov7` |          <a href="https://github.com/WongKinYiu/yolov7/blob/main/README.md" target="_blank">GPL-3.0</a>          |
-| `inference/models/yolov8` |      <a href="https://github.com/ultralytics/ultralytics/blob/master/LICENSE" target="_blank">AGPL-3.0</a>       |
+See [Roboflow Licensing](https://inference.roboflow.com/quickstart/licensing/) for information on how Inference and models supported in Inference are licensed.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,18 +43,6 @@ nav:
           - YOLOv7: fine-tuned/yolov7.md
           - YOLOv5: fine-tuned/yolov5.md
           - YOLO-NAS: fine-tuned/yolonas.md
-      - Run a Model:
-          - Predict on an Image Over HTTP: quickstart/run_model_on_image.md
-          - Predict on a Video, Webcam or RTSP Stream: quickstart/run_model_on_rtsp_webcam.md
-          - Predict Over UDP: quickstart/run_model_over_udp.md
-          - Keypoint Detection: quickstart/run_keypoint_detection.md
-
-      - Deploy a Model:
-          - Configure Your Deployment: https://roboflow.github.io/deploy-setup-widget/results.html
-          - How Do I Run Inference?: quickstart/inference_101.md
-          - What Devices Can I Use?: quickstart/devices.md
-          - Retrieve Your API Key: quickstart/configure_api_key.md
-          - Model Licenses: quickstart/licensing.md
       - Foundation Model:
           - What is a Foundation Model?: foundation/about.md
           - CLIP (Classification, Embeddings): foundation/clip.md
@@ -64,6 +52,17 @@ nav:
           - L2CS-Net (Gaze Detection): foundation/gaze.md
           - Segment Anything (Segmentation): foundation/sam.md
           - YOLO-World (Object Detection): foundation/yolo_world.md
+      - Run a Model:
+          - Predict on an Image Over HTTP: quickstart/run_model_on_image.md
+          - Predict on a Video, Webcam or RTSP Stream: quickstart/run_model_on_rtsp_webcam.md
+          - Predict Over UDP: quickstart/run_model_over_udp.md
+          - Keypoint Detection: quickstart/run_keypoint_detection.md
+      - Deploy a Model:
+          - Configure Your Deployment: https://roboflow.github.io/deploy-setup-widget/results.html
+          - How Do I Run Inference?: quickstart/inference_101.md
+          - What Devices Can I Use?: quickstart/devices.md
+          - Retrieve Your API Key: quickstart/configure_api_key.md
+          - Model Licenses: https://roboflow.com/licensing
   - Workflows:
       - What is a Workflow?: workflows/about.md
       - Understanding Workflows: workflows/understanding.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,6 +50,7 @@ nav:
           - DocTR (OCR): foundation/doctr.md
           - Grounding DINO (Object Detection): foundation/grounding_dino.md
           - L2CS-Net (Gaze Detection): foundation/gaze.md
+          - PaliGemma: foundation/paligemma.md
           - Segment Anything (Segmentation): foundation/sam.md
           - YOLO-World (Object Detection): foundation/yolo_world.md
       - Run a Model:


### PR DESCRIPTION
# Description

This PR:

1. Adds PaliGemma reference documentation
2. Re-orders the Table of Contents so that foundation models are more prominent
3. Updates the licensing page to link to the canonical Roboflow licensing page

## Type of change

Documentation updates

## How has this change been tested, please provide a testcase or example of how you tested the change?

You can test this PR by opening the documentation locally and browsing the new PaliGemma page and ensuring the table of contents appears correctly.

## Any specific deployment considerations

N/A

## Docs

N/A