### PR TITLE
Change GPT-4 default model into GPT-4o

### DIFF
--- a/inference/core/workflows/core_steps/models/foundation/lmm.py
+++ b/inference/core/workflows/core_steps/models/foundation/lmm.py
@@ -57,7 +57,7 @@ class LMMConfig(BaseModel):
         default="auto",
         description="To be used for GPT-4V only.",
     )
-    gpt_model_version: str = Field(default="gpt-4-vision-preview")
+    gpt_model_version: str = Field(default="gpt-4o")
 
 
 LONG_DESCRIPTION = """

--- a/inference_cli/lib/cloud_adapter.py
+++ b/inference_cli/lib/cloud_adapter.py
@@ -90,24 +90,28 @@ def _random_char(y):
 
 def cloud_status():
     import sky
+
     print("Getting status from skypilot...")
     print(sky.status())
 
 
 def cloud_stop(cluster_name):
     import sky
+
     print(f"Stopping skypilot deployment {cluster_name}...")
     print(sky.stop(cluster_name))
 
 
 def cloud_start(cluster_name):
     import sky
+
     print(f"Starting skypilot deployment {cluster_name}")
     print(sky.start(cluster_name))
 
 
 def cloud_undeploy(cluster_name):
     import sky
+
     print(
         f"Undeploying Roboflow Inference and deleting {cluster_name}, this may take a few minutes."
     )

--- a/tests/workflows/unit_tests/core_steps/models/foundation/test_lmm.py
+++ b/tests/workflows/unit_tests/core_steps/models/foundation/test_lmm.py
@@ -497,7 +497,7 @@ async def test_execute_gpt_4v_request() -> None:
         "image": {"width": 168, "height": 192},
     }
     call_kwargs = client.chat.completions.create.call_args[1]
-    assert call_kwargs["model"] == "gpt-4-vision-preview"
+    assert call_kwargs["model"] == "gpt-4o"
     assert call_kwargs["max_tokens"] == 120
     assert (
         len(call_kwargs["messages"]) == 1


### PR DESCRIPTION
# Description

Changing default LLM for gpt-4 into gpt-4o, as `gpt-4-vision-preview` is no longer operational.

List any dependencies that are required for this change.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

tested e2e at local instance of inference

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
