### PR TITLE
fix: replace match statement with if-else for Python 3.9 compatibility

### DIFF
--- a/inference/enterprise/device_manager/command_handler.py
+++ b/inference/enterprise/device_manager/command_handler.py
@@ -38,21 +38,21 @@ def handle_command(cmd_payload: dict):
         return
     cmd = cmd_payload.get("command")
     data = None
-    match cmd:
-        case "restart":
-            was_processed, data = container.restart()
-        case "stop":
-            was_processed, data = container.stop()
-        case "ping":
-            was_processed, data = container.ping()
-        case "snapshot":
-            was_processed, data = container.snapshot()
-        case "start":
-            was_processed, data = container.start()
-        case "update_version":
-            was_processed, data = handle_version_update(container)
-        case _:
-            logger.error("Unknown command: {}".format(cmd))
+    if cmd == "restart":
+        was_processed, data = container.restart()
+    elif cmd == "stop":
+        was_processed, data = container.stop()
+    elif cmd == "ping":
+        was_processed, data = container.ping()
+    elif cmd == "snapshot":
+        was_processed, data = container.snapshot()
+    elif cmd == "start":
+        was_processed, data = container.start()
+    elif cmd == "update_version":
+        was_processed, data = handle_version_update(container)
+    else:
+        logger.error("Unknown command: {}".format(cmd))
+
     return ack_command(cmd_payload.get("id"), was_processed, data=data)
 
 


### PR DESCRIPTION
# Description

There was an issue when installing [inference](https://github.com/roboflow/inference) on python version 3.9. Since, python 3.9 doesn't support match statement

https://github.com/roboflow/inference/blob/d6cb89de97438187940bc18440109b78a55960bd/inference/enterprise/device_manager/command_handler.py#L41

> inference package requires Python>=3.8,<=3.11. 

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

**Specifications**:
```sh
Python 3.9.19
```

**Reproduce**:

```bash
pip install inference
```

The installation may have completed successfully, but you will encounter errors when package compiled:

![Screen Shot 2024-06-27 at 12 55 51](https://github.com/roboflow/inference/assets/31182611/86f8dbb3-7daf-4664-98f1-917cc228bae7)
![Screen Shot 2024-06-27 at 19 51 51](https://github.com/roboflow/inference/assets/31182611/0e6fcc6a-48e2-4f00-9a11-eec55e173110)


## Any specific deployment considerations
- Do we need to validate the Python version?

```py
 def validate_python_version(cls, values: Dict) -> Dict:
  """Validate valid python version."""
  if sys.version_info < (3, 8):
      raise ValueError(
          "inference relies on Python 3.8 or higher "
          f"you have Python version: {sys.version}"
      )
  return values
```

## Docs

-   [ ] Docs updated? What were the changes:
