### PR TITLE
Step Name Property Copy Changes

### DIFF
--- a/inference/core/workflows/core_steps/models/foundation/clip_comparison.py
+++ b/inference/core/workflows/core_steps/models/foundation/clip_comparison.py
@@ -55,7 +55,6 @@ class BlockManifest(WorkflowBlockManifest):
         }
     )
     type: Literal["ClipComparison"]
-    name: str = Field(description="Unique name of step in workflows")
     images: Union[WorkflowImageSelector, StepOutputImageSelector] = Field(
         description="Reference an image to be used as input for step processing",
         examples=["$inputs.image", "$steps.cropping.crops"],

--- a/inference/core/workflows/core_steps/models/foundation/ocr.py
+++ b/inference/core/workflows/core_steps/models/foundation/ocr.py
@@ -56,7 +56,6 @@ class BlockManifest(WorkflowBlockManifest):
         }
     )
     type: Literal["OCRModel"]
-    name: str = Field(description="Unique name of step in workflows")
     images: Union[WorkflowImageSelector, StepOutputImageSelector] = Field(
         description="Reference an image to be used as input for step processing",
         examples=["$inputs.image", "$steps.cropping.crops"],

--- a/inference/core/workflows/core_steps/models/foundation/yolo_world.py
+++ b/inference/core/workflows/core_steps/models/foundation/yolo_world.py
@@ -62,7 +62,6 @@ class BlockManifest(WorkflowBlockManifest):
         }
     )
     type: Literal["YoloWorldModel", "YoloWorld"]
-    name: str = Field(description="Unique name of step in workflows")
     images: Union[WorkflowImageSelector, StepOutputImageSelector] = Field(
         description="Reference an image to be used as input for step processing",
         examples=["$inputs.image", "$steps.cropping.crops"],
@@ -75,7 +74,16 @@ class BlockManifest(WorkflowBlockManifest):
         examples=[["person", "car", "license plate"], "$inputs.class_names"],
     )
     version: Union[
-        Literal["v2-s", "v2-m", "v2-l", "v2-x", "s", "m", "l", "x", ],
+        Literal[
+            "v2-s",
+            "v2-m",
+            "v2-l",
+            "v2-x",
+            "s",
+            "m",
+            "l",
+            "x",
+        ],
         WorkflowParameterSelector(kind=[STRING_KIND]),
     ] = Field(
         default="v2-s",

--- a/inference/core/workflows/core_steps/transformations/detection_offset.py
+++ b/inference/core/workflows/core_steps/transformations/detection_offset.py
@@ -50,7 +50,6 @@ class BlockManifest(WorkflowBlockManifest):
         }
     )
     type: Literal["DetectionOffset"]
-    name: str = Field(description="Unique name of step in workflows")
     predictions: StepOutputSelector(
         kind=[
             BATCH_OF_OBJECT_DETECTION_PREDICTION_KIND,

--- a/inference/core/workflows/core_steps/transformations/relative_static_crop.py
+++ b/inference/core/workflows/core_steps/transformations/relative_static_crop.py
@@ -52,7 +52,6 @@ class BlockManifest(WorkflowBlockManifest):
         }
     )
     type: Literal["RelativeStaticCrop"]
-    name: str = Field(description="Unique name of step in workflows")
     images: Union[WorkflowImageSelector, StepOutputImageSelector] = Field(
         description="Reference an image to be used as input for step processing",
         examples=["$inputs.image", "$steps.cropping.crops"],

--- a/inference/core/workflows/prototypes/block.py
+++ b/inference/core/workflows/prototypes/block.py
@@ -19,7 +19,7 @@ class WorkflowBlockManifest(BaseModel, ABC):
     )
 
     type: str
-    name: str = Field(description="Unique name of step in workflows")
+    name: str = Field(title="Step Name", description="The unique name of this step.")
 
     @classmethod
     @abstractmethod


### PR DESCRIPTION
# Description

Updates the `name` property to be `Step Name` & have a new description.

After exporting the manifest it now looks like this in the UI:

<img width="576" alt="image" src="https://github.com/roboflow/inference/assets/870796/f65501b9-1b16-4bbc-87e4-389d196c80ba">

Fix https://github.com/roboflow/roboflow/issues/3533

## Type of change

-   [x] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Exporting manifest & running in core app

## Any specific deployment considerations

No

## Docs

- Self-documenting
