### PR TITLE
Add glue workflows steps - expressions with UQL, dimensionality collapse, take-first-non-empty etc

### DIFF
--- a/inference/core/entities/responses/inference.py
+++ b/inference/core/entities/responses/inference.py
@@ -143,6 +143,7 @@ class MultiLabelClassificationPrediction(BaseModel):
     confidence: float = Field(
         description="The class label confidence as a fraction between 0 and 1"
     )
+    class_id: int = Field(description="Numeric ID associated with the class label")
 
 
 class InferenceResponseImage(BaseModel):

--- a/inference/core/workflows/core_steps/common/query_language/entities/enums.py
+++ b/inference/core/workflows/core_steps/common/query_language/entities/enums.py
@@ -18,6 +18,13 @@ class SequenceAggregationMode(Enum):
     LEAST_COMMON = "least_common"
 
 
+class ClassificationProperty(Enum):
+    TOP_CLASS = "top_class"
+    TOP_CLASS_CONFIDENCE = "top_class_confidence"
+    ALL_CLASSES = "all_classes"
+    ALL_CONFIDENCES = "all_confidences"
+
+
 class DetectionsProperty(Enum):
     CONFIDENCE = "confidence"
     CLASS_NAME = "class_name"

--- a/inference/core/workflows/core_steps/common/query_language/entities/operations.py
+++ b/inference/core/workflows/core_steps/common/query_language/entities/operations.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel, ConfigDict, Field
 from typing_extensions import Annotated
 
 from inference.core.workflows.core_steps.common.query_language.entities.enums import (
+    ClassificationProperty,
     DetectionsProperty,
     DetectionsSelectionMode,
     DetectionsSortProperties,
@@ -14,6 +15,7 @@ from inference.core.workflows.core_steps.common.query_language.entities.enums im
     StatementsGroupsOperator,
 )
 from inference.core.workflows.entities.types import (
+    BATCH_OF_CLASSIFICATION_PREDICTION_KIND,
     BOOLEAN_KIND,
     DETECTION_KIND,
     DICTIONARY_KIND,
@@ -203,6 +205,22 @@ class DetectionsPropertyExtract(OperationDefinition):
     )
     type: Literal["DetectionsPropertyExtract"]
     property_name: DetectionsProperty
+
+
+class ClassificationPropertyExtract(OperationDefinition):
+    model_config = ConfigDict(
+        json_schema_extra={
+            "description": "Extracts property from detections-based prediction"
+            "(as a list of elements - one element represents single detection)",
+            "compound": False,
+            "input_kind": [
+                BATCH_OF_CLASSIFICATION_PREDICTION_KIND,
+            ],
+            "output_kind": [STRING_KIND, LIST_OF_VALUES_KIND, FLOAT_ZERO_TO_ONE_KIND],
+        },
+    )
+    type: Literal["ClassificationPropertyExtract"]
+    property_name: ClassificationProperty
 
 
 class DetectionsSelection(OperationDefinition):
@@ -459,6 +477,7 @@ AllOperationsType = Annotated[
         Divide,
         DetectionsSelection,
         SortDetections,
+        ClassificationPropertyExtract,
     ],
     Field(discriminator="type"),
 ]
@@ -484,6 +503,7 @@ class Equals(BinaryOperator):
                     FLOAT_KIND,
                     FLOAT_ZERO_TO_ONE_KIND,
                     BOOLEAN_KIND,
+                    LIST_OF_VALUES_KIND,
                 ],
                 [
                     INTEGER_KIND,
@@ -491,12 +511,13 @@ class Equals(BinaryOperator):
                     FLOAT_KIND,
                     FLOAT_ZERO_TO_ONE_KIND,
                     BOOLEAN_KIND,
+                    LIST_OF_VALUES_KIND,
                 ],
             ],
             "output_kind": [BOOLEAN_KIND],
         },
     )
-    type: Literal["(Number) =="]
+    type: Literal["(Number) ==", "=="]
 
 
 class NotEquals(BinaryOperator):
@@ -511,6 +532,7 @@ class NotEquals(BinaryOperator):
                     FLOAT_KIND,
                     FLOAT_ZERO_TO_ONE_KIND,
                     BOOLEAN_KIND,
+                    LIST_OF_VALUES_KIND,
                 ],
                 [
                     INTEGER_KIND,
@@ -518,12 +540,13 @@ class NotEquals(BinaryOperator):
                     FLOAT_KIND,
                     FLOAT_ZERO_TO_ONE_KIND,
                     BOOLEAN_KIND,
+                    LIST_OF_VALUES_KIND,
                 ],
             ],
             "output_kind": [BOOLEAN_KIND],
         },
     )
-    type: Literal["(Number) !="]
+    type: Literal["(Number) !=", "!="]
 
 
 class NumberGreater(BinaryOperator):

--- a/inference/core/workflows/core_steps/common/query_language/errors.py
+++ b/inference/core/workflows/core_steps/common/query_language/errors.py
@@ -5,6 +5,10 @@ class RoboflowQueryLanguageError(WorkflowExecutionEngineError):
     pass
 
 
+class UndeclaredSymbolError(RoboflowQueryLanguageError):
+    pass
+
+
 class InvalidInputTypeError(RoboflowQueryLanguageError):
     pass
 

