### PR TITLE
Fail tests on supervision warnings

### DIFF
--- a/inference/core/interfaces/stream/sinks.py
+++ b/inference/core/interfaces/stream/sinks.py
@@ -17,7 +17,7 @@ from inference.core.interfaces.stream.utils import wrap_in_list
 from inference.core.utils.drawing import create_tiles
 from inference.core.utils.preprocess import letterbox_image
 
-DEFAULT_BBOX_ANNOTATOR = sv.BoundingBoxAnnotator()
+DEFAULT_BBOX_ANNOTATOR = sv.BoxAnnotator()
 DEFAULT_LABEL_ANNOTATOR = sv.LabelAnnotator()
 DEFAULT_FPS_MONITOR = sv.FPSMonitor()
 
@@ -50,7 +50,7 @@ def render_boxes(
     """
     Helper tool to render object detection predictions on top of video frame. It is designed
     to be used with `InferencePipeline`, as sink for predictions. By default it uses
-    standard `sv.BoundingBoxAnnotator()` chained with `sv.LabelAnnotator()`
+    standard `sv.BoxAnnotator()` chained with `sv.LabelAnnotator()`
     to draw bounding boxes and resizes prediction to 1280x720 (keeping aspect ratio and adding black padding).
     One may configure default behaviour, for instance to display latency and throughput statistics.
     In batch mode it will display tiles of frames and overlay predictions.
@@ -69,7 +69,7 @@ def render_boxes(
             by `VideoSource` or list of frames from (it is possible for empty batch frames at corresponding positions
             to `predictions` list). Order is expected to match with `predictions`
         annotator (Union[BaseAnnotator, List[BaseAnnotator]]): instance of class inheriting from supervision BaseAnnotator
-            or list of such instances. If nothing is passed chain of `sv.BoundingBoxAnnotator()` and `sv.LabelAnnotator()` is used.
+            or list of such instances. If nothing is passed chain of `sv.BoxAnnotator()` and `sv.LabelAnnotator()` is used.
         display_size (Tuple[int, int]): tuple in format (width, height) to resize visualisation output
         fps_monitor (Optional[sv.FPSMonitor]): FPS monitor used to monitor throughput
         display_statistics (bool): Flag to decide if throughput and latency can be displayed in the result image,
@@ -419,7 +419,7 @@ class VideoFileSink:
         Args:
             video_file_name (str): name of the video file to save predictions
             annotator (Union[BaseAnnotator, List[BaseAnnotator]]): instance of class inheriting from supervision BaseAnnotator
-                or list of such instances. If nothing is passed chain of `sv.BoundingBoxAnnotator()` and `sv.LabelAnnotator()` is used.
+                or list of such instances. If nothing is passed chain of `sv.BoxAnnotator()` and `sv.LabelAnnotator()` is used.
             display_size (Tuple[int, int]): tuple in format (width, height) to resize visualisation output. Should
                 be set to the same value as `display_size` for InferencePipeline with single video source, otherwise
                 it represents the size of single visualisation tile (whole tiles mosaic will be scaled to

--- a/inference_cli/lib/infer_adapter.py
+++ b/inference_cli/lib/infer_adapter.py
@@ -8,7 +8,7 @@ import cv2
 import numpy as np
 from supervision import (
     BlurAnnotator,
-    BoundingBoxAnnotator,
+    BoxAnnotator,
     BoxCornerAnnotator,
     ByteTrack,
     CircleAnnotator,
@@ -46,7 +46,7 @@ CONFIGS_DIR_PATH = os.path.abspath(
 )
 
 ANNOTATOR_TYPE2CLASS = {
-    "bounding_box": BoundingBoxAnnotator,
+    "bounding_box": BoxAnnotator,
     "mask": MaskAnnotator,
     "polygon": PolygonAnnotator,
     "color": ColorAnnotator,
@@ -313,7 +313,7 @@ def is_something_to_do(
 def build_visualisation_callback(
     visualisation_config: Optional[str],
 ) -> Callable[[np.ndarray, dict], Optional[np.ndarray]]:
-    annotators = [BoundingBoxAnnotator()]
+    annotators = [BoxAnnotator()]
     byte_tracker = None
     if visualisation_config is not None:
         raw_configuration = retrieve_visualisation_config(

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,5 @@
 [pytest]
 markers =
     slow: marks tests as slow (deselect with '-m "not slow"')
+filterwarnings =
+    error::supervision.utils.internal.SupervisionWarnings

--- a/tests/workflows/integration_tests/execution/stub_plugins/dimensionality_manipulation_plugin/tile_detections_batch.py
+++ b/tests/workflows/integration_tests/execution/stub_plugins/dimensionality_manipulation_plugin/tile_detections_batch.py
@@ -84,7 +84,7 @@ class TileDetectionsBatchBlock(WorkflowBlock):
         images_crops: Batch[Batch[WorkflowImageData]],
         crops_predictions: Batch[Batch[sv.Detections]],
     ) -> BlockResult:
-        annotator = sv.BoundingBoxAnnotator()
+        annotator = sv.BoxAnnotator()
         visualisations = []
         for image_crops, crop_predictions in zip(images_crops, crops_predictions):
             visualisations_batch_element = []

--- a/tests/workflows/integration_tests/execution/stub_plugins/dimensionality_manipulation_plugin/tile_detections_non_batch.py
+++ b/tests/workflows/integration_tests/execution/stub_plugins/dimensionality_manipulation_plugin/tile_detections_non_batch.py
@@ -80,7 +80,7 @@ class TileDetectionsNonBatchBlock(WorkflowBlock):
         crops: Batch[WorkflowImageData],
         crops_predictions: Batch[sv.Detections],
     ) -> BlockResult:
-        annotator = sv.BoundingBoxAnnotator()
+        annotator = sv.BoxAnnotator()
         visualisations = []
         for image, prediction in zip(crops, crops_predictions):
             annotated_image = annotator.annotate(


### PR DESCRIPTION
# Description

Make pytest fail with supervision warnings to be able to fix them faster.

Tests are broken because of supervision release, #526 have many fixes to support it properly.

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

CI pass
