### PR TITLE
Fix `GDAL` issue in GHA

### DIFF
--- a/.github/workflows/integration_tests_inference_models.yml
+++ b/.github/workflows/integration_tests_inference_models.yml
@@ -24,6 +24,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           check-latest: true
+      - name: 🚧 Install GDAL OS library
+        run: sudo apt-get install gdal-bin
       - name: 📦 Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/integration_tests_workflows_x86.yml
+++ b/.github/workflows/integration_tests_workflows_x86.yml
@@ -24,6 +24,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           check-latest: true
+      - name: 🚧 Install GDAL OS library
+        run: sudo apt-get install gdal-bin
       - name: 📦 Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/test_package_install_inference_gpu_with_extras.yml
+++ b/.github/workflows/test_package_install_inference_gpu_with_extras.yml
@@ -25,6 +25,8 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: "3.9"
+      - name: 🚧 Install GDAL OS library
+        run: sudo apt-get install gdal-bin
       - name: 🛞 Create Wheels
         run: |
           make create_wheels

--- a/.github/workflows/test_package_install_inference_with_extras.yml
+++ b/.github/workflows/test_package_install_inference_with_extras.yml
@@ -25,6 +25,8 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: "3.9"
+      - name: 🚧 Install GDAL OS library
+        run: sudo apt-get install gdal-bin
       - name: 🛞 Create Wheels
         run: |
           make create_wheels

--- a/inference/models/sam2/segment_anything2.py
+++ b/inference/models/sam2/segment_anything2.py
@@ -1,4 +1,3 @@
-import base64
 import copy
 import hashlib
 from io import BytesIO
@@ -6,7 +5,6 @@ from time import perf_counter
 from typing import Any, Dict, List, Optional, Tuple, TypedDict, Union
 
 import numpy as np
-import rasterio.features
 import sam2.utils.misc
 import torch
 from torch.nn.attention import SDPBackend
@@ -17,7 +15,6 @@ sam2.utils.misc.get_sdp_backends = lambda z: [
 ]
 from sam2.build_sam import build_sam2
 from sam2.sam2_image_predictor import SAM2ImagePredictor
-from shapely.geometry import Polygon as ShapelyPolygon
 
 from inference.core.entities.requests.inference import InferenceRequestImage
 from inference.core.entities.requests.sam2 import (


### PR DESCRIPTION
# Description

There is a problem with `rasterio` dependency for SAM, dependency of `rasterio` is `GDAL` library that must be present in OS. Apparently something has changed in runners and the lib is not there - this may also uncover issue that some of the clients may experience depending on their config when installing `pip install inference[sam]`

List any dependencies that are required for this change.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [x] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

YOUR_ANSWER

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
