### PR TITLE
Allow model type "yolov8" without size

### DIFF
--- a/inference/models/utils.py
+++ b/inference/models/utils.py
@@ -27,6 +27,7 @@ from inference.models.yolov8.yolov8_keypoints_detection import YOLOv8KeypointsDe
 ROBOFLOW_MODEL_TYPES = {
     ("classification", "stub"): ClassificationModelStub,
     ("classification", "vit"): VitClassification,
+    ("classification", "yolov8"): YOLOv8Classification,
     ("classification", "yolov8n"): YOLOv8Classification,
     ("classification", "yolov8s"): YOLOv8Classification,
     ("classification", "yolov8m"): YOLOv8Classification,
@@ -97,6 +98,10 @@ ROBOFLOW_MODEL_TYPES = {
     ): YOLOv8InstanceSegmentation,
     (
         "instance-segmentation",
+        "yolov8",
+    ): YOLOv8InstanceSegmentation,
+    (
+        "instance-segmentation",
         "yolov8s",
     ): YOLOv8InstanceSegmentation,
     (
@@ -136,6 +141,7 @@ ROBOFLOW_MODEL_TYPES = {
         "yolov8-seg",
     ): YOLOv8InstanceSegmentation,
     ("keypoint-detection", "stub"): KeypointsDetectionModelStub,
+    ("keypoint-detection", "yolov8"): YOLOv8KeypointsDetection,
     ("keypoint-detection", "yolov8n"): YOLOv8KeypointsDetection,
     ("keypoint-detection", "yolov8s"): YOLOv8KeypointsDetection,
     ("keypoint-detection", "yolov8m"): YOLOv8KeypointsDetection,


### PR DESCRIPTION
# Description

Allow modelType `yolov8`, without size specified for instance-seg, classification, and keypoint project types. This is already enabled for object-detection. Sometimes Roboflow Models do not have size specified for yolov8 models -- especially custom trained ones.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Regression tests!

## Any specific deployment considerations

Can go out as part of any release.

## Docs

-   [ ] Docs updated? What were the changes:
