### PR TITLE
Fix broken type coercion in Github Actions

### DIFF
--- a/.github/workflows/docker.cpu.parallel.yml
+++ b/.github/workflows/docker.cpu.parallel.yml
@@ -42,7 +42,7 @@ jobs:
         name: Build and Push
         uses: docker/build-push-action@v4
         with:
-          push: ${{ github.event_name == 'release' || github.event.inputs.force_push }}
+          push: ${{ github.event_name == 'release' || (github.event.inputs.force_push == 'true')}}
           tags: roboflow/roboflow-inference-server-cpu-parallel:latest,roboflow/roboflow-inference-server-cpu-parallel:${{env.VERSION}}
           cache-from: type=registry,ref=roboflow/roboflow-inference-server-cpu-parallel:cache
           cache-to: type=registry,ref=roboflow/roboflow-inference-server-cpu-parallel:cache,mode=max

--- a/.github/workflows/docker.cpu.slim.yml
+++ b/.github/workflows/docker.cpu.slim.yml
@@ -42,7 +42,7 @@ jobs:
         name: Build and Push
         uses: docker/build-push-action@v4
         with:
-          push: ${{ github.event_name == 'release' || github.event.inputs.force_push }}
+          push: ${{ github.event_name == 'release' || (github.event.inputs.force_push == 'true')}}
           tags: roboflow/roboflow-inference-server-cpu-slim:latest,roboflow/roboflow-inference-server-cpu-slim:${{env.VERSION}}
           cache-from: type=registry,ref=roboflow/roboflow-inference-server-cpu-slim:cache
           cache-to: type=registry,ref=roboflow/roboflow-inference-server-cpu-slim:cache,mode=max

--- a/.github/workflows/docker.cpu.yml
+++ b/.github/workflows/docker.cpu.yml
@@ -42,7 +42,7 @@ jobs:
         name: Build and Push
         uses: docker/build-push-action@v4
         with:
-          push: ${{ github.event_name == 'release' || github.event.inputs.force_push }}
+          push: ${{ github.event_name == 'release' || (github.event.inputs.force_push == 'true')}}
           tags: roboflow/roboflow-inference-server-cpu:latest,roboflow/roboflow-inference-server-cpu:${{env.VERSION}}
           cache-from: type=registry,ref=roboflow/roboflow-inference-server-cpu:cache
           cache-to: type=registry,ref=roboflow/roboflow-inference-server-cpu:cache,mode=max

--- a/.github/workflows/docker.device_manager.yml
+++ b/.github/workflows/docker.device_manager.yml
@@ -41,7 +41,7 @@ jobs:
         name: Build and Push
         uses: docker/build-push-action@v4
         with:
-          push: ${{ github.event_name == 'release' || github.event.inputs.force_push }}
+          push: ${{ github.event_name == 'release' || (github.event.inputs.force_push == 'true')}}
           tags: roboflow/roboflow-device-manager:latest,roboflow/roboflow-device-manager:${{env.VERSION}}
           cache-from: type=registry,ref=roboflow/roboflow-device-manager:cache
           cache-to: type=registry,ref=roboflow/roboflow-device-manager:cache,mode=max

--- a/.github/workflows/docker.gpu.parallel.yml
+++ b/.github/workflows/docker.gpu.parallel.yml
@@ -46,7 +46,7 @@ jobs:
         name: Build and Push
         uses: docker/build-push-action@v4
         with:
-          push: ${{ github.event_name == 'release' || github.event.inputs.force_push }}
+          push: ${{ github.event_name == 'release' || (github.event.inputs.force_push == 'true')}}
           tags: roboflow/roboflow-inference-server-gpu-parallel:latest,roboflow/roboflow-inference-server-gpu-parallel:${{env.VERSION}}
           cache-from: type=registry,ref=roboflow/roboflow-inference-server-gpu-parallel:cache
           cache-to: type=registry,ref=roboflow/roboflow-inference-server-gpu-parallel:cache,mode=max

--- a/.github/workflows/docker.gpu.slim.yml
+++ b/.github/workflows/docker.gpu.slim.yml
@@ -45,7 +45,7 @@ jobs:
         name: Build and Push
         uses: docker/build-push-action@v4
         with:
-          push: ${{ github.event_name == 'release' || github.event.inputs.force_push }}
+          push: ${{ github.event_name == 'release' || (github.event.inputs.force_push == 'true')}}
           tags: roboflow/roboflow-inference-server-gpu-slim:latest,roboflow/roboflow-inference-server-gpu-slim:${{env.VERSION}}
           cache-from: type=registry,ref=roboflow/roboflow-inference-server-gpu-slim:cache
           cache-to: type=registry,ref=roboflow/roboflow-inference-server-gpu-slim:cache,mode=max

