### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ cd inference
 python3 -m venv inf
 source inf/bin/activate
 pip install .
-cp docker/config/cpu_http:app .
+cp docker/config/cpu_http.py .
 ```
 
 Then start the server by running `uvicorn` with the `cpu_http` module in your virtual environment:


### PR DESCRIPTION
Fixing the cp command under Mac / Apple Silicon (MPS) section on running on-prem/self-hosted.

# Description

The following command fails

```
% cp docker/config/cpu_http:app .
cp: docker/config/cpu_http:app: No such file or directory
```

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Updated `cp` so it specifies the correct filename

```
cp docker/config/cpu_http.py . 
```

## Any specific deployment considerations

None

## Docs

-   [ ] Docs updated? What were the changes:
