### PR TITLE
Allow using video metadata for rate limiter on recorded video

### DIFF
--- a/inference/core/workflows/core_steps/flow_control/rate_limiter/v1.py
+++ b/inference/core/workflows/core_steps/flow_control/rate_limiter/v1.py
@@ -19,6 +19,8 @@ from inference.core.workflows.prototypes.block import (
     WorkflowBlockManifest,
 )
 
+PATTERN_STR = r"(^\$inputs.[A-Za-z_0-9\-]+$)"
+
 LONG_DESCRIPTION = """
 The **Rate Limiter** block controls the execution frequency of a branch within a Workflow by enforcing a 
 cooldown period. It ensures that the connected steps do not run more frequently than a specified interval, 
@@ -80,7 +82,7 @@ class RateLimiterManifest(WorkflowBlockManifest):
         examples=[["$steps.upload"]],
     )
     video_reference_image: Optional[
-        Selector(kind=[IMAGE_KIND], pattern=r"(^\$inputs.[A-Za-z_0-9\-]+$)")
+        Selector(kind=[IMAGE_KIND], pattern=PATTERN_STR)
     ] = Field(
         description="Reference to a video frame to use for timestamp generation (if running faster than realtime on recorded video).",
         examples=["$inputs.image"],

--- a/inference/core/workflows/core_steps/flow_control/rate_limiter/v1.py
+++ b/inference/core/workflows/core_steps/flow_control/rate_limiter/v1.py
@@ -11,6 +11,7 @@ from inference.core.workflows.execution_engine.entities.types import (
     IMAGE_KIND,
     Selector,
     StepSelector,
+    WorkflowImageSelector,
 )
 from inference.core.workflows.execution_engine.v1.entities import FlowControl
 from inference.core.workflows.prototypes.block import (
@@ -81,9 +82,7 @@ class RateLimiterManifest(WorkflowBlockManifest):
         description="Reference to steps which shall be executed if rate limit allows.",
         examples=[["$steps.upload"]],
     )
-    video_reference_image: Optional[
-        Selector(kind=[IMAGE_KIND], pattern=PATTERN_STR)
-    ] = Field(
+    video_reference_image: Optional[WorkflowImageSelector] = Field(
         description="Reference to a video frame to use for timestamp generation (if running faster than realtime on recorded video).",
         examples=["$inputs.image"],
         default=None,
@@ -117,7 +116,9 @@ class RateLimiterBlockV1(WorkflowBlock):
         current_time = datetime.now()
         try:
             metadata = video_reference_image.video_metadata
-            current_time = datetime.fromtimestamp(1 / metadata.fps * metadata.frame_number)
+            current_time = datetime.fromtimestamp(
+                1 / metadata.fps * metadata.frame_number
+            )
         except Exception:
             # reference not passed, metadata not set, or not a video frame
             pass

--- a/inference/core/workflows/core_steps/flow_control/rate_limiter/v1.py
+++ b/inference/core/workflows/core_steps/flow_control/rate_limiter/v1.py
@@ -20,8 +20,6 @@ from inference.core.workflows.prototypes.block import (
     WorkflowBlockManifest,
 )
 
-PATTERN_STR = r"(^\$inputs.[A-Za-z_0-9\-]+$)"
-
 LONG_DESCRIPTION = """
 The **Rate Limiter** block controls the execution frequency of a branch within a Workflow by enforcing a 
 cooldown period. It ensures that the connected steps do not run more frequently than a specified interval, 

--- a/inference/core/workflows/core_steps/flow_control/rate_limiter/v1.py
+++ b/inference/core/workflows/core_steps/flow_control/rate_limiter/v1.py
@@ -3,8 +3,12 @@ from typing import List, Literal, Optional, Type, Union
 
 from pydantic import ConfigDict, Field
 
-from inference.core.workflows.execution_engine.entities.base import OutputDefinition
+from inference.core.workflows.execution_engine.entities.base import (
+    OutputDefinition,
+    WorkflowImageData,
+)
 from inference.core.workflows.execution_engine.entities.types import (
+    IMAGE_KIND,
     Selector,
     StepSelector,
 )
@@ -75,6 +79,11 @@ class RateLimiterManifest(WorkflowBlockManifest):
         description="Reference to steps which shall be executed if rate limit allows.",
         examples=[["$steps.upload"]],
     )
+    video_reference_image: Optional[Selector(kind=[IMAGE_KIND], pattern=r"(^\$inputs.[A-Za-z_0-9\-]+$)")] = Field(
+        description="Reference to a video frame to use for timestamp generation (if running faster than realtime on recorded video).",
+        examples=["$inputs.image"],
+        default=None
+    )
 
     @classmethod
     def describe_outputs(cls) -> List[OutputDefinition]:
@@ -99,8 +108,17 @@ class RateLimiterBlockV1(WorkflowBlock):
         cooldown_seconds: float,
         depends_on: any,
         next_steps: List[StepSelector],
+        video_reference_image: Optional[WorkflowImageData] = None,
     ) -> BlockResult:
         current_time = datetime.now()
