### PR TITLE
rename PropertyExtraction -> PropertyDefinition

### DIFF
--- a/inference/core/workflows/core_steps/formatters/property_definition.py
+++ b/inference/core/workflows/core_steps/formatters/property_definition.py
@@ -23,7 +23,7 @@ from inference.core.workflows.prototypes.block import (
 )
 
 LONG_DESCRIPTION = """
-Takes input data and execute operation to extract specific data property.
+Define a field using properties from previous workflow steps.
 
 Example use-cases:
 * extraction of all class names for object-detection predictions
@@ -31,7 +31,7 @@ Example use-cases:
 * extraction ocr text from OCR result
 """
 
-SHORT_DESCRIPTION = "Extracts specific property from input data."
+SHORT_DESCRIPTION = "Define a field using properties from previous workflow steps."
 
 
 class BlockManifest(WorkflowBlockManifest):

--- a/inference/core/workflows/core_steps/formatters/property_definition.py
+++ b/inference/core/workflows/core_steps/formatters/property_definition.py
@@ -43,7 +43,7 @@ class BlockManifest(WorkflowBlockManifest):
             "block_type": "formatter",
         }
     )
-    type: Literal["PropertyExtraction"]
+    type: Literal["PropertyDefinition", "PropertyExtraction"]
     data: StepOutputSelector(
         kind=[
             BATCH_OF_OBJECT_DETECTION_PREDICTION_KIND,
@@ -62,7 +62,7 @@ class BlockManifest(WorkflowBlockManifest):
         return [OutputDefinition(name="output")]
 
 
-class PropertyExtractionBlock(WorkflowBlock):
+class PropertyDefinitionBlock(WorkflowBlock):
 
     @classmethod
     def get_manifest(cls) -> Type[WorkflowBlockManifest]:

--- a/inference/core/workflows/core_steps/fusion/detections_classes_replacement.py
+++ b/inference/core/workflows/core_steps/fusion/detections_classes_replacement.py
@@ -30,10 +30,7 @@ for multi-label classification results, most confident label is taken as boundin
 class.  
 """
 
-SHORT_DESCRIPTION = (
-    "Replaces classes of bounding boxes with classes predicted on cropped images"
-    "by classification model."
-)
+SHORT_DESCRIPTION = "Replaces classes of detections with classes predicted by a chained classification model"
 
 
 class BlockManifest(WorkflowBlockManifest):

--- a/inference/core/workflows/core_steps/loader.py
+++ b/inference/core/workflows/core_steps/loader.py
@@ -5,7 +5,7 @@ from inference.core.workflows.core_steps.formatters.expression import Expression
 from inference.core.workflows.core_steps.formatters.first_non_empty_or_default import (
     FirstNonEmptyOrDefaultBlock,
 )
-from inference.core.workflows.core_steps.formatters.property_extraction import (
+from inference.core.workflows.core_steps.formatters.property_definition import (
     PropertyDefinitionBlock,
 )
 from inference.core.workflows.core_steps.fusion.detections_classes_replacement import (

--- a/inference/core/workflows/core_steps/loader.py
+++ b/inference/core/workflows/core_steps/loader.py
@@ -6,7 +6,7 @@ from inference.core.workflows.core_steps.formatters.first_non_empty_or_default i
     FirstNonEmptyOrDefaultBlock,
 )
 from inference.core.workflows.core_steps.formatters.property_extraction import (
-    PropertyExtractionBlock,
+    PropertyDefinitionBlock,
 )
 from inference.core.workflows.core_steps.fusion.detections_classes_replacement import (
     DetectionsClassesReplacementBlock,
@@ -106,7 +106,7 @@ def load_blocks() -> List[Type[WorkflowBlock]]:
         DynamicZonesBlock,
         DetectionsClassesReplacementBlock,
         ExpressionBlock,
-        PropertyExtractionBlock,
+        PropertyDefinitionBlock,
         DimensionCollapseBlock,
         FirstNonEmptyOrDefaultBlock,
     ]

--- a/tests/workflows/integration_tests/execution/test_workflows_with_property_extraction.py
+++ b/tests/workflows/integration_tests/execution/test_workflows_with_property_extraction.py
@@ -21,7 +21,7 @@ WORKFLOW_WITH_EXTRACTION_OF_CLASSES_FOR_DETECTIONS = {
             "model_id": "yolov8n-640",
         },
         {
-            "type": "PropertyExtraction",
+            "type": "PropertyDefinition",
             "name": "property_extraction",
             "data": "$steps.general_detection.predictions",
             "operations": [
@@ -29,7 +29,7 @@ WORKFLOW_WITH_EXTRACTION_OF_CLASSES_FOR_DETECTIONS = {
             ],
         },
         {
-            "type": "PropertyExtraction",
+            "type": "PropertyDefinition",
             "name": "instances_counter",
             "data": "$steps.general_detection.predictions",
             "operations": [{"type": "SequenceLength"}],
@@ -177,7 +177,7 @@ WORKFLOW_WITH_EXTRACTION_OF_CLASS_NAME_FROM_CROPS_AND_CONCATENATION_OF_RESULTS =
             "model_id": "dog-breed-xpaq6/1",
         },
         {
-            "type": "PropertyExtraction",
+            "type": "PropertyDefinition",
             "name": "property_extraction",
             "data": "$steps.breds_classification.predictions",
             "operations": [

--- a/tests/workflows/unit_tests/core_steps/formatters/test_property_extraction.py
+++ b/tests/workflows/unit_tests/core_steps/formatters/test_property_extraction.py
@@ -1,9 +1,16 @@
 import pytest
 
-from inference.core.entities.responses.inference import ClassificationInferenceResponse, InferenceResponseImage, \
-    ClassificationPrediction
-from inference.core.workflows.core_steps.common.query_language.entities.operations import OperationsChain
-from inference.core.workflows.core_steps.formatters.property_extraction import PropertyExtractionBlock
+from inference.core.entities.responses.inference import (
+    ClassificationInferenceResponse,
+    InferenceResponseImage,
+    ClassificationPrediction,
+)
+from inference.core.workflows.core_steps.common.query_language.entities.operations import (
+    OperationsChain,
+)
+from inference.core.workflows.core_steps.formatters.property_extraction import (
+    PropertyDefinitionBlock,
+)
 
 
 @pytest.mark.asyncio
@@ -23,19 +30,21 @@ async def test_property_extraction_block() -> None:
         confidence=0.6,
         parent_id="some",
     ).dict(by_alias=True, exclude_none=True)
-    operations = OperationsChain.model_validate({
-        "operations": [
-            {
-                "type": "ClassificationPropertyExtract",
-                "property_name": "top_class",
-            },
-            {
-                "type": "LookupTable",
-                "lookup_table": {"cat": "cat-mutated"},
-            }
-        ]
-    }).operations
-    step = PropertyExtractionBlock()
+    operations = OperationsChain.model_validate(
+        {
+            "operations": [
+                {
+                    "type": "ClassificationPropertyExtract",
+                    "property_name": "top_class",
+                },
+                {
+                    "type": "LookupTable",
+                    "lookup_table": {"cat": "cat-mutated"},
+                },
+            ]
+        }
+    ).operations
+    step = PropertyDefinitionBlock()
 
     # when
     result = await step.run(data=data, operations=operations)

--- a/tests/workflows/unit_tests/core_steps/formatters/test_property_extraction.py
+++ b/tests/workflows/unit_tests/core_steps/formatters/test_property_extraction.py
@@ -8,7 +8,7 @@ from inference.core.entities.responses.inference import (
 from inference.core.workflows.core_steps.common.query_language.entities.operations import (
     OperationsChain,
 )
-from inference.core.workflows.core_steps.formatters.property_extraction import (
+from inference.core.workflows.core_steps.formatters.property_definition import (
     PropertyDefinitionBlock,
 )
 


### PR DESCRIPTION
# Description

Renames `PropertyExtraction` block to `PropertyDefinition`, leaving `PropertyExtraction` as alias

## Type of change
new block rename 

## How has this change been tested, please provide a testcase or example of how you tested the change?


## Any specific deployment considerations
n/a 

## Docs
n/a