### PR TITLE
add env for roboflow serverless service

### DIFF
--- a/inference/core/env.py
+++ b/inference/core/env.py
@@ -515,3 +515,5 @@ IGNORE_MODEL_DEPENDENCIES_WARNINGS = str2bool(
 )
 if IGNORE_MODEL_DEPENDENCIES_WARNINGS:
     warnings.simplefilter("ignore", ModelDependencyMissing)
+
+IS_ROBOFLOW_SERVERLESS = str2bool(os.getenv("IS_ROBOFLOW_SERVERLESS", "False"))

--- a/inference/core/interfaces/http/http_api.py
+++ b/inference/core/interfaces/http/http_api.py
@@ -131,6 +131,7 @@ from inference.core.env import (
     WORKFLOWS_MAX_CONCURRENT_STEPS,
     WORKFLOWS_PROFILER_BUFFER_SIZE,
     WORKFLOWS_STEP_EXECUTION_MODE,
+    IS_ROBOFLOW_SERVERLESS,
 )
 from inference.core.exceptions import (
     ContentTypeInvalid,
@@ -911,7 +912,7 @@ class HttpInterface(BaseInterface):
             )
 
         # The current AWS Lambda authorizer only supports path parameters, therefore we can only use the legacy infer route. This case statement excludes routes which won't work for the current Lambda authorizer.
-        if not LAMBDA:
+        if not LAMBDA and not IS_ROBOFLOW_SERVERLESS:
 
             @app.get(
                 "/model/registry",
@@ -1004,6 +1005,8 @@ class HttpInterface(BaseInterface):
                     models_descriptions=models_descriptions
                 )
 
+        # these NEW endpoints need authentication protection
+        if not LAMBDA and not IS_ROBOFLOW_SERVERLESS:
             @app.post(
                 "/infer/object_detection",
                 response_model=Union[
@@ -2104,7 +2107,7 @@ class HttpInterface(BaseInterface):
                         trackUsage(trocr_model_id, actor)
                     return response
 
-        if not LAMBDA:
+        if not LAMBDA and not IS_ROBOFLOW_SERVERLESS:
 
             @app.get(
                 "/notebook/start",

--- a/inference_sdk/http/entities.py
+++ b/inference_sdk/http/entities.py
@@ -25,6 +25,8 @@ ALL_ROBOFLOW_API_URLS = {
     "https://outline.roboflow.com",
     "https://classify.roboflow.com",
     "https://infer.roboflow.com",
+    "https://serverless.roboflow.com",
+    "https://serverless.roboflow.one",
 }
 
 


### PR DESCRIPTION
# Description

1. add env for roboflow serverless service: IS_ROBOFLOW_SERVERLESS
2. switch http_client's mode to v0 for serverless domains, since we'll not support endpoints `/model/*` which are required by mode v1

List any dependencies that are required for this change.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Tested in staging

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
