### PR TITLE
Fix Google Vision Block bounding box parsing

### DIFF
--- a/inference/core/workflows/core_steps/models/foundation/google_vision_ocr/v1.py
+++ b/inference/core/workflows/core_steps/models/foundation/google_vision_ocr/v1.py
@@ -162,10 +162,10 @@ class GoogleVisionOCRBlockV1(WorkflowBlock):
             for block in page["blocks"]:
                 # Get bounding box coordinates
                 box = block["boundingBox"]["vertices"]
-                x_min = min(v["x"] for v in box)
-                y_min = min(v["y"] for v in box)
-                x_max = max(v["x"] for v in box)
-                y_max = max(v["y"] for v in box)
+                x_min = min(v.get("x", 0) for v in box)
+                y_min = min(v.get("y", 0) for v in box)
+                x_max = max(v.get("x", 0) for v in box)
+                y_max = max(v.get("y", 0) for v in box)
                 xyxy.append([x_min, y_min, x_max, y_max])
 
                 # Only DOCUMENT_TEXT_DETECTION provides confidence score, use 1.0 otherwise


### PR DESCRIPTION
# Description

Fixes a bug caused by Google Vision API responses that contain vertices with 'x' or 'y' coordinates only. Their doc doesn't cover this case, but after some testing, it seems like treating the default as '0' gives the correct bounding boxes.

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Tested locally with a workflow that like the following:

```json
{
  "version": "1.0",
  "inputs": [
    {
      "type": "WorkflowParameter",
      "name": "api_key"
    },
    {
      "type": "InferenceImage",
      "name": "image"
    }
  ],
  "steps": [
    {
      "type": "roboflow_core/roboflow_instance_segmentation_model@v1",
      "name": "model",
      "images": "$inputs.image",
      "model_id": "yolov8n-seg-640",
      "confidence": 0.1,
      "iou_threshold": 0
    },
    {
      "type": "roboflow_core/detections_filter@v1",
      "name": "detections_filter",
      "predictions": "$steps.model.predictions",
      "operations": [
        {
          "type": "DetectionsFilter",
          "filter_operation": {
            "type": "StatementGroup",
            "operator": "and",
            "statements": [
              {
                "type": "BinaryStatement",
                "left_operand": {
                  "type": "DynamicOperand",
                  "operand_name": "_",
                  "operations": [
                    {
                      "type": "ExtractDetectionProperty",
                      "property_name": "confidence"
                    }
                  ]
                },
                "comparator": {
                  "type": "(Number) >="
                },
                "right_operand": {
                  "type": "StaticOperand",
                  "value": 0.5
                }
              }
            ]
          }
        }
      ],
      "operations_parameters": {}
    },
    {
      "type": "roboflow_core/polygon_visualization@v1",
      "name": "bounding_box_visualization",
      "predictions": "$steps.detections_filter.predictions",
      "image": "$inputs.image"
    },
    {
      "type": "roboflow_core/crop_visualization@v1",
      "name": "crop_visualization",
      "image": "$steps.bounding_box_visualization.image",
      "predictions": "$steps.detections_filter.predictions",
      "scale_factor": 0.3
    },
    {
      "type": "roboflow_core/dynamic_crop@v1",
      "name": "dynamic_crop",
      "images": "$steps.crop_visualization.image",
      "predictions": "$steps.detections_filter.predictions"
    },
    {
      "type": "roboflow_core/google_vision_ocr@v1",
      "name": "google_vision_ocr",
      "image": "$steps.dynamic_crop.crops",
      "ocr_type": "text_detection",
      "api_key": "$inputs.api_key"
    }
  ],
  "outputs": [
    {
      "type": "JsonField",
      "name": "google_vision_ocr",
      "coordinates_system": "own",
      "selector": "$steps.google_vision_ocr.*"
    },
    {
      "type": "JsonField",
      "name": "predictions",
      "coordinates_system": "own",
      "selector": "$steps.model.predictions"
    }
  ]
}
```

## Any specific deployment considerations

No