--- a/inference/core/workflows/core_steps/common/query_language/evaluation_engine/core.py
+++ b/inference/core/workflows/core_steps/common/query_language/evaluation_engine/core.py
@@ -25,8 +25,10 @@ from inference.core.workflows.core_steps.common.query_language.evaluation_engine
 )
 
 BINARY_OPERATORS = {
+    "==": lambda a, b: a == b,
     "(Number) ==": lambda a, b: a == b,
     "(Number) !=": lambda a, b: a != b,
+    "!=": lambda a, b: a != b,
     "(Number) >": lambda a, b: a > b,
     "(Number) >=": lambda a, b: a >= b,
     "(Number) <": lambda a, b: a < b,

--- a/inference/core/workflows/core_steps/common/query_language/evaluation_engine/core.py
+++ b/inference/core/workflows/core_steps/common/query_language/evaluation_engine/core.py
@@ -19,6 +19,7 @@ from inference.core.workflows.core_steps.common.query_language.entities.types im
 from inference.core.workflows.core_steps.common.query_language.errors import (
     EvaluationEngineError,
     RoboflowQueryLanguageError,
+    UndeclaredSymbolError,
 )
 from inference.core.workflows.core_steps.common.query_language.evaluation_engine.detection.geometry import (
     is_point_in_zone,
@@ -175,6 +176,11 @@ def dynamic_operand_builder(
     operand_name: str,
     operations_function: Callable[[T, Dict[str, Any]], V],
 ) -> V:
+    if operand_name not in values:
+        raise UndeclaredSymbolError(
+            public_message=f"Encountered undefined symbol `{operand_name}`",
+            context="unknown",
+        )
     return operations_function(values[operand_name], global_parameters=values)
 
 
@@ -197,6 +203,12 @@ def binary_eval(
         if negate:
             result = not result
         return result
+    except UndeclaredSymbolError as error:
+        raise UndeclaredSymbolError(
+            public_message=f"Attempted to execute evaluation of type: {operation_type} in context {execution_context}, "
+            f"but encountered error: {error.public_message}",
+            context=f"step_execution | roboflow_query_language_evaluation | {execution_context}",
+        ) from error
     except RoboflowQueryLanguageError as error:
         raise error
     except Exception as error:
@@ -227,6 +239,7 @@ def build_unary_statement(
         operator=operator,
         negate=definition.negate,
         operation_type=definition.type,
+        execution_context=execution_context,
         operator_parameters=operator_parameters,
     )
 
@@ -237,6 +250,7 @@ def unary_eval(
     operator: Callable[[V, Any], bool],
     negate: bool,
     operation_type: str,
+    execution_context: str,
     operator_parameters: Optional[Dict[str, Any]] = None,
 ) -> bool:
     if operator_parameters is None:
@@ -247,13 +261,19 @@ def unary_eval(
         if negate:
             result = not result
         return result
+    except UndeclaredSymbolError as error:
+        raise UndeclaredSymbolError(
+            public_message=f"Attempted to execute evaluation of type: {operation_type} in context {execution_context}, "
+            f"but encountered error: {error.public_message}",
+            context=f"step_execution | roboflow_query_language_evaluation | {execution_context}",
+        ) from error
     except RoboflowQueryLanguageError as error:
         raise error
     except Exception as error:
         raise EvaluationEngineError(
-            public_message=f"Attempted to execute evaluation of type: {operation_type}, "
+            public_message=f"Attempted to execute evaluation of type: {operation_type} in context {execution_context}, "
             f"but encountered error: {error}",
-            context="step_execution | roboflow_query_language_evaluation",
+            context=f"step_execution | roboflow_query_language_evaluation | {execution_context}",
             inner_error=error,
         ) from error
 

--- a/inference/core/workflows/core_steps/common/query_language/introspection/core.py
+++ b/inference/core/workflows/core_steps/common/query_language/introspection/core.py
@@ -79,12 +79,13 @@ def prepare_operators_descriptions() -> List[OperatorDescription]:
     results = []
     for operator_type in operator_types:
         operator_schema = operator_type.schema()
-        results.append(
-            OperatorDescription(
-                operator_type=operator_schema["properties"]["type"]["const"],
-                operands_number=operator_schema["operands_number"],
-                operands_kinds=operator_schema["operands_kinds"],
-                description=operator_schema.get("description"),
+        for alias in operator_schema["properties"]["type"].get("enum", []):
+            results.append(
+                OperatorDescription(
+                    operator_type=alias,
+                    operands_number=operator_schema["operands_number"],
+                    operands_kinds=operator_schema["operands_kinds"],
+                    description=operator_schema.get("description"),
+                )
             )
-        )
     return results

--- a/inference/core/workflows/core_steps/common/query_language/operations/classification_results/base.py
+++ b/inference/core/workflows/core_steps/common/query_language/operations/classification_results/base.py
@@ -22,7 +22,7 @@ def extract_top_class_confidence(prediction: dict) -> Union[float, List[float]]:
         return prediction["confidence"]
     predicted_classes = prediction.get("predicted_classes", [])
     return [
-        prediction["predictions"]["confidence"][class_name]
+        prediction["predictions"][class_name]["confidence"]
         for class_name in predicted_classes
     ]
 
@@ -30,16 +30,23 @@ def extract_top_class_confidence(prediction: dict) -> Union[float, List[float]]:
 def extract_all_class_names(prediction: dict) -> List[str]:
     predictions = prediction["predictions"]
     if isinstance(predictions, list):
-        return [p["class_name"] for p in predictions]
-    return sorted(predictions.keys())
+        return [p["class"] for p in predictions]
+    class_id2_class_name = {
+        value["class_id"]: name for name, value in predictions.items()
+    }
+    sorted_ids = sorted(class_id2_class_name.keys())
+    return [class_id2_class_name[class_id] for class_id in sorted_ids]
 
 
 def extract_all_classes_confidence(prediction: dict) -> List[float]:
     predictions = prediction["predictions"]
     if isinstance(predictions, list):
         return [p["confidence"] for p in predictions]
-    class_order = sorted(predictions.keys())
-    return [predictions[class_name]["confidence"] for class_name in class_order]
+    class_id2_class_confidence = {
+        value["class_id"]: value["confidence"] for value in predictions.values()
+    }
+    sorted_ids = sorted(class_id2_class_confidence.keys())
+    return [class_id2_class_confidence[class_id] for class_id in sorted_ids]
 
 
 CLASSIFICATION_PROPERTY_EXTRACTORS = {

--- a/inference/core/workflows/core_steps/common/query_language/operations/classification_results/base.py
+++ b/inference/core/workflows/core_steps/common/query_language/operations/classification_results/base.py
@@ -1,0 +1,69 @@
+from typing import Any, List, Union
+
+from inference.core.workflows.core_steps.common.query_language.entities.enums import (
+    ClassificationProperty,
+)
+from inference.core.workflows.core_steps.common.query_language.errors import (
+    InvalidInputTypeError,
+)
+from inference.core.workflows.core_steps.common.query_language.operations.utils import (
+    safe_stringify,
+)
+
+
+def extract_top_class(prediction: dict) -> Union[str, List[str]]:
+    if "top" in prediction:
+        return prediction["top"]
+    return prediction.get("predicted_classes", [])
+
+
+def extract_top_class_confidence(prediction: dict) -> Union[float, List[float]]:
+    if "confidence" in prediction:
+        return prediction["confidence"]
+    predicted_classes = prediction.get("predicted_classes", [])
+    return [
+        prediction["predictions"]["confidence"][class_name]
+        for class_name in predicted_classes
+    ]
+
+
+def extract_all_class_names(prediction: dict) -> List[str]:
+    predictions = prediction["predictions"]
+    if isinstance(predictions, list):
+        return [p["class_name"] for p in predictions]
+    return sorted(predictions.keys())
+
+
+def extract_all_classes_confidence(prediction: dict) -> List[float]:
+    predictions = prediction["predictions"]
+    if isinstance(predictions, list):
+        return [p["confidence"] for p in predictions]
+    class_order = sorted(predictions.keys())
+    return [predictions[class_name]["confidence"] for class_name in class_order]
+
+
+CLASSIFICATION_PROPERTY_EXTRACTORS = {
+    ClassificationProperty.TOP_CLASS: extract_top_class,
+    ClassificationProperty.TOP_CLASS_CONFIDENCE: extract_top_class_confidence,
+    ClassificationProperty.ALL_CLASSES: extract_all_class_names,
+    ClassificationProperty.ALL_CONFIDENCES: extract_all_classes_confidence,
+}
+
+
+def extract_classification_property(
+    value: Any, property_name: ClassificationProperty, **kwargs
+) -> Union[str, float, list]:
+    if not isinstance(value, dict):
+        value_as_str = safe_stringify(value=value)
+        raise InvalidInputTypeError(
+            public_message=f"Executing extract_classification_property(...), expected classification results object, "
+            f"got {value_as_str} of type {type(value)}",
+            context="step_execution | roboflow_query_language_evaluation",
+        )
+    if property_name not in CLASSIFICATION_PROPERTY_EXTRACTORS:
+        raise InvalidInputTypeError(
+            public_message=f"Executing extract_classification_property(...), expected property_name to be one of "
+            f"{CLASSIFICATION_PROPERTY_EXTRACTORS.values()}, got {property_name}.",
+            context="step_execution | roboflow_query_language_evaluation",
+        )
+    return CLASSIFICATION_PROPERTY_EXTRACTORS[property_name](value)

--- a/inference/core/workflows/core_steps/common/query_language/operations/core.py
+++ b/inference/core/workflows/core_steps/common/query_language/operations/core.py
@@ -18,6 +18,9 @@ from inference.core.workflows.core_steps.common.query_language.errors import (
 from inference.core.workflows.core_steps.common.query_language.operations.booleans.base import (
     to_bool,
 )
+from inference.core.workflows.core_steps.common.query_language.operations.classification_results.base import (
+    extract_classification_property,
+)
 from inference.core.workflows.core_steps.common.query_language.operations.detection.base import (
     extract_detection_property,
 )
@@ -183,6 +186,7 @@ REGISTERED_SIMPLE_OPERATIONS = {
     "Divide": divide,
     "DetectionsSelection": select_detections,
     "SortDetections": sort_detections,
+    "ClassificationPropertyExtract": extract_classification_property,
 }
 
 REGISTERED_COMPOUND_OPERATIONS_BUILDERS = {

--- a/inference/core/workflows/core_steps/common/query_language/operations/detections/base.py
+++ b/inference/core/workflows/core_steps/common/query_language/operations/detections/base.py
@@ -173,7 +173,7 @@ def sort_detections(
             context="step_execution | roboflow_query_language_evaluation",
         )
     if mode not in SORT_PROPERTIES_EXTRACT:
-        InvalidInputTypeError(
+        raise InvalidInputTypeError(
             public_message=f"Executing sort_detections(...), expected mode to be one of "
             f"{SORT_PROPERTIES_EXTRACT.values()}, got {mode}.",
             context="step_execution | roboflow_query_language_evaluation",

--- a/inference/core/workflows/core_steps/common/query_language/operations/detections/base.py
+++ b/inference/core/workflows/core_steps/common/query_language/operations/detections/base.py
@@ -22,9 +22,9 @@ from inference.core.workflows.core_steps.common.query_language.operations.utils 
 
 PROPERTIES_EXTRACTORS = {
     DetectionsProperty.CONFIDENCE: lambda detections: detections.confidence.tolist(),
-    DetectionsProperty.CLASS_NAME: lambda detections: detections.data[
-        "class_name"
-    ].tolist(),
+    DetectionsProperty.CLASS_NAME: lambda detections: detections.data.get(
+        "class_name", np.array([], dtype=str)
+    ).tolist(),
     DetectionsProperty.X_MIN: lambda detections: detections.xyxy[:, 0].tolist(),
     DetectionsProperty.Y_MIN: lambda detections: detections.xyxy[:, 1].tolist(),
     DetectionsProperty.X_MAX: lambda detections: detections.xyxy[:, 2].tolist(),

--- a/inference/core/workflows/core_steps/formatters/empty_values_replacement.py
+++ b/inference/core/workflows/core_steps/formatters/empty_values_replacement.py
@@ -1,0 +1,78 @@
+from typing import Any, List, Literal, Type
+
+from pydantic import ConfigDict, Field
+
+from inference.core.workflows.core_steps.common.query_language.entities.operations import (
+    AllOperationsType,
+)
+from inference.core.workflows.core_steps.common.query_language.operations.core import (
+    build_operations_chain,
+)
+from inference.core.workflows.entities.base import OutputDefinition
+from inference.core.workflows.entities.types import (
+    BATCH_OF_CLASSIFICATION_PREDICTION_KIND,
+    BATCH_OF_INSTANCE_SEGMENTATION_PREDICTION_KIND,
+    BATCH_OF_KEYPOINT_DETECTION_PREDICTION_KIND,
+    BATCH_OF_OBJECT_DETECTION_PREDICTION_KIND,
+    StepOutputSelector,
+)
+from inference.core.workflows.prototypes.block import (
+    BlockResult,
+    WorkflowBlock,
+    WorkflowBlockManifest,
+)
+
+LONG_DESCRIPTION = """
+Takes input data which may not be present due to filtering or conditional execution and
+fills with default value to make it compliant with further processing.
+"""
+
+SHORT_DESCRIPTION = "Takes first non-empty data element or default"
+
+
+class BlockManifest(WorkflowBlockManifest):
+    model_config = ConfigDict(
+        json_schema_extra={
+            "short_description": SHORT_DESCRIPTION,
+            "long_description": LONG_DESCRIPTION,
+            "license": "Apache-2.0",
+            "block_type": "formatter",
+        }
+    )
+    type: Literal["FirstNonEmptyOrDefault"]
+    data: List[StepOutputSelector()] = Field(
+        description="Reference data to replace empty values",
+        examples=["$steps.my_step.predictions"],
+        min_items=1,
+    )
+    default: Any = Field(
+        description="Default value that will be placed whenever there is no data found",
+        examples=["empty"],
+        default=None,
+    )
+
+    @classmethod
+    def accepts_empty_values(cls) -> bool:
+        return True
+
+    @classmethod
+    def describe_outputs(cls) -> List[OutputDefinition]:
+        return [OutputDefinition(name="output")]
+
+
+class FirstNonEmptyOrDefaultBlock(WorkflowBlock):
+
+    @classmethod
+    def get_manifest(cls) -> Type[WorkflowBlockManifest]:
+        return BlockManifest
+
+    async def run(
+        self,
+        data: List[Any],
+        default: Any,
+    ) -> BlockResult:
+        result = default
+        for data_element in data:
+            if data_element is not None:
+                return {"output": data_element}
+        return {"output": result}

--- a/inference/core/workflows/core_steps/formatters/expression.py
+++ b/inference/core/workflows/core_steps/formatters/expression.py
@@ -82,9 +82,19 @@ class BlockManifest(WorkflowBlockManifest):
     ] = Field(
         description="References data to be used to construct results",
         examples=["$inputs.confidence", "$inputs.image", "$steps.my_step.top"],
+    )
+    data_operations: Dict[str, List[AllOperationsType]] = Field(
+        description="UQL definitions of operations to be performed on defined data "
+        "before switch-case instruction",
+        examples=[
+            {
+                "predictions": [
+                    {"type": "DetectionsPropertyExtract", "property_name": "class_name"}
+                ]
+            }
+        ],
         default_factory=lambda: {},
     )
-    data_operations: Dict[str, List[AllOperationsType]]
     switch: CasesDefinition
 
     @classmethod

--- a/inference/core/workflows/core_steps/formatters/expression.py
+++ b/inference/core/workflows/core_steps/formatters/expression.py
@@ -137,5 +137,5 @@ def build_result(
     if not result_definition.operations:
         return {"output": selected_variable}
     operations_chain = build_operations_chain(operations=result_definition.operations)
-    result = operations_chain(selected_variable, global_parameters={})
+    result = operations_chain(selected_variable, global_parameters=variables)
     return {"output": result}

--- a/inference/core/workflows/core_steps/formatters/expression.py
+++ b/inference/core/workflows/core_steps/formatters/expression.py
@@ -1,0 +1,130 @@
+from copy import copy
+from typing import Annotated, Any, Dict, List, Literal, Optional, Type, Union
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from inference.core.workflows.core_steps.common.query_language.entities.operations import (
+    AllOperationsType,
+    StatementGroup,
+)
+from inference.core.workflows.core_steps.common.query_language.evaluation_engine.core import (
+    build_eval_function,
+)
+from inference.core.workflows.core_steps.common.query_language.operations.core import (
+    build_operations_chain,
+)
+from inference.core.workflows.entities.base import OutputDefinition
+from inference.core.workflows.entities.types import (
+    StepOutputSelector,
+    WorkflowImageSelector,
+    WorkflowParameterSelector,
+)
+from inference.core.workflows.prototypes.block import (
+    BlockResult,
+    WorkflowBlock,
+    WorkflowBlockManifest,
+)
+
+LONG_DESCRIPTION = """
+Creates specific output based on defined input variables and configured rules - which is
+useful while creating business logic in workflows.
+
+Based on configuration, block takes input data, optionally performs operation on data, 
+save it as variables and evaluate switch-case like statements to get the final result.
+"""
+
+SHORT_DESCRIPTION = (
+    "Creates specific output based on defined input variables and configured rules."
+)
+
+
+class StaticCaseResult(BaseModel):
+    type: Literal["StaticCaseResult"]
+    value: Any
+
+
+class DynamicCaseResult(BaseModel):
+    type: Literal["DynamicCaseResult"]
+    parameter_name: str
+    operations: Optional[List[AllOperationsType]] = Field(default=None)
+
+
+class CaseDefinition(BaseModel):
+    type: Literal["CaseDefinition"]
+    condition: StatementGroup
+    result: Annotated[
+        Union[StaticCaseResult, DynamicCaseResult], Field(discriminator="type")
+    ]
+
+
+class CasesDefinition(BaseModel):
+    type: Literal["CasesDefinition"]
+    cases: List[CaseDefinition]
+    default: Annotated[
+        Union[StaticCaseResult, DynamicCaseResult], Field(discriminator="type")
+    ]
+
+
+class BlockManifest(WorkflowBlockManifest):
+    model_config = ConfigDict(
+        json_schema_extra={
+            "short_description": SHORT_DESCRIPTION,
+            "long_description": LONG_DESCRIPTION,
+            "license": "Apache-2.0",
+            "block_type": "formatter",
+        }
+    )
+    type: Literal["Expression"]
+    data: Dict[
+        str,
+        Union[WorkflowImageSelector, WorkflowParameterSelector(), StepOutputSelector()],
+    ] = Field(
+        description="References data to be used to construct results",
+        examples=["$inputs.confidence", "$inputs.image", "$steps.my_step.top"],
+        default_factory=lambda: {},
+    )
+    data_operations: Dict[str, List[AllOperationsType]]
+    switch: CasesDefinition
+
+    @classmethod
+    def describe_outputs(cls) -> List[OutputDefinition]:
+        return [OutputDefinition(name="output")]
+
+
+class ExpressionBlock(WorkflowBlock):
+
+    @classmethod
+    def get_manifest(cls) -> Type[WorkflowBlockManifest]:
+        return BlockManifest
+
+    async def run(
+        self,
+        data: Dict[str, Any],
+        data_operations: Dict[str, List[AllOperationsType]],
+        switch: CasesDefinition,
+    ) -> BlockResult:
+        variables = copy(data)
+        for variable_name, operations in data_operations.items():
+            operations_chain = build_operations_chain(operations=operations)
+            variables[variable_name] = operations_chain(
+                variables[variable_name], global_parameters={}
+            )
+        for case in switch.cases:
+            case_eval_operation = build_eval_function(definition=case.condition)
+            if case_eval_operation(variables):
+                return build_result(variables=variables, result_definition=case.result)
+        return build_result(variables=variables, result_definition=switch.default)
+
+
+def build_result(
+    variables: Dict[str, Any],
+    result_definition: Union[StaticCaseResult, DynamicCaseResult],
+) -> Dict[str, Any]:
+    if result_definition.type == "StaticCaseResult":
+        return {"output": result_definition.value}
+    selected_variable = variables[result_definition.parameter_name]
+    if not result_definition.operations:
+        return {"output": selected_variable}
+    operations_chain = build_operations_chain(operations=result_definition.operations)
+    result = operations_chain(selected_variable, global_parameters={})
+    return {"output": result}

--- a/inference/core/workflows/core_steps/formatters/expression.py
+++ b/inference/core/workflows/core_steps/formatters/expression.py
@@ -1,7 +1,8 @@
 from copy import copy
-from typing import Annotated, Any, Dict, List, Literal, Optional, Type, Union
+from typing import Any, Dict, List, Literal, Optional, Type, Union
 
 from pydantic import BaseModel, ConfigDict, Field
+from typing_extensions import Annotated
 
 from inference.core.workflows.core_steps.common.query_language.entities.operations import (
     AllOperationsType,

--- a/inference/core/workflows/core_steps/formatters/first_non_empty_or_default.py
+++ b/inference/core/workflows/core_steps/formatters/first_non_empty_or_default.py
@@ -2,20 +2,8 @@ from typing import Any, List, Literal, Type
 
 from pydantic import ConfigDict, Field
 
-from inference.core.workflows.core_steps.common.query_language.entities.operations import (
-    AllOperationsType,
-)
-from inference.core.workflows.core_steps.common.query_language.operations.core import (
-    build_operations_chain,
-)
-from inference.core.workflows.entities.base import OutputDefinition
-from inference.core.workflows.entities.types import (
-    BATCH_OF_CLASSIFICATION_PREDICTION_KIND,
-    BATCH_OF_INSTANCE_SEGMENTATION_PREDICTION_KIND,
-    BATCH_OF_KEYPOINT_DETECTION_PREDICTION_KIND,
-    BATCH_OF_OBJECT_DETECTION_PREDICTION_KIND,
-    StepOutputSelector,
-)
+from inference.core.workflows.entities.base import Batch, OutputDefinition
+from inference.core.workflows.entities.types import StepOutputSelector
 from inference.core.workflows.prototypes.block import (
     BlockResult,
     WorkflowBlock,
@@ -68,7 +56,7 @@ class FirstNonEmptyOrDefaultBlock(WorkflowBlock):
 
     async def run(
         self,
-        data: List[Any],
+        data: Batch[Any],
         default: Any,
     ) -> BlockResult:
         result = default

--- a/inference/core/workflows/core_steps/formatters/property_extraction.py
+++ b/inference/core/workflows/core_steps/formatters/property_extraction.py
@@ -1,0 +1,77 @@
+from typing import Any, List, Literal, Type
+
+from pydantic import ConfigDict, Field
+
+from inference.core.workflows.core_steps.common.query_language.entities.operations import (
+    AllOperationsType,
+)
+from inference.core.workflows.core_steps.common.query_language.operations.core import (
+    build_operations_chain,
+)
+from inference.core.workflows.entities.base import OutputDefinition
+from inference.core.workflows.entities.types import (
+    BATCH_OF_CLASSIFICATION_PREDICTION_KIND,
+    BATCH_OF_INSTANCE_SEGMENTATION_PREDICTION_KIND,
+    BATCH_OF_KEYPOINT_DETECTION_PREDICTION_KIND,
+    BATCH_OF_OBJECT_DETECTION_PREDICTION_KIND,
+    StepOutputSelector,
+)
+from inference.core.workflows.prototypes.block import (
+    BlockResult,
+    WorkflowBlock,
+    WorkflowBlockManifest,
+)
+
+LONG_DESCRIPTION = """
+Takes input data and execute operation to extract specific data property.
+
+Example use-cases:
+* extraction of all class names for object-detection predictions
+* extraction of class / confidence from classification result
+* extraction ocr text from OCR result
+"""
+
+SHORT_DESCRIPTION = "Extracts specific property from input data."
+
+
+class BlockManifest(WorkflowBlockManifest):
+    model_config = ConfigDict(
+        json_schema_extra={
+            "short_description": SHORT_DESCRIPTION,
+            "long_description": LONG_DESCRIPTION,
+            "license": "Apache-2.0",
+            "block_type": "formatter",
+        }
+    )
+    type: Literal["PropertyExtraction"]
+    data: StepOutputSelector(
+        kind=[
+            BATCH_OF_OBJECT_DETECTION_PREDICTION_KIND,
+            BATCH_OF_INSTANCE_SEGMENTATION_PREDICTION_KIND,
+            BATCH_OF_KEYPOINT_DETECTION_PREDICTION_KIND,
+            BATCH_OF_CLASSIFICATION_PREDICTION_KIND,
+        ]
+    ) = Field(
+        description="Reference data to extract property from",
+        examples=["$steps.my_step.predictions"],
+    )
+    operations: List[AllOperationsType]
+
+    @classmethod
+    def describe_outputs(cls) -> List[OutputDefinition]:
+        return [OutputDefinition(name="output")]
+
+
+class PropertyExtractionBlock(WorkflowBlock):
+
+    @classmethod
+    def get_manifest(cls) -> Type[WorkflowBlockManifest]:
+        return BlockManifest
+
+    async def run(
+        self,
+        data: Any,
+        operations: List[AllOperationsType],
+    ) -> BlockResult:
+        operations_chain = build_operations_chain(operations=operations)
+        return {"output": operations_chain(data, global_parameters={})}

--- a/inference/core/workflows/core_steps/fusion/detections_classes_replacement.py
+++ b/inference/core/workflows/core_steps/fusion/detections_classes_replacement.py
@@ -1,4 +1,5 @@
 from typing import Dict, List, Literal, Optional, Tuple, Type
+from uuid import uuid4
 
 import numpy as np
 import supervision as sv
@@ -116,7 +117,7 @@ class DetectionsClassesReplacementBlock(WorkflowBlock):
             if prediction is not None
         }
         detections_to_remain_mask = [
-            detection_id_by_class[detection_id] is not None
+            detection_id_by_class.get(detection_id) is not None
             for detection_id in object_detection_predictions.data[DETECTION_ID_KEY]
         ]
         selected_object_detection_predictions = object_detection_predictions[
@@ -151,6 +152,9 @@ class DetectionsClassesReplacementBlock(WorkflowBlock):
         selected_object_detection_predictions.data[CLASS_NAME_DATA_FIELD] = (
             replaced_class_names
         )
+        selected_object_detection_predictions.data[DETECTION_ID_KEY] = np.array(
+            [f"{uuid4()}" for _ in range(len(selected_object_detection_predictions))]
+        )
         return {"predictions": selected_object_detection_predictions}
 
 
@@ -160,7 +164,7 @@ def extract_leading_class_from_prediction(
     if "top" in prediction:
         class_name = prediction["top"]
         matching_class_ids = [
-            (p["class"], p["confidence"])
+            (p["class_id"], p["confidence"])
             for p in prediction["predictions"]
             if p["class"] == class_name
         ]

--- a/inference/core/workflows/core_steps/fusion/detections_classes_replacement.py
+++ b/inference/core/workflows/core_steps/fusion/detections_classes_replacement.py
@@ -1,0 +1,192 @@
+from typing import Dict, List, Literal, Optional, Tuple, Type
+
+import numpy as np
+import supervision as sv
+from pydantic import ConfigDict, Field
+from supervision.config import CLASS_NAME_DATA_FIELD
+
+from inference.core.workflows.constants import DETECTION_ID_KEY, PARENT_ID_KEY
+from inference.core.workflows.entities.base import Batch, OutputDefinition
+from inference.core.workflows.entities.types import (
+    BATCH_OF_CLASSIFICATION_PREDICTION_KIND,
+    BATCH_OF_INSTANCE_SEGMENTATION_PREDICTION_KIND,
+    BATCH_OF_KEYPOINT_DETECTION_PREDICTION_KIND,
+    BATCH_OF_OBJECT_DETECTION_PREDICTION_KIND,
+    StepOutputSelector,
+)
+from inference.core.workflows.prototypes.block import (
+    BlockResult,
+    WorkflowBlock,
+    WorkflowBlockManifest,
+)
+
+LONG_DESCRIPTION = """
+Combine results of detection model with classification results performed separately for 
+each and every bounding box. 
+
+Bounding boxes without top class predicted by classification model are discarded, 
+for multi-label classification results, most confident label is taken as bounding box
+class.  
+"""
+
+SHORT_DESCRIPTION = (
+    "Replaces classes of bounding boxes with classes predicted on cropped images"
+    "by classification model."
+)
+
+
+class BlockManifest(WorkflowBlockManifest):
+    model_config = ConfigDict(
+        json_schema_extra={
+            "short_description": SHORT_DESCRIPTION,
+            "long_description": LONG_DESCRIPTION,
+            "license": "Apache-2.0",
+            "block_type": "fusion",
+        }
+    )
+    type: Literal["DetectionsClassesReplacement"]
+    object_detection_predictions: StepOutputSelector(
+        kind=[
+            BATCH_OF_OBJECT_DETECTION_PREDICTION_KIND,
+            BATCH_OF_INSTANCE_SEGMENTATION_PREDICTION_KIND,
+            BATCH_OF_KEYPOINT_DETECTION_PREDICTION_KIND,
+        ]
+    ) = Field(
+        title="Regions of Interest",
+        description="The output of a detection model describing the bounding boxes that will have classes replaced.",
+        examples=["$steps.my_object_detection_model.predictions"],
+    )
+    classification_predictions: StepOutputSelector(
+        kind=[BATCH_OF_CLASSIFICATION_PREDICTION_KIND]
+    ) = Field(
+        title="Classification results for crops",
+        description="The output of classification model for crops taken based on RoIs pointed as the other parameter",
+        examples=["$steps.my_classification_model.predictions"],
+    )
+
+    @classmethod
+    def accepts_empty_values(cls) -> bool:
+        return True
+
+    @classmethod
+    def get_input_dimensionality_offsets(cls) -> Dict[str, int]:
+        return {
+            "object_detection_predictions": 0,
+            "classification_predictions": 1,
+        }
+
+    @classmethod
+    def get_dimensionality_reference_property(cls) -> Optional[str]:
+        return "object_detection_predictions"
+
+    @classmethod
+    def describe_outputs(cls) -> List[OutputDefinition]:
+        return [
+            OutputDefinition(
+                name="predictions",
+                kind=[
+                    BATCH_OF_OBJECT_DETECTION_PREDICTION_KIND,
+                    BATCH_OF_INSTANCE_SEGMENTATION_PREDICTION_KIND,
+                    BATCH_OF_KEYPOINT_DETECTION_PREDICTION_KIND,
+                ],
+            )
+        ]
+
+
+class DetectionsClassesReplacementBlock(WorkflowBlock):
+
+    @classmethod
+    def get_manifest(cls) -> Type[WorkflowBlockManifest]:
+        return BlockManifest
+
+    async def run(
+        self,
+        object_detection_predictions: Optional[sv.Detections],
+        classification_predictions: Optional[Batch[dict]],
+    ) -> BlockResult:
+        if object_detection_predictions is None:
+            return {"predictions": None}
+        if classification_predictions is None:
+            return {"predictions": sv.Detections.empty()}
+        detection_id_by_class: Dict[str, Optional[Tuple[str, int]]] = {
+            prediction[PARENT_ID_KEY]: extract_leading_class_from_prediction(
+                prediction=prediction
+            )
+            for prediction in classification_predictions
+            if prediction is not None
+        }
+        detections_to_remain_mask = [
+            detection_id_by_class[detection_id] is not None
+            for detection_id in object_detection_predictions.data[DETECTION_ID_KEY]
+        ]
+        selected_object_detection_predictions = object_detection_predictions[
+            detections_to_remain_mask
+        ]
+        replaced_class_names = np.array(
+            [
+                detection_id_by_class[detection_id][0]
+                for detection_id in selected_object_detection_predictions.data[
+                    DETECTION_ID_KEY
+                ]
+            ]
+        )
+        replaced_class_ids = np.array(
+            [
+                detection_id_by_class[detection_id][1]
+                for detection_id in selected_object_detection_predictions.data[
+                    DETECTION_ID_KEY
+                ]
+            ]
+        )
+        replaced_confidences = np.array(
+            [
+                detection_id_by_class[detection_id][2]
+                for detection_id in selected_object_detection_predictions.data[
+                    DETECTION_ID_KEY
+                ]
+            ]
+        )
+        selected_object_detection_predictions.class_id = replaced_class_ids
+        selected_object_detection_predictions.confidence = replaced_confidences
+        selected_object_detection_predictions.data[CLASS_NAME_DATA_FIELD] = (
+            replaced_class_names
+        )
+        return {"predictions": selected_object_detection_predictions}
+
+
+def extract_leading_class_from_prediction(
+    prediction: dict,
+) -> Optional[Tuple[str, int, float]]:
+    if "top" in prediction:
+        class_name = prediction["top"]
+        matching_class_ids = [
+            (p["class"], p["confidence"])
+            for p in prediction["predictions"]
+            if p["class"] == class_name
+        ]
+        if len(matching_class_ids) != 1:
+            raise ValueError(f"Could not resolve class id for prediction: {prediction}")
+        return class_name, matching_class_ids[0][0], matching_class_ids[0][1]
+    predicted_classes = prediction.get("predicted_classes", [])
+    if not predicted_classes:
+        return None
+    max_confidence, max_confidence_class_name, max_confidence_class_id = (
+        None,
+        None,
+        None,
+    )
+    for class_name, prediction_details in prediction["predictions"].items():
+        current_class_confidence = prediction_details["confidence"]
+        current_class_id = prediction_details["class_id"]
+        if max_confidence is None:
+            max_confidence = current_class_confidence
+            max_confidence_class_name = class_name
+            max_confidence_class_id = current_class_id
+            continue
+        if max_confidence < current_class_confidence:
+            max_confidence = current_class_confidence
+            max_confidence_class_name = class_name
+            max_confidence_class_id = current_class_id
+    if not max_confidence:
+        return None
+    return max_confidence_class_name, max_confidence_class_id, max_confidence

--- a/inference/core/workflows/core_steps/fusion/detections_classes_replacement.py
+++ b/inference/core/workflows/core_steps/fusion/detections_classes_replacement.py
@@ -102,7 +102,7 @@ class DetectionsClassesReplacementBlock(WorkflowBlock):
     async def run(
         self,
         object_detection_predictions: Optional[sv.Detections],
-        classification_predictions: Optional[Batch[dict]],
+        classification_predictions: Optional[Batch[Optional[dict]]],
     ) -> BlockResult:
         if object_detection_predictions is None:
             return {"predictions": None}

--- a/inference/core/workflows/core_steps/fusion/dimension_collapse.py
+++ b/inference/core/workflows/core_steps/fusion/dimension_collapse.py
@@ -22,7 +22,9 @@ Useful in scenarios like:
 * aggregation of OCR results for dynamically cropped images
 """
 
-SHORT_DESCRIPTION = "Aggregates step outputs at specific data depth into list of values at one level above."
+SHORT_DESCRIPTION = (
+    "Collapses dimensionality level by aggregation of nested data into list"
+)
 
 
 class BlockManifest(WorkflowBlockManifest):
@@ -34,7 +36,7 @@ class BlockManifest(WorkflowBlockManifest):
             "block_type": "fusion",
         }
     )
-    type: Literal["NestedOutputsConcatenation"]
+    type: Literal["DimensionCollapse"]
     data: StepOutputSelector() = Field(
         description="Reference to step outputs at depth level n to be concatenated and moved into level n-1.",
         examples=["$steps.ocr_step.results"],
@@ -56,7 +58,7 @@ class BlockManifest(WorkflowBlockManifest):
         ]
 
 
-class NestedOutputsConcatenationBlock(WorkflowBlock):
+class DimensionCollapseBlock(WorkflowBlock):
 
     @classmethod
     def get_manifest(cls) -> Type[WorkflowBlockManifest]:

--- a/inference/core/workflows/core_steps/fusion/outputs_concatenation.py
+++ b/inference/core/workflows/core_steps/fusion/outputs_concatenation.py
@@ -1,0 +1,66 @@
+from typing import Any, List, Literal, Type
+
+from pydantic import ConfigDict, Field
+
+from inference.core.workflows.entities.base import Batch, OutputDefinition
+from inference.core.workflows.entities.types import (
+    LIST_OF_VALUES_KIND,
+    StepOutputSelector,
+)
+from inference.core.workflows.prototypes.block import (
+    BlockResult,
+    WorkflowBlock,
+    WorkflowBlockManifest,
+)
+
+LONG_DESCRIPTION = """
+Takes multiple step outputs at data depth level n, concatenate them into list and reduce dimensionality
+to level n-1.
+
+Useful in scenarios like:
+* aggregation of classification results for dynamically cropped images
+* aggregation of OCR results for dynamically cropped images
+"""
+
+SHORT_DESCRIPTION = "Aggregates step outputs at specific data depth into list of values at one level above."
+
+
+class BlockManifest(WorkflowBlockManifest):
+    model_config = ConfigDict(
+        json_schema_extra={
+            "short_description": SHORT_DESCRIPTION,
+            "long_description": LONG_DESCRIPTION,
+            "license": "Apache-2.0",
+            "block_type": "fusion",
+        }
+    )
+    type: Literal["NestedOutputsConcatenation"]
+    data: StepOutputSelector() = Field(
+        description="Reference to step outputs at depth level n to be concatenated and moved into level n-1.",
+        examples=["$steps.ocr_step.results"],
+    )
+
+    @classmethod
+    def get_output_dimensionality_offset(
+        cls,
+    ) -> int:
+        return -1
+
+    @classmethod
+    def describe_outputs(cls) -> List[OutputDefinition]:
+        return [
+            OutputDefinition(
+                name="output",
+                kind=[LIST_OF_VALUES_KIND],
+            )
+        ]
+
+
+class NestedOutputsConcatenationBlock(WorkflowBlock):
+
+    @classmethod
+    def get_manifest(cls) -> Type[WorkflowBlockManifest]:
+        return BlockManifest
+
+    async def run(self, data: Batch[Any]) -> BlockResult:
+        return {"output": [e for e in data]}

--- a/inference/core/workflows/core_steps/loader.py
+++ b/inference/core/workflows/core_steps/loader.py
@@ -1,6 +1,10 @@
 from typing import List, Type
 
 from inference.core.workflows.core_steps.flow_control.continue_if import ContinueIfBlock
+from inference.core.workflows.core_steps.formatters.expression import ExpressionBlock
+from inference.core.workflows.core_steps.fusion.detections_classes_replacement import (
+    DetectionsClassesReplacementBlock,
+)
 from inference.core.workflows.core_steps.fusion.detections_consensus import (
     DetectionsConsensusBlock,
 )
@@ -91,4 +95,6 @@ def load_blocks() -> List[Type[WorkflowBlock]]:
         ContinueIfBlock,
         PerspectiveCorrectionBlock,
         DynamicZonesBlock,
+        DetectionsClassesReplacementBlock,
+        ExpressionBlock,
     ]

--- a/inference/core/workflows/core_steps/loader.py
+++ b/inference/core/workflows/core_steps/loader.py
@@ -14,8 +14,8 @@ from inference.core.workflows.core_steps.fusion.detections_classes_replacement i
 from inference.core.workflows.core_steps.fusion.detections_consensus import (
     DetectionsConsensusBlock,
 )
-from inference.core.workflows.core_steps.fusion.outputs_concatenation import (
-    NestedOutputsConcatenationBlock,
+from inference.core.workflows.core_steps.fusion.dimension_collapse import (
+    DimensionCollapseBlock,
 )
 from inference.core.workflows.core_steps.models.foundation.clip_comparison import (
     ClipComparisonBlock,
@@ -107,6 +107,6 @@ def load_blocks() -> List[Type[WorkflowBlock]]:
         DetectionsClassesReplacementBlock,
         ExpressionBlock,
         PropertyExtractionBlock,
-        NestedOutputsConcatenationBlock,
+        DimensionCollapseBlock,
         FirstNonEmptyOrDefaultBlock,
     ]

--- a/inference/core/workflows/core_steps/loader.py
+++ b/inference/core/workflows/core_steps/loader.py
@@ -1,10 +1,10 @@
 from typing import List, Type
 
 from inference.core.workflows.core_steps.flow_control.continue_if import ContinueIfBlock
-from inference.core.workflows.core_steps.formatters.empty_values_replacement import (
+from inference.core.workflows.core_steps.formatters.expression import ExpressionBlock
+from inference.core.workflows.core_steps.formatters.first_non_empty_or_default import (
     FirstNonEmptyOrDefaultBlock,
 )
-from inference.core.workflows.core_steps.formatters.expression import ExpressionBlock
 from inference.core.workflows.core_steps.formatters.property_extraction import (
     PropertyExtractionBlock,
 )

--- a/inference/core/workflows/core_steps/loader.py
+++ b/inference/core/workflows/core_steps/loader.py
@@ -1,12 +1,21 @@
 from typing import List, Type
 
 from inference.core.workflows.core_steps.flow_control.continue_if import ContinueIfBlock
+from inference.core.workflows.core_steps.formatters.empty_values_replacement import (
+    FirstNonEmptyOrDefaultBlock,
+)
 from inference.core.workflows.core_steps.formatters.expression import ExpressionBlock
+from inference.core.workflows.core_steps.formatters.property_extraction import (
+    PropertyExtractionBlock,
+)
 from inference.core.workflows.core_steps.fusion.detections_classes_replacement import (
     DetectionsClassesReplacementBlock,
 )
 from inference.core.workflows.core_steps.fusion.detections_consensus import (
     DetectionsConsensusBlock,
+)
+from inference.core.workflows.core_steps.fusion.outputs_concatenation import (
+    NestedOutputsConcatenationBlock,
 )
 from inference.core.workflows.core_steps.models.foundation.clip_comparison import (
     ClipComparisonBlock,
@@ -97,4 +106,7 @@ def load_blocks() -> List[Type[WorkflowBlock]]:
         DynamicZonesBlock,
         DetectionsClassesReplacementBlock,
         ExpressionBlock,
+        PropertyExtractionBlock,
+        NestedOutputsConcatenationBlock,
+        FirstNonEmptyOrDefaultBlock,
     ]

--- a/inference/core/workflows/execution_engine/executor/execution_data_manager/manager.py
+++ b/inference/core/workflows/execution_engine/executor/execution_data_manager/manager.py
@@ -286,12 +286,13 @@ class ExecutionDataManager:
             )
         if not selector_lineage:
             return None
-        if not self._dynamic_batches_manager.is_lineage_registered(
-            lineage=selector_lineage
-        ):
+        return self.get_lineage_indices(lineage=selector_lineage)
+
+    def get_lineage_indices(self, lineage: List[str]) -> List[DynamicBatchIndex]:
+        if not self._dynamic_batches_manager.is_lineage_registered(lineage=lineage):
             return []
         return self._dynamic_batches_manager.get_indices_for_data_lineage(
-            lineage=selector_lineage
+            lineage=lineage
         )
 
     def get_non_batch_data(self, selector: str) -> Any:

--- a/inference/core/workflows/execution_engine/executor/output_constructor.py
+++ b/inference/core/workflows/execution_engine/executor/output_constructor.py
@@ -4,6 +4,7 @@ import numpy as np
 import supervision as sv
 from networkx import DiGraph
 
+from inference.core.workflows.constants import WORKFLOW_INPUT_BATCH_LINEAGE_ID
 from inference.core.workflows.core_steps.common.utils import (
     sv_detections_to_root_coordinates,
 )
@@ -63,10 +64,13 @@ def construct_workflow_output(
         for output in workflow_outputs
         if output.coordinates_system is CoordinatesSystem.PARENT
     }
-    major_batch_size = 0
+    major_batch_size = len(
+        execution_data_manager.get_lineage_indices(
+            lineage=[WORKFLOW_INPUT_BATCH_LINEAGE_ID]
+        )
+    )
     for name in batch_oriented_outputs:
         array = outputs_arrays[name]
-        major_batch_size = max(len(array) if array else 0, major_batch_size)
         indices = output_name2indices[name]
         data = execution_data_manager.get_batch_data(
             selector=name2selector[name],

--- a/inference_cli/lib/cloud_adapter.py
+++ b/inference_cli/lib/cloud_adapter.py
@@ -90,24 +90,28 @@ def _random_char(y):
 
 def cloud_status():
     import sky
+
     print("Getting status from skypilot...")
     print(sky.status())
 
 
 def cloud_stop(cluster_name):
     import sky
+
     print(f"Stopping skypilot deployment {cluster_name}...")
     print(sky.stop(cluster_name))
 
 
 def cloud_start(cluster_name):
     import sky
+
     print(f"Starting skypilot deployment {cluster_name}")
     print(sky.start(cluster_name))
 
 
 def cloud_undeploy(cluster_name):
     import sky
+
     print(
         f"Undeploying Roboflow Inference and deleting {cluster_name}, this may take a few minutes."
     )

--- a/tests/workflows/integration_tests/execution/stub_plugins/rock_paper_scissor_plugin/expression.py
+++ b/tests/workflows/integration_tests/execution/stub_plugins/rock_paper_scissor_plugin/expression.py
@@ -46,7 +46,7 @@ class BlockManifest(WorkflowBlockManifest):
             "block_type": "",
         }
     )
-    type: Literal["Expression"]
+    type: Literal["ExpressionTestBlock"]
     data: Dict[
         str,
         Union[WorkflowImageSelector, WorkflowParameterSelector(), StepOutputSelector()],

--- a/tests/workflows/integration_tests/execution/stub_plugins/rock_paper_scissor_plugin/take_first_non_empty.py
+++ b/tests/workflows/integration_tests/execution/stub_plugins/rock_paper_scissor_plugin/take_first_non_empty.py
@@ -3,24 +3,12 @@ This is just example, test implementation, please do not assume it being fully f
 This is extremely unsafe block - be aware for injected code execution!
 """
 
-from copy import deepcopy
-from typing import Any, Dict, List, Literal, Optional, Type, Union
+from typing import Any, List, Literal, Type, Union
 
-import numpy as np
-import supervision as sv
-from pydantic import AliasChoices, BaseModel, ConfigDict, Field
+from pydantic import ConfigDict, Field
 
-from inference.core.workflows.entities.base import (
-    Batch,
-    OutputDefinition,
-    WorkflowImageData,
-)
+from inference.core.workflows.entities.base import OutputDefinition
 from inference.core.workflows.entities.types import (
-    BATCH_OF_IMAGES_KIND,
-    BATCH_OF_INSTANCE_SEGMENTATION_PREDICTION_KIND,
-    BATCH_OF_KEYPOINT_DETECTION_PREDICTION_KIND,
-    BATCH_OF_OBJECT_DETECTION_PREDICTION_KIND,
-    StepOutputImageSelector,
     StepOutputSelector,
     WorkflowImageSelector,
     WorkflowParameterSelector,
@@ -30,11 +18,6 @@ from inference.core.workflows.prototypes.block import (
     WorkflowBlock,
     WorkflowBlockManifest,
 )
-
-
-class PythonCodeBlock(BaseModel):
-    type: Literal["PythonBlock"]
-    code: str
 
 
 class BlockManifest(WorkflowBlockManifest):

--- a/tests/workflows/integration_tests/execution/test_workflow_solving_rock_paper_scissor.py
+++ b/tests/workflows/integration_tests/execution/test_workflow_solving_rock_paper_scissor.py
@@ -53,7 +53,7 @@ ROCK_PAPER_SCISSOR_IF_ELSE_WORKFLOW = {
             "steps_if_false": ["$steps.undefined_verdict_generator"],
         },
         {
-            "type": "Expression",
+            "type": "ExpressionTestBlock",
             "name": "undefined_verdict_generator",
             "data": {
                 "image_only_for_dimension": "$inputs.image",
@@ -73,7 +73,7 @@ ROCK_PAPER_SCISSOR_IF_ELSE_WORKFLOW = {
             "operations": [{"type": "DetectionsSelection", "mode": "right_most"}],
         },
         {
-            "type": "Expression",
+            "type": "ExpressionTestBlock",
             "name": "defined_verdict_generator",
             "data": {
                 "left_player_detections": "$steps.take_leftmost_detection.predictions",

--- a/tests/workflows/integration_tests/execution/test_workflow_with_branches_that_may_not_execute.py
+++ b/tests/workflows/integration_tests/execution/test_workflow_with_branches_that_may_not_execute.py
@@ -1,17 +1,9 @@
 import numpy as np
 import pytest
-import supervision as sv
 
 from inference.core.env import WORKFLOWS_MAX_CONCURRENT_STEPS
 from inference.core.managers.base import ModelManager
 from inference.core.workflows.core_steps.common.entities import StepExecutionMode
-from inference.core.workflows.core_steps.common.query_language.entities.enums import (
-    DetectionsSortProperties,
-)
-from inference.core.workflows.core_steps.common.query_language.errors import (
-    EvaluationEngineError,
-)
-from inference.core.workflows.errors import RuntimeInputError, StepExecutionError
 from inference.core.workflows.execution_engine.core import ExecutionEngine
 
 WORKFLOW_WITH_BRANCHES_THAT_MAY_NOT_EXECUTE = {

--- a/tests/workflows/integration_tests/execution/test_workflow_with_custom_expression_built_for_detections_with_specialised_classification.py
+++ b/tests/workflows/integration_tests/execution/test_workflow_with_custom_expression_built_for_detections_with_specialised_classification.py
@@ -1,0 +1,167 @@
+import numpy as np
+import pytest
+
+from inference.core.env import WORKFLOWS_MAX_CONCURRENT_STEPS
+from inference.core.managers.base import ModelManager
+from inference.core.workflows.core_steps.common.entities import StepExecutionMode
+from inference.core.workflows.execution_engine.core import ExecutionEngine
+
+WORKFLOW_WITH_DETECTIONS_SPECIALISED_CLASSIFICATION_AND_CUSTOM_EXPRESSION = {
+    "version": "1.0",
+    "inputs": [
+        {"type": "WorkflowImage", "name": "image"},
+        {"type": "WorkflowParameter", "name": "reference"},
+    ],
+    "steps": [
+        {
+            "type": "ObjectDetectionModel",
+            "name": "general_detection",
+            "image": "$inputs.image",
+            "model_id": "yolov8n-640",
+            "class_filter": ["dog"],
+        },
+        {
+            "type": "Crop",
+            "name": "cropping",
+            "image": "$inputs.image",
+            "predictions": "$steps.general_detection.predictions",
+        },
+        {
+            "type": "ClassificationModel",
+            "name": "breds_classification",
+            "image": "$steps.cropping.crops",
+            "model_id": "dog-breed-xpaq6/1",
+        },
+        {
+            "type": "DetectionsClassesReplacement",
+            "name": "classes_replacement",
+            "object_detection_predictions": "$steps.general_detection.predictions",
+            "classification_predictions": "$steps.breds_classification.predictions",
+        },
+        {
+            "type": "Expression",
+            "name": "expression",
+            "data": {
+                "reference_value": "$inputs.reference",
+                "predictions": "$steps.classes_replacement.predictions",
+            },
+            "data_operations": {
+                "predictions": [
+                    {"type": "DetectionsPropertyExtract", "property_name": "class_name"}
+                ]
+            },
+            "switch": {
+                "type": "CasesDefinition",
+                "cases": [
+                    {
+                        "type": "CaseDefinition",
+                        "condition": {
+                            "type": "StatementGroup",
+                            "statements": [
+                                {
+                                    "type": "BinaryStatement",
+                                    "left_operand": {
+                                        "type": "DynamicOperand",
+                                        "operand_name": "reference_value",
+                                    },
+                                    "comparator": {"type": "in (Sequence)"},
+                                    "right_operand": {
+                                        "type": "DynamicOperand",
+                                        "operand_name": "predictions",
+                                    },
+                                }
+                            ],
+                        },
+                        "result": {"type": "StaticCaseResult", "value": "FOUND"},
+                    }
+                ],
+                "default": {"type": "StaticCaseResult", "value": "NOT FOUND"},
+            },
+        },
+    ],
+    "outputs": [
+        {
+            "type": "JsonField",
+            "name": "verdict",
+            "selector": "$steps.expression.output",
+        }
+    ],
+}
+
+
+@pytest.mark.asyncio
+async def test_detection_plus_classification_workflow_when_reference_found_at_least_in_one_image(
+    model_manager: ModelManager,
+    dogs_image: np.ndarray,
+    crowd_image: np.ndarray,
+    roboflow_api_key: str,
+) -> None:
+    # given
+    workflow_init_parameters = {
+        "workflows_core.model_manager": model_manager,
+        "workflows_core.api_key": roboflow_api_key,
+        "workflows_core.step_execution_mode": StepExecutionMode.LOCAL,
+    }
+    execution_engine = ExecutionEngine.init(
+        workflow_definition=WORKFLOW_WITH_DETECTIONS_SPECIALISED_CLASSIFICATION_AND_CUSTOM_EXPRESSION,
+        init_parameters=workflow_init_parameters,
+        max_concurrent_steps=WORKFLOWS_MAX_CONCURRENT_STEPS,
+    )
+
+    # when
+    result = await execution_engine.run_async(
+        runtime_parameters={
+            "image": [dogs_image, crowd_image],
+            "reference": "116.Parson_russell_terrier",
+        }
+    )
+
+    assert isinstance(result, list), "Expected list to be delivered"
+    assert len(result) == 2, "Expected 2 element in the output for two input images"
+    assert set(result[0].keys()) == {
+        "verdict",
+    }, "Expected all declared outputs to be delivered for first output"
+    assert set(result[1].keys()) == {
+        "verdict",
+    }, "Expected all declared outputs to be delivered for second output"
+    assert result[0]["verdict"] == "FOUND"
+    assert result[1]["verdict"] == "NOT FOUND"
+
+
+@pytest.mark.asyncio
+async def test_detection_plus_classification_workflow_when_reference_not_found(
+    model_manager: ModelManager,
+    dogs_image: np.ndarray,
+    crowd_image: np.ndarray,
+    roboflow_api_key: str,
+) -> None:
+    # given
+    workflow_init_parameters = {
+        "workflows_core.model_manager": model_manager,
+        "workflows_core.api_key": roboflow_api_key,
+        "workflows_core.step_execution_mode": StepExecutionMode.LOCAL,
+    }
+    execution_engine = ExecutionEngine.init(
+        workflow_definition=WORKFLOW_WITH_DETECTIONS_SPECIALISED_CLASSIFICATION_AND_CUSTOM_EXPRESSION,
+        init_parameters=workflow_init_parameters,
+        max_concurrent_steps=WORKFLOWS_MAX_CONCURRENT_STEPS,
+    )
+
+    # when
+    result = await execution_engine.run_async(
+        runtime_parameters={
+            "image": [dogs_image, crowd_image],
+            "reference": "NON-EXISTING",
+        }
+    )
+
+    assert isinstance(result, list), "Expected list to be delivered"
+    assert len(result) == 2, "Expected 2 element in the output for two input images"
+    assert set(result[0].keys()) == {
+        "verdict",
+    }, "Expected all declared outputs to be delivered for first output"
+    assert set(result[1].keys()) == {
+        "verdict",
+    }, "Expected all declared outputs to be delivered for second output"
+    assert result[0]["verdict"] == "NOT FOUND"
+    assert result[1]["verdict"] == "NOT FOUND"

--- a/tests/workflows/integration_tests/execution/test_workflow_with_detections_classes_replacement_by_specialised_classification.py
+++ b/tests/workflows/integration_tests/execution/test_workflow_with_detections_classes_replacement_by_specialised_classification.py
@@ -1,0 +1,148 @@
+import numpy as np
+import pytest
+
+from inference.core.env import WORKFLOWS_MAX_CONCURRENT_STEPS
+from inference.core.managers.base import ModelManager
+from inference.core.workflows.core_steps.common.entities import StepExecutionMode
+from inference.core.workflows.execution_engine.core import ExecutionEngine
+
+DETECTION_CLASSES_REPLACEMENT_WORKFLOW = {
+    "version": "1.0",
+    "inputs": [{"type": "WorkflowImage", "name": "image"}],
+    "steps": [
+        {
+            "type": "ObjectDetectionModel",
+            "name": "general_detection",
+            "image": "$inputs.image",
+            "model_id": "yolov8n-640",
+            "class_filter": ["dog"],
+        },
+        {
+            "type": "Crop",
+            "name": "cropping",
+            "image": "$inputs.image",
+            "predictions": "$steps.general_detection.predictions",
+        },
+        {
+            "type": "ClassificationModel",
+            "name": "breds_classification",
+            "image": "$steps.cropping.crops",
+            "model_id": "dog-breed-xpaq6/1",
+        },
+        {
+            "type": "DetectionsClassesReplacement",
+            "name": "classes_replacement",
+            "object_detection_predictions": "$steps.general_detection.predictions",
+            "classification_predictions": "$steps.breds_classification.predictions",
+        },
+    ],
+    "outputs": [
+        {
+            "type": "JsonField",
+            "name": "original_predictions",
+            "selector": "$steps.general_detection.predictions",
+        },
+        {
+            "type": "JsonField",
+            "name": "predictions_with_replaced_classes",
+            "selector": "$steps.classes_replacement.predictions",
+        },
+    ],
+}
+
+
+@pytest.mark.asyncio
+async def test_detection_plus_classification_workflow_when_minimal_valid_input_provided(
+    model_manager: ModelManager,
+    dogs_image: np.ndarray,
+    crowd_image: np.ndarray,
+    roboflow_api_key: str,
+) -> None:
+    # given
+    workflow_init_parameters = {
+        "workflows_core.model_manager": model_manager,
+        "workflows_core.api_key": roboflow_api_key,
+        "workflows_core.step_execution_mode": StepExecutionMode.LOCAL,
+    }
+    execution_engine = ExecutionEngine.init(
+        workflow_definition=DETECTION_CLASSES_REPLACEMENT_WORKFLOW,
+        init_parameters=workflow_init_parameters,
+        max_concurrent_steps=WORKFLOWS_MAX_CONCURRENT_STEPS,
+    )
+
+    # when
+    result = await execution_engine.run_async(
+        runtime_parameters={
+            "image": [dogs_image, dogs_image, crowd_image],
+        }
+    )
+
+    assert isinstance(result, list), "Expected list to be delivered"
+    assert len(result) == 3, "Expected 3 element in the output for three input images"
+    assert set(result[0].keys()) == {
+        "original_predictions",
+        "predictions_with_replaced_classes",
+    }, "Expected all declared outputs to be delivered for first output"
+    assert set(result[1].keys()) == {
+        "original_predictions",
+        "predictions_with_replaced_classes",
+    }, "Expected all declared outputs to be delivered for second output"
+    assert set(result[2].keys()) == {
+        "original_predictions",
+        "predictions_with_replaced_classes",
+    }, "Expected all declared outputs to be delivered for third output"
+    assert (
+        len(result[0]["original_predictions"])
+        == len(result[0]["predictions_with_replaced_classes"])
+        == 2
+    ), "Expected 2 dogs detected for first image"
+    assert (
+        len(result[1]["original_predictions"])
+        == len(result[1]["predictions_with_replaced_classes"])
+        == 2
+    ), "Expected 2 dogs detected for second image"
+    assert (
+        len(result[2]["original_predictions"])
+        == len(result[2]["predictions_with_replaced_classes"])
+        == 0
+    ), "Expected 0 dogs detected for third image"
+    assert (
+        result[0]["predictions_with_replaced_classes"].confidence.tolist()
+        != result[0]["original_predictions"].confidence.tolist()
+    ), "Expected confidences to be altered"
+    assert (
+        result[0]["predictions_with_replaced_classes"].class_id.tolist()
+        != result[0]["original_predictions"].class_id.tolist()
+    ), "Expected class_id to be altered"
+    assert result[0]["predictions_with_replaced_classes"]["class_name"].tolist() == [
+        "116.Parson_russell_terrier",
+        "131.Wirehaired_pointing_griffon",
+    ], "Expected classes to be changed"
+    assert result[0]["original_predictions"]["class_name"].tolist() == [
+        "dog",
+        "dog",
+    ], "Expected classes not to be changed"
+    assert result[1]["predictions_with_replaced_classes"]["class_name"].tolist() == [
+        "116.Parson_russell_terrier",
+        "131.Wirehaired_pointing_griffon",
+    ], "Expected classes to be changed"
+    assert result[1]["original_predictions"]["class_name"].tolist() == [
+        "dog",
+        "dog",
+    ], "Expected classes not to be changed"
+    assert (
+        result[0]["predictions_with_replaced_classes"].xyxy
+        is not result[0]["original_predictions"].xyxy
+    ), "Expected copy of data to be created by step"
+    assert (
+        result[1]["predictions_with_replaced_classes"].xyxy
+        is not result[1]["original_predictions"].xyxy
+    ), "Expected copy of data to be created by step"
+    assert np.allclose(
+        result[0]["predictions_with_replaced_classes"].xyxy,
+        result[0]["original_predictions"].xyxy,
+    ), "Expected values of other fields in detections to be untouched"
+    assert np.allclose(
+        result[1]["predictions_with_replaced_classes"].xyxy,
+        result[1]["original_predictions"].xyxy,
+    ), "Expected values of other fields in detections to be untouched"

--- a/tests/workflows/integration_tests/execution/test_workflows_with_property_extraction.py
+++ b/tests/workflows/integration_tests/execution/test_workflows_with_property_extraction.py
@@ -185,7 +185,7 @@ WORKFLOW_WITH_EXTRACTION_OF_CLASS_NAME_FROM_CROPS_AND_CONCATENATION_OF_RESULTS =
             ],
         },
         {
-            "type": "NestedOutputsConcatenation",
+            "type": "DimensionCollapse",
             "name": "outputs_concatenation",
             "data": "$steps.property_extraction.output",
         },
@@ -347,7 +347,7 @@ WORKFLOW_PERFORMING_OCR_AND_AGGREGATION_TO_PERFORM_PASS_FAIL_FOR_ALL_PLATES_FOUN
             "image": "$steps.plates_crops.crops",
         },
         {
-            "type": "NestedOutputsConcatenation",
+            "type": "DimensionCollapse",
             "name": "outputs_concatenation",
             "data": "$steps.ocr.result",
         },
@@ -605,7 +605,7 @@ WORKFLOW_WITH_INVALID_AGGREGATION = {
             "model_id": "vehicle-registration-plates-trudk/2",
         },
         {
-            "type": "NestedOutputsConcatenation",
+            "type": "DimensionCollapse",
             "name": "invalid_concatenation",
             "data": "$steps.plates_detection.predictions",
         },

--- a/tests/workflows/integration_tests/execution/test_workflows_with_property_extraction.py
+++ b/tests/workflows/integration_tests/execution/test_workflows_with_property_extraction.py
@@ -1,0 +1,642 @@
+import numpy as np
+import pytest
+
+from inference.core.env import WORKFLOWS_MAX_CONCURRENT_STEPS
+from inference.core.managers.base import ModelManager
+from inference.core.workflows.core_steps.common.entities import StepExecutionMode
+from inference.core.workflows.errors import StepOutputLineageError
+from inference.core.workflows.execution_engine.core import ExecutionEngine
+
+WORKFLOW_WITH_EXTRACTION_OF_CLASSES_FOR_DETECTIONS = {
+    "version": "1.0",
+    "inputs": [
+        {"type": "WorkflowImage", "name": "image"},
+        {"type": "WorkflowParameter", "name": "reference"},
+    ],
+    "steps": [
+        {
+            "type": "ObjectDetectionModel",
+            "name": "general_detection",
+            "image": "$inputs.image",
+            "model_id": "yolov8n-640",
+        },
+        {
+            "type": "PropertyExtraction",
+            "name": "property_extraction",
+            "data": "$steps.general_detection.predictions",
+            "operations": [
+                {"type": "DetectionsPropertyExtract", "property_name": "class_name"}
+            ],
+        },
+        {
+            "type": "PropertyExtraction",
+            "name": "instances_counter",
+            "data": "$steps.general_detection.predictions",
+            "operations": [{"type": "SequenceLength"}],
+        },
+        {
+            "type": "Expression",
+            "name": "expression",
+            "data": {
+                "class_names": "$steps.property_extraction.output",
+                "reference": "$inputs.reference",
+            },
+            "switch": {
+                "type": "CasesDefinition",
+                "cases": [
+                    {
+                        "type": "CaseDefinition",
+                        "condition": {
+                            "type": "StatementGroup",
+                            "statements": [
+                                {
+                                    "type": "BinaryStatement",
+                                    "left_operand": {
+                                        "type": "DynamicOperand",
+                                        "operand_name": "class_names",
+                                    },
+                                    "comparator": {"type": "=="},
+                                    "right_operand": {
+                                        "type": "DynamicOperand",
+                                        "operand_name": "reference",
+                                    },
+                                }
+                            ],
+                        },
+                        "result": {"type": "StaticCaseResult", "value": "PASS"},
+                    }
+                ],
+                "default": {"type": "StaticCaseResult", "value": "FAIL"},
+            },
+        },
+    ],
+    "outputs": [
+        {
+            "type": "JsonField",
+            "name": "detected_classes",
+            "selector": "$steps.property_extraction.output",
+        },
+        {
+            "type": "JsonField",
+            "name": "number_of_detected_boxes",
+            "selector": "$steps.instances_counter.output",
+        },
+        {
+            "type": "JsonField",
+            "name": "verdict",
+            "selector": "$steps.expression.output",
+        },
+    ],
+}
+
+
+@pytest.mark.asyncio
+async def test_workflow_with_extraction_of_classes_for_detections(
+    model_manager: ModelManager,
+    dogs_image: np.ndarray,
+    crowd_image: np.ndarray,
+    roboflow_api_key: str,
+) -> None:
+    # given
+    workflow_init_parameters = {
+        "workflows_core.model_manager": model_manager,
+        "workflows_core.api_key": roboflow_api_key,
+        "workflows_core.step_execution_mode": StepExecutionMode.LOCAL,
+    }
+    execution_engine = ExecutionEngine.init(
+        workflow_definition=WORKFLOW_WITH_EXTRACTION_OF_CLASSES_FOR_DETECTIONS,
+        init_parameters=workflow_init_parameters,
+        max_concurrent_steps=WORKFLOWS_MAX_CONCURRENT_STEPS,
+    )
+
+    # when
+    result = await execution_engine.run_async(
+        runtime_parameters={
+            "image": [dogs_image, crowd_image],
+            "reference": ["dog", "dog"],
+        }
+    )
+
+    assert isinstance(result, list), "Expected list to be delivered"
+    assert len(result) == 2, "Expected 2 elements in the output for two input images"
+    assert set(result[0].keys()) == {
+        "detected_classes",
+        "verdict",
+        "number_of_detected_boxes",
+    }, "Expected all declared outputs to be delivered"
+    assert set(result[1].keys()) == {
+        "detected_classes",
+        "verdict",
+        "number_of_detected_boxes",
+    }, "Expected all declared outputs to be delivered"
+    assert result[0]["detected_classes"] == [
+        "dog",
+        "dog",
+    ], "Expected two instances of dogs found in first image"
+    assert (
+        result[0]["verdict"] == "PASS"
+    ), "Expected first image to match expected classes"
+    assert (
+        result[0]["number_of_detected_boxes"] == 2
+    ), "Expected 2 dogs detected in first image"
+    assert (
+        result[1]["detected_classes"] == ["person"] * 12
+    ), "Expected 12 instances of person found in second image"
+    assert (
+        result[1]["verdict"] == "FAIL"
+    ), "Expected second image not to match expected classes"
+    assert (
+        result[1]["number_of_detected_boxes"] == 12
+    ), "Expected 12 people detected in second image"
+
+
+WORKFLOW_WITH_EXTRACTION_OF_CLASS_NAME_FROM_CROPS_AND_CONCATENATION_OF_RESULTS = {
+    "version": "1.0",
+    "inputs": [
+        {"type": "WorkflowImage", "name": "image"},
+        {"type": "WorkflowParameter", "name": "reference"},
+    ],
+    "steps": [
+        {
+            "type": "ObjectDetectionModel",
+            "name": "general_detection",
+            "image": "$inputs.image",
+            "model_id": "yolov8n-640",
+            "class_filter": ["dog"],
+        },
+        {
+            "type": "Crop",
+            "name": "cropping",
+            "image": "$inputs.image",
+            "predictions": "$steps.general_detection.predictions",
+        },
+        {
+            "type": "ClassificationModel",
+            "name": "breds_classification",
+            "image": "$steps.cropping.crops",
+            "model_id": "dog-breed-xpaq6/1",
+        },
+        {
+            "type": "PropertyExtraction",
+            "name": "property_extraction",
+            "data": "$steps.breds_classification.predictions",
+            "operations": [
+                {"type": "ClassificationPropertyExtract", "property_name": "top_class"}
+            ],
+        },
+        {
+            "type": "NestedOutputsConcatenation",
+            "name": "outputs_concatenation",
+            "data": "$steps.property_extraction.output",
+        },
+        {
+            "type": "FirstNonEmptyOrDefault",
+            "name": "empty_values_replacement",
+            "data": ["$steps.outputs_concatenation.output"],
+            "default": [],
+        },
+        {
+            "type": "Expression",
+            "name": "expression",
+            "data": {
+                "detected_classes": "$steps.empty_values_replacement.output",
+                "reference": "$inputs.reference",
+            },
+            "switch": {
+                "type": "CasesDefinition",
+                "cases": [
+                    {
+                        "type": "CaseDefinition",
+                        "condition": {
+                            "type": "StatementGroup",
+                            "statements": [
+                                {
+                                    "type": "BinaryStatement",
+                                    "left_operand": {
+                                        "type": "DynamicOperand",
+                                        "operand_name": "detected_classes",
+                                    },
+                                    "comparator": {"type": "=="},
+                                    "right_operand": {
+                                        "type": "DynamicOperand",
+                                        "operand_name": "reference",
+                                    },
+                                }
+                            ],
+                        },
+                        "result": {"type": "StaticCaseResult", "value": "PASS"},
+                    }
+                ],
+                "default": {"type": "StaticCaseResult", "value": "FAIL"},
+            },
+        },
+    ],
+    "outputs": [
+        {
+            "type": "JsonField",
+            "name": "detected_classes",
+            "selector": "$steps.property_extraction.output",
+        },
+        {
+            "type": "JsonField",
+            "name": "wrapped_classes",
+            "selector": "$steps.empty_values_replacement.output",
+        },
+        {
+            "type": "JsonField",
+            "name": "verdict",
+            "selector": "$steps.expression.output",
+        },
+    ],
+}
+
+
+@pytest.mark.asyncio
+async def test_workflow_with_extraction_of_classes_for_classification_on_crops(
+    model_manager: ModelManager,
+    dogs_image: np.ndarray,
+    crowd_image: np.ndarray,
+    roboflow_api_key: str,
+) -> None:
+    # given
+    workflow_init_parameters = {
+        "workflows_core.model_manager": model_manager,
+        "workflows_core.api_key": roboflow_api_key,
+        "workflows_core.step_execution_mode": StepExecutionMode.LOCAL,
+    }
+    execution_engine = ExecutionEngine.init(
+        workflow_definition=WORKFLOW_WITH_EXTRACTION_OF_CLASS_NAME_FROM_CROPS_AND_CONCATENATION_OF_RESULTS,
+        init_parameters=workflow_init_parameters,
+        max_concurrent_steps=WORKFLOWS_MAX_CONCURRENT_STEPS,
+    )
+
+    # when
+    result = await execution_engine.run_async(
+        runtime_parameters={
+            "image": [dogs_image, crowd_image],
+            "reference": [
+                "116.Parson_russell_terrier",
+                "131.Wirehaired_pointing_griffon",
+            ],
+        }
+    )
+
+    assert isinstance(result, list), "Expected list to be delivered"
+    assert len(result) == 2, "Expected 2 elements in the output for two input images"
+    assert set(result[0].keys()) == {
+        "detected_classes",
+        "wrapped_classes",
+        "verdict",
+    }, "Expected all declared outputs to be delivered"
+    assert set(result[1].keys()) == {
+        "detected_classes",
+        "wrapped_classes",
+        "verdict",
+    }, "Expected all declared outputs to be delivered"
+    assert result[0]["detected_classes"] == [
+        "116.Parson_russell_terrier",
+        "131.Wirehaired_pointing_griffon",
+    ], "Expected two instances of dogs found in first image"
+    assert result[0]["wrapped_classes"] == [
+        "116.Parson_russell_terrier",
+        "131.Wirehaired_pointing_griffon",
+    ], "Expected two instances of dogs found in first image"
+    assert (
+        result[0]["verdict"] == "PASS"
+    ), "Expected first image to match expected classes"
+    assert (
+        result[1]["detected_classes"] == []
+    ), "Expected no instances of dogs found in second image"
+    assert (
+        result[1]["wrapped_classes"] == []
+    ), "Expected no instances of dogs found in second image"
+    assert (
+        result[1]["verdict"] == "FAIL"
+    ), "Expected second image not to match expected classes"
+
+
+WORKFLOW_PERFORMING_OCR_AND_AGGREGATION_TO_PERFORM_PASS_FAIL_FOR_ALL_PLATES_FOUND_IN_IMAGE_AT_ONCE = {
+    "version": "1.0",
+    "inputs": [
+        {"type": "WorkflowImage", "name": "image"},
+        {"type": "WorkflowParameter", "name": "reference"},
+    ],
+    "steps": [
+        {
+            "type": "RoboflowObjectDetectionModel",
+            "name": "plates_detection",
+            "image": "$inputs.image",
+            "model_id": "vehicle-registration-plates-trudk/2",
+        },
+        {
+            "type": "DetectionOffset",
+            "name": "plates_offset",
+            "predictions": "$steps.plates_detection.predictions",
+            "offset_width": 50,
+            "offset_height": 50,
+        },
+        {
+            "type": "Crop",
+            "name": "plates_crops",
+            "image": "$inputs.image",
+            "predictions": "$steps.plates_offset.predictions",
+        },
+        {
+            "type": "OCRModel",
+            "name": "ocr",
+            "image": "$steps.plates_crops.crops",
+        },
+        {
+            "type": "NestedOutputsConcatenation",
+            "name": "outputs_concatenation",
+            "data": "$steps.ocr.result",
+        },
+        {
+            "type": "FirstNonEmptyOrDefault",
+            "name": "empty_values_replacement",
+            "data": ["$steps.outputs_concatenation.output"],
+            "default": [],
+        },
+        {
+            "type": "Expression",
+            "name": "expression",
+            "data": {
+                "outputs_concatenation": "$steps.empty_values_replacement.output",
+                "reference": "$inputs.reference",
+            },
+            "data_operations": {
+                "outputs_concatenation": [{"type": "SequenceLength"}],
+            },
+            "switch": {
+                "type": "CasesDefinition",
+                "cases": [
+                    {
+                        "type": "CaseDefinition",
+                        "condition": {
+                            "type": "StatementGroup",
+                            "statements": [
+                                {
+                                    "type": "BinaryStatement",
+                                    "left_operand": {
+                                        "type": "DynamicOperand",
+                                        "operand_name": "outputs_concatenation",
+                                    },
+                                    "comparator": {"type": "=="},
+                                    "right_operand": {
+                                        "type": "DynamicOperand",
+                                        "operand_name": "reference",
+                                    },
+                                }
+                            ],
+                        },
+                        "result": {"type": "StaticCaseResult", "value": "PASS"},
+                    }
+                ],
+                "default": {"type": "StaticCaseResult", "value": "FAIL"},
+            },
+        },
+    ],
+    "outputs": [
+        {"type": "JsonField", "name": "plates_ocr", "selector": "$steps.ocr.result"},
+        {
+            "type": "JsonField",
+            "name": "concatenated_ocr",
+            "selector": "$steps.empty_values_replacement.output",
+        },
+        {
+            "type": "JsonField",
+            "name": "verdict",
+            "selector": "$steps.expression.output",
+        },
+    ],
+}
+
+
+@pytest.mark.asyncio
+async def test_workflow_with_aggregation_of_ocr_results_globally_for_image(
+    model_manager: ModelManager,
+    license_plate_image: np.ndarray,
+    roboflow_api_key: str,
+) -> None:
+    # given
+    workflow_init_parameters = {
+        "workflows_core.model_manager": model_manager,
+        "workflows_core.api_key": roboflow_api_key,
+        "workflows_core.step_execution_mode": StepExecutionMode.LOCAL,
+    }
+    execution_engine = ExecutionEngine.init(
+        workflow_definition=WORKFLOW_PERFORMING_OCR_AND_AGGREGATION_TO_PERFORM_PASS_FAIL_FOR_ALL_PLATES_FOUND_IN_IMAGE_AT_ONCE,
+        init_parameters=workflow_init_parameters,
+        max_concurrent_steps=WORKFLOWS_MAX_CONCURRENT_STEPS,
+    )
+
+    # when
+    result = await execution_engine.run_async(
+        runtime_parameters={
+            "image": license_plate_image,
+            "reference": 2,
+        }
+    )
+
+    # then
+    assert isinstance(result, list), "Expected list to be delivered"
+    assert len(result) == 1, "Expected 1 elements in the output for one input image"
+    assert set(result[0].keys()) == {
+        "plates_ocr",
+        "concatenated_ocr",
+        "verdict",
+    }, "Expected all declared outputs to be delivered"
+    assert (
+        isinstance(result[0]["plates_ocr"], list) and len(result[0]["plates_ocr"]) == 2
+    ), "Expected 2 plates to be found"
+    # In this case, output does not reveal the concatenation result, but we could not make expression without concat
+    assert (
+        isinstance(result[0]["concatenated_ocr"], list)
+        and len(result[0]["concatenated_ocr"]) == 2
+    ), "Expected 2 plates to be found"
+    assert result[0]["verdict"] == "PASS", "Expected to meet the condition"
+
+
+WORKFLOW_PERFORMING_OCR_AND_AGGREGATION_TO_PERFORM_PASS_FAIL_FOR_EACH_PLATE_SEPARATELY = {
+    "version": "1.0",
+    "inputs": [
+        {"type": "WorkflowImage", "name": "image"},
+        {"type": "WorkflowParameter", "name": "reference"},
+    ],
+    "steps": [
+        {
+            "type": "RoboflowObjectDetectionModel",
+            "name": "plates_detection",
+            "image": "$inputs.image",
+            "model_id": "vehicle-registration-plates-trudk/2",
+        },
+        {
+            "type": "DetectionOffset",
+            "name": "plates_offset",
+            "predictions": "$steps.plates_detection.predictions",
+            "offset_width": 50,
+            "offset_height": 50,
+        },
+        {
+            "type": "Crop",
+            "name": "plates_crops",
+            "image": "$inputs.image",
+            "predictions": "$steps.plates_offset.predictions",
+        },
+        {
+            "type": "OCRModel",
+            "name": "ocr",
+            "image": "$steps.plates_crops.crops",
+        },
+        {
+            "type": "Expression",
+            "name": "expression",
+            "data": {
+                "outputs_concatenation": "$steps.ocr.result",
+                "reference": "$inputs.reference",
+            },
+            "data_operations": {
+                "outputs_concatenation": [{"type": "SequenceLength"}],
+            },
+            "switch": {
+                "type": "CasesDefinition",
+                "cases": [
+                    {
+                        "type": "CaseDefinition",
+                        "condition": {
+                            "type": "StatementGroup",
+                            "statements": [
+                                {
+                                    "type": "BinaryStatement",
+                                    "left_operand": {
+                                        "type": "DynamicOperand",
+                                        "operand_name": "outputs_concatenation",
+                                    },
+                                    "comparator": {"type": "(Number) >"},
+                                    "right_operand": {
+                                        "type": "DynamicOperand",
+                                        "operand_name": "reference",
+                                    },
+                                }
+                            ],
+                        },
+                        "result": {"type": "StaticCaseResult", "value": "PASS"},
+                    }
+                ],
+                "default": {"type": "StaticCaseResult", "value": "FAIL"},
+            },
+        },
+    ],
+    "outputs": [
+        {"type": "JsonField", "name": "plates_ocr", "selector": "$steps.ocr.result"},
+        {
+            "type": "JsonField",
+            "name": "verdict",
+            "selector": "$steps.expression.output",
+        },
+    ],
+}
+
+
+@pytest.mark.asyncio
+async def test_workflow_with_pass_fail_applied_for_each_ocr_result(
+    model_manager: ModelManager,
+    license_plate_image: np.ndarray,
+    dogs_image: np.ndarray,
+    roboflow_api_key: str,
+) -> None:
+    # given
+    workflow_init_parameters = {
+        "workflows_core.model_manager": model_manager,
+        "workflows_core.api_key": roboflow_api_key,
+        "workflows_core.step_execution_mode": StepExecutionMode.LOCAL,
+    }
+    execution_engine = ExecutionEngine.init(
+        workflow_definition=WORKFLOW_PERFORMING_OCR_AND_AGGREGATION_TO_PERFORM_PASS_FAIL_FOR_EACH_PLATE_SEPARATELY,
+        init_parameters=workflow_init_parameters,
+        max_concurrent_steps=WORKFLOWS_MAX_CONCURRENT_STEPS,
+    )
+
+    # when
+    result = await execution_engine.run_async(
+        runtime_parameters={
+            "image": [license_plate_image, dogs_image],
+            "reference": 0,
+        }
+    )
+
+    # then
+    assert isinstance(result, list), "Expected list to be delivered"
+    assert len(result) == 2, "Expected 2 elements in the output for two input images"
+    assert set(result[0].keys()) == {
+        "plates_ocr",
+        "verdict",
+    }, "Expected all declared outputs to be delivered"
+    assert set(result[1].keys()) == {
+        "plates_ocr",
+        "verdict",
+    }, "Expected all declared outputs to be delivered"
+    assert (
+        isinstance(result[0]["plates_ocr"], list) and len(result[0]["plates_ocr"]) == 2
+    ), "Expected 2 plates to be found in first image"
+    assert (
+        isinstance(result[0]["verdict"], list) and len(result[0]["verdict"]) == 2
+    ), "Expected verdict for each plate recognised in first image"
+    assert result[0]["verdict"][0] in {"PASS", "FAIL"}, "Expected valid verdict"
+    assert result[0]["verdict"][1] in {"PASS", "FAIL"}, "Expected valid verdict"
+    assert (
+        isinstance(result[1]["plates_ocr"], list) and len(result[1]["plates_ocr"]) == 0
+    ), "Expected 0 plates to be found in second image"
+    assert (
+        isinstance(result[1]["verdict"], list) and len(result[1]["verdict"]) == 0
+    ), "Expected 0 verdicts to be given in second image"
+
+
+WORKFLOW_WITH_INVALID_AGGREGATION = {
+    "version": "1.0",
+    "inputs": [
+        {"type": "WorkflowImage", "name": "image"},
+    ],
+    "steps": [
+        {
+            "type": "RoboflowObjectDetectionModel",
+            "name": "plates_detection",
+            "image": "$inputs.image",
+            "model_id": "vehicle-registration-plates-trudk/2",
+        },
+        {
+            "type": "NestedOutputsConcatenation",
+            "name": "invalid_concatenation",
+            "data": "$steps.plates_detection.predictions",
+        },
+    ],
+    "outputs": [
+        {
+            "type": "JsonField",
+            "name": "result",
+            "selector": "$steps.invalid_concatenation.output",
+        },
+    ],
+}
+
+
+@pytest.mark.asyncio
+async def test_workflow_when_there_is_faulty_application_of_aggregation_step_at_batch_with_dimension_1(
+    model_manager: ModelManager,
+    license_plate_image: np.ndarray,
+    roboflow_api_key: str,
+) -> None:
+    # given
+    workflow_init_parameters = {
+        "workflows_core.model_manager": model_manager,
+        "workflows_core.api_key": roboflow_api_key,
+        "workflows_core.step_execution_mode": StepExecutionMode.LOCAL,
+    }
+
+    # when
+    with pytest.raises(StepOutputLineageError):
+        _ = ExecutionEngine.init(
+            workflow_definition=WORKFLOW_WITH_INVALID_AGGREGATION,
+            init_parameters=workflow_init_parameters,
+            max_concurrent_steps=WORKFLOWS_MAX_CONCURRENT_STEPS,
+        )

--- a/tests/workflows/unit_tests/core_steps/common/query_language/operations/test_classification_results_operations.py
+++ b/tests/workflows/unit_tests/core_steps/common/query_language/operations/test_classification_results_operations.py
@@ -1,0 +1,315 @@
+import pytest
+
+from inference.core.entities.responses.inference import (
+    ClassificationInferenceResponse,
+    ClassificationPrediction,
+    InferenceResponseImage,
+    MultiLabelClassificationInferenceResponse,
+    MultiLabelClassificationPrediction,
+)
+from inference.core.workflows.core_steps.common.query_language.errors import (
+    InvalidInputTypeError,
+)
+from inference.core.workflows.core_steps.common.query_language.operations.core import (
+    execute_operations,
+)
+
+
+def test_classification_result_extraction_when_data_is_empty() -> None:
+    # given
+    operations = [
+        {
+            "type": "ClassificationPropertyExtract",
+            "property_name": "top_class",
+        }
+    ]
+
+    # when
+    with pytest.raises(InvalidInputTypeError):
+        _ = execute_operations(value=None, operations=operations)
+
+
+def test_classification_result_extraction_of_top_class_for_multi_class_classification_result() -> (
+    None
+):
+    # given
+    operations = [
+        {
+            "type": "ClassificationPropertyExtract",
+            "property_name": "top_class",
+        }
+    ]
+    data = ClassificationInferenceResponse(
+        image=InferenceResponseImage(width=128, height=256),
+        predictions=[
+            ClassificationPrediction(
+                **{"class": "cat", "class_id": 0, "confidence": 0.6}
+            ),
+            ClassificationPrediction(
+                **{"class": "dog", "class_id": 1, "confidence": 0.4}
+            ),
+        ],
+        top="cat",
+        confidence=0.6,
+        parent_id="some",
+    ).dict(by_alias=True, exclude_none=True)
+
+    # when
+    result = execute_operations(value=data, operations=operations)
+
+    # then
+    assert result == "cat"
+
+
+def test_classification_result_extraction_of_top_class_for_multi_label_classification_result_when_no_class_detected() -> (
+    None
+):
+    # given
+    operations = [
+        {
+            "type": "ClassificationPropertyExtract",
+            "property_name": "top_class",
+        }
+    ]
+    data = MultiLabelClassificationInferenceResponse(
+        image=InferenceResponseImage(width=128, height=256),
+        predictions={
+            "cat": MultiLabelClassificationPrediction(class_id=0, confidence=0.6),
+            "dog": MultiLabelClassificationPrediction(class_id=1, confidence=0.4),
+        },
+        predicted_classes=[],
+    ).dict(by_alias=True, exclude_none=True)
+
+    # when
+    result = execute_operations(value=data, operations=operations)
+
+    # then
+    assert result == []
+
+
+def test_classification_result_extraction_of_top_class_for_multi_label_classification_result_when_classes_detected() -> (
+    None
+):
+    # given
+    operations = [
+        {
+            "type": "ClassificationPropertyExtract",
+            "property_name": "top_class",
+        }
+    ]
+    data = MultiLabelClassificationInferenceResponse(
+        image=InferenceResponseImage(width=128, height=256),
+        predictions={
+            "cat": MultiLabelClassificationPrediction(class_id=0, confidence=0.6),
+            "dog": MultiLabelClassificationPrediction(class_id=1, confidence=0.4),
+        },
+        predicted_classes=["cat", "dog"],
+    ).dict(by_alias=True, exclude_none=True)
+
+    # when
+    result = execute_operations(value=data, operations=operations)
+
+    # then
+    assert result == ["cat", "dog"]
+
+
+def test_classification_result_extraction_of_top_class_confidence_for_multi_class_classification_result() -> (
+    None
+):
+    # given
+    operations = [
+        {
+            "type": "ClassificationPropertyExtract",
+            "property_name": "top_class_confidence",
+        }
+    ]
+    data = ClassificationInferenceResponse(
+        image=InferenceResponseImage(width=128, height=256),
+        predictions=[
+            ClassificationPrediction(
+                **{"class": "cat", "class_id": 0, "confidence": 0.6}
+            ),
+            ClassificationPrediction(
+                **{"class": "dog", "class_id": 1, "confidence": 0.4}
+            ),
+        ],
+        top="cat",
+        confidence=0.6,
+        parent_id="some",
+    ).dict(by_alias=True, exclude_none=True)
+
+    # when
+    result = execute_operations(value=data, operations=operations)
+
+    # then
+    assert abs(result - 0.6) < 1e-5
+
+
+def test_classification_result_extraction_of_top_class_confidence_for_multi_label_classification_result_when_no_class_detected() -> (
+    None
+):
+    # given
+    operations = [
+        {
+            "type": "ClassificationPropertyExtract",
+            "property_name": "top_class_confidence",
+        }
+    ]
+    data = MultiLabelClassificationInferenceResponse(
+        image=InferenceResponseImage(width=128, height=256),
+        predictions={
+            "cat": MultiLabelClassificationPrediction(class_id=0, confidence=0.6),
+            "dog": MultiLabelClassificationPrediction(class_id=1, confidence=0.4),
+        },
+        predicted_classes=[],
+    ).dict(by_alias=True, exclude_none=True)
+
+    # when
+    result = execute_operations(value=data, operations=operations)
+
+    # then
+    assert result == []
+
+
+def test_classification_result_extraction_of_top_class_confidence_for_multi_label_classification_result_when_class_detected() -> (
+    None
+):
+    # given
+    operations = [
+        {
+            "type": "ClassificationPropertyExtract",
+            "property_name": "top_class_confidence",
+        }
+    ]
+    data = MultiLabelClassificationInferenceResponse(
+        image=InferenceResponseImage(width=128, height=256),
+        predictions={
+            "cat": MultiLabelClassificationPrediction(class_id=0, confidence=0.6),
+            "dog": MultiLabelClassificationPrediction(class_id=1, confidence=0.4),
+        },
+        predicted_classes=["dog"],
+    ).dict(by_alias=True, exclude_none=True)
+
+    # when
+    result = execute_operations(value=data, operations=operations)
+
+    # then
+    assert result == [0.4]
+
+
+def test_classification_result_extraction_of_all_classes_for_multi_class_classification_result() -> (
+    None
+):
+    # given
+    operations = [
+        {
+            "type": "ClassificationPropertyExtract",
+            "property_name": "all_classes",
+        }
+    ]
+    data = ClassificationInferenceResponse(
+        image=InferenceResponseImage(width=128, height=256),
+        predictions=[
+            ClassificationPrediction(
+                **{"class": "cat", "class_id": 0, "confidence": 0.6}
+            ),
+            ClassificationPrediction(
+                **{"class": "dog", "class_id": 1, "confidence": 0.4}
+            ),
+        ],
+        top="cat",
+        confidence=0.6,
+        parent_id="some",
+    ).dict(by_alias=True, exclude_none=True)
+
+    # when
+    result = execute_operations(value=data, operations=operations)
+
+    # then
+    assert result == ["cat", "dog"]
+
+
+def test_classification_result_extraction_of_all_classes_for_multi_label_classification_result() -> (
+    None
+):
+    # given
+    operations = [
+        {
+            "type": "ClassificationPropertyExtract",
+            "property_name": "all_classes",
+        }
+    ]
+    data = MultiLabelClassificationInferenceResponse(
+        image=InferenceResponseImage(width=128, height=256),
+        predictions={
+            "cat": MultiLabelClassificationPrediction(class_id=0, confidence=0.6),
+            "dog": MultiLabelClassificationPrediction(class_id=1, confidence=0.4),
+            "animal": MultiLabelClassificationPrediction(class_id=3, confidence=0.0),
+        },
+        predicted_classes=["dog"],
+    ).dict(by_alias=True, exclude_none=True)
+
+    # when
+    result = execute_operations(value=data, operations=operations)
+
+    # then
+    assert result == ["cat", "dog", "animal"]
+
+
+def test_classification_result_extraction_of_all_confidences_for_multi_class_classification_result() -> (
+    None
+):
+    # given
+    operations = [
+        {
+            "type": "ClassificationPropertyExtract",
+            "property_name": "all_confidences",
+        }
+    ]
+    data = ClassificationInferenceResponse(
+        image=InferenceResponseImage(width=128, height=256),
+        predictions=[
+            ClassificationPrediction(
+                **{"class": "cat", "class_id": 0, "confidence": 0.6}
+            ),
+            ClassificationPrediction(
+                **{"class": "dog", "class_id": 1, "confidence": 0.4}
+            ),
+        ],
+        top="cat",
+        confidence=0.6,
+        parent_id="some",
+    ).dict(by_alias=True, exclude_none=True)
+
+    # when
+    result = execute_operations(value=data, operations=operations)
+
+    # then
+    assert result == [0.6, 0.4]
+
+
+def test_classification_result_extraction_of_all_confidences_for_multi_label_classification_result() -> (
+    None
+):
+    # given
+    operations = [
+        {
+            "type": "ClassificationPropertyExtract",
+            "property_name": "all_confidences",
+        }
+    ]
+    data = MultiLabelClassificationInferenceResponse(
+        image=InferenceResponseImage(width=128, height=256),
+        predictions={
+            "cat": MultiLabelClassificationPrediction(class_id=0, confidence=0.6),
+            "animal": MultiLabelClassificationPrediction(class_id=3, confidence=0.0),
+            "dog": MultiLabelClassificationPrediction(class_id=1, confidence=0.4),
+        },
+        predicted_classes=["dog"],
+    ).dict(by_alias=True, exclude_none=True)
+
+    # when
+    result = execute_operations(value=data, operations=operations)
+
+    # then
+    assert result == [0.6, 0.4, 0.0]

--- a/tests/workflows/unit_tests/core_steps/formatters/test_expression.py
+++ b/tests/workflows/unit_tests/core_steps/formatters/test_expression.py
@@ -1,0 +1,431 @@
+import pytest
+
+from inference.core.workflows.core_steps.common.query_language.entities.operations import (
+    OperationsChain,
+)
+from inference.core.workflows.core_steps.common.query_language.errors import (
+    EvaluationEngineError,
+    UndeclaredSymbolError,
+)
+from inference.core.workflows.core_steps.formatters.expression import (
+    CasesDefinition,
+    ExpressionBlock,
+    StaticCaseResult,
+)
+
+
+@pytest.mark.asyncio
+async def test_block_run_when_no_data_provided_and_static_output_to_be_returned() -> (
+    None
+):
+    # given
+    step = ExpressionBlock()
+    switch = CasesDefinition(
+        type="CasesDefinition",
+        cases=[],
+        default=StaticCaseResult(type="StaticCaseResult", value="static-value"),
+    )
+
+    # when
+    result = await step.run(data={}, data_operations={}, switch=switch)
+
+    # then
+    assert result == {"output": "static-value"}
+
+
+@pytest.mark.asyncio
+async def test_block_run_when_data_provided_and_default_output_to_be_returned() -> None:
+    # given
+    step = ExpressionBlock()
+    switch = CasesDefinition.model_validate(
+        {
+            "type": "CasesDefinition",
+            "cases": [
+                {
+                    "type": "CaseDefinition",
+                    "condition": {
+                        "type": "StatementGroup",
+                        "statements": [
+                            {
+                                "type": "UnaryStatement",
+                                "operand": {
+                                    "type": "DynamicOperand",
+                                    "operand_name": "input_list",
+                                },
+                                "operator": {"type": "(Sequence) is empty"},
+                            }
+                        ],
+                    },
+                    "result": {"type": "StaticCaseResult", "value": "some"},
+                }
+            ],
+            "default": {"type": "StaticCaseResult", "value": "default"},
+        }
+    )
+
+    # when
+    result = await step.run(
+        data={"input_list": [1, 2]}, data_operations={}, switch=switch
+    )
+
+    # then
+    assert result == {"output": "default"}
+
+
+@pytest.mark.asyncio
+async def test_block_run_when_data_provided_and_first_matching_case_to_be_returned() -> (
+    None
+):
+    # given
+    step = ExpressionBlock()
+    switch = CasesDefinition.model_validate(
+        {
+            "type": "CasesDefinition",
+            "cases": [
+                {
+                    "type": "CaseDefinition",
+                    "condition": {
+                        "type": "StatementGroup",
+                        "statements": [
+                            {
+                                "type": "UnaryStatement",
+                                "operand": {
+                                    "type": "DynamicOperand",
+                                    "operand_name": "input_list",
+                                },
+                                "operator": {"type": "(Sequence) is empty"},
+                            }
+                        ],
+                    },
+                    "result": {"type": "StaticCaseResult", "value": "not-matching"},
+                },
+                {
+                    "type": "CaseDefinition",
+                    "condition": {
+                        "type": "StatementGroup",
+                        "statements": [
+                            {
+                                "type": "UnaryStatement",
+                                "operand": {
+                                    "type": "DynamicOperand",
+                                    "operand_name": "input_list",
+                                },
+                                "operator": {"type": "(Sequence) is not empty"},
+                            }
+                        ],
+                    },
+                    "result": {"type": "StaticCaseResult", "value": "first-matching"},
+                },
+                {
+                    "type": "CaseDefinition",
+                    "condition": {
+                        "type": "StatementGroup",
+                        "statements": [
+                            {
+                                "type": "UnaryStatement",
+                                "operand": {
+                                    "type": "DynamicOperand",
+                                    "operand_name": "input_list",
+                                },
+                                "operator": {"type": "(Sequence) is not empty"},
+                            }
+                        ],
+                    },
+                    "result": {"type": "StaticCaseResult", "value": "second-matching"},
+                },
+            ],
+            "default": {"type": "StaticCaseResult", "value": "default"},
+        }
+    )
+
+    # when
+    result = await step.run(
+        data={"input_list": [1, 2]}, data_operations={}, switch=switch
+    )
+
+    # then
+    assert result == {"output": "first-matching"}
+
+
+@pytest.mark.asyncio
+async def test_block_run_when_data_provided_and_data_operations_to_be_performed() -> (
+    None
+):
+    # given
+    step = ExpressionBlock()
+    switch = CasesDefinition.model_validate(
+        {
+            "type": "CasesDefinition",
+            "cases": [
+                {
+                    "type": "CaseDefinition",
+                    "condition": {
+                        "type": "StatementGroup",
+                        "statements": [
+                            {
+                                "type": "UnaryStatement",
+                                "operand": {
+                                    "type": "DynamicOperand",
+                                    "operand_name": "input_list",
+                                },
+                                "operator": {"type": "(Sequence) is not empty"},
+                            }
+                        ],
+                    },
+                    "result": {
+                        "type": "DynamicCaseResult",
+                        "parameter_name": "additional_param",
+                    },
+                }
+            ],
+            "default": {"type": "StaticCaseResult", "value": "default"},
+        }
+    )
+    data_operations = {
+        "additional_param": OperationsChain.model_validate(
+            {"operations": [{"type": "StringToUpperCase"}]}
+        ).operations
+    }
+
+    # when
+    result = await step.run(
+        data={
+            "input_list": [1, 2],
+            "additional_param": "some",
+        },
+        data_operations=data_operations,
+        switch=switch,
+    )
+
+    # then
+    assert result == {"output": "SOME"}
+
+
+@pytest.mark.asyncio
+async def test_block_run_when_data_provided_and_operations_on_dynamic_result_to_be_performed() -> (
+    None
+):
+    # given
+    step = ExpressionBlock()
+    switch = CasesDefinition.model_validate(
+        {
+            "type": "CasesDefinition",
+            "cases": [
+                {
+                    "type": "CaseDefinition",
+                    "condition": {
+                        "type": "StatementGroup",
+                        "statements": [
+                            {
+                                "type": "UnaryStatement",
+                                "operand": {
+                                    "type": "DynamicOperand",
+                                    "operand_name": "input_list",
+                                },
+                                "operator": {"type": "(Sequence) is not empty"},
+                            }
+                        ],
+                    },
+                    "result": {
+                        "type": "DynamicCaseResult",
+                        "parameter_name": "additional_param",
+                        "operations": OperationsChain.model_validate(
+                            {
+                                "operations": [
+                                    {
+                                        "type": "LookupTable",
+                                        "lookup_table": {"SOME": "MUTATED"},
+                                    }
+                                ]
+                            }
+                        ).operations,
+                    },
+                }
+            ],
+            "default": {"type": "StaticCaseResult", "value": "default"},
+        }
+    )
+    data_operations = {
+        "additional_param": OperationsChain.model_validate(
+            {"operations": [{"type": "StringToUpperCase"}]}
+        ).operations
+    }
+
+    # when
+    result = await step.run(
+        data={
+            "input_list": [1, 2],
+            "additional_param": "some",
+        },
+        data_operations=data_operations,
+        switch=switch,
+    )
+
+    # then
+    assert result == {"output": "MUTATED"}
+
+
+@pytest.mark.asyncio
+async def test_block_run_when_uql_error_happens() -> None:
+    # given
+    step = ExpressionBlock()
+    switch = CasesDefinition.model_validate(
+        {
+            "type": "CasesDefinition",
+            "cases": [
+                {
+                    "type": "CaseDefinition",
+                    "condition": {
+                        "type": "StatementGroup",
+                        "statements": [
+                            {
+                                "type": "UnaryStatement",
+                                "operand": {
+                                    "type": "DynamicOperand",
+                                    "operand_name": "input_list",
+                                },
+                                "operator": {"type": "(Sequence) is empty"},
+                            }
+                        ],
+                    },
+                    "result": {"type": "StaticCaseResult", "value": "some"},
+                }
+            ],
+            "default": {"type": "StaticCaseResult", "value": "default"},
+        }
+    )
+
+    # when
+    with pytest.raises(EvaluationEngineError):
+        _ = await step.run(data={"input_list": 1}, data_operations={}, switch=switch)
+
+
+@pytest.mark.asyncio
+async def test_block_run_when_data_provided_and_missing_variable_detected_on_data_operations() -> (
+    None
+):
+    # given
+    step = ExpressionBlock()
+    switch = CasesDefinition.model_validate(
+        {
+            "type": "CasesDefinition",
+            "cases": [
+                {
+                    "type": "CaseDefinition",
+                    "condition": {
+                        "type": "StatementGroup",
+                        "statements": [
+                            {
+                                "type": "UnaryStatement",
+                                "operand": {
+                                    "type": "DynamicOperand",
+                                    "operand_name": "input_list",
+                                },
+                                "operator": {"type": "(Sequence) is not empty"},
+                            }
+                        ],
+                    },
+                    "result": {
+                        "type": "DynamicCaseResult",
+                        "parameter_name": "additional_param",
+                    },
+                }
+            ],
+            "default": {"type": "StaticCaseResult", "value": "default"},
+        }
+    )
+    data_operations = {
+        "additional_param": OperationsChain.model_validate(
+            {"operations": [{"type": "StringToUpperCase"}]}
+        ).operations
+    }
+
+    # when
+    with pytest.raises(KeyError):
+        _ = await step.run(
+            data={"input_list": [1, 2]}, data_operations=data_operations, switch=switch
+        )
+
+
+@pytest.mark.asyncio
+async def test_block_run_when_data_provided_and_missing_variable_detected_in_output_building() -> (
+    None
+):
+    # given
+    step = ExpressionBlock()
+    switch = CasesDefinition.model_validate(
+        {
+            "type": "CasesDefinition",
+            "cases": [
+                {
+                    "type": "CaseDefinition",
+                    "condition": {
+                        "type": "StatementGroup",
+                        "statements": [
+                            {
+                                "type": "UnaryStatement",
+                                "operand": {
+                                    "type": "DynamicOperand",
+                                    "operand_name": "input_list",
+                                },
+                                "operator": {"type": "(Sequence) is not empty"},
+                            }
+                        ],
+                    },
+                    "result": {
+                        "type": "DynamicCaseResult",
+                        "parameter_name": "additional_param",
+                    },
+                }
+            ],
+            "default": {"type": "StaticCaseResult", "value": "default"},
+        }
+    )
+
+    # when
+    with pytest.raises(KeyError):
+        _ = await step.run(
+            data={"input_list": [1, 2]}, data_operations={}, switch=switch
+        )
+
+
+@pytest.mark.asyncio
+async def test_block_run_when_data_provided_and_missing_variable_detected_in_uql_building() -> (
+    None
+):
+    # given
+    step = ExpressionBlock()
+    switch = CasesDefinition.model_validate(
+        {
+            "type": "CasesDefinition",
+            "cases": [
+                {
+                    "type": "CaseDefinition",
+                    "condition": {
+                        "type": "StatementGroup",
+                        "statements": [
+                            {
+                                "type": "UnaryStatement",
+                                "operand": {
+                                    "type": "DynamicOperand",
+                                    "operand_name": "input_list",
+                                },
+                                "operator": {"type": "(Sequence) is not empty"},
+                            }
+                        ],
+                    },
+                    "result": {
+                        "type": "DynamicCaseResult",
+                        "parameter_name": "additional_param",
+                    },
+                }
+            ],
+            "default": {"type": "StaticCaseResult", "value": "default"},
+        }
+    )
+
+    # when
+    with pytest.raises(UndeclaredSymbolError):
+        _ = await step.run(
+            data={"additional_param": "some"}, data_operations={}, switch=switch
+        )

--- a/tests/workflows/unit_tests/core_steps/formatters/test_first_non_empty_or_default.py
+++ b/tests/workflows/unit_tests/core_steps/formatters/test_first_non_empty_or_default.py
@@ -1,0 +1,51 @@
+import pytest
+
+from inference.core.workflows.core_steps.formatters.first_non_empty_or_default import (
+    FirstNonEmptyOrDefaultBlock,
+)
+from inference.core.workflows.entities.base import Batch
+
+
+@pytest.mark.asyncio
+async def test_block_run_when_only_empty_data_provided() -> None:
+    # given
+    step = FirstNonEmptyOrDefaultBlock()
+    data = Batch(content=[None, None, None], indices=[(0,), (1,), (2,)])
+
+    # when
+    result = await step.run(data=data, default="some")
+
+    # then
+    assert result == {"output": "some"}
+
+
+@pytest.mark.asyncio
+async def test_block_run_when_only_empty_single_non_empty_data_element_provided() -> (
+    None
+):
+    # given
+    step = FirstNonEmptyOrDefaultBlock()
+    data = Batch(content=[None, "non-empty", None], indices=[(0,), (1,), (2,)])
+
+    # when
+    result = await step.run(data=data, default="some")
+
+    # then
+    assert result == {"output": "non-empty"}
+
+
+@pytest.mark.asyncio
+async def test_block_run_when_only_empty_multiple_non_empty_data_element_provided() -> (
+    None
+):
+    # given
+    step = FirstNonEmptyOrDefaultBlock()
+    data = Batch(
+        content=[None, "non-empty", "another-non-empty"], indices=[(0,), (1,), (2,)]
+    )
+
+    # when
+    result = await step.run(data=data, default="some")
+
+    # then
+    assert result == {"output": "non-empty"}

--- a/tests/workflows/unit_tests/core_steps/formatters/test_property_extraction.py
+++ b/tests/workflows/unit_tests/core_steps/formatters/test_property_extraction.py
@@ -1,0 +1,44 @@
+import pytest
+
+from inference.core.entities.responses.inference import ClassificationInferenceResponse, InferenceResponseImage, \
+    ClassificationPrediction
+from inference.core.workflows.core_steps.common.query_language.entities.operations import OperationsChain
+from inference.core.workflows.core_steps.formatters.property_extraction import PropertyExtractionBlock
+
+
+@pytest.mark.asyncio
+async def test_property_extraction_block() -> None:
+    # given
+    data = ClassificationInferenceResponse(
+        image=InferenceResponseImage(width=128, height=256),
+        predictions=[
+            ClassificationPrediction(
+                **{"class": "cat", "class_id": 0, "confidence": 0.6}
+            ),
+            ClassificationPrediction(
+                **{"class": "dog", "class_id": 1, "confidence": 0.4}
+            ),
+        ],
+        top="cat",
+        confidence=0.6,
+        parent_id="some",
+    ).dict(by_alias=True, exclude_none=True)
+    operations = OperationsChain.model_validate({
+        "operations": [
+            {
+                "type": "ClassificationPropertyExtract",
+                "property_name": "top_class",
+            },
+            {
+                "type": "LookupTable",
+                "lookup_table": {"cat": "cat-mutated"},
+            }
+        ]
+    }).operations
+    step = PropertyExtractionBlock()
+
+    # when
+    result = await step.run(data=data, operations=operations)
+
+    # then
+    assert result == {"output": "cat-mutated"}

--- a/tests/workflows/unit_tests/core_steps/fusion/test_detections_classes_replacement.py
+++ b/tests/workflows/unit_tests/core_steps/fusion/test_detections_classes_replacement.py
@@ -1,0 +1,317 @@
+import numpy as np
+import pytest
+
+import supervision as sv
+from supervision.config import CLASS_NAME_DATA_FIELD
+
+from inference.core.entities.responses.inference import MultiLabelClassificationInferenceResponse, \
+    InferenceResponseImage, MultiLabelClassificationPrediction, ClassificationInferenceResponse, \
+    ClassificationPrediction
+from inference.core.workflows.constants import DETECTION_ID_KEY
+from inference.core.workflows.core_steps.fusion.detections_classes_replacement import DetectionsClassesReplacementBlock, \
+    extract_leading_class_from_prediction
+from inference.core.workflows.entities.base import Batch
+
+
+@pytest.mark.asyncio
+async def test_classes_replacement_when_object_detection_object_is_none() -> None:
+    # given
+    step = DetectionsClassesReplacementBlock()
+
+    # when
+    result = await step.run(
+        object_detection_predictions=None,
+        classification_predictions=None,
+    )
+
+    # then
+    assert result == {"predictions": None}, "object_detection_predictions is superior object so lack of value means lack of output"
+
+
+@pytest.mark.asyncio
+async def test_classes_replacement_when_there_are_no_predictions_is_none() -> None:
+    # given
+    step = DetectionsClassesReplacementBlock()
+    detections = sv.Detections(
+        xyxy=np.array([[10, 20, 30, 40]]),
+    )
+
+    # when
+    result = await step.run(
+        object_detection_predictions=detections,
+        classification_predictions=None,
+    )
+
+    # then
+    assert result == {"predictions": sv.Detections.empty()}, "classification_predictions is inferior object so lack of value means empty output"
+
+
+@pytest.mark.asyncio
+async def test_classes_replacement_when_replacement_to_happen_without_filtering_for_multi_label_results() -> None:
+    # given
+    step = DetectionsClassesReplacementBlock()
+    detections = sv.Detections(
+        xyxy=np.array([
+            [10, 20, 30, 40],
+            [11, 21, 31, 41],
+        ]),
+        class_id=np.array([7, 7]),
+        confidence=np.array([0.36, 0.91]),
+        data={
+            "class_name": np.array(["animal", "animal"]),
+            "detection_id": np.array(["zero", "one"])
+        }
+    )
+    first_cls_prediction = MultiLabelClassificationInferenceResponse(
+        image=InferenceResponseImage(width=128, height=256),
+        predictions={
+            "cat": MultiLabelClassificationPrediction(class_id=0, confidence=0.6),
+            "dog": MultiLabelClassificationPrediction(class_id=1, confidence=0.4),
+        },
+        predicted_classes=["cat", "dog"],
+    ).dict(by_alias=True, exclude_none=True)
+    second_cls_prediction = MultiLabelClassificationInferenceResponse(
+        image=InferenceResponseImage(width=128, height=256),
+        predictions={
+            "cat": MultiLabelClassificationPrediction(class_id=0, confidence=0.2),
+            "dog": MultiLabelClassificationPrediction(class_id=1, confidence=0.4),
+        },
+        predicted_classes=["dog"],
+    ).dict(by_alias=True, exclude_none=True)
+    first_cls_prediction["parent_id"] = "zero"
+    second_cls_prediction["parent_id"] = "one"
+    classification_predictions = Batch(
+        content=[
+            first_cls_prediction,
+            second_cls_prediction,
+        ],
+        indices=[(0, 0), (0, 1)]
+    )
+
+    # when
+    result = await step.run(
+        object_detection_predictions=detections,
+        classification_predictions=classification_predictions,
+    )
+
+    # then
+    assert np.allclose(result["predictions"].xyxy, np.array([[10, 20, 30, 40], [11, 21, 31, 41]])), "Expected coordinates not to be touched"
+    assert np.allclose(result["predictions"].confidence, np.array([0.6, 0.4])), "Expected to choose [cat, dog] confidences"
+    assert np.allclose(result["predictions"].class_id, np.array([0, 1])), "Expected to choose [cat, dog] class ids"
+    assert result["predictions"].data["class_name"].tolist() == ["cat", "dog"], "Expected cat class to be assigned"
+    assert result["predictions"].data["detection_id"].tolist() != ["zero", "one"], "Expected to generate new detection id"
+
+
+@pytest.mark.asyncio
+async def test_classes_replacement_when_replacement_to_happen_without_filtering_for_multi_class_results() -> None:
+    # given
+    step = DetectionsClassesReplacementBlock()
+    detections = sv.Detections(
+        xyxy=np.array([
+            [10, 20, 30, 40],
+            [11, 21, 31, 41],
+        ]),
+        class_id=np.array([7, 7]),
+        confidence=np.array([0.36, 0.91]),
+        data={
+            "class_name": np.array(["animal", "animal"]),
+            "detection_id": np.array(["zero", "one"])
+        }
+    )
+    first_cls_prediction = ClassificationInferenceResponse(
+        image=InferenceResponseImage(width=128, height=256),
+        predictions=[
+            ClassificationPrediction(
+                **{"class": "cat", "class_id": 0, "confidence": 0.6}
+            ),
+            ClassificationPrediction(
+                **{"class": "dog", "class_id": 1, "confidence": 0.4}
+            ),
+        ],
+        top="cat",
+        confidence=0.6,
+        parent_id="some",
+    ).dict(by_alias=True, exclude_none=True)
+    second_cls_prediction = ClassificationInferenceResponse(
+        image=InferenceResponseImage(width=128, height=256),
+        predictions=[
+            ClassificationPrediction(
+                **{"class": "cat", "class_id": 0, "confidence": 0.4}
+            ),
+            ClassificationPrediction(
+                **{"class": "dog", "class_id": 1, "confidence": 0.6}
+            ),
+        ],
+        top="dog",
+        confidence=0.6,
+        parent_id="some",
+    ).dict(by_alias=True, exclude_none=True)
+    first_cls_prediction["parent_id"] = "zero"
+    second_cls_prediction["parent_id"] = "one"
+    classification_predictions = Batch(
+        content=[
+            first_cls_prediction,
+            second_cls_prediction,
+        ],
+        indices=[(0, 0), (0, 1)]
+    )
+
+    # when
+    result = await step.run(
+        object_detection_predictions=detections,
+        classification_predictions=classification_predictions,
+    )
+
+    # then
+    assert np.allclose(result["predictions"].xyxy, np.array([[10, 20, 30, 40], [11, 21, 31, 41]])), "Expected coordinates not to be touched"
+    assert np.allclose(result["predictions"].confidence, np.array([0.6, 0.6])), "Expected to choose [cat, dog] confidences"
+    assert np.allclose(result["predictions"].class_id, np.array([0, 1])), "Expected to choose [cat, dog] class ids"
+    assert result["predictions"].data["class_name"].tolist() == ["cat", "dog"], "Expected cat class to be assigned"
+    assert result["predictions"].data["detection_id"].tolist() != ["zero", "one"], "Expected to generate new detection id"
+
+
+@pytest.mark.asyncio
+async def test_classes_replacement_when_replacement_to_happen_and_one_result_to_be_filtered_out() -> None:
+    # given
+    step = DetectionsClassesReplacementBlock()
+    detections = sv.Detections(
+        xyxy=np.array([
+            [10, 20, 30, 40],
+            [11, 21, 31, 41],
+        ]),
+        class_id=np.array([7, 7]),
+        confidence=np.array([0.36, 0.91]),
+        data={
+            "class_name": np.array(["animal", "animal"]),
+            "detection_id": np.array(["zero", "one"])
+        }
+    )
+    first_cls_prediction = MultiLabelClassificationInferenceResponse(
+        image=InferenceResponseImage(width=128, height=256),
+        predictions={
+            "cat": MultiLabelClassificationPrediction(class_id=0, confidence=0.6),
+            "dog": MultiLabelClassificationPrediction(class_id=1, confidence=0.4),
+        },
+        predicted_classes=["cat", "dog"],
+    ).dict(by_alias=True, exclude_none=True)
+    first_cls_prediction["parent_id"] = "zero"
+    classification_predictions = Batch(
+        content=[
+            first_cls_prediction,
+            None,
+        ],
+        indices=[(0, 0), (0, 1)]
+    )
+
+    # when
+    result = await step.run(
+        object_detection_predictions=detections,
+        classification_predictions=classification_predictions,
+    )
+
+    # then
+    assert len(result["predictions"]) == 1, "Expected only one bbox left, as there was mo cls result for second bbox"
+    assert np.allclose(result["predictions"].xyxy, np.array([[10, 20, 30, 40]])), "Expected first bbox to be left"
+    assert np.allclose(result["predictions"].confidence, np.array([0.6])), "Expected to choose cat confidence"
+    assert np.allclose(result["predictions"].class_id, np.array([0])), "Expected to choose cat class id"
+    assert result["predictions"].data["class_name"].tolist() == ["cat"], "Expected cat class to be assigned"
+    assert len(result["predictions"].data["detection_id"]) == 1, "Expected only single detection_id"
+    assert result["predictions"].data["detection_id"].tolist() != ["zero"], "Expected to generate new detection id"
+
+
+def test_extract_leading_class_from_prediction_when_prediction_is_multi_label() -> None:
+    # given
+    prediction = ClassificationInferenceResponse(
+        image=InferenceResponseImage(width=128, height=256),
+        predictions=[
+            ClassificationPrediction(
+                **{"class": "cat", "class_id": 0, "confidence": 0.6}
+            ),
+            ClassificationPrediction(
+                **{"class": "dog", "class_id": 1, "confidence": 0.4}
+            ),
+        ],
+        top="cat",
+        confidence=0.6,
+        parent_id="some",
+    ).dict(by_alias=True, exclude_none=True)
+
+    # when
+    result = extract_leading_class_from_prediction(prediction=prediction)
+
+    # then
+    assert result == ("cat", 0, 0.6)
+
+
+def test_extract_leading_class_from_prediction_when_prediction_is_faulty_multi_label() -> None:
+    # given
+    prediction = ClassificationInferenceResponse(
+        image=InferenceResponseImage(width=128, height=256),
+        predictions=[
+            ClassificationPrediction(
+                **{"class": "cat", "class_id": 1, "confidence": 0.6}
+            ),
+            ClassificationPrediction(
+                **{"class": "cat", "class_id": 0, "confidence": 0.4}
+            ),
+        ],
+        top="cat",
+        confidence=0.6,
+        parent_id="some",
+    ).dict(by_alias=True, exclude_none=True)
+
+    # when
+    with pytest.raises(ValueError):
+        _ = extract_leading_class_from_prediction(prediction=prediction)
+
+
+def test_extract_leading_class_from_prediction_when_prediction_is_multi_class_with_predicted_classes() -> None:
+    # given
+    prediction = MultiLabelClassificationInferenceResponse(
+        image=InferenceResponseImage(width=128, height=256),
+        predictions={
+            "cat": MultiLabelClassificationPrediction(class_id=0, confidence=0.6),
+            "dog": MultiLabelClassificationPrediction(class_id=1, confidence=0.4),
+        },
+        predicted_classes=["cat", "dog"],
+    ).dict(by_alias=True, exclude_none=True)
+
+    # when
+    result = extract_leading_class_from_prediction(prediction=prediction)
+
+    # then
+    assert result == ("cat", 0, 0.6)
+
+
+def test_extract_leading_class_from_prediction_when_prediction_is_multi_class_without_predicted_classes() -> None:
+    # given
+    prediction = MultiLabelClassificationInferenceResponse(
+        image=InferenceResponseImage(width=128, height=256),
+        predictions={
+            "cat": MultiLabelClassificationPrediction(class_id=0, confidence=0.6),
+            "dog": MultiLabelClassificationPrediction(class_id=1, confidence=0.4),
+        },
+        predicted_classes=[],
+    ).dict(by_alias=True, exclude_none=True)
+
+    # when
+    result = extract_leading_class_from_prediction(prediction=prediction)
+
+    # then
+    assert result is None
+
+
+def test_extract_leading_class_from_prediction_when_prediction_is_multi_class_without_classes_defined() -> None:
+    # given
+    prediction = MultiLabelClassificationInferenceResponse(
+        image=InferenceResponseImage(width=128, height=256),
+        predictions={
+        },
+        predicted_classes=[],
+    ).dict(by_alias=True, exclude_none=True)
+
+    # when
+    result = extract_leading_class_from_prediction(prediction=prediction)
+
+    # then
+    assert result is None

--- a/tests/workflows/unit_tests/core_steps/fusion/test_domension_collapse.py
+++ b/tests/workflows/unit_tests/core_steps/fusion/test_domension_collapse.py
@@ -1,0 +1,20 @@
+import pytest
+
+from inference.core.workflows.core_steps.fusion.dimension_collapse import DimensionCollapseBlock
+from inference.core.workflows.entities.base import Batch
+
+
+@pytest.mark.asyncio
+async def test_dimension_collapse() -> None:
+    # given
+    step = DimensionCollapseBlock()
+    data = Batch(
+        content=[1, 2, 3, 4],
+        indices=[(0, 1), (0, 2), (0, 3), (0, 4)]
+    )
+
+    # when
+    result = await step.run(data=data)
+
+    # then
+    assert result == {"output": [1, 2, 3, 4]}

--- a/tests/workflows/unit_tests/execution_engine/executor/execution_data_manager/test_step_input_assembler.py
+++ b/tests/workflows/unit_tests/execution_engine/executor/execution_data_manager/test_step_input_assembler.py
@@ -513,6 +513,7 @@ def test_reduce_batch_dimensionality_when_reduction_is_legal() -> None:
     # when
     result = reduce_batch_dimensionality(
         indices=[(0, 0), (0, 1), (1, 2), (1, 3)],
+        upper_level_index=[(0,), (1,)],
         data=["a", "b", "c", "d"],
         guard_of_indices_wrapping=guard_of_indices_wrapping,
     )
@@ -541,6 +542,46 @@ def test_reduce_batch_dimensionality_when_reduction_is_legal() -> None:
     ], "Part of original index must be preserved"
 
 
+def test_reduce_batch_dimensionality_when_reduction_is_legal_but_nested_result_skip_high_level_index_element() -> (
+    None
+):
+    # given
+    guard_of_indices_wrapping = GuardForIndicesWrapping()
+
+    # when
+    result = reduce_batch_dimensionality(
+        indices=[(0, 0), (0, 1), (2, 2), (2, 3)],
+        upper_level_index=[(0,), (1,), (2,)],
+        data=["a", "b", "c", "d"],
+        guard_of_indices_wrapping=guard_of_indices_wrapping,
+    )
+
+    # then
+    assert len(result) == 3, "Expected 3 output batches"
+    assert result.indices == [
+        (0,),
+        (1,),
+        (2,),
+    ], "Expected index to be reduced 1 lvl of dimensionality"
+    assert list(result[0]) == [
+        "a",
+        "b",
+    ], "Expected 1st batch to contain elements with prefix (0, ) in index"
+    assert result[0].indices == [
+        (0, 0),
+        (0, 1),
+    ], "Part of original index must be preserved"
+    assert result[1] is None, "Expected missing element to be None"
+    assert list(result[2]) == [
+        "c",
+        "d",
+    ], "Expected 3rd batch to contain elements with prefix (2, ) in index"
+    assert result[2].indices == [
+        (2, 2),
+        (2, 3),
+    ], "Part of original index must be preserved"
+
+
 def test_reduce_batch_dimensionality_when_reduction_is_illegal() -> None:
     # given
     guard_of_indices_wrapping = GuardForIndicesWrapping()
@@ -552,6 +593,7 @@ def test_reduce_batch_dimensionality_when_reduction_is_illegal() -> None:
     with pytest.raises(ExecutionEngineRuntimeError):
         _ = reduce_batch_dimensionality(
             indices=[(0, 0), (0, 1), (1, 2), (1, 3)],
+            upper_level_index=[(0,), (1,)],
             data=["a", "b", "c", "d"],
             guard_of_indices_wrapping=guard_of_indices_wrapping,
         )

--- a/tests/workflows/unit_tests/execution_engine/executor/test_output_constructor.py
+++ b/tests/workflows/unit_tests/execution_engine/executor/test_output_constructor.py
@@ -522,6 +522,7 @@ def test_construct_workflow_output_when_batch_outputs_present() -> None:
         return [batch_data_lookup[selector][index] for index in indices]
 
     execution_data_manager.get_batch_data = get_batch_data
+    execution_data_manager.get_lineage_indices.return_value = [(0,), (1,), (2,)]
 
     # when
     result = construct_workflow_output(


### PR DESCRIPTION
# Description

In this PR we attempt to add suites of blocks serving for the following use cases:
* there is detection followed by specialised classification model
* there is need to construct outputs based on "switch-case" like statements
* there is need to collapse dimension 
* there is need to extract specific property from specific data
* there is need to put default values when not step executed
* there is need to collapse execution branches

Found 3 different solutions for situation when we detect -> crop -> classify -> construct results based on comparison of aggregated cls results with reference:
* `SOLUTION A`: put crops classification results into "class",  "class_id" and "confidence" fields of detections
* `SOLUTION B`: grab classification results into list of values (list of class names, following the order, maybe letting people configure what to extract - class names / confidences etc)
* `SOLUTION C`: generalised `SOLUTION B` - step to transform each cls result to extract property, step to aggregate properties into lists based on dimensionality, step with expression

Implemented `SOLUTION A` and `SOLUTION C` solutions as all may be relevant for some people, for instance `SOLUTION A` is most practical when visualisation of classes is requested, `SOLUTION C` is very generic and may be useful in plenty other occasions

Two bugs fixed in this PR:
* results of multi-label classification did not expose class_id which was present in model output, just not included into entity stating API responses
* Execution Engine was broken whenever there were situations of empty results in dimensionality unwrapping (no detections -> crops, then "stitch" taking detections and cropped results, with some of upper-level data missing - fixed by producing `None` elements which will be filtered out if that's the wish of block)

List any dependencies that are required for this change.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

* new tests
* CI still green
* todo - e2e tests before release, waiting for UI

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
