### PR TITLE
Refactor Visualization Workflow Block Inheritance

### DIFF
--- a/inference/core/workflows/core_steps/visualizations/base.py
+++ b/inference/core/workflows/core_steps/visualizations/base.py
@@ -58,93 +58,6 @@ class VisualizationManifest(WorkflowBlockManifest, ABC):
         default=True,
     )
 
-    color_palette: Union[
-        Literal[
-            "DEFAULT",
-            "CUSTOM",
-            "ROBOFLOW",
-            "Matplotlib Viridis",
-            "Matplotlib Plasma",
-            "Matplotlib Inferno",
-            "Matplotlib Magma",
-            "Matplotlib Cividis",
-            # TODO: Re-enable once supervision 0.23 is released with a fix
-            # "Matplotlib Twilight",
-            # "Matplotlib Twilight_Shifted",
-            # "Matplotlib HSV",
-            # "Matplotlib Jet",
-            # "Matplotlib Turbo",
-            # "Matplotlib Rainbow",
-            # "Matplotlib gist_rainbow",
-            # "Matplotlib nipy_spectral",
-            # "Matplotlib gist_ncar",
-            "Matplotlib Pastel1",
-            "Matplotlib Pastel2",
-            "Matplotlib Paired",
-            "Matplotlib Accent",
-            "Matplotlib Dark2",
-            "Matplotlib Set1",
-            "Matplotlib Set2",
-            "Matplotlib Set3",
-            "Matplotlib Tab10",
-            "Matplotlib Tab20",
-            "Matplotlib Tab20b",
-            "Matplotlib Tab20c",
-            # TODO: Re-enable once supervision 0.23 is released with a fix
-            # "Matplotlib Ocean",
-            # "Matplotlib Gist_Earth",
-            # "Matplotlib Terrain",
-            # "Matplotlib Stern",
-            # "Matplotlib gnuplot",
-            # "Matplotlib gnuplot2",
-            # "Matplotlib Spring",
-            # "Matplotlib Summer",
-            # "Matplotlib Autumn",
-            # "Matplotlib Winter",
-            # "Matplotlib Cool",
-            # "Matplotlib Hot",
-            # "Matplotlib Copper",
-            # "Matplotlib Bone",
-            # "Matplotlib Greys_R",
-            # "Matplotlib Purples_R",
-            # "Matplotlib Blues_R",
-            # "Matplotlib Greens_R",
-            # "Matplotlib Oranges_R",
-            # "Matplotlib Reds_R",
-        ],
-        WorkflowParameterSelector(kind=[STRING_KIND]),
-    ] = Field(  # type: ignore
-        default="DEFAULT",
-        description="Color palette to use for annotations.",
-        examples=["DEFAULT", "$inputs.color_palette"],
-    )
-
-    palette_size: Union[
-        int,
-        WorkflowParameterSelector(kind=[INTEGER_KIND]),
-    ] = Field(  # type: ignore
-        default=10,
-        description="Number of colors in the color palette. Applies when using a matplotlib `color_palette`.",
-        examples=[10, "$inputs.palette_size"],
-    )
-
-    custom_colors: Union[
-        List[str], WorkflowParameterSelector(kind=[LIST_OF_VALUES_KIND])
-    ] = Field(  # type: ignore
-        default=[],
-        description='List of colors to use for annotations when `color_palette` is set to "CUSTOM".',
-        examples=[["#FF0000", "#00FF00", "#0000FF"], "$inputs.custom_colors"],
-    )
-
-    color_axis: Union[
-        Literal["INDEX", "CLASS", "TRACK"],
-        WorkflowParameterSelector(kind=[STRING_KIND]),
-    ] = Field(  # type: ignore
-        default="CLASS",
-        description="Strategy to use for mapping colors to annotations.",
-        examples=["CLASS", "$inputs.color_axis"],
-    )
-
     @classmethod
     def describe_outputs(cls) -> List[OutputDefinition]:
         return [
@@ -170,50 +83,12 @@ class VisualizationBlock(WorkflowBlock, ABC):
     def getAnnotator(self, *args, **kwargs) -> sv.annotators.base.BaseAnnotator:
         pass
 
-    @classmethod
-    def getPalette(self, color_palette, palette_size, custom_colors):
-        if color_palette == "CUSTOM":
-            return sv.ColorPalette(
-                colors=[str_to_color(color) for color in custom_colors]
-            )
-        elif hasattr(sv.ColorPalette, color_palette):
-            return getattr(sv.ColorPalette, color_palette)
-        else:
-            palette_name = color_palette.replace("Matplotlib ", "")
-
-            if palette_name in [
-                "Greys_R",
-                "Purples_R",
-                "Blues_R",
-                "Greens_R",
-                "Oranges_R",
-                "Reds_R",
-                "Wistia",
-                "Pastel1",
-                "Pastel2",
-                "Paired",
-                "Accent",
-                "Dark2",
-                "Set1",
-                "Set2",
-                "Set3",
-            ]:
-                palette_name = palette_name.capitalize()
-            else:
-                palette_name = palette_name.lower()
-
-            return sv.ColorPalette.from_matplotlib(palette_name, int(palette_size))
-
     @abstractmethod
     async def run(
         self,
         image: WorkflowImageData,
         predictions: sv.Detections,
         copy_image: bool,
-        color_palette: Optional[str],
-        palette_size: Optional[int],
-        custom_colors: Optional[List[str]],
-        color_axis: Optional[str],
         *args,
         **kwargs
     ) -> BlockResult:

--- a/inference/core/workflows/core_steps/visualizations/base_colorable.py
+++ b/inference/core/workflows/core_steps/visualizations/base_colorable.py
@@ -1,0 +1,159 @@
+from abc import ABC, abstractmethod
+from typing import List, Literal, Optional, Union
+
+import supervision as sv
+from pydantic import Field
+
+from inference.core.workflows.core_steps.visualizations.base import (
+    VisualizationBlock,
+    VisualizationManifest,
+)
+from inference.core.workflows.core_steps.visualizations.utils import str_to_color
+from inference.core.workflows.entities.base import WorkflowImageData
+from inference.core.workflows.entities.types import (
+    INTEGER_KIND,
+    LIST_OF_VALUES_KIND,
+    STRING_KIND,
+    WorkflowParameterSelector,
+)
+from inference.core.workflows.prototypes.block import BlockResult
+
+
+class ColorableVisualizationManifest(VisualizationManifest, ABC):
+    color_palette: Union[
+        Literal[
+            "DEFAULT",
+            "CUSTOM",
+            "ROBOFLOW",
+            "Matplotlib Viridis",
+            "Matplotlib Plasma",
+            "Matplotlib Inferno",
+            "Matplotlib Magma",
+            "Matplotlib Cividis",
+            # TODO: Re-enable once supervision 0.23 is released with a fix
+            # "Matplotlib Twilight",
+            # "Matplotlib Twilight_Shifted",
+            # "Matplotlib HSV",
+            # "Matplotlib Jet",
+            # "Matplotlib Turbo",
+            # "Matplotlib Rainbow",
+            # "Matplotlib gist_rainbow",
+            # "Matplotlib nipy_spectral",
+            # "Matplotlib gist_ncar",
+            "Matplotlib Pastel1",
+            "Matplotlib Pastel2",
+            "Matplotlib Paired",
+            "Matplotlib Accent",
+            "Matplotlib Dark2",
+            "Matplotlib Set1",
+            "Matplotlib Set2",
+            "Matplotlib Set3",
+            "Matplotlib Tab10",
+            "Matplotlib Tab20",
+            "Matplotlib Tab20b",
+            "Matplotlib Tab20c",
+            # TODO: Re-enable once supervision 0.23 is released with a fix
+            # "Matplotlib Ocean",
+            # "Matplotlib Gist_Earth",
+            # "Matplotlib Terrain",
+            # "Matplotlib Stern",
+            # "Matplotlib gnuplot",
+            # "Matplotlib gnuplot2",
+            # "Matplotlib Spring",
+            # "Matplotlib Summer",
+            # "Matplotlib Autumn",
+            # "Matplotlib Winter",
+            # "Matplotlib Cool",
+            # "Matplotlib Hot",
+            # "Matplotlib Copper",
+            # "Matplotlib Bone",
+            # "Matplotlib Greys_R",
+            # "Matplotlib Purples_R",
+            # "Matplotlib Blues_R",
+            # "Matplotlib Greens_R",
+            # "Matplotlib Oranges_R",
+            # "Matplotlib Reds_R",
+        ],
+        WorkflowParameterSelector(kind=[STRING_KIND]),
+    ] = Field(  # type: ignore
+        default="DEFAULT",
+        description="Color palette to use for annotations.",
+        examples=["DEFAULT", "$inputs.color_palette"],
+    )
+
+    palette_size: Union[
+        int,
+        WorkflowParameterSelector(kind=[INTEGER_KIND]),
+    ] = Field(  # type: ignore
+        default=10,
+        description="Number of colors in the color palette. Applies when using a matplotlib `color_palette`.",
+        examples=[10, "$inputs.palette_size"],
+    )
+
+    custom_colors: Union[
+        List[str], WorkflowParameterSelector(kind=[LIST_OF_VALUES_KIND])
+    ] = Field(  # type: ignore
+        default=[],
+        description='List of colors to use for annotations when `color_palette` is set to "CUSTOM".',
+        examples=[["#FF0000", "#00FF00", "#0000FF"], "$inputs.custom_colors"],
+    )
+
+    color_axis: Union[
+        Literal["INDEX", "CLASS", "TRACK"],
+        WorkflowParameterSelector(kind=[STRING_KIND]),
+    ] = Field(  # type: ignore
+        default="CLASS",
+        description="Strategy to use for mapping colors to annotations.",
+        examples=["CLASS", "$inputs.color_axis"],
+    )
+
+
+class ColorableVisualizationBlock(VisualizationBlock, ABC):
+    @classmethod
+    def getPalette(self, color_palette, palette_size, custom_colors):
+        if color_palette == "CUSTOM":
+            return sv.ColorPalette(
+                colors=[str_to_color(color) for color in custom_colors]
+            )
+        elif hasattr(sv.ColorPalette, color_palette):
+            return getattr(sv.ColorPalette, color_palette)
+        else:
+            palette_name = color_palette.replace("Matplotlib ", "")
+
+            if palette_name in [
+                "Greys_R",
+                "Purples_R",
+                "Blues_R",
+                "Greens_R",
+                "Oranges_R",
+                "Reds_R",
+                "Wistia",
+                "Pastel1",
+                "Pastel2",
+                "Paired",
+                "Accent",
+                "Dark2",
+                "Set1",
+                "Set2",
+                "Set3",
+            ]:
+                palette_name = palette_name.capitalize()
+            else:
+                palette_name = palette_name.lower()
+
+            return sv.ColorPalette.from_matplotlib(palette_name, int(palette_size))
+
+    @abstractmethod
+    async def run(
+        self,
+        image: WorkflowImageData,
+        predictions: sv.Detections,
+        copy_image: bool,
+        color_palette: Optional[str],
+        palette_size: Optional[int],
+        custom_colors: Optional[List[str]],
+        color_axis: Optional[str],
+        *args,
+        **kwargs
+    ) -> BlockResult:
+        pass

--- a/inference/core/workflows/core_steps/visualizations/blur.py
+++ b/inference/core/workflows/core_steps/visualizations/blur.py
@@ -1,28 +1,19 @@
-from typing import List, Literal, Optional, Type, Union
+from typing import Literal, Optional, Type, Union
 
 import supervision as sv
-from pydantic import AliasChoices, ConfigDict, Field
+from pydantic import ConfigDict, Field
 
-from inference.core.workflows.entities.base import OutputDefinition, WorkflowImageData
+from inference.core.workflows.core_steps.visualizations.base import (
+    OUTPUT_IMAGE_KEY,
+    VisualizationBlock,
+    VisualizationManifest,
+)
+from inference.core.workflows.entities.base import WorkflowImageData
 from inference.core.workflows.entities.types import (
-    BATCH_OF_IMAGES_KIND,
-    BATCH_OF_INSTANCE_SEGMENTATION_PREDICTION_KIND,
-    BATCH_OF_KEYPOINT_DETECTION_PREDICTION_KIND,
-    BATCH_OF_OBJECT_DETECTION_PREDICTION_KIND,
-    BOOLEAN_KIND,
     INTEGER_KIND,
-    StepOutputImageSelector,
-    StepOutputSelector,
-    WorkflowImageSelector,
     WorkflowParameterSelector,
 )
-from inference.core.workflows.prototypes.block import (
-    BlockResult,
-    WorkflowBlock,
-    WorkflowBlockManifest,
-)
-
-OUTPUT_IMAGE_KEY: str = "image"
+from inference.core.workflows.prototypes.block import BlockResult, WorkflowBlockManifest
 
 TYPE: str = "BlurVisualization"
 SHORT_DESCRIPTION = "Blurs detected objects in an image."
@@ -32,7 +23,7 @@ objects in an image using Supervision's `sv.BlurAnnotator`.
 """
 
 
-class BlurManifest(WorkflowBlockManifest):
+class BlurManifest(VisualizationManifest):
     type: Literal[f"{TYPE}"]
     model_config = ConfigDict(
         json_schema_extra={
@@ -43,47 +34,14 @@ class BlurManifest(WorkflowBlockManifest):
         }
     )
 
-    predictions: StepOutputSelector(
-        kind=[
-            BATCH_OF_OBJECT_DETECTION_PREDICTION_KIND,
-            BATCH_OF_INSTANCE_SEGMENTATION_PREDICTION_KIND,
-            BATCH_OF_KEYPOINT_DETECTION_PREDICTION_KIND,
-        ]
-    ) = Field(  # type: ignore
-        description="Predictions",
-        examples=["$steps.object_detection_model.predictions"],
-    )
-    image: Union[WorkflowImageSelector, StepOutputImageSelector] = Field(
-        title="Input Image",
-        description="The input image for this step.",
-        examples=["$inputs.image", "$steps.cropping.crops"],
-        validation_alias=AliasChoices("image", "images"),
-    )
-
-    copy_image: Union[bool, WorkflowParameterSelector(kind=[BOOLEAN_KIND])] = Field(  # type: ignore
-        description="Duplicate the image contents (vs overwriting the image in place). Deselect for chained visualizations that should stack on previous ones where the intermediate state is not needed.",
-        default=True,
-    )
-
     kernel_size: Union[int, WorkflowParameterSelector(kind=[INTEGER_KIND])] = Field(  # type: ignore
         description="Size of the average pooling kernel used for blurring.",
         default=15,
         examples=[15, "$inputs.kernel_size"],
     )
 
-    @classmethod
-    def describe_outputs(cls) -> List[OutputDefinition]:
-        return [
-            OutputDefinition(
-                name=OUTPUT_IMAGE_KEY,
-                kind=[
-                    BATCH_OF_IMAGES_KIND,
-                ],
-            ),
-        ]
 
-
-class BlurVisualizationBlock(WorkflowBlock):
+class BlurVisualizationBlock(VisualizationBlock):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.annotatorCache = {}

--- a/inference/core/workflows/core_steps/visualizations/bounding_box.py
+++ b/inference/core/workflows/core_steps/visualizations/bounding_box.py
@@ -3,9 +3,10 @@ from typing import List, Literal, Optional, Type, Union
 import supervision as sv
 from pydantic import ConfigDict, Field
 
-from inference.core.workflows.core_steps.visualizations.base import (
-    VisualizationBlock,
-    VisualizationManifest,
+from inference.core.workflows.core_steps.visualizations.base import OUTPUT_IMAGE_KEY
+from inference.core.workflows.core_steps.visualizations.base_colorable import (
+    ColorableVisualizationBlock,
+    ColorableVisualizationManifest,
 )
 from inference.core.workflows.entities.base import WorkflowImageData
 from inference.core.workflows.entities.types import (
@@ -16,8 +17,6 @@ from inference.core.workflows.entities.types import (
 )
 from inference.core.workflows.prototypes.block import BlockResult, WorkflowBlockManifest
 
-OUTPUT_IMAGE_KEY: str = "image"
-
 TYPE: str = "BoundingBoxVisualization"
 SHORT_DESCRIPTION = "Draws a box around detected objects in an image."
 LONG_DESCRIPTION = """
@@ -26,7 +25,7 @@ objects in an image using Supervision's `sv.RoundBoxAnnotator`.
 """
 
 
-class BoundingBoxManifest(VisualizationManifest):
+class BoundingBoxManifest(ColorableVisualizationManifest):
     type: Literal[f"{TYPE}"]
     model_config = ConfigDict(
         json_schema_extra={
@@ -50,7 +49,7 @@ class BoundingBoxManifest(VisualizationManifest):
     )
 
 
-class BoundingBoxVisualizationBlock(VisualizationBlock):
+class BoundingBoxVisualizationBlock(ColorableVisualizationBlock):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.annotatorCache = {}

--- a/inference/core/workflows/core_steps/visualizations/circle.py
+++ b/inference/core/workflows/core_steps/visualizations/circle.py
@@ -3,9 +3,10 @@ from typing import List, Literal, Optional, Type, Union
 import supervision as sv
 from pydantic import ConfigDict, Field
 
-from inference.core.workflows.core_steps.visualizations.base import (
-    VisualizationBlock,
-    VisualizationManifest,
+from inference.core.workflows.core_steps.visualizations.base import OUTPUT_IMAGE_KEY
+from inference.core.workflows.core_steps.visualizations.base_colorable import (
+    ColorableVisualizationBlock,
+    ColorableVisualizationManifest,
 )
 from inference.core.workflows.entities.base import WorkflowImageData
 from inference.core.workflows.entities.types import (
@@ -13,8 +14,6 @@ from inference.core.workflows.entities.types import (
     WorkflowParameterSelector,
 )
 from inference.core.workflows.prototypes.block import BlockResult, WorkflowBlockManifest
-
-OUTPUT_IMAGE_KEY: str = "image"
 
 TYPE: str = "CircleVisualization"
 SHORT_DESCRIPTION = "Draws a circle around detected objects in an image."
@@ -24,7 +23,7 @@ objects in an image using Supervision's `sv.CircleAnnotator`.
 """
 
 
-class CircleManifest(VisualizationManifest):
+class CircleManifest(ColorableVisualizationManifest):
     type: Literal[f"{TYPE}"]
     model_config = ConfigDict(
         json_schema_extra={
@@ -42,7 +41,7 @@ class CircleManifest(VisualizationManifest):
     )
 
 
-class CircleVisualizationBlock(VisualizationBlock):
+class CircleVisualizationBlock(ColorableVisualizationBlock):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.annotatorCache = {}

--- a/inference/core/workflows/core_steps/visualizations/color.py
+++ b/inference/core/workflows/core_steps/visualizations/color.py
@@ -3,9 +3,10 @@ from typing import List, Literal, Optional, Type, Union
 import supervision as sv
 from pydantic import ConfigDict, Field
 
-from inference.core.workflows.core_steps.visualizations.base import (
-    VisualizationBlock,
-    VisualizationManifest,
+from inference.core.workflows.core_steps.visualizations.base import OUTPUT_IMAGE_KEY
+from inference.core.workflows.core_steps.visualizations.base_colorable import (
+    ColorableVisualizationBlock,
+    ColorableVisualizationManifest,
 )
 from inference.core.workflows.entities.base import WorkflowImageData
 from inference.core.workflows.entities.types import (
@@ -15,8 +16,6 @@ from inference.core.workflows.entities.types import (
 )
 from inference.core.workflows.prototypes.block import BlockResult, WorkflowBlockManifest
 
-OUTPUT_IMAGE_KEY: str = "image"
-
 TYPE: str = "ColorVisualization"
 SHORT_DESCRIPTION = "Paints a solid color on detected objects in an image."
 LONG_DESCRIPTION = """
@@ -25,7 +24,7 @@ objects in an image using Supervision's `sv.ColorAnnotator`.
 """
 
 
-class ColorManifest(VisualizationManifest):
+class ColorManifest(ColorableVisualizationManifest):
     type: Literal[f"{TYPE}"]
     model_config = ConfigDict(
         json_schema_extra={
@@ -43,7 +42,7 @@ class ColorManifest(VisualizationManifest):
     )
 
 
-class ColorVisualizationBlock(VisualizationBlock):
+class ColorVisualizationBlock(ColorableVisualizationBlock):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.annotatorCache = {}

--- a/inference/core/workflows/core_steps/visualizations/corner.py
+++ b/inference/core/workflows/core_steps/visualizations/corner.py
@@ -3,9 +3,10 @@ from typing import List, Literal, Optional, Type, Union
 import supervision as sv
 from pydantic import ConfigDict, Field
 
-from inference.core.workflows.core_steps.visualizations.base import (
-    VisualizationBlock,
-    VisualizationManifest,
+from inference.core.workflows.core_steps.visualizations.base import OUTPUT_IMAGE_KEY
+from inference.core.workflows.core_steps.visualizations.base_colorable import (
+    ColorableVisualizationBlock,
+    ColorableVisualizationManifest,
 )
 from inference.core.workflows.entities.base import WorkflowImageData
 from inference.core.workflows.entities.types import (
@@ -13,8 +14,6 @@ from inference.core.workflows.entities.types import (
     WorkflowParameterSelector,
 )
 from inference.core.workflows.prototypes.block import BlockResult, WorkflowBlockManifest
-
-OUTPUT_IMAGE_KEY: str = "image"
 
 TYPE: str = "CornerVisualization"
 SHORT_DESCRIPTION = "Draws the corners of detected objects in an image."
@@ -24,7 +23,7 @@ objects in an image using Supervision's `sv.BoxCornerAnnotator`.
 """
 
 
-class CornerManifest(VisualizationManifest):
+class CornerManifest(ColorableVisualizationManifest):
     type: Literal[f"{TYPE}"]
     model_config = ConfigDict(
         json_schema_extra={
@@ -48,7 +47,7 @@ class CornerManifest(VisualizationManifest):
     )
 
 
-class CornerVisualizationBlock(VisualizationBlock):
+class CornerVisualizationBlock(ColorableVisualizationBlock):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.annotatorCache = {}

--- a/inference/core/workflows/core_steps/visualizations/crop.py
+++ b/inference/core/workflows/core_steps/visualizations/crop.py
@@ -3,9 +3,10 @@ from typing import List, Literal, Optional, Type, Union
 import supervision as sv
 from pydantic import ConfigDict, Field
 
-from inference.core.workflows.core_steps.visualizations.base import (
-    VisualizationBlock,
-    VisualizationManifest,
+from inference.core.workflows.core_steps.visualizations.base import OUTPUT_IMAGE_KEY
+from inference.core.workflows.core_steps.visualizations.base_colorable import (
+    ColorableVisualizationBlock,
+    ColorableVisualizationManifest,
 )
 from inference.core.workflows.entities.base import WorkflowImageData
 from inference.core.workflows.entities.types import (
@@ -16,8 +17,6 @@ from inference.core.workflows.entities.types import (
 )
 from inference.core.workflows.prototypes.block import BlockResult, WorkflowBlockManifest
 
-OUTPUT_IMAGE_KEY: str = "image"
-
 TYPE: str = "CropVisualization"
 SHORT_DESCRIPTION = "Draws scaled up crops of detections on the scene."
 LONG_DESCRIPTION = """
@@ -26,7 +25,7 @@ on the scene using Supervision's `sv.CropAnnotator`.
 """
 
 
-class CropManifest(VisualizationManifest):
+class CropManifest(ColorableVisualizationManifest):
     type: Literal[f"{TYPE}"]
     model_config = ConfigDict(
         json_schema_extra={
@@ -70,7 +69,7 @@ class CropManifest(VisualizationManifest):
     )
 
 
-class CropVisualizationBlock(VisualizationBlock):
+class CropVisualizationBlock(ColorableVisualizationBlock):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.annotatorCache = {}

--- a/inference/core/workflows/core_steps/visualizations/dot.py
+++ b/inference/core/workflows/core_steps/visualizations/dot.py
@@ -3,9 +3,10 @@ from typing import List, Literal, Optional, Type, Union
 import supervision as sv
 from pydantic import ConfigDict, Field
 
-from inference.core.workflows.core_steps.visualizations.base import (
-    VisualizationBlock,
-    VisualizationManifest,
+from inference.core.workflows.core_steps.visualizations.base import OUTPUT_IMAGE_KEY
+from inference.core.workflows.core_steps.visualizations.base_colorable import (
+    ColorableVisualizationBlock,
+    ColorableVisualizationManifest,
 )
 from inference.core.workflows.entities.base import WorkflowImageData
 from inference.core.workflows.entities.types import (
@@ -14,8 +15,6 @@ from inference.core.workflows.entities.types import (
     WorkflowParameterSelector,
 )
 from inference.core.workflows.prototypes.block import BlockResult, WorkflowBlockManifest
-
-OUTPUT_IMAGE_KEY: str = "image"
 
 TYPE: str = "DotVisualization"
 SHORT_DESCRIPTION = (
@@ -27,7 +26,7 @@ based on provided detections using Supervision's `sv.DotAnnotator`.
 """
 
 
-class DotManifest(VisualizationManifest):
+class DotManifest(ColorableVisualizationManifest):
     type: Literal[f"{TYPE}"]
     model_config = ConfigDict(
         json_schema_extra={
@@ -71,7 +70,7 @@ class DotManifest(VisualizationManifest):
     )
 
 
-class DotVisualizationBlock(VisualizationBlock):
+class DotVisualizationBlock(ColorableVisualizationBlock):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.annotatorCache = {}

--- a/inference/core/workflows/core_steps/visualizations/ellipse.py
+++ b/inference/core/workflows/core_steps/visualizations/ellipse.py
@@ -3,9 +3,10 @@ from typing import List, Literal, Optional, Type, Union
 import supervision as sv
 from pydantic import ConfigDict, Field
 
-from inference.core.workflows.core_steps.visualizations.base import (
-    VisualizationBlock,
-    VisualizationManifest,
+from inference.core.workflows.core_steps.visualizations.base import OUTPUT_IMAGE_KEY
+from inference.core.workflows.core_steps.visualizations.base_colorable import (
+    ColorableVisualizationBlock,
+    ColorableVisualizationManifest,
 )
 from inference.core.workflows.entities.base import WorkflowImageData
 from inference.core.workflows.entities.types import (
@@ -13,8 +14,6 @@ from inference.core.workflows.entities.types import (
     WorkflowParameterSelector,
 )
 from inference.core.workflows.prototypes.block import BlockResult, WorkflowBlockManifest
-
-OUTPUT_IMAGE_KEY: str = "image"
 
 TYPE: str = "EllipseVisualization"
 SHORT_DESCRIPTION = "Draws ellipses that highlight detected objects in an image."
@@ -24,7 +23,7 @@ objects in an image using Supervision's `sv.EllipseAnnotator`.
 """
 
 
-class EllipseManifest(VisualizationManifest):
+class EllipseManifest(ColorableVisualizationManifest):
     type: Literal[f"{TYPE}"]
     model_config = ConfigDict(
         json_schema_extra={
@@ -54,7 +53,7 @@ class EllipseManifest(VisualizationManifest):
     )
 
 
-class EllipseVisualizationBlock(VisualizationBlock):
+class EllipseVisualizationBlock(ColorableVisualizationBlock):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.annotatorCache = {}

--- a/inference/core/workflows/core_steps/visualizations/halo.py
+++ b/inference/core/workflows/core_steps/visualizations/halo.py
@@ -3,9 +3,10 @@ from typing import List, Literal, Optional, Type, Union
 import supervision as sv
 from pydantic import ConfigDict, Field
 
-from inference.core.workflows.core_steps.visualizations.base import (
-    VisualizationBlock,
-    VisualizationManifest,
+from inference.core.workflows.core_steps.visualizations.base import OUTPUT_IMAGE_KEY
+from inference.core.workflows.core_steps.visualizations.base_colorable import (
+    ColorableVisualizationBlock,
+    ColorableVisualizationManifest,
 )
 from inference.core.workflows.entities.base import WorkflowImageData
 from inference.core.workflows.entities.types import (
@@ -18,8 +19,6 @@ from inference.core.workflows.entities.types import (
 )
 from inference.core.workflows.prototypes.block import BlockResult, WorkflowBlockManifest
 
-OUTPUT_IMAGE_KEY: str = "image"
-
 TYPE: str = "HaloVisualization"
 SHORT_DESCRIPTION = "Paints a halo around detected objects in an image."
 LONG_DESCRIPTION = """
@@ -29,7 +28,7 @@ from an instance segmentation to draw a halo using
 """
 
 
-class HaloManifest(VisualizationManifest):
+class HaloManifest(ColorableVisualizationManifest):
     type: Literal[f"{TYPE}"]
     model_config = ConfigDict(
         json_schema_extra={
@@ -62,7 +61,7 @@ class HaloManifest(VisualizationManifest):
     )
 
 
-class HaloVisualizationBlock(VisualizationBlock):
+class HaloVisualizationBlock(ColorableVisualizationBlock):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.annotatorCache = {}

--- a/inference/core/workflows/core_steps/visualizations/label.py
+++ b/inference/core/workflows/core_steps/visualizations/label.py
@@ -3,9 +3,10 @@ from typing import List, Literal, Optional, Type, Union
 import supervision as sv
 from pydantic import ConfigDict, Field
 
-from inference.core.workflows.core_steps.visualizations.base import (
-    VisualizationBlock,
-    VisualizationManifest,
+from inference.core.workflows.core_steps.visualizations.base import OUTPUT_IMAGE_KEY
+from inference.core.workflows.core_steps.visualizations.base_colorable import (
+    ColorableVisualizationBlock,
+    ColorableVisualizationManifest,
 )
 from inference.core.workflows.core_steps.visualizations.utils import str_to_color
 from inference.core.workflows.entities.base import WorkflowImageData
@@ -17,8 +18,6 @@ from inference.core.workflows.entities.types import (
 )
 from inference.core.workflows.prototypes.block import BlockResult, WorkflowBlockManifest
 
-OUTPUT_IMAGE_KEY: str = "image"
-
 TYPE: str = "LabelVisualization"
 SHORT_DESCRIPTION = (
     "Draws labels on an image at specific coordinates based on provided detections."
@@ -29,7 +28,7 @@ based on provided detections using Supervision's `sv.LabelAnnotator`.
 """
 
 
-class LabelManifest(VisualizationManifest):
+class LabelManifest(ColorableVisualizationManifest):
     type: Literal[f"{TYPE}"]
     model_config = ConfigDict(
         json_schema_extra={
@@ -102,7 +101,7 @@ class LabelManifest(VisualizationManifest):
     )
 
 
-class LabelVisualizationBlock(VisualizationBlock):
+class LabelVisualizationBlock(ColorableVisualizationBlock):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.annotatorCache = {}

--- a/inference/core/workflows/core_steps/visualizations/mask.py
+++ b/inference/core/workflows/core_steps/visualizations/mask.py
@@ -3,9 +3,10 @@ from typing import List, Literal, Optional, Type, Union
 import supervision as sv
 from pydantic import ConfigDict, Field
 
-from inference.core.workflows.core_steps.visualizations.base import (
-    VisualizationBlock,
-    VisualizationManifest,
+from inference.core.workflows.core_steps.visualizations.base import OUTPUT_IMAGE_KEY
+from inference.core.workflows.core_steps.visualizations.base_colorable import (
+    ColorableVisualizationBlock,
+    ColorableVisualizationManifest,
 )
 from inference.core.workflows.entities.base import WorkflowImageData
 from inference.core.workflows.entities.types import (
@@ -17,8 +18,6 @@ from inference.core.workflows.entities.types import (
 )
 from inference.core.workflows.prototypes.block import BlockResult, WorkflowBlockManifest
 
-OUTPUT_IMAGE_KEY: str = "image"
-
 TYPE: str = "MaskVisualization"
 SHORT_DESCRIPTION = "Paints a mask over detected objects in an image."
 LONG_DESCRIPTION = """
@@ -28,7 +27,7 @@ from an instance segmentation to draw a mask using
 """
 
 
-class MaskManifest(VisualizationManifest):
+class MaskManifest(ColorableVisualizationManifest):
     type: Literal[f"{TYPE}"]
     model_config = ConfigDict(
         json_schema_extra={
@@ -55,7 +54,7 @@ class MaskManifest(VisualizationManifest):
     )
 
 
-class MaskVisualizationBlock(VisualizationBlock):
+class MaskVisualizationBlock(ColorableVisualizationBlock):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.annotatorCache = {}

--- a/inference/core/workflows/core_steps/visualizations/polygon.py
+++ b/inference/core/workflows/core_steps/visualizations/polygon.py
@@ -3,9 +3,10 @@ from typing import List, Literal, Optional, Type, Union
 import supervision as sv
 from pydantic import ConfigDict, Field
 
-from inference.core.workflows.core_steps.visualizations.base import (
-    VisualizationBlock,
-    VisualizationManifest,
+from inference.core.workflows.core_steps.visualizations.base import OUTPUT_IMAGE_KEY
+from inference.core.workflows.core_steps.visualizations.base_colorable import (
+    ColorableVisualizationBlock,
+    ColorableVisualizationManifest,
 )
 from inference.core.workflows.entities.base import WorkflowImageData
 from inference.core.workflows.entities.types import (
@@ -16,8 +17,6 @@ from inference.core.workflows.entities.types import (
 )
 from inference.core.workflows.prototypes.block import BlockResult, WorkflowBlockManifest
 
-OUTPUT_IMAGE_KEY: str = "image"
-
 TYPE: str = "PolygonVisualization"
 SHORT_DESCRIPTION = "Draws a polygon around detected objects in an image."
 LONG_DESCRIPTION = """
@@ -27,7 +26,7 @@ instance segmentation to draw polygons around objects using
 """
 
 
-class PolygonManifest(VisualizationManifest):
+class PolygonManifest(ColorableVisualizationManifest):
     type: Literal[f"{TYPE}"]
     model_config = ConfigDict(
         json_schema_extra={
@@ -54,7 +53,7 @@ class PolygonManifest(VisualizationManifest):
     )
 
 
-class PolygonVisualizationBlock(VisualizationBlock):
+class PolygonVisualizationBlock(ColorableVisualizationBlock):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.annotatorCache = {}

--- a/inference/core/workflows/core_steps/visualizations/triangle.py
+++ b/inference/core/workflows/core_steps/visualizations/triangle.py
@@ -3,9 +3,10 @@ from typing import List, Literal, Optional, Type, Union
 import supervision as sv
 from pydantic import ConfigDict, Field
 
-from inference.core.workflows.core_steps.visualizations.base import (
-    VisualizationBlock,
-    VisualizationManifest,
+from inference.core.workflows.core_steps.visualizations.base import OUTPUT_IMAGE_KEY
+from inference.core.workflows.core_steps.visualizations.base_colorable import (
+    ColorableVisualizationBlock,
+    ColorableVisualizationManifest,
 )
 from inference.core.workflows.entities.base import WorkflowImageData
 from inference.core.workflows.entities.types import (
@@ -15,8 +16,6 @@ from inference.core.workflows.entities.types import (
 )
 from inference.core.workflows.prototypes.block import BlockResult, WorkflowBlockManifest
 
-OUTPUT_IMAGE_KEY: str = "image"
-
 TYPE: str = "TriangleVisualization"
 SHORT_DESCRIPTION = "Draws triangle markers on an image at specific coordinates based on provided detections."
 LONG_DESCRIPTION = """
@@ -25,7 +24,7 @@ based on provided detections using Supervision's `sv.TriangleAnnotator`.
 """
 
 
-class TriangleManifest(VisualizationManifest):
+class TriangleManifest(ColorableVisualizationManifest):
     type: Literal[f"{TYPE}"]
     model_config = ConfigDict(
         json_schema_extra={
@@ -75,7 +74,7 @@ class TriangleManifest(VisualizationManifest):
     )
 
 
-class TriangleVisualizationBlock(VisualizationBlock):
+class TriangleVisualizationBlock(ColorableVisualizationBlock):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.annotatorCache = {}


### PR DESCRIPTION
# Description

Refactors the inheritance of the blocks introduced in #533 so that blocks that don't accept color palettes can benefit from the standardization of the other visualizer inputs (image, predictions, copy).

## Type of change

-   [x] Refactor - does not change user-facing functionality

## How has this change been tested, please provide a testcase or example of how you tested the change?

Tests still pass; validated visually that the outputs remain as expected with my Visualizer Kitchen Sink workflow.

## Any specific deployment considerations

No

## Docs

- No user-facing changes, just code structure cleanup
