### PR TITLE
json.dumps resource_details when adding to usage payload

### DIFF
--- a/inference/usage_tracking/collector.py
+++ b/inference/usage_tracking/collector.py
@@ -138,7 +138,7 @@ class UsageCollector:
                     "source_duration": 0,
                     "category": "",
                     "resource_id": "",
-                    "resource_details": {},
+                    "resource_details": "{}",
                     "hosted": LAMBDA,
                     "api_key_hash": "",
                     "is_gpu_available": False,
@@ -325,7 +325,7 @@ class UsageCollector:
             )
             source_usage["category"] = category
             source_usage["resource_id"] = resource_id
-            source_usage["resource_details"] = resource_details
+            source_usage["resource_details"] = json.dumps(resource_details)
             source_usage["api_key_hash"] = api_key_hash
             source_usage["enterprise"] = enterprise
             source_usage["ip_address_hash"] = ip_address_hash

--- a/tests/inference/unit_tests/usage_tracking/test_collector.py
+++ b/tests/inference/unit_tests/usage_tracking/test_collector.py
@@ -38,7 +38,7 @@ def test_create_empty_usage_dict():
                     "source_duration": 0,
                     "category": "",
                     "resource_id": "",
-                    "resource_details": {},
+                    "resource_details": "{}",
                     "hosted": LAMBDA,
                     "api_key_hash": "",
                     "is_gpu_available": False,


### PR DESCRIPTION
# Description

Do not store `resource_details` as JSON when creating new usage payload

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

CI tests are passing

## Any specific deployment considerations

N/A

## Docs

N/A