### PR TITLE
merge lora into base model for 3x speedup

### DIFF
--- a/inference/models/transformers/transformers.py
+++ b/inference/models/transformers/transformers.py
@@ -252,6 +252,8 @@ class LoRATransformerModel(TransformerModel):
             .to(self.dtype)
         )
 
+        self.model.merge_and_unload()
+
         self.processor = self.processor_class.from_pretrained(
             model_load_id, revision=revision, cache_dir=cache_dir, token=token
         )


### PR DESCRIPTION
# Description

Working on speeding up Florence2 deployment. There was a bug where LoRA-trained models were about 3x slower at inference time because the LoRA weights were being run independently of the model weights. Merging them in resolved the issue.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Benchmarked speed with a tiny custom script and am assuming existing integration tests cover correctness.

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
