### PR TITLE
Optimize some imports

### DIFF
--- a/inference/core/managers/active_learning.py
+++ b/inference/core/managers/active_learning.py
@@ -1,7 +1,7 @@
-import time
-from typing import Dict, Optional
+from __future__ import annotations
 
-from fastapi import BackgroundTasks
+import time
+from typing import TYPE_CHECKING, Dict, Optional
 
 from inference.core import logger
 from inference.core.active_learning.middlewares import ActiveLearningMiddleware
@@ -12,6 +12,9 @@ from inference.core.env import DISABLE_PREPROC_AUTO_ORIENT
 from inference.core.managers.base import ModelManager
 from inference.core.registries.base import ModelRegistry
 from inference.models.aliases import resolve_roboflow_model_alias
+
+if TYPE_CHECKING:
+    from fastapi import BackgroundTasks
 
 ACTIVE_LEARNING_ELIGIBLE_PARAM = "active_learning_eligible"
 DISABLE_ACTIVE_LEARNING_PARAM = "disable_active_learning"

--- a/inference_cli/lib/infer_adapter.py
+++ b/inference_cli/lib/infer_adapter.py
@@ -1,11 +1,12 @@
+from __future__ import annotations
+
 import base64
 import os.path
 from functools import partial
 from glob import glob
-from typing import Callable, List, Optional, Union
+from typing import TYPE_CHECKING, Callable, List, Optional, Union
 
 import cv2
