### PR TITLE
Fix OwlV2.__init__

### DIFF
--- a/inference/models/owlv2/owlv2.py
+++ b/inference/models/owlv2/owlv2.py
@@ -293,8 +293,8 @@ class OwlV2(RoboflowInferenceModel):
     task_type = "object-detection"
     box_format = "xywh"
 
-    def __init__(self, *args, model_id=f"owlv2/{OWLV2_VERSION_ID}", **kwargs):
-        super().__init__(*args, model_id=model_id, **kwargs)
+    def __init__(self, model_id=f"owlv2/{OWLV2_VERSION_ID}", *args, **kwargs):
+        super().__init__(model_id, *args, **kwargs)
         hf_id = os.path.join("google", self.version_id)
         processor = Owlv2Processor.from_pretrained(hf_id)
         self.image_size = tuple(processor.image_processor.size.values())


### PR DESCRIPTION
# Description

Fix OwlV2.__init__

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

CI passing
Manually tested:

```python3
from inference.core.entities.requests.inference import ObjectDetectionInferenceRequest


model = get_model("owlv2/owlv2-large-patch14-ensemble")
```

## Any specific deployment considerations

N/A

## Docs

N/A