### PR TITLE
Relax openvino version

### DIFF
--- a/requirements/requirements.vino.txt
+++ b/requirements/requirements.vino.txt
@@ -1,1 +1,1 @@
-onnxruntime-openvino~=1.15.1
+onnxruntime-openvino~=1.15.0


### PR DESCRIPTION
# Description

Open vino ort doesn't have match 1.15.1


builds succesfully here: https://github.com/roboflow/inference/actions/runs/11183240407
## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

tests

## Any specific deployment considerations

no
## Docs

-   [ ] Docs updated? What were the changes:
