### PR TITLE
Add http get support for legacy model inference

### DIFF
--- a/inference/core/interfaces/http/http_api.py
+++ b/inference/core/interfaces/http/http_api.py
@@ -1392,6 +1392,20 @@ class HttpInterface(BaseInterface):
 
         if LEGACY_ROUTE_ENABLED:
             # Legacy object detection inference path for backwards compatability
+            @app.get(
+                "/{dataset_id}/{version_id}",
+                # Order matters in this response model Union. It will use the first matching model. For example, Object Detection Inference Response is a subset of Instance segmentation inference response, so instance segmentation must come first in order for the matching logic to work.
+                response_model=Union[
+                    InstanceSegmentationInferenceResponse,
+                    KeypointsDetectionInferenceResponse,
+                    ObjectDetectionInferenceResponse,
+                    ClassificationInferenceResponse,
+                    MultiLabelClassificationInferenceResponse,
+                    StubResponse,
+                    Any,
+                ],
+                response_model_exclude_none=True,
+            )
             @app.post(
                 "/{dataset_id}/{version_id}",
                 # Order matters in this response model Union. It will use the first matching model. For example, Object Detection Inference Response is a subset of Instance segmentation inference response, so instance segmentation must come first in order for the matching logic to work.


### PR DESCRIPTION
# Description

Add http get support for legacy model inference, so users can request: 
https://detect.roboflow.com/model_name/version_id?api_key=1xxx&confidence=40&overlap=30&format=image&labels=on&stroke=2&image=xxx

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Tested locally
