### PR TITLE
Control what properties are visible in the UI by default

### DIFF
--- a/inference/core/workflows/core_steps/models/foundation/anthropic_claude/v1.py
+++ b/inference/core/workflows/core_steps/models/foundation/anthropic_claude/v1.py
@@ -109,13 +109,7 @@ class BlockManifest(WorkflowBlockManifest):
     type: Literal["roboflow_core/anthropic_claude@v1"]
     images: Union[WorkflowImageSelector, StepOutputImageSelector] = ImageInputField
     task_type: TaskType = Field(
-        description="Task type to be performed by model. Value of parameter determine set of fields "
-        "that are required. For `unconstrained`, `visual-question-answering`, "
-        " - `prompt` parameter must be provided."
-        "For `structured-answering` - `output-structure` must be provided. For "
-        "`classification`, `multi-label-classification` and `object-detection` - "
-        "`classes` must be filled. `ocr`, `caption`, `detailed-caption` do not"
-        "require any additional parameter.",
+        description="Task type to be performed by model. Value determines required parameters and output response.",
     )
     prompt: Optional[Union[WorkflowParameterSelector(kind=[STRING_KIND]), str]] = Field(
         default=None,

--- a/inference/core/workflows/core_steps/models/foundation/google_gemini/v1.py
+++ b/inference/core/workflows/core_steps/models/foundation/google_gemini/v1.py
@@ -117,13 +117,7 @@ class BlockManifest(WorkflowBlockManifest):
     type: Literal["roboflow_core/google_gemini@v1"]
     images: Union[WorkflowImageSelector, StepOutputImageSelector] = ImageInputField
     task_type: TaskType = Field(
-        description="Task type to be performed by model. Value of parameter determine set of fields "
-        "that are required. For `unconstrained`, `visual-question-answering`, "
-        " - `prompt` parameter must be provided."
-        "For `structured-answering` - `output-structure` must be provided. For "
-        "`classification`, `multi-label-classification` and `object-detection` - "
-        "`classes` must be filled. `ocr`, `caption`, `detailed-caption` do not"
-        "require any additional parameter.",
+        description="Task type to be performed by model. Value determines required parameters and output response.",
     )
     prompt: Optional[Union[WorkflowParameterSelector(kind=[STRING_KIND]), str]] = Field(
         default=None,

--- a/inference/core/workflows/core_steps/models/foundation/openai/v2.py
+++ b/inference/core/workflows/core_steps/models/foundation/openai/v2.py
@@ -39,7 +39,7 @@ You can specify arbitrary text prompts or predefined ones, the block supports th
 
 - `unconstrained` - any arbitrary prompt you like 
 
-- `ocr`- predefined prompt to recognise text from image
+- `ocr`- predefined prompt to recognize text from image
 
 - `visual-question-answering` - your prompt is supposed to provide question and will be 
 wrapped into structure that is suited for VQA task
@@ -101,13 +101,7 @@ class BlockManifest(WorkflowBlockManifest):
     type: Literal["roboflow_core/open_ai@v2"]
     images: Union[WorkflowImageSelector, StepOutputImageSelector] = ImageInputField
     task_type: TaskType = Field(
-        description="Task type to be performed by model. Value of parameter determine set of fields "
-        "that are required. For `unconstrained`, `visual-question-answering`, "
-        " - `prompt` parameter must be provided."
-        "For `structured-answering` - `output-structure` must be provided. For "
-        "`classification`, `multi-label-classification` - "
-        "`classes` must be filled. `ocr`, `caption`, `detailed-caption` do not"
-        "require any additional parameter.",
+        description="Task type to be performed by model. Value determines required parameters and output response."
     )
     prompt: Optional[Union[WorkflowParameterSelector(kind=[STRING_KIND]), str]] = Field(
         default=None,
@@ -125,7 +119,10 @@ class BlockManifest(WorkflowBlockManifest):
         examples=[{"my_key": "description"}, "$inputs.output_structure"],
         json_schema_extra={
             "relevant_for": {
-                "task_type": {"values": TASKS_REQUIRING_CLASSES, "required": True},
+                "task_type": {
+                    "values": TASKS_REQUIRING_OUTPUT_STRUCTURE,
+                    "required": True,
+                },
             },
         },
     )
@@ -138,7 +135,7 @@ class BlockManifest(WorkflowBlockManifest):
         json_schema_extra={
             "relevant_for": {
                 "task_type": {
-                    "values": TASKS_REQUIRING_OUTPUT_STRUCTURE,
+                    "values": TASKS_REQUIRING_CLASSES,
                     "required": True,
                 },
             },

--- a/inference/core/workflows/core_steps/models/foundation/segment_anything2/v1.py
+++ b/inference/core/workflows/core_steps/models/foundation/segment_anything2/v1.py
@@ -90,9 +90,10 @@ class BlockManifest(WorkflowBlockManifest):
             ]
         )
     ] = Field(  # type: ignore
-        description="Boxes (from other model predictions) to ground SAM2",
+        description="Bounding boxes (from another model) to convert to polygons",
         examples=["$steps.object_detection_model.predictions"],
         default=None,
+        json_schema_extra={"always_visible": True},
     )
     version: Union[
         WorkflowParameterSelector(kind=[STRING_KIND]),

--- a/inference/core/workflows/core_steps/sinks/roboflow/dataset_upload/v2.py
+++ b/inference/core/workflows/core_steps/sinks/roboflow/dataset_upload/v2.py
@@ -69,6 +69,18 @@ class BlockManifest(WorkflowBlockManifest):
     )
     type: Literal["roboflow_core/roboflow_dataset_upload@v2"]
     images: Union[WorkflowImageSelector, StepOutputImageSelector] = ImageInputField
