### PR TITLE
Fix broken NMS function

### DIFF
--- a/inference/core/nms.py
+++ b/inference/core/nms.py
@@ -52,7 +52,7 @@ def w_np_non_max_suppression(
     batch_predictions = []
     for np_image_i, np_image_pred in enumerate(prediction):
         filtered_predictions = []
-        np_conf_mask = (np_image_pred[:, 4] >= conf_thresh).squeeze()
+        np_conf_mask = np_image_pred[:, 4] >= conf_thresh
 
         np_image_pred = np_image_pred[np_conf_mask]
         cls_confs = np_image_pred[:, 5 : num_classes + 5]

--- a/inference/models/yolo_world/yolo_world.py
+++ b/inference/models/yolo_world/yolo_world.py
@@ -1,6 +1,6 @@
 import os.path
 from time import perf_counter
-from typing import Any, Optional
+from typing import Any, List, Optional
 
 import clip
 import numpy as np
@@ -127,7 +127,13 @@ class YOLOWorld(RoboflowCoreModel):
             bbox_array = np.array([box.xywh.tolist()[0] for box in results.boxes])
             conf_array = np.array([[float(box.conf)] for box in results.boxes])
             cls_array = np.array(
-                [self.get_cls_conf_array(int(box.cls)) for box in results.boxes]
+                [
+                    self.get_cls_conf_array(
+                        max_class_id=int(box.cls),
+                        max_class_confidence=float(box.conf),
+                    )
+                    for box in results.boxes
+                ]
             )
 
             pred_array = np.concatenate([bbox_array, conf_array, cls_array], axis=1)
@@ -224,7 +230,9 @@ class YOLOWorld(RoboflowCoreModel):
         """
         return ["yolo-world.pt"]
 
-    def get_cls_conf_array(self, class_id) -> list:
-        arr = [0] * len(self.class_names)
-        arr[class_id] = 1
+    def get_cls_conf_array(
+        self, max_class_id: int, max_class_confidence: float
+    ) -> List[float]:
+        arr = [0.0] * len(self.class_names)
+        arr[max_class_id] = max_class_confidence
         return arr

--- a/tests/inference/models_predictions_tests/test_yolo_world.py
+++ b/tests/inference/models_predictions_tests/test_yolo_world.py
@@ -1,7 +1,7 @@
 import numpy as np
+import supervision as sv
 
 from inference.models import YOLOWorld
-import supervision as sv
 
 
 def test_yolo_world_v1_s_against_single_image(person_image: np.ndarray) -> None:
@@ -29,6 +29,46 @@ def test_yolo_world_v1_s_against_single_image(person_image: np.ndarray) -> None:
     detection_results = sv.Detections.from_inference(results)
 
     # then
+    assert len(detection_results) == len(
+        expected_detections
+    ), "Expected the same number of boxes"
+    assert np.allclose(
+        detection_results.xyxy, expected_detections.xyxy, atol=0.05
+    ), "Boxes coordinates detection differ"
+    assert np.allclose(
+        detection_results.confidence, expected_detections.confidence, atol=1e-4
+    ), "Confidences differ"
+    assert np.allclose(
+        detection_results.class_id, expected_detections.class_id
+    ), "Classes id differ"
+
+
+def test_yolo_world_v1_s_against_single_image_with_only_one_detected_box(
+    person_image: np.ndarray,
+) -> None:
+    # given
+    model = YOLOWorld(model_id="yolo_world/s")
+    model.set_classes(["person"])
+    expected_detections = sv.Detections(
+        xyxy=np.array(
+            [
+                [273.18, 160.18, 358.61, 378.85],
+            ]
+        ),
+        confidence=np.array([0.9503]),
+        class_id=np.array([0]),
+    )
+
+    # when
+    results = model.infer(person_image, confidence=0.03).dict(
+        by_alias=True, exclude_none=True
+    )
+    detection_results = sv.Detections.from_inference(results)
+
+    # then
+    assert len(detection_results) == len(
+        expected_detections
+    ), "Expected the same number of boxes"
     assert np.allclose(
         detection_results.xyxy, expected_detections.xyxy, atol=0.05
     ), "Boxes coordinates detection differ"
@@ -62,7 +102,11 @@ def test_yolo_world_v1_m_against_single_image(person_image: np.ndarray) -> None:
         by_alias=True, exclude_none=True
     )
     detection_results = sv.Detections.from_inference(results)
+
     # then
+    assert len(detection_results) == len(
+        expected_detections
+    ), "Expected the same number of boxes"
     assert np.allclose(
         detection_results.xyxy,
         expected_detections.xyxy,
@@ -98,7 +142,11 @@ def test_yolo_world_v1_l_against_single_image(person_image: np.ndarray) -> None:
         by_alias=True, exclude_none=True
     )
     detection_results = sv.Detections.from_inference(results)
+
     # then
+    assert len(detection_results) == len(
+        expected_detections
+    ), "Expected the same number of boxes"
     assert np.allclose(
         detection_results.xyxy, expected_detections.xyxy, atol=0.05
     ), "Boxes coordinates detection differ"
@@ -132,7 +180,11 @@ def test_yolo_world_v1_x_against_single_image(person_image: np.ndarray) -> None:
         by_alias=True, exclude_none=True
     )
     detection_results = sv.Detections.from_inference(results)
+
     # then
+    assert len(detection_results) == len(
+        expected_detections
+    ), "Expected the same number of boxes"
     assert np.allclose(
         detection_results.xyxy, expected_detections.xyxy, atol=0.05
     ), "Boxes coordinates detection differ"
@@ -168,6 +220,9 @@ def test_yolo_world_v2_s_against_single_image(person_image: np.ndarray) -> None:
     detection_results = sv.Detections.from_inference(results)
 
     # then
+    assert len(detection_results) == len(
+        expected_detections
+    ), "Expected the same number of boxes"
     assert np.allclose(
         detection_results.xyxy, expected_detections.xyxy, atol=0.05
     ), "Boxes coordinates detection differ"
@@ -202,6 +257,9 @@ def test_yolo_world_v2_m_against_single_image(person_image: np.ndarray) -> None:
     )
     detection_results = sv.Detections.from_inference(results)
     # then
+    assert len(detection_results) == len(
+        expected_detections
+    ), "Expected the same number of boxes"
     assert np.allclose(
         detection_results.xyxy, expected_detections.xyxy, atol=0.05
     ), "Boxes coordinates detection differ"
@@ -235,7 +293,11 @@ def test_yolo_world_v2_l_against_single_image(person_image: np.ndarray) -> None:
         by_alias=True, exclude_none=True
     )
     detection_results = sv.Detections.from_inference(results)
+
     # then
+    assert len(detection_results) == len(
+        expected_detections
+    ), "Expected the same number of boxes"
     assert np.allclose(
         detection_results.xyxy, expected_detections.xyxy, atol=0.05
     ), "Boxes coordinates detection differ"
@@ -269,7 +331,11 @@ def test_yolo_world_v2_x_against_single_image(person_image: np.ndarray) -> None:
         by_alias=True, exclude_none=True
     )
     detection_results = sv.Detections.from_inference(results)
+
     # then
+    assert len(detection_results) == len(
+        expected_detections
+    ), "Expected the same number of boxes"
     assert np.allclose(
         detection_results.xyxy, expected_detections.xyxy, atol=0.05
     ), "Boxes coordinates detection differ"

--- a/tests/inference/models_predictions_tests/test_yolonas.py
+++ b/tests/inference/models_predictions_tests/test_yolonas.py
@@ -1,9 +1,7 @@
 import numpy as np
 import pytest
 
-from inference.core.entities.responses.inference import (
-    ObjectDetectionInferenceResponse,
-)
+from inference.core.entities.responses.inference import ObjectDetectionInferenceResponse
 from inference.core.env import MAX_BATCH_SIZE
 from inference.models import YOLONASObjectDetection
 

--- a/tests/inference/models_predictions_tests/test_yolov10.py
+++ b/tests/inference/models_predictions_tests/test_yolov10.py
@@ -1,13 +1,9 @@
 import numpy as np
 import pytest
 
-from inference.core.entities.responses.inference import (
-    ObjectDetectionInferenceResponse,
-)
+from inference.core.entities.responses.inference import ObjectDetectionInferenceResponse
 from inference.core.env import MAX_BATCH_SIZE
-from inference.models import (
-    YOLOv10ObjectDetection,
-)
+from inference.models import YOLOv10ObjectDetection
 
 
 @pytest.mark.slow


### PR DESCRIPTION
# Description
Bug report: https://github.com/roboflow/inference/issues/529

There was a bug in NMS function causing very strange errors:

Old:
```
np_conf_mask = (np_image_pred[:, 4] >= conf_thresh).squeeze()
```

when np_image_pred was of size (1, n) - which represents one box for image - `squeeze()` were pushing `np.array([True]) -> True` and leaving `(k, n)` -> lists of k-elements booleans.

Now, let's take a look what happens if we run this:
```
np.array([1, 2, 3])[True]
>>> array([[1, 2, 3]])  # dimension expand!
```
so `np_conf_mask` used in `np_image_pred = np_image_pred[np_conf_mask]` were causing dim expansion, instead of 
selecting one or none elements.

Then - expanded `np_conf_mask` had size `(1, 1, n)` in problematic case - and line `cls_confs = np_image_pred[:, 5 : num_classes + 5]` selecting from 2nd dim - was returning empty array shape=`(1, 0, n)`
this was causing adding empty `filtered_predictions` to results!
```
        if (
            np_image_pred.shape[0] == 0
            or np_image_pred.shape[1] == 0
            or cls_confs.shape[1] == 0
        ):
            batch_predictions.append(filtered_predictions)
            continue
```

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

YOUR_ANSWER

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
