### PR TITLE
Fix undo image padding for predicted boxes

### DIFF
--- a/inference/core/models/object_detection_base.py
+++ b/inference/core/models/object_detection_base.py
@@ -240,11 +240,11 @@ class ObjectDetectionBaseOnnxRoboflowInferenceModel(OnnxRoboflowInferenceModel):
             width_remainder = img_in.shape[2] % 32
             height_remainder = img_in.shape[3] % 32
             if width_remainder > 0:
-                width_padding = 32 - (img_in.shape[2] % 32)
+                width_padding = 32 - width_remainder
             else:
                 width_padding = 0
             if height_remainder > 0:
-                height_padding = 32 - (img_in.shape[3] % 32)
+                height_padding = 32 - height_remainder
             else:
                 height_padding = 0
             img_in = np.pad(

--- a/inference/core/utils/postprocess.py
+++ b/inference/core/utils/postprocess.py
@@ -151,8 +151,8 @@ def undo_image_padding_for_predicted_boxes(
     scale = min(infer_shape[0] / origin_shape[0], infer_shape[1] / origin_shape[1])
     inter_h = round(origin_shape[0] * scale)
     inter_w = round(origin_shape[1] * scale)
-    pad_x = (infer_shape[0] - inter_w) / 2
-    pad_y = (infer_shape[1] - inter_h) / 2
+    pad_x = (infer_shape[1] - inter_w) / 2
+    pad_y = (infer_shape[0] - inter_h) / 2
     predicted_bboxes = shift_bboxes(
         bboxes=predicted_bboxes, shift_x=-pad_x, shift_y=-pad_y
     )

--- a/inference/core/version.py
+++ b/inference/core/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.13.0"
+__version__ = "0.13.1"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

Fix - infer_shape was passed as (height, width), and used both as (height, width) and (width, height) in `undo_image_padding_for_predicted_boxes`. Add correction where it was used as (width, height).

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Model had training images shape width: 1000 and height: 1333
Image had width: 720, height: 1280
Bug was not observable after adding fix.

```python3
from typing import List

import cv2 as cv
import supervision as sv

from inference import get_model
from inference.core.entities.responses.inference import ObjectDetectionInferenceResponse


model = get_model(model_id="<custom model ID that had training widthxheight as 1000x1333>")
img_path = "/path/to/image/width_720_height_1280.jpg"
results: List[ObjectDetectionInferenceResponse] = model.infer(img_path)

img = cv.imread(img_path)
h, w, _ = img.shape

results = [r.model_dump() for r in results]
preds = results[0]
for p in preds["predictions"]:
    p["class"] = p["class_name"]
    del p["tracker_id"]
preds["image"] = {"width": w, "height": h}
print(preds)
dets = sv.Detections.from_inference(preds)

bbox_annotator = sv.BoundingBoxAnnotator()
bbox_annotator.annotate(img, dets)

cv.imshow("localhost script", img)
cv.waitKey(0)

print(dets)
```

## Any specific deployment considerations

N/A

## Docs

N/A