### PR TITLE
fix Docker Getting Started link in docs returns 404

### DIFF
--- a/docs/quickstart/compatability_matrix.md
+++ b/docs/quickstart/compatability_matrix.md
@@ -2,7 +2,7 @@
 
 The table below shows on what devices you can deploy models supported by Inference.
 
-See our [Docker Getting Started](/docs/quickstart/docker) guide for more information on how to deploy Inference on your device.
+See our [Docker Getting Started](/quickstart/docker) guide for more information on how to deploy Inference on your device.
 
 Table key:
 

--- a/docs/quickstart/devices.md
+++ b/docs/quickstart/devices.md
@@ -15,7 +15,7 @@ You can set up a server to use computer vision models with Inference on the foll
 
 The table below shows on what devices you can deploy models supported by Inference.
 
-See our [Docker Getting Started](/docs/quickstart/docker) guide for more information on how to deploy Inference on your device.
+See our [Docker Getting Started](/quickstart/docker) guide for more information on how to deploy Inference on your device.
 
 Table key:
 

--- a/inference/core/version.py
+++ b/inference/core/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.12.0"
+__version__ = "0.12.1"
 
 
 if __name__ == "__main__":

--- a/requirements/requirements.sdk.http.txt
+++ b/requirements/requirements.sdk.http.txt
@@ -4,7 +4,7 @@ opencv-python>=4.8.0.0
 pillow>=9.0.0
 requests>=2.27.0
 supervision<1.0.0
-numpy>=1.20.0
+numpy<=1.26.4
 aiohttp>=3.9.0
 backoff>=2.2.0
 aioresponses>=0.7.6

--- a/requirements/requirements.test.integration.txt
+++ b/requirements/requirements.test.integration.txt
@@ -3,4 +3,4 @@ requests
 pytest
 pillow 
 requests_toolbelt
-numpy
+numpy<=1.26.4


### PR DESCRIPTION
# Description

Fix broken link to `quickstart/docker`

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

N/A

## Any specific deployment considerations

N/A

## Docs

-   [x] Docs updated? What were the changes:
