### PR TITLE
Update Landing Page

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Inference turns any computer or edge device into a command center for your compu
 * 🔗 [Extend](https://inference.roboflow.com/workflows/create_workflow_block/) with your own code and models
 * 🚀 Deploy production systems at scale
 
-See [Example Workflows](https://roboflow.com/workflows/templates) for common use-cases like detecting small objects with SAHI, multi-model consensus, active learning, reading license plates, blurring faces, background removal, and more.
+See [Example Workflows](https://inference.roboflow.com/workflows/gallery/) for common use-cases like detecting small objects with SAHI, multi-model consensus, active learning, reading license plates, blurring faces, background removal, and more.
 
 [Time In Zone Workflow Example](https://github.com/user-attachments/assets/743233d9-3460-442d-83f8-20e29e76b346)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,7 +32,53 @@ See [Example Workflows](https://roboflow.com/workflows/templates) for common use
   <a href="/workflows/about/" class="button half-button">Build a visual agent with Workflows</a>
 </div>
 
+## Video Tutorials
+
+<div class="tutorial-list">
+  <!-- Tutorial 1 -->
+  <div class="tutorial-item">
+    <a href="https://youtu.be/tZa-QgFn7jg">
+      <img src="https://img.youtube.com/vi/tZa-QgFn7jg/0.jpg" alt="Smart Parking with AI" />
+    </a>
+    <div class="tutorial-content">
+      <a href="https://youtu.be/tZa-QgFn7jg">
+        <strong>Tutorial: Build a Smart Parking System</strong>
+      </a>
+      <div><strong>Created: 27 Nov 2024</strong></div>
+      <p>
+        Build a smart parking lot management system using Roboflow Workflows!
+        This tutorial covers license plate detection with YOLOv8, object tracking
+        with ByteTrack, and real-time notifications with a Telegram bot.
+      </p>
+    </div>
+  </div>
+
+  <!-- Tutorial 2 -->
+  <div class="tutorial-item">
+    <a href="https://youtu.be/VCbcC5OEGRU">
+      <img src="https://img.youtube.com/vi/VCbcC5OEGRU/0.jpg" alt="Workflows Tutorial" />
+    </a>
+    <div class="tutorial-content">
+      <a href="https://youtu.be/VCbcC5OEGRU">
+        <strong>Tutorial: Build a Traffic Monitoring Application with Workflows</strong>
+      </a>
+      <div><strong>Created: 22 Oct 2024</strong></div>
+      <p>
+        Learn how to build and deploy Workflows for common use-cases like detecting 
+        vehicles, filtering detections, visualizing results, and calculating dwell 
+        time on a live video stream.
+      </p>
+    </div>
+  </div>
+  
+  <!-- Add more .tutorial-item blocks as needed -->
+</div>
+
 <style>
+.button-holder {
+  margin-bottom: 1.5rem;
+}
+
 .button {
   background-color: var(--md-primary-fg-color);
   display: flex;
@@ -69,5 +115,52 @@ ul {
 /* hide edit button */
 article > a.md-content__button.md-icon:first-child {
     display: none;
+}
+
+/* tutorial list styling */
+.tutorial-list {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 2rem;
+}
+
+.tutorial-item {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 1rem;
+
+  border-bottom: 1px solid #ccc;
+  padding-bottom: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.tutorial-item:last-of-type {
+  border-bottom: none;
+  margin-bottom: 0;
+}
+
+.tutorial-item img {
+  max-width: 300px;
+  height: auto;
+  flex-shrink: 0;
+  border: 1px solid #ccc;
+}
+
+.tutorial-content {
+  flex: 1 1 auto;
+}
+
+/* On mobile: stack content and center the thumbnail */
+@media (max-width: 768px) {
+  .tutorial-item {
+    flex-direction: column;
+    align-items: center;
+  }
+  .tutorial-item img {
+    max-width: 100%;
+    margin: 0 auto;
+    display: block;
+  }
 }
 </style>

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,6 +19,11 @@ hide:
   max-width: 50rem;
   margin: auto;
 }
+
+/* hide edit button */
+article > a.md-content__button.md-icon:first-child {
+    display: none;
+}
 </style>
 
 ![Roboflow Inference banner](https://github.com/roboflow/inference/blob/main/banner.png?raw=true)

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@ Inference turns any computer or edge device into a command center for your compu
 * 🔗 [Extend](/workflows/create_workflow_block.md) with your own code and models
 * 🚀 Deploy production systems at scale
 
-See [Example Workflows](https://roboflow.com/workflows/templates) for common use-cases like detecting small objects with SAHI, multi-model consensus, active learning, reading license plates, blurring faces, background removal, and more.
+See [Example Workflows](/workflows/gallery/index.md) for common use-cases like detecting small objects with SAHI, multi-model consensus, active learning, reading license plates, blurring faces, background removal, and more.
 
 <a href="/quickstart/run_a_model/" class="button">Get started with our "Run your first model" guide</a>
 <div class="button-holder">

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,53 @@ hide:
   - toc
 ---
 
+<video width="100%" autoplay loop muted>
+  <source src="https://github.com/user-attachments/assets/743233d9-3460-442d-83f8-20e29e76b346" type="video/mp4">
+</video>
+
+## Make Any Camera an AI Camera
+
+Inference turns any computer or edge device into a command center for your computer vision projects.
+
+* 🛠️ Self-host [your own fine-tuned models](/quickstart/explore_models.md)
+* 🧠 Access the latest and greatest foundation models (like [Florence-2](https://blog.roboflow.com/florence-2/), [CLIP](https://blog.roboflow.com/openai-clip/), and [SAM2](https://blog.roboflow.com/what-is-segment-anything-2/))
+* 🤝 Use Workflows to track, count, time, measure, and visualize
+* 👁️ Combine ML with traditional CV methods (like OCR, Barcode Reading, QR, and template matching)
+* 📈 Monitor, record, and analyze predictions
+* 🎥 Manage cameras and video streams
+* 📬 Send notifications when events happen
+* 🛜 Connect with external systems and APIs
+* 🔗 [Extend](/workflows/create_workflow_block.md) with your own code and models
+* 🚀 Deploy production systems at scale
+
+See [Example Workflows](https://roboflow.com/workflows/templates) for common use-cases like detecting small objects with SAHI, multi-model consensus, active learning, reading license plates, blurring faces, background removal, and more.
+
+<a href="/quickstart/run_a_model/" class="button">Get started with our "Run your first model" guide</a>
+<div class="button-holder">
+  <a href="/quickstart/inference_101/" class="button half-button">Learn about the various ways you can use Inference</a>
+  <a href="/workflows/about/" class="button half-button">Build a visual agent with Workflows</a>
+</div>
+
 <style>
+.button {
+  background-color: var(--md-primary-fg-color);
+  display: flex;
+  padding: 10px;
+  color: white !important;
+  border-radius: 5px;
+  text-align: center;
+  align-items: center;
+  justify-content: center;
+}
+
+.md-typeset h2 {
+  margin-top: 1rem;
+}
+
+ul {
+  line-height: 1rem;
+}
+
 /* Hide <h1> on homepage */
 .md-typeset h1 {
   display: none;
@@ -25,262 +71,3 @@ article > a.md-content__button.md-icon:first-child {
     display: none;
 }
 </style>
-
-![Roboflow Inference banner](https://github.com/roboflow/inference/blob/main/banner.png?raw=true)
-
-Roboflow Inference is an open-source platform designed to simplify the deployment of computer vision models. It enables developers to perform object detection, classification, instance segmentation and [keypoint detection](/quickstart/run_keypoint_detection.md), and utilize foundation models like [CLIP](/foundation/clip.md), [Segment Anything](/foundation/sam.md), and [YOLO-World](/foundation/yolo_world.md) through a Python-native package, a self-hosted inference server, or a fully [managed API](https://docs.roboflow.com/).
-
-Explore our [enterprise options](https://roboflow.com/sales) for advanced features like server deployment, active learning, and commercial licenses for YOLOv5 and YOLOv8.
-
-<a href="/quickstart/run_a_model/" class="button">Get started with our "Run your first model" guide</a>
-
-<div class="button-holder">
-<a href="/quickstart/inference_101/" class="button half-button">Learn about the various ways you can use Inference</a>
-<a href="/workflows/about/" class="button half-button">Build a visual agent with Workflows</a>
-</div>
-
-<style>
-  .button {
-    background-color: var(--md-primary-fg-color);
-    display: block;
-    padding: 10px;
-    color: white !important;
-    border-radius: 5px;
-    text-align: center;
-  }
-</style>
-
-Here is an example of a model running on a video using Inference:
-
-<video width="100%" autoplay loop muted>
-  <source src="https://media.roboflow.com/football-video.mp4" type="video/mp4">
-</video>
-
-## 💻 install
-
-Inference package requires [**Python>=3.8,<=3.11**](https://www.python.org/). Click [here](/quickstart/docker.md) to learn more about running Inference inside Docker.
-
-```bash
-pip install inference
-```
-
-<details>
-<summary>👉 running on a GPU</summary>
-
-  To enhance model performance in GPU-accelerated environments, install CUDA-compatible dependencies instead:
-  
-  ```bash
-  pip install inference-gpu
-  ```
-</details>
-
-<details>
-<summary>👉 advanced models</summary>
-
-  Inference supports multiple model types for specialized tasks. From Grounding DINO for identifying objects with a text prompt, to DocTR for OCR, to CogVLM for asking questions about images - you can find out more in the <a href="/foundation/about">Foundation Models</a> page.
-
-  <br/><br/>
-
-  Note that <code>inference</code> and <code>inference-gpu</code> packages install only the minimal shared dependencies. <b>Instead</b>, install model-specific dependencies to ensure code compatibility and license compliance.
-
-  <br/><br/>
-
-  The <code>inference</code> and <code>inference-gpu</code> packages install only the minimal shared dependencies. Install model-specific dependencies to ensure code compatibility and license compliance. Learn more about the <a href="#extras">models</a> supported by Inference.
-
-  ```bash
-  pip install inference[yolo-world]
-  ```
-
-</details>
-
-## 🔥 quickstart
-
-Use Inference SDK to run models locally with just a few lines of code. The image input can be a URL, a numpy array, or a PIL image.
-
-```python
-from inference import get_model
-
-model = get_model(model_id="yolov8n-640")
-
-results = model.infer("https://media.roboflow.com/inference/people-walking.jpg")
-```
-
-<details>
-<summary>👉 roboflow models</summary>
-
-<br>
-
-Set up your <code>ROBOFLOW_API_KEY</code> to access thousands of fine-tuned models shared by the <a href="https://universe.roboflow.com/">Roboflow Universe</a> community and your custom model. Navigate to 🔑 keys section to learn more.
-
-```python
-from inference import get_model
-
-model = get_model(model_id="soccer-players-5fuqs/1")
-
-results = model.infer(
-    image="https://media.roboflow.com/inference/soccer.jpg",
-    confidence=0.5,
-    iou_threshold=0.5
-)
-```
-
-</details>
-
-<details>
-<summary>👉 foundational models</summary>
-
-- <a href="/foundation/clip">CLIP Embeddings</a> - generate text and image embeddings that you can use for zero-shot classification or assessing image similarity.
-
-  ```python
-  from inference.models import Clip
-
-  model = Clip()
-
-  embeddings_text = clip.embed_text("a football match")
-  embeddings_image = model.embed_image("https://media.roboflow.com/inference/soccer.jpg")
-  ```
-
-- <a href="/foundation/sam">Segment Anything</a> - segment all objects visible in the image or only those associated with selected points or boxes.
-
-  ```python
-  from inference.models import SegmentAnything
-
-  model = SegmentAnything()
-
-  result = model.segment_image("https://media.roboflow.com/inference/soccer.jpg")
-  ```
-
-- <a href="/foundation/yolo_world">YOLO-World</a> - an almost real-time zero-shot detector that enables the detection of any objects without any training.
-
-  ```python
-  from inference.models import YOLOWorld
-
-  model = YOLOWorld(model_id="yolo_world/l")
-
-  result = model.infer(
-      image="https://media.roboflow.com/inference/dog.jpeg",
-      text=["person", "backpack", "dog", "eye", "nose", "ear", "tongue"],
-      confidence=0.03
-  )
-  ```
-
-</details>
-
-## 📟 inference server
-
-You can also run Inference as a microservice with Docker.
-
-### deploy server
-
-The inference server is distributed via Docker. Behind the scenes, inference will download and run the image that is appropriate for your hardware. [Here](/quickstart/docker.md#advanced-build-a-docker-container-from-scratch), you can learn more about the supported images.
-
-```bash
-inference server start
-```
-
-### run client
-
-Consume inference server predictions using the HTTP client available in the Inference SDK.
-
-```python
-from inference_sdk import InferenceHTTPClient
-
-client = InferenceHTTPClient(
-    api_url="http://localhost:9001",
-    api_key=<ROBOFLOW_API_KEY>
-)
-with client.use_model(model_id="soccer-players-5fuqs/1"):
-    predictions = client.infer("https://media.roboflow.com/inference/soccer.jpg")
-```
-
-If you're using the hosted API, change the local API URL to `https://detect.roboflow.com`. Accessing the hosted inference server and/or using any of the fine-tuned models require a `ROBOFLOW_API_KEY`. For further information, visit the 🔑 keys section.
-
-## 🎥 inference pipeline
-
-The inference pipeline is an efficient method for processing static video files and streams. Select a model, define the video source, and set a callback action. You can choose from predefined callbacks that allow you to [display results](/reference/inference/core/interfaces/stream/sinks.md#inference.core.interfaces.stream.sinks.render_boxes) on the screen or [save them to a file](/reference/inference/core/interfaces/stream/sinks.md#inference.core.interfaces.stream.sinks.VideoFileSink).
-
-```python
-from inference import InferencePipeline
-from inference.core.interfaces.stream.sinks import render_boxes
-
-pipeline = InferencePipeline.init(
-    model_id="yolov8x-1280",
-    video_reference="https://media.roboflow.com/inference/people-walking.mp4",
-    on_prediction=render_boxes
-)
-
-pipeline.start()
-pipeline.join()
-```
-
-## 🔑 keys
-
-Inference enables the deployment of a wide range of pre-trained and foundational models without an API key. To access thousands of fine-tuned models shared by the [Roboflow Universe](https://universe.roboflow.com/) community, [configure your](https://app.roboflow.com/settings/api) API key.
-
-```bash
-export ROBOFLOW_API_KEY=<YOUR_API_KEY>
-```
-
-## 📚 documentation
-
-Visit our [documentation](/) to explore comprehensive guides, detailed API references, and a wide array of tutorials designed to help you harness the full potential of the Inference package.
-
-## © license
-
-The Roboflow Inference code is distributed under the [Apache 2.0](https://github.com/roboflow/inference/blob/master/LICENSE.core) license. However, each supported model is subject to its licensing. Detailed information on each model's license can be found [here](https://roboflow.com/licensing).
-
-
-## ⚡️ extras
-
-Below you can find list of extras available for `inference` and `inference-gpu`
-
-<table>
-<tr>
-  <th>Name</th>
-  <th style="width:30%">Description</th>
-  <th style="width:50%">Notes</th>
-</tr>
-<tr>
-  <td><code>clip</code></td>
-  <td><a href="/foundation/clip">CLIP model</a></td>
-  <td><code>N/A</code></td>
-</tr>
-<tr>
-  <td><code>gaze</code></td>
-  <td><a href="/foundation/gaze">L2CS-Net model</a></td>
-  <td><code>N/A</code></td>
-</tr>
-<tr>
-  <td><code>grounding-dino</code></td>
-  <td><a href="/foundation/grounding_dino/">Grounding Dino model</a></td>
-  <td><code>N/A</code></td>
-</tr>
-<tr>
-  <td><code>sam</code></td>
-  <td><a href="/foundation/sam">SAM</a> and <a href="/foundation/sam2">SAM2</a> models</td>
-  <td>The extras depend on <code>rasterio</code> which require <code>GDAL</code> library to work. If the installation fails with <code>gdal-config</code> command error - run <code>sudo apt-get install libgdal-dev</code> for Linux or follow <a href="https://gdal.org/en/latest/download.html#binaries">official installation guide</a></td>
-</tr>
-<tr>
-  <td><code>yolo-world</code></td>
-  <td><a href="/foundation/yolo_world/">Yolo-World model</a></td>
-  <td><code>N/A</code></td>
-</tr>
-<tr>
-  <td><code>transformers</code></td>
-  <td><code>transformers</code> based models, like <a href="/foundation/florence2/">Florence-2</a></td>
-  <td><code>N/A</code></td>
-</tr>
-</table>
-
-??? note "Installing extras"
-
-    To install specific extras you need to run
-
-    ```bash
-    pip install inferenence[extras-name]
-    ```
-    or 
-
-    ```bash
-    pip install inferenence-gpu[extras-name]
-    ```

--- a/docs/scripts/gen_ref_pages.py
+++ b/docs/scripts/gen_ref_pages.py
@@ -3,39 +3,41 @@
 from pathlib import Path
 
 import mkdocs_gen_files
+import os
 
 SKIP_MODULES = [
     "inference.enterprise.device_manager.command_handler",
     "inference.enterprise.parallel.celeryconfig",
 ]
 
-for package in ["inference", "inference_sdk", "inference_cli"]:
-    nav = mkdocs_gen_files.Nav()
-    src = Path(__file__).parent.parent.parent / package
+if not os.environ.get("SKIP_CODEGEN"):
+    for package in ["inference", "inference_sdk", "inference_cli"]:
+        nav = mkdocs_gen_files.Nav()
+        src = Path(__file__).parent.parent.parent / package
 
-    for path in sorted(p for p in src.rglob("*.py") if "landing" not in p.parts):
-        module_path = path.relative_to(src.parent).with_suffix("")
-        doc_path = path.relative_to(src.parent).with_suffix(".md")
-        full_doc_path = Path("reference", doc_path)
+        for path in sorted(p for p in src.rglob("*.py") if "landing" not in p.parts):
+            module_path = path.relative_to(src.parent).with_suffix("")
+            doc_path = path.relative_to(src.parent).with_suffix(".md")
+            full_doc_path = Path("reference", doc_path)
 
-        parts = list(module_path.parts)
-        identifier = ".".join(parts)
-        if parts[-1] == "__main__" or parts[-1] == "__init__" or identifier in SKIP_MODULES:
-            # print("SKIPPING", identifier)
-            continue
+            parts = list(module_path.parts)
+            identifier = ".".join(parts)
+            if parts[-1] == "__main__" or parts[-1] == "__init__" or identifier in SKIP_MODULES:
+                # print("SKIPPING", identifier)
+                continue
 
-        nav[parts] = f"/reference/{module_path.as_posix()}.md"
+            nav[parts] = f"/reference/{module_path.as_posix()}.md"
 
-        with mkdocs_gen_files.open(full_doc_path, "w") as fd:
-            fd.write(f"::: {identifier}")
+            with mkdocs_gen_files.open(full_doc_path, "w") as fd:
+                fd.write(f"::: {identifier}")
 
-        edit_path = f"https://github.com/roboflow/inference/tree/main/{module_path.as_posix()}.py"
-        # print("Edit path:", edit_path)
-        mkdocs_gen_files.set_edit_path(full_doc_path, edit_path)
+            edit_path = f"https://github.com/roboflow/inference/tree/main/{module_path.as_posix()}.py"
+            # print("Edit path:", edit_path)
+            mkdocs_gen_files.set_edit_path(full_doc_path, edit_path)
 
-    with mkdocs_gen_files.open(f"reference/{package}/index.md", "w") as nav_file:
-        generator = nav.build_literate_nav()
-        lines = list(generator)
-        # print("GENERATING NAVIGATION")
-        # print("\n".join(lines))
-        nav_file.writelines(lines)
+        with mkdocs_gen_files.open(f"reference/{package}/index.md", "w") as nav_file:
+            generator = nav.build_literate_nav()
+            lines = list(generator)
+            # print("GENERATING NAVIGATION")
+            # print("\n".join(lines))
+            nav_file.writelines(lines)

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -18,6 +18,10 @@
   justify-content: space-between;
 }
 
+.grecaptcha-badge {
+  box-shadow: none !important;
+}
+
 @media screen and (min-width: 76.25em) {
   .md-nav__item--section>.md-nav__link {
       font-weight: 700;


### PR DESCRIPTION
# Description

This is a temporary update to the docs landing page. We'll replace it with something better soon, but making way for the new "Start" section of the docs I'm going to follow up with.

Also added an option to skip the reference docs generation locally via an environment variable because they slow down the feedback cycle while editing things.

Now looks like this:
<img width="1290" alt="image" src="https://github.com/user-attachments/assets/33d08977-55fd-47d9-93f9-7d36ba06927a" />

## Type of change

-   [x] This change is a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Non-functional change; previewed it on my local docs build

## Any specific deployment considerations

No, just docs

## Docs

-   [x] Docs updated? What were the changes: this is the docs update.
