### PR TITLE
Switch base class of blur and pixelate to PredictionsVisualizationManifest / PredictionsVisualizationBlock

### DIFF
--- a/inference/core/workflows/core_steps/visualizations/blur/v1.py
+++ b/inference/core/workflows/core_steps/visualizations/blur/v1.py
@@ -5,8 +5,8 @@ from pydantic import ConfigDict, Field
 
 from inference.core.workflows.core_steps.visualizations.common.base import (
     OUTPUT_IMAGE_KEY,
-    VisualizationBlock,
-    VisualizationManifest,
+    PredictionsVisualizationBlock,
+    PredictionsVisualizationManifest,
 )
 from inference.core.workflows.execution_engine.entities.base import WorkflowImageData
 from inference.core.workflows.execution_engine.entities.types import (
@@ -23,7 +23,7 @@ objects in an image using Supervision's `sv.BlurAnnotator`.
 """
 
 
-class BlurManifest(VisualizationManifest):
+class BlurManifest(PredictionsVisualizationManifest):
     type: Literal[f"{TYPE}", "BlurVisualization"]
     model_config = ConfigDict(
         json_schema_extra={
@@ -47,7 +47,7 @@ class BlurManifest(VisualizationManifest):
         return ">=1.0.0,<2.0.0"
 
 
-class BlurVisualizationBlockV1(VisualizationBlock):
+class BlurVisualizationBlockV1(PredictionsVisualizationBlock):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.annotatorCache = {}

--- a/inference/core/workflows/core_steps/visualizations/pixelate/v1.py
+++ b/inference/core/workflows/core_steps/visualizations/pixelate/v1.py
@@ -5,8 +5,8 @@ from pydantic import ConfigDict, Field
 
 from inference.core.workflows.core_steps.visualizations.common.base import (
     OUTPUT_IMAGE_KEY,
-    VisualizationBlock,
-    VisualizationManifest,
+    PredictionsVisualizationBlock,
+    PredictionsVisualizationManifest,
 )
 from inference.core.workflows.execution_engine.entities.base import WorkflowImageData
 from inference.core.workflows.execution_engine.entities.types import (
@@ -23,7 +23,7 @@ objects in an image using Supervision's `sv.PixelateAnnotator`.
 """
 
 
-class PixelateManifest(VisualizationManifest):
+class PixelateManifest(PredictionsVisualizationManifest):
     type: Literal[f"{TYPE}", "PixelateVisualization"]
     model_config = ConfigDict(
         json_schema_extra={
@@ -47,7 +47,7 @@ class PixelateManifest(VisualizationManifest):
         return ">=1.0.0,<2.0.0"
 
 
-class PixelateVisualizationBlockV1(VisualizationBlock):
+class PixelateVisualizationBlockV1(PredictionsVisualizationBlock):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.annotatorCache = {}


### PR DESCRIPTION
# Description

blur and pixelate were not inheriting from ColorableVisualizationManifest / ColorableVisualizationBlock, hence #650 resulted in regression (`predictions` missing from `run` args).

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

CI passing; adding tests covering regression

## Any specific deployment considerations

N/A

## Docs

N/A