### PR TITLE
Prepare version of Workflows EE where thread pool executor is injectable instead of created at each run

### DIFF
--- a/inference/core/version.py
+++ b/inference/core/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.37.0"
+__version__ = "0.38.0rc1"
 
 
 if __name__ == "__main__":

--- a/inference/core/workflows/execution_engine/core.py
+++ b/inference/core/workflows/execution_engine/core.py
@@ -1,3 +1,4 @@
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Dict, List, Optional, Type
 
 from packaging.specifiers import SpecifierSet
@@ -37,6 +38,7 @@ class ExecutionEngine(BaseExecutionEngine):
         prevent_local_images_loading: bool = False,
         workflow_id: Optional[str] = None,
         profiler: Optional[WorkflowsProfiler] = None,
+        executor: Optional[ThreadPoolExecutor] = None,
     ) -> "ExecutionEngine":
         requested_engine_version = retrieve_requested_execution_engine_version(
             workflow_definition=workflow_definition,
@@ -51,6 +53,7 @@ class ExecutionEngine(BaseExecutionEngine):
             prevent_local_images_loading=prevent_local_images_loading,
             workflow_id=workflow_id,
             profiler=profiler,
+            executor=executor,
         )
         return cls(engine=engine)
 

--- a/inference/core/workflows/execution_engine/entities/engine.py
+++ b/inference/core/workflows/execution_engine/entities/engine.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Dict, List, Optional
 
 from inference.core.workflows.execution_engine.profiling.core import WorkflowsProfiler
@@ -16,6 +17,7 @@ class BaseExecutionEngine(ABC):
         prevent_local_images_loading: bool = False,
         workflow_id: Optional[str] = None,
         profiler: Optional[WorkflowsProfiler] = None,
+        executor: Optional[ThreadPoolExecutor] = None,
     ) -> "BaseExecutionEngine":
         pass
 

--- a/inference/core/workflows/execution_engine/v1/core.py
+++ b/inference/core/workflows/execution_engine/v1/core.py
@@ -1,3 +1,4 @@
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Dict, List, Optional
 
 from packaging.version import Version
@@ -36,6 +37,7 @@ class ExecutionEngineV1(BaseExecutionEngine):
         prevent_local_images_loading: bool = False,
         workflow_id: Optional[str] = None,
         profiler: Optional[WorkflowsProfiler] = None,
+        executor: Optional[ThreadPoolExecutor] = None,
     ) -> "ExecutionEngineV1":
         if init_parameters is None:
             init_parameters = {}
@@ -54,6 +56,7 @@ class ExecutionEngineV1(BaseExecutionEngine):
             profiler=profiler,
             workflow_id=workflow_id,
             internal_id=workflow_definition.get("id"),
+            executor=executor,
         )
 
     def __init__(
@@ -64,6 +67,7 @@ class ExecutionEngineV1(BaseExecutionEngine):
         profiler: WorkflowsProfiler,
         workflow_id: Optional[str] = None,
         internal_id: Optional[str] = None,
+        executor: Optional[ThreadPoolExecutor] = None,
     ):
         self._compiled_workflow = compiled_workflow
         self._max_concurrent_steps = max_concurrent_steps
@@ -71,6 +75,7 @@ class ExecutionEngineV1(BaseExecutionEngine):
         self._workflow_id = workflow_id
         self._profiler = profiler
         self._internal_id = internal_id
+        self._executor = executor
 
     def run(
         self,
@@ -109,6 +114,7 @@ class ExecutionEngineV1(BaseExecutionEngine):
             kinds_serializers=self._compiled_workflow.kinds_serializers,
             serialize_results=serialize_results,
             profiler=self._profiler,
+            executor=self._executor,
         )
         self._profiler.end_workflow_run()
         return result

--- a/inference/core/workflows/execution_engine/v1/executor/utils.py
+++ b/inference/core/workflows/execution_engine/v1/executor/utils.py
@@ -1,15 +1,36 @@
-import concurrent
 from concurrent.futures import ThreadPoolExecutor
-from typing import Callable, List, TypeVar
+from typing import Callable, Generator, Iterable, List, Optional, TypeVar
 
 T = TypeVar("T")
 
 
 def run_steps_in_parallel(
-    steps: List[Callable[[], T]], max_workers: int = 1
+    steps: List[Callable[[], T]],
+    max_workers: int = 1,
+    executor: Optional[ThreadPoolExecutor] = None,
 ) -> List[T]:
-    with ThreadPoolExecutor(max_workers=max_workers) as executor:
-        return list(executor.map(_run, steps))
+    if executor is None:
+        with ThreadPoolExecutor(max_workers=max_workers) as inner_executor:
+            return list(inner_executor.map(_run, steps))
+    results = []
+    for batch in create_batches(sequence=steps, batch_size=max_workers):
+        batch_results = list(executor.map(_run, batch))
+        results.extend(batch_results)
+    return results
+
+
+def create_batches(
+    sequence: Iterable[T], batch_size: int
+) -> Generator[List[T], None, None]:
+    batch_size = max(batch_size, 1)
+    current_batch = []
+    for element in sequence:
+        if len(current_batch) == batch_size:
+            yield current_batch
+            current_batch = []
+        current_batch.append(element)
+    if len(current_batch) > 0:
+        yield current_batch
 
 
 def _run(fun: Callable[[], T]) -> T:

