### PR TITLE
Remove debug print from owlv2

### DIFF
--- a/inference/models/owlv2/owlv2.py
+++ b/inference/models/owlv2/owlv2.py
@@ -554,7 +554,6 @@ class OwlV2(RoboflowCoreModel):
             # grab and normalize box prompts for this image
             image_size = self.compute_image_size(train_image["image"])
             boxes = train_image["boxes"]
-            print(f"boxes: {boxes}")
             coords = [[box["x"], box["y"], box["w"], box["h"]] for box in boxes]
             coords = [tuple([c / max(image_size) for c in coord]) for coord in coords]
             classes = [box["cls"] for box in boxes]


### PR DESCRIPTION
# Description

Remove print statement used in debugging owlv2.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update
