### PR TITLE
Upgrade OpenCV to mitigate security vulnerability

### DIFF
--- a/examples/inference-dashboard-example/requirements.txt
+++ b/examples/inference-dashboard-example/requirements.txt
@@ -1,4 +1,4 @@
 matplotlib==3.7.1
-opencv_python==4.7.0.72
+opencv-python>=4.8.1.78,<=4.10.0.84
 pandas==2.0.2
 Requests==2.31.0

--- a/examples/sam-client/requirements.txt
+++ b/examples/sam-client/requirements.txt
@@ -1,2 +1,2 @@
 supervision
-opencv-python
+opencv-python>=4.8.1.78,<=4.10.0.84

--- a/requirements/_requirements.txt
+++ b/requirements/_requirements.txt
@@ -3,7 +3,7 @@ cython<=3.0.0
 python-dotenv<=2.0.0
 fastapi>=0.100,<0.111
 numpy<=1.26.4
-opencv-python<=4.8.0.76
+opencv-python>=4.8.1.78,<=4.10.0.84
 piexif<=1.1.3
 pillow<11.0
 prometheus-fastapi-instrumentator<=6.0.0

--- a/requirements/requirements.cli.txt
+++ b/requirements/requirements.cli.txt
@@ -5,7 +5,7 @@ rich<=13.5.2
 skypilot[aws,gcp]==0.5.0
 PyYAML>=6.0.0
 supervision>=0.20.0,<1.0.0
-opencv-python>=4.6.0
+opencv-python>=4.8.1.78,<=4.10.0.84
 tqdm>=4.0.0
 GPUtil>=1.4.0
 py-cpuinfo>=9.0.0

--- a/requirements/requirements.sdk.http.txt
+++ b/requirements/requirements.sdk.http.txt
@@ -1,6 +1,6 @@
 requests>=2.0.0
 dataclasses-json>=0.6.0
-opencv-python>=4.8.0.0
+opencv-python>=4.8.1.78,<=4.10.0.84
 pillow>=9.0.0
 requests>=2.27.0
 supervision>=0.20.0,<1.0.0


### PR DESCRIPTION
# Description

opencv-python versions before v4.8.1.78 bundled libwebp binaries in wheels that are vulnerable to https://github.com/advisories/GHSA-j7hp-h8jx-5ppr. opencv-python v4.8.1.78 upgrades the bundled libwebp binary to v1.3.2.

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

* CI

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
