### PR TITLE
Add inference_id for classification

### DIFF
--- a/inference/core/models/classification_base.py
+++ b/inference/core/models/classification_base.py
@@ -256,6 +256,7 @@ class ClassificationBaseOnnxRoboflowInferenceModel(OnnxRoboflowInferenceModel):
         responses = self.infer(**request.dict(), return_image_dims=True)
         for response in responses:
             response.time = perf_counter() - t1
+            response.inference_id = getattr(request, "id", None)
 
         if request.visualize_predictions:
             for response in responses:

--- a/inference/core/version.py
+++ b/inference/core/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.16.4"
+__version__ = "0.16.3"
 
 
 if __name__ == "__main__":

--- a/inference/core/version.py
+++ b/inference/core/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.16.2"
+__version__ = "0.16.4"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

- The `inference_id` is missing in responses in requests made to classification projects, adding it in this change

## Type of change

Please delete options that are not relevant.

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

- Made several requests against local running inference container and confirmed that the inference_id was in the results. Repeated for other project types: instance-seg, single/multi classification
<img width="762" alt="Screenshot 2024-08-21 at 10 52 43" src="https://github.com/user-attachments/assets/f3bcc099-988b-4efc-a966-b701b14a31b0">
<img width="1457" alt="Screenshot 2024-08-21 at 11 06 57" src="https://github.com/user-attachments/assets/8e74aaf2-696a-4ca9-b8ce-f121fa8d61b5">


## Any specific deployment considerations

- Normal hosted inference deploy

## Docs

-   [ ] Docs updated? What were the changes:
