### PR TITLE
Fix Google Vision OCR icon

### DIFF
--- a/inference/core/workflows/core_steps/models/foundation/google_vision_ocr/v1.py
+++ b/inference/core/workflows/core_steps/models/foundation/google_vision_ocr/v1.py
@@ -55,7 +55,7 @@ class BlockManifest(WorkflowBlockManifest):
             "block_type": "model",
             "ui_manifest": {
                 "section": "model",
-                "icon": "far fa-google",
+                "icon": "fa-brands fa-google",
             },
         },
         protected_namespaces=(),


### PR DESCRIPTION
# Description

Google Vision OCR was using wrong fontawesome classes.

Before:

![CleanShot 2024-10-16 at 17 50 27@2x](https://github.com/user-attachments/assets/0173bcb2-283b-4721-b654-fd2656c9b1a8)

After:

![CleanShot 2024-10-16 at 17 51 17@2x](https://github.com/user-attachments/assets/9dfa76fe-5e02-4f00-aa09-d1e011fdbc26)
