### PR TITLE
Disable scraping for containers where model_manager is not defined

### DIFF
--- a/inference/core/managers/prometheus.py
+++ b/inference/core/managers/prometheus.py
@@ -37,6 +37,11 @@ class CustomCollector(Collector):
         start = now - self.time_window
         count = 0
         results = {}
+        if self.model_manager is None:
+            logger.warning(
+                "This inference server type does not support custom Prometheus metrics, skipping."
+            )
+            return results
         for model_id in self.model_manager.models():
             if count >= maxModels:
                 break


### PR DESCRIPTION
# Description

The parallel containers dont have the model_manager object so custom per-model Prometheus scraping implemented in https://github.com/roboflow/inference/pull/750 will not work for them. 

This bugfix disables custom prometheus scraping for parallel dockers.


## Type of change

Please delete options that are not relevant.

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Tested locally on parallel and non-parallel inference containers.

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