--- a/.github/workflows/docker.gpu.udp.yml
+++ b/.github/workflows/docker.gpu.udp.yml
@@ -44,7 +44,7 @@ jobs:
         name: Build and Push
         uses: docker/build-push-action@v4
         with:
-          push: ${{ github.event_name == 'release' || github.event.inputs.force_push }}
+          push: ${{ github.event_name == 'release' || (github.event.inputs.force_push == 'true')}}
           tags: roboflow/roboflow-inference-server-udp-gpu:latest,roboflow/roboflow-inference-server-udp-gpu:${{env.VERSION}}
           cache-from: type=registry,ref=roboflow/roboflow-inference-server-udp-gpu:cache
           cache-to: type=registry,ref=roboflow/roboflow-inference-server-udp-gpu:cache,mode=max

--- a/.github/workflows/docker.gpu.yml
+++ b/.github/workflows/docker.gpu.yml
@@ -45,7 +45,7 @@ jobs:
         name: Build and Push
         uses: docker/build-push-action@v4
         with:
-          push: ${{ github.event_name == 'release' || github.event.inputs.force_push }}
+          push: ${{ github.event_name == 'release' || (github.event.inputs.force_push == 'true')}}
           tags: roboflow/roboflow-inference-server-gpu:latest,roboflow/roboflow-inference-server-gpu:${{env.VERSION}}
           cache-from: type=registry,ref=roboflow/roboflow-inference-server-gpu:cache
           cache-to: type=registry,ref=roboflow/roboflow-inference-server-gpu:cache,mode=max

--- a/.github/workflows/docker.jetson.4.5.0.yml
+++ b/.github/workflows/docker.jetson.4.5.0.yml
@@ -45,7 +45,7 @@ jobs:
         name: Build and Push
         uses: docker/build-push-action@v4
         with:
-          push: ${{ github.event_name == 'release' || github.event.inputs.force_push }}
+          push: ${{ github.event_name == 'release' || (github.event.inputs.force_push == 'true')}}
           tags: roboflow/roboflow-inference-server-jetson-4.5.0:latest,roboflow/roboflow-inference-server-jetson-4.5.0:${{env.VERSION}}
           cache-from: type=registry,ref=roboflow/roboflow-inference-server-jetson-4.5.0:cache
           cache-to: type=registry,ref=roboflow/roboflow-inference-server-jetson-4.5.0:cache,mode=max

--- a/.github/workflows/docker.jetson.4.6.1.yml
+++ b/.github/workflows/docker.jetson.4.6.1.yml
@@ -45,7 +45,7 @@ jobs:
         name: Build and Push
         uses: docker/build-push-action@v4
         with:
-          push: ${{ github.event_name == 'release' || github.event.inputs.force_push }}
+          push: ${{ github.event_name == 'release' || (github.event.inputs.force_push == 'true')}}
           tags: roboflow/roboflow-inference-server-jetson-4.6.1:latest,roboflow/roboflow-inference-server-jetson-4.6.1:${{env.VERSION}}
           cache-from: type=registry,ref=roboflow/roboflow-inference-server-jetson-4.6.1:cache
           cache-to: type=registry,ref=roboflow/roboflow-inference-server-jetson-4.6.1:cache,mode=max

--- a/.github/workflows/docker.jetson.5.1.1.yml
+++ b/.github/workflows/docker.jetson.5.1.1.yml
@@ -45,7 +45,7 @@ jobs:
         name: Build and Push
         uses: docker/build-push-action@v4
         with:
-          push: ${{ github.event_name == 'release' || github.event.inputs.force_push }}
+          push: ${{ github.event_name == 'release' || (github.event.inputs.force_push == 'true')}}
           tags: roboflow/roboflow-inference-server-jetson-5.1.1:latest,roboflow/roboflow-inference-server-jetson-5.1.1:${{ env.VERSION}}
           cache-from: type=registry,ref=roboflow/roboflow-inference-server-jetson-5.1.1:cache
           cache-to: type=registry,ref=roboflow/roboflow-inference-server-jetson-5.1.1:cache,mode=max

--- a/.github/workflows/docker.stream_management_api.yml
+++ b/.github/workflows/docker.stream_management_api.yml
@@ -41,7 +41,7 @@ jobs:
         name: Build and Push
         uses: docker/build-push-action@v4
         with:
