### PR TITLE
Fix dead supported blocks link

### DIFF
--- a/docs/workflows/create_and_run.md
+++ b/docs/workflows/create_and_run.md
@@ -178,4 +178,4 @@ Now that we have our specification, we can run our workflow using the Inference 
 
 Now that you have created and run your first workflow, you can explore our other supported blocks and create a more complex workflow.
 
-Refer to our [Supported Blocks](/workflows/supported_blocks/) documentation to learn more about what blocks are supported.
+Refer to our [Supported Blocks](/workflows/blocks/) documentation to learn more about what blocks are supported.

--- a/inference/core/workflows/core_steps/models/foundation/yolo_world.py
+++ b/inference/core/workflows/core_steps/models/foundation/yolo_world.py
@@ -75,7 +75,16 @@ class BlockManifest(WorkflowBlockManifest):
         examples=[["person", "car", "license plate"], "$inputs.class_names"],
     )
     version: Union[
-        Literal["v2-s", "v2-m", "v2-l", "v2-x", "s", "m", "l", "x", ],
+        Literal[
+            "v2-s",
+            "v2-m",
+            "v2-l",
+            "v2-x",
+            "s",
+            "m",
+            "l",
+            "x",
+        ],
         WorkflowParameterSelector(kind=[STRING_KIND]),
     ] = Field(
         default="v2-s",


### PR DESCRIPTION
# Description

The "Supported Blocks" link https://inference.roboflow.com/workflows/supported_blocks/ in page https://inference.roboflow.com/workflows/create_and_run/#next-steps is dead.

This PR changes it to https://inference.roboflow.com/workflows/blocks/

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [x] Docs updated? What were the changes:
