### PR TITLE
fixing and testing for empty prompts

### DIFF
--- a/inference/models/owlv2/owlv2.py
+++ b/inference/models/owlv2/owlv2.py
@@ -327,6 +327,8 @@ class OwlV2(RoboflowCoreModel):
             query_boxes_tensor = torch.tensor(
                 query_boxes, dtype=image_boxes.dtype, device=image_boxes.device
             )
+            if image_boxes.numel() == 0 or query_boxes_tensor.numel() == 0:
+                continue
             iou, _ = box_iou(
                 to_corners(image_boxes), to_corners(query_boxes_tensor)
             )  # 3000, k
@@ -455,6 +457,9 @@ class OwlV2(RoboflowCoreModel):
             query_spec = {image_hash: coords}
             # NOTE: because we just computed the embedding for this image, this should never result in a KeyError
             embeddings = self.get_query_embedding(query_spec, iou_threshold)
+
+            if embeddings is None:
+                continue
 
             # add the embeddings to their appropriate class and positive/negative list
             for embedding, class_name, is_positive in zip(

--- a/tests/inference/models_predictions_tests/test_owlv2.py
+++ b/tests/inference/models_predictions_tests/test_owlv2.py
@@ -7,6 +7,43 @@ def test_owlv2():
         "type": "url",
         "value": "https://media.roboflow.com/inference/seawithdock.jpeg",
     }
+
+    # test we can handle a single positive prompt
+    request = OwlV2InferenceRequest(
+        image=image,
+        training_data=[
+            {
+                "image": image,
+                "boxes": [
+                    {"x": 223, "y": 306, "w": 40, "h": 226, "cls": "post", "negative": False},
+                ],
+            }
+        ],
+        visualize_predictions=True,
+        confidence=0.9,
+    )
+
+    response = OwlV2().infer_from_request(request)
+    # we assert that we're finding all of the posts in the image
+    assert len(response.predictions) == 5
+    # next we check the x coordinates to force something about localization
+    # the exact value here is sensitive to:
+    # 1. the image interpolation mode used
+    # 2. the data type used in the model, ie bfloat16 vs float16 vs float32
+    # 3. the size of the model itself, ie base vs large
+    # 4. the specific hardware used to run the model
+    # we set a tolerance of 1.5 pixels from the expected value, which should cover most of the cases
+    # first we sort by x coordinate to make sure we're getting the correct post
+    posts = [p for p in response.predictions if p.class_name == "post"]
+    posts.sort(key=lambda x: x.x)
+    assert abs(223 - posts[0].x) < 1.5
+    assert abs(248 - posts[1].x) < 1.5
+    assert abs(264 - posts[2].x) < 1.5
+    assert abs(532 - posts[3].x) < 1.5
+    assert abs(572 - posts[4].x) < 1.5
+
+
+    # test we can handle multiple (positive and negative) prompts for the same image
     request = OwlV2InferenceRequest(
         image=image,
         training_data=[
@@ -24,19 +61,32 @@ def test_owlv2():
     )
 
     response = OwlV2().infer_from_request(request)
-    # we assert that we're finding all of the posts in the image
     assert len(response.predictions) == 4
-    # next we check the x coordinates to force something about localization
-    # the exact value here is sensitive to:
-    # 1. the image interpolation mode used
-    # 2. the data type used in the model, ie bfloat16 vs float16 vs float32
-    # 3. the size of the model itself, ie base vs large
-    # 4. the specific hardware used to run the model
-    # we set a tolerance of 1.5 pixels from the expected value, which should cover most of the cases
-    # first we sort by x coordinate to make sure we're getting the correct post
     posts = [p for p in response.predictions if p.class_name == "post"]
     posts.sort(key=lambda x: x.x)
     assert abs(223 - posts[0].x) < 1.5
     assert abs(264 - posts[1].x) < 1.5
     assert abs(532 - posts[2].x) < 1.5
     assert abs(572 - posts[3].x) < 1.5
+
+    # test that we can handle no prompts for an image
+    request = OwlV2InferenceRequest(
+        image=image,
+        training_data=[
+            {
+                "image": image,
+                "boxes": [
+                    {"x": 223, "y": 306, "w": 40, "h": 226, "cls": "post", "negative": False}
+                ],
+            },
+            {
+                "image": image,
+                "boxes": [],
+            },
+        ],
+        visualize_predictions=True,
+        confidence=0.9,
+    )
+
+    response = OwlV2().infer_from_request(request)
+    assert len(response.predictions) == 5


### PR DESCRIPTION
# Description

Empty prompts for an image caused a crash due to a bug in the fix for the finite sized cache causing a crash. I've added a test case to prevent something like this from reemerging.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Passed (new) integration test

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
