### PR TITLE
Reuse existing ids

### DIFF
--- a/inference/core/entities/requests/inference.py
+++ b/inference/core/entities/requests/inference.py
@@ -16,7 +16,7 @@ class BaseRequest(BaseModel):
     """
 
     def __init__(self, **kwargs):
-        kwargs["id"] = str(uuid4())
+        kwargs["id"] = kwargs["id"] or str(uuid4())
         super().__init__(**kwargs)
 
     model_config = ConfigDict(protected_namespaces=())

--- a/inference/core/entities/requests/inference.py
+++ b/inference/core/entities/requests/inference.py
@@ -16,7 +16,7 @@ class BaseRequest(BaseModel):
     """
 
     def __init__(self, **kwargs):
-        kwargs["id"] = kwargs["id"] or str(uuid4())
+        kwargs["id"] = kwargs.get("id", str(uuid4()))
         super().__init__(**kwargs)
 
     model_config = ConfigDict(protected_namespaces=())


### PR DESCRIPTION
# Description

- There's an issue with the inference_id changing for the same request between when the inference is resulted and when the ActiveLearning middleware runs and creates the batch. This is resulting in images created by AL having an inferenceId that doesn't map to an inference in our model monitoring database. This changes ensures that we reuse the same id if it exists

## Type of change

Please delete options that are not relevant.

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

- Need to check whether this interferes with the parallel request processing

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207404293795098