### PR TITLE
Cache workflow specification for offline use

### DIFF
--- a/inference/core/roboflow_api.py
+++ b/inference/core/roboflow_api.py
@@ -362,7 +362,10 @@ def get_workflow_cache_file(workspace_id: WorkspaceID, workflow_id: str):
     sanitized_workspace_id = sanitize_path_segment(workspace_id)
     sanitized_workflow_id = sanitize_path_segment(workflow_id)
     return os.path.join(
-        MODEL_CACHE_DIR, "workflow", sanitized_workspace_id, f"{sanitized_workflow_id}.json"
+        MODEL_CACHE_DIR,
+        "workflow",
+        sanitized_workspace_id,
+        f"{sanitized_workflow_id}.json",
     )
 
 

--- a/inference/core/roboflow_api.py
+++ b/inference/core/roboflow_api.py
@@ -31,6 +31,7 @@ from inference.core.exceptions import (
     RoboflowAPIUnsuccessfulRequestError,
     WorkspaceLoadError,
 )
+from inference.core.utils.file_system import sanitize_path_segment
 from inference.core.utils.requests import api_key_safe_raise_for_status
 from inference.core.utils.url_utils import wrap_url
 
@@ -358,8 +359,10 @@ def get_roboflow_labeling_jobs(
 
 
 def get_workflow_cache_file(workspace_id: WorkspaceID, workflow_id: str):
+    sanitized_workspace_id = sanitize_path_segment(workspace_id)
+    sanitized_workflow_id = sanitize_path_segment(workflow_id)
     return os.path.join(
-        MODEL_CACHE_DIR, "workflow", workspace_id, f"{workflow_id}.json"
+        MODEL_CACHE_DIR, "workflow", sanitized_workspace_id, f"{sanitized_workflow_id}.json"
     )
 
 

--- a/inference/core/utils/file_system.py
+++ b/inference/core/utils/file_system.py
@@ -1,5 +1,6 @@
 import json
 import os.path
+import re
 from typing import List, Optional, Union
 
 
@@ -63,3 +64,8 @@ def ensure_parent_dir_exists(path: str) -> None:
 def ensure_write_is_allowed(path: str, allow_override: bool) -> None:
     if os.path.exists(path) and not allow_override:
         raise RuntimeError(f"File {path} exists and override is forbidden.")
+
+
+def sanitize_path_segment(path_segment: str) -> str:
+    # Keep only letters, numbers, underscores and dashes
+    return re.sub(r"[^A-Za-z0-9_-]", "_", path_segment)

--- a/tests/inference/unit_tests/core/test_roboflow_api.py
+++ b/tests/inference/unit_tests/core/test_roboflow_api.py
@@ -1693,21 +1693,6 @@ def test_get_workflow_specification_when_connection_error_occurs(
     get_mock: MagicMock,
 ) -> None:
     # given
-    get_mock.side_effect = ConnectionError()
-
-    # when
-    with pytest.raises(RoboflowAPIConnectionError):
-        _ = get_workflow_specification(
-            api_key="my_api_key",
-            workspace_id="my_workspace",
-            workflow_id="some_workflow",
-        )
-
-@mock.patch.object(roboflow_api.requests, "get")
-def test_get_workflow_specification_when_connection_error_occurs(
-    get_mock: MagicMock,
-) -> None:
-    # given
     delete_cached_workflow_response_if_exists("my_workspace", "some_workflow")
     get_mock.side_effect = ConnectionError()
 

--- a/tests/inference/unit_tests/core/test_roboflow_api.py
+++ b/tests/inference/unit_tests/core/test_roboflow_api.py
@@ -31,12 +31,14 @@ from inference.core.roboflow_api import (
     get_roboflow_model_data,
     get_roboflow_model_type,
     get_roboflow_workspace,
+    delete_cached_workflow_response_if_exists,
     get_workflow_specification,
     raise_from_lambda,
     register_image_at_roboflow,
     wrap_roboflow_api_errors,
 )
 from inference.core.utils.url_utils import wrap_url
+import json
 
 
 class TestException(Exception):
@@ -1700,6 +1702,49 @@ def test_get_workflow_specification_when_connection_error_occurs(
             workspace_id="my_workspace",
             workflow_id="some_workflow",
         )
+
+@mock.patch.object(roboflow_api.requests, "get")
+def test_get_workflow_specification_when_connection_error_occurs(
+    get_mock: MagicMock,
+) -> None:
+    # given
+    delete_cached_workflow_response_if_exists("my_workspace", "some_workflow")
+    get_mock.side_effect = ConnectionError()
+
+    # when
+    with pytest.raises(RoboflowAPIConnectionError):
+        _ = get_workflow_specification(
+            api_key="my_api_key",
+            workspace_id="my_workspace",
+            workflow_id="some_workflow",
+        )
+
+
+@mock.patch.object(roboflow_api.requests, "get")
+def test_get_workflow_specification_when_connection_error_occurs_but_file_is_cached(
+    get_mock: MagicMock,
+) -> None:
+    # given
+    delete_cached_workflow_response_if_exists("my_workspace", "some_workflow")
+
+    get_mock.return_value = MagicMock(
+        status_code=200,
+        json= MagicMock(return_value={"workflow": {"config": json.dumps({"specification": "some"}) }}),
+    )
+
+    _ = get_workflow_specification(
+        api_key="my_api_key",
+        workspace_id="my_workspace",
+        workflow_id="some_workflow",
+    )
+
+    get_mock.side_effect = ConnectionError()
+    
+    _ = get_workflow_specification(
+        api_key="my_api_key",
+        workspace_id="my_workspace",
+        workflow_id="some_workflow",
+    )
 
 
 def test_get_workflow_specification_when_wrong_api_key_used(


### PR DESCRIPTION
# Description

Caches workflow specification for offline use. If a ConnectionError occurs when fetching the specification, then return the cached response.

## Type of change

Please delete options that are not relevant.

-   [x] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Tested locally and with unit tests.

## Any specific deployment considerations

normal release.

## Docs

-   n/a