### PR TITLE
Caching compilation results

### DIFF
--- a/inference/core/workflows/execution_engine/v1/compiler/cache.py
+++ b/inference/core/workflows/execution_engine/v1/compiler/cache.py
@@ -1,0 +1,48 @@
+import hashlib
+from collections import deque
+from threading import Lock
+from typing import Any, Callable, Dict, Generic, List, Optional, Tuple, TypeVar
+
+from inference.core.workflows.errors import (
+    WorkflowEnvironmentConfigurationError,
+    WorkflowError,
+)
+
+V = TypeVar("V")
+
+
+class BasicWorkflowsCache(Generic[V]):
+
+    def __init__(
+        self,
+        cache_size: int,
+        hash_functions: List[Tuple[str, Callable[[Any], str]]],
+    ):
+        self._keys_buffer = deque(maxlen=max(cache_size, 1))
+        self._cache: Dict[str, V] = {}
+        self._hash_functions = hash_functions
+        self._cache_lock = Lock()
+
+    def get_hash_key(self, **kwargs) -> str:
+        hash_chunks = []
+        for key_name, hashing_function in self._hash_functions:
+            if key_name not in kwargs:
+                raise WorkflowEnvironmentConfigurationError(
+                    public_message=f"Cache is miss configured.",
+                    context="workflows_cache | hash_key_generation",
+                )
+            hash_value = hashing_function(kwargs[key_name])
+            hash_chunks.append(hash_value)
+        return hashlib.md5("<|>".join(hash_chunks).encode("utf-8")).hexdigest()
+
+    def get(self, key: str) -> Optional[V]:
+        with self._cache_lock:
+            return self._cache.get(key)
+
+    def cache(self, key: str, value: V) -> None:
+        with self._cache_lock:
+            if len(self._keys_buffer) == self._keys_buffer.maxlen:
+                to_pop = self._keys_buffer.pop()
+                del self._cache[to_pop]
+            self._keys_buffer.append(key)
+            self._cache[key] = value

--- a/inference/core/workflows/execution_engine/v1/compiler/syntactic_parser.py
+++ b/inference/core/workflows/execution_engine/v1/compiler/syntactic_parser.py
@@ -1,8 +1,6 @@
 from typing import Dict, List, Optional, Type, Union
 
 import pydantic
-
-# from packaging.version import Version
 from pydantic import BaseModel, Field, create_model
 from typing_extensions import Annotated
 

--- a/inference/core/workflows/execution_engine/v1/compiler/syntactic_parser.py
+++ b/inference/core/workflows/execution_engine/v1/compiler/syntactic_parser.py
@@ -1,7 +1,8 @@
 from typing import Dict, List, Optional, Type, Union
 
 import pydantic
-from packaging.version import Version
+
+# from packaging.version import Version
 from pydantic import BaseModel, Field, create_model
 from typing_extensions import Annotated
 
@@ -15,43 +16,25 @@ from inference.core.workflows.execution_engine.profiling.core import (
     WorkflowsProfiler,
     execution_phase,
 )
+from inference.core.workflows.execution_engine.v1.compiler.cache import (
+    BasicWorkflowsCache,
+)
 from inference.core.workflows.execution_engine.v1.compiler.entities import (
     BlockSpecification,
     ParsedWorkflowDefinition,
 )
 
