### PR TITLE
Add env-injectable headers to RF API requests

### DIFF
--- a/inference/core/env.py
+++ b/inference/core/env.py
@@ -48,6 +48,8 @@ API_BASE_URL = os.getenv(
         else "https://api.roboflow.one"
     ),
 )
+# extra headers expected to be serialised json
+ROBOFLOW_API_EXTRA_HEADERS = os.getenv("ROBOFLOW_API_EXTRA_HEADERS")
 
 # Debug flag for the API, default is False
 API_DEBUG = os.getenv("API_DEBUG", False)

--- a/inference/usage_tracking/payload_helpers.py
+++ b/inference/usage_tracking/payload_helpers.py
@@ -3,6 +3,8 @@ from typing import Any, DefaultDict, Dict, List, Optional, Set, Union
 
 import requests
 
+from inference.core.roboflow_api import build_roboflow_api_headers
+
 ResourceID = str
 Usage = Union[DefaultDict[str, Any], Dict[str, Any]]
 ResourceUsage = Union[DefaultDict[ResourceID, Usage], Dict[ResourceID, Usage]]
@@ -160,11 +162,14 @@ def send_usage_payload(
                 if "api_key_hash" in workflow_payload:
                     del workflow_payload["api_key_hash"]
                 workflow_payload["api_key"] = api_key
+            headers = build_roboflow_api_headers(
+                explicit_headers={"Authorization": f"Bearer {api_key}"}
+            )
             response = requests.post(
                 api_usage_endpoint_url,
                 json=complete_workflow_payloads,
                 verify=ssl_verify,
-                headers={"Authorization": f"Bearer {api_key}"},
+                headers=headers,
                 timeout=1,
             )
         except Exception:


### PR DESCRIPTION
# Description

This feature let us to inject extra headers to RF API requests.

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

* New tests
* CI still green

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
