### PR TITLE
Docker auto-reload configuration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,17 @@ repo_root$ docker build -t roboflow/roboflow-inference-server-cpu:dev -f docker/
 repo_root$ docker build -t roboflow/roboflow-inference-server-gpu:dev -f docker/dockerfiles/Dockerfile.onnx.gpu .
 ```
 
+> [!TIP]
+> While the Dockerfiles mentioned above are used for production builds, it can be beneficial during development to use 
+> a version of the Dockerfile that incorporates a watchdog to automatically restart the service whenever code changes 
+> are detected. 
+> We have prepared a development-specific Dockerfile that supports this functionality. 
+> You can find it at `docker/dockerfiles/Dockerfile.onnx.cpu.dev`.
+> To build the image, use the following command:
+> ```bash
+> repo_root$ docker build -t roboflow/roboflow-inference-server-cpu:dev -f docker/dockerfiles/Dockerfile.onnx.cpu.dev .
+> ```
+
 Running the container is possible using the following command:
 
 ```bash

--- a/docker/dockerfiles/Dockerfile.onnx.cpu.dev
+++ b/docker/dockerfiles/Dockerfile.onnx.cpu.dev
@@ -1,0 +1,78 @@
+FROM python:3.9 as base
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt update -y && apt install -y \
+    libxext6 \
+    libopencv-dev \
+    uvicorn \
+    python3-pip \
+    git \
+    libgdal-dev \
+    cmake \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements/requirements.sam.txt \
+    requirements/requirements.clip.txt \
+    requirements/requirements.cpu.txt \
+    requirements/requirements.vino.txt \
+    requirements/requirements.http.txt \
+    requirements/requirements.waf.txt \
+    requirements/requirements.gaze.txt \
+    requirements/requirements.doctr.txt \
+    requirements/requirements.groundingdino.txt \
+    requirements/requirements.yolo_world.txt \
+    requirements/requirements.transformers.txt \
+    requirements/_requirements.txt \
+    ./
+
+RUN pip3 install --upgrade pip  && pip3 install \
+    -r _requirements.txt \
+    -r requirements.sam.txt \
+    -r requirements.clip.txt \
+    -r requirements.cpu.txt \
+    -r requirements.http.txt \
+    -r requirements.waf.txt \
+    -r requirements.gaze.txt \
+    -r requirements.doctr.txt \
+    -r requirements.groundingdino.txt \
+    -r requirements.yolo_world.txt \
+    -r requirements.transformers.txt \
+    jupyterlab \
+    wheel>=0.38.0 \
+    --upgrade \
+    && rm -rf ~/.cache/pip
+
+FROM scratch
+ARG TARGETPLATFORM
+
+COPY --from=base / /
+
+WORKDIR /build
+COPY . .
+RUN make create_wheels
+RUN pip3 install dist/inference_cli*.whl dist/inference_core*.whl dist/inference_cpu*.whl dist/inference_sdk*.whl
+RUN pip3 install watchdog[watchmedo]
+RUN if [ "${TARGETPLATFORM}" = "linux/amd64" ]; then pip3 install -r requirements/requirements.vino.txt; rm -rf ~/.cache/pip; fi
+
+
+WORKDIR /notebooks
+COPY examples/notebooks .
+
+WORKDIR /app
+COPY inference inference
+COPY docker/config/cpu_http.py cpu_http.py
+
+ENV VERSION_CHECK_MODE=continuous
+ENV PROJECT=roboflow-platform
+ENV NUM_WORKERS=1
+ENV HOST=0.0.0.0
+ENV PORT=9001
+ENV WORKFLOWS_STEP_EXECUTION_MODE=local
+ENV WORKFLOWS_MAX_CONCURRENT_STEPS=1
+ENV API_LOGGING_ENABLED=True
+ENV CORE_MODEL_SAM2_ENABLED=True
+ENV CORE_MODEL_OWLV2_ENABLED=True
+ENV ENABLE_STREAM_API=True
+
+ENTRYPOINT watchmedo auto-restart --directory=/app/inference --pattern=*.py --recursive -- uvicorn cpu_http:app --workers $NUM_WORKERS --host $HOST --port $PORT


### PR DESCRIPTION
# Description

Added a `Dockerfile.onnx.cpu.dev` file that uses watchdog to listen to code changes and auto restart the inference server

## Type of change
-   [X] Development improvement

## How has this change been tested, please provide a testcase or example of how you tested the change?
Use this dockerfile to dev locally

## Any specific deployment considerations
n/a

## Docs
should update the developer docs to recommend using this dockerfile when deving locally
