### PR TITLE
When stream output received in camera streaming payload is not WorkflowImageData, select first available WorkflowImageData output

### DIFF
--- a/inference/core/interfaces/stream_manager/manager_app/inference_pipeline_manager.py
+++ b/inference/core/interfaces/stream_manager/manager_app/inference_pipeline_manager.py
@@ -299,7 +299,7 @@ class InferencePipelineManager(Process):
                         )
                     from_inference_queue.sync_put(result_frame)
                     return
-                if not isinstance(
+                if parsed_payload.stream_output[0] not in prediction or not isinstance(
                     prediction[parsed_payload.stream_output[0]], WorkflowImageData
                 ):
                     for output in prediction.values():

--- a/inference/core/interfaces/stream_manager/manager_app/inference_pipeline_manager.py
+++ b/inference/core/interfaces/stream_manager/manager_app/inference_pipeline_manager.py
@@ -286,15 +286,6 @@ class InferencePipelineManager(Process):
                         "Please try to adjust the scene so models detect objects"
                     )
                     errors.append("or stop preview, update workflow and try again.")
-                elif parsed_payload.stream_output[0] not in prediction:
-                    if not parsed_payload.stream_output[0]:
-                        errors.append("No stream output selected to show")
-                    else:
-                        errors.append(
-                            f"{parsed_payload.stream_output[0]} not available in results"
-                        )
-                    errors.append("Please stop, update outputs and try again")
-                if errors:
                     result_frame = video_frame.image.copy()
                     for row, error in enumerate(errors):
                         result_frame = cv.putText(
@@ -308,6 +299,13 @@ class InferencePipelineManager(Process):
                         )
                     from_inference_queue.sync_put(result_frame)
                     return
+                if not isinstance(
+                    prediction[parsed_payload.stream_output[0]], WorkflowImageData
+                ):
+                    for output in prediction.values():
+                        if isinstance(output, WorkflowImageData):
+                            from_inference_queue.sync_put(output.numpy_image)
+                            return
                 from_inference_queue.sync_put(
                     prediction[parsed_payload.stream_output[0]].numpy_image
                 )


### PR DESCRIPTION
# Description

With current implementation of webrtc stream we are attempting to send back image specified within request `stream_output` parameter. If this output is not visual and we have other visual outputs then pipeline would not send anything back to the user. In this change type of output is checked and in case it's not WorkflowImageData, first WorkflowImageData output is sent instead.

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

CI passing
E2E tested

## Any specific deployment considerations

N/A

## Docs

N/A