### PR TITLE
Fix SAM2 dependencies

### DIFF
--- a/requirements/_requirements.txt
+++ b/requirements/_requirements.txt
@@ -31,3 +31,5 @@ tldextract~=5.1.2
 packaging~=24.0
 anthropic~=0.34.2
 pandas>=2.0.0,<2.3.0
+pytest>=8.0.0,<9.0.0  # this is not a joke, sam2 requires this as the fork we are using is dependent on that, yet
+# do not mark the dependency: https://github.com/SauravMaheshkar/samv2/blob/main/sam2/utils/download.py 


### PR DESCRIPTION
# Description

There is strange issue with sam2 pip package from the fork we are using: https://github.com/SauravMaheshkar/samv2/blob/main/sam2/utils/download.py
basically making `pytest` our prod dependency - without it, SAM2 will be broken 🤷 

We got it working before clean-up just by the virtue of `pytest-asyncio` wrongly added into `_requirements.txt`. When that was fixed, we end up with SAM2 being impossible to import model - this seems to be impossible to be avoided as the module with `import pytest` is entangled in one of `__init__.py` in a function to download weights....

List any dependencies that are required for this change.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

* CI

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