--- a/inference_cli/lib/workflows/local_image_adapter.py
+++ b/inference_cli/lib/workflows/local_image_adapter.py
@@ -48,41 +48,47 @@ def process_image_with_workflow_using_inference_package(
     api_key: Optional[str] = None,
     save_image_outputs: bool = True,
     force_reprocessing: bool = False,
+    max_concurrent_workflows_steps: int = 4,
 ) -> None:
     if api_key is None:
         api_key = API_KEY
     log_file, log_content = open_progress_log(output_directory=output_directory)
-    try:
-        image_name = os.path.basename(image_path)
-        if image_name in log_content and not force_reprocessing:
-            return None
-        model_manager = _prepare_model_manager()
-        workflow_specification = _get_workflow_specification(
-            workflow_specification=workflow_specification,
-            workspace_name=workspace_name,
-            workflow_id=workflow_id,
-            api_key=api_key,
-        )
-        result = _run_workflow_for_single_image_with_inference(
-            model_manager=model_manager,
-            image_path=image_path,
-            workflow_specification=workflow_specification,
-            workflow_id=workflow_id,
-            image_input_name=image_input_name,
-            workflow_parameters=workflow_parameters,
-            api_key=api_key,
-        )
-        _ = dump_image_processing_results(
-            result=result,
-            image_path=image_path,
-            output_directory=output_directory,
-            save_image_outputs=save_image_outputs,
-        )
-        denote_image_processed(log_file=log_file, image_path=image_path)
-    except Exception as e:
-        raise RuntimeError(f"Could not process image: {image_path}") from e
-    finally:
-        log_file.close()
+    with ThreadPoolExecutor(
+        max_workers=max_concurrent_workflows_steps
+    ) as thread_pool_executor:
+        try:
+            image_name = os.path.basename(image_path)
+            if image_name in log_content and not force_reprocessing:
+                return None
+            model_manager = _prepare_model_manager()
+            workflow_specification = _get_workflow_specification(
+                workflow_specification=workflow_specification,
+                workspace_name=workspace_name,
+                workflow_id=workflow_id,
+                api_key=api_key,
+            )
+            result = _run_workflow_for_single_image_with_inference(
+                model_manager=model_manager,
+                image_path=image_path,
+                workflow_specification=workflow_specification,
+                workflow_id=workflow_id,
+                image_input_name=image_input_name,
+                workflow_parameters=workflow_parameters,
+                api_key=api_key,
+                thread_pool_executor=thread_pool_executor,
+                max_concurrent_workflows_steps=max_concurrent_workflows_steps,
+            )
+            _ = dump_image_processing_results(
+                result=result,
+                image_path=image_path,
+                output_directory=output_directory,
+                save_image_outputs=save_image_outputs,
+            )
+            denote_image_processed(log_file=log_file, image_path=image_path)
+        except Exception as e:
+            raise RuntimeError(f"Could not process image: {image_path}") from e
+        finally:
+            log_file.close()
 
 
 def process_image_directory_with_workflow_using_inference_package(
@@ -100,6 +106,7 @@ def process_image_directory_with_workflow_using_inference_package(
     aggregation_format: OutputFileType = OutputFileType.JSONL,
     debug_mode: bool = False,
     max_failures: Optional[int] = None,
+    max_concurrent_workflows_steps: int = 4,
 ) -> ImagesDirectoryProcessingDetails:
     if api_key is None:
         api_key = API_KEY
@@ -125,6 +132,7 @@ def process_image_directory_with_workflow_using_inference_package(
             api_key=api_key,
             save_image_outputs=save_image_outputs,
             log_file=log_file,
+            max_concurrent_workflows_steps=max_concurrent_workflows_steps,
             debug_mode=debug_mode,
             max_failures=max_failures,
         )
@@ -164,6 +172,7 @@ def _process_images_within_directory(
     api_key: Optional[str],
     save_image_outputs: bool,
     log_file: TextIO,
+    max_concurrent_workflows_steps: int,
     debug_mode: bool = False,
     max_failures: Optional[int] = None,
 ) -> List[Tuple[str, str]]:
@@ -194,44 +203,49 @@ def _process_images_within_directory(
         progress_bar=progress_bar,
         task_id=processing_task,
     )
-    processing_fun = partial(
-        _process_single_image_from_directory,
-        model_manager=model_manager,
-        workflow_specification=workflow_specification,
-        workflow_id=workflow_id,
-        image_input_name=image_input_name,
-        workflow_parameters=workflow_parameters,
-        api_key=api_key,
-        output_directory=output_directory,
-        save_image_outputs=save_image_outputs,
-        log_file=log_file,
-        on_success=on_success,
-        on_failure=on_failure,
-        debug_mode=debug_mode,
-    )
-    failures = 0
-    succeeded_files = set()
-    with progress_bar:
-        for image_path in files_to_process:
-            success = processing_fun(image_path)
-            if not success:
-                failures += 1
-            else:
-                succeeded_files.add(image_path)
-            if failures >= max_failures:
-                break
-    failed_files_lookup = {f[0] for f in failed_files}
-    aborted_files = [
-        f
-        for f in files_to_process
-        if f not in succeeded_files and f not in failed_files_lookup
-    ]
-    for file in aborted_files:
-        on_failure(
-            file,
-            "Aborted processing due to exceeding max failures of Workflows executions.",
+    with ThreadPoolExecutor(
+        max_workers=max_concurrent_workflows_steps
+    ) as thread_pool_executor:
+        processing_fun = partial(
+            _process_single_image_from_directory,
+            model_manager=model_manager,
+            workflow_specification=workflow_specification,
+            workflow_id=workflow_id,
+            image_input_name=image_input_name,
+            workflow_parameters=workflow_parameters,
+            api_key=api_key,
+            output_directory=output_directory,
+            save_image_outputs=save_image_outputs,
+            log_file=log_file,
+            on_success=on_success,
+            on_failure=on_failure,
+            thread_pool_executor=thread_pool_executor,
+            max_concurrent_workflows_steps=max_concurrent_workflows_steps,
+            debug_mode=debug_mode,
         )
-    return failed_files
+        failures = 0
+        succeeded_files = set()
+        with progress_bar:
+            for image_path in files_to_process:
+                success = processing_fun(image_path)
+                if not success:
+                    failures += 1
+                else:
+                    succeeded_files.add(image_path)
+                if failures >= max_failures:
+                    break
+        failed_files_lookup = {f[0] for f in failed_files}
+        aborted_files = [
+            f
+            for f in files_to_process
+            if f not in succeeded_files and f not in failed_files_lookup
+        ]
+        for file in aborted_files:
+            on_failure(
+                file,
+                "Aborted processing due to exceeding max failures of Workflows executions.",
+            )
+        return failed_files
 
 
 def _on_success(
@@ -269,6 +283,8 @@ def _process_single_image_from_directory(
     log_file: TextIO,
     on_success: Callable[[ImagePath, ImageResultsIndexEntry], None],
     on_failure: Callable[[ImagePath, str], None],
+    thread_pool_executor: ThreadPoolExecutor,
+    max_concurrent_workflows_steps: int,
     log_file_lock: Optional[Lock] = None,
     debug_mode: bool = False,
 ) -> bool:
@@ -281,6 +297,8 @@ def _process_single_image_from_directory(
             image_input_name=image_input_name,
             workflow_parameters=workflow_parameters,
             api_key=api_key,
+            thread_pool_executor=thread_pool_executor,
+            max_concurrent_workflows_steps=max_concurrent_workflows_steps,
         )
         index_entry = dump_image_processing_results(
             result=result,
@@ -344,24 +362,25 @@ def _run_workflow_for_single_image_with_inference(
     image_input_name: str,
     workflow_parameters: Optional[Dict[str, Any]],
     api_key: Optional[str],
+    thread_pool_executor: ThreadPoolExecutor,
+    max_concurrent_workflows_steps: int,
 ) -> Dict[str, Any]:
-    profiler = NullWorkflowsProfiler.init()
-    with ThreadPoolExecutor() as thread_pool_executor:
-        workflow_init_parameters = {
-            "workflows_core.model_manager": model_manager,
-            "workflows_core.api_key": api_key,
-            "workflows_core.thread_pool_executor": thread_pool_executor,
-        }
-        execution_engine = ExecutionEngine.init(
-            workflow_definition=workflow_specification,
-            init_parameters=workflow_init_parameters,
-            workflow_id=workflow_id,
-            profiler=profiler,
-        )
-        runtime_parameters = workflow_parameters or {}
-        runtime_parameters[image_input_name] = cv2.imread(image_path)
-        results = execution_engine.run(
-            runtime_parameters=runtime_parameters,
-            serialize_results=True,
-        )
-        return results[0]
+    workflow_init_parameters = {
+        "workflows_core.model_manager": model_manager,
+        "workflows_core.api_key": api_key,
+        "workflows_core.thread_pool_executor": thread_pool_executor,
+    }
+    execution_engine = ExecutionEngine.init(
+        workflow_definition=workflow_specification,
+        init_parameters=workflow_init_parameters,
+        max_concurrent_steps=max_concurrent_workflows_steps,
+        workflow_id=workflow_id,
+        executor=thread_pool_executor,
+    )
+    runtime_parameters = workflow_parameters or {}
+    runtime_parameters[image_input_name] = cv2.imread(image_path)
+    results = execution_engine.run(
+        runtime_parameters=runtime_parameters,
+        serialize_results=True,
+    )
+    return results[0]


### PR DESCRIPTION
# Description

We had a non-optimal way of dealing with thread pool executors - which may have been the root cause of memory leak. Fixing by letting the caller to inject.

List any dependencies that are required for this change.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

YOUR_ANSWER

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
