### PR TITLE
Allow CORS by default

### DIFF
--- a/docs/quickstart/docker_configuration_options.md
+++ b/docs/quickstart/docker_configuration_options.md
@@ -31,7 +31,7 @@ Sets the default non-maximal suppression (NMS) behavior for detection type model
 
 Variable: **ALLOW_ORIGINS**
 
-Type: String (default = "")
+Type: String (default = "*")
 
 Sets the allow_origins property on the CORSMiddleware used with FastAPI for HTTP interfaces. Multiple values can be provided separated by a comma (ex. ALLOW_ORIGINS=orig1.com,orig2.com).
 

--- a/inference/core/env.py
+++ b/inference/core/env.py
@@ -16,7 +16,7 @@ PROJECT = os.getenv("PROJECT", "roboflow-platform")
 ALLOW_NUMPY_INPUT = str2bool(os.getenv("ALLOW_NUMPY_INPUT", True))
 
 # List of allowed origins
-ALLOW_ORIGINS = os.getenv("ALLOW_ORIGINS", "")
+ALLOW_ORIGINS = os.getenv("ALLOW_ORIGINS", "*")
 ALLOW_ORIGINS = ALLOW_ORIGINS.split(",")
 
 # Base URL for the API


### PR DESCRIPTION
# Description

I'm working on making the core app be able to connect to and communicate with self-hosted inference servers. We have CORS off by default which means you can't communicate with the server from a web browser.

This seems like a bad default because it prevents you from hitting it from any web service you're building. We have it on already for our Hosted API via the lambda config.

## Type of change

-   [x] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?

With a self-hosted server locally & via ngrok connecting with my web dev environment.

## Any specific deployment considerations

No

## Docs

- [x] Updated
