### PR TITLE
Change "fire" to "run" in rate limiter description

### DIFF
--- a/inference/core/workflows/core_steps/flow_control/rate_limiter/v1.py
+++ b/inference/core/workflows/core_steps/flow_control/rate_limiter/v1.py
@@ -60,7 +60,7 @@ class RateLimiterManifest(WorkflowBlockManifest):
         json_schema_extra={
             "name": "Rate Limiter",
             "version": "v1",
-            "short_description": "Limits the rate at which a branch of the Workflow will fire.",
+            "short_description": "Limits the rate at which a branch of the Workflow will run.",
             "long_description": LONG_DESCRIPTION,
             "license": "Apache-2.0",
             "block_type": "flow_control",


### PR DESCRIPTION
# Description

This PR changes the copy of the Rate Limiter block to use the word "run" instead of "fire".

"run" will resonate more with our users. 

## Type of change

- Copy change

## How has this change been tested, please provide a testcase or example of how you tested the change?

This can be tested by ensuring the Workflow manifest contains the new copy.

## Any specific deployment considerations

N/A

## Docs

-   [x] Docs updated? What were the changes: Auto-documenting via manifest
