### PR TITLE
fix letterbox and postprocess for YOLOv10

### DIFF
--- a/inference/core/models/roboflow.py
+++ b/inference/core/models/roboflow.py
@@ -401,7 +401,8 @@ class RoboflowInferenceModel(Model):
             )
         elif self.resize_method == "Fit (black edges) in":
             resized = letterbox_image(
-                preprocessed_image, (self.img_size_w, self.img_size_h)
+                preprocessed_image, (self.img_size_w, self.img_size_h),
+                color=(114, 114, 114)
             )
         elif self.resize_method == "Fit (white edges) in":
             resized = letterbox_image(

--- a/inference/core/models/roboflow.py
+++ b/inference/core/models/roboflow.py
@@ -346,6 +346,7 @@ class RoboflowInferenceModel(Model):
                 "Stretch to",
                 "Fit (black edges) in",
                 "Fit (white edges) in",
+                "Fit (grey edges) in"
             ]:
                 self.resize_method = "Stretch to"
         else:
@@ -401,14 +402,18 @@ class RoboflowInferenceModel(Model):
             )
         elif self.resize_method == "Fit (black edges) in":
             resized = letterbox_image(
-                preprocessed_image, (self.img_size_w, self.img_size_h),
-                color=(114, 114, 114)
+                preprocessed_image, (self.img_size_w, self.img_size_h)
             )
         elif self.resize_method == "Fit (white edges) in":
             resized = letterbox_image(
                 preprocessed_image,
                 (self.img_size_w, self.img_size_h),
                 color=(255, 255, 255),
+            )
+        elif self.resize_method == "Fit (grey edges) in":
+            resized = letterbox_image(
+                preprocessed_image, (self.img_size_w, self.img_size_h),
+                color=(114, 114, 114)
             )
 
         if is_bgr:

