### PR TITLE
Update Docker Tag Logic

### DIFF
--- a/.github/actions/determine-tags/action.yml
+++ b/.github/actions/determine-tags/action.yml
@@ -27,17 +27,19 @@ runs:
         VERSION="${{ inputs.version }}"
         BASE_IMAGE="${{ inputs.base_image }}"
         BRANCH="${{ github.ref_name }}"
+        EVENT_NAME="${{ github.event_name }}"
 
         # Determine the tags
         if [ -n "$CUSTOM_TAG" ]; then
           IMAGE_TAGS="$BASE_IMAGE:$CUSTOM_TAG"
         else
           VERSION_TAG="$BASE_IMAGE:$VERSION"
-          if [ "$BRANCH" == "main" ]; then
+          IMAGE_TAGS="$VERSION_TAG"
+
+          # Add latest tag if it's a release event and the branch is main
+          if [ "$EVENT_NAME" == "release" ] && [ "$BRANCH" == "main" ]; then
             LATEST_TAG="$BASE_IMAGE:latest"
             IMAGE_TAGS="$VERSION_TAG,$LATEST_TAG"
-          else
-            IMAGE_TAGS="$VERSION_TAG"
           fi
         fi
 

--- a/.github/actions/determine-tags/action.yml
+++ b/.github/actions/determine-tags/action.yml
@@ -6,11 +6,18 @@ inputs:
     required: false
     default: ""
   version:
-    description: "Version of the image"
+    description: "Version of the image (e.g., 0.0.1, without the 'v')"
     required: true
   base_image:
     description: "Base image name for the Docker tags (e.g., 'roboflow/roboflow-inference-server-gpu')"
     required: true
+  token:
+    description: "GitHub token for accessing repository data"
+    required: true
+  force_push:
+    description: "Force push the release tag (only outputs the version tag)"
+    required: false
+    default: "false"
 outputs:
   image_tags:
     description: "Comma-separated list of Docker image tags"
@@ -26,25 +33,73 @@ runs:
         CUSTOM_TAG="${{ inputs.custom_tag }}"
         VERSION="${{ inputs.version }}"
         BASE_IMAGE="${{ inputs.base_image }}"
+        TOKEN="${{ inputs.token }}"
+        FORCE_PUSH="${{ inputs.force_push }}"
         BRANCH="${{ github.ref_name }}"
         EVENT_NAME="${{ github.event_name }}"
+        TARGET_BRANCH="${{ github.event.release.target_commitish }}"
 
-        # Determine the tags
-        if [ -n "$CUSTOM_TAG" ]; then
-          IMAGE_TAGS="$BASE_IMAGE:$CUSTOM_TAG"
+        # Initialize the tags
+        IMAGE_TAGS=""
+
+        # Workflow Dispatch Logic
+        if [ "$EVENT_NAME" == "workflow_dispatch" ]; then
+          echo "Triggered manually via workflow_dispatch"
+          if [ -n "$CUSTOM_TAG" ]; then
+            echo "Custom tag set, force push ignored."
+            CUSTOM_TAG="$VERSION-$CUSTOM_TAG"
+            IMAGE_TAGS="$BASE_IMAGE:$CUSTOM_TAG"
+          else
+            echo "Force push set or defaulting to version tag."
+            IMAGE_TAGS="$BASE_IMAGE:$VERSION"
+          fi
+
+        # Automatic Trigger Logic
         else
-          VERSION_TAG="$BASE_IMAGE:$VERSION"
-          IMAGE_TAGS="$VERSION_TAG"
+          echo "Triggered automatically via $EVENT_NAME"
+          # Fetch the latest release tag for release events
+          if [ "$EVENT_NAME" == "release" ]; then
+            RELEASE=$BRANCH
+            NORMALIZED_RELEASE=$(if echo "$RELEASE" | grep -Eq '^v?[0-9]+\.[0-9]+\.[0-9]$'; then echo "$RELEASE" | sed 's/^v//'; else echo "$RELEASE"; fi)
+            echo "Normalized release: $NORMALIZED_RELEASE"
 
-          # Add latest tag if it's a release event and the branch is main
-          if [ "$EVENT_NAME" == "release" ] && [ "$BRANCH" == "main" ]; then
-            LATEST_TAG="$BASE_IMAGE:latest"
-            IMAGE_TAGS="$VERSION_TAG,$LATEST_TAG"
+            LATEST_RELEASE=$(curl -s -H "Authorization: Bearer $TOKEN" \
+              "https://api.github.com/repos/${{ github.repository }}/releases/latest" | jq -r '.tag_name')
+            echo "Fetched latest release: $LATEST_RELEASE"
+
+            # Normalize versions: remove 'v' from the latest release tag
+            NORMALIZED_LATEST_RELEASE=$(echo "$LATEST_RELEASE" | sed 's/^v//')
+            echo "Normalized latest release: $NORMALIZED_LATEST_RELEASE"
+          else
+            LATEST_RELEASE=""
+            NORMALIZED_RELEASE=""
+            NORMALIZED_LATEST_RELEASE=""
+          fi
+
+          # Logic for push events to main
+          if [ "$EVENT_NAME" == "push" ] && [ "$BRANCH" == "main" ]; then
+            IMAGE_TAGS="$BASE_IMAGE:main"
+          fi
+
+          # Logic for release events
+          if [ "$EVENT_NAME" == "release" ]; then
+            IMAGE_TAGS="$BASE_IMAGE:$NORMALIZED_RELEASE"
+            if [ "$VERSION" == "$NORMALIZED_RELEASE" ] && [ "$NORMALIZED_RELEASE" == "$NORMALIZED_LATEST_RELEASE" ]; then
+              IMAGE_TAGS="$IMAGE_TAGS,$BASE_IMAGE:latest"
+            fi
           fi
         fi
 
+        # Clean up leading/trailing commas
+        IMAGE_TAGS=$(echo "$IMAGE_TAGS" | sed 's/^,//;s/,$//')
+
         # Echo the computed tags
         echo "Computed image tags: $IMAGE_TAGS"
+
+        if [ -z $IMAGE_TAGS ]; then
+          echo "No valid image tags found."
+          exit 1
+        fi
 
         # Export the tags to outputs
         echo "image_tags=$IMAGE_TAGS" >> $GITHUB_OUTPUT

--- a/.github/workflows/docker.cpu.yml
+++ b/.github/workflows/docker.cpu.yml
@@ -46,6 +46,8 @@ jobs:
           custom_tag: ${{ github.event.inputs.custom_tag }}
           version: ${{ env.VERSION }}
           base_image: ${{ env.BASE_IMAGE }}
+          force_push: ${{ github.event.inputs.force_push }}
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up Depot CLI
         uses: depot/setup-action@v1
       - name: Build and Push

--- a/.github/workflows/docker.gpu.yml
+++ b/.github/workflows/docker.gpu.yml
@@ -46,6 +46,8 @@ jobs:
           custom_tag: ${{ github.event.inputs.custom_tag }}
           version: ${{ env.VERSION }}
           base_image: ${{ env.BASE_IMAGE }}
+          force_push: ${{ github.event.inputs.force_push }}
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up Depot CLI
         uses: depot/setup-action@v1
       - name: Build and Push


### PR DESCRIPTION
# Description

Update the release logic to support the following cases:
- releases will also push to `latest` if the GitHub release is tagged as the latest release AND the version in version.py matches the tag of the release. The tag of the release is normalized to remove the leading `v`. If both of those aren't true, the container tag will be set to the tag of the github release.
- push to `main` will only tag an image as `main`. This will allow for a bleeding-edge build
- custom tag will prepend the version from `version.py` to the tag, and will ONLY allow pushing the custom tag
- Force push will only update the container tag that matches the value in `version.py`

![docker_tag_flow](https://github.com/user-attachments/assets/f3faf0b4-93a3-4ea6-babf-7c75511af422)

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

This has been tested on a separate repository to verify all this functionality works:

- [Actions runs testing all the features](https://github.com/alexnorell/actions_test/actions/workflows/test_tags.yaml)

## Any specific deployment considerations

Release will push to `latest` again. This will also allow us to enable `main` builds in the future if desired.

## Docs

-   [ ] Docs updated? What were the changes:
