### PR TITLE
Send raw image over WebRTC if no visualisation is available

### DIFF
--- a/inference/core/interfaces/stream_manager/manager_app/inference_pipeline_manager.py
+++ b/inference/core/interfaces/stream_manager/manager_app/inference_pipeline_manager.py
@@ -275,6 +275,16 @@ class InferencePipelineManager(Process):
             def webrtc_sink(
                 prediction: Dict[str, WorkflowImageData], video_frame: VideoFrame
             ) -> None:
+                if parsed_payload.stream_output[0] not in prediction:
+                    from_inference_queue.sync_put(
+                        video_frame.image
+                    )
+                    return
+                if prediction[parsed_payload.stream_output[0]] is None:
+                    from_inference_queue.sync_put(
+                        video_frame.image
+                    )
+                    return
                 from_inference_queue.sync_put(
                     prediction[parsed_payload.stream_output[0]].numpy_image
                 )

--- a/inference/core/interfaces/stream_manager/manager_app/inference_pipeline_manager.py
+++ b/inference/core/interfaces/stream_manager/manager_app/inference_pipeline_manager.py
@@ -276,14 +276,10 @@ class InferencePipelineManager(Process):
                 prediction: Dict[str, WorkflowImageData], video_frame: VideoFrame
             ) -> None:
                 if parsed_payload.stream_output[0] not in prediction:
-                    from_inference_queue.sync_put(
-                        video_frame.image
-                    )
+                    from_inference_queue.sync_put(video_frame.image)
                     return
                 if prediction[parsed_payload.stream_output[0]] is None:
-                    from_inference_queue.sync_put(
-                        video_frame.image
-                    )
+                    from_inference_queue.sync_put(video_frame.image)
                     return
                 from_inference_queue.sync_put(
                     prediction[parsed_payload.stream_output[0]].numpy_image


### PR DESCRIPTION
# Description

When handling stream through WebRTC we currently expect image to be available. It is possible workflow branch with image generation was not executed - in such case we should send raw image.

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

CI passing
E2E tested

## Any specific deployment considerations

N/A

## Docs

N/A