### PR TITLE
Fix issues with dynamic crop and lint tests

### DIFF
--- a/inference/core/workflows/core_steps/fusion/detections_consensus/v1.py
+++ b/inference/core/workflows/core_steps/fusion/detections_consensus/v1.py
@@ -366,9 +366,6 @@ def agree_on_consensus_for_all_detections_sources(
         )
         consensus_detections += consensus_detections_update
     consensus_detections = sv.Detections.merge(consensus_detections)
-    if len(consensus_detections) == 0:
-        # we need to add all metadata that were lost
-        pass
     (
         object_present,
         presence_confidence,

--- a/inference/core/workflows/core_steps/fusion/detections_consensus/v1.py
+++ b/inference/core/workflows/core_steps/fusion/detections_consensus/v1.py
@@ -336,7 +336,7 @@ def agree_on_consensus_for_all_detections_sources(
     if does_not_detect_objects_in_any_source(
         detections_from_sources=detections_from_sources
     ):
-        return "undefined", False, {}, []
+        return "undefined", False, {}, sv.Detections.empty()
     parent_id = get_parent_id_of_detections_from_sources(
         detections_from_sources=detections_from_sources,
     )

--- a/inference/core/workflows/core_steps/fusion/detections_consensus/v1.py
+++ b/inference/core/workflows/core_steps/fusion/detections_consensus/v1.py
@@ -366,6 +366,9 @@ def agree_on_consensus_for_all_detections_sources(
         )
         consensus_detections += consensus_detections_update
     consensus_detections = sv.Detections.merge(consensus_detections)
+    if len(consensus_detections) == 0:
+        # we need to add all metadata that were lost
+        pass
     (
         object_present,
         presence_confidence,

--- a/inference/core/workflows/core_steps/transformations/dynamic_crop/v1.py
+++ b/inference/core/workflows/core_steps/transformations/dynamic_crop/v1.py
@@ -109,6 +109,13 @@ def crop_image(
     detections: sv.Detections,
     detection_id_key: str = DETECTION_ID_KEY,
 ) -> List[Dict[str, WorkflowImageData]]:
+    if len(detections) == 0:
+        return []
+    if detection_id_key not in detections.data:
+        raise ValueError(
+            f"sv.Detections object passed to crop step do not fulfill contract - lack of {detection_id_key} key "
+            f"in data dictionary."
+        )
     crops = []
     for (x_min, y_min, x_max, y_max), detection_id in zip(
         detections.xyxy.round().astype(dtype=int), detections[detection_id_key]

--- a/tests/inference/models_predictions_tests/conftest.py
+++ b/tests/inference/models_predictions_tests/conftest.py
@@ -191,6 +191,7 @@ def sam2_small_model() -> Generator[str, None, None]:
 def sam2_small_truck_logits() -> Generator[np.ndarray, None, None]:
     yield np.load(SAM2_TRUCK_LOGITS)
 
+
 @pytest.fixture(scope="function")
 def sam2_small_truck_mask_from_cached_logits() -> Generator[np.ndarray, None, None]:
     yield np.load(SAM2_TRUCK_MASK_FROM_CACHE)

--- a/tests/inference/models_predictions_tests/test_sam2.py
+++ b/tests/inference/models_predictions_tests/test_sam2.py
@@ -3,11 +3,11 @@ import pytest
 import torch
 
 from inference.core.entities.requests.sam2 import Sam2PromptSet
+from inference.models.sam2 import SegmentAnything2
 from inference.models.sam2.segment_anything2 import (
     hash_prompt_set,
     maybe_load_low_res_logits_from_cache,
 )
-from inference.models.sam2 import SegmentAnything2
 
 
 @pytest.mark.slow
@@ -116,9 +116,11 @@ def test_sam2_single_prompted_image_segmentation_mask_cache_works(
     # then
     assert True, "doesnt crash when passing mask_input"
 
+
 @pytest.mark.slow
 def test_sam2_single_prompted_image_segmentation_mask_cache_changes_behavior(
-    sam2_small_model: str, truck_image: np.ndarray,
+    sam2_small_model: str,
+    truck_image: np.ndarray,
     sam2_small_truck_mask_from_cached_logits: np.ndarray,
 ) -> None:
     # given
@@ -152,6 +154,9 @@ def test_sam2_single_prompted_image_segmentation_mask_cache_changes_behavior(
         is not None
     )
     masks2, scores2, low_res_logits2 = model.segment_image(
-        truck_image, prompts=prompt, mask_input=low_res_logits, load_logits_from_cache=True
+        truck_image,
+        prompts=prompt,
+        mask_input=low_res_logits,
+        load_logits_from_cache=True,
     )
     assert np.allclose(sam2_small_truck_mask_from_cached_logits, masks2, atol=0.01)

--- a/tests/inference/unit_tests/core/interfaces/stream/test_interface_pipeline.py
+++ b/tests/inference/unit_tests/core/interfaces/stream/test_interface_pipeline.py
@@ -118,6 +118,7 @@ class VideoSourceStub:
 class ModelStub:
     def __init__(self):
         self.api_key = None
+
     def infer(self, image: Any, **kwargs) -> List[ObjectDetectionInferenceResponse]:
         return [
             ObjectDetectionInferenceResponse(

--- a/tests/inference/unit_tests/usage_tracking/test_collector.py
+++ b/tests/inference/unit_tests/usage_tracking/test_collector.py
@@ -5,7 +5,11 @@ import pytest
 
 from inference.core.env import LAMBDA
 from inference.usage_tracking.collector import UsageCollector
-from inference.usage_tracking.payload_helpers import get_api_key_usage_containing_resource, merge_usage_dicts, zip_usage_payloads
+from inference.usage_tracking.payload_helpers import (
+    get_api_key_usage_containing_resource,
+    merge_usage_dicts,
+    zip_usage_payloads,
+)
 
 
 def test_create_empty_usage_dict():
@@ -61,14 +65,8 @@ def test_merge_usage_dicts_merge_with_empty():
     }
     usage_payload_2 = {"resource_id": "some", "api_key_hash": "some"}
 
-    assert (
-        merge_usage_dicts(d1=usage_payload_1, d2=usage_payload_2)
-        == usage_payload_1
-    )
-    assert (
-        merge_usage_dicts(d1=usage_payload_2, d2=usage_payload_1)
-        == usage_payload_1
-    )
+    assert merge_usage_dicts(d1=usage_payload_1, d2=usage_payload_2) == usage_payload_1
+    assert merge_usage_dicts(d1=usage_payload_2, d2=usage_payload_1) == usage_payload_1
 
 
 def test_merge_usage_dicts():
@@ -90,9 +88,7 @@ def test_merge_usage_dicts():
         "source_duration": 1,
     }
 
-    assert merge_usage_dicts(
-        d1=usage_payload_1, d2=usage_payload_2
-    ) == {
+    assert merge_usage_dicts(d1=usage_payload_1, d2=usage_payload_2) == {
         "resource_id": "some",
         "api_key_hash": "some",
         "timestamp_start": 1721032989934855000,
@@ -304,9 +300,7 @@ def test_zip_usage_payloads():
     ]
 
     # when
-    zipped_usage_payloads = zip_usage_payloads(
-        usage_payloads=dumped_usage_payloads
-    )
+    zipped_usage_payloads = zip_usage_payloads(usage_payloads=dumped_usage_payloads)
 
     # then
     assert zipped_usage_payloads == [
@@ -396,9 +390,7 @@ def test_zip_usage_payloads_with_system_info_missing_resource_id_and_no_resource
     ]
 
     # when
-    zipped_usage_payloads = zip_usage_payloads(
-        usage_payloads=dumped_usage_payloads
-    )
+    zipped_usage_payloads = zip_usage_payloads(usage_payloads=dumped_usage_payloads)
 
     # then
     assert zipped_usage_payloads == [
@@ -459,9 +451,7 @@ def test_zip_usage_payloads_with_system_info_missing_resource_id():
     ]
 
     # when
-    zipped_usage_payloads = zip_usage_payloads(
-        usage_payloads=dumped_usage_payloads
-    )
+    zipped_usage_payloads = zip_usage_payloads(usage_payloads=dumped_usage_payloads)
 
     # then
     assert zipped_usage_payloads == [
@@ -514,9 +504,7 @@ def test_zip_usage_payloads_with_system_info_missing_resource_id_and_api_key():
     ]
 
     # when
-    zipped_usage_payloads = zip_usage_payloads(
-        usage_payloads=dumped_usage_payloads
-    )
+    zipped_usage_payloads = zip_usage_payloads(usage_payloads=dumped_usage_payloads)
 
     # then
     assert zipped_usage_payloads == [

--- a/tests/workflows/integration_tests/execution/test_workflow_detection_plus_classification.py
+++ b/tests/workflows/integration_tests/execution/test_workflow_detection_plus_classification.py
@@ -76,3 +76,37 @@ def test_detection_plus_classification_workflow_when_minimal_valid_input_provide
         "116.Parson_russell_terrier",
         "131.Wirehaired_pointing_griffon",
     ], "Expected predictions to be as measured in reference run"
+
+
+def test_detection_plus_classification_workflow_when_nothing_gets_predicted(
+    model_manager: ModelManager,
+    crowd_image: np.ndarray,
+    roboflow_api_key: str,
+) -> None:
+    # given
+    workflow_init_parameters = {
+        "workflows_core.model_manager": model_manager,
+        "workflows_core.api_key": roboflow_api_key,
+        "workflows_core.step_execution_mode": StepExecutionMode.LOCAL,
+    }
+    execution_engine = ExecutionEngine.init(
+        workflow_definition=DETECTION_PLUS_CLASSIFICATION_WORKFLOW,
+        init_parameters=workflow_init_parameters,
+        max_concurrent_steps=WORKFLOWS_MAX_CONCURRENT_STEPS,
+    )
+
+    # when
+    result = execution_engine.run(
+        runtime_parameters={
+            "image": crowd_image,
+        }
+    )
+
+    assert isinstance(result, list), "Expected list to be delivered"
+    assert len(result) == 1, "Expected 1 element in the output for one input image"
+    assert set(result[0].keys()) == {
+        "predictions",
+    }, "Expected all declared outputs to be delivered"
+    assert (
+        len(result[0]["predictions"]) == 0
+    ), "Expected no prediction from 2nd model, as no dogs detected"

--- a/tests/workflows/integration_tests/execution/test_workflow_detection_plus_classification.py
+++ b/tests/workflows/integration_tests/execution/test_workflow_detection_plus_classification.py
@@ -110,3 +110,79 @@ def test_detection_plus_classification_workflow_when_nothing_gets_predicted(
     assert (
         len(result[0]["predictions"]) == 0
     ), "Expected no prediction from 2nd model, as no dogs detected"
+
+
+DETECTION_PLUS_CLASSIFICATION_PLUS_CONSENSUS_WORKFLOW = {
+    "version": "1.0",
+    "inputs": [{"type": "WorkflowImage", "name": "image"}],
+    "steps": [
+        {
+            "type": "ObjectDetectionModel",
+            "name": "general_detection",
+            "image": "$inputs.image",
+            "model_id": "yolov8n-640",
+            "class_filter": ["dog"],
+        },
+        {
+            "type": "DetectionsConsensus",
+            "name": "detections_consensus",
+            "predictions_batches": [
+                "$steps.general_detection.predictions",
+            ],
+            "required_votes": 1,
+        },
+        {
+            "type": "Crop",
+            "name": "cropping",
+            "image": "$inputs.image",
+            "predictions": "$steps.detections_consensus.predictions",
+        },
+        {
+            "type": "ClassificationModel",
+            "name": "breds_classification",
+            "image": "$steps.cropping.crops",
+            "model_id": "dog-breed-xpaq6/1",
+        },
+    ],
+    "outputs": [
+        {
+            "type": "JsonField",
+            "name": "predictions",
+            "selector": "$steps.breds_classification.predictions",
+        },
+    ],
+}
+
+
+def test_detection_plus_classification_workflow_when_nothing_gets_predicted_and_empty_sv_detections_produced_without_metadata(
+    model_manager: ModelManager,
+    crowd_image: np.ndarray,
+    roboflow_api_key: str,
+) -> None:
+    # given
+    workflow_init_parameters = {
+        "workflows_core.model_manager": model_manager,
+        "workflows_core.api_key": roboflow_api_key,
+        "workflows_core.step_execution_mode": StepExecutionMode.LOCAL,
+    }
+    execution_engine = ExecutionEngine.init(
+        workflow_definition=DETECTION_PLUS_CLASSIFICATION_PLUS_CONSENSUS_WORKFLOW,
+        init_parameters=workflow_init_parameters,
+        max_concurrent_steps=WORKFLOWS_MAX_CONCURRENT_STEPS,
+    )
+
+    # when
+    result = execution_engine.run(
+        runtime_parameters={
+            "image": crowd_image,
+        }
+    )
+
+    assert isinstance(result, list), "Expected list to be delivered"
+    assert len(result) == 1, "Expected 1 element in the output for one input image"
+    assert set(result[0].keys()) == {
+        "predictions",
+    }, "Expected all declared outputs to be delivered"
+    assert (
+        len(result[0]["predictions"]) == 0
+    ), "Expected no prediction from 2nd model, as no dogs detected"

--- a/tests/workflows/unit_tests/core_steps/fusion/test_detections_consensus.py
+++ b/tests/workflows/unit_tests/core_steps/fusion/test_detections_consensus.py
@@ -1908,7 +1908,7 @@ def test_agree_on_consensus_for_all_detections_sources_when_empty_predictions_gi
     )
 
     # then
-    assert result == ("undefined", False, {}, [])
+    assert result == ("undefined", False, {}, sv.Detections.empty())
 
 
 def test_agree_on_consensus_for_all_detections_sources_when_predictions_do_not_match_classes() -> (


### PR DESCRIPTION
# Description

There is a bug in dynamic crop which was iterating through detections like that:

```python
for (x_min, y_min, x_max, y_max), detection_id in zip(
        detections.xyxy.round().astype(dtype=int), detections[detection_id_key]
```

assuming `detection_id` key in data. This is not always the case, as a side effect of some blocks - for instance Detections consensus or detections Stitch - which use `sv.Detections.merge(...)` which on no predictions simply returns `sv.Detections.empty()` removing whole `data` dict.
We have two options:
* fix the problem in each source of detcetions
* fix the problem in each place where we process detections

The former seems to be laborious and fragile - especially with blocks from community. The latter seems to be more "defensive" which I prefer attempting to ensure more bullet-proof ecosystem.

Added tests covering issue.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

* new tests in CI
* E2E run of problematic workflow

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
