### PR TITLE
remove print from cli docs generation script

### DIFF
--- a/development/docs/write_cli_docs.py
+++ b/development/docs/write_cli_docs.py
@@ -24,7 +24,6 @@ def write_file(path: str, content: str) -> None:
 def main():
     cmd = f"typer inference_cli.main utils docs --name inference"
     result = subprocess.run(cmd.split(), capture_output=True, text=True)
-    print(result.stdout)
     write_file(FILENAME, result.stdout)
 
 


### PR DESCRIPTION
# Description
unnecessary print in script to generate cli docs reference

List any dependencies that are required for this change.

## Type of change
remove print

## How has this change been tested, please provide a testcase or example of how you tested the change?
locally via ` python -m development.docs.write_cli_docs` 

## Any specific deployment considerations
n/a

## Docs
updates script to generate cli docs