### PR TITLE
Expand supervision support to 0.30.0

### DIFF
--- a/requirements/_requirements.txt
+++ b/requirements/_requirements.txt
@@ -11,7 +11,7 @@ prometheus-fastapi-instrumentator<=6.0.0
 redis~=5.0.0
 requests>=2.32.0,<3.0.0
 rich>=13.0.0,<13.10.0
-supervision>=0.21.0,<=0.22.0
+supervision>=0.23.0,<=0.30.0
 pybase64~=1.0.0
 scikit-image>=0.19.0,<=0.24.0
 requests-toolbelt~=1.0.0

--- a/requirements/_requirements.txt
+++ b/requirements/_requirements.txt
@@ -11,7 +11,7 @@ prometheus-fastapi-instrumentator<=6.0.0
 redis~=5.0.0
 requests>=2.32.0,<3.0.0
 rich>=13.0.0,<13.10.0
-supervision>=0.23.0,<=0.30.0
+supervision>=0.25.1,<=0.30.0
 pybase64~=1.0.0
 scikit-image>=0.19.0,<=0.24.0
 requests-toolbelt~=1.0.0

--- a/requirements/requirements.cli.txt
+++ b/requirements/requirements.cli.txt
@@ -3,7 +3,7 @@ docker>=7.0.0,<8.0.0
 typer>=0.9.0,<=0.12.5
 rich>=13.0.0,<13.10.0
 PyYAML~=6.0.0
-supervision>=0.23.0,<=0.30.0
+supervision>=0.25.1,<=0.30.0
 opencv-python>=4.8.1.78,<=4.10.0.84
 tqdm>=4.0.0,<5.0.0
 nvidia-ml-py<13.0.0

--- a/requirements/requirements.cli.txt
+++ b/requirements/requirements.cli.txt
@@ -3,7 +3,7 @@ docker>=7.0.0,<8.0.0
 typer>=0.9.0,<=0.12.5
 rich>=13.0.0,<13.10.0
 PyYAML~=6.0.0
-supervision>=0.21.0,<=0.22.0
+supervision>=0.23.0,<=0.30.0
 opencv-python>=4.8.1.78,<=4.10.0.84
 tqdm>=4.0.0,<5.0.0
 nvidia-ml-py<13.0.0

--- a/requirements/requirements.sdk.http.txt
+++ b/requirements/requirements.sdk.http.txt
@@ -2,7 +2,7 @@ requests>=2.32.0,<3.0.0
 dataclasses-json~=0.6.0
 opencv-python>=4.8.1.78,<=4.10.0.84
 pillow>=9.0.0,<11.0
-supervision>=0.23.0,<=0.30.0
+supervision>=0.25.1,<=0.30.0
 numpy<=1.26.4
 aiohttp>=3.9.0,<=3.10.11
 backoff~=2.2.0

--- a/requirements/requirements.sdk.http.txt
+++ b/requirements/requirements.sdk.http.txt
@@ -2,7 +2,7 @@ requests>=2.32.0,<3.0.0
 dataclasses-json~=0.6.0
 opencv-python>=4.8.1.78,<=4.10.0.84
 pillow>=9.0.0,<11.0
-supervision>=0.21.0,<=0.22.0
+supervision>=0.23.0,<=0.30.0
 numpy<=1.26.4
 aiohttp>=3.9.0,<=3.10.11
 backoff~=2.2.0

--- a/requirements/requirements.test.unit.txt
+++ b/requirements/requirements.test.unit.txt
@@ -10,4 +10,4 @@ pytest-timeout>=2.2.0
 httpx>=0.25.1,<0.28.0
 uvicorn<=0.22.0
 aioresponses>=0.7.6
-supervision>=0.23.0,<=0.30.0
+supervision>=0.25.1,<=0.30.0

--- a/requirements/requirements.test.unit.txt
+++ b/requirements/requirements.test.unit.txt
@@ -10,4 +10,4 @@ pytest-timeout>=2.2.0
 httpx>=0.25.1,<0.28.0
 uvicorn<=0.22.0
 aioresponses>=0.7.6
-supervision>=0.21.0,<=0.22.0
+supervision>=0.23.0,<=0.30.0

--- a/tests/workflows/integration_tests/execution/test_workflow_with_sahi.py
+++ b/tests/workflows/integration_tests/execution/test_workflow_with_sahi.py
@@ -394,7 +394,7 @@ def test_sahi_workflow_provides_the_same_result_as_sahi_applied_directly(
         callback=slicer_callback,
         slice_wh=(640, 640),
         overlap_ratio_wh=(0.2, 0.2),
-        overlap_filter_strategy=sv.OverlapFilter.NON_MAX_SUPPRESSION,
+        overlap_filter=sv.OverlapFilter.NON_MAX_SUPPRESSION,
         iou_threshold=0.3,
     )
 

--- a/tests/workflows/integration_tests/execution/test_workflow_with_video_metadata_processing.py
+++ b/tests/workflows/integration_tests/execution/test_workflow_with_video_metadata_processing.py
@@ -214,7 +214,7 @@ def test_workflow_with_tracker(
         first_crowd_frame_tracker_ids == second_crowd_frame_tracker_ids
     ), "The same image, expected no tracker IDs change"
     assert first_license_plate_frame_tracker_ids == [
-        15,
-        16,
-        17,
-    ], "External IDs for all trackers are global, hence we offset by numer of all ever generated tracker IDs"
+        1,
+        2,
+        3,
+    ], "Expected tracker IDs to be generated sequentially, independent of other trackers"


### PR DESCRIPTION
# Description

Supervision has a policy where deprecations are announced 5 releases in advance.

This PR makes the single change required to support supervision up to release `0.30.0` based on the [planned deprecations](https://supervision.roboflow.com/latest/deprecated/). However, we expect to move to `1.0.0` before `0.30.0`.

Changes:
* Updated InferenceSlicer parameter (deprecated in `0.27.0`)
* Bumped lower supervision bound to `0.25.1` (dependency versions, specifically addressing `numpy` version clash)
* Bumped upper version to `0.30.0` (safe to do due to deprecation policy)

Note: this PR uses the corrected variable name `overlap_filter` - I left a mistake in the deprecations doc.

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

* I used `inference` with `supervision` throughout this release, from a custom inference branch, which permits latest supervision version.
* I installed supervision together with changes in this PR and checked that models can be run (Py 3.10).

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
