### PR TITLE
Remove sv.FPSMonitor deprecation warnings

### DIFF
--- a/inference/core/interfaces/camera/video_source.py
+++ b/inference/core/interfaces/camera/video_source.py
@@ -921,7 +921,10 @@ class VideoConsumer:
         ):
             # not enough observations
             return False
-        stream_consumption_pace = self._stream_consumption_pace_monitor()
+        if hasattr(self._stream_consumption_pace_monitor, "fps"):
+            stream_consumption_pace = self._stream_consumption_pace_monitor.fps
+        else:
+            stream_consumption_pace = self._stream_consumption_pace_monitor()
         announced_stream_fps = stream_consumption_pace
         if declared_source_fps is not None and declared_source_fps > 0:
             announced_stream_fps = declared_source_fps
@@ -943,7 +946,10 @@ class VideoConsumer:
         actual_reader_pace = get_fps_if_tick_happens_now(
             fps_monitor=self._reader_pace_monitor
         )
-        decoding_pace = self._decoding_pace_monitor()
+        if hasattr(self._decoding_pace_monitor, "fps"):
+            decoding_pace = self._decoding_pace_monitor.fps
+        else:
+            decoding_pace = self._decoding_pace_monitor()
         if (
             decoding_pace - actual_reader_pace
             > self._adaptive_mode_reader_pace_tolerance

--- a/inference/core/interfaces/stream/sinks.py
+++ b/inference/core/interfaces/stream/sinks.py
@@ -159,7 +159,10 @@ def _handle_frame_rendering(
     else:
         try:
             labels = [p["class"] for p in prediction["predictions"]]
-            detections = sv.Detections.from_roboflow(prediction)
+            if hasattr(sv.Detections, "from_inference"):
+                detections = sv.Detections.from_inference(prediction)
+            else:
+                detections = sv.Detections.from_roboflow(prediction)
             image = frame.image.copy()
             for annotator in annotators:
                 kwargs = {
@@ -173,7 +176,7 @@ def _handle_frame_rendering(
             logger.warning(
                 f"Used `render_boxes(...)` sink, but predictions that were provided do not match the expected "
                 f"format of object detection prediction that could be accepted by "
-                f"`supervision.Detection.from_roboflow(...)"
+                f"`supervision.Detection.from_inference(...)"
             )
             image = frame.image.copy()
     if display_size is not None:

--- a/inference/core/interfaces/stream/sinks.py
+++ b/inference/core/interfaces/stream/sinks.py
@@ -122,7 +122,10 @@ def render_boxes(
         ticks = sum(f is not None for f in video_frame)
         for _ in range(ticks):
             fps_monitor.tick()
-        fps_value = fps_monitor()
+        if hasattr(fps_monitor, "fps"):
+            fps_value = fps_monitor.fps
+        else:
+            fps_value = fps_monitor()
     images: List[ImageWithSourceID] = []
     annotators = annotator if isinstance(annotator, list) else [annotator]
     for idx, (single_frame, frame_prediction) in enumerate(

--- a/inference/core/interfaces/stream/stream.py
+++ b/inference/core/interfaces/stream/stream.py
@@ -274,9 +274,14 @@ class Stream(BaseInterface):
                     prediction_type=self.task_type,
                 )
                 if self.use_bytetrack:
-                    detections = sv.Detections.from_roboflow(
-                        predictions.dict(by_alias=True, exclude_none=True)
-                    )
+                    if hasattr(sv.Detections, "from_inference"):
+                        detections = sv.Detections.from_inference(
+                            predictions.dict(by_alias=True, exclude_none=True)
+                        )
+                    else:
+                        detections = sv.Detections.from_roboflow(
+                            predictions.dict(by_alias=True, exclude_none=True)
+                        )
                     detections = self.byte_tracker.update_with_detections(detections)
 
                     if detections.tracker_id is None:

--- a/inference/core/interfaces/stream/watchdog.py
+++ b/inference/core/interfaces/stream/watchdog.py
@@ -244,9 +244,13 @@ class BasePipelineWatchDog(PipelineWatchDog):
         latency_reports = [
             monitor.summarise_reports() for monitor in self._latency_monitors.values()
         ]
+        if hasattr(self._inference_throughput_monitor(), "fps"):
+            _inference_throughput_fps = self._inference_throughput_monitor.fps
+        else:
+            _inference_throughput_fps = self._inference_throughput_monitor()
         return PipelineStateReport(
             video_source_status_updates=list(self._stream_updates),
             latency_reports=latency_reports,
-            inference_throughput=self._inference_throughput_monitor(),
+            inference_throughput=_inference_throughput_fps,
             sources_metadata=sources_metadata,
         )

--- a/inference/core/interfaces/udp/udp_stream.py
+++ b/inference/core/interfaces/udp/udp_stream.py
@@ -227,9 +227,14 @@ class UdpStream(BaseInterface):
                     prediction_type=self.task_type,
                 )
                 if self.use_bytetrack:
-                    detections = sv.Detections.from_roboflow(
-                        predictions.dict(by_alias=True), self.model.class_names
-                    )
+                    if hasattr(sv.Detections, "from_inference"):
+                        detections = sv.Detections.from_inference(
+                            predictions.dict(by_alias=True), self.model.class_names
+                        )
+                    else:
+                        detections = sv.Detections.from_roboflow(
+                            predictions.dict(by_alias=True), self.model.class_names
+                        )
                     detections = self.byte_tracker.update_with_detections(detections)
                     for pred, detect in zip(predictions.predictions, detections):
                         pred.tracker_id = int(detect[4])


### PR DESCRIPTION
# Description

When running inference pipeline log is spammed with deprecation warnings:

```
SupervisionWarnings: __call__ is deprecated: `FPSMonitor.__call__` is deprecated and will be removed in `supervision-0.22.0`. Use `FPSMonitor.fps` instead.
```

## Type of change

This is quality of life change.

## How has this change been tested, please provide a testcase or example of how you tested the change?

```python3
from inference import InferencePipeline
from inference.core.interfaces.stream.sinks import render_boxes

pipeline = InferencePipeline.init(
    model_id="yolov8n-640",
    video_reference=0,
    on_prediction=render_boxes,
)

pipeline.start()
pipeline.join()
```

## Any specific deployment considerations

N/A

## Docs

N/A