### PR TITLE
Fix issue with serialisation of empty outputs

### DIFF
--- a/.github/workflows/test.nvidia_t4.yml
+++ b/.github/workflows/test.nvidia_t4.yml
@@ -73,5 +73,7 @@ jobs:
       - name: 🧹 Cleanup Test Docker - SAM2
         run: make stop_test_docker
       - name: 🚨 Show server logs on error
-        run: docker logs inference-test
+        run: |
+          docker logs inference-test
+          make stop_test_docker
         if: failure()

--- a/.github/workflows/test.nvidia_t4.yml
+++ b/.github/workflows/test.nvidia_t4.yml
@@ -34,12 +34,8 @@ jobs:
         id: regression_tests
         run: |
           MINIMUM_FPS=25 FUNCTIONAL=true PORT=9101 SKIP_LMM_TEST=True API_KEY=${{ secrets.API_KEY }} asl_instance_segmentation_API_KEY=${{ secrets.ASL_INSTANCE_SEGMENTATION_API_KEY }} asl_poly_instance_seg_API_KEY=${{ secrets.ASL_POLY_INSTANCE_SEG_API_KEY }} bccd_favz3_API_KEY=${{ secrets.BCCD_FAVZ3_API_KEY }} bccd_i4nym_API_KEY=${{ secrets.BCCD_I4NYM_API_KEY }} cats_and_dogs_smnpl_API_KEY=${{ secrets.CATS_AND_DOGS_SMNPL_API_KEY }} coins_xaz9i_API_KEY=${{ secrets.COINS_XAZ9I_API_KEY }} melee_API_KEY=${{ secrets.MELEE_API_KEY }} yolonas_test_API_KEY=${{ secrets.YOLONAS_TEST_API_KEY }} python3 -m pytest tests/inference/integration_tests/
-      - name: 🚨 Show server logs on error
-        run: docker logs inference-test
-        if: ${{ steps.regression_tests.outcome != 'success' }}
       - name: 🧹 Cleanup Test Docker - GPU
         run: make stop_test_docker
-        if: success() || failure()
       - name: 🔋 Start Test Docker - GPU
         run: |
           PORT=9101 INFERENCE_SERVER_REPO=roboflow-inference-server-gpu make start_test_docker_gpu
@@ -47,12 +43,8 @@ jobs:
         id: cog_vlm_tests
         run: |
           PORT=9101 API_KEY=${{ secrets.API_KEY }} python3 -m pytest tests/inference/integration_tests/test_cogvlm.py
-      - name: 🚨 Show server logs on error
-        run: docker logs inference-test
-        if: ${{ steps.cog_vlm_tests.outcome != 'success' }}
       - name: 🧹 Cleanup Test Docker - GPU
         run: make stop_test_docker
-        if: success() || failure()
       - name: 🔋 Start Test Docker - GPU
         run: |
           PORT=9101 INFERENCE_SERVER_REPO=roboflow-inference-server-gpu make start_test_docker_gpu
@@ -60,12 +52,8 @@ jobs:
         id: paligemma_tests
         run: |
           PORT=9101 melee_API_KEY=${{ secrets.MELEE_API_KEY }} python3 -m pytest tests/inference/integration_tests/test_paligemma.py
-      - name: 🚨 Show server logs on error
-        run: docker logs inference-test
-        if: ${{ steps.paligemma_tests.outcome != 'success' }}
       - name: 🧹 Cleanup Test Docker - GPU
         run: make stop_test_docker
-        if: success() || failure()
       - name: 🔋 Start Test Docker - GPU
         run: |
           PORT=9101 INFERENCE_SERVER_REPO=roboflow-inference-server-gpu make start_test_docker_gpu
@@ -73,12 +61,8 @@ jobs:
         id: florence_tests
         run: |
           PORT=9101 melee_API_KEY=${{ secrets.MELEE_API_KEY }} python3 -m pytest tests/inference/integration_tests/test_florence.py
