### PR TITLE
Fix issue with SAM2 producing segmentation masks as points and lines

### DIFF
--- a/inference/core/version.py
+++ b/inference/core/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.21.0"
+__version__ = "0.21.1"
 
 
 if __name__ == "__main__":

--- a/inference/core/workflows/core_steps/models/foundation/segment_anything2/v1.py
+++ b/inference/core/workflows/core_steps/models/foundation/segment_anything2/v1.py
@@ -297,7 +297,7 @@ def convert_sam2_segmentation_response_to_inference_instances_seg_response(
         prompt_detection_ids,
     ):
         for mask in prediction.masks:
-            if len(mask) == 0:
+            if len(mask) < 3:
                 # skipping empty masks
                 continue
             if prediction.confidence < threshold:


### PR DESCRIPTION
# Description

We had a problem with SAM2 model - sometimes it produces segmentation masks being points or lines. That do not come in line with `sv.Detections(...)` which skip the mask if it contains less than 3 points instead leaving blank. That was colliding with the code that associate detections id (more detections were visible - vs trimmed list in sv.Detections). Added filtering of malformed segmentations early-on

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

* E2E test

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
