### PR TITLE
Fix Detection Offset Bug

### DIFF
--- a/inference/core/workflows/core_steps/transformations/detection_offset/v1.py
+++ b/inference/core/workflows/core_steps/transformations/detection_offset/v1.py
@@ -134,15 +134,16 @@ def offset_detections(
     if len(detections) == 0:
         return detections
     _detections = deepcopy(detections)
+    image_dimensions = detections.data["image_dimensions"]
     _detections.xyxy = np.array(
         [
             (
-                x1 - offset_width // 2,
-                y1 - offset_height // 2,
-                x2 + offset_width // 2,
-                y2 + offset_height // 2,
+                max(0, x1 - offset_width // 2),
+                max(0, y1 - offset_height // 2),
+                min(image_dimensions[i][1], x2 + offset_width // 2),
+                min(image_dimensions[i][0], y2 + offset_height // 2),
             )
-            for (x1, y1, x2, y2) in _detections.xyxy
+            for i, (x1, y1, x2, y2) in enumerate(_detections.xyxy)
         ]
     )
     _detections[parent_id_key] = detections[detection_id_key].copy()

--- a/tests/workflows/unit_tests/core_steps/transformations/test_detection_offset.py
+++ b/tests/workflows/unit_tests/core_steps/transformations/test_detection_offset.py
@@ -85,6 +85,7 @@ def test_offset_detection() -> None:
             "detection_id": np.array(["two"]),
             "class_name": np.array(["car"]),
             "parent_id": np.array(["p2"]),
+            "image_dimensions": np.array([[640, 640]]),
         },
     )
 
@@ -107,6 +108,42 @@ def test_offset_detection() -> None:
     assert result["detection_id"] != str(
         detections["parent_id"][0]
     ), "New detection id (random) must be assigned"
+
+def test_offset_detection_when_larger_than_image() -> None:
+    # given
+    detections = sv.Detections(
+        xyxy=np.array([[90, 190, 110, 210]], dtype=np.float64),
+        class_id=np.array([1]),
+        confidence=np.array([0.5], dtype=np.float64),
+        data={
+            "detection_id": np.array(["two"]),
+            "class_name": np.array(["car"]),
+            "parent_id": np.array(["p2"]),
+            "image_dimensions": np.array([[640, 640]]),
+        },
+    )
+
+    # when
+    result = offset_detections(
+        detections=detections,
+        offset_width=2000,
+        offset_height=2000,
+    )
+
+    # then
+    x1, y1, x2, y2 = result.xyxy[0]
+    assert x1 == 0, "Left corner should be at the image border"
+    assert y1 == 0, "Top corner should be at the image border"
+    assert x2 == 640, "Right corner should be at the image border"
+    assert y2 == 640, "Bottom corner should be at the image border"
+    assert result["parent_id"] == str(
+        detections["detection_id"][0]
+    ), "Parent id should be set to origin detection id"
+    assert result["detection_id"] != str(
+        detections["parent_id"][0]
+    ), "New detection id (random) must be assigned"
+
+
 
 
 def test_offset_detection_when_nothing_predicted() -> None:


### PR DESCRIPTION
# Description

When using the detection offset block, one could set values larger than the image demensions and would result in over offset and null values. This can also be seen when detections are near the edge of the images. 
This PR fixes the detection offset block to the image demensions provided. 


https://github.com/user-attachments/assets/e243b0e5-3d82-4f0a-91a4-bacbdf6f7eb3


## Type of change

-   [X] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a test case or example of how you tested the change?

New unit test which tests extremely large offsets.