-      - name: 🚨 Show server logs on error
-        run: docker logs inference-test
-        if: ${{ steps.florence_tests.outcome != 'success' }}
       - name: 🧹 Cleanup Test Docker - GPU
         run: make stop_test_docker
-        if: success() || failure()
       - name: � Start Test Docker - SAM2
         run: |
           PORT=9101 INFERENCE_SERVER_REPO=roboflow-inference-server-gpu make start_test_docker_gpu
@@ -86,9 +70,8 @@ jobs:
         id: sam2_tests
         run: |
            PORT=9101 API_KEY=${{ secrets.API_KEY }} SKIP_SAM2_TESTS=False python3 -m pytest tests/inference/integration_tests/test_sam2.py
-      - name: 🚨 Show server logs on error
-        run: docker logs inference-test
-        if: ${{ steps.sam2_tests.outcome != 'success' }}
       - name: 🧹 Cleanup Test Docker - SAM2
         run: make stop_test_docker
-        if: success() || failure()
+      - name: 🚨 Show server logs on error
+        run: docker logs inference-test
+        if: failure()

--- a/.github/workflows/test.nvidia_t4_parallel_server.yml
+++ b/.github/workflows/test.nvidia_t4_parallel_server.yml
@@ -44,7 +44,7 @@ jobs:
           IS_PARALLEL_SERVER=true SKIP_VISUALISATION_TESTS=true FUNCTIONAL=true PORT=9101 API_KEY=${{ secrets.API_KEY }} asl_instance_segmentation_API_KEY=${{ secrets.ASL_INSTANCE_SEGMENTATION_API_KEY }} asl_poly_instance_seg_API_KEY=${{ secrets.ASL_POLY_INSTANCE_SEG_API_KEY }} bccd_favz3_API_KEY=${{ secrets.BCCD_FAVZ3_API_KEY }} bccd_i4nym_API_KEY=${{ secrets.BCCD_I4NYM_API_KEY }} cats_and_dogs_smnpl_API_KEY=${{ secrets.CATS_AND_DOGS_SMNPL_API_KEY }} coins_xaz9i_API_KEY=${{ secrets.COINS_XAZ9I_API_KEY }} melee_API_KEY=${{ secrets.MELEE_API_KEY }} yolonas_test_API_KEY=${{ secrets.YOLONAS_TEST_API_KEY }} python3 -m pytest tests/inference/integration_tests/regression_test.py tests/inference/integration_tests/batch_regression_test.py
       - name: 🚨 Show server logs on error
         run: docker logs inference-test
-        if: ${{ steps.regression_tests.outcome != 'success' }}
+        if: failure()
       - name: 🧹 Cleanup Test Docker - Parallel GPU
         run: make stop_test_docker
         if: success() || failure()

--- a/inference/core/workflows/execution_engine/v1/executor/output_constructor.py
+++ b/inference/core/workflows/execution_engine/v1/executor/output_constructor.py
@@ -177,6 +177,8 @@ def serialize_data_piece(
     kind: Union[List[Union[Kind, str]], Dict[str, List[Union[Kind, str]]]],
     kinds_serializers: Dict[str, Callable[[Any], Any]],
 ) -> Any:
+    if data_piece is None:
+        return None
     if isinstance(kind, dict):
         if not isinstance(data_piece, dict):
             raise AssumptionError(
@@ -210,6 +212,8 @@ def serialize_single_workflow_result_field(
     kind: List[Union[Kind, str]],
     kinds_serializers: Dict[str, Callable[[Any], Any]],
 ) -> Any:
+    if value is None:
+        return None
     kinds_without_serializer = set()
     for single_kind in kind:
         kind_name = single_kind.name if isinstance(single_kind, Kind) else kind

--- a/tests/workflows/integration_tests/execution/test_workflow_detection_plus_classification.py
+++ b/tests/workflows/integration_tests/execution/test_workflow_detection_plus_classification.py
@@ -173,6 +173,45 @@ def test_detection_plus_classification_workflow_when_minimal_valid_input_provide
     ], "Expected predictions to be as measured in reference run"
 
 
