### PR TITLE
Fixed a Regression in the Custom Metadata Block

### DIFF
--- a/inference/core/workflows/core_steps/sinks/roboflow/custom_metadata/v1.py
+++ b/inference/core/workflows/core_steps/sinks/roboflow/custom_metadata/v1.py
@@ -151,7 +151,7 @@ class RoboflowCustomMetadataBlockV1(WorkflowBlock):
             api_key=self._api_key,
             inference_ids=inference_ids,
             field_name=field_name,
-            field_value=field_value[0],
+            field_value=field_value,
         )
         error_status = False
         message = "Registration happens in the background task"


### PR DESCRIPTION
# Description

Fixed a regression in the Custom Metadata block where only the first character of the expected `field_value` was being written as metadata.

## Type of change

-   [X] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Tested locally using a custom Docker image. Passed all unit and integration tests. Confirmed that the change in the PR fixes the issue.

## Any specific deployment considerations

N/A

## Docs

N/A