### PR TITLE
add openapi.json to whitelist of dedicated deployment authorizer

### DIFF
--- a/inference/core/interfaces/http/http_api.py
+++ b/inference/core/interfaces/http/http_api.py
@@ -651,7 +651,7 @@ class HttpInterface(BaseInterface):
                         "/docs",
                         "/redoc",
                         "/info",
-                        "/openapi.json", # needed for /docs and /redoc
+                        "/openapi.json",  # needed for /docs and /redoc
                         "/workflows/blocks/describe",
                         "/workflows/definition/schema",
                     ]

--- a/inference/core/interfaces/http/http_api.py
+++ b/inference/core/interfaces/http/http_api.py
@@ -651,6 +651,7 @@ class HttpInterface(BaseInterface):
                         "/docs",
                         "/redoc",
                         "/info",
+                        "/openapi.json", # needed for /docs and /redoc
                         "/workflows/blocks/describe",
                         "/workflows/definition/schema",
                     ]


### PR DESCRIPTION
…aded without api_key

# Description

add openapi.json to dedicated deployment authorizer whitelist so /docs and redoc can be loaded without api_key

List any dependencies that are required for this change.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Tested in staging

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
