### PR TITLE
Do not store usage in cache when API key is not available

### DIFF
--- a/inference/usage_tracking/collector.py
+++ b/inference/usage_tracking/collector.py
@@ -340,6 +340,8 @@ class UsageCollector:
         inference_test_run: bool = False,
         fps: float = 0,
     ) -> DefaultDict[str, Any]:
+        if not api_key:
+            return
         if self._settings.opt_out and not api_key:
             return
         self.record_system_info()

--- a/inference/usage_tracking/payload_helpers.py
+++ b/inference/usage_tracking/payload_helpers.py
@@ -56,28 +56,7 @@ def zip_usage_payloads(usage_payloads: List[APIKeyUsage]) -> List[APIKeyUsage]:
     for usage_payload in usage_payloads:
         for api_key_hash, resource_payloads in usage_payload.items():
             if api_key_hash == "":
-                if (
-                    resource_payloads
-                    and len(resource_payloads) > 1
-                    or list(resource_payloads.keys()) != [""]
-                ):
-                    continue
-                api_key_usage_with_resource = get_api_key_usage_containing_resource(
-                    api_key_hash=api_key_hash,
-                    usage_payloads=usage_payloads,
-                )
-                if not api_key_usage_with_resource:
-                    system_info_payload = resource_payloads
-                    continue
-                api_key_hash = api_key_usage_with_resource["api_key_hash"]
-                resource_id = api_key_usage_with_resource["resource_id"]
-                category = api_key_usage_with_resource.get("category")
-                for v in resource_payloads.values():
-                    v["api_key_hash"] = api_key_hash
-                    if "resource_id" not in v or not v["resource_id"]:
-                        v["resource_id"] = resource_id
-                    if "category" not in v or not v["category"]:
-                        v["category"] = category
+                continue
             api_key_usage_by_exec_session_id = usage_by_exec_session_id.setdefault(
                 api_key_hash, {}
             )

--- a/tests/inference/unit_tests/usage_tracking/test_collector.py
+++ b/tests/inference/unit_tests/usage_tracking/test_collector.py
@@ -486,9 +486,9 @@ def test_zip_usage_payloads_with_system_info_missing_resource_id():
 def test_zip_usage_payloads_with_system_info_missing_resource_id_and_api_key():
     dumped_usage_payloads = [
         {
-            "": {
+            "api2": {
                 "": {
-                    "api_key_hash": "",
+                    "api_key_hash": "api2",
                     "resource_id": "",
                     "timestamp_start": 1721032989934855000,
                     "is_gpu_available": False,


### PR DESCRIPTION
# Description

Currently usage is stored in local cache even if api key is not available. In this PR caching usage when api key is not provided is turned off.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Affected tests corrected.

## Any specific deployment considerations

N/A

## Docs

N/A