### PR TITLE
InferencePipeline: Gracefully handle connection failure when fetching Active Learning config

### DIFF
--- a/inference/core/active_learning/configuration.py
+++ b/inference/core/active_learning/configuration.py
@@ -47,12 +47,18 @@ def prepare_active_learning_configuration(
     model_id: str,
     cache: BaseCache,
 ) -> Optional[ActiveLearningConfiguration]:
-    project_metadata = get_roboflow_project_metadata(
-        api_key=api_key,
-        target_dataset=target_dataset,
-        model_id=model_id,
-        cache=cache,
-    )
+    try:
+        project_metadata = get_roboflow_project_metadata(
+            api_key=api_key,
+            target_dataset=target_dataset,
+            model_id=model_id,
+            cache=cache,
+        )
+    except Exception as e:
+        logger.warn(
+            f"Failed to initialise Active Learning configuration. Active Learning will not be enabled for this session. Cause: {str(e)}"
+        )
+        return None
     if not project_metadata.active_learning_configuration.get("enabled", False):
         return None
     logger.info(


### PR DESCRIPTION
# Description

Currently, when you start InferencePipeline offline, if `active_learning_enabled` is not set to false, there is a pretty ugly error and the application doesn't start:

<img width="1105" alt="Code 2024-06-26 13 57 56" src="https://github.com/roboflow/inference/assets/100066/7a7f7321-0262-4f63-b575-7ab0ca09603b">


---------

With this change, you get a nice warning letting you know what's going on, and the application still starts:

<img width="1157" alt="image" src="https://github.com/roboflow/inference/assets/100066/f4459cae-bf59-4000-87e1-ebf2aa2a4192">

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Tested locally.

## Any specific deployment considerations

n/a

## Docs

-   not needed
