### PR TITLE
add more code owners for docs

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 * @PawelPeczek-Roboflow @grzegorz-roboflow @yeldarby @probicheaux @hansent
-docs/ @capjamesg @PawelPeczek-Roboflow @grzegorz-roboflow
+docs/ @capjamesg @PawelPeczek-Roboflow @grzegorz-roboflow @hansent @yeldarby

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 * @PawelPeczek-Roboflow @grzegorz-roboflow @yeldarby @probicheaux @hansent
-docs/ @capjamesg @PawelPeczek-Roboflow @grzegorz-roboflow @hansent @yeldarby
+docs/ @capjamesg @PawelPeczek-Roboflow @grzegorz-roboflow @hansent @yeldarby @EmilyGavrilenko @probicheaux


### PR DESCRIPTION
# Description

add @probicheaux @EmilyGavrilenko @hansent and @yeldarby as code owners for docs

## Type of change

Please delete options that are not relevant.
maintanance

## How has this change been tested, please provide a testcase or example of how you tested the change?
n/a 

## Any specific deployment considerations
n/a 

## Docs
n/a 
