### PR TITLE
Cache CLIP Text Embeddings in Workflow Block

### DIFF
--- a/inference/core/cache/lru_cache.py
+++ b/inference/core/cache/lru_cache.py
@@ -1,0 +1,30 @@
+import collections
+
+
+class LRUCache:
+    def __init__(self, capacity=128):
+        self.capacity = capacity
+        self.cache = collections.OrderedDict()
+
+    def set_max_size(self, capacity):
+        self.capacity = capacity
+        self.enforce_size()
+
+    def enforce_size(self):
+        while len(self.cache) > self.capacity:
+            self.cache.popitem(last=False)
+
+    def get(self, key):
+        try:
+            value = self.cache.pop(key)
+            self.cache[key] = value
+            return value
+        except KeyError:
+            return None
+
+    def set(self, key, value):
+        try:
+            self.cache.pop(key)
+        except KeyError:
+            self.enforce_size()
+        self.cache[key] = value

--- a/inference/core/workflows/core_steps/models/foundation/clip/v1.py
+++ b/inference/core/workflows/core_steps/models/foundation/clip/v1.py
@@ -138,10 +138,7 @@ class ClipModelBlockV1(WorkflowBlock):
 
             cached_value = text_cache.get(hash_key)
             if cached_value is not None:
-                print("Using cached value")
                 return {"embedding": cached_value}
-            else:
-                print("Cache miss")
 
             inference_request = ClipTextEmbeddingRequest(
                 clip_version_id=version,

--- a/inference/core/workflows/core_steps/models/foundation/clip/v1.py
+++ b/inference/core/workflows/core_steps/models/foundation/clip/v1.py
@@ -93,7 +93,10 @@ class BlockManifest(WorkflowBlockManifest):
     def get_execution_engine_compatibility(cls) -> Optional[str]:
         return ">=1.3.0,<2.0.0"
 
+
 text_cache = LRUCache()
+
+
 class ClipModelBlockV1(WorkflowBlock):
 
     def __init__(


### PR DESCRIPTION
# Description

This adds a least recently used cache to store CLIP text embeddings so they don't need to be recalculated every time. Text embeddings are often used for eg class names which remain constant across runs so this greatly speeds up using CLIP to compare text/image embeddings.

Memory usage should be negligible; 512k for a full cache with the largest CLIP embedding dimensions.

## Type of change

-   [x] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Locally & ensured tests don't break

## Any specific deployment considerations

No

## Docs

-  No updates needed; internal change to the block
