### PR TITLE
Remove explicit checkout ref

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,7 +22,6 @@ jobs:
       - name: Check out inference repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
           path: inference_repo
 
       - name: Create GitHub App token (enterprise blocks)

--- a/.github/workflows/hosted_inference_e2e_test_production.yml
+++ b/.github/workflows/hosted_inference_e2e_test_production.yml
@@ -17,8 +17,6 @@ jobs:
     steps:
       - name: 🛎️ Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref }}
       - name: 🐍 Set up Python 3.12
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/hosted_inference_e2e_test_staging.yml
+++ b/.github/workflows/hosted_inference_e2e_test_staging.yml
@@ -17,8 +17,6 @@ jobs:
     steps:
       - name: 🛎️ Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref }}
       - name: 🐍 Set up Python 3.12
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/integration_tests_inference_cli_depending_on_inference_x86.yml
+++ b/.github/workflows/integration_tests_inference_cli_depending_on_inference_x86.yml
@@ -22,8 +22,6 @@ jobs:
     steps:
       - name: 🛎️ Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref }}
       - name: 🐍 Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/integration_tests_inference_cli_x86.yml
+++ b/.github/workflows/integration_tests_inference_cli_x86.yml
@@ -22,8 +22,6 @@ jobs:
     steps:
       - name: 🛎️ Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref }}
       - name: 🐍 Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/integration_tests_inference_models.yml
+++ b/.github/workflows/integration_tests_inference_models.yml
@@ -22,8 +22,6 @@ jobs:
     steps:
       - name: 🛎️ Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref }}
       - name: 🐍 Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/integration_tests_workflows_x86.yml
+++ b/.github/workflows/integration_tests_workflows_x86.yml
@@ -24,8 +24,6 @@ jobs:
     steps:
       - name: 🛎️ Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref }}
       - name: 🐍 Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/load_test_hosted_inference.yml
+++ b/.github/workflows/load_test_hosted_inference.yml
@@ -27,8 +27,6 @@ jobs:
     steps:
       - name: 🛎️ Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref }}
       - name: 🐍 Set up Python 3.12
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/prod_build_and_push_hosted_inference_image.yml
+++ b/.github/workflows/prod_build_and_push_hosted_inference_image.yml
@@ -21,8 +21,6 @@ jobs:
     steps:
       - name: 🛎️ Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref }}
       - name: ⚙️ Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:

--- a/.github/workflows/staging_build_and_push_hosted_inference_image.yml
+++ b/.github/workflows/staging_build_and_push_hosted_inference_image.yml
@@ -21,8 +21,6 @@ jobs:
     steps:
       - name: 🛎️ Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref }}
       - name: ⚙️ Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:

--- a/.github/workflows/static_code_analysis.yml
+++ b/.github/workflows/static_code_analysis.yml
@@ -15,8 +15,6 @@ jobs:
     steps:
       - name: 🛎️ Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref }}
       - name: Install code analysis dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/test.jetson_4.5.0.yml
+++ b/.github/workflows/test.jetson_4.5.0.yml
@@ -20,8 +20,6 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: 🛎️ Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref }}
       - name: 📦 Cache Python packages
         uses: actions/cache@v3
         with:

--- a/.github/workflows/test.jetson_4.6.1.yml
+++ b/.github/workflows/test.jetson_4.6.1.yml
@@ -20,8 +20,6 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: 🛎️ Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref }}
       - name: 📦 Cache Python packages
         uses: actions/cache@v3
         with:

--- a/.github/workflows/test.jetson_5.1.1.yml
+++ b/.github/workflows/test.jetson_5.1.1.yml
@@ -20,8 +20,6 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: 🛎️ Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref }}
       - name: 📦 Cache Python packages
         uses: actions/cache@v3
         with:

--- a/.github/workflows/test.jetson_6.0.0.yml
+++ b/.github/workflows/test.jetson_6.0.0.yml
@@ -20,8 +20,6 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: 🛎️ Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref }}
       - name: 📦 Cache Python packages
         uses: actions/cache@v3
         with:

--- a/.github/workflows/test.nvidia_t4_parallel_server.yml
+++ b/.github/workflows/test.nvidia_t4_parallel_server.yml
@@ -19,8 +19,6 @@ jobs:
         uses: docker/setup-buildx-action@v2
       - name: 🛎️ Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref }}
       - name: 📦 Cache Python packages
         uses: actions/cache@v3
         with:

--- a/.github/workflows/unit_tests_inference_cli_x86.yml
+++ b/.github/workflows/unit_tests_inference_cli_x86.yml
@@ -24,8 +24,6 @@ jobs:
     steps:
       - name: 🛎️ Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref }}
       - name: 📦 Cache Python packages
         uses: actions/cache@v3
         with:

--- a/.github/workflows/unit_tests_inference_sdk_x86.yml
+++ b/.github/workflows/unit_tests_inference_sdk_x86.yml
@@ -24,8 +24,6 @@ jobs:
     steps:
       - name: 🛎️ Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref }}
       - name: 📦 Cache Python packages
         uses: actions/cache@v3
         with:

--- a/.github/workflows/unit_tests_inference_x86.yml
+++ b/.github/workflows/unit_tests_inference_x86.yml
@@ -24,8 +24,6 @@ jobs:
     steps:
       - name: 🛎️ Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref }}
       - name: 📦 Cache Python packages
         uses: actions/cache@v3
         with:

--- a/.github/workflows/unit_tests_workflows_x86.yml
+++ b/.github/workflows/unit_tests_workflows_x86.yml
@@ -24,8 +24,6 @@ jobs:
     steps:
       - name: 🛎️ Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref }}
       - name: 📦 Cache Python packages
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
Fix checkout process for forked repository workflows by removing explicit `ref: ${{ github.head_ref }}` configurations from all GitHub Actions. 

Context:
- When running workflows from forks, the explicit head_ref configuration was causing checkout issues
- actions/checkout@v4 automatically handles the correct ref for both fork and non-fork scenarios

Changes:
- Remove `ref: ${{ github.head_ref }}` from all workflow files (20+ files modified)
- Let actions/checkout@v4 handle the ref selection automatically based on the context

This change simplifies our workflow configurations and fixes checkout issues when running from forked repositories. The checkout action will now automatically select the appropriate ref whether running from a fork or internal branch.