### PR TITLE
auto generate command line docs for  CLI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -90,6 +90,10 @@ jobs:
         run: python -m development.docs.workflows_gallery_builder
         working-directory: ./inference_repo
 
+      - name: Write CLI docs
+        run: python -m development.docs.write_cli_docs
+        working-directory: ./inference_repo
+
       - name: Deploy docs
         # Only deploy if release event OR if deploy input was set to true
         if: ${{ github.event_name == 'release' || github.event.inputs.deploy == 'true' }}

--- a/.gitignore
+++ b/.gitignore
@@ -167,6 +167,7 @@ scratch
 docs/workflows/blocks/*
 docs/workflows/kinds/*
 docs/workflows/gallery/*
+docs/inference_helpers/cli_commands/reference.md
 !tests/workflows/integration_tests/execution/assets/*.jpg
 !tests/workflows/integration_tests/execution/assets/rock_paper_scissors/*.jpg
 !tests/workflows/unit_tests/core_steps/models/third_party/assets/*.png

--- a/development/docs/write_cli_docs.py
+++ b/development/docs/write_cli_docs.py
@@ -1,0 +1,32 @@
+import subprocess
+import os 
+
+FILENAME = os.path.abspath(
+    os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "..",
+        "docs",
+        "inference_helpers",
+        "cli_commands",
+        "reference.md"
+    )
+)
+
+def write_file(path: str, content: str) -> None:
+    path = os.path.abspath(path)
+    parent_dir = os.path.dirname(path)
+    os.makedirs(parent_dir, exist_ok=True)
+    with open(path, "w") as f:
+        f.write(content)
+
+
+def main():
+    cmd = f"typer inference_cli.main utils docs --name inference"
+    result = subprocess.run(cmd.split(), capture_output=True, text=True)
+    print(result.stdout)
+    write_file(FILENAME, result.stdout)
+
+
+if __name__ == "__main__":
+    main()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -102,7 +102,7 @@ nav:
           - Benchmark Inference: inference_helpers/cli_commands/benchmark.md
           - Make Predictions: inference_helpers/cli_commands/infer.md
           - Deploy To Cloud: inference_helpers/cli_commands/cloud.md
-          - Reference: reference/inference_cli/
+          - Reference: inference_helpers/cli_commands/reference.md
       - inference Python Package: reference/inference/
       - Active Learning:
           - Use Active Learning: enterprise/active-learning/active_learning.md
@@ -176,6 +176,7 @@ plugins:
       implicit_index: True
   - macros:
       include_dir: docs/include
+  
 
 markdown_extensions:
   - admonition
@@ -187,6 +188,7 @@ markdown_extensions:
       alternate_style: true
   - toc:
       permalink: true
+  
 
 extra_javascript:
   - "https://cdnjs.cloudflare.com/ajax/libs/dompurify/3.0.8/purify.min.js"


### PR DESCRIPTION
# Description
auto generate command line docs for  CLI using typer command line tool.

This is loosely based on the code from https://github.com/syn54x/mkdocs-typer2

I tried both the existing `mkdocs-typer` and `mkdocs-typer2` pip packages, but couldn't get either to work.  The first one hasn't been updated for 3 years and I couldn't get it to generate anything.  

`mkdocs-typer2` hooked / tried to generate, but failed internally trying to update the html tree with `ParseError: mismatched tag: line 449, column 3`.  Looking at the sourcecode I saw it used the `typer` command line tool to generate markdown and then generate html from it.  I think the error is either in the generated HTML or because of the way its tryin to hook it into our material theme.

So instead I just added a script like the other docs generation scripts we have and write the markdown directly

IT looks like this when renderd:
![CleanShot 2025-01-13 at 16 26 33@2x](https://github.com/user-attachments/assets/e82ad237-c745-4644-863a-d2a148cb79bf)

## Type of change
New reference docs for CLI interface

## How has this change been tested, please provide a testcase or example of how you tested the change?
locally running the script and `mkdocs serve`


## Any specific deployment considerations
docs only

## Docs
auto generates cli interace docs