-          push: ${{ github.event_name == 'release' || github.event.inputs.force_push }}
+          push: ${{ github.event_name == 'release' || (github.event.inputs.force_push == 'true')}}
           tags: roboflow/roboflow-inference-stream-management-api:latest,roboflow/roboflow-inference-stream-management-api:${{env.VERSION}}
           cache-from: type=registry,ref=roboflow/roboflow-inference-stream-management-api:cache
           cache-to: type=registry,ref=roboflow/roboflow-inference-stream-management-api:cache,mode=max

--- a/.github/workflows/docker.stream_manager.cpu.yml
+++ b/.github/workflows/docker.stream_manager.cpu.yml
@@ -41,7 +41,7 @@ jobs:
         name: Build and Push
         uses: docker/build-push-action@v4
         with:
-          push: ${{ github.event_name == 'release' || github.event.inputs.force_push }}
+          push: ${{ github.event_name == 'release' || (github.event.inputs.force_push == 'true')}}
           tags: roboflow/roboflow-inference-stream-manager-cpu:latest,roboflow/roboflow-inference-stream-manager-cpu:${{env.VERSION}}
           cache-from: type=registry,ref=roboflow/roboflow-inference-stream-manager-cpu:cache
           cache-to: type=registry,ref=roboflow/roboflow-inference-stream-manager-cpu:cache,mode=max

--- a/.github/workflows/docker.stream_manager.gpu.yml
+++ b/.github/workflows/docker.stream_manager.gpu.yml
@@ -45,7 +45,7 @@ jobs:
         name: Build and Push
         uses: docker/build-push-action@v4
         with:
-          push: ${{ github.event_name == 'release' || github.event.inputs.force_push }}
+          push: ${{ github.event_name == 'release' || (github.event.inputs.force_push == 'true')}}
           tags: roboflow/roboflow-inference-stream-manager-gpu:latest,roboflow/roboflow-inference-stream-manager-gpu:${{env.VERSION}}
           cache-from: type=registry,ref=roboflow/roboflow-inference-stream-manager-gpu:cache
           cache-to: type=registry,ref=roboflow/roboflow-inference-stream-manager-gpu,mode=max

--- a/.github/workflows/docker.stream_manager.jetson.5.1.1.yml
+++ b/.github/workflows/docker.stream_manager.jetson.5.1.1.yml
@@ -46,7 +46,7 @@ jobs:
         name: Build and Push
         uses: docker/build-push-action@v4
         with:
-          push: ${{ github.event_name == 'release' || github.event.inputs.force_push }}
+          push: ${{ github.event_name == 'release' || (github.event.inputs.force_push == 'true')}}
           tags: roboflow/roboflow-inference-stream-manager-jetson-5.1.1:latest,roboflow/roboflow-inference-stream-manager-jetson-5.1.1:${{ env.VERSION}}
           cache-from: type=registry,ref=roboflow/roboflow-inference-stream-manager-jetson-5.1.1:cache
           cache-to: type=registry,ref=roboflow/roboflow-inference-stream-manager-jetson-5.1.1:cache,mode=max

--- a/.github/workflows/docker.trt.yml
+++ b/.github/workflows/docker.trt.yml
@@ -45,7 +45,7 @@ jobs:
         name: Build and Push
         uses: docker/build-push-action@v4
         with:
-          push: ${{ github.event_name == 'release' || github.event.inputs.force_push }}
+          push: ${{ github.event_name == 'release' || (github.event.inputs.force_push == 'true')}}
           tags: roboflow/roboflow-inference-server-trt:latest,roboflow/roboflow-inference-server-trt:${{env.VERSION}}
           cache-from: type=registry,ref=roboflow/roboflow-inference-server-trt:cache
           cache-to: type=registry,ref=roboflow/roboflow-inference-server-trt:cache,mode=max


### PR DESCRIPTION
# Description

All docker builds on merge to main (`push` event) were failing on `build_and_push` step with error:
```
Input does not meet YAML 1.2 "Core Schema" specification: push Support boolean input list: `true \| True \| TRUE \| false \| False \| FALSE`
```
that was due to:
```
        name: Build and Push
        uses: docker/build-push-action@v4
        with:
          push: ${{ github.event_name == 'release' || github.event.inputs.force_push }}
                                                                                    ^^^ this gets substituted with empty str and we have false || '' -> '' which is string, not bool as expected
```

Fixed that by checking the value with `==`. What is important - tested against literal `true` in my private repo and it does not work, in GHA, when taking bool input we must assume string - hence `== 'true'`. 


## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

* tested e2e on representative worklflow in private repo

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
