### PR TITLE
Add @capjamesg to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,2 @@
 * @PawelPeczek-Roboflow @grzegorz-roboflow @yeldarby @probicheaux @hansent
+/docs/ @capjamesg


### PR DESCRIPTION
# Description

This PR adds myself as a codeowner to the `docs` directory per the instructions on https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners. This will grant permission for me to merge PRs that change exclusively the `docs` directory.

## Type of change

- [ ] CODEOWNERS change

## How has this change been tested, please provide a testcase or example of how you tested the change?

The syntax follows the official GitHub documentation linked above.

## Any specific deployment considerations

N/A

## Docs

N/A
