### PR TITLE
Increase timeout to 30 minutes for .github/workflows/test_package_install_inference_with_extras.yml

### DIFF
--- a/.github/workflows/test_package_install_inference_with_extras.yml
+++ b/.github/workflows/test_package_install_inference_with_extras.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     runs-on:
       group: group8core
-    timeout-minutes: 15
+    timeout-minutes: 30
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]


### PR DESCRIPTION
## Any specific deployment considerations

N/A

## Docs

N/A