### PR TITLE
Import `sky` only when required because it is slow

### DIFF
--- a/inference_cli/lib/cloud_adapter.py
+++ b/inference_cli/lib/cloud_adapter.py
@@ -2,8 +2,6 @@ import random
 import string
 import tempfile
 
-import sky
-
 YAML_DEFS = {
     "gcp_cpu": """
 name: roboflow-gcp-inference-cpu
@@ -91,21 +89,25 @@ def _random_char(y):
 
 
 def cloud_status():
+    import sky
     print("Getting status from skypilot...")
     print(sky.status())
 
 
 def cloud_stop(cluster_name):
+    import sky
     print(f"Stopping skypilot deployment {cluster_name}...")
     print(sky.stop(cluster_name))
 
 
 def cloud_start(cluster_name):
+    import sky
     print(f"Starting skypilot deployment {cluster_name}")
     print(sky.start(cluster_name))
 
 
 def cloud_undeploy(cluster_name):
+    import sky
     print(
         f"Undeploying Roboflow Inference and deleting {cluster_name}, this may take a few minutes."
     )


### PR DESCRIPTION
# Description

The `sky` package is very slow to import and is required only in some cases.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

You can paste these traces [here](http://www.softwareishard.com/har/viewer/) to check the results. It is almost 30% of the import time.

[trace-before.txt](https://github.com/user-attachments/files/16026809/trace-before.txt)
[trace-after.txt](https://github.com/user-attachments/files/16026808/trace-after.txt)