### PR TITLE
Pass roboflow workflow ID as usage_workflow_id if available

### DIFF
--- a/inference/core/roboflow_api.py
+++ b/inference/core/roboflow_api.py
@@ -529,6 +529,7 @@ def get_workflow_specification(
                 specification=specification,
                 ephemeral_cache=ephemeral_cache,
             )
+        specification["id"] = response["workflow"]["id"]
         return specification
     except KeyError as error:
         raise MalformedWorkflowResponseError(

--- a/inference/core/workflows/execution_engine/v1/core.py
+++ b/inference/core/workflows/execution_engine/v1/core.py
@@ -52,6 +52,7 @@ class ExecutionEngineV1(BaseExecutionEngine):
             prevent_local_images_loading=prevent_local_images_loading,
             profiler=profiler,
             workflow_id=workflow_id,
+            internal_id=workflow_definition.get("id")
         )
 
     def __init__(
@@ -61,12 +62,14 @@ class ExecutionEngineV1(BaseExecutionEngine):
         prevent_local_images_loading: bool,
         profiler: WorkflowsProfiler,
         workflow_id: Optional[str] = None,
+        internal_id: Optional[str] = None,
     ):
         self._compiled_workflow = compiled_workflow
         self._max_concurrent_steps = max_concurrent_steps
         self._prevent_local_images_loading = prevent_local_images_loading
         self._workflow_id = workflow_id
         self._profiler = profiler
+        self._internal_id = internal_id
 
     def run(
         self,
@@ -93,7 +96,7 @@ class ExecutionEngineV1(BaseExecutionEngine):
             runtime_parameters=runtime_parameters,
             max_concurrent_steps=self._max_concurrent_steps,
             usage_fps=fps,
-            usage_workflow_id=self._workflow_id,
+            usage_workflow_id=self._workflow_id if not self._internal_id else self._internal_id,
             usage_workflow_preview=_is_preview,
             kinds_serializers=self._compiled_workflow.kinds_serializers,
             serialize_results=serialize_results,


### PR DESCRIPTION
# Description

workflow ID is not guaranteed to be unique, pass internal workflow ID as `usage_workflow_id` if available.

## Type of change

-   [x] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?

CI passing, non-breaking change

## Any specific deployment considerations

N/A

## Docs

N/A