-
-class WorkflowDefinitionEntitiesCache:
-
-    def __init__(self, cache_size: int):
-        self._cache_size = max(1, cache_size)
-        self._entries: Dict[str, Type[BaseModel]] = {}
-
-    def add_entry(
-        self, blocks: List[BlockSpecification], entry: Type[BaseModel]
-    ) -> None:
-        hash_value = self._hash_blocks(blocks=blocks)
-        if hash_value in self._entries:
-            self._entries[hash_value] = entry
-            return None
-        if len(self._entries) == self._cache_size:
-            key_to_drop = next(self._entries.__iter__())
-            self._entries.pop(key_to_drop)
-        self._entries[hash_value] = entry
-
-    def cache_hit(self, blocks: List[BlockSpecification]) -> bool:
-        hash_value = self._hash_blocks(blocks=blocks)
-        return hash_value in self._entries
-
-    def get(self, blocks: List[BlockSpecification]) -> Type[BaseModel]:
-        hash_value = self._hash_blocks(blocks=blocks)
-        return self._entries[hash_value]
-
-    def _hash_blocks(self, blocks: List[BlockSpecification]) -> str:
-        return "<|>".join(block.block_source + block.identifier for block in blocks)
-
-
-WORKFLOW_DEFINITION_ENTITIES_CACHE = WorkflowDefinitionEntitiesCache(cache_size=64)
+WORKFLOW_DEFINITION_ENTITIES_CACHE = BasicWorkflowsCache[Type[BaseModel]](
+    cache_size=64,
+    hash_functions=[
+        (
+            "available_blocks",
+            lambda blocks: "<|>".join(
+                block.block_source + block.identifier for block in blocks
+            ),
+        )
+    ],
+)
 
 
 @execution_phase(
@@ -87,8 +70,12 @@ def parse_workflow_definition(
 def build_workflow_definition_entity(
     available_blocks: List[BlockSpecification],
 ) -> Type[BaseModel]:
-    if WORKFLOW_DEFINITION_ENTITIES_CACHE.cache_hit(blocks=available_blocks):
-        return WORKFLOW_DEFINITION_ENTITIES_CACHE.get(blocks=available_blocks)
+    cache_key = WORKFLOW_DEFINITION_ENTITIES_CACHE.get_hash_key(
+        available_blocks=available_blocks
+    )
+    cached_value = WORKFLOW_DEFINITION_ENTITIES_CACHE.get(key=cache_key)
+    if cached_value is not None:
+        return cached_value
     steps_manifests = tuple(block.manifest_class for block in available_blocks)
     block_manifest_types_union = Union[steps_manifests]
     block_type = Annotated[block_manifest_types_union, Field(discriminator="type")]
@@ -99,9 +86,9 @@ def build_workflow_definition_entity(
         steps=(List[block_type], ...),
         outputs=(List[JsonField], ...),
     )
-    WORKFLOW_DEFINITION_ENTITIES_CACHE.add_entry(
-        blocks=available_blocks,
-        entry=entity,
+    WORKFLOW_DEFINITION_ENTITIES_CACHE.cache(
+        key=cache_key,
+        value=entity,
     )
     return entity
 

--- a/inference/core/workflows/execution_engine/v1/dynamic_blocks/block_assembler.py
+++ b/inference/core/workflows/execution_engine/v1/dynamic_blocks/block_assembler.py
@@ -56,13 +56,7 @@ def compile_dynamic_blocks(
 ) -> List[BlockSpecification]:
     if not dynamic_blocks_definitions:
         return []
-    if not ALLOW_CUSTOM_PYTHON_EXECUTION_IN_WORKFLOWS:
-        raise WorkflowEnvironmentConfigurationError(
-            public_message="Cannot use dynamic blocks with custom Python code in this installation of `workflows`. "
-            "This can be changed by setting environmental variable "
-            "`ALLOW_CUSTOM_PYTHON_EXECUTION_IN_WORKFLOWS=True`",
-            context="workflow_compilation | dynamic_blocks_compilation",
-        )
+    ensure_dynamic_blocks_allowed(dynamic_blocks_definitions=dynamic_blocks_definitions)
     all_defined_kinds = load_all_defined_kinds()
     kinds_lookup = {kind.name: kind for kind in all_defined_kinds}
     dynamic_blocks = [
@@ -77,6 +71,16 @@ def compile_dynamic_blocks(
         )
         compiled_blocks.append(block_specification)
     return compiled_blocks
+
+
+def ensure_dynamic_blocks_allowed(dynamic_blocks_definitions: List[dict]) -> None:
+    if dynamic_blocks_definitions and not ALLOW_CUSTOM_PYTHON_EXECUTION_IN_WORKFLOWS:
+        raise WorkflowEnvironmentConfigurationError(
+            public_message="Cannot use dynamic blocks with custom Python code in this installation of `workflows`. "
+            "This can be changed by setting environmental variable "
+            "`ALLOW_CUSTOM_PYTHON_EXECUTION_IN_WORKFLOWS=True`",
+            context="workflow_compilation | dynamic_blocks_compilation",
+        )
 
 
 def create_dynamic_block_specification(

--- a/tests/workflows/unit_tests/execution_engine/compiler/test_cache.py
+++ b/tests/workflows/unit_tests/execution_engine/compiler/test_cache.py
@@ -1,0 +1,85 @@
+import pytest
+
+from inference.core.workflows.errors import WorkflowEnvironmentConfigurationError
+from inference.core.workflows.execution_engine.v1.compiler.cache import (
+    BasicWorkflowsCache,
+)
+
+
+def test_cache_when_hash_key_cannot_be_obtained() -> None:
+    # given
+    cache = BasicWorkflowsCache[int](
+        cache_size=16,
+        hash_functions=[("some", lambda v: str(v))],
+    )
+
+    # when
+    with pytest.raises(WorkflowEnvironmentConfigurationError):
+        _ = cache.get_hash_key(other=3)
+
+
+def test_cache_when_hash_key_can_be_obtained() -> None:
+    # given
+    cache = BasicWorkflowsCache[int](
+        cache_size=16,
+        hash_functions=[("some", lambda v: str(v))],
+    )
+
+    # when
+    value = cache.get_hash_key(some=3)
+
+    # then
+    assert isinstance(value, str)
+
+
+def test_get_cache_value_on_cache_hit() -> None:
+    # given
+    cache = BasicWorkflowsCache[str](
+        cache_size=16,
+        hash_functions=[("some", lambda v: str(v))],
+    )
+    key = cache.get_hash_key(some=3)
+    cache.cache(key=key, value="my_value")
+
+    # when
+    result = cache.get(key=key)
+
+    # then
+    assert result == "my_value"
+
+
+def test_get_cache_value_on_cache_miss() -> None:
+    # given
+    cache = BasicWorkflowsCache[str](
+        cache_size=16,
+        hash_functions=[("some", lambda v: str(v))],
+    )
+
+    # when
+    result = cache.get(key="my_key")
+
+    # then
+    assert result is None
+
+
+def test_cache_being_emptied_properly() -> None:
+    # given
+    cache = BasicWorkflowsCache[str](
+        cache_size=2,
+        hash_functions=[("some", lambda v: str(v))],
+    )
+
+    # when
+    key_one = cache.get_hash_key(some=1)
+    cache.cache(key=key_one, value="my_value_1")
+
+    key_two = cache.get_hash_key(some=2)
+    cache.cache(key=key_two, value="my_value_2")
+
+    key_three = cache.get_hash_key(some=3)
+    cache.cache(key=key_three, value="my_value_3")
+
+    # then
+    assert cache.get(key_one) is None
+    assert cache.get(key_two) == "my_value_2"
+    assert cache.get(key_three) == "my_value_3"


### PR DESCRIPTION
# Description

In this PR, workflows compilation results cache is introduced to reduce latency of consecutive invocations of the same workflow definition.


## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

* CI still 🟢 
* E2E speed test

## 🏇 Speedup report

### Test
Compare the outcome of command: `inference benchmark api-speed` for model inference vs the same model within Workflow with only a single block, `inference-cli` **uses 1 client and call requests sequentially**

Abbreviations:
* **SR** stands for initial @PacificDou Report raising the speed issues with EE
* **+CC** stands for the Compiler Cache extension added in **this** PR
* **EE** and **EE overhead [%]** columns are results of the test after https://github.com/roboflow/inference/pull/710 optimisations

❗ **notes**
* *`inference benchmark api-speed` for model used without `--legacy-endpoints` which tends to slightly be more optimal for localhost, left as is to be compliant with previous tests*
* Test executed on GCP machine with Nvidia T4 

<table>
<tr>
<th>Model</th><th>img-size</th><th>SR server</th><th>server</th><th>SR EE</th><th>EE</th><th>EE overhead [%]</th><th>EE+CC</th><th>EE+CC overhead [%]</th>
</tr>

<tr>
<td>football-player-detection-ej9zh/12</td>
<td>320</td>
<td>52.4 RPS</td>
<td>48 RPS</td>
<td>2 RPS</td>
<td><b>28 RPS</b></td>
<td>+75% </td>
<td><b>47 RPS</b></td>
<td>+2.2% </td>
</tr>

<tr>
<td>football-player-detection-ej9zh/13</td>
<td>640</td>
<td>45 RPS</td>
<td>36.5 RPS</td>
<td>2 RPS</td>
<td><b>24 RPS</b></td>
<td>+52% </td>
<td><b>36 RPS</b></td>
<td>+1.4% </td>
</tr>

<tr>
<td>football-player-detection-ej9zh/14</td>
<td>960</td>
<td>31.9 RPS</td>
<td>26 RPS</td>
<td>2 RPS</td>
<td><b>18.5 RPS</b></td>
<td>+38.5% </td>
<td><b>25 RPS</b></td>
<td>+4% </td>
</tr>


<tr>
<td>football-player-detection-ej9zh/15</td>
<td>1280</td>
<td>24 RPS</td>
<td>19 RPS</td>
<td>1.8 RPS</td>
<td><b>13.5 RPS</b></td>
<td>+39% </td>
<td><b>17.5 RPS</b></td>
<td>+8.5% </td>
</tr>

</table>

**Outcome:**
Significantly reduced compilation overhead when the same workflow definition is used


❗ Observatiion
**GPU utilisation is peaking to ~25% which is significant underutilisation**


### Test - maxing out throughput
In this test, we run model inference vs model-in-workflow, but we use `inference benchmark api-speed` with `rps` value seeking for parameter that:
* maximises throughput
* not causing latency to constantly grows over time

Reporting ranges of average latencies in 5s windows

<table>
<tr>
<th>Model</th><th>img-size</th><th>server</th><th>server latency</th><th>EE+CC</th><th>EE+CC latency</th>
</tr>

<tr>
<td>football-player-detection-ej9zh/12</td>
<td>320</td>
<td>60 RPS</td>
<td>100-650ms</td>
<td><b>56 RPS</b></td>
<td>110-500ms</td>
</tr>

<tr>
<td>football-player-detection-ej9zh/13</td>
<td>640</td>
<td>45 RPS</td>
<td>80-300ms</td>
<td><b>39 RPS</b></td>
<td>110-550ms</td>
</tr>

<tr>
<td>football-player-detection-ej9zh/14</td>
<td>960</td>
<td>33 RPS</td>
<td>200-800ms</td>
<td><b>26 RPS</b></td>
<td>350-450ms</td>
</tr>


<tr>
<td>football-player-detection-ej9zh/15</td>
<td>1280</td>
<td>21 RPS</td>
<td>150-300ms</td>
<td><b>19 RPS</b></td>
<td>300-400ms</td>
</tr>

</table>

❗ **Observations**
* Utilisation of GPU was only 40% in peak
* Workflows cannot stable process the same amount of frames and latency is usually worse at max load
* we are blocking asyncio event loop in HTTP API - maybe that's why we underutilise resources (my other tests shown that this is not necessarily the case)

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
