### PR TITLE
Docs: Remove banner saying Sv Keypoint annotators are experimental

### DIFF
--- a/docs/quickstart/run_keypoint_detection.md
+++ b/docs/quickstart/run_keypoint_detection.md
@@ -168,17 +168,6 @@ You may use keypoint detection models available on the [Universe](https://univer
 
 With [supervision](https://supervision.roboflow.com/latest/) you may visualize the results, carry out post-processing. Supervision library standardizes results from various keypoint detection and pose estimation models into a consistent format, using adaptors such as `from_inference`.
 
-<details>
-<summary>⚠️ release candidate feature</summary>
-
-`from_inference` will be supported in `supervision>=0.21.0`. If you'd like to try it now, install the following:
-
-```bash
-pip install supervision==0.21.0rc3
-```
-
-</details>
-
 Example usage:
 
 ```python

--- a/inference/core/workflows/core_steps/models/foundation/yolo_world.py
+++ b/inference/core/workflows/core_steps/models/foundation/yolo_world.py
@@ -75,7 +75,16 @@ class BlockManifest(WorkflowBlockManifest):
         examples=[["person", "car", "license plate"], "$inputs.class_names"],
     )
     version: Union[
-        Literal["v2-s", "v2-m", "v2-l", "v2-x", "s", "m", "l", "x", ],
+        Literal[
+            "v2-s",
+            "v2-m",
+            "v2-l",
+            "v2-x",
+            "s",
+            "m",
+            "l",
+            "x",
+        ],
         WorkflowParameterSelector(kind=[STRING_KIND]),
     ] = Field(
         default="v2-s",


### PR DESCRIPTION
# Description

Removed the banner suggesting to install `supervision==0.21.0.rc3` release candidate, as `0.21.0` is being released right now.

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [x] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

⚠️ I failed to serve the docs, with `mkdocs` requiring `mkdocstrings`, which wasn't found even when installed.
 
## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [x] Docs updated? What were the changes:

Removed 1 banner.