### PR TITLE
Loose boto3 requirements

### DIFF
--- a/requirements/_requirements.txt
+++ b/requirements/_requirements.txt
@@ -23,5 +23,6 @@ pydantic~=2.6
 openai>=1.12.0
 structlog>=24.1.0
 zxing-cpp>=2.2.0
+boto3<2
 typing_extensions>=4.8.0
 pydot>=2.0.0

--- a/requirements/_requirements.txt
+++ b/requirements/_requirements.txt
@@ -23,6 +23,5 @@ pydantic~=2.6
 openai>=1.12.0
 structlog>=24.1.0
 zxing-cpp>=2.2.0
-boto3<=1.28.23
 typing_extensions>=4.8.0
 pydot>=2.0.0

--- a/requirements/_requirements.txt
+++ b/requirements/_requirements.txt
@@ -23,6 +23,6 @@ pydantic~=2.6
 openai>=1.12.0
 structlog>=24.1.0
 zxing-cpp>=2.2.0
-boto3<2
+boto3<=1.34.123
 typing_extensions>=4.8.0
 pydot>=2.0.0


### PR DESCRIPTION
# Description

Bump the max boto3 version to avoid pip trying to install many versions before finding one that works.

It is reasonably safe, boto3 is very stable.

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

🟢 CI pass 🟢 
