### PR TITLE
Add fix for the problem with inference-cli workflows predictions saving

### DIFF
--- a/inference/core/version.py
+++ b/inference/core/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.31.1"
+__version__ = "0.31.2rc1"
 
 
 if __name__ == "__main__":

--- a/inference_cli/lib/workflows/common.py
+++ b/inference_cli/lib/workflows/common.py
@@ -228,12 +228,15 @@ def aggregate_batch_processing_results(
     file_descriptor.close()
     all_results = [
         os.path.join(output_directory, f, "results.json")
-        for f in all_processed_files
+        for f in sorted(all_processed_files)
         if os.path.exists(os.path.join(output_directory, f, "results.json"))
     ]
     decoded_content = []
     for result_path in track(all_results, description="Grabbing processing results..."):
-        decoded_content.append(read_json(path=result_path))
+        content = read_json(path=result_path)
+        processed_file = result_path.split("/")[-2]
+        content["image"] = processed_file
+        decoded_content.append(content)
     if aggregation_format is OutputFileType.JSONL:
         aggregated_results_path = os.path.join(
             output_directory, "aggregated_results.jsonl"

--- a/tests/inference_cli/integration_tests/test_workflows.py
+++ b/tests/inference_cli/integration_tests/test_workflows.py
@@ -97,8 +97,8 @@ def test_processing_images_directory_with_hosted_api(
     result_csv = pd.read_csv(os.path.join(empty_directory, "aggregated_results.csv"))
     assert len(result_csv) == 3
     assert (
-        len(result_csv.columns) == 2
-    ), "Two columns expected - predictions and deducted visualization"
+        len(result_csv.columns) == 3
+    ), "3 columns expected - predictions and deducted visualization"
 
 
 @pytest.mark.skipif(
@@ -238,8 +238,8 @@ def test_processing_images_directory_with_inference_package(
     result_csv = pd.read_csv(os.path.join(empty_directory, "aggregated_results.csv"))
     assert len(result_csv) == 3
     assert (
-        len(result_csv.columns) == 2
-    ), "Two columns expected - predictions and deducted visualization"
+        len(result_csv.columns) == 3
+    ), "3 columns expected - predictions and deducted visualization"
 
 
 @pytest.mark.skipif(

--- a/tests/inference_cli/unit_tests/lib/workflows/test_common.py
+++ b/tests/inference_cli/unit_tests/lib/workflows/test_common.py
@@ -85,17 +85,25 @@ def test_aggregate_batch_processing_results_when_json_output_is_expected_and_res
             if len(line.strip()) == 0:
                 continue
             decoded_results.append(json.loads(line))
+    print(decoded_results)
     assert (
         decoded_results
         == [
             {
                 "some": "value",
+                "image": "other.jpg",
+                "other": 3.0,
+                "list_field": [1, 2, 3],
+                "object_field": {"nested": "value"},
+            },
+            {
+                "some": "value",
+                "image": "some.jpg",
                 "other": 3.0,
                 "list_field": [1, 2, 3],
                 "object_field": {"nested": "value"},
             }
         ]
-        * 2
     )
 
 


### PR DESCRIPTION
# Description

This is a fix for a problem with image reference not saved in predictions file 

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

* test added

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
