### PR TITLE
Allow easier inheritance of pipeline

### DIFF
--- a/inference/core/interfaces/stream/inference_pipeline.py
+++ b/inference/core/interfaces/stream/inference_pipeline.py
@@ -282,7 +282,7 @@ class InferencePipeline:
             on_prediction = partial(multi_sink, sinks=[on_prediction, al_sink])
         on_pipeline_start = active_learning_middleware.start_registration_thread
         on_pipeline_end = active_learning_middleware.stop_registration_thread
-        return InferencePipeline.init_with_custom_logic(
+        return cls.init_with_custom_logic(
             video_reference=video_reference,
             on_video_frame=on_video_frame,
             on_prediction=on_prediction,
@@ -422,7 +422,7 @@ class InferencePipeline:
                 f"Could not initialise yolo_world/{model_size} due to lack of sufficient dependencies. "
                 f"Use pip install inference[yolo-world] to install missing dependencies and try again."
             ) from error
-        return InferencePipeline.init_with_custom_logic(
+        return cls.init_with_custom_logic(
             video_reference=video_reference,
             on_video_frame=on_video_frame,
             on_prediction=on_prediction,
@@ -642,7 +642,7 @@ class InferencePipeline:
             profiler=profiler,
             profiling_directory=profiling_directory,
         )
-        return InferencePipeline.init_with_custom_logic(
+        return cls.init_with_custom_logic(
             video_reference=video_reference,
             on_video_frame=on_video_frame,
             on_prediction=on_prediction,


### PR DESCRIPTION
# Description

I have recently tried to apply some simple changes to the InferencePipeline through inheritance but the way the classmethods are implemented means that non of the changes I apply get picked up.

If I do the following:

```
class Pipeline(InferencePipeline):

    def __init__(self, *args, **kwargs):
        super().__init__(*args, **kwargs)
        on_video_frame = self._on_video_frame
        def _on_video_frame(video_frames):
            predictions = on_video_frame(video_frames)
            # some additional functionality
            return predictions

        self._on_video_frame = _on_video_frame


pipeline = Pipeline.init(
    model_id=ROBOFLOW_MODEL,
    video_reference="rtp://192.168.1.23:1234",
    on_prediction=func,
)

print("Pipeline type:", type(pipeline))
# -> Pipeline type: <class 'inference.core.interfaces.stream.inference_pipeline.InferencePipeline'>
```
Note that the pipeline class is the inference class not my own.

This means that in order to add a minor change to the pipeline I would have to use `init_with_custom_logic`. But in my case I want all of the same logic as `init` but just some extra stuff. I'd rather not have to copy paste the entire content of the init function just to do this.

## Type of change

Please delete options that are not relevant.

-   [x] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?

I ran the code above (a more complete version) and it is working fine

## Any specific deployment considerations

None

## Docs

None