+def test_detection_plus_classification_workflow_when_minimal_valid_input_provided_and_serialization_requested(
+    model_manager: ModelManager,
+    dogs_image: np.ndarray,
+    roboflow_api_key: str,
+) -> None:
+    # given
+    workflow_init_parameters = {
+        "workflows_core.model_manager": model_manager,
+        "workflows_core.api_key": roboflow_api_key,
+        "workflows_core.step_execution_mode": StepExecutionMode.LOCAL,
+    }
+    execution_engine = ExecutionEngine.init(
+        workflow_definition=DETECTION_PLUS_CLASSIFICATION_WORKFLOW_V2_BLOCKS,
+        init_parameters=workflow_init_parameters,
+        max_concurrent_steps=WORKFLOWS_MAX_CONCURRENT_STEPS,
+    )
+
+    # when
+    result = execution_engine.run(
+        runtime_parameters={
+            "image": dogs_image,
+        },
+        serialize_results=True,
+    )
+
+    assert isinstance(result, list), "Expected list to be delivered"
+    assert len(result) == 1, "Expected 1 element in the output for one input image"
+    assert set(result[0].keys()) == {
+        "predictions",
+    }, "Expected all declared outputs to be delivered"
+    assert (
+        len(result[0]["predictions"]) == 2
+    ), "Expected 2 dogs crops on input image, hence 2 nested classification results"
+    assert [result[0]["predictions"][0]["top"], result[0]["predictions"][1]["top"]] == [
+        "116.Parson_russell_terrier",
+        "131.Wirehaired_pointing_griffon",
+    ], "Expected predictions to be as measured in reference run"
+
+
 def test_detection_plus_classification_workflow_when_nothing_gets_predicted(
     model_manager: ModelManager,
     crowd_image: np.ndarray,
@@ -271,6 +310,41 @@ def test_detection_plus_classification_workflow_when_nothing_gets_predicted_and_
         runtime_parameters={
             "image": crowd_image,
         }
+    )
+
+    assert isinstance(result, list), "Expected list to be delivered"
+    assert len(result) == 1, "Expected 1 element in the output for one input image"
+    assert set(result[0].keys()) == {
+        "predictions",
+    }, "Expected all declared outputs to be delivered"
+    assert (
+        len(result[0]["predictions"]) == 0
+    ), "Expected no prediction from 2nd model, as no dogs detected"
+
+
+def test_detection_plus_classification_workflow_when_nothing_gets_predicted_and_serialization_requested(
+    model_manager: ModelManager,
+    crowd_image: np.ndarray,
+    roboflow_api_key: str,
+) -> None:
+    # given
+    workflow_init_parameters = {
+        "workflows_core.model_manager": model_manager,
+        "workflows_core.api_key": roboflow_api_key,
+        "workflows_core.step_execution_mode": StepExecutionMode.LOCAL,
+    }
+    execution_engine = ExecutionEngine.init(
+        workflow_definition=DETECTION_PLUS_CLASSIFICATION_PLUS_CONSENSUS_WORKFLOW,
+        init_parameters=workflow_init_parameters,
+        max_concurrent_steps=WORKFLOWS_MAX_CONCURRENT_STEPS,
+    )
+
+    # when
+    result = execution_engine.run(
+        runtime_parameters={
+            "image": crowd_image,
+        },
+        serialize_results=True,
     )
 
     assert isinstance(result, list), "Expected list to be delivered"

--- a/tests/workflows/integration_tests/execution/test_workflow_top_prediction.py
+++ b/tests/workflows/integration_tests/execution/test_workflow_top_prediction.py
@@ -1,18 +1,10 @@
 import numpy as np
