### PR TITLE
Add 'longer' and 'shorter' keys to the output of size_measurement block

### DIFF
--- a/inference/core/workflows/core_steps/classical_cv/size_measurement/v1.py
+++ b/inference/core/workflows/core_steps/classical_cv/size_measurement/v1.py
@@ -271,7 +271,14 @@ class SizeMeasurementBlockV1(WorkflowBlock):
             if obj_w_pixels > 0 and obj_h_pixels > 0:
                 obj_w_actual = obj_w_pixels * width_scale
                 obj_h_actual = obj_h_pixels * height_scale
-                dimensions.append({"width": obj_w_actual, "height": obj_h_actual})
+                dimensions.append(
+                    {
+                        "width": obj_w_actual,
+                        "height": obj_h_actual,
+                        "longer": max(obj_w_actual, obj_h_actual),
+                        "shorter": min(obj_w_actual, obj_h_actual),
+                    }
+                )
             else:
                 dimensions.append(None)
 

--- a/tests/workflows/unit_tests/core_steps/classical_cv/test_size_measurement.py
+++ b/tests/workflows/unit_tests/core_steps/classical_cv/test_size_measurement.py
@@ -30,7 +30,10 @@ def test_size_measurement_block():
     result = block.run(reference_predictions, object_predictions, reference_dimensions)
 
     # then
-    expected_dimensions = [{"width": 5.0, "height": 5.0}, {"width": 5.0, "height": 5.0}]
+    expected_dimensions = [
+        {"width": 5.0, "height": 5.0, "longer": 5.0, "shorter": 5.0},
+        {"width": 5.0, "height": 5.0, "longer": 5.0, "shorter": 5.0},
+    ]
     assert result == {
         OUTPUT_KEY: expected_dimensions
     }, f"Expected {expected_dimensions}, but got {result}"
@@ -59,7 +62,10 @@ def test_size_measurement_block_with_mask():
     result = block.run(reference_predictions, object_predictions, reference_dimensions)
 
     # then
-    expected_dimensions = [{"width": 5.0, "height": 5.0}, {"width": 5.0, "height": 5.0}]
+    expected_dimensions = [
+        {"width": 5.0, "height": 5.0, "longer": 5.0, "shorter": 5.0},
+        {"width": 5.0, "height": 5.0, "longer": 5.0, "shorter": 5.0},
+    ]
     assert result == {
         OUTPUT_KEY: expected_dimensions
     }, f"Expected {expected_dimensions}, but got {result}"


### PR DESCRIPTION
# Description

size_measurement block stores dimensions as width/height based on angle of the bounding rect. Based on camera angle it's possible to have width/height swapped - if user expects width to be longer than height however due to angle shorter dimension can be returned as width. This change adds extra parameters storing longer and shorter dimensions.

## Type of change

-   [x] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?

CI passing

## Any specific deployment considerations

N/A

## Docs

N/A