### PR TITLE
Add support for image_and_json format

### DIFF
--- a/docs/inference_helpers/inference_sdk.md
+++ b/docs/inference_helpers/inference_sdk.md
@@ -555,7 +555,7 @@ The following fields are passed to API
 - `confidence_threshold` (as `confidence`) - to alter model thresholding
 - `keypoint_confidence_threshold` as (`keypoint_confidence`) - to filter out detected keypoints
   based on model confidence
-- `format`: to visualise on server side - use `image` (but then you loose prediction details from response)
+- `format`: to visualise on server side - use `image` (just the image) or `image_and_json` (prediction details and image base64)
 - `visualize_labels` (as `labels`) - used in visualisation to show / hide labels for classes
 - `mask_decode_mode`
 - `tradeoff_factor`

--- a/inference/core/interfaces/http/http_api.py
+++ b/inference/core/interfaces/http/http_api.py
@@ -1622,7 +1622,9 @@ class HttpInterface(BaseInterface):
                     max_detections=max_detections,
                     visualization_labels=labels,
                     visualization_stroke_width=stroke,
-                    visualize_predictions=(format == "image" or format == "image_and_json"),
+                    visualize_predictions=(
+                        format == "image" or format == "image_and_json"
+                    ),
                     disable_preproc_auto_orient=disable_preproc_auto_orient,
                     disable_preproc_contrast=disable_preproc_contrast,
                     disable_preproc_grayscale=disable_preproc_grayscale,

--- a/inference/core/interfaces/http/http_api.py
+++ b/inference/core/interfaces/http/http_api.py
@@ -1622,7 +1622,7 @@ class HttpInterface(BaseInterface):
                     max_detections=max_detections,
                     visualization_labels=labels,
                     visualization_stroke_width=stroke,
-                    visualize_predictions=True if format == "image" else False,
+                    visualize_predictions=(format == "image" or format == "image_and_json"),
                     disable_preproc_auto_orient=disable_preproc_auto_orient,
                     disable_preproc_contrast=disable_preproc_contrast,
                     disable_preproc_grayscale=disable_preproc_grayscale,

--- a/inference_sdk/http/client.py
+++ b/inference_sdk/http/client.py
@@ -449,11 +449,11 @@ class InferenceHTTPClient:
                 parsed_response, request_data.image_scaling_factors
             ):
                 if parsed_response_element.get("visualization") is not None:
-                    parsed_response_element[
-                        "visualization"
-                    ] = transform_base64_visualisation(
-                        visualisation=parsed_response_element["visualization"],
-                        expected_format=self.__inference_configuration.output_visualisation_format,
+                    parsed_response_element["visualization"] = (
+                        transform_base64_visualisation(
+                            visualisation=parsed_response_element["visualization"],
+                            expected_format=self.__inference_configuration.output_visualisation_format,
+                        )
                     )
                 parsed_response_element = adjust_prediction_to_client_scaling_factor(
                     prediction=parsed_response_element,
@@ -521,11 +521,11 @@ class InferenceHTTPClient:
                 parsed_response, request_data.image_scaling_factors
             ):
                 if parsed_response_element.get("visualization") is not None:
-                    parsed_response_element[
-                        "visualization"
-                    ] = transform_base64_visualisation(
-                        visualisation=parsed_response_element["visualization"],
-                        expected_format=self.__inference_configuration.output_visualisation_format,
+                    parsed_response_element["visualization"] = (
+                        transform_base64_visualisation(
+                            visualisation=parsed_response_element["visualization"],
+                            expected_format=self.__inference_configuration.output_visualisation_format,
+                        )
                     )
                 parsed_response_element = adjust_prediction_to_client_scaling_factor(
                     prediction=parsed_response_element,

--- a/inference_sdk/http/client.py
+++ b/inference_sdk/http/client.py
@@ -122,7 +122,6 @@ def wrap_errors_async(function: callable) -> callable:
 
 
 class InferenceHTTPClient:
-
     @classmethod
     def init(
         cls,
@@ -317,11 +316,9 @@ class InferenceHTTPClient:
             else:
                 parsed_response = response.json()
                 if parsed_response.get("visualization") is not None:
-                    parsed_response["visualization"] = (
-                        transform_base64_visualisation(
-                            visualisation=parsed_response["visualization"],
-                            expected_format=self.__inference_configuration.output_visualisation_format,
-                        )
+                    parsed_response["visualization"] = transform_base64_visualisation(
+                        visualisation=parsed_response["visualization"],
+                        expected_format=self.__inference_configuration.output_visualisation_format,
                     )
             parsed_response = adjust_prediction_to_client_scaling_factor(
                 prediction=parsed_response,
@@ -383,11 +380,9 @@ class InferenceHTTPClient:
             else:
                 parsed_response = response
                 if parsed_response.get("visualization") is not None:
-                    parsed_response["visualization"] = (
-                        transform_base64_visualisation(
-                            visualisation=parsed_response["visualization"],
-                            expected_format=self.__inference_configuration.output_visualisation_format,
-                        )
+                    parsed_response["visualization"] = transform_base64_visualisation(
+                        visualisation=parsed_response["visualization"],
+                        expected_format=self.__inference_configuration.output_visualisation_format,
                     )
             parsed_response = adjust_prediction_to_client_scaling_factor(
                 prediction=parsed_response,
@@ -454,11 +449,11 @@ class InferenceHTTPClient:
                 parsed_response, request_data.image_scaling_factors
             ):
                 if parsed_response_element.get("visualization") is not None:
-                    parsed_response_element["visualization"] = (
-                        transform_base64_visualisation(
-                            visualisation=parsed_response_element["visualization"],
-                            expected_format=self.__inference_configuration.output_visualisation_format,
-                        )
+                    parsed_response_element[
+                        "visualization"
+                    ] = transform_base64_visualisation(
+                        visualisation=parsed_response_element["visualization"],
+                        expected_format=self.__inference_configuration.output_visualisation_format,
                     )
                 parsed_response_element = adjust_prediction_to_client_scaling_factor(
                     prediction=parsed_response_element,
@@ -526,11 +521,11 @@ class InferenceHTTPClient:
                 parsed_response, request_data.image_scaling_factors
             ):
                 if parsed_response_element.get("visualization") is not None:
-                    parsed_response_element["visualization"] = (
-                        transform_base64_visualisation(
-                            visualisation=parsed_response_element["visualization"],
-                            expected_format=self.__inference_configuration.output_visualisation_format,
-                        )
+                    parsed_response_element[
+                        "visualization"
+                    ] = transform_base64_visualisation(
+                        visualisation=parsed_response_element["visualization"],
+                        expected_format=self.__inference_configuration.output_visualisation_format,
                     )
                 parsed_response_element = adjust_prediction_to_client_scaling_factor(
                     prediction=parsed_response_element,

--- a/inference_sdk/http/client.py
+++ b/inference_sdk/http/client.py
@@ -316,6 +316,13 @@ class InferenceHTTPClient:
                 parsed_response = {"visualization": visualisation}
             else:
                 parsed_response = response.json()
+                if parsed_response.get("visualization") is not None:
+                    parsed_response["visualization"] = (
+                        transform_base64_visualisation(
+                            visualisation=parsed_response["visualization"],
+                            expected_format=self.__inference_configuration.output_visualisation_format,
+                        )
+                    )
             parsed_response = adjust_prediction_to_client_scaling_factor(
                 prediction=parsed_response,
                 scaling_factor=request_data.image_scaling_factors[0],
@@ -375,6 +382,13 @@ class InferenceHTTPClient:
                 parsed_response = {"visualization": visualisation}
             else:
                 parsed_response = response
+                if parsed_response.get("visualization") is not None:
+                    parsed_response["visualization"] = (
+                        transform_base64_visualisation(
+                            visualisation=parsed_response["visualization"],
+                            expected_format=self.__inference_configuration.output_visualisation_format,
+                        )
+                    )
             parsed_response = adjust_prediction_to_client_scaling_factor(
                 prediction=parsed_response,
                 scaling_factor=request_data.image_scaling_factors[0],

--- a/tests/inference_sdk/unit_tests/http/test_client.py
+++ b/tests/inference_sdk/unit_tests/http/test_client.py
@@ -167,7 +167,6 @@ async def test_wrap_errors_async_when_http_error_occurs() -> None:
     # given
     @wrap_errors_async
     async def example() -> None:
-
         raise ClientResponseError(
             request_info=RequestInfo(
                 url=URL("https://some.com"),
@@ -1431,7 +1430,9 @@ def test_infer_from_api_v0_when_request_succeed_for_object_detection_with_visual
     api_url = "http://some.com"
     http_client = InferenceHTTPClient(api_key="my-api-key", api_url=api_url)
     load_static_inference_input_mock.return_value = [("base64_image", 0.5)]
-    configuration = InferenceConfiguration(confidence_threshold=0.5, format="image_and_json")
+    configuration = InferenceConfiguration(
+        confidence_threshold=0.5, format="image_and_json"
+    )
     http_client.configure(inference_configuration=configuration)
     requests_mock.post(
         f"{api_url}/some/1",

--- a/tests/inference_sdk/unit_tests/http/test_client.py
+++ b/tests/inference_sdk/unit_tests/http/test_client.py
@@ -1423,6 +1423,62 @@ async def test_infer_from_api_v0_async_when_request_succeed_for_object_detection
 
 
 @mock.patch.object(client, "load_static_inference_input")
+def test_infer_from_api_v0_when_request_succeed_for_object_detection_with_visualisation_and_json(
+    load_static_inference_input_mock: MagicMock,
+    requests_mock: Mocker,
+) -> None:
+    # given
+    api_url = "http://some.com"
+    http_client = InferenceHTTPClient(api_key="my-api-key", api_url=api_url)
+    load_static_inference_input_mock.return_value = [("base64_image", 0.5)]
+    configuration = InferenceConfiguration(confidence_threshold=0.5, format="image_and_json")
+    http_client.configure(inference_configuration=configuration)
+    requests_mock.post(
+        f"{api_url}/some/1",
+        json={
+            "image": {"height": 480, "width": 640},
+            "predictions": [
+                {
+                    "x": 100.0,
+                    "y": 200.0,
+                    "width": 200.0,
+                    "height": 300.0,
+                    "confidence": 0.9,
+                    "class": "A",
+                }
+            ],
+            "visualization": "aGVsbG8=",
+        },
+        headers={"content-type": "application/json"},
+    )
+
+    # when
+    result = http_client.infer_from_api_v0(
+        inference_input="https://some/image.jpg", model_id="some/1"
+    )
+
+    # then
+    assert result == {
+        "visualization": "aGVsbG8=",
+        "image": {"height": 960, "width": 1280},
+        "predictions": [
+            {
+                "x": 200.0,
+                "y": 400.0,
+                "width": 400.0,
+                "height": 600.0,
+                "confidence": 0.9,
+                "class": "A",
+            }
+        ],
+    }
+    assert (
+        requests_mock.last_request.query
+        == "api_key=my-api-key&confidence=0.5&format=image_and_json&disable_active_learning=false"
+    )
+
+
+@mock.patch.object(client, "load_static_inference_input")
 def test_infer_from_api_v0_when_request_succeed_for_object_detection_with_visualisation(
     load_static_inference_input_mock: MagicMock,
     requests_mock: Mocker,


### PR DESCRIPTION
# Description

Adds new format option for v0 http request, `image_and_json`. This will create the image visualization, and return it with the predictions json. Also updates inference_sdk to output the image in the desired format (pillow, numpy, etc).

Adding this as a separate initiative to the ongoing workflows feature improvements because it is relatively small update.

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Tested locally w/ inference_sdk, and on staging hosted API.

## Any specific deployment considerations

- hosted API

## Docs

-   [ ] Docs updated? What were the changes:
