### PR TITLE
chore: remove supervision version block

### DIFF
--- a/requirements/_requirements.txt
+++ b/requirements/_requirements.txt
@@ -11,7 +11,7 @@ prometheus-fastapi-instrumentator<=6.0.0
 redis<6.0.0
 requests>=2.26.0
 rich<=13.5.2
-supervision>=0.21.0,<=0.22.0
+supervision>=0.21.0
 pybase64<2.0.0
 scikit-image>=0.19.0
 requests-toolbelt>=1.0.0


### PR DESCRIPTION

# Description

Hello 👋  It is simple fix for removing version block so that we can install supervision latest always. 