### PR TITLE
Add possibility to inject sink function to batch video processing

### DIFF
--- a/inference/core/version.py
+++ b/inference/core/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.36.2"
+__version__ = "0.37.0rc1"
 
 
 if __name__ == "__main__":

--- a/inference_cli/lib/workflows/video_adapter.py
+++ b/inference_cli/lib/workflows/video_adapter.py
@@ -1,7 +1,6 @@
 import os.path
 from collections import defaultdict
 from functools import partial
-from glob import glob
 from typing import Any, Dict, List, Optional, Union
 
 import cv2
@@ -12,6 +11,7 @@ from rich.progress import Progress, TaskID
 
 from inference import InferencePipeline
 from inference.core.interfaces.camera.entities import VideoFrame
+from inference.core.interfaces.stream.entities import SinkHandler
 from inference.core.interfaces.stream.sinks import multi_sink
 from inference.core.utils.image_utils import load_image_bgr
 from inference_cli.lib.utils import dump_jsonl
@@ -31,6 +31,7 @@ def process_video_with_workflow(
     max_fps: Optional[float] = None,
     save_image_outputs_as_video: bool = True,
     api_key: Optional[str] = None,
+    on_prediction: Optional[SinkHandler] = None,
 ) -> VideoProcessingDetails:
     structured_sink = WorkflowsStructuredDataSink(
         output_directory=output_directory,
@@ -39,6 +40,8 @@ def process_video_with_workflow(
     )
     progress_sink = ProgressSink.init(input_video_path=input_video_path)
     sinks = [structured_sink.on_prediction, progress_sink.on_prediction]
+    if on_prediction:
+        sinks.append(on_prediction)
     video_sink: Optional[WorkflowsVideoSink] = None
     if save_image_outputs_as_video:
         video_sink = WorkflowsVideoSink.init(


### PR DESCRIPTION
# Description

We need ability to track video processing progress also by the caller (not only using progress sink inside a function to display on the screen).

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

* e2e
* ci still 🟢 

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
