### PR TITLE
Detection Offset - Use bbox for percent padding

### DIFF
--- a/inference/core/workflows/core_steps/transformations/detection_offset/v1.py
+++ b/inference/core/workflows/core_steps/transformations/detection_offset/v1.py
@@ -118,7 +118,7 @@ class DetectionOffsetBlockV1(WorkflowBlock):
         offset_height: int,
         units: str = "Pixels",
     ) -> BlockResult:
-        use_percentage = units == "Percent (%)"
+        use_percentage = units == "Percent (%) - of bounding box width / height"
         return [
             {
                 "predictions": offset_detections(
@@ -148,18 +148,19 @@ def offset_detections(
         _detections.xyxy = np.array(
             [
                 (
-                    max(0, x1 - int(image_dimensions[i][1] * offset_width / 200)),
-                    max(0, y1 - int(image_dimensions[i][0] * offset_height / 200)),
+                    max(0, x1 - int(box_width * offset_width / 200)),
+                    max(0, y1 - int(box_height * offset_height / 200)),
                     min(
                         image_dimensions[i][1],
-                        x2 + int(image_dimensions[i][1] * offset_width / 200),
+                        x2 + int(box_width * offset_width / 200),
                     ),
                     min(
                         image_dimensions[i][0],
-                        y2 + int(image_dimensions[i][0] * offset_height / 200),
+                        y2 + int(box_height * offset_height / 200),
                     ),
                 )
                 for i, (x1, y1, x2, y2) in enumerate(_detections.xyxy)
+                for box_width, box_height in [(x2 - x1, y2 - y1)]
             ]
         )
     else:

--- a/tests/workflows/unit_tests/core_steps/transformations/test_detection_offset.py
+++ b/tests/workflows/unit_tests/core_steps/transformations/test_detection_offset.py
@@ -163,7 +163,7 @@ def test_offset_detection_when_nothing_predicted() -> None:
 def test_offset_detection_with_percentage() -> None:
     # given
     detections = sv.Detections(
-        xyxy=np.array([[100, 200, 300, 400]], dtype=np.float64),
+        xyxy=np.array([[100, 200, 400, 600]], dtype=np.float64),
         class_id=np.array([1]),
         confidence=np.array([0.5], dtype=np.float64),
         data={
@@ -184,7 +184,7 @@ def test_offset_detection_with_percentage() -> None:
 
     # then
     x1, y1, x2, y2 = result.xyxy[0]
-    assert x1 == 68, "Left corner should be moved by 10% of image width to the left"
-    assert y1 == 168, "Top corner should be moved by 10% of image height to the top"
-    assert x2 == 332, "Right corner should be moved by 10% of image width to the right"
-    assert y2 == 432, "Bottom corner should be moved by 10% of image height to the bottom"
+    assert x1 == 85, "Left corner should be moved by 5% of detection width to the left"
+    assert y1 == 180, "Top corner should be moved by 5% of detection height to the top"
+    assert x2 == 415, "Right corner should be moved by 5% of detection width to the right"
+    assert y2 == 620, "Bottom corner should be moved by 5% of detection height to the bottom"


### PR DESCRIPTION
# Description

Padding bounding boxes by percent rather than pixels is a new feature (implemented in https://github.com/roboflow/inference/pull/956/files) and I don't think was implemented correctly. When talking with potential users, they want padding based on a percentage of the size of the bounding box, not the size of the image. This is done because larger detections need more padding because they are closer to the camera. I don't think padding based on image size is very useful. I'm hoping since this functionality is new enough and was implemented for a specific use case that we can modify it.


## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Unit tests cover this change fully.

## Any specific deployment considerations

n/a - standard deploy

## Docs

-   [x] Updated description of input to reflect the use of bounding box percent.
