### PR TITLE
Fix problem with VLM as classifier block

### DIFF
--- a/inference/core/version.py
+++ b/inference/core/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.18.0"
+__version__ = "0.18.1"
 
 
 if __name__ == "__main__":

--- a/inference/core/workflows/core_steps/formatters/vlm_as_classifier/v1.py
+++ b/inference/core/workflows/core_steps/formatters/vlm_as_classifier/v1.py
@@ -177,7 +177,7 @@ def parse_multi_class_classification_results(
         if top_class not in class2id_mapping:
             predictions.append(
                 {
-                    "class_name": top_class,
+                    "class": top_class,
                     "class_id": -1,
                     "confidence": confidences.get(top_class, 0.0),
                 }
@@ -185,7 +185,7 @@ def parse_multi_class_classification_results(
         for class_name, class_id in class2id_mapping.items():
             predictions.append(
                 {
-                    "class_name": class_name,
+                    "class": class_name,
                     "class_id": class_id,
                     "confidence": confidences.get(class_name, 0.0),
                 }

--- a/tests/inference/hosted_platform_tests/workflows_examples/test_workflow_with_claude.py
+++ b/tests/inference/hosted_platform_tests/workflows_examples/test_workflow_with_claude.py
@@ -240,3 +240,98 @@ def test_object_detection_workflow(
         "dog",
         "dog",
     ], "Expected 2 dogs to be detected"
+
+
+VLM_AS_SECONDARY_CLASSIFIER_WORKFLOW = {
+    "version": "1.0",
+    "inputs": [
+        {"type": "WorkflowImage", "name": "image"},
+        {"type": "WorkflowParameter", "name": "api_key"},
+        {
+            "type": "WorkflowParameter",
+            "name": "classes",
+            "default_value": [
+                "russell-terrier",
+                "wirehaired-pointing-griffon",
+                "beagle",
+            ],
+        },
+    ],
+    "steps": [
+        {
+            "type": "ObjectDetectionModel",
+            "name": "general_detection",
+            "image": "$inputs.image",
+            "model_id": "yolov8n-640",
+            "class_filter": ["dog"],
+        },
+        {
+            "type": "Crop",
+            "name": "cropping",
+            "image": "$inputs.image",
+            "predictions": "$steps.general_detection.predictions",
+        },
+        {
+            "type": "roboflow_core/anthropic_claude@v1",
+            "name": "claude",
+            "images": "$steps.cropping.crops",
+            "task_type": "classification",
+            "classes": "$inputs.classes",
+            "api_key": "$inputs.api_key",
+        },
+        {
+            "type": "roboflow_core/vlm_as_classifier@v1",
+            "name": "parser",
+            "image": "$steps.cropping.crops",
+            "vlm_output": "$steps.claude.output",
+            "classes": "$steps.claude.classes",
+        },
+        {
+            "type": "roboflow_core/detections_classes_replacement@v1",
+            "name": "classes_replacement",
+            "object_detection_predictions": "$steps.general_detection.predictions",
+            "classification_predictions": "$steps.parser.predictions",
+        },
+    ],
+    "outputs": [
+        {
+            "type": "JsonField",
+            "name": "predictions",
+            "selector": "$steps.classes_replacement.predictions",
+        },
+    ],
+}
+
+
+@pytest.mark.skipif(ANTHROPIC_API_KEY is None, reason="No Antropic API key provided")
+@pytest.mark.flaky(retries=4, delay=1)
+def test_workflow_with_secondary_classifier(
+    object_detection_service_url: str,
+    dogs_image: np.ndarray,
+) -> None:
+    # given
+    client = InferenceHTTPClient(
+        api_url=object_detection_service_url,
+        api_key=ROBOFLOW_API_KEY,
+    )
+
+    # when
+    result = client.run_workflow(
+        specification=VLM_AS_SECONDARY_CLASSIFIER_WORKFLOW,
+        images={
+            "image": dogs_image,
+        },
+        parameters={
+            "api_key": ANTHROPIC_API_KEY,
+            "classes": ["russell-terrier", "wirehaired-pointing-griffon", "beagle"],
+        },
+    )
+
+    # then
+    assert len(result) == 1, "Single image given, expected single output"
+    assert set(result[0].keys()) == {
+        "predictions",
+    }, "Expected all outputs to be delivered"
+    assert "dog" not in set(
+        [e["class"] for e in result[0]["predictions"]["predictions"]]
+    ), "Expected classes to be substituted"

--- a/tests/inference/hosted_platform_tests/workflows_examples/test_workflow_with_claude.py
+++ b/tests/inference/hosted_platform_tests/workflows_examples/test_workflow_with_claude.py
@@ -247,6 +247,7 @@ VLM_AS_SECONDARY_CLASSIFIER_WORKFLOW = {
     "inputs": [
         {"type": "WorkflowImage", "name": "image"},
         {"type": "WorkflowParameter", "name": "api_key"},
+        {"type": "WorkflowParameter", "name": "model_id"},
         {
             "type": "WorkflowParameter",
             "name": "classes",
@@ -262,7 +263,7 @@ VLM_AS_SECONDARY_CLASSIFIER_WORKFLOW = {
             "type": "ObjectDetectionModel",
             "name": "general_detection",
             "image": "$inputs.image",
-            "model_id": "yolov8n-640",
+            "model_id": "$inputs.model_id",
             "class_filter": ["dog"],
         },
         {
@@ -308,6 +309,7 @@ VLM_AS_SECONDARY_CLASSIFIER_WORKFLOW = {
 def test_workflow_with_secondary_classifier(
     object_detection_service_url: str,
     dogs_image: np.ndarray,
+    yolov8n_640_model_id: str,
 ) -> None:
     # given
     client = InferenceHTTPClient(
@@ -324,6 +326,7 @@ def test_workflow_with_secondary_classifier(
         parameters={
             "api_key": ANTHROPIC_API_KEY,
             "classes": ["russell-terrier", "wirehaired-pointing-griffon", "beagle"],
+            "model_id": yolov8n_640_model_id,
         },
     )
 

--- a/tests/inference/hosted_platform_tests/workflows_examples/test_workflow_with_gemini.py
+++ b/tests/inference/hosted_platform_tests/workflows_examples/test_workflow_with_gemini.py
@@ -247,6 +247,7 @@ VLM_AS_SECONDARY_CLASSIFIER_WORKFLOW = {
     "inputs": [
         {"type": "WorkflowImage", "name": "image"},
         {"type": "WorkflowParameter", "name": "api_key"},
+        {"type": "WorkflowParameter", "name": "model_id"},
         {
             "type": "WorkflowParameter",
             "name": "classes",
@@ -262,7 +263,7 @@ VLM_AS_SECONDARY_CLASSIFIER_WORKFLOW = {
             "type": "ObjectDetectionModel",
             "name": "general_detection",
             "image": "$inputs.image",
-            "model_id": "yolov8n-640",
+            "model_id": "$inputs.model_id",
             "class_filter": ["dog"],
         },
         {
@@ -308,6 +309,7 @@ VLM_AS_SECONDARY_CLASSIFIER_WORKFLOW = {
 def test_workflow_with_secondary_classifier(
     object_detection_service_url: str,
     dogs_image: np.ndarray,
+    yolov8n_640_model_id: str,
 ) -> None:
     client = InferenceHTTPClient(
         api_url=object_detection_service_url,
@@ -323,6 +325,7 @@ def test_workflow_with_secondary_classifier(
         parameters={
             "api_key": GOOGLE_API_KEY,
             "classes": ["russell-terrier", "wirehaired-pointing-griffon", "beagle"],
+            "model_id": yolov8n_640_model_id,
         },
     )
 

--- a/tests/inference/hosted_platform_tests/workflows_examples/test_workflow_with_gemini.py
+++ b/tests/inference/hosted_platform_tests/workflows_examples/test_workflow_with_gemini.py
@@ -240,3 +240,97 @@ def test_object_detection_workflow(
         "dog",
         "dog",
     ], "Expected 2 dogs to be detected"
+
+
+VLM_AS_SECONDARY_CLASSIFIER_WORKFLOW = {
+    "version": "1.0",
+    "inputs": [
+        {"type": "WorkflowImage", "name": "image"},
+        {"type": "WorkflowParameter", "name": "api_key"},
+        {
+            "type": "WorkflowParameter",
+            "name": "classes",
+            "default_value": [
+                "russell-terrier",
+                "wirehaired-pointing-griffon",
+                "beagle",
+            ],
+        },
+    ],
+    "steps": [
+        {
+            "type": "ObjectDetectionModel",
+            "name": "general_detection",
+            "image": "$inputs.image",
+            "model_id": "yolov8n-640",
+            "class_filter": ["dog"],
+        },
+        {
+            "type": "Crop",
+            "name": "cropping",
+            "image": "$inputs.image",
+            "predictions": "$steps.general_detection.predictions",
+        },
+        {
+            "type": "roboflow_core/google_gemini@v1",
+            "name": "gemini",
+            "images": "$steps.cropping.crops",
+            "task_type": "classification",
+            "classes": "$inputs.classes",
+            "api_key": "$inputs.api_key",
+        },
+        {
+            "type": "roboflow_core/vlm_as_classifier@v1",
+            "name": "parser",
+            "image": "$steps.cropping.crops",
+            "vlm_output": "$steps.gemini.output",
+            "classes": "$steps.gemini.classes",
+        },
+        {
+            "type": "roboflow_core/detections_classes_replacement@v1",
+            "name": "classes_replacement",
+            "object_detection_predictions": "$steps.general_detection.predictions",
+            "classification_predictions": "$steps.parser.predictions",
+        },
+    ],
+    "outputs": [
+        {
+            "type": "JsonField",
+            "name": "predictions",
+            "selector": "$steps.classes_replacement.predictions",
+        },
+    ],
+}
+
+
+@pytest.mark.skipif(GOOGLE_API_KEY is None, reason="No Google API key provided")
+@pytest.mark.flaky(retries=4, delay=1)
+def test_workflow_with_secondary_classifier(
+    object_detection_service_url: str,
+    dogs_image: np.ndarray,
+) -> None:
+    client = InferenceHTTPClient(
+        api_url=object_detection_service_url,
+        api_key=ROBOFLOW_API_KEY,
+    )
+
+    # when
+    result = client.run_workflow(
+        specification=VLM_AS_SECONDARY_CLASSIFIER_WORKFLOW,
+        images={
+            "image": dogs_image,
+        },
+        parameters={
+            "api_key": GOOGLE_API_KEY,
+            "classes": ["russell-terrier", "wirehaired-pointing-griffon", "beagle"],
+        },
+    )
+
+    # then
+    assert len(result) == 1, "Single image given, expected single output"
+    assert set(result[0].keys()) == {
+        "predictions",
+    }, "Expected all outputs to be delivered"
+    assert "dog" not in set(
+        [e["class"] for e in result[0]["predictions"]["predictions"]]
+    ), "Expected classes to be substituted"

--- a/tests/inference/hosted_platform_tests/workflows_examples/test_workflow_with_openai.py
+++ b/tests/inference/hosted_platform_tests/workflows_examples/test_workflow_with_openai.py
@@ -260,6 +260,7 @@ VLM_AS_SECONDARY_CLASSIFIER_WORKFLOW = {
     "inputs": [
         {"type": "WorkflowImage", "name": "image"},
         {"type": "WorkflowParameter", "name": "api_key"},
+        {"type": "WorkflowParameter", "name": "model_id"},
         {
             "type": "WorkflowParameter",
             "name": "classes",
@@ -275,7 +276,7 @@ VLM_AS_SECONDARY_CLASSIFIER_WORKFLOW = {
             "type": "ObjectDetectionModel",
             "name": "general_detection",
             "image": "$inputs.image",
-            "model_id": "yolov8n-640",
+            "model_id": "$inputs.model_id",
             "class_filter": ["dog"],
         },
         {
@@ -321,6 +322,7 @@ VLM_AS_SECONDARY_CLASSIFIER_WORKFLOW = {
 def test_structured_prompting_workflow(
     object_detection_service_url: str,
     dogs_image: np.ndarray,
+    yolov8n_640_model_id: str,
 ) -> None:
     client = InferenceHTTPClient(
         api_url=object_detection_service_url,
@@ -336,6 +338,7 @@ def test_structured_prompting_workflow(
         parameters={
             "api_key": OPENAI_KEY,
             "classes": ["russell-terrier", "wirehaired-pointing-griffon", "beagle"],
+            "model_id": yolov8n_640_model_id,
         },
     )
 

--- a/tests/workflows/integration_tests/execution/test_workflow_with_claude_models.py
+++ b/tests/workflows/integration_tests/execution/test_workflow_with_claude_models.py
@@ -673,3 +673,114 @@ def test_workflow_with_object_detection_prompt(
         "dog",
         "dog",
     ], "Expected 2 dogs to be detected"
+
+
+VLM_AS_SECONDARY_CLASSIFIER_WORKFLOW = {
+    "version": "1.0",
+    "inputs": [
+        {"type": "WorkflowImage", "name": "image"},
+        {"type": "WorkflowParameter", "name": "api_key"},
+        {
+            "type": "WorkflowParameter",
+            "name": "classes",
+            "default_value": [
+                "russell-terrier",
+                "wirehaired-pointing-griffon",
+                "beagle",
+            ],
+        },
+    ],
+    "steps": [
+        {
+            "type": "ObjectDetectionModel",
+            "name": "general_detection",
+            "image": "$inputs.image",
+            "model_id": "yolov8n-640",
+            "class_filter": ["dog"],
+        },
+        {
+            "type": "Crop",
+            "name": "cropping",
+            "image": "$inputs.image",
+            "predictions": "$steps.general_detection.predictions",
+        },
+        {
+            "type": "roboflow_core/anthropic_claude@v1",
+            "name": "claude",
+            "images": "$steps.cropping.crops",
+            "task_type": "classification",
+            "classes": "$inputs.classes",
+            "api_key": "$inputs.api_key",
+        },
+        {
+            "type": "roboflow_core/vlm_as_classifier@v1",
+            "name": "parser",
+            "image": "$steps.cropping.crops",
+            "vlm_output": "$steps.claude.output",
+            "classes": "$steps.claude.classes",
+        },
+        {
+            "type": "roboflow_core/detections_classes_replacement@v1",
+            "name": "classes_replacement",
+            "object_detection_predictions": "$steps.general_detection.predictions",
+            "classification_predictions": "$steps.parser.predictions",
+        },
+    ],
+    "outputs": [
+        {
+            "type": "JsonField",
+            "name": "predictions",
+            "selector": "$steps.classes_replacement.predictions",
+        },
+    ],
+}
+
+
+@add_to_workflows_gallery(
+    category="Workflows with Visual Language Models",
+    use_case_title="Using Anthropic Claude as secondary classifier",
+    use_case_description="""
+In this example, Anthropic Claude model is used as secondary classifier - first, YOLO model
+detects dogs, then for each dog we run classification with VLM and at the end we replace 
+detections classes to have bounding boxes with dogs breeds labels.
+
+Breeds that we classify: `russell-terrier`, `wirehaired-pointing-griffon`, `beagle`
+    """,
+    workflow_definition=VLM_AS_SECONDARY_CLASSIFIER_WORKFLOW,
+    workflow_name_in_app="claude-secondary-classifier",
+)
+@pytest.mark.skipif(
+    condition=ANTHROPIC_API_KEY is None, reason="Anthropic API key not provided"
+)
+def test_workflow_with_secondary_classifier(
+    model_manager: ModelManager,
+    dogs_image: np.ndarray,
+) -> None:
+    # given
+    workflow_init_parameters = {
+        "workflows_core.model_manager": model_manager,
+        "workflows_core.step_execution_mode": StepExecutionMode.LOCAL,
+    }
+    execution_engine = ExecutionEngine.init(
+        workflow_definition=VLM_AS_SECONDARY_CLASSIFIER_WORKFLOW,
+        init_parameters=workflow_init_parameters,
+        max_concurrent_steps=WORKFLOWS_MAX_CONCURRENT_STEPS,
+    )
+
+    # when
+    result = execution_engine.run(
+        runtime_parameters={
+            "image": [dogs_image],
+            "api_key": ANTHROPIC_API_KEY,
+            "classes": ["russell-terrier", "wirehaired-pointing-griffon", "beagle"],
+        }
+    )
+
+    # then
+    assert len(result) == 1, "Single image given, expected single output"
+    assert set(result[0].keys()) == {
+        "predictions",
+    }, "Expected all outputs to be delivered"
+    assert "dog" not in set(
+        result[0]["predictions"].data["class_name"].tolist()
+    ), "Expected classes to be substituted"

--- a/tests/workflows/integration_tests/execution/test_workflow_with_open_ai_models.py
+++ b/tests/workflows/integration_tests/execution/test_workflow_with_open_ai_models.py
@@ -582,3 +582,114 @@ def test_workflow_with_structured_prompt(
     assert len(result) == 1, "Single image given, expected single output"
     assert set(result[0].keys()) == {"result"}, "Expected all outputs to be delivered"
     assert result[0]["result"] == "2"
+
+
+VLM_AS_SECONDARY_CLASSIFIER_WORKFLOW = {
+    "version": "1.0",
+    "inputs": [
+        {"type": "WorkflowImage", "name": "image"},
+        {"type": "WorkflowParameter", "name": "api_key"},
+        {
+            "type": "WorkflowParameter",
+            "name": "classes",
+            "default_value": [
+                "russell-terrier",
+                "wirehaired-pointing-griffon",
+                "beagle",
+            ],
+        },
+    ],
+    "steps": [
+        {
+            "type": "ObjectDetectionModel",
+            "name": "general_detection",
+            "image": "$inputs.image",
+            "model_id": "yolov8n-640",
+            "class_filter": ["dog"],
+        },
+        {
+            "type": "Crop",
+            "name": "cropping",
+            "image": "$inputs.image",
+            "predictions": "$steps.general_detection.predictions",
+        },
+        {
+            "type": "roboflow_core/open_ai@v2",
+            "name": "gpt",
+            "images": "$steps.cropping.crops",
+            "task_type": "classification",
+            "classes": "$inputs.classes",
+            "api_key": "$inputs.api_key",
+        },
+        {
+            "type": "roboflow_core/vlm_as_classifier@v1",
+            "name": "parser",
+            "image": "$steps.cropping.crops",
+            "vlm_output": "$steps.gpt.output",
+            "classes": "$steps.gpt.classes",
+        },
+        {
+            "type": "roboflow_core/detections_classes_replacement@v1",
+            "name": "classes_replacement",
+            "object_detection_predictions": "$steps.general_detection.predictions",
+            "classification_predictions": "$steps.parser.predictions",
+        },
+    ],
+    "outputs": [
+        {
+            "type": "JsonField",
+            "name": "predictions",
+            "selector": "$steps.classes_replacement.predictions",
+        },
+    ],
+}
+
+
+@add_to_workflows_gallery(
+    category="Workflows with Visual Language Models",
+    use_case_title="Using GPT as secondary classifier",
+    use_case_description="""
+In this example, GPT model is used as secondary classifier - first, YOLO model
+detects dogs, then for each dog we run classification with VLM and at the end we replace 
+detections classes to have bounding boxes with dogs breeds labels.
+
+Breeds that we classify: `russell-terrier`, `wirehaired-pointing-griffon`, `beagle`
+    """,
+    workflow_definition=VLM_AS_SECONDARY_CLASSIFIER_WORKFLOW,
+    workflow_name_in_app="gpt-secondary-classifier",
+)
+@pytest.mark.skipif(
+    condition=OPEN_AI_API_KEY is None, reason="Open AI API key not provided"
+)
+def test_workflow_with_secondary_classifier(
+    model_manager: ModelManager,
+    dogs_image: np.ndarray,
+) -> None:
+    # given
+    workflow_init_parameters = {
+        "workflows_core.model_manager": model_manager,
+        "workflows_core.step_execution_mode": StepExecutionMode.LOCAL,
+    }
+    execution_engine = ExecutionEngine.init(
+        workflow_definition=VLM_AS_SECONDARY_CLASSIFIER_WORKFLOW,
+        init_parameters=workflow_init_parameters,
+        max_concurrent_steps=WORKFLOWS_MAX_CONCURRENT_STEPS,
+    )
+
+    # when
+    result = execution_engine.run(
+        runtime_parameters={
+            "image": [dogs_image],
+            "api_key": OPEN_AI_API_KEY,
+            "classes": ["russell-terrier", "wirehaired-pointing-griffon", "beagle"],
+        }
+    )
+
+    # then
+    assert len(result) == 1, "Single image given, expected single output"
+    assert set(result[0].keys()) == {
+        "predictions",
+    }, "Expected all outputs to be delivered"
+    assert "dog" not in set(
+        result[0]["predictions"].data["class_name"].tolist()
+    ), "Expected classes to be substituted"

--- a/tests/workflows/unit_tests/core_steps/formatters/test_vlm_as_classifier.py
+++ b/tests/workflows/unit_tests/core_steps/formatters/test_vlm_as_classifier.py
@@ -62,8 +62,8 @@ def test_run_when_valid_json_given_for_multi_class_classification() -> None:
     assert result["error_status"] is False
     assert result["predictions"]["image"] == {"width": 168, "height": 192}
     assert result["predictions"]["predictions"] == [
-        {"class_name": "car", "class_id": 0, "confidence": 0.7},
-        {"class_name": "cat", "class_id": 1, "confidence": 0.0},
+        {"class": "car", "class_id": 0, "confidence": 0.7},
+        {"class": "cat", "class_id": 1, "confidence": 0.0},
     ]
     assert result["predictions"]["top"] == "car"
     assert abs(result["predictions"]["confidence"] - 0.7) < 1e-5
@@ -94,9 +94,9 @@ def test_run_when_valid_json_given_for_multi_class_classification_when_unknown_c
     assert result["error_status"] is False
     assert result["predictions"]["image"] == {"width": 168, "height": 192}
     assert result["predictions"]["predictions"] == [
-        {"class_name": "my_class", "class_id": -1, "confidence": 0.7},
-        {"class_name": "car", "class_id": 0, "confidence": 0.0},
-        {"class_name": "cat", "class_id": 1, "confidence": 0.0},
+        {"class": "my_class", "class_id": -1, "confidence": 0.7},
+        {"class": "car", "class_id": 0, "confidence": 0.0},
+        {"class": "cat", "class_id": 1, "confidence": 0.0},
     ]
     assert result["predictions"]["top"] == "my_class"
     assert abs(result["predictions"]["confidence"] - 0.7) < 1e-5


### PR DESCRIPTION
# Description

There was a bug with VLM as Classifier block - details of predictions had "class_name" instead of "class" key which is 
incompatible with other blocks - like detections classes replacement.
This shall be released as hotfix.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

* new tests
* CI still green

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
