### PR TITLE
When running bounding_rect update mask and xyxy of source sv.Detections so results can be visualized

### DIFF
--- a/inference/core/workflows/core_steps/transformations/bounding_rect/v1.py
+++ b/inference/core/workflows/core_steps/transformations/bounding_rect/v1.py
@@ -111,6 +111,18 @@ class BoundingRectBlockV1(WorkflowBlock):
                 det.mask[0]
             )
 
+            det.mask = np.array(
+                [
+                    sv.polygon_to_mask(
+                        polygon=np.around(rect).astype(np.int32),
+                        resolution_wh=det.mask[0].shape,
+                    ).astype(bool)
+                ]
+            )
+            det.xyxy = np.array(
+                [sv.polygon_to_xyxy(polygon=np.around(rect).astype(np.int32))]
+            )
+
             det[BOUNDING_RECT_RECT_KEY_IN_SV_DETECTIONS] = np.array(
                 [rect], dtype=np.float16
             )

--- a/inference/core/workflows/core_steps/transformations/bounding_rect/v1.py
+++ b/inference/core/workflows/core_steps/transformations/bounding_rect/v1.py
@@ -115,7 +115,7 @@ class BoundingRectBlockV1(WorkflowBlock):
                 [
                     sv.polygon_to_mask(
                         polygon=np.around(rect).astype(np.int32),
-                        resolution_wh=det.mask[0].shape,
+                        resolution_wh=(det.mask[0].shape[1], det.mask[0].shape[0]),
                     ).astype(bool)
                 ]
             )


### PR DESCRIPTION
# Description

Current implementation of bounding_rect stores results in custom keys in sv.Detections.data. Users chain this block with expectation that results will be seamlessly used by other blocks. This change allows users to visualize results of this block.

![Screenshot 2025-01-29 at 10 51 17](https://github.com/user-attachments/assets/8fa8c656-0e34-4e9b-b369-88d3fb9b88ab)

This change also enables results of this block to be used by size measurement block.

## Type of change

Please delete options that are not relevant.

-   [x] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?

CI passing
E2E tested

## Any specific deployment considerations

N/A

## Docs

N/A