### PR TITLE
Fix weird paligemma generation

### DIFF
--- a/docker/dockerfiles/Dockerfile.paligemma
+++ b/docker/dockerfiles/Dockerfile.paligemma
@@ -1,4 +1,4 @@
-FROM nvcr.io/nvidia/cuda:11.7.1-cudnn8-runtime-ubuntu22.04 as base
+FROM nvcr.io/nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu22.04 as base
 
 WORKDIR /app
 
@@ -41,6 +41,7 @@ FROM scratch
 COPY --from=base / /
 
 WORKDIR /app/
+RUN pip3 uninstall -y nvidia-cudnn-cu11
 COPY inference inference
 COPY inference_sdk inference_sdk
 COPY inference_cli inference_cli


### PR DESCRIPTION
# Description

There was some weird bug (at least on my machine) where multiple subsequent calls to paligemma would degrade performance, I tracked it down to mismatch between the pytorch installed cudnn and the system one. Pytorch says "oh don't even bother having yoru own cudnn", but we need it for onnx stuff. So we uninstall the pytorch installed cudnn.

I think the error came in the flash attention implementation or some improperly intialized tensor or something

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Locally

## Any specific deployment considerations

Depends on system cuda maybe

## Docs

-   [ ] Docs updated? What were the changes:
