### PR TITLE
replace usage of np_image_to_base64 with encode_image_to_jpeg_bytes

### DIFF
--- a/inference/core/models/stubs.py
+++ b/inference/core/models/stubs.py
@@ -9,7 +9,7 @@ from inference.core.entities.requests.inference import InferenceRequest
 from inference.core.entities.responses.inference import InferenceResponse, StubResponse
 from inference.core.models.base import Model
 from inference.core.models.types import PreprocessReturnMetadata
-from inference.core.utils.image_utils import np_image_to_base64
+from inference.core.utils.image_utils import encode_image_to_jpeg_bytes
 
 
 class ModelStub(Model):
@@ -67,7 +67,7 @@ class ClassificationModelStub(ModelStub):
     ) -> Union[InferenceResponse, List[InferenceResponse]]:
         stub_visualisation = None
         if getattr(request, "visualize_predictions", False):
-            stub_visualisation = np_image_to_base64(
+            stub_visualisation = encode_image_to_jpeg_bytes(
                 np.zeros((128, 128, 3), dtype=np.uint8)
             )
         return StubResponse(
@@ -86,7 +86,7 @@ class ObjectDetectionModelStub(ModelStub):
     ) -> Union[InferenceResponse, List[InferenceResponse]]:
         stub_visualisation = None
         if getattr(request, "visualize_predictions", False):
-            stub_visualisation = np_image_to_base64(
+            stub_visualisation = encode_image_to_jpeg_bytes(
                 np.zeros((128, 128, 3), dtype=np.uint8)
             )
         return StubResponse(
@@ -105,7 +105,7 @@ class InstanceSegmentationModelStub(ModelStub):
     ) -> Union[InferenceResponse, List[InferenceResponse]]:
         stub_visualisation = None
         if getattr(request, "visualize_predictions", False):
-            stub_visualisation = np_image_to_base64(
+            stub_visualisation = encode_image_to_jpeg_bytes(
                 np.zeros((128, 128, 3), dtype=np.uint8)
             )
         return StubResponse(
@@ -124,7 +124,7 @@ class KeypointsDetectionModelStub(ModelStub):
     ) -> Union[InferenceResponse, List[InferenceResponse]]:
         stub_visualisation = None
         if getattr(request, "visualize_predictions", False):
-            stub_visualisation = np_image_to_base64(
+            stub_visualisation = encode_image_to_jpeg_bytes(
                 np.zeros((128, 128, 3), dtype=np.uint8)
             )
         return StubResponse(

--- a/inference/core/utils/image_utils.py
+++ b/inference/core/utils/image_utils.py
@@ -423,18 +423,19 @@ def convert_gray_image_to_bgr(image: np.ndarray) -> np.ndarray:
 )
 def np_image_to_base64(image: np.ndarray) -> bytes:
     """
-    Convert a numpy image to bytes.
+    Convert a numpy image to a base64 encoded byte string.
 
     Args:
         image (np.ndarray): The numpy array representing an image.
 
     Returns:
-        bytes
-
+        bytes: The base64 encoded image.
     """
-    encoded_result: Tuple[bool, np.ndarray] = cv2.imencode(".jpg", image)
+    image = Image.fromarray(image)
     with BytesIO() as buffer:
-        buffer.write(encoded_result[1].tobytes())
+        image = image.convert("RGB")
+        image.save(buffer, format="JPEG")
+        buffer.seek(0)
         return buffer.getvalue()
 
 

--- a/inference/core/utils/image_utils.py
+++ b/inference/core/utils/image_utils.py
@@ -418,6 +418,7 @@ def convert_gray_image_to_bgr(image: np.ndarray) -> np.ndarray:
     return image
 
 
+@deprecated(reason="Method replaced with inference.core.utils.image_utils.encode_image_to_jpeg_bytes")
 def np_image_to_base64(image: np.ndarray) -> bytes:
     """
     Convert a numpy image to bytes.
@@ -429,9 +430,6 @@ def np_image_to_base64(image: np.ndarray) -> bytes:
         bytes
 
     """
-    deprecated(
-        reason="Method replaced with inference.core.utils.image_utils.encode_image_to_jpeg_bytes"
-    )
     encoded_result: Tuple[bool, np.ndarray] = cv2.imencode(".jpg", image)
     with BytesIO() as buffer:
         buffer.write(encoded_result[1].tobytes())

--- a/inference/core/utils/image_utils.py
+++ b/inference/core/utils/image_utils.py
@@ -461,7 +461,7 @@ def encode_image_to_jpeg_bytes(image: np.ndarray, jpeg_quality: int = 90) -> byt
     Encode a numpy image to JPEG format in bytes.
 
     Args:
-        image (np.ndarray): The numpy array representing an image.
+        image (np.ndarray): The numpy array representing a BGR image.
         jpeg_quality (int): Quality of the JPEG image.
 
     Returns:

--- a/inference/core/utils/image_utils.py
+++ b/inference/core/utils/image_utils.py
@@ -427,11 +427,9 @@ def np_image_to_base64(image: np.ndarray) -> bytes:
     Returns:
         bytes: The base64 encoded image.
     """
-    image = Image.fromarray(image)
+    encoded_result: Tuple[bool, np.ndarray] = cv2.imencode(".jpg", image)
     with BytesIO() as buffer:
-        image = image.convert("RGB")
-        image.save(buffer, format="JPEG")
-        buffer.seek(0)
+        buffer.write(encoded_result[1].tobytes())
         return buffer.getvalue()
 
 

--- a/inference/core/utils/image_utils.py
+++ b/inference/core/utils/image_utils.py
@@ -418,7 +418,9 @@ def convert_gray_image_to_bgr(image: np.ndarray) -> np.ndarray:
     return image
 
 
-@deprecated(reason="Method replaced with inference.core.utils.image_utils.encode_image_to_jpeg_bytes")
+@deprecated(
+    reason="Method replaced with inference.core.utils.image_utils.encode_image_to_jpeg_bytes"
+)
 def np_image_to_base64(image: np.ndarray) -> bytes:
     """
     Convert a numpy image to bytes.

--- a/inference/core/utils/image_utils.py
+++ b/inference/core/utils/image_utils.py
@@ -23,6 +23,7 @@ from inference.core.exceptions import (
     InvalidImageTypeDeclared,
     InvalidNumpyInput,
 )
+from inference.core.utils.function import deprecated
 from inference.core.utils.requests import api_key_safe_raise_for_status
 
 BASE64_DATA_TYPE_PATTERN = re.compile(r"^data:image\/[a-z]+;base64,")
@@ -419,14 +420,18 @@ def convert_gray_image_to_bgr(image: np.ndarray) -> np.ndarray:
 
 def np_image_to_base64(image: np.ndarray) -> bytes:
     """
-    Convert a numpy image to a base64 encoded byte string.
+    Convert a numpy image to bytes.
 
     Args:
         image (np.ndarray): The numpy array representing an image.
 
     Returns:
-        bytes: The base64 encoded image.
+        bytes
+
     """
+    deprecated(
+        reason="Method replaced with inference.core.utils.image_utils.encode_image_to_jpeg_bytes"
+    )
     encoded_result: Tuple[bool, np.ndarray] = cv2.imencode(".jpg", image)
     with BytesIO() as buffer:
         buffer.write(encoded_result[1].tobytes())

--- a/inference/core/utils/visualisation.py
+++ b/inference/core/utils/visualisation.py
@@ -16,7 +16,7 @@ from inference.core.entities.responses.inference import (
     ObjectDetectionPrediction,
     Point,
 )
-from inference.core.utils.image_utils import load_image_rgb, np_image_to_base64
+from inference.core.utils.image_utils import encode_image_to_jpeg_bytes, load_image_rgb
 
 
 def draw_detection_predictions(
@@ -63,7 +63,7 @@ def draw_detection_predictions(
                 box=box,
                 color=color,
             )
-    return np_image_to_base64(image=image)
+    return encode_image_to_jpeg_bytes(image=image)
 
 
 def draw_bbox(

--- a/inference/core/utils/visualisation.py
+++ b/inference/core/utils/visualisation.py
@@ -63,7 +63,8 @@ def draw_detection_predictions(
                 box=box,
                 color=color,
             )
-    return encode_image_to_jpeg_bytes(image=image)
+    image_bgr = image[:, :, ::-1]
+    return encode_image_to_jpeg_bytes(image=image_bgr)
 
 
 def draw_bbox(


### PR DESCRIPTION
# Description

Use cv2.imencode to convert image into buffer, avoid converting between BGR/RGB manually.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

```python
import cv2 as cv
from inference.core.utils.image_utils import load_image_from_encoded_bytes, np_image_to_base64
x = cv.imread("/path/to/my/image.jpg")
y = np_image_to_base64(x)  # should convert to RGB first - cv2.cvtColor(x, cv2.COLOR_RGB2BGR)
z = load_image_from_encoded_bytes(y)
cv.imshow("original image", x)
cv.waitKey(0)
cv.imshow("loaded", z)  # colors inverted
cv.waitKey(0)
cv.destroyAllWindows()
```

Also tested through SDK:

```python
import base64

import cv2 as cv
import numpy as np

from inference.core.utils.image_utils import load_image_from_encoded_bytes, np_image_to_base64
from inference_sdk import InferenceHTTPClient
from inference_sdk.http.entities import InferenceConfiguration

client = InferenceHTTPClient(
    api_url="http://localhost:9001",
    api_key="...",
)

client.use_configuration(InferenceConfiguration(visualize_predictions=True, visualize_labels=True))
client.configure(InferenceConfiguration(visualize_predictions=True, visualize_labels=True))
print(client.inference_configuration.visualize_predictions)

with client.use_model(model_id="yolov8n-640"):
    predictions = client.infer("/path/to/image.jpg")

b64_encoded_img = predictions.get("visualization")
blob = base64.b64decode(b64_encoded_img)
np_array = np.frombuffer(blob, dtype=np.uint8)
img = cv.imdecode(np_array, cv.IMREAD_COLOR)
cv.imshow("", img)
cv.waitKey(0)
```

## Any specific deployment considerations

N/A

## Docs

N/A