### PR TITLE
bugfix (reappending the wrong key in the cache)

### DIFF
--- a/inference/models/sam2/segment_anything2.py
+++ b/inference/models/sam2/segment_anything2.py
@@ -325,7 +325,7 @@ class SegmentAnything2(RoboflowCoreModel):
         }
         if prompt_id in self.low_res_logits_cache_keys:
             self.low_res_logits_cache_keys.remove(prompt_id)
-        self.low_res_logits_cache_keys.append(image_id)
+        self.low_res_logits_cache_keys.append(prompt_id)
         if len(self.low_res_logits_cache_keys) > SAM2_MAX_LOGITS_CACHE_SIZE:
             cache_key = self.low_res_logits_cache_keys.pop(0)
             del self.low_res_logits_cache[cache_key]


### PR DESCRIPTION
# Description

Should fix this error seen in production.
![CleanShot 2024-08-23 at 11 45 17@2x](https://github.com/user-attachments/assets/0e7f9419-be2c-4377-a80b-5aaafe51370e)

Explanation
![CleanShot 2024-08-23 at 11 46 07@2x](https://github.com/user-attachments/assets/3c0c08f7-2475-48c9-ac5a-de5605ab2423)

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Not yet

