### PR TITLE
Video metadata in `workflows`

### DIFF
--- a/inference/core/interfaces/camera/entities.py
+++ b/inference/core/interfaces/camera/entities.py
@@ -62,7 +62,7 @@ class VideoFrame:
     image: np.ndarray
     frame_id: FrameID
     frame_timestamp: FrameTimestamp
-    fps: Optional[float] = 0
+    fps: Optional[float] = None
     source_id: Optional[int] = None
     comes_from_video_file: Optional[bool] = None
 

--- a/inference/core/interfaces/camera/entities.py
+++ b/inference/core/interfaces/camera/entities.py
@@ -53,14 +53,18 @@ class VideoFrame:
         image (np.ndarray): The image data of the frame as a NumPy array.
         frame_id (FrameID): A unique identifier for the frame.
         frame_timestamp (FrameTimestamp): The timestamp when the frame was captured.
-        source_id (int): The index of the video_reference element which was passed to InferencePipeline for this frame (useful when multiple streams are passed to InferencePipeline).
+        source_id (int): The index of the video_reference element which was passed to InferencePipeline for this frame
+            (useful when multiple streams are passed to InferencePipeline).
+        fps (Optional[float]): FPS of source (if possible to be acquired)
+        comes_from_video_file (Optional[bool]): flag to determine if frame comes from video file
     """
 
     image: np.ndarray
     frame_id: FrameID
     frame_timestamp: FrameTimestamp
-    fps: float = 0
+    fps: Optional[float] = 0
     source_id: Optional[int] = None
+    comes_from_video_file: Optional[bool] = None
 
 
 @dataclass(frozen=True)

--- a/inference/core/interfaces/camera/video_source.py
+++ b/inference/core/interfaces/camera/video_source.py
@@ -1092,7 +1092,7 @@ def decode_video_frame_to_buffer(
     buffer: Queue,
     decoding_pace_monitor: sv.FPSMonitor,
     source_id: Optional[int],
-    fps: Optional[float] = 0,
+    fps: Optional[float] = None,
     comes_from_video_file: Optional[bool] = None,
 ) -> bool:
     success, image = video.retrieve()

--- a/inference/core/interfaces/stream/inference_pipeline.py
+++ b/inference/core/interfaces/stream/inference_pipeline.py
@@ -444,6 +444,7 @@ class InferencePipeline:
         workflow_init_parameters: Optional[Dict[str, Any]] = None,
         workflows_thread_pool_workers: int = 4,
         cancel_thread_pool_tasks_on_exit: bool = True,
+        video_metadata_input_name: str = "video_metadata",
     ) -> "InferencePipeline":
         """
         This class creates the abstraction for making inferences from given workflow against video stream.
@@ -463,8 +464,9 @@ class InferencePipeline:
             workflow_id (Optional[str]): When using registered workflows - Roboflow workflow id needs to be given.
             api_key (Optional[str]): Roboflow API key - if not passed - will be looked in env under "ROBOFLOW_API_KEY"
                 and "API_KEY" variables. API key, passed in some form is required.
-            image_input_name (str): Name of input image defined in `workflow_specification`. `InferencePipeline` will be
-                injecting video frames to workflow through that parameter name.
+            image_input_name (str): Name of input image defined in `workflow_specification` or Workflow definition saved
+                at Roboflow Platform. `InferencePipeline` will be injecting video frames to workflow through that
+                parameter name.
             workflows_parameters (Optional[Dict[str, Any]]): Dictionary with additional parameters that can be
                 defined within `workflow_specification`.
             on_prediction (Callable[AnyPrediction, VideoFrame], None]): Function to be called
@@ -498,7 +500,9 @@ class InferencePipeline:
             cancel_thread_pool_tasks_on_exit (bool): Flag to decide if unstated background tasks should be
                 canceled at the end of InferencePipeline processing. By default, when video file ends or
                 pipeline is stopped, tasks that has not started will be cancelled.
-
+            video_metadata_input_name (str): Name of input for video metadata defined in `workflow_specification` or
+                Workflow definition saved  at Roboflow Platform. `InferencePipeline` will be injecting video frames
+                metadata to workflows through that parameter name.
         Other ENV variables involved in low-level configuration:
         * INFERENCE_PIPELINE_PREDICTIONS_QUEUE_SIZE - size of buffer for predictions that are ready for dispatching
         * INFERENCE_PIPELINE_RESTART_ATTEMPT_DELAY - delay for restarts on stream connection drop

--- a/inference/core/interfaces/stream/model_handlers/workflows.py
+++ b/inference/core/interfaces/stream/model_handlers/workflows.py
@@ -3,6 +3,7 @@ from typing import List, Optional
 
 from inference.core.interfaces.camera.entities import VideoFrame
 from inference.core.workflows.execution_engine.core import ExecutionEngine
+from inference.core.workflows.execution_engine.entities.base import VideoMetadata
 
 
 class WorkflowRunner:
@@ -13,13 +14,31 @@ class WorkflowRunner:
         workflows_parameters: Optional[dict],
         execution_engine: ExecutionEngine,
         image_input_name: str,
+        video_metadata_input_name: str,
     ) -> List[dict]:
         if workflows_parameters is None:
             workflows_parameters = {}
         # TODO: pass fps reflecting each stream to workflows_parameters
         fps = video_frames[0].fps
+        if fps is None:
+            # for FPS reporting we expect 0 when FPS cannot be determined
+            fps = 0
         workflows_parameters[image_input_name] = [
             video_frame.image for video_frame in video_frames
+        ]
+        workflows_parameters[video_metadata_input_name] = [
+            VideoMetadata(
+                video_identifier=(
+                    str(video_frame.source_id)
+                    if video_frame.source_id
+                    else "default_source"
+                ),
+                frame_number=video_frame.frame_id,
+                frame_timestamp=video_frame.frame_timestamp,
+                fps=video_frame.fps,
+                comes_from_video_file=video_frame.comes_from_video_file,
+            )
+            for video_frame in video_frames
         ]
         return execution_engine.run(
             runtime_parameters=workflows_parameters,

--- a/inference/core/workflows/execution_engine/entities/base.py
+++ b/inference/core/workflows/execution_engine/entities/base.py
@@ -279,7 +279,11 @@ class VideoMetadata(BaseModel):
         description="Identifier string for video. To be treated as opaque."
     )
     frame_number: int
