### PR TITLE
Fix model type for classification

### DIFF
--- a/inference/core/cache/serializers.py
+++ b/inference/core/cache/serializers.py
@@ -32,7 +32,7 @@ def to_cachable_inference_item(
         "source_info",
     }
     request = infer_request.dict(include=included_request_fields)
-    response = build_condensed_response(infer_response)
+    response = build_condensed_response(infer_response, infer_request)
 
     return {
         "inference_id": infer_request.id,
@@ -43,7 +43,7 @@ def to_cachable_inference_item(
     }
 
 
-def build_condensed_response(responses):
+def build_condensed_response(responses, request):
     if not isinstance(responses, list):
         responses = [responses]
 
@@ -52,10 +52,19 @@ def build_condensed_response(responses):
         if not getattr(response, "predictions", None):
             continue
         try:
-            predictions = [
-                {"confidence": pred.confidence, "class": pred.class_name}
-                for pred in response.predictions
-            ]
+            predictions = []
+            for pred in response.predictions:
+                if type(pred) == str:
+                    predictions.append(
+                        {"class": pred, "confidence": request.confidence}
+                    )
+                else:
+                    predictions.append(
+                        {
+                            "confidence": pred.confidence,
+                            "class": pred.class_name,
+                        }
+                    )
             formatted_responses.append(
                 {
                     "predictions": predictions,

--- a/inference/core/entities/requests/inference.py
+++ b/inference/core/entities/requests/inference.py
@@ -202,6 +202,10 @@ class ClassificationInferenceRequest(CVInferenceRequest):
         visualize_predictions (Optional[bool]): If true, the predictions will be drawn on the original image and returned as a base64 string.
     """
 
+    def __init__(self, **kwargs):
+        kwargs["model_type"] = "classification"
+        super().__init__(**kwargs)
+
     confidence: Optional[float] = Field(
         default=0.4,
         examples=[0.5],

--- a/inference/core/interfaces/http/http_api.py
+++ b/inference/core/interfaces/http/http_api.py
@@ -2303,7 +2303,6 @@ class HttpInterface(BaseInterface):
                     source_info=source_info,
                     **args,
                 )
-
                 inference_response = await self.model_manager.infer_from_request(
                     inference_request.model_id,
                     inference_request,

--- a/tests/inference/unit_tests/core/cache/test_serializers.py
+++ b/tests/inference/unit_tests/core/cache/test_serializers.py
@@ -1,0 +1,61 @@
+import unittest
+from unittest.mock import MagicMock
+from inference.core.cache.serializers import (
+    to_cachable_inference_item,
+    build_condensed_response,
+)
+from inference.core.entities.requests.inference import InferenceRequest
+from inference.core.entities.responses.inference import InferenceResponse
+
+
+class TestSerializers(unittest.TestCase):
+
+    def setUp(self):
+        self.mock_request = MagicMock(spec=InferenceRequest)
+        self.mock_request.id = "test_id"
+        self.mock_request.confidence = 0.9
+        self.mock_request.dict.return_value = {
+            "api_key": "test_key",
+            "confidence": 0.9,
+            "model_id": "test_model",
+            "model_type": "test_type",
+            "source": "test_source",
+            "source_info": "test_info",
+        }
+
+        self.mock_response = MagicMock(spec=InferenceResponse)
+        self.mock_response.predictions = [
+            {"class_name": "cat", "confidence": 0.95},
+            {"class_name": "dog", "confidence": 0.85},
+        ]
+        self.mock_response.time = "2023-10-01T12:00:00Z"
+
+    def test_to_cachable_inference_item_no_tiny_cache(self):
+        # Assuming TINY_CACHE is False
+        result = to_cachable_inference_item(self.mock_request, self.mock_response)
+        self.assertIn("inference_id", result)
+        self.assertIn("request", result)
+        self.assertIn("response", result)
+
+    def test_to_cachable_inference_item_with_tiny_cache(self):
+        # TINY_CACHE is True
+        result = to_cachable_inference_item(self.mock_request, self.mock_response)
+        self.assertIn("inference_id", result)
+        self.assertIn("request", result)
+        self.assertIn("response", result)
+
+    def test_build_condensed_response_single(self):
+        result = build_condensed_response(self.mock_response, self.mock_request)
+        self.assertEqual(len(result), 1)
+        self.assertIn("predictions", result[0])
+        self.assertIn("time", result[0])
+
+    def test_build_condensed_response_multiple(self):
+        responses = [self.mock_response, self.mock_response]
+        result = build_condensed_response(responses, self.mock_request)
+        self.assertEqual(len(result), 2)
+
+    def test_build_condensed_response_no_predictions(self):
+        self.mock_response.predictions = None
+        result = build_condensed_response(self.mock_response, self.mock_request)
+        self.assertEqual(len(result), 0)


### PR DESCRIPTION
# Description

- Classification inference requests don't have a null `model_type` which is causing downstream issues in Model Monitoring (missing label/misreporting)
- This change manually sets the classification model type and adds some unit tests

## Type of change

Please delete options that are not relevant.

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

- Tested that classification projects have a defined model_type when making a legacy infer request and checking the item in a local cache
- Added unit tests for the serializers file

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
