### PR TITLE
Support forks

### DIFF
--- a/.github/workflows/check_if_branch_is_mergeable.yml
+++ b/.github/workflows/check_if_branch_is_mergeable.yml
@@ -1,12 +1,10 @@
 name: mergeable
-
 on:
   workflow_call:
     outputs:
       mergeable_state:
         description: "Set to 'clean' if branch is mergeable, otherwise set to 'not_clean'"
         value: ${{ jobs.check_if_branch_is_mergeable.outputs.mergeable_state }}
-
 jobs:
   check_if_branch_is_mergeable:
     name: Check if branch is mergeable
@@ -30,11 +28,21 @@ jobs:
           target_branch="main"
           source_branch="${{ github.head_ref || github.ref_name }}"
 
-          echo "Comparing $source_repo:$source_branch with $target_repo:$target_branch"
+          echo "Source repo: $source_repo"
+          echo "Target repo: $target_repo"
+          echo "Source branch: $source_branch"
+          echo "Target branch: $target_branch"
 
-          # For forks, we need to use the full repository path
-          response=$(gh api "/repos/$target_repo/compare/$target_branch...$source_repo:$source_branch")
+          # The comparison URL format should be base...head
+          api_url="/repos/$target_repo/compare/$target_branch...${source_repo}:${source_branch}"
+          echo "API URL: $api_url"
+
+          response=$(gh api "$api_url" || echo '{"status": "error"}')
+          echo "Raw API response:"
+          echo "$response"
+
           status=$(echo "$response" | jq -r '.status')
+          echo "Parsed status: $status"
 
           if [ "$status" = "ahead" ]; then
             echo "[OK] Selected branch is ahead of main and can be merged"

--- a/.github/workflows/check_if_branch_is_mergeable.yml
+++ b/.github/workflows/check_if_branch_is_mergeable.yml
@@ -23,15 +23,30 @@ jobs:
             echo "[OK] Merging to main"
             exit 0
           fi
-          response=$(gh api /repos/${{ github.repository }}/compare/main...${{ github.head_ref || github.ref_name }} )
 
+          # Extract repository information
+          target_repo="${{ github.repository }}"
+          source_repo="${{ github.event.pull_request.head.repo.full_name || github.repository }}"
+          target_branch="main"
+          source_branch="${{ github.head_ref || github.ref_name }}"
+
+          echo "Comparing $source_repo:$source_branch with $target_repo:$target_branch"
+
+          # For forks, we need to use the full repository path
+          response=$(gh api "/repos/$target_repo/compare/$target_branch...$source_repo:$source_branch")
           status=$(echo "$response" | jq -r '.status')
 
           if [ "$status" = "ahead" ]; then
             echo "[OK] Selected branch is ahead of main and can be merged"
             echo "mergeable_state=clean" >> "$GITHUB_OUTPUT"
+          elif [ "$status" = "behind" ]; then
+            echo "[FAIL] Selected branch is behind main and needs to be updated"
+            echo "mergeable_state=not_clean" >> "$GITHUB_OUTPUT"
+          elif [ "$status" = "diverged" ]; then
+            echo "[FAIL] Selected branch has diverged from main and needs to be rebased"
+            echo "mergeable_state=not_clean" >> "$GITHUB_OUTPUT"
           else
-            echo "[FAIL] Selected branch does NOT meet the criteria."
+            echo "[FAIL] Selected branch does NOT meet the criteria"
             echo "Status: $status"
             echo "mergeable_state=not_clean" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/check_if_branch_is_mergeable.yml
+++ b/.github/workflows/check_if_branch_is_mergeable.yml
@@ -22,19 +22,29 @@ jobs:
             exit 0
           fi
 
+          # Sanitize and escape input values
+          sanitize() {
+            local input="$1"
+            # URL encode the string
+            printf "%s" "$input" | jq -sRr @uri
+          }
+
           # Extract repository information
           target_repo="${{ github.repository }}"
-          source_repo="${{ github.event.pull_request.head.repo.full_name || github.repository }}"
-          target_branch="main"
-          source_branch="${{ github.head_ref || github.ref_name }}"
+          source_owner=$(sanitize "${{ github.event.pull_request.head.user.login || github.repository_owner }}")
+          target_repo_name=$(echo "$target_repo" | cut -d'/' -f2)
+          target_repo_name=$(sanitize "$target_repo_name")
+          target_branch=$(sanitize "main")
+          source_branch=$(sanitize "${{ github.head_ref || github.ref_name }}")
 
-          echo "Source repo: $source_repo"
+          echo "Source owner: $source_owner"
           echo "Target repo: $target_repo"
+          echo "Target repo name: $target_repo_name"
           echo "Source branch: $source_branch"
           echo "Target branch: $target_branch"
 
