### PR TITLE
Fix confidence not applied when inferring classification models

### DIFF
--- a/inference/core/models/classification_base.py
+++ b/inference/core/models/classification_base.py
@@ -162,6 +162,7 @@ class ClassificationBaseOnnxRoboflowInferenceModel(OnnxRoboflowInferenceModel):
             disable_preproc_grayscale=disable_preproc_grayscale,
             disable_preproc_static_crop=disable_preproc_static_crop,
             return_image_dims=return_image_dims,
+            **kwargs,
         )
 
     def postprocess(


### PR DESCRIPTION
# Description

Pass kwargs down the call chain in ClassificationBaseOnnxRoboflowInferenceModel.infer

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Tested manually
CI passing

## Any specific deployment considerations

N/A

## Docs

N/A