--- a/inference/core/utils/postprocess.py
+++ b/inference/core/utils/postprocess.py
@@ -108,6 +108,7 @@ def post_process_bboxes(
         elif (
             resize_method == "Fit (black edges) in"
             or resize_method == "Fit (white edges) in"
+            or resize_method == "Fit (grey edges) in"
         ):
             predicted_bboxes = undo_image_padding_for_predicted_boxes(
                 predicted_bboxes=predicted_bboxes,
@@ -372,7 +373,7 @@ def post_process_polygons(
         infer_shape (tuple of int): Shape of the target image (height, width).
         polys (list of list of tuple): List of polygons, where each polygon is represented by a list of (x, y) coordinates.
         preproc (object): Preprocessing details used for generating the transformation.
-        resize_method (str, optional): Resizing method, either "Stretch to", "Fit (black edges) in", or "Fit (white edges) in". Defaults to "Stretch to".
+        resize_method (str, optional): Resizing method, either "Stretch to", "Fit (black edges) in", "Fit (white edges) in", or "Fit (grey edges) in". Defaults to "Stretch to".
 
     Returns:
         list of list of tuple: A list of shifted and scaled polygons.
@@ -389,7 +390,7 @@ def post_process_polygons(
             x_scale=width_ratio,
             y_scale=height_ratio,
         )
-    elif resize_method in {"Fit (black edges) in", "Fit (white edges) in"}:
+    elif resize_method in {"Fit (black edges) in", "Fit (white edges) in", "Fit (grey edges) in"}:
         new_polys = undo_image_padding_for_predicted_polygons(
             polygons=polys,
             infer_shape=infer_shape,
@@ -500,7 +501,7 @@ def post_process_keypoints(
         img_dims list of (tuple of int): Shape of the source image (height, width).
         infer_shape (tuple of int): Shape of the target image (height, width).
         preproc (object): Preprocessing details used for generating the transformation.
-        resize_method (str, optional): Resizing method, either "Stretch to", "Fit (black edges) in", or "Fit (white edges) in". Defaults to "Stretch to".
+        resize_method (str, optional): Resizing method, either "Stretch to", "Fit (black edges) in", "Fit (white edges) in", or "Fit (grey edges) in". Defaults to "Stretch to".
         disable_preproc_static_crop: flag to disable static crop
     Returns:
         list of list of list: predictions with post-processed keypoints
@@ -528,6 +529,7 @@ def post_process_keypoints(
         elif (
             resize_method == "Fit (black edges) in"
             or resize_method == "Fit (white edges) in"
+            or resize_method == "Fit (grey edges) in"
         ):
             keypoints = undo_image_padding_for_predicted_keypoints(
                 keypoints=keypoints,

--- a/inference/models/yolov10/yolov10_object_detection.py
+++ b/inference/models/yolov10/yolov10_object_detection.py
@@ -5,6 +5,16 @@ import numpy as np
 from inference.core.models.object_detection_base import (
     ObjectDetectionBaseOnnxRoboflowInferenceModel,
 )
+from inference.core.models.defaults import (
+    DEFAULT_CONFIDENCE,
+    DEFAUlT_MAX_DETECTIONS,
+)
+from inference.core.models.types import PreprocessReturnMetadata
+from inference.core.entities.responses.inference import (
+    ObjectDetectionInferenceResponse,
+)
+from typing import List, Tuple
+from inference.core.utils.postprocess import post_process_bboxes
 
 
 class YOLOv10ObjectDetection(ObjectDetectionBaseOnnxRoboflowInferenceModel):
@@ -41,19 +51,48 @@ class YOLOv10ObjectDetection(ObjectDetectionBaseOnnxRoboflowInferenceModel):
             Tuple[np.ndarray]: NumPy array representing the predictions, including boxes, confidence scores, and class confidence scores.
         """
         predictions = self.onnx_session.run(None, {self.input_name: img_in})[0]
-        boxes = predictions[:, :, :4]
-        batch_size = boxes.shape[0]
-        num_boxes = boxes.shape[1]
-        class_confs = np.zeros(
-            (batch_size, num_boxes, self.num_classes), dtype=np.float32
-        )
-        for batch in range(batch_size):
-            for box in range(num_boxes):
-                class_id = int(predictions[batch, box, 5])
-                confidence = predictions[batch, box, 4]
-                class_confs[batch, box, class_id] = confidence
-
-        confs = predictions[:, :, 4:5]
-        predictions = np.concatenate([boxes, confs, class_confs], axis=2)
 
         return (predictions,)
+
+    def postprocess(
+        self,
+        predictions: Tuple[np.ndarray, ...],
+        preproc_return_metadata: PreprocessReturnMetadata,
+        confidence: float = DEFAULT_CONFIDENCE,
+        max_detections: int = DEFAUlT_MAX_DETECTIONS,
+        **kwargs,
+    ) -> List[ObjectDetectionInferenceResponse]:
+        """Postprocesses the object detection predictions.
+
+        Args:
+            predictions (np.ndarray): Raw predictions from the model.
+            img_dims (List[Tuple[int, int]]): Dimensions of the images.
+            confidence (float): Confidence threshold for filtering detections. Default is 0.5.
+            max_detections (int): Maximum number of final detections. Default is 300.
+
+        Returns:
+            List[ObjectDetectionInferenceResponse]: The post-processed predictions.
+        """
+        predictions = predictions[0]
+        predictions = np.append(predictions, predictions[..., 5:], axis=-1)
+        predictions[..., 5] = predictions[..., 4]
+
+        mask = predictions[..., 4] > confidence
+        predictions = [p[mask[idx]][:max_detections] for idx, p in enumerate(predictions)]
+
+        infer_shape = (self.img_size_h, self.img_size_w)
+        img_dims = preproc_return_metadata["img_dims"]
+        predictions = post_process_bboxes(
+            predictions,
+            infer_shape,
+            img_dims,
+            self.preproc,
+            resize_method=self.resize_method,
+            disable_preproc_static_crop=preproc_return_metadata[
+                "disable_preproc_static_crop"
+            ],
+        )
+        return self.make_response(predictions, img_dims, **kwargs)
+
+    def validate_model_classes(self) -> None:
+        pass


### PR DESCRIPTION
# Description

1. NMS is not needed for YOLOv10. This PR removes NMS for the postprocessing in YOLOv10
2. The `color` used in LetterBox is `(114,114,114)` in ultralytics. This PR change the `color` to `(114,114,114)` to make LetterBox consistent with it.
3. The onnx models of YOLOv10 in Roboflow inference may be incorrectly exported. This PR hopes replace the onnx models of YOLOv10 with the follows: [yolov10n.onnx](https://github.com/THU-MIG/yolov10/releases/download/v1.1/yolov10n.onnx), [yolov10s.onnx](https://github.com/THU-MIG/yolov10/releases/download/v1.1/yolov10s.onnx), [yolov10m.onnx](https://github.com/THU-MIG/yolov10/releases/download/v1.1/yolov10m.onnx), [yolov10b.onnx](https://github.com/THU-MIG/yolov10/releases/download/v1.1/yolov10b.onnx), [yolov10l.onnx](https://github.com/THU-MIG/yolov10/releases/download/v1.1/yolov10l.onnx) and [yolov10x.onnx](https://github.com/THU-MIG/yolov10/releases/download/v1.1/yolov10x.onnx).


## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?
Here is a minimal testcase:
```bash
wget https://skalskip-yolo-arena.hf.space/file=/tmp/gradio/56eee51b0a661453cbf915229dfbadc00b7a0cad/vehicles.png
pip install -q git+https://github.com/THU-MIG/yolov10.git
```
```python
import numpy as np
import supervision as sv
from inference import get_model
from PIL import Image

LABEL_ANNOTATORS = sv.LabelAnnotator(text_color=sv.Color.black())
BOUNDING_BOX_ANNOTATORS = sv.BoundingBoxAnnotator()
def detect_and_annotate(
    input_image: np.ndarray,
    confidence_threshold: float,
    iou_threshold: float = 0,
):
    model = get_model(model_id="coco/22")
    result = model.infer(
        input_image,
        confidence=confidence_threshold,
        iou_threshold=iou_threshold
    )[0]
    detections = sv.Detections.from_inference(result)

    labels = [
        f"{class_name} ({confidence:.2f})"
        for class_name, confidence
        in zip(detections['class_name'], detections.confidence)
    ]

    annotated_image = input_image.copy()
    annotated_image = BOUNDING_BOX_ANNOTATORS.annotate(
        scene=annotated_image, detections=detections)
    annotated_image = LABEL_ANNOTATORS.annotate(
        scene=annotated_image, detections=detections, labels=labels)
    annotated_image.save('annotated_vehicles.png')
    return annotated_image

detect_and_annotate(Image.open('vehicles.png'), 0.4)
```
The `annotated_vehicles.png` should be like below

![annotated_vehicles](https://github.com/roboflow/inference/assets/43805318/c08340e8-e8f9-4107-8014-89a54ad305c9)

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