-import pytest
 import supervision as sv
 
 from inference.core.env import WORKFLOWS_MAX_CONCURRENT_STEPS
 from inference.core.managers.base import ModelManager
 from inference.core.workflows.core_steps.common.entities import StepExecutionMode
-from inference.core.workflows.core_steps.common.query_language.errors import (
-    EvaluationEngineError,
-)
-from inference.core.workflows.errors import RuntimeInputError, StepExecutionError
 from inference.core.workflows.execution_engine.core import ExecutionEngine
-from tests.workflows.integration_tests.execution.workflows_gallery_collector.decorators import (
-    add_to_workflows_gallery,
-)
 
 TOP_PREDICTION_WORKFLOW = {
     "version": "1.0",

--- a/tests/workflows/integration_tests/execution/test_workflow_with_empty_outputs_serialisation.py
+++ b/tests/workflows/integration_tests/execution/test_workflow_with_empty_outputs_serialisation.py
@@ -1,0 +1,275 @@
+import numpy as np
+
+from inference.core.env import WORKFLOWS_MAX_CONCURRENT_STEPS
+from inference.core.managers.base import ModelManager
+from inference.core.workflows.core_steps.common.entities import StepExecutionMode
+from inference.core.workflows.execution_engine.core import ExecutionEngine
+
+WORKFLOW_DEFINITION = {
+    "version": "1.0",
+    "inputs": [{"type": "InferenceImage", "name": "image"}],
+    "steps": [
+        {
+            "type": "roboflow_core/roboflow_multi_label_classification_model@v1",
+            "name": "multi_label",
+            "images": "$inputs.image",
+            "model_id": "animal-classification-9lufm/1",
+            "confidence": 0.2,
+        },
+        {
+            "type": "roboflow_core/property_definition@v1",
+            "name": "multi_classes",
+            "data": "$steps.multi_label.predictions",
+            "operations": [
+                {"type": "ClassificationPropertyExtract", "property_name": "top_class"}
+            ],
+        },
+        {
+            "type": "roboflow_core/continue_if@v1",
+            "name": "includes_any",
+            "condition_statement": {
+                "type": "StatementGroup",
+                "statements": [
+                    {
+                        "type": "BinaryStatement",
+                        "left_operand": {
+                            "type": "StaticOperand",
+                            "value": ["cat", "dog"],
+                        },
+                        "comparator": {"type": "any in (Sequence)"},
+                        "right_operand": {
+                            "type": "DynamicOperand",
+                            "operand_name": "left",
+                            "operations": [
+                                {
+                                    "type": "ClassificationPropertyExtract",
+                                    "property_name": "top_class",
+                                }
+                            ],
+                        },
+                    }
+                ],
+            },
+            "next_steps": ["$steps.resize"],
+            "evaluation_parameters": {"left": "$steps.multi_label.predictions"},
+        },
+        {
+            "type": "roboflow_core/continue_if@v1",
+            "name": "includes_all",
+            "condition_statement": {
+                "type": "StatementGroup",
+                "statements": [
+                    {
+                        "type": "BinaryStatement",
+                        "left_operand": {
+                            "type": "StaticOperand",
+                            "value": ["cat", "dog"],
+                        },
+                        "comparator": {"type": "all in (Sequence)"},
+                        "right_operand": {
+                            "type": "DynamicOperand",
+                            "operand_name": "left",
+                            "operations": [
+                                {
+                                    "type": "ClassificationPropertyExtract",
+                                    "property_name": "top_class",
+                                }
+                            ],
+                        },
+                    }
+                ],
+            },
+            "next_steps": ["$steps.rotate"],
+            "evaluation_parameters": {"left": "$steps.multi_label.predictions"},
+        },
+        {
+            "type": "roboflow_core/image_preprocessing@v1",
+            "name": "rotate",
+            "image": "$inputs.image",
+            "task_type": "rotate",
+            "rotation_degrees": 45,
+        },
+        {
+            "type": "roboflow_core/continue_if@v1",
+            "name": "exact_match",
+            "condition_statement": {
+                "type": "StatementGroup",
+                "statements": [
+                    {
+                        "type": "BinaryStatement",
+                        "left_operand": {
+                            "type": "StaticOperand",
+                            "value": ["dog", "cat"],
+                        },
+                        "comparator": {"type": "=="},
+                        "right_operand": {
+                            "type": "DynamicOperand",
+                            "operand_name": "left",
+                            "operations": [
+                                {
+                                    "type": "ClassificationPropertyExtract",
+                                    "property_name": "top_class",
+                                }
+                            ],
+                        },
+                    }
+                ],
+            },
+            "next_steps": ["$steps.flip"],
+            "evaluation_parameters": {"left": "$steps.multi_label.predictions"},
+        },
+        {
+            "type": "roboflow_core/image_preprocessing@v1",
+            "name": "flip",
+            "image": "$inputs.image",
+            "task_type": "flip",
+        },
+        {
+            "type": "roboflow_core/image_preprocessing@v1",
+            "name": "resize",
+            "image": "$inputs.image",
+            "task_type": "resize",
+            "width": 50,
+            "height": 50,
+        },
+        {
+            "type": "roboflow_core/roboflow_classification_model@v1",
+            "name": "single_label",
+            "images": "$inputs.image",
+            "model_id": "animals-2kk5l/1",
+        },
+        {
+            "type": "roboflow_core/continue_if@v1",
+            "name": "top_class",
+            "condition_statement": {
+                "type": "StatementGroup",
+                "statements": [
+                    {
+                        "type": "BinaryStatement",
+                        "left_operand": {
+                            "type": "DynamicOperand",
+                            "operand_name": "left",
+                            "operations": [
+                                {
+                                    "type": "ClassificationPropertyExtract",
+                                    "property_name": "top_class",
+                                }
+                            ],
+                        },
+                        "comparator": {"type": "=="},
+                        "right_operand": {"type": "StaticOperand", "value": "cat"},
+                    }
+                ],
+            },
+            "next_steps": ["$steps.grayscale"],
+            "evaluation_parameters": {"left": "$steps.single_label.predictions"},
+        },
+        {
+            "type": "roboflow_core/convert_grayscale@v1",
+            "name": "grayscale",
+            "image": "$inputs.image",
+        },
+        {
+            "type": "roboflow_core/property_definition@v1",
+            "name": "single_classes",
+            "data": "$steps.single_label.predictions",
+            "operations": [
+                {"type": "ClassificationPropertyExtract", "property_name": "top_class"}
+            ],
+        },
+    ],
+    "outputs": [
+        {
+            "type": "JsonField",
+            "name": "multi",
+            "coordinates_system": "own",
+            "selector": "$steps.multi_label.predictions",
+        },
+        {
+            "type": "JsonField",
+            "name": "single_classes",
+            "coordinates_system": "own",
+            "selector": "$steps.single_classes.output",
+        },
+        {
+            "type": "JsonField",
+            "name": "multi_classes",
+            "coordinates_system": "own",
+            "selector": "$steps.multi_classes.output",
+        },
+        {
+            "type": "JsonField",
+            "name": "single_class_matched",
+            "coordinates_system": "own",
+            "selector": "$steps.grayscale.image",
+        },
+        {
+            "type": "JsonField",
+            "name": "includes_any_passed",
+            "coordinates_system": "own",
+            "selector": "$steps.resize.*",
+        },
+        {
+            "type": "JsonField",
+            "name": "includes_all_passed",
+            "coordinates_system": "own",
+            "selector": "$steps.rotate.image",
+        },
+        {
+            "type": "JsonField",
+            "name": "exact_match_passed",
+            "coordinates_system": "own",
+            "selector": "$steps.flip.image",
+        },
+    ],
+}
+
+
+def test_workflow_which_requires_empty_outputs_serialisation(
+    model_manager: ModelManager,
+    dogs_image: np.ndarray,
+    roboflow_api_key: str,
+) -> None:
+    # given
+    workflow_init_parameters = {
+        "workflows_core.model_manager": model_manager,
+        "workflows_core.api_key": roboflow_api_key,
+        "workflows_core.step_execution_mode": StepExecutionMode.LOCAL,
+    }
+    execution_engine = ExecutionEngine.init(
+        workflow_definition=WORKFLOW_DEFINITION,
+        init_parameters=workflow_init_parameters,
+        max_concurrent_steps=WORKFLOWS_MAX_CONCURRENT_STEPS,
+    )
+
+    # when
+    result = execution_engine.run(
+        runtime_parameters={
+            "image": dogs_image,
+        },
+        serialize_results=True,
+    )
+
+    assert isinstance(result, list), "Expected list to be delivered"
+    assert len(result) == 1, "Expected 1 element in the output for one input image"
+    assert set(result[0].keys()) == {
+        "includes_any_passed",
+        "multi",
+        "single_class_matched",
+        "multi_classes",
+        "includes_all_passed",
+        "single_classes",
+        "exact_match_passed",
+    }, "Expected all declared outputs to be delivered"
+    assert (
+        result[0]["single_class_matched"] is None
+    ), "Expected empty result to serialize properly"
+    assert result[0]["includes_any_passed"] == {
+        "image": None
+    }, "Expect compound empty result to be serialized properly"
+    assert (
+        result[0]["includes_all_passed"] is None
+    ), "Expected empty result to serialize properly"
+    assert (
+        result[0]["exact_match_passed"] is None
+    ), "Expected empty result to serialize properly"

--- a/tests/workflows/integration_tests/execution/test_workflow_with_sahi.py
+++ b/tests/workflows/integration_tests/execution/test_workflow_with_sahi.py
@@ -1,3 +1,6 @@
+import base64
+
+import cv2
 import matplotlib.pyplot as plt
 import numpy as np
 import supervision as sv
@@ -305,6 +308,45 @@ def test_sahi_workflow_with_nmm_as_filtering_strategy(
         ),
         atol=1e-1,
     ), "Expected boxes for second image to be exactly as measured during test creation"
