### PR TITLE
Add opencv-contrib-python to requirements to resolve problems with rtsp streaming

### DIFF
--- a/requirements/_requirements.txt
+++ b/requirements/_requirements.txt
@@ -6,6 +6,7 @@ python-dotenv~=1.0.0
 fastapi>=0.100,<0.111  # be careful with upper pin - fastapi might remove support for on_event
 numpy<=1.26.4
 opencv-python>=4.8.1.78,<=4.10.0.84
+opencv-contrib-python>=4.8.1.78,<=4.10.0.84  # Note: opencv-python considers this as a bad practice, but since our dependencies rely on both we pin both here
 pillow<11.0
 prometheus-fastapi-instrumentator<=6.0.0
 redis~=5.0.0


### PR DESCRIPTION
# Description

One of our dependencies is `mediapipe` which is installed through  `requirements.gaze.txt`
One of `mediapipe` requirements is `opencv-contrib-python`
`inference` relies on `opencv-python` and have it installed with pinned version
`opencv-contrib-python` installed as `mediapipe` dependency is unconstrained.
`opencv-contrib-python` released in January 2025 (version `4.11.0.86`) results in following code to time out when running on `linux/amd64` :

```
import cv2

cap = cv2.VideoCapture("rtsp://<ip>:<port>/mystream4")
err, frame = cap.read()
```

According to `opencv-python` documentation it's bad practice to install more than one flavor of `opencv` package. We understand this however we have no control over what our dependencies install hence the decision to include both `opencv-python` and `opencv-contrib-python` in requirements.

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

CI passing
streaming tested manually on `linux/amd64` architecture

## Any specific deployment considerations

We advice our users to follow advice of `opencv-python` maintainers - that is, uninstall all flavors of `opencv-python` and install one that is required by the project.

## Docs

N/A