### PR TITLE
Kapa: remove duplicate initialization

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -193,6 +193,5 @@ markdown_extensions:
       permalink: true
 
 extra_javascript:
-  - 'https://widget.kapa.ai/kapa-widget.bundle.js'
   - 'javascript/init_kapa_widget.js'
   - 'javascript/cookbooks.js'


### PR DESCRIPTION
# Description

This is a tiny change that removes duplicate initialization of the Kapa widget.

With duplicate initialization no Roboflow logo is displayed on the chat button, and attempts to chat with the agent result in a configuration error message.

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

⚠️ This worked with `mkdocs serve`, but not with `mike serve`.

<img width="1110" alt="Screenshot 2024-12-10 at 12 17 44 PM" src="https://github.com/user-attachments/assets/d7b24827-1b94-4b2e-9e5a-82812dbcc418">

<img width="1130" alt="image" src="https://github.com/user-attachments/assets/f6f10909-42b1-4e09-8093-a2d86e6d05f3">

## Any specific deployment considerations

⚠️ As mentioned, this worked with `mkdocs serve`, but not with `mike serve`.

## Docs

-   [ ] Docs updated? What were the changes:
