### PR TITLE
send api key for model registry to make it work on dedicated deployments

### DIFF
--- a/inference_sdk/http/client.py
+++ b/inference_sdk/http/client.py
@@ -821,7 +821,9 @@ class InferenceHTTPClient:
             HTTPClientError: If there is an error with the server connection.
         """
         self.__ensure_v1_client_mode()
-        response = requests.get(f"{self.__api_url}/model/registry?api_key={self.__api_key}")
+        response = requests.get(
+            f"{self.__api_url}/model/registry?api_key={self.__api_key}"
+        )
         response.raise_for_status()
         response_payload = response.json()
         return RegisteredModels.from_dict(response_payload)
@@ -840,7 +842,9 @@ class InferenceHTTPClient:
         """
         self.__ensure_v1_client_mode()
         async with aiohttp.ClientSession() as session:
-            async with session.get(f"{self.__api_url}/model/registry?api_key={self.__api_key}") as response:
+            async with session.get(
+                f"{self.__api_url}/model/registry?api_key={self.__api_key}"
+            ) as response:
                 response.raise_for_status()
                 response_payload = await response.json()
                 return RegisteredModels.from_dict(response_payload)

--- a/inference_sdk/http/client.py
+++ b/inference_sdk/http/client.py
@@ -821,7 +821,7 @@ class InferenceHTTPClient:
             HTTPClientError: If there is an error with the server connection.
         """
         self.__ensure_v1_client_mode()
-        response = requests.get(f"{self.__api_url}/model/registry")
+        response = requests.get(f"{self.__api_url}/model/registry?api_key={self.__api_key}")
         response.raise_for_status()
         response_payload = response.json()
         return RegisteredModels.from_dict(response_payload)
@@ -840,7 +840,7 @@ class InferenceHTTPClient:
         """
         self.__ensure_v1_client_mode()
         async with aiohttp.ClientSession() as session:
-            async with session.get(f"{self.__api_url}/model/registry") as response:
+            async with session.get(f"{self.__api_url}/model/registry?api_key={self.__api_key}") as response:
                 response.raise_for_status()
                 response_payload = await response.json()
                 return RegisteredModels.from_dict(response_payload)

--- a/tests/inference_sdk/unit_tests/http/test_client.py
+++ b/tests/inference_sdk/unit_tests/http/test_client.py
@@ -842,7 +842,7 @@ async def test_list_loaded_models_async_when_successful_response_expected() -> N
 
     with aioresponses() as m:
         m.get(
-            f"{api_url}/model/registry",
+            f"{api_url}/model/registry?api_key=my-api-key",
             payload={
                 "models": [
                     {
@@ -892,7 +892,7 @@ async def test_list_loaded_models_when_unsuccessful_response_expected() -> None:
 
     with aioresponses() as m:
         m.get(
-            f"{api_url}/model/registry",
+            f"{api_url}/model/registry?api_key=my-api-key",
             payload={"message": "Internal error."},
             status=500,
         )
@@ -951,7 +951,7 @@ async def test_get_model_description_async_when_model_when_error_occurs_in_model
 
     with aioresponses() as m:
         m.get(
-            f"{api_url}/model/registry",
+            f"{api_url}/model/registry?api_key=my-api-key",
             payload={"message": "Internal error."},
             status=500,
         )
@@ -1004,7 +1004,7 @@ async def test_get_model_description_async_when_model_was_loaded_already() -> No
 
     with aioresponses() as m:
         m.get(
-            f"{api_url}/model/registry",
+            f"{api_url}/model/registry?api_key=my-api-key",
             payload={"models": [{"model_id": "some/1", "task_type": "classification"}]},
         )
         # when
@@ -1024,7 +1024,7 @@ async def test_get_model_description_async_when_model_was_loaded_already_and_ali
 
     with aioresponses() as m:
         m.get(
-            f"{api_url}/model/registry",
+            f"{api_url}/model/registry?api_key=my-api-key",
             payload={
                 "models": [{"model_id": "coco/3", "task_type": "object-detection"}]
             },
@@ -1096,7 +1096,7 @@ async def test_get_model_description_async_when_model_was_not_loaded_before_and_
 
     with aioresponses() as m:
         m.get(
-            f"{api_url}/model/registry",
+            f"{api_url}/model/registry?api_key=my-api-key",
             payload={"models": []},
         )
         m.post(
@@ -1121,7 +1121,7 @@ async def test_get_model_description_async_when_model_was_not_loaded_before_and_
 
     with aioresponses() as m:
         m.get(
-            f"{api_url}/model/registry",
+            f"{api_url}/model/registry?api_key=my-api-key",
             payload={"models": []},
         )
         m.post(
@@ -1173,7 +1173,7 @@ async def test_get_model_description_async_when_model_was_not_loaded_before_and_
 
     with aioresponses() as m:
         m.get(
-            f"{api_url}/model/registry",
+            f"{api_url}/model/registry?api_key=my-api-key",
             payload={"models": []},
         )
         m.post(


### PR DESCRIPTION
# Description
the /model/registry endpoint usually doesnt require api keys when run locally.  However on dedicated deployments all requests need to pass api key to validate they come from workspace that the dedicated deployment belongs to.

Without this change the benchmark cli tool doesn't work.

## Type of change

Please delete options that are not relevant.
-   [c] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?
locally

## Any specific deployment considerations
n/a

## Docs
n/a