### PR TITLE
Add batch usage sink for hosted serverless inference

### DIFF
--- a/inference/core/env.py
+++ b/inference/core/env.py
@@ -485,6 +485,9 @@ DEDICATED_DEPLOYMENT_ID = os.getenv("DEDICATED_DEPLOYMENT_ID")
 ROBOFLOW_INTERNAL_SERVICE_SECRET = os.getenv("ROBOFLOW_INTERNAL_SERVICE_SECRET")
 ROBOFLOW_INTERNAL_SERVICE_NAME = os.getenv("ROBOFLOW_INTERNAL_SERVICE_NAME")
 
+# pub/sub topic name, set when running in serverless hosted by Roboflow
+ROBOFLOW_USAGE_PUBSUB_TOPIC_NAME = os.getenv("ROBOFLOW_USAGE_PUBSUB_TOPIC_NAME")
+
 # Preload Models
 PRELOAD_MODELS = (
     os.getenv("PRELOAD_MODELS").split(",") if os.getenv("PRELOAD_MODELS") else None

--- a/inference/core/version.py
+++ b/inference/core/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.40.0rc2"
+__version__ = "0.40.0rc3"
 
 
 if __name__ == "__main__":

--- a/inference/usage_tracking/__init__.py
+++ b/inference/usage_tracking/__init__.py
@@ -1,5 +1,4 @@
 """
 Inference utilizes Roboflow's cloud services and requires telemetry during deployment.
-Customers with an offline deployment can turn the telemetry off by setting TELEMETRY_OPT_OUT environment variable to True.
 For more information please consult our licensing page [roboflow.com/licensing] or contact sales [roboflow.com/sales].
 """

--- a/inference/usage_tracking/config.py
+++ b/inference/usage_tracking/config.py
@@ -17,6 +17,11 @@ class TelemetrySettings(BaseSettings):
         f"{METRICS_COLLECTOR_BASE_URL}/usage/inference"
     )
     api_plan_endpoint_url: str = wrap_url(f"{METRICS_COLLECTOR_BASE_URL}/usage/plan")
+    resolve_workspace_id_url: str = wrap_url(
+        f"{METRICS_COLLECTOR_BASE_URL}/key/publishable_key"
+    )
+    workspace_id_response_key: str = "publishable_key"
+    workspace_id_skip_prefix: int = 3
     flush_interval: int = Field(default=10, ge=10, le=300)
     opt_out: Optional[bool] = False
     queue_size: int = Field(default=10, ge=10, le=10000)

--- a/inference/usage_tracking/gcp_pub_sub_queue.py
+++ b/inference/usage_tracking/gcp_pub_sub_queue.py
@@ -1,0 +1,62 @@
+import json
+import time
+from threading import Lock
+from typing import Any, Dict, List
+
+from inference.core.logger import logger
+
+
+class GCPPubSubQueue:
+    """
+    Push to GCP pub/sub topic
+    """
+
+    def __init__(
+        self,
+        topic: str,
+        dry_run: bool = False,
+    ):
+        self._lock: Lock = Lock()
+        self._google_cloud_pub_sub_client = ""
+        self._dry_run: bool = dry_run
+
+    def put(self, payload: Any):
+        if not isinstance(payload, str):
+            try:
+                payload = json.dumps(payload)
+            except Exception as exc:
+                logger.error("Failed to parse payload '%s' to JSON - %s", payload, exc)
+                return
+        with self._lock:
+            try:
+                self._increment += 1
+                redis_key = f"{self._prefix}:{self._increment}"
+                # https://redis.io/docs/latest/develop/interact/transactions/
+                redis_pipeline = self._redis_cache.client.pipeline()
+                redis_pipeline.set(
+                    name=redis_key,
+                    value=payload,
+                )
+                redis_pipeline.zadd(
+                    name="UsageCollector",
+                    mapping={redis_key: time.time()},
+                )
+                results = redis_pipeline.execute()
+                if not all(results):
+                    # TODO: partial insert, retry
+                    logger.error(
+                        "Failed to store payload and sorted set (partial insert): %s",
+                        results,
+                    )
+            except Exception as exc:
+                logger.error("Failed to store usage records '%s', %s", payload, exc)
+
+    @staticmethod
+    def full() -> bool:
+        return False
+
+    def empty(self) -> bool:
+        return True
+
+    def get_nowait(self) -> List[Dict[str, Any]]:
+        return []

--- a/inference/usage_tracking/gcp_pub_sub_queue.py
+++ b/inference/usage_tracking/gcp_pub_sub_queue.py
@@ -1,9 +1,19 @@
+import atexit
+from functools import lru_cache
 import json
-import time
-from threading import Lock
-from typing import Any, Dict, List
+from queue import Queue
+from threading import Event, Lock, Thread
+from typing import Any, Dict, List, Optional
+
+try:
+    from google.cloud import pubsub_v1
+except ModuleNotFoundError:
+    pass
+import requests
 
 from inference.core.logger import logger
+from inference.core.roboflow_api import build_roboflow_api_headers
+from inference.usage_tracking.payload_helpers import APIKey, APIKeyUsage, UsagePayload
 
 
 class GCPPubSubQueue:
@@ -14,42 +24,108 @@ class GCPPubSubQueue:
     def __init__(
         self,
         topic: str,
-        dry_run: bool = False,
+        resolve_workspace_id_url: str,
+        workspace_id_response_key: str,
+        workspace_id_skip_prefix: int,
     ):
+        self._resolve_workspace_id_url: str = resolve_workspace_id_url
+        self._workspace_id_response_key: str = workspace_id_response_key
+        self._workspace_id_skip_prefix: int = workspace_id_skip_prefix
         self._lock: Lock = Lock()
-        self._google_cloud_pub_sub_client = ""
-        self._dry_run: bool = dry_run
+        self._pub_sub_client = pubsub_v1.PublisherClient()
+        self._topic = topic
 
-    def put(self, payload: Any):
-        if not isinstance(payload, str):
-            try:
-                payload = json.dumps(payload)
-            except Exception as exc:
-                logger.error("Failed to parse payload '%s' to JSON - %s", payload, exc)
-                return
-        with self._lock:
-            try:
-                self._increment += 1
-                redis_key = f"{self._prefix}:{self._increment}"
-                # https://redis.io/docs/latest/develop/interact/transactions/
-                redis_pipeline = self._redis_cache.client.pipeline()
-                redis_pipeline.set(
-                    name=redis_key,
-                    value=payload,
-                )
-                redis_pipeline.zadd(
-                    name="UsageCollector",
-                    mapping={redis_key: time.time()},
-                )
-                results = redis_pipeline.execute()
-                if not all(results):
-                    # TODO: partial insert, retry
+        self._queue: "Queue[UsagePayload]" = Queue()
+
+        self._terminate_publisher_thread = Event()
+        self._publisher_thread: Thread = Thread(target=self._publisher, daemon=True)
+        self._publisher_thread.start()
+
+        atexit.register(self._cleanup)
+
+    def put(self, payload: UsagePayload):
+        self._queue.put(payload)
+
+    def _publisher(self):
+        while not self._terminate_publisher_thread.is_set():
+            payload = self._queue.get()
+            if payload is None:
+                break
+            failed_payloads: Dict[APIKey, APIKeyUsage] = {}
+            for api_key, api_key_usage in payload.items():
+                if not isinstance(api_key_usage, dict) or not api_key_usage:
+                    logger.error("Empty usage report for API key %s, dropping", api_key)
+                    continue
+                try:
+                    workspace_id = self._resolve_workspace_id(api_key=api_key)
+                except Exception as exc:
+                    logger.error(exc)
+                    failed_payloads[api_key] = api_key_usage
+                    continue
+                if not workspace_id:
                     logger.error(
-                        "Failed to store payload and sorted set (partial insert): %s",
-                        results,
+                        "Could not resolve workspace id from API key: %s - dropping usage payload",
+                        api_key,
                     )
-            except Exception as exc:
-                logger.error("Failed to store usage records '%s', %s", payload, exc)
+                    continue
+                for resource_usage in api_key_usage.values():
+                    try:
+                        if "api_key_hash" in resource_usage:
+                            del resource_usage["api_key_hash"]
+                        resource_usage["api_key"] = api_key[:3] + "***"
+                        resource_usage["reporter_api_key"] = api_key[:3] + "***"
+                        resource_usage["workspace_id"] = workspace_id
+                        resource_usage["hosted"] = True
+                        resource_usage = json.dumps(resource_usage).encode()
+                        try:
+                            future = self._pub_sub_client.publish(
+                                topic=self._topic, data=resource_usage
+                            )
+                            future.result()
+                        except Exception as exc:
+                            logger.error(
+                                "Failed to store usage records '%s', %s",
+                                resource_usage,
+                                exc,
+                            )
+
+                    except Exception as exc:
+                        logger.error(
+                            "Failed to parse payload '%s' to JSON - %s",
+                            resource_usage,
+                            exc,
+                        )
+                        return
+            if failed_payloads:
+                self.put(failed_payloads)
+
+    @lru_cache(maxsize=100000)
+    def _resolve_workspace_id(self, api_key: APIKey) -> Optional[str]:
+        headers = build_roboflow_api_headers(
+            explicit_headers={"Authorization": f"Bearer {api_key}"}
+        )
+        ssl_verify = True
+        if "localhost" in self._resolve_workspace_id_url.lower():
+            ssl_verify = False
+        if "127.0.0.1" in self._resolve_workspace_id_url.lower():
+            ssl_verify = False
+
+        response = requests.get(
+            self._resolve_workspace_id_url,
+            verify=ssl_verify,
+            headers=headers,
+            timeout=1,
+        )
+
+        if 400 <= response.status_code < 500:
+            return None
+        if response.status_code != 200:
+            raise Exception(
+                f"Failed to resolve workspace id for api key {api_key} due to API error (code {response.status_code})"
+            )
+        return str(response.json()[self._workspace_id_response_key])[
+            self._workspace_id_skip_prefix :
+        ]
 
     @staticmethod
     def full() -> bool:
@@ -60,3 +136,8 @@ class GCPPubSubQueue:
 
     def get_nowait(self) -> List[Dict[str, Any]]:
         return []
+
+    def _cleanup(self):
+        self._terminate_publisher_thread.set()
+        self.put(None)
+        self._publisher_thread.join()

--- a/requirements/requirements.hosted.txt
+++ b/requirements/requirements.hosted.txt
@@ -1,2 +1,3 @@
 pymemcache~=4.0.0
 elasticache_auto_discovery~=1.0.0
+google-cloud-pubsub<3.0.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,3 @@
 import os
 
-os.environ["TELEMETRY_OPT_OUT"] = "True"
 os.environ["ONNXRUNTIME_EXECUTION_PROVIDERS"] = "[CUDAExecutionProvider,CPUExecutionProvider]"


### PR DESCRIPTION
# Description

Add pub/sub queue usage sink for hosted serverless inference

## Type of change

-   [x] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?

CI passing
E2E tested on staging

## Any specific deployment considerations

pub/sub is enabled when ROBOFLOW_USAGE_PUBSUB_TOPIC_NAME is set

## Docs

N/A