-          # The comparison URL format should be base...head
-          api_url="/repos/$target_repo/compare/$target_branch...${source_repo}:${source_branch}"
+          # Format: /repos/OWNER/REPO/compare/BASE...FORK_OWNER:REPO:BRANCH
+          api_url="/repos/$target_repo/compare/$target_branch...$source_owner:$target_repo_name:$source_branch"
           echo "API URL: $api_url"
 
           response=$(gh api "$api_url" || echo '{"status": "error"}')
@@ -47,14 +57,18 @@ jobs:
           if [ "$status" = "ahead" ]; then
             echo "[OK] Selected branch is ahead of main and can be merged"
             echo "mergeable_state=clean" >> "$GITHUB_OUTPUT"
+            exit 0
           elif [ "$status" = "behind" ]; then
             echo "[FAIL] Selected branch is behind main and needs to be updated"
             echo "mergeable_state=not_clean" >> "$GITHUB_OUTPUT"
+            exit 1
           elif [ "$status" = "diverged" ]; then
             echo "[FAIL] Selected branch has diverged from main and needs to be rebased"
             echo "mergeable_state=not_clean" >> "$GITHUB_OUTPUT"
+            exit 1
           else
             echo "[FAIL] Selected branch does NOT meet the criteria"
             echo "Status: $status"
             echo "mergeable_state=not_clean" >> "$GITHUB_OUTPUT"
+            exit 1
           fi

--- a/.github/workflows/check_if_branch_is_mergeable.yml
+++ b/.github/workflows/check_if_branch_is_mergeable.yml
@@ -18,18 +18,17 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           if [ "main" = "${{ github.head_ref || github.ref_name }}" ]; then
-            echo "[OK] Merging to main"
+            echo "ℹ️ Branch is main, proceeding"
             exit 0
           fi
 
           # Sanitize and escape input values
           sanitize() {
             local input="$1"
-            # URL encode the string
             printf "%s" "$input" | jq -sRr @uri
           }
 
-          # Extract repository information
+          # Extract and sanitize repository information
           target_repo="${{ github.repository }}"
           source_owner=$(sanitize "${{ github.event.pull_request.head.user.login || github.repository_owner }}")
           target_repo_name=$(echo "$target_repo" | cut -d'/' -f2)
@@ -37,38 +36,27 @@ jobs:
           target_branch=$(sanitize "main")
           source_branch=$(sanitize "${{ github.head_ref || github.ref_name }}")
 
-          echo "Source owner: $source_owner"
-          echo "Target repo: $target_repo"
-          echo "Target repo name: $target_repo_name"
-          echo "Source branch: $source_branch"
-          echo "Target branch: $target_branch"
-
-          # Format: /repos/OWNER/REPO/compare/BASE...FORK_OWNER:REPO:BRANCH
+          # Construct and execute API request
           api_url="/repos/$target_repo/compare/$target_branch...$source_owner:$target_repo_name:$source_branch"
-          echo "API URL: $api_url"
+          echo "ℹ️ Comparing branches..."
 
           response=$(gh api "$api_url" || echo '{"status": "error"}')
-          echo "Raw API response:"
-          echo "$response"
-
           status=$(echo "$response" | jq -r '.status')
-          echo "Parsed status: $status"
 
           if [ "$status" = "ahead" ]; then
-            echo "[OK] Selected branch is ahead of main and can be merged"
+            echo "✅ Branch is ahead of main and can be merged"
             echo "mergeable_state=clean" >> "$GITHUB_OUTPUT"
             exit 0
           elif [ "$status" = "behind" ]; then
-            echo "[FAIL] Selected branch is behind main and needs to be updated"
+            echo "❌ Branch is behind main and needs to be updated"
             echo "mergeable_state=not_clean" >> "$GITHUB_OUTPUT"
             exit 1
           elif [ "$status" = "diverged" ]; then
-            echo "[FAIL] Selected branch has diverged from main and needs to be rebased"
+            echo "❌ Branch has diverged from main and needs to be rebased"
             echo "mergeable_state=not_clean" >> "$GITHUB_OUTPUT"
             exit 1
           else
-            echo "[FAIL] Selected branch does NOT meet the criteria"
-            echo "Status: $status"
+            echo "❌ Branch comparison failed with status: $status"
             echo "mergeable_state=not_clean" >> "$GITHUB_OUTPUT"
             exit 1
           fi


### PR DESCRIPTION
Extends the mergeable action to support comparing branches from forked repositories.
Key changes:
- Add URL sanitization for branch names to prevent injection attacks
- Update GitHub API comparison format to support fork comparisons
- Add proper exit codes and improved status messages
- Handle behind/diverged states explicitly

Before this change, the action only worked for branches within the same repository.
Now it correctly handles fork comparisons by using the OWNER:REPO:BRANCH format
and sanitizes all inputs to prevent command injection via malicious branch names.