### PR TITLE
Fix workflows batch processing for Windows paths

### DIFF
--- a/inference/core/version.py
+++ b/inference/core/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.40.0rc1"
+__version__ = "0.40.0rc2"
 
 
 if __name__ == "__main__":

--- a/inference_cli/lib/workflows/common.py
+++ b/inference_cli/lib/workflows/common.py
@@ -205,7 +205,9 @@ def aggregate_batch_processing_results(
     decoded_content = []
     for result_path in track(all_results, description="Grabbing processing results..."):
         content = read_json(path=result_path)
-        processed_file = result_path.split("/")[-2]
+        processed_file = extract_processed_image_name_from_predictions_path(
+            predictions_path=result_path
+        )
         content["image"] = processed_file
         decoded_content.append(content)
     if aggregation_format is OutputFileType.JSONL:
@@ -230,6 +232,11 @@ def aggregate_batch_processing_results(
     aggregated_results_path = os.path.join(output_directory, "aggregated_results.csv")
     data_frame.to_csv(aggregated_results_path, index=False)
     return aggregated_results_path
+
+
+def extract_processed_image_name_from_predictions_path(predictions_path: str) -> str:
+    # we expect path to be <out_dir>/<image_name>/results.json - hence we extract basename of parent dir
+    return os.path.basename(os.path.dirname(predictions_path))
 
 
 def dump_objects_to_json(value: Any) -> Any:


### PR DESCRIPTION
# Description

We had a bug that was causing issues on Windows with `inference-cli` batch processing command.

Paths on windows have the following separator `\` or `\\` - so using `/` to extract path chunks was a mistake. Instead now we use `os.path` to achieve the same effect for all platforms.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

* E2E
* tests still 🟢 

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
