### PR TITLE
Extend roboflow_api.annotate_image_at_roboflow to pass list of classes if multi-label-classification model was used

### DIFF
--- a/inference/core/workflows/core_steps/models/roboflow/multi_label_classification/v2.py
+++ b/inference/core/workflows/core_steps/models/roboflow/multi_label_classification/v2.py
@@ -181,7 +181,7 @@ class RoboflowMultiLabelClassificationModelBlockV2(WorkflowBlock):
             api_key=self._api_key,
         )
         predictions = self._model_manager.infer_from_request_sync(
-            model_id=model_id, request=request
+            model_id=model_id, request=request, confidence=confidence
         )
         if isinstance(predictions, list):
             predictions = [

--- a/inference/core/workflows/core_steps/sinks/roboflow/dataset_upload/v1.py
+++ b/inference/core/workflows/core_steps/sinks/roboflow/dataset_upload/v1.py
@@ -552,7 +552,7 @@ def is_prediction_registration_forbidden(
         return True
     if isinstance(prediction, sv.Detections) and len(prediction) == 0:
         return True
-    if isinstance(prediction, dict) and "top" not in prediction:
+    if isinstance(prediction, dict) and all(k not in prediction for k in ["top", "predicted_classes"]):
         return True
     return False
 
@@ -561,6 +561,8 @@ def encode_prediction(
     prediction: Union[sv.Detections, dict],
 ) -> Tuple[str, str]:
     if isinstance(prediction, dict):
+        if "predicted_classes" in prediction:
+            return ",".join(prediction["predicted_classes"]), "txt"
         return prediction["top"], "txt"
     detections_in_inference_format = serialise_sv_detections(detections=prediction)
     return json.dumps(detections_in_inference_format), "json"

--- a/inference/core/workflows/core_steps/sinks/roboflow/dataset_upload/v1.py
+++ b/inference/core/workflows/core_steps/sinks/roboflow/dataset_upload/v1.py
@@ -552,7 +552,9 @@ def is_prediction_registration_forbidden(
         return True
     if isinstance(prediction, sv.Detections) and len(prediction) == 0:
         return True
-    if isinstance(prediction, dict) and all(k not in prediction for k in ["top", "predicted_classes"]):
+    if isinstance(prediction, dict) and all(
+        k not in prediction for k in ["top", "predicted_classes"]
+    ):
         return True
     return False
 


### PR DESCRIPTION
# Description

Extend roboflow_api.annotate_image_at_roboflow to pass list of classes if multi-label-classification model was used.
This enables `roboflow_core/roboflow_dataset_upload@v2` block to upload image as well as annotations (list of classes) when multi-label-classification model was inferred on.

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

CI passing
tested manually

## Any specific deployment considerations

N/A

## Docs

N/A