### PR TITLE
Remove piexif dependency

### DIFF
--- a/requirements/_requirements.txt
+++ b/requirements/_requirements.txt
@@ -6,7 +6,6 @@ python-dotenv~=1.0.0
 fastapi>=0.100,<0.111
 numpy<=1.26.4
 opencv-python>=4.8.1.78,<=4.10.0.84
-piexif~=1.1.3
 pillow<11.0
 prometheus-fastapi-instrumentator<=6.0.0
 redis~=5.0.0


### PR DESCRIPTION
# Description

Piexif usage was removed some time ago in https://github.com/roboflow/inference/pull/52.

## Type of change

-   [x] Maintentance

## How has this change been tested, please provide a testcase or example of how you tested the change?

CI tests should be enough.