+    target_project: Union[
+        WorkflowParameterSelector(kind=[ROBOFLOW_PROJECT_KIND]), str
+    ] = Field(
+        description="name of Roboflow dataset / project to be used as target for collected data",
+        examples=["my_dataset", "$inputs.target_al_dataset"],
+    )
+    usage_quota_name: str = Field(
+        description="Unique name for Roboflow project pointed by `target_project` parameter, that identifies "
+        "usage quota applied for this block.",
+        examples=["quota-for-data-sampling-1"],
+        json_schema_extra={"hidden": True},
+    )
     predictions: Optional[
         StepOutputSelector(
             kind=[
@@ -80,23 +92,14 @@ class BlockManifest(WorkflowBlockManifest):
         )
     ] = Field(
         default=None,
-        description="Reference q detection-like predictions",
+        description="Model predictions to be saved",
         examples=["$steps.object_detection_model.predictions"],
-    )
-    target_project: Union[
-        WorkflowParameterSelector(kind=[ROBOFLOW_PROJECT_KIND]), str
-    ] = Field(
-        description="name of Roboflow dataset / project to be used as target for collected data",
-        examples=["my_dataset", "$inputs.target_al_dataset"],
-    )
-    usage_quota_name: str = Field(
-        description="Unique name for Roboflow project pointed by `target_project` parameter, that identifies "
-        "usage quota applied for this block.",
-        examples=["quota-for-data-sampling-1"],
+        json_schema_extra={"always_visible": True},
     )
     data_percentage: Union[
         FloatZeroToHundred, WorkflowParameterSelector(kind=[FLOAT_KIND])
     ] = Field(
+        default=100,
         description="Percent of data that will be saved (in range [0.0, 100.0])",
         examples=[True, False, "$inputs.persist_predictions"],
     )


### PR DESCRIPTION
# Description

In this PR:
- Simplify model task_type descriptions by auto hiding/showing the relevant properties
- Add properties `always_visible` and `hidden` to block parameters
- bugfix: TASKS_REQUIRING_CLASSES and TASKS_REQUIRING_OUTPUT_STRUCTURE were swapped

![image](https://github.com/user-attachments/assets/7a5801d1-ce2b-49d7-b6ef-e11ed09d8019)

https://github.com/user-attachments/assets/69228301-5dc7-4537-8526-aa6e894c34a6


## Type of change
-   [X] Bug fix (non-breaking change which fixes an issue)
-   [X] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?
locally

## Any specific deployment considerations
deploy [frontend PR](https://github.com/roboflow/roboflow/pull/4365)

## Docs
N/A
