### PR TITLE
Fix issue with broken builds after last release of `tokenizers`

### DIFF
--- a/inference/core/version.py
+++ b/inference/core/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.28.1"
+__version__ = "0.28.2"
 
 
 if __name__ == "__main__":

--- a/requirements/_requirements.txt
+++ b/requirements/_requirements.txt
@@ -33,4 +33,4 @@ anthropic~=0.34.2
 pandas>=2.0.0,<2.3.0
 pytest>=8.0.0,<9.0.0  # this is not a joke, sam2 requires this as the fork we are using is dependent on that, yet
 # do not mark the dependency: https://github.com/SauravMaheshkar/samv2/blob/main/sam2/utils/download.py
-tokenizers>=0.20.0,<=0.20.3
+tokenizers>=0.19.0,<=0.20.3

--- a/requirements/_requirements.txt
+++ b/requirements/_requirements.txt
@@ -32,4 +32,5 @@ packaging~=24.0
 anthropic~=0.34.2
 pandas>=2.0.0,<2.3.0
 pytest>=8.0.0,<9.0.0  # this is not a joke, sam2 requires this as the fork we are using is dependent on that, yet
-# do not mark the dependency: https://github.com/SauravMaheshkar/samv2/blob/main/sam2/utils/download.py 
+# do not mark the dependency: https://github.com/SauravMaheshkar/samv2/blob/main/sam2/utils/download.py
+tokenizers>=0.20.0,<=0.20.3


### PR DESCRIPTION
# Description

`tokenizers` is dependency of our dependenices, not enlisted in our requirements, they introduced "silent" breaking change (seems like the discussions suggest they revert it), but as a result - `inference` is broken to be installed.

We are pinning to last working version, hoping problem will be solved by community soon, in release notes of `0.28.2` we will guide users of older versions how to deal with the problem.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

* CI

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