+
+
+def test_sahi_workflow_with_serialization(
+    model_manager: ModelManager,
+    license_plate_image: np.ndarray,
+    crowd_image: np.ndarray,
+) -> None:
+    # given
+    workflow_init_parameters = {
+        "workflows_core.model_manager": model_manager,
+        "workflows_core.step_execution_mode": StepExecutionMode.LOCAL,
+    }
+    execution_engine = ExecutionEngine.init(
+        workflow_definition=SAHI_WORKFLOW,
+        init_parameters=workflow_init_parameters,
+        max_concurrent_steps=WORKFLOWS_MAX_CONCURRENT_STEPS,
+    )
+
+    # when
+    result = execution_engine.run(
+        runtime_parameters={
+            "image": [license_plate_image, crowd_image],
+            "overlap_filtering_strategy": "nms",
+        },
+        serialize_results=True,
+    )
+
+    # then
+    result_1 = sv.Detections.from_inference(result[0]["predictions"])
+    result_2 = sv.Detections.from_inference(result[1]["predictions"])
+    assert len(result_1) == 11, "Expected to deserialize 1st image detections properly"
+    assert len(result_2) == 12, "Expected to deserialize 2nd image detections properly"
+    decoded_image_bytes = base64.b64decode(result[0]["visualisation"]["value"])
+    decoded_image = cv2.imdecode(
+        np.frombuffer(decoded_image_bytes, np.uint8), cv2.IMREAD_COLOR
+    )
+    assert (
+        decoded_image.shape == license_plate_image.shape
+    ), "Expected to deserialize result image properly"
 
 
 def test_sahi_workflow_provides_the_same_result_as_sahi_applied_directly(

--- a/tests/workflows/integration_tests/execution/test_workflow_with_single_model.py
+++ b/tests/workflows/integration_tests/execution/test_workflow_with_single_model.py
@@ -171,6 +171,60 @@ def test_object_detection_workflow_when_batch_input_provided(
     ), "Expected confidences for 2nd image to match what was validated manually as workflow outcome"
 
 
+def test_object_detection_workflow_when_batch_input_provided_and_serialization_requested(
+    model_manager: ModelManager,
+    crowd_image: np.ndarray,
+) -> None:
+    # given
+    workflow_init_parameters = {
+        "workflows_core.model_manager": model_manager,
+        "workflows_core.api_key": None,
+        "workflows_core.step_execution_mode": StepExecutionMode.LOCAL,
+    }
+    execution_engine = ExecutionEngine.init(
+        workflow_definition=OBJECT_DETECTION_WORKFLOW,
+        init_parameters=workflow_init_parameters,
+        max_concurrent_steps=WORKFLOWS_MAX_CONCURRENT_STEPS,
+    )
+
+    # when
+    result = execution_engine.run(
+        runtime_parameters={
+            "image": [crowd_image, crowd_image],
+            "model_id": "yolov8n-640",
+        },
+        serialize_results=True,
+    )
+
+    # then
+    assert isinstance(result, list), "Expected result to be list"
+    assert len(result) == 2, "Two images provided - two outputs expected"
+    detections_1 = sv.Detections.from_inference(result[0]["result"]["predictions"])
+    detections_2 = sv.Detections = sv.Detections.from_inference(
+        result[1]["result"]["predictions"]
+    )
+    assert np.allclose(
+        detections_1.xyxy,
+        EXPECTED_OBJECT_DETECTION_BBOXES,
+        atol=1,
+    ), "Expected bboxes for first image to match what was validated manually as workflow outcome"
+    assert np.allclose(
+        detections_1.confidence,
+        EXPECTED_OBJECT_DETECTION_CONFIDENCES,
+        atol=0.01,
+    ), "Expected confidences for first image to match what was validated manually as workflow outcome"
+    assert np.allclose(
+        detections_2.xyxy,
+        EXPECTED_OBJECT_DETECTION_BBOXES,
+        atol=1,
+    ), "Expected bboxes for 2nd image to match what was validated manually as workflow outcome"
+    assert np.allclose(
+        detections_2.confidence,
+        EXPECTED_OBJECT_DETECTION_CONFIDENCES,
+        atol=0.01,
+    ), "Expected confidences for 2nd image to match what was validated manually as workflow outcome"
+
+
 def test_object_detection_workflow_when_confidence_is_restricted_by_input_parameter(
     model_manager: ModelManager,
     crowd_image: np.ndarray,

--- a/tests/workflows/integration_tests/execution/test_workflow_with_stitch_image.py
+++ b/tests/workflows/integration_tests/execution/test_workflow_with_stitch_image.py
@@ -2,7 +2,6 @@ import numpy as np
 
 from inference.core.env import WORKFLOWS_MAX_CONCURRENT_STEPS
 from inference.core.managers.base import ModelManager
-from inference.core.workflows.core_steps.common.entities import StepExecutionMode
 from inference.core.workflows.core_steps.transformations.stitch_images.v1 import (
     OUTPUT_KEY,
 )


### PR DESCRIPTION
# Description

We had this kind of errors when serialization was enforced on empty outputs (None values were not excluded from type-strict serialization of results):

```
{
  "error": "Requested Workflow output serialization, but for output `exact_match_passed` which evaluates into Python type: <class 'NoneType'> cannot successfully apply any of registered serializers.",
  "inner_error": "None"
}
```
As a test, added the workflow that was reported to be broken.

Additionally - fixed CI action to actually print server logs on failure

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

YOUR_ANSWER

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
