### PR TITLE
Make skypilot optional for inference-cli

### DIFF
--- a/.release/pypi/inference.cli.setup.py
+++ b/.release/pypi/inference.cli.setup.py
@@ -61,6 +61,9 @@ setuptools.setup(
             "inference=inference_cli.main:app",
         ],
     },
+    extras_require={
+        "cloud-deploy": read_requirements("requirements/requirements.cloud_deploy.txt"),
+    },
     package_data={"": ["configs/*.yml"]},
     install_requires=read_requirements([
         "requirements/requirements.cli.txt",

--- a/docs/inference_helpers/inference_cli.md
+++ b/docs/inference_helpers/inference_cli.md
@@ -79,19 +79,29 @@ The Roboflow Inference CLI assumes the corresponding cloud CLI is configured for
 
 Roboflow Inference cloud deploy is powered by the popular [Skypilot project](https://github.com/skypilot-org/skypilot).
 
+### Important: Cloud Deploy Installation
+
+Before using cloud deploy, optional dependencies must be installed:
+
+```bash
+# Install dependencies required for cloud deploy
+pip install inference[cloud-deploy]
+```
+
+
 ### Cloud Deploy Examples
 
 We illustrate Inference cloud deploy with some examples, below.
 
 *Deploy GPU or CPU inference to AWS or GCP*
 
-```
+```bash
 # Deploy the roboflow Inference GPU container into a GPU-enabled VM in AWS
 
 inference cloud deploy --provider aws --compute-type gpu
 ```
 
-```
+```bash
 # Deploy the roboflow Inference CPU container into a CPU-only VM in GCP
 
 inference cloud deploy --provider gcp --compute-type cpu
@@ -107,13 +117,13 @@ Note that the port 9001 is automatically opened - check with your security admin
 
 ### View status of deployments
 
-```
+```bash
 inference cloud status
 ```
 
 ### Stop and start deployments
 
-```
+```bash
 # Stop the VM, you only pay for disk storage while the VM is stopped
 inference cloud stop <deployment_handle>
 
@@ -121,20 +131,20 @@ inference cloud stop <deployment_handle>
 
 ### Restart deployments
 
-```
+```bash
 inference cloud start <deployment_handle>
 ```
 
 ### Undeploy (delete) the cloud deployment
 
-```
+```bash
 inference cloud undeploy <deployment_handle>
 ```
 
 ### SSH into the cloud deployment
 
 You can SSH into your cloud deployment with the following command:
-```
+```bash
 ssh <deployment_handle>
 ```
 
@@ -146,13 +156,13 @@ Roboflow Inference cloud deploy will create VMs based on internally tested templ
 
 For advanced usecases and to customize the template, you can use your [sky yaml](https://skypilot.readthedocs.io/en/latest/reference/yaml-spec.html) template on the command-line, like so:
 
-```
+```bash
 inference cloud deploy --custom /path/to/sky-template.yaml
 ```
 
 If you want you can download the standard template stored in the roboflow cli and the modify it for your needs, this command will do that.
 
-```
+```bash
 # This command will print out the standard gcp/cpu sky template.
 inference cloud deploy --dry-run --provider gcp --compute-type cpu
 ```

--- a/inference_cli/lib/cloud_adapter.py
+++ b/inference_cli/lib/cloud_adapter.py
@@ -83,34 +83,40 @@ run: |
 """,
 }
 
+def check_sky_installed():
+    try:
+        global sky
+        import sky
+    except ImportError as e:
+        print("Please install cloud deploy dependencies with 'pip install inference[cloud-deploy]'")
+        raise e
 
 def _random_char(y):
     return "".join(random.choice(string.ascii_lowercase) for x in range(y))
 
 
 def cloud_status():
-    import sky
-
+    check_sky_installed()
     print("Getting status from skypilot...")
     print(sky.status())
 
 
 def cloud_stop(cluster_name):
-    import sky
+    check_sky_installed()
 
     print(f"Stopping skypilot deployment {cluster_name}...")
     print(sky.stop(cluster_name))
 
 
 def cloud_start(cluster_name):
-    import sky
+    check_sky_installed()
 
     print(f"Starting skypilot deployment {cluster_name}")
     print(sky.start(cluster_name))
 
 
 def cloud_undeploy(cluster_name):
-    import sky
+    check_sky_installed()
 
     print(
         f"Undeploying Roboflow Inference and deleting {cluster_name}, this may take a few minutes."
@@ -133,6 +139,8 @@ def cloud_deploy(provider, compute_type, dry_run, custom, help, roboflow_api_key
               and deploy the Roboflow Inference container to it.
 
                 Usage examples:
+                # Important: install cloud deploy dependencies
+                pip install inference[cloud-deploy]
                 # Deploy to GCP with CPU
                 inference cloud deploy --provider gcp --compute-type cpu
                 # Deploy to AWS with GPU

--- a/requirements/requirements.cli.txt
+++ b/requirements/requirements.cli.txt
@@ -2,8 +2,6 @@ requests<=2.31.0
 docker==6.1.3
 typer>=0.9.0,<=0.12.5
 rich<=13.5.2
-skypilot[aws,gcp]==0.5.0
-cryptography>=43.0.1
 PyYAML>=6.0.0
 supervision>=0.20.0,<1.0.0
 opencv-python>=4.8.1.78,<=4.10.0.84

--- a/requirements/requirements.cloud_deploy.txt
+++ b/requirements/requirements.cloud_deploy.txt
@@ -1,0 +1,2 @@
+skypilot[aws,gcp]==0.5.0
+cryptography>=43.0.1


### PR DESCRIPTION
# Description

Skypilot is a fairly large dependency of `inference-cli` that is not frequently used by most users. In this PR, I am adding it as an optional dependency and I added error messages to guide the user toward installing these dependencies if needed.

## Type of change

Please delete options that are not relevant.

-   [x] New feature (non-breaking change which adds functionality)
-   [x] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Tested locally

## Any specific deployment considerations

n/a

## Docs

-   [X] Docs updated? What were the changes:
