### PR TITLE
Extend perspective correction to warp image

### DIFF
--- a/examples/run_perspective_correction.py
+++ b/examples/run_perspective_correction.py
@@ -256,14 +256,14 @@ if __name__ == "__main__":
     img = cv.imread(args.source_path)
 
     polygon_annotator = sv.PolygonAnnotator(thickness=10)
-    detections = result[0].get("predictions")[0]
+    detections = result[0].get("predictions")
     original_polygons = polygon_annotator.annotate(
         scene=img.copy(),
         detections=detections[detections["class_name"] != args.zones_from_class_name],
     )
     cv.drawContours(
         original_polygons,
-        [np.array(result[0].get(DYNAMIC_ZONES_OUTPUT_KEY)[0], dtype=int)],
+        [np.array(result[0].get(DYNAMIC_ZONES_OUTPUT_KEY), dtype=int)],
         -1,
         (0, 0, 255),
         10,


### PR DESCRIPTION
# Description

Extend perspective correction block to allow user to also warp the image into new perspective

## Type of change

Please delete options that are not relevant.

-   [x] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?

VSCode run config:
```json
        {  /* perspective correction */
            "name": "perspective correction",
            "type": "debugpy",
            "request": "launch",
            "program": "${workspaceFolder}/examples/run_perspective_correction.py",
            "console": "integratedTerminal",
            "args": [
                "--source-path",
                "/path/to/image.src",
                "--model-id",
                "chess-pieces-and-chess-board-instance-segmentation/6",
                "--zones-from-class-name", "board",
                "--extend-perspective-polygon-by-detections-anchor", "",
                "--warp-image"
            ],
            "env": {
                "ROBOFLOW_API_KEY": "<secret>",
                "LOG_LEVEL": "DEBUG",
                "DISABLE_VERSION_CHECK": "True"
            },
            "justMyCode": false,
        },
```
<img width="1844" alt="Screenshot 2024-07-02 at 15 10 21" src="https://github.com/roboflow/inference/assets/166530809/d1711c35-b36b-4ecf-a86a-e6e6bfe65726">

## Any specific deployment considerations

N/A

## Docs

N/A