-    frame_timestamp: datetime
+    frame_timestamp: datetime = Field(
+        description="The timestamp of video frame. When processing video it is suggested that "
+        "blocks rely on `fps` and `frame_number`, as real-world time-elapse will not "
+        "match time-elapse in video file",
+    )
     fps: Optional[float] = Field(
         description="Field represents FPS value (if possible to be retrieved)",
         default=None,

--- a/inference/core/workflows/execution_engine/entities/types.py
+++ b/inference/core/workflows/execution_engine/entities/types.py
@@ -62,6 +62,29 @@ BATCH_OF_IMAGES_KIND = Kind(
     name="Batch[image]", description="Image in workflows", docs=IMAGE_KIND_DOCS
 )
 
+VIDEO_METADATA_KIND_DOCS = """
+This is representation of metadata that describe images that come from videos.  
+It is helpful in cases of stateful video processing, as the metadata may bring 
+pieces of information that are required by specific blocks.
+
+Example of actual data:
+```
+{
+    "video_identifier": "rtsp://some.com/stream1",
+    "comes_from_video_file": False,
+    "fps": 23.99,
+    "frame_number": 24,
+    "frame_timestamp": "2024-08-21T11:13:44.313999", 
+}   
+```
+"""
+
+VIDEO_METADATA_KIND = Kind(
+    name="video_metadata",
+    description="Video image metadata",
+    docs=VIDEO_METADATA_KIND_DOCS,
+)
+
 ROBOFLOW_MODEL_ID_KIND_DOCS = """
 This kind represents value specific for Roboflow platform. At the platform, models are
 identified with special strings in the format: `<project_name>/<version>`. You should
@@ -730,3 +753,16 @@ StepOutputImageSelector = Annotated[
 ]
 
 FloatZeroToOne = Annotated[float, Field(ge=0.0, le=1.0)]
+
+
+WorkflowVideoMetadataSelector = Annotated[
+    str,
+    StringConstraints(pattern=r"^\$inputs.[A-Za-z_0-9\-]+$"),
+    Field(
+        json_schema_extra={
+            REFERENCE_KEY: True,
+            SELECTED_ELEMENT_KEY: "workflow_video_metadata",
+            KIND_KEY: [VIDEO_METADATA_KIND.dict()],
+        }
+    ),
+]

--- a/inference/core/workflows/execution_engine/v1/core.py
+++ b/inference/core/workflows/execution_engine/v1/core.py
@@ -11,7 +11,7 @@ from inference.core.workflows.execution_engine.v1.compiler.entities import (
 )
 from inference.core.workflows.execution_engine.v1.executor.core import run_workflow
 from inference.core.workflows.execution_engine.v1.executor.runtime_input_assembler import (
-    assembly_runtime_parameters,
+    assemble_runtime_parameters,
 )
 from inference.core.workflows.execution_engine.v1.executor.runtime_input_validator import (
     validate_runtime_input,
@@ -62,7 +62,7 @@ class ExecutionEngineV1(BaseExecutionEngine):
         runtime_parameters: Dict[str, Any],
         fps: float = 0,
     ) -> List[Dict[str, Any]]:
-        runtime_parameters = assembly_runtime_parameters(
+        runtime_parameters = assemble_runtime_parameters(
             runtime_parameters=runtime_parameters,
             defined_inputs=self._compiled_workflow.workflow_definition.inputs,
             prevent_local_images_loading=self._prevent_local_images_loading,

--- a/inference/core/workflows/execution_engine/v1/core.py
+++ b/inference/core/workflows/execution_engine/v1/core.py
@@ -17,7 +17,7 @@ from inference.core.workflows.execution_engine.v1.executor.runtime_input_validat
     validate_runtime_input,
 )
 
-EXECUTION_ENGINE_V1_VERSION = Version("1.0.1")
+EXECUTION_ENGINE_V1_VERSION = Version("1.1.0")
 
 
 class ExecutionEngineV1(BaseExecutionEngine):

--- a/inference/core/workflows/execution_engine/v1/executor/runtime_input_assembler.py
+++ b/inference/core/workflows/execution_engine/v1/executor/runtime_input_assembler.py
@@ -22,7 +22,7 @@ from inference.core.workflows.execution_engine.entities.base import (
 BATCH_ORIENTED_PARAMETER_TYPES = {WorkflowImage, WorkflowVideoMetadata}
 
 
-def assembly_runtime_parameters(
+def assemble_runtime_parameters(
     runtime_parameters: Dict[str, Any],
     defined_inputs: List[InputType],
     prevent_local_images_loading: bool = False,
@@ -33,20 +33,20 @@ def assembly_runtime_parameters(
     )
     for defined_input in defined_inputs:
         if isinstance(defined_input, WorkflowImage):
-            runtime_parameters[defined_input.name] = assembly_input_image(
+            runtime_parameters[defined_input.name] = assemble_input_image(
                 parameter=defined_input.name,
                 image=runtime_parameters.get(defined_input.name),
                 input_batch_size=input_batch_size,
                 prevent_local_images_loading=prevent_local_images_loading,
             )
         elif isinstance(defined_input, WorkflowVideoMetadata):
-            runtime_parameters[defined_input.name] = assembly_video_metadata(
+            runtime_parameters[defined_input.name] = assemble_video_metadata(
                 parameter=defined_input.name,
                 video_metadata=runtime_parameters.get(defined_input.name),
                 input_batch_size=input_batch_size,
             )
         else:
-            runtime_parameters[defined_input.name] = assembly_inference_parameter(
+            runtime_parameters[defined_input.name] = assemble_inference_parameter(
                 parameter=defined_input.name,
                 runtime_parameters=runtime_parameters,
                 default_value=defined_input.default_value,
@@ -66,7 +66,7 @@ def determine_input_batch_size(
     return 1
 
 
-def assembly_input_image(
+def assemble_input_image(
     parameter: str,
     image: Any,
     input_batch_size: int,
@@ -80,14 +80,14 @@ def assembly_input_image(
         )
     if not isinstance(image, list):
         return [
-            _assembly_input_image(
+            _assemble_input_image(
                 parameter=parameter,
                 image=image,
                 prevent_local_images_loading=prevent_local_images_loading,
             )
         ] * input_batch_size
     result = [
-        _assembly_input_image(
+        _assemble_input_image(
             parameter=parameter,
             image=element,
             identifier=idx,
@@ -105,7 +105,7 @@ def assembly_input_image(
     return result
 
 
-def _assembly_input_image(
+def _assemble_input_image(
     parameter: str,
     image: Any,
     identifier: Optional[int] = None,
@@ -161,7 +161,7 @@ def _assembly_input_image(
     )
 
 
-def assembly_video_metadata(
+def assemble_video_metadata(
     parameter: str,
     video_metadata: Any,
     input_batch_size: int,
@@ -174,13 +174,13 @@ def assembly_video_metadata(
         )
     if not isinstance(video_metadata, list):
         return [
-            _assembly_video_metadata(
+            _assemble_video_metadata(
                 parameter=parameter,
                 video_metadata=video_metadata,
             )
         ] * input_batch_size
     result = [
-        _assembly_video_metadata(
+        _assemble_video_metadata(
             parameter=parameter,
             video_metadata=element,
         )
@@ -196,7 +196,7 @@ def assembly_video_metadata(
     return result
 
 
-def _assembly_video_metadata(
+def _assemble_video_metadata(
     parameter: str,
     video_metadata: Any,
 ) -> VideoMetadata:
@@ -220,7 +220,7 @@ def _assembly_video_metadata(
         )
 
 
-def assembly_inference_parameter(
+def assemble_inference_parameter(
     parameter: str,
     runtime_parameters: Dict[str, Any],
     default_value: Any,

--- a/inference/core/workflows/execution_engine/v1/executor/runtime_input_assembler.py
+++ b/inference/core/workflows/execution_engine/v1/executor/runtime_input_assembler.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, List, Optional
 
 import cv2
 import numpy as np
+from pydantic import ValidationError
 
 from inference.core.utils.image_utils import (
     attempt_loading_image_from_string,
@@ -12,9 +13,13 @@ from inference.core.workflows.errors import RuntimeInputError
 from inference.core.workflows.execution_engine.entities.base import (
     ImageParentMetadata,
     InputType,
+    VideoMetadata,
     WorkflowImage,
     WorkflowImageData,
+    WorkflowVideoMetadata,
 )
+
+BATCH_ORIENTED_PARAMETER_TYPES = {WorkflowImage, WorkflowVideoMetadata}
 
 
 def assembly_runtime_parameters(
@@ -22,16 +27,24 @@ def assembly_runtime_parameters(
     defined_inputs: List[InputType],
     prevent_local_images_loading: bool = False,
 ) -> Dict[str, Any]:
-    batch_input_size: Optional[int] = None
+    input_batch_size = determine_input_batch_size(
+        runtime_parameters=runtime_parameters,
+        defined_inputs=defined_inputs,
+    )
     for defined_input in defined_inputs:
         if isinstance(defined_input, WorkflowImage):
             runtime_parameters[defined_input.name] = assembly_input_image(
                 parameter=defined_input.name,
                 image=runtime_parameters.get(defined_input.name),
-                batch_input_size=batch_input_size,
+                input_batch_size=input_batch_size,
                 prevent_local_images_loading=prevent_local_images_loading,
             )
-            batch_input_size = len(runtime_parameters[defined_input.name])
+        elif isinstance(defined_input, WorkflowVideoMetadata):
+            runtime_parameters[defined_input.name] = assembly_video_metadata(
+                parameter=defined_input.name,
+                video_metadata=runtime_parameters.get(defined_input.name),
+                input_batch_size=input_batch_size,
+            )
         else:
             runtime_parameters[defined_input.name] = assembly_inference_parameter(
                 parameter=defined_input.name,
@@ -41,27 +54,38 @@ def assembly_runtime_parameters(
     return runtime_parameters
 
 
+def determine_input_batch_size(
+    runtime_parameters: Dict[str, Any], defined_inputs: List[InputType]
+) -> int:
+    for defined_input in defined_inputs:
+        if type(defined_input) not in BATCH_ORIENTED_PARAMETER_TYPES:
+            continue
+        parameter_value = runtime_parameters.get(defined_input.name)
+        if isinstance(parameter_value, list) and len(parameter_value) > 1:
+            return len(parameter_value)
+    return 1
+
+
 def assembly_input_image(
     parameter: str,
     image: Any,
-    batch_input_size: Optional[int],
+    input_batch_size: int,
     prevent_local_images_loading: bool = False,
 ) -> List[WorkflowImageData]:
     if image is None:
         raise RuntimeInputError(
             public_message=f"Detected runtime parameter `{parameter}` defined as "
-            f"`InferenceImage`, but value is not provided.",
+            f"`WorkflowImage`, but value is not provided.",
             context="workflow_execution | runtime_input_validation",
         )
     if not isinstance(image, list):
-        expected_input_length = 1 if batch_input_size is None else batch_input_size
         return [
             _assembly_input_image(
                 parameter=parameter,
                 image=image,
                 prevent_local_images_loading=prevent_local_images_loading,
             )
-        ] * expected_input_length
+        ] * input_batch_size
     result = [
         _assembly_input_image(
             parameter=parameter,
@@ -71,14 +95,11 @@ def assembly_input_image(
         )
         for idx, element in enumerate(image)
     ]
-    expected_input_length = (
-        len(result) if batch_input_size is None else batch_input_size
-    )
-    if len(result) != expected_input_length:
+    if len(result) != input_batch_size:
         raise RuntimeInputError(
             public_message="Expected all batch-oriented workflow inputs be the same length, or of length 1 - "
             f"but parameter: {parameter} provided with batch size {len(result)}, where expected "
-            f"batch size based on remaining parameters is: {expected_input_length}.",
+            f"batch size based on remaining parameters is: {input_batch_size}.",
             context="workflow_execution | runtime_input_validation",
         )
     return result
@@ -138,6 +159,65 @@ def _assembly_input_image(
         f"and dicts with keys `type` and `value` compatible with `inference` (or list of them).",
         context="workflow_execution | runtime_input_validation",
     )
+
+
+def assembly_video_metadata(
+    parameter: str,
+    video_metadata: Any,
+    input_batch_size: int,
+) -> List[VideoMetadata]:
+    if video_metadata is None:
+        raise RuntimeInputError(
+            public_message=f"Detected runtime parameter `{parameter}` defined as "
+            f"`WorkflowVideoMetadata`, but value is not provided.",
+            context="workflow_execution | runtime_input_validation",
+        )
+    if not isinstance(video_metadata, list):
+        return [
+            _assembly_video_metadata(
+                parameter=parameter,
+                video_metadata=video_metadata,
+            )
+        ] * input_batch_size
+    result = [
+        _assembly_video_metadata(
+            parameter=parameter,
+            video_metadata=element,
+        )
+        for element in enumerate(video_metadata)
+    ]
+    if len(result) != input_batch_size:
+        raise RuntimeInputError(
+            public_message="Expected all batch-oriented workflow inputs be the same length, or of length 1 - "
+            f"but parameter: {parameter} provided with batch size {len(result)}, where expected "
+            f"batch size based on remaining parameters is: {input_batch_size}.",
+            context="workflow_execution | runtime_input_validation",
+        )
+    return result
+
+
+def _assembly_video_metadata(
+    parameter: str,
+    video_metadata: Any,
+) -> VideoMetadata:
+    if isinstance(video_metadata, VideoMetadata):
+        return video_metadata
+    if not isinstance(video_metadata, dict):
+        raise RuntimeInputError(
+            public_message=f"Detected runtime parameter `{parameter}` defined as "
+            f"`WorkflowVideoMetadata`, but provided value is not a dict.",
+            context="workflow_execution | runtime_input_validation",
+        )
+    try:
+        return VideoMetadata.model_validate(video_metadata)
+    except ValidationError as error:
+        raise RuntimeInputError(
+            public_message=f"Detected runtime parameter `{parameter}` defined as "
+            f"`WorkflowVideoMetadata`, but provided value is malformed. "
+            f"See details in inner error.",
+            context="workflow_execution | runtime_input_validation",
+            inner_error=error,
+        )
 
 
 def assembly_inference_parameter(

--- a/inference/core/workflows/execution_engine/v1/executor/runtime_input_assembler.py
+++ b/inference/core/workflows/execution_engine/v1/executor/runtime_input_assembler.py
@@ -184,7 +184,7 @@ def assembly_video_metadata(
             parameter=parameter,
             video_metadata=element,
         )
-        for element in enumerate(video_metadata)
+        for element in video_metadata
     ]
     if len(result) != input_batch_size:
         raise RuntimeInputError(

--- a/tests/inference/hosted_platform_tests/test_workflows.py
+++ b/tests/inference/hosted_platform_tests/test_workflows.py
@@ -125,7 +125,7 @@ def test_get_versions_of_execution_engine(object_detection_service_url: str) -> 
     # then
     response.raise_for_status()
     response_data = response.json()
-    assert response_data["versions"] == ["1.0.1"]
+    assert response_data["versions"] == ["1.1.0"]
 
 
 FUNCTION = """

--- a/tests/inference/integration_tests/test_workflow_endpoints.py
+++ b/tests/inference/integration_tests/test_workflow_endpoints.py
@@ -691,7 +691,7 @@ def test_get_versions_of_execution_engine(server_url: str) -> None:
     # then
     response.raise_for_status()
     response_data = response.json()
-    assert response_data["versions"] == ["1.0.1"]
+    assert response_data["versions"] == ["1.1.0"]
 
 
 def test_getting_block_schema_using_get_endpoint(server_url) -> None:

--- a/tests/inference/unit_tests/core/interfaces/camera/test_video_source.py
+++ b/tests/inference/unit_tests/core/interfaces/camera/test_video_source.py
@@ -759,6 +759,7 @@ def test_stream_consumption_when_frame_cannot_be_grabbed() -> None:
     result = consumer.consume_frame(
         video=video,
         declared_source_fps=source_properties.fps,
+        is_source_video_file=source_properties.is_file,
         buffer=buffer,
         frames_buffering_allowed=True,
     )
@@ -790,6 +791,7 @@ def test_stream_consumption_when_buffering_not_allowed() -> None:
     result = consumer.consume_frame(
         video=video,
         declared_source_fps=source_properties.fps,
+        is_source_video_file=source_properties.is_file,
         buffer=buffer,
         frames_buffering_allowed=False,
     )
@@ -826,6 +828,7 @@ def test_stream_consumption_when_buffer_is_ready_to_accept_frame_but_decoding_fa
     result = consumer.consume_frame(
         video=video,
         declared_source_fps=source_properties.fps,
+        is_source_video_file=source_properties.is_file,
         buffer=buffer,
         frames_buffering_allowed=True,
     )
@@ -864,6 +867,7 @@ def test_stream_consumption_when_buffer_is_ready_to_accept_frame_and_decoding_su
     result = consumer.consume_frame(
         video=video,
         declared_source_fps=source_properties.fps,
+        is_source_video_file=source_properties.is_file,
         buffer=buffer,
         frames_buffering_allowed=True,
     )
@@ -905,6 +909,7 @@ def test_stream_consumption_when_buffer_full_and_latest_frames_to_be_dropped() -
     result = consumer.consume_frame(
         video=video,
         declared_source_fps=source_properties.fps,
+        is_source_video_file=source_properties.is_file,
         buffer=buffer,
         frames_buffering_allowed=True,
     )
@@ -940,6 +945,7 @@ def test_stream_consumption_when_buffer_full_and_oldest_frames_to_be_dropped() -
     result = consumer.consume_frame(
         video=video,
         declared_source_fps=source_properties.fps,
+        is_source_video_file=source_properties.is_file,
         buffer=buffer,
         frames_buffering_allowed=True,
     )
@@ -987,6 +993,7 @@ def test_stream_consumption_when_adaptive_strategy_does_not_prevent_decoding_due
     result = consumer.consume_frame(
         video=video,
         declared_source_fps=source_properties.fps,
+        is_source_video_file=source_properties.is_file,
         buffer=buffer,
         frames_buffering_allowed=True,
     )
@@ -1038,6 +1045,7 @@ def test_stream_consumption_when_adaptive_strategy_eventually_stops_preventing_d
         result = consumer.consume_frame(
             video=video,
             declared_source_fps=source_properties.fps,
+            is_source_video_file=source_properties.is_file,
             buffer=buffer,
             frames_buffering_allowed=True,
         )
@@ -1051,6 +1059,7 @@ def test_stream_consumption_when_adaptive_strategy_eventually_stops_preventing_d
         result = consumer.consume_frame(
             video=video,
             declared_source_fps=source_properties.fps,
+            is_source_video_file=source_properties.is_file,
             buffer=buffer,
             frames_buffering_allowed=True,
         )
@@ -1109,6 +1118,7 @@ def test_stream_consumption_when_adaptive_strategy_is_disabled_as_announced_fps_
         result = consumer.consume_frame(
             video=video,
             declared_source_fps=None,
+            is_source_video_file=None,
             buffer=buffer,
             frames_buffering_allowed=True,
         )
@@ -1122,6 +1132,7 @@ def test_stream_consumption_when_adaptive_strategy_is_disabled_as_announced_fps_
         result = consumer.consume_frame(
             video=video,
             declared_source_fps=None,
+            is_source_video_file=None,
             buffer=buffer,
             frames_buffering_allowed=True,
         )
@@ -1179,6 +1190,7 @@ def test_stream_consumption_when_adaptive_strategy_drops_frames_due_to_reader_la
         result = consumer.consume_frame(
             video=video,
             declared_source_fps=None,
+            is_source_video_file=None,
             buffer=buffer,
             frames_buffering_allowed=True,
         )
@@ -1190,6 +1202,7 @@ def test_stream_consumption_when_adaptive_strategy_drops_frames_due_to_reader_la
         result = consumer.consume_frame(
             video=video,
             declared_source_fps=None,
+            is_source_video_file=None,
             buffer=buffer,
             frames_buffering_allowed=True,
         )

--- a/tests/workflows/integration_tests/execution/stub_plugins/plugin_handling_video_metadata/__init__.py
+++ b/tests/workflows/integration_tests/execution/stub_plugins/plugin_handling_video_metadata/__init__.py
@@ -1,0 +1,48 @@
+from typing import List, Literal, Optional, Type
+
+from pydantic import Field
+
+from inference.core.workflows.execution_engine.entities.base import (
+    OutputDefinition,
+    VideoMetadata,
+)
+from inference.core.workflows.execution_engine.entities.types import (
+    INTEGER_KIND,
+    WorkflowVideoMetadataSelector,
+)
+from inference.core.workflows.prototypes.block import (
+    BlockResult,
+    WorkflowBlock,
+    WorkflowBlockManifest,
+)
+
+
+class Manifest(WorkflowBlockManifest):
+    type: Literal["ExampleVideoMetadataProcessing"]
+    name: str = Field(description="name field")
+    metadata: WorkflowVideoMetadataSelector
+
+    @classmethod
+    def describe_outputs(cls) -> List[OutputDefinition]:
+        return [OutputDefinition(name="frame_number", kind=[INTEGER_KIND])]
+
+    @classmethod
+    def get_execution_engine_compatibility(cls) -> Optional[str]:
+        return ">=1.1.0,<2.0.0"
+
+
+class VideoMetadataBlock(WorkflowBlock):
+
+    @classmethod
+    def get_manifest(cls) -> Type[WorkflowBlockManifest]:
+        return Manifest
+
+    def run(
+        self,
+        metadata: VideoMetadata,
+    ) -> BlockResult:
+        return {"frame_number": metadata.frame_number}
+
+
+def load_blocks() -> List[Type[WorkflowBlock]]:
+    return [VideoMetadataBlock]

--- a/tests/workflows/integration_tests/execution/stub_plugins/plugin_handling_video_metadata/__init__.py
+++ b/tests/workflows/integration_tests/execution/stub_plugins/plugin_handling_video_metadata/__init__.py
@@ -1,5 +1,7 @@
-from typing import List, Literal, Optional, Type
+from copy import deepcopy
+from typing import Dict, List, Literal, Optional, Type
 
+import supervision as sv
 from pydantic import Field
 
 from inference.core.workflows.execution_engine.entities.base import (
@@ -7,7 +9,12 @@ from inference.core.workflows.execution_engine.entities.base import (
     VideoMetadata,
 )
 from inference.core.workflows.execution_engine.entities.types import (
+    BATCH_OF_INSTANCE_SEGMENTATION_PREDICTION_KIND,
+    BATCH_OF_KEYPOINT_DETECTION_PREDICTION_KIND,
+    BATCH_OF_OBJECT_DETECTION_PREDICTION_KIND,
     INTEGER_KIND,
+    LIST_OF_VALUES_KIND,
+    StepOutputSelector,
     WorkflowVideoMetadataSelector,
 )
 from inference.core.workflows.prototypes.block import (
@@ -17,7 +24,7 @@ from inference.core.workflows.prototypes.block import (
 )
 
 
-class Manifest(WorkflowBlockManifest):
+class VideoMetadataBlockManifest(WorkflowBlockManifest):
     type: Literal["ExampleVideoMetadataProcessing"]
     name: str = Field(description="name field")
     metadata: WorkflowVideoMetadataSelector
@@ -35,7 +42,7 @@ class VideoMetadataBlock(WorkflowBlock):
 
     @classmethod
     def get_manifest(cls) -> Type[WorkflowBlockManifest]:
-        return Manifest
+        return VideoMetadataBlockManifest
 
     def run(
         self,
@@ -44,5 +51,53 @@ class VideoMetadataBlock(WorkflowBlock):
         return {"frame_number": metadata.frame_number}
 
 
+class TrackerManifest(WorkflowBlockManifest):
+    type: Literal["Tracker"]
+    name: str = Field(description="name field")
+    metadata: WorkflowVideoMetadataSelector
+    predictions: StepOutputSelector(
+        kind=[
+            BATCH_OF_OBJECT_DETECTION_PREDICTION_KIND,
+            BATCH_OF_INSTANCE_SEGMENTATION_PREDICTION_KIND,
+            BATCH_OF_KEYPOINT_DETECTION_PREDICTION_KIND,
+        ]
+    )
+
+    @classmethod
+    def describe_outputs(cls) -> List[OutputDefinition]:
+        return [OutputDefinition(name="tracker_id", kind=[LIST_OF_VALUES_KIND])]
+
+    @classmethod
+    def get_execution_engine_compatibility(cls) -> Optional[str]:
+        return ">=1.1.0,<2.0.0"
+
+
+class TrackerBlock(WorkflowBlock):
+
+    def __init__(self):
+        self._trackers: Dict[str, sv.ByteTrack] = {}
+
+    @classmethod
+    def get_manifest(cls) -> Type[WorkflowBlockManifest]:
+        return TrackerManifest
+
+    def run(
+        self,
+        metadata: VideoMetadata,
+        predictions: sv.Detections,
+    ) -> BlockResult:
+        if metadata.video_identifier not in self._trackers:
+            self._trackers[metadata.video_identifier] = sv.ByteTrack()
+        tracked_detections = self._trackers[
+            metadata.video_identifier
+        ].update_with_detections(detections=deepcopy(predictions))
+        result = (
+            tracked_detections.tracker_id.tolist()
+            if tracked_detections.tracker_id is not None
+            else None
+        )
+        return {"tracker_id": result}
+
+
 def load_blocks() -> List[Type[WorkflowBlock]]:
-    return [VideoMetadataBlock]
+    return [VideoMetadataBlock, TrackerBlock]

--- a/tests/workflows/integration_tests/execution/test_workflow_with_video_metadata_processing.py
+++ b/tests/workflows/integration_tests/execution/test_workflow_with_video_metadata_processing.py
@@ -1,0 +1,95 @@
+import time
+from datetime import datetime
+from unittest import mock
+from unittest.mock import MagicMock
+
+from inference.core.env import WORKFLOWS_MAX_CONCURRENT_STEPS
+from inference.core.managers.base import ModelManager
+from inference.core.workflows.core_steps.common.entities import StepExecutionMode
+from inference.core.workflows.execution_engine.core import ExecutionEngine
+from inference.core.workflows.execution_engine.entities.base import VideoMetadata
+from inference.core.workflows.execution_engine.introspection import blocks_loader
+
+WORKFLOW_PROCESSING_VIDEO_METADATA = {
+    "version": "1.1",
+    "inputs": [{"type": "WorkflowVideoMetadata", "name": "video_metadata"}],
+    "steps": [
+        {
+            "type": "ExampleVideoMetadataProcessing",
+            "name": "metadata_handler",
+            "metadata": "$inputs.video_metadata",
+        }
+    ],
+    "outputs": [
+        {
+            "type": "JsonField",
+            "name": "frame_number",
+            "selector": "$steps.metadata_handler.frame_number",
+        },
+    ],
+}
+
+
+@mock.patch.object(blocks_loader, "get_plugin_modules")
+def test_workflow_processing_video_metadata(
+    get_plugin_modules_mock: MagicMock,
+    model_manager: ModelManager,
+) -> None:
+    """
+    In this test scenario, we verify compatibility of new input type (WorkflowVideoMetadata)
+    with Workflows compiler and execution engine.
+    """
+    # given
+    get_plugin_modules_mock.return_value = [
+        "tests.workflows.integration_tests.execution.stub_plugins.plugin_handling_video_metadata"
+    ]
+    workflow_init_parameters = {
+        "workflows_core.model_manager": model_manager,
+        "workflows_core.api_key": None,
+        "workflows_core.step_execution_mode": StepExecutionMode.LOCAL,
+    }
+    execution_engine = ExecutionEngine.init(
+        workflow_definition=WORKFLOW_PROCESSING_VIDEO_METADATA,
+        init_parameters=workflow_init_parameters,
+        max_concurrent_steps=WORKFLOWS_MAX_CONCURRENT_STEPS,
+    )
+
+    # when
+    result = execution_engine.run(
+        runtime_parameters={
+            "video_metadata": [
+                {
+                    "video_identifier": "a",
+                    "frame_number": 21,
+                    "frame_timestamp": datetime.now().isoformat(),
+                    "fps": 50,
+                    "comes_from_video_file": True,
+                },
+                VideoMetadata(
+                    video_identifier="b",
+                    frame_number=37,
+                    frame_timestamp=time.time(),
+                    fps=None,
+                    comes_from_video_file=None,
+                ),
+            ]
+        }
+    )
+
+    # then
+    assert isinstance(result, list), "Expected list to be delivered"
+    assert (
+        len(result) == 2
+    ), "Expected 2 element in the output for two input batch elements"
+    assert set(result[0].keys()) == {
+        "frame_number",
+    }, "Expected all declared outputs to be delivered"
+    assert set(result[1].keys()) == {
+        "frame_number",
+    }, "Expected all declared outputs to be delivered"
+    assert (
+        result[0]["frame_number"] == 21
+    ), "Expected step to correctly extract frame number"
+    assert (
+        result[1]["frame_number"] == 37
+    ), "Expected step to correctly extract frame number"

--- a/tests/workflows/integration_tests/execution/test_workflow_with_video_metadata_processing.py
+++ b/tests/workflows/integration_tests/execution/test_workflow_with_video_metadata_processing.py
@@ -3,6 +3,8 @@ from datetime import datetime
 from unittest import mock
 from unittest.mock import MagicMock
 
+import numpy as np
+
 from inference.core.env import WORKFLOWS_MAX_CONCURRENT_STEPS
 from inference.core.managers.base import ModelManager
 from inference.core.workflows.core_steps.common.entities import StepExecutionMode
@@ -93,3 +95,126 @@ def test_workflow_processing_video_metadata(
     assert (
         result[1]["frame_number"] == 37
     ), "Expected step to correctly extract frame number"
+
+
+WORKFLOW_WITH_TRACKER = {
+    "version": "1.1",
+    "inputs": [
+        {"type": "WorkflowImage", "name": "image"},
+        {"type": "WorkflowVideoMetadata", "name": "video_metadata"},
+    ],
+    "steps": [
+        {
+            "type": "RoboflowObjectDetectionModel",
+            "name": "detection",
+            "image": "$inputs.image",
+            "model_id": "yolov8n-640",
+        },
+        {
+            "type": "Tracker",
+            "name": "tracker",
+            "metadata": "$inputs.video_metadata",
+            "predictions": "$steps.detection.predictions",
+        },
+    ],
+    "outputs": [
+        {
+            "type": "JsonField",
+            "name": "predictions",
+            "selector": "$steps.detection.predictions",
+        },
+        {
+            "type": "JsonField",
+            "name": "tracker_id",
+            "selector": "$steps.tracker.tracker_id",
+        },
+    ],
+}
+
+
+@mock.patch.object(blocks_loader, "get_plugin_modules")
+def test_workflow_with_tracker(
+    get_plugin_modules_mock: MagicMock,
+    model_manager: ModelManager,
+    dogs_image: np.ndarray,
+    crowd_image: np.ndarray,
+    license_plate_image: np.ndarray,
+) -> None:
+    """
+    In this test scenario, we verify compatibility of new input type (WorkflowVideoMetadata)
+    with Workflows compiler and execution engine.
+    """
+    # given
+    get_plugin_modules_mock.return_value = [
+        "tests.workflows.integration_tests.execution.stub_plugins.plugin_handling_video_metadata"
+    ]
+    workflow_init_parameters = {
+        "workflows_core.model_manager": model_manager,
+        "workflows_core.api_key": None,
+        "workflows_core.step_execution_mode": StepExecutionMode.LOCAL,
+    }
+    execution_engine = ExecutionEngine.init(
+        workflow_definition=WORKFLOW_WITH_TRACKER,
+        init_parameters=workflow_init_parameters,
+        max_concurrent_steps=WORKFLOWS_MAX_CONCURRENT_STEPS,
+    )
+    metadata_dogs_image = {
+        "video_identifier": "a",
+        "frame_number": 1,
+        "frame_timestamp": datetime.now().isoformat(),
+        "fps": 50,
+        "comes_from_video_file": True,
+    }
+    metadata_crowd_image = {
+        "video_identifier": "b",
+        "frame_number": 1,
+        "frame_timestamp": datetime.now().isoformat(),
+        "fps": 50,
+        "comes_from_video_file": True,
+    }
+    metadata_license_plare_image = {
+        "video_identifier": "c",
+        "frame_number": 1,
+        "frame_timestamp": datetime.now().isoformat(),
+        "fps": 50,
+        "comes_from_video_file": True,
+    }
+
+    # when
+    # simulating sequence of video frames to be processed from different sources
+    result_1 = execution_engine.run(
+        runtime_parameters={
+            "image": [dogs_image, crowd_image],
+            "video_metadata": [metadata_dogs_image, metadata_crowd_image],
+        }
+    )
+    result_2 = execution_engine.run(
+        runtime_parameters={
+            "image": [crowd_image],
+            "video_metadata": [metadata_crowd_image],
+        }
+    )
+    result_3 = execution_engine.run(
+        runtime_parameters={
+            "image": [dogs_image, license_plate_image],
+            "video_metadata": [metadata_dogs_image, metadata_license_plare_image],
+        }
+    )
+    first_dogs_frame_tracker_ids = result_1[0]["tracker_id"]
+    second_dogs_frame_tracker_ids = result_3[0]["tracker_id"]
+    first_crowd_frame_tracker_ids = result_1[1]["tracker_id"]
+    second_crowd_frame_tracker_ids = result_2[0]["tracker_id"]
+    first_license_plate_frame_tracker_ids = result_3[1]["tracker_id"]
+
+    # then
+    assert (
+        first_dogs_frame_tracker_ids == second_dogs_frame_tracker_ids
+    ), "The same image, expected no tracker IDs change"
+    assert (
+        first_crowd_frame_tracker_ids == second_crowd_frame_tracker_ids
+    ), "The same image, expected no tracker IDs change"
+    assert first_license_plate_frame_tracker_ids == [
+        15,
+        16,
+        17,
+    ], "External IDs for all trackers are global, hence we offset by numer of all ever generated tracker IDs"

--- a/tests/workflows/unit_tests/core_steps/transformations/test_perspective_correction.py
+++ b/tests/workflows/unit_tests/core_steps/transformations/test_perspective_correction.py
@@ -4,6 +4,7 @@ import pytest
 import supervision as sv
 
 from inference.core.workflows.core_steps.transformations.perspective_correction.v1 import (
+    PerspectiveCorrectionBlockV1,
     correct_detections,
     extend_perspective_polygon,
     generate_transformation_matrix,
@@ -16,13 +17,10 @@ from inference.core.workflows.execution_engine.constants import (
 )
 from inference.core.workflows.execution_engine.entities.base import (
     Batch,
+    ImageParentMetadata,
     WorkflowImageData,
-    ImageParentMetadata
 )
 
-from inference.core.workflows.core_steps.transformations.perspective_correction.v1 import (
-    PerspectiveCorrectionBlockV1,
-)
 
 @pytest.mark.parametrize("broken_input", [1, "cat", np.array([])])
 def test_pick_largest_perspective_polygons_raises_on_unexpected_type_of_input(
@@ -301,7 +299,9 @@ def test_warp_image():
     dummy_predictions = sv.Detections(xyxy=np.array([[10, 10, 20, 20]]))
     perspective_correction_block = PerspectiveCorrectionBlockV1()
 
-    workflow_image_data = WorkflowImageData(parent_metadata=ImageParentMetadata(parent_id="test"), numpy_image=dummy_image)
+    workflow_image_data = WorkflowImageData(
+        parent_metadata=ImageParentMetadata(parent_id="test"), numpy_image=dummy_image
+    )
 
     # when
     result = perspective_correction_block.run(
@@ -316,4 +316,6 @@ def test_warp_image():
 
     # then
     assert "warped_image" in result[0], "warped_image key must be present in the result"
-    assert isinstance(result[0]["warped_image"], WorkflowImageData), f"warped_image must be of type WorkflowImageData"
+    assert isinstance(
+        result[0]["warped_image"], WorkflowImageData
+    ), f"warped_image must be of type WorkflowImageData"

--- a/tests/workflows/unit_tests/execution_engine/executor/test_runtime_input_assembler.py
+++ b/tests/workflows/unit_tests/execution_engine/executor/test_runtime_input_assembler.py
@@ -13,7 +13,7 @@ from inference.core.workflows.execution_engine.v1.executor import (
     runtime_input_assembler,
 )
 from inference.core.workflows.execution_engine.v1.executor.runtime_input_assembler import (
-    assembly_runtime_parameters,
+    assemble_runtime_parameters,
 )
 
 
@@ -24,7 +24,7 @@ def test_assembly_runtime_parameters_when_image_is_not_provided() -> None:
 
     # when
     with pytest.raises(RuntimeInputError):
-        _ = assembly_runtime_parameters(
+        _ = assemble_runtime_parameters(
             runtime_parameters=runtime_parameters,
             defined_inputs=defined_inputs,
         )
@@ -45,7 +45,7 @@ def test_assembly_runtime_parameters_when_image_is_provided_as_single_element_di
     defined_inputs = [WorkflowImage(type="WorkflowImage", name="image1")]
 
     # when
-    result = assembly_runtime_parameters(
+    result = assemble_runtime_parameters(
         runtime_parameters=runtime_parameters,
         defined_inputs=defined_inputs,
     )
@@ -75,7 +75,7 @@ def test_assembly_runtime_parameters_when_image_is_provided_as_single_element_di
     defined_inputs = [WorkflowImage(type="WorkflowImage", name="image1")]
 
     # when
-    result = assembly_runtime_parameters(
+    result = assemble_runtime_parameters(
         runtime_parameters=runtime_parameters,
         defined_inputs=defined_inputs,
     )
@@ -106,7 +106,7 @@ def test_assembly_runtime_parameters_when_image_is_provided_as_single_element_di
 
     # when
     with pytest.raises(RuntimeInputError):
-        _ = assembly_runtime_parameters(
+        _ = assemble_runtime_parameters(
             runtime_parameters=runtime_parameters,
             defined_inputs=defined_inputs,
             prevent_local_images_loading=True,
@@ -121,7 +121,7 @@ def test_assembly_runtime_parameters_when_image_is_provided_as_single_element_np
     defined_inputs = [WorkflowImage(type="WorkflowImage", name="image1")]
 
     # when
-    result = assembly_runtime_parameters(
+    result = assemble_runtime_parameters(
         runtime_parameters=runtime_parameters,
         defined_inputs=defined_inputs,
     )
@@ -145,7 +145,7 @@ def test_assembly_runtime_parameters_when_image_is_provided_as_unknown_element()
 
     # when
     with pytest.raises(RuntimeInputError):
-        _ = assembly_runtime_parameters(
+        _ = assemble_runtime_parameters(
             runtime_parameters=runtime_parameters,
             defined_inputs=defined_inputs,
         )
@@ -165,7 +165,7 @@ def test_assembly_runtime_parameters_when_image_is_provided_in_batch() -> None:
     defined_inputs = [WorkflowImage(type="WorkflowImage", name="image1")]
 
     # when
-    result = assembly_runtime_parameters(
+    result = assemble_runtime_parameters(
         runtime_parameters=runtime_parameters,
         defined_inputs=defined_inputs,
     )
@@ -191,7 +191,7 @@ def test_assembly_runtime_parameters_when_parameter_not_provided() -> None:
     defined_inputs = [WorkflowParameter(type="WorkflowParameter", name="parameter")]
 
     # when
-    result = assembly_runtime_parameters(
+    result = assemble_runtime_parameters(
         runtime_parameters=runtime_parameters,
         defined_inputs=defined_inputs,
     )
@@ -206,7 +206,7 @@ def test_assembly_runtime_parameters_when_parameter_provided() -> None:
     defined_inputs = [WorkflowParameter(type="WorkflowParameter", name="parameter")]
 
     # when
-    result = assembly_runtime_parameters(
+    result = assemble_runtime_parameters(
         runtime_parameters=runtime_parameters,
         defined_inputs=defined_inputs,
     )


### PR DESCRIPTION
# Description

In this PR I try to add video metadata to `workflows` to make it possible for stateful stream- / video- processing blocks to operate.

We have two options basically:
- add optional fields for `WorkflowImage` input
- create additional type of batch-oriented input with metadata

The latter is more elegant imo, does not break bckw compatibility and is also a proof that adding new types of inputs (batch of text data to process by LMM model) will be easily possible. 

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

YOUR_ANSWER

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
