### PR TITLE
More exclusions for dedicated deployment authorizer

### DIFF
--- a/inference/core/interfaces/http/http_api.py
+++ b/inference/core/interfaces/http/http_api.py
@@ -472,8 +472,15 @@ class HttpInterface(BaseInterface):
                 # exclusions
                 skip_check = (
                     request.method not in ["GET", "POST"]
-                    or request.url.path in ["/", "/info"]
+                    or request.url.path
+                    in [
+                        "/",
+                        "/info",
+                        "/workflows/blocks/describe",
+                        "/workflows/definition/schema",
+                    ]
                     or request.url.path.startswith("/static/")
+                    or request.url.path.startswith("/_next/")
                 )
                 if skip_check:
                     return await call_next(request)

--- a/inference/core/interfaces/http/http_api.py
+++ b/inference/core/interfaces/http/http_api.py
@@ -186,8 +186,9 @@ if LAMBDA:
 if METLO_KEY:
     from metlo.fastapi import ASGIMiddleware
 
-from inference.core.version import __version__
 import time
+
+from inference.core.version import __version__
 
 
 def with_route_exceptions(route):

--- a/inference/core/interfaces/http/http_api.py
+++ b/inference/core/interfaces/http/http_api.py
@@ -542,7 +542,7 @@ class HttpInterface(BaseInterface):
                         )
 
                         cached_projects[project_url] = (
-                            time.time()
+                            time.time() + 3600
                         )  # expired after 1 hour
                     except RoboflowAPINotNotFoundError as e:
                         return _unauthorized_response("Unauthorized project")


### PR DESCRIPTION
# Description

1. more exclusions: `/workflows/blocks/describe`, `/workflows/definition/schema`, `/_next/*`
2. add expiration to cached api_key and project_url
3. skip parsing json parameters when request body is empty

List any dependencies that are required for this change.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Tested locally.

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