+        try:
+            metadata = video_reference_image.video_metadata
+            current_time = datetime.fromtimestamp(metadata.fps * metadata.frame_number)
+        except Exception:
+            # reference not passed, metadata not set, or not a video frame
+            pass
+
+
         should_throttle = False
         if self._last_executed_at is not None:
             should_throttle = (

--- a/inference/core/workflows/core_steps/flow_control/rate_limiter/v1.py
+++ b/inference/core/workflows/core_steps/flow_control/rate_limiter/v1.py
@@ -79,10 +79,12 @@ class RateLimiterManifest(WorkflowBlockManifest):
         description="Reference to steps which shall be executed if rate limit allows.",
         examples=[["$steps.upload"]],
     )
-    video_reference_image: Optional[Selector(kind=[IMAGE_KIND], pattern=r"(^\$inputs.[A-Za-z_0-9\-]+$)")] = Field(
+    video_reference_image: Optional[
+        Selector(kind=[IMAGE_KIND], pattern=r"(^\$inputs.[A-Za-z_0-9\-]+$)")
+    ] = Field(
         description="Reference to a video frame to use for timestamp generation (if running faster than realtime on recorded video).",
         examples=["$inputs.image"],
-        default=None
+        default=None,
     )
 
     @classmethod
@@ -117,7 +119,6 @@ class RateLimiterBlockV1(WorkflowBlock):
         except Exception:
             # reference not passed, metadata not set, or not a video frame
             pass
-
 
         should_throttle = False
         if self._last_executed_at is not None:

--- a/inference/core/workflows/core_steps/flow_control/rate_limiter/v1.py
+++ b/inference/core/workflows/core_steps/flow_control/rate_limiter/v1.py
@@ -117,7 +117,7 @@ class RateLimiterBlockV1(WorkflowBlock):
         current_time = datetime.now()
         try:
             metadata = video_reference_image.video_metadata
-            current_time = datetime.fromtimestamp(metadata.fps * metadata.frame_number)
+            current_time = datetime.fromtimestamp(1 / metadata.fps * metadata.frame_number)
         except Exception:
             # reference not passed, metadata not set, or not a video frame
             pass

--- a/inference/core/workflows/execution_engine/entities/types.py
+++ b/inference/core/workflows/execution_engine/entities/types.py
@@ -1172,6 +1172,7 @@ WorkflowVideoMetadataSelector = Annotated[
 
 def Selector(
     kind: Optional[List[Kind]] = None,
+    pattern: str = r"(^\$steps\.[A-Za-z_\-0-9]+\.[A-Za-z_*0-9\-]+$)|(^\$inputs.[A-Za-z_0-9\-]+$)",
 ):
     if kind is None:
         kind = [WILDCARD_KIND]
@@ -1183,8 +1184,6 @@ def Selector(
     }
     return Annotated[
         str,
-        StringConstraints(
-            pattern=r"(^\$steps\.[A-Za-z_\-0-9]+\.[A-Za-z_*0-9\-]+$)|(^\$inputs.[A-Za-z_0-9\-]+$)"
-        ),
+        StringConstraints(pattern=pattern),
         Field(json_schema_extra=json_schema_extra),
     ]

--- a/inference/core/workflows/execution_engine/entities/types.py
+++ b/inference/core/workflows/execution_engine/entities/types.py
@@ -1172,7 +1172,6 @@ WorkflowVideoMetadataSelector = Annotated[
 
 def Selector(
     kind: Optional[List[Kind]] = None,
-    pattern: str = r"(^\$steps\.[A-Za-z_\-0-9]+\.[A-Za-z_*0-9\-]+$)|(^\$inputs.[A-Za-z_0-9\-]+$)",
 ):
     if kind is None:
         kind = [WILDCARD_KIND]
@@ -1184,6 +1183,8 @@ def Selector(
     }
     return Annotated[
         str,
-        StringConstraints(pattern=pattern),
+        StringConstraints(
+            pattern=r"(^\$steps\.[A-Za-z_\-0-9]+\.[A-Za-z_*0-9\-]+$)|(^\$inputs.[A-Za-z_0-9\-]+$)"
+        ),
         Field(json_schema_extra=json_schema_extra),
     ]


### PR DESCRIPTION
# Description

The Rate Limiter operates on the system clock by default. But if you're running on async video you can run it at faster than realtime. This means the block fires out of sync with the video (eg if the video is 60 seconds and processes in 3 real world seconds then a rate limiter with a cooldown of 1s only fires 3 times vs 60).

This is often not desirable if you're looking to speed up your processing time while otherwise keeping the behavior the same. For example, sampling a frame for upload once per second shouldn't sample 2x fewer frames from a video if you run it twice as fast.

To fix, we add an optional parameter that lets you synchronize the rate limiter clock to the video rate instead of the wall rate.

## Type of change

-   [x] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Locally on realtime & async video running at various framerates, ensured tests still pass.

## Any specific deployment considerations

No, backwards compatible.

## Docs

-   [x] Self documenting via manifest
