### PR TITLE
Added Inference IDs to Sources when Uploaded via the Dataset Upload Block

### DIFF
--- a/inference/core/workflows/core_steps/sinks/roboflow/roboflow_dataset_upload.py
+++ b/inference/core/workflows/core_steps/sinks/roboflow/roboflow_dataset_upload.py
@@ -457,7 +457,11 @@ def register_datapoint(
     batch_name: str,
     tags: List[str],
 ) -> str:
-    inference_id = prediction.data["inference_id"][0] if prediction and "inference_id" in prediction.data else None
+    inference_id = (
+        prediction.data["inference_id"][0]
+        if prediction and "inference_id" in prediction.data
+        else None
+    )
     roboflow_image_id = safe_register_image_at_roboflow(
         target_project=target_project,
         encoded_image=encoded_image,

--- a/inference/core/workflows/core_steps/sinks/roboflow/roboflow_dataset_upload.py
+++ b/inference/core/workflows/core_steps/sinks/roboflow/roboflow_dataset_upload.py
@@ -464,6 +464,7 @@ def register_datapoint(
         api_key=api_key,
         batch_name=batch_name,
         tags=tags,
+        inference_id=prediction.data["inference_id"][0],
     )
     if roboflow_image_id is None:
         return DUPLICATED_STATUS
@@ -489,6 +490,7 @@ def safe_register_image_at_roboflow(
     api_key: str,
     batch_name: str,
     tags: List[str],
+    inference_id: Optional[str] = None,
 ) -> Optional[str]:
     registration_response = register_image_at_roboflow(
         api_key=api_key,
@@ -497,6 +499,7 @@ def safe_register_image_at_roboflow(
         image_bytes=encoded_image,
         batch_name=batch_name,
         tags=tags,
+        inference_id=inference_id,
     )
     image_duplicated = registration_response.get("duplicate", False)
     if image_duplicated:

--- a/inference/core/workflows/core_steps/sinks/roboflow/roboflow_dataset_upload.py
+++ b/inference/core/workflows/core_steps/sinks/roboflow/roboflow_dataset_upload.py
@@ -457,6 +457,7 @@ def register_datapoint(
     batch_name: str,
     tags: List[str],
 ) -> str:
+    inference_id = prediction.data["inference_id"][0] if prediction and "inference_id" in prediction.data else None
     roboflow_image_id = safe_register_image_at_roboflow(
         target_project=target_project,
         encoded_image=encoded_image,
@@ -464,7 +465,7 @@ def register_datapoint(
         api_key=api_key,
         batch_name=batch_name,
         tags=tags,
-        inference_id=prediction.data["inference_id"][0],
+        inference_id=inference_id,
     )
     if roboflow_image_id is None:
         return DUPLICATED_STATUS
@@ -490,7 +491,7 @@ def safe_register_image_at_roboflow(
     api_key: str,
     batch_name: str,
     tags: List[str],
-    inference_id: Optional[str] = None,
+    inference_id: Optional[str],
 ) -> Optional[str]:
     registration_response = register_image_at_roboflow(
         api_key=api_key,


### PR DESCRIPTION
# Description

When an image is uploaded through Active Learning, Model Monitoring allows users to view the image in its "Recent Inferences" table. This currently works with Active Learning, however, it does not work with the new "Roboflow Dataset Upload" block in Workflows.

Modified the Dataset Upload block to provide the `inference_id` to `register_image_at_roboflow()` (As is currently being done in Active Learning).

## Type of change

-   [X] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

- Passed all unit and integration tests.
- Confirmed that images show up in Model Monitoring with the changes in this PR.

## Any specific deployment considerations

N/A

## Docs

N/A