-import numpy as np
 from supervision import (
     BlurAnnotator,
     BoundingBoxAnnotator,
@@ -27,7 +28,6 @@ from supervision import (
     VideoInfo,
     VideoSink,
 )
-from supervision.annotators.base import BaseAnnotator
 from supervision.utils.file import read_yaml_file
 from tqdm import tqdm
 
@@ -36,6 +36,10 @@ from inference_cli.lib.logger import CLI_LOGGER
 from inference_cli.lib.utils import dump_json, initialise_client
 from inference_sdk.http.utils.encoding import bytes_to_opencv_image
 from inference_sdk.http.utils.loaders import load_image_from_string
+
+if TYPE_CHECKING:
+    import numpy as np
+    from supervision.annotators.base import BaseAnnotator
 
 CONFIGS_DIR_PATH = os.path.abspath(
     os.path.join(

--- a/inference_cli/lib/utils.py
+++ b/inference_cli/lib/utils.py
@@ -1,12 +1,28 @@
 import json
 import os.path
+from pathlib import Path
 from typing import Dict, List, Optional, Union
 
-from supervision.utils.file import read_yaml_file
+import yaml
 
 from inference_cli.lib.env import ROBOFLOW_API_KEY
 from inference_cli.lib.logger import CLI_LOGGER
 from inference_sdk import InferenceConfiguration, InferenceHTTPClient
+
+
+def read_yaml_file(file_path: Union[str, Path]) -> Dict:
+    """
+    Read a yaml file and return a dict.
+
+    Args:
+        file_path (Union[str, Path]): The file path as a string or Path object.
+
+    Returns:
+        dict: A dict of content information
+    """
+    with open(str(file_path), "r") as file:
+        data = yaml.safe_load(file)
+    return data
 
 
 def read_env_file(path: str) -> Dict[str, str]:

--- a/inference_sdk/http/client.py
+++ b/inference_sdk/http/client.py
@@ -1,8 +1,9 @@
+from __future__ import annotations
+
 from contextlib import contextmanager
-from typing import Any, Dict, Generator, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, Generator, List, Optional, Tuple, Union
 
 import aiohttp
-import numpy as np
 import requests
 from aiohttp import ClientConnectionError, ClientResponseError
 from requests import HTTPError
@@ -63,6 +64,10 @@ from inference_sdk.http.utils.requests import (
     inject_images_into_payload,
 )
 from inference_sdk.utils.decorators import deprecated
+
+if TYPE_CHECKING:
+    import numpy as np
+
 
 SUCCESSFUL_STATUS_CODE = 200
 DEFAULT_HEADERS = {

--- a/inference_sdk/http/utils/loaders.py
+++ b/inference_sdk/http/utils/loaders.py
@@ -6,7 +6,6 @@ import aiohttp
 import cv2
 import numpy as np
 import requests
-import supervision as sv
 from PIL import Image
 
 from inference_sdk.http.entities import ImagesReference
@@ -27,6 +26,8 @@ def load_stream_inference_input(
     input_uri: str,
     image_extensions: Optional[List[str]],
 ) -> Generator[Tuple[Union[str, int], np.ndarray], None, None]:
+    import supervision as sv
+
     if os.path.isdir(input_uri):
         yield from load_directory_inference_input(
             directory_path=input_uri, image_extensions=image_extensions
@@ -39,6 +40,8 @@ def load_directory_inference_input(
     directory_path: str,
     image_extensions: Optional[List[str]],
 ) -> Generator[Tuple[Union[str, int], np.ndarray], None, None]:
+    import supervision as sv
+
     paths = {
         path.as_posix().lower()
         for path in sv.list_files_with_extensions(

--- a/tests/inference_sdk/unit_tests/http/utils/test_loaders.py
+++ b/tests/inference_sdk/unit_tests/http/utils/test_loaders.py
@@ -630,7 +630,7 @@ def test_load_directory_inference_input_when_filtering_by_extension_is_enabled(
     assert file_name2results["file_1.jpg"].shape == (128, 128, 3)
 
 
-@mock.patch.object(loaders.sv, "get_video_frames_generator")
+@mock.patch("supervision.get_video_frames_generator")
 def test_load_stream_inference_input(
     get_video_frames_generator_mock: MagicMock,
 ) -> None:

--- a/tests/workflows/integration_tests/execution/test_workflow_with_detections_consensus_block.py
+++ b/tests/workflows/integration_tests/execution/test_workflow_with_detections_consensus_block.py
@@ -1,12 +1,19 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import numpy as np
 import pytest
-import supervision as sv
 
 from inference.core.env import WORKFLOWS_MAX_CONCURRENT_STEPS
-from inference.core.managers.base import ModelManager
 from inference.core.workflows.core_steps.common.entities import StepExecutionMode
 from inference.core.workflows.errors import RuntimeInputError, StepExecutionError
 from inference.core.workflows.execution_engine.core import ExecutionEngine
+
+if TYPE_CHECKING:
+    import supervision as sv
+
+    from inference.core.managers.base import ModelManager
 
 CONSENSUS_WORKFLOW = {
     "version": "1.0",

--- a/tests/workflows/integration_tests/execution/test_workflow_with_filtering.py
+++ b/tests/workflows/integration_tests/execution/test_workflow_with_filtering.py
@@ -1,15 +1,22 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import numpy as np
 import pytest
-import supervision as sv
 
 from inference.core.env import WORKFLOWS_MAX_CONCURRENT_STEPS
-from inference.core.managers.base import ModelManager
 from inference.core.workflows.core_steps.common.entities import StepExecutionMode
 from inference.core.workflows.core_steps.common.query_language.errors import (
     EvaluationEngineError,
 )
 from inference.core.workflows.errors import RuntimeInputError, StepExecutionError
 from inference.core.workflows.execution_engine.core import ExecutionEngine
+
+if TYPE_CHECKING:
+    import supervision as sv
+
+    from inference.core.managers.base import ModelManager
 
 FILTERING_WORKFLOW = {
     "version": "1.0",

--- a/tests/workflows/integration_tests/execution/test_workflow_with_model_running_on_absolute_static_crop.py
+++ b/tests/workflows/integration_tests/execution/test_workflow_with_model_running_on_absolute_static_crop.py
@@ -1,12 +1,19 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import numpy as np
 import pytest
-import supervision as sv
 
 from inference.core.env import WORKFLOWS_MAX_CONCURRENT_STEPS
-from inference.core.managers.base import ModelManager
 from inference.core.workflows.core_steps.common.entities import StepExecutionMode
 from inference.core.workflows.errors import RuntimeInputError
 from inference.core.workflows.execution_engine.core import ExecutionEngine
+
+if TYPE_CHECKING:
+    import supervision as sv
+
+    from inference.core.managers.base import ModelManager
 
 ABSOLUTE_STATIC_CROP_WORKFLOW = {
     "version": "1.0",

--- a/tests/workflows/integration_tests/execution/test_workflow_with_model_running_on_relative_static_crop.py
+++ b/tests/workflows/integration_tests/execution/test_workflow_with_model_running_on_relative_static_crop.py
@@ -1,12 +1,19 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import numpy as np
 import pytest
-import supervision as sv
 
 from inference.core.env import WORKFLOWS_MAX_CONCURRENT_STEPS
-from inference.core.managers.base import ModelManager
 from inference.core.workflows.core_steps.common.entities import StepExecutionMode
 from inference.core.workflows.errors import RuntimeInputError
 from inference.core.workflows.execution_engine.core import ExecutionEngine
+
+if TYPE_CHECKING:
+    import supervision as sv
+
+    from inference.core.managers.base import ModelManager
 
 RELATIVE_STATIC_CROP_WORKFLOW = {
     "version": "1.0",

--- a/tests/workflows/integration_tests/execution/test_workflow_with_single_model.py
+++ b/tests/workflows/integration_tests/execution/test_workflow_with_single_model.py
@@ -1,12 +1,19 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import numpy as np
 import pytest
-import supervision as sv
 
 from inference.core.env import WORKFLOWS_MAX_CONCURRENT_STEPS
-from inference.core.managers.base import ModelManager
 from inference.core.workflows.core_steps.common.entities import StepExecutionMode
 from inference.core.workflows.errors import RuntimeInputError, StepExecutionError
 from inference.core.workflows.execution_engine.core import ExecutionEngine
+
+if TYPE_CHECKING:
+    import supervision as sv
+
+    from inference.core.managers.base import ModelManager
 
 OBJECT_DETECTION_WORKFLOW = {
     "version": "1.0",

--- a/tests/workflows/integration_tests/execution/test_workflow_with_sorting.py
+++ b/tests/workflows/integration_tests/execution/test_workflow_with_sorting.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import numpy as np
 import pytest
-import supervision as sv
 
 from inference.core.env import WORKFLOWS_MAX_CONCURRENT_STEPS
-from inference.core.managers.base import ModelManager
 from inference.core.workflows.core_steps.common.entities import StepExecutionMode
 from inference.core.workflows.core_steps.common.query_language.entities.enums import (
     DetectionsSortProperties,
@@ -14,6 +16,10 @@ from inference.core.workflows.core_steps.common.query_language.errors import (
 from inference.core.workflows.errors import RuntimeInputError, StepExecutionError
 from inference.core.workflows.execution_engine.core import ExecutionEngine
 
+if TYPE_CHECKING:
+    import supervision as sv
+
+    from inference.core.managers.base import ModelManager
 
 def build_sorting_workflow_definition(
     sort_operation_mode: DetectionsSortProperties,


### PR DESCRIPTION
# Description

It fixes a few import issues, found with `ruff check --select="TCH" .` and with `importtime-waterfall` lib.

* Move some imports to `if TYPE_CHECKING` block
* Lazy import supervision when it is possible
* Implement own read yaml function instead of use supervision (it was triggering many extra imports)

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

CI should pass.