### PR TITLE
Suppress ONNX providers warning

### DIFF
--- a/inference/core/models/roboflow.py
+++ b/inference/core/models/roboflow.py
@@ -705,6 +705,7 @@ class OnnxRoboflowInferenceModel(RoboflowInferenceModel):
                 providers = ["OpenVINOExecutionProvider", "CPUExecutionProvider"]
             try:
                 session_options = onnxruntime.SessionOptions()
+                session_options.log_severity_level = 3
                 # TensorRT does better graph optimization for its EP than onnx
                 if has_trt(providers):
                     session_options.graph_optimization_level = (


### PR DESCRIPTION
# Description

Supporess warnings from ONNX like one below:

```
UserWarning: Specified provider 'CUDAExecutionProvider' is not in available provider names.Available providers: 'OpenVINOExecutionProvider, CPUExecutionProvider'
```

ONNX session log severity is set to 3 (ERROR) ((docs)[https://onnxruntime.ai/docs/api/python/api_summary.html])

## Type of change

-   [x] Quality of life

## How has this change been tested, please provide a testcase or example of how you tested the change?

CI passing

## Any specific deployment considerations

N/A

## Docs

N/A