### PR TITLE
Fix bug with `InferencePipeline` introduced with `VideoMetadata`

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 * @PawelPeczek-Roboflow @grzegorz-roboflow @yeldarby @probicheaux @hansent
-/docs/ @capjamesg
+docs/ @capjamesg

--- a/docs/using_inference/inference_pipeline.md
+++ b/docs/using_inference/inference_pipeline.md
@@ -188,7 +188,7 @@ pipeline = InferencePipeline.init_with_workflow(
     workflow_specification=workflow_specification,
     on_prediction=workflows_sink,
     image_input_name="image",  # adjust according to name of WorkflowImage input you define
-    video_metadata_input_name="video_metadata" # AVAILABLE from v0.17.0! adjust according to name of WorkflowVideoMetadata input you define - 
+    video_metadata_input_name="video_metadata" # AVAILABLE from v0.17.0! adjust according to name of WorkflowVideoMetadata input you define
 )
 
 # start the pipeline

--- a/docs/using_inference/inference_pipeline.md
+++ b/docs/using_inference/inference_pipeline.md
@@ -187,6 +187,8 @@ pipeline = InferencePipeline.init_with_workflow(
     video_reference="./my_video.mp4",
     workflow_specification=workflow_specification,
     on_prediction=workflows_sink,
+    image_input_name="image",  # adjust according to name of WorkflowImage input you define
+    video_metadata_input_name="video_metadata" # AVAILABLE from v0.17.0! adjust according to name of WorkflowVideoMetadata input you define - 
 )
 
 # start the pipeline

--- a/inference/core/interfaces/stream/inference_pipeline.py
+++ b/inference/core/interfaces/stream/inference_pipeline.py
@@ -577,6 +577,7 @@ class InferencePipeline:
                 workflows_parameters=workflows_parameters,
                 execution_engine=execution_engine,
                 image_input_name=image_input_name,
+                video_metadata_input_name=video_metadata_input_name,
             )
         except ImportError as error:
             raise CannotInitialiseModelError(

--- a/inference/usage_tracking/collector.py
+++ b/inference/usage_tracking/collector.py
@@ -461,7 +461,7 @@ class UsageCollector:
         usage_payloads = self._dump_usage_queue_with_lock()
         if not usage_payloads:
             return
-        merged_payloads: APIKeyUsage = self._zip_usage_payloads(
+        merged_payloads: APIKeyUsage = zip_usage_payloads(
             usage_payloads=usage_payloads,
         )
         self._offload_to_api(payloads=merged_payloads)
@@ -477,7 +477,7 @@ class UsageCollector:
 
         for payload in payloads:
             api_keys_hashes_failed = send_usage_payload(
-                payloads=payloads,
+                payload=payload,
                 api_usage_endpoint_url=self._settings.api_usage_endpoint_url,
                 hashes_to_api_keys=hashes_to_api_keys,
                 ssl_verify=ssl_verify,


### PR DESCRIPTION
# Description

There was a bug in `InferencePipeline` with workflows which do not use the parameter to specify video metadata causing always runtime error - fixed.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

* E2E tests

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [x] Docs updated? What were the changes:
