### PR TITLE
Prevent pipeline creation if there is insufficient memory available

### DIFF
--- a/inference/core/env.py
+++ b/inference/core/env.py
@@ -518,10 +518,10 @@ if IGNORE_MODEL_DEPENDENCIES_WARNINGS:
 
 # Stream manager configuration
 try:
-    STREAM_MANAGER_MAX_RAM_MB = abs(float(os.getenv("STREAM_MANAGER_MAX_RAM_MB")))
-    STREAM_MANAGER_RAM_USAGE_QUEUE_SIZE = abs(
+    STREAM_MANAGER_MAX_RAM_MB: Optional[float] = abs(float(os.getenv("STREAM_MANAGER_MAX_RAM_MB")))
+    STREAM_MANAGER_RAM_USAGE_QUEUE_SIZE: int = abs(
         int(os.getenv("STREAM_MANAGER_RAM_USAGE_QUEUE_SIZE"))
     )
 except:
-    STREAM_MANAGER_MAX_RAM_MB = None
+    STREAM_MANAGER_MAX_RAM_MB: Optional[float] = None
     STREAM_MANAGER_RAM_USAGE_QUEUE_SIZE = 10

--- a/inference/core/env.py
+++ b/inference/core/env.py
@@ -521,9 +521,12 @@ try:
     STREAM_MANAGER_MAX_RAM_MB: Optional[float] = abs(
         float(os.getenv("STREAM_MANAGER_MAX_RAM_MB"))
     )
+except:
+    STREAM_MANAGER_MAX_RAM_MB: Optional[float] = None
+
+try:
     STREAM_MANAGER_RAM_USAGE_QUEUE_SIZE: int = abs(
         int(os.getenv("STREAM_MANAGER_RAM_USAGE_QUEUE_SIZE"))
     )
 except:
-    STREAM_MANAGER_MAX_RAM_MB: Optional[float] = None
     STREAM_MANAGER_RAM_USAGE_QUEUE_SIZE = 10

--- a/inference/core/env.py
+++ b/inference/core/env.py
@@ -518,7 +518,9 @@ if IGNORE_MODEL_DEPENDENCIES_WARNINGS:
 
 # Stream manager configuration
 try:
-    STREAM_MANAGER_MAX_RAM_MB: Optional[float] = abs(float(os.getenv("STREAM_MANAGER_MAX_RAM_MB")))
+    STREAM_MANAGER_MAX_RAM_MB: Optional[float] = abs(
+        float(os.getenv("STREAM_MANAGER_MAX_RAM_MB"))
+    )
     STREAM_MANAGER_RAM_USAGE_QUEUE_SIZE: int = abs(
         int(os.getenv("STREAM_MANAGER_RAM_USAGE_QUEUE_SIZE"))
     )

--- a/inference/core/env.py
+++ b/inference/core/env.py
@@ -517,7 +517,11 @@ if IGNORE_MODEL_DEPENDENCIES_WARNINGS:
     warnings.simplefilter("ignore", ModelDependencyMissing)
 
 # Stream manager configuration
-STREAM_MANAGER_MAX_RAM_MB = abs(float(os.getenv("STREAM_MANAGER_MAX_RAM_MB", "10240")))
-STREAM_MANAGER_RAM_USAGE_QUEUE_SIZE = abs(
-    int(os.getenv("STREAM_MANAGER_RAM_USAGE_QUEUE_SIZE", "100"))
-)
+try:
+    STREAM_MANAGER_MAX_RAM_MB = abs(float(os.getenv("STREAM_MANAGER_MAX_RAM_MB")))
+    STREAM_MANAGER_RAM_USAGE_QUEUE_SIZE = abs(
+        int(os.getenv("STREAM_MANAGER_RAM_USAGE_QUEUE_SIZE"))
+    )
+except:
+    STREAM_MANAGER_MAX_RAM_MB = None
+    STREAM_MANAGER_RAM_USAGE_QUEUE_SIZE = 10

--- a/inference/core/env.py
+++ b/inference/core/env.py
@@ -515,3 +515,9 @@ IGNORE_MODEL_DEPENDENCIES_WARNINGS = str2bool(
 )
 if IGNORE_MODEL_DEPENDENCIES_WARNINGS:
     warnings.simplefilter("ignore", ModelDependencyMissing)
+
+# Stream manager configuration
+STREAM_MANAGER_MAX_RAM_MB = abs(float(os.getenv("STREAM_MANAGER_MAX_RAM_MB", "10240")))
+STREAM_MANAGER_RAM_USAGE_QUEUE_SIZE = abs(
+    int(os.getenv("STREAM_MANAGER_RAM_USAGE_QUEUE_SIZE", "100"))
+)

--- a/inference/core/interfaces/stream_manager/manager_app/app.py
+++ b/inference/core/interfaces/stream_manager/manager_app/app.py
@@ -5,7 +5,7 @@ import sys
 import time
 import uuid
 from collections import deque
-from dataclasses import field, dataclass
+from dataclasses import dataclass, field
 from functools import partial
 from multiprocessing import Process, Queue
 from socketserver import BaseRequestHandler, BaseServer

--- a/inference/core/interfaces/stream_manager/manager_app/app.py
+++ b/inference/core/interfaces/stream_manager/manager_app/app.py
@@ -323,15 +323,23 @@ def check_process_health() -> None:
                 managed_pipeline.ram_usage_queue.append(process_ram_usage_mb)
 
                 if not process.is_alive():
-                    logger.warning("Process for pipeline_id=%s is not alive. Terminating...", pipeline_id)
+                    logger.warning(
+                        "Process for pipeline_id=%s is not alive. Terminating...",
+                        pipeline_id,
+                    )
                     process.terminate()
                     process.join()
                     del PROCESSES_TABLE[pipeline_id]
                     continue
 
                 total_ram_usage += process_ram_usage_mb
-                if STREAM_MANAGER_MAX_RAM_MB is not None and total_ram_usage > STREAM_MANAGER_MAX_RAM_MB:
-                    logger.warning("Process for pipeline_id=%s is above RAM limit.", pipeline_id)
+                if (
+                    STREAM_MANAGER_MAX_RAM_MB is not None
+                    and total_ram_usage > STREAM_MANAGER_MAX_RAM_MB
+                ):
+                    logger.warning(
+                        "Process for pipeline_id=%s is above RAM limit.", pipeline_id
+                    )
 
                 if managed_pipeline.is_idle:
                     # skipping idle pipelines in status probing
@@ -398,17 +406,28 @@ def get_or_spawn_pipeline_process(
             chosen_pipeline.is_idle = False
             return chosen_pipeline
 
-        current_ram_usage = sum(
-            managed_pipeline.ram_usage_queue[-1] if managed_pipeline.ram_usage_queue else 0
-            for managed_pipeline in processes_table.values()
-        ) + _get_current_process_ram_usage_mb()
+        current_ram_usage = (
+            sum(
+                (
+                    managed_pipeline.ram_usage_queue[-1]
+                    if managed_pipeline.ram_usage_queue
+                    else 0
+                )
+                for managed_pipeline in processes_table.values()
+            )
+            + _get_current_process_ram_usage_mb()
+        )
         highest_pipeline_ram_usage = max(
-            max(managed_pipeline.ram_usage_queue for managed_pipeline in processes_table.values())
+            max(
+                managed_pipeline.ram_usage_queue
+                for managed_pipeline in processes_table.values()
+            )
         )
 
         if (
             STREAM_MANAGER_MAX_RAM_MB is not None
-            and current_ram_usage + highest_pipeline_ram_usage > STREAM_MANAGER_MAX_RAM_MB
+            and current_ram_usage + highest_pipeline_ram_usage
+            > STREAM_MANAGER_MAX_RAM_MB
         ):
             raise Exception(
                 "Cannot spawn new pipeline due to insufficient RAM,"

--- a/inference/core/interfaces/stream_manager/manager_app/app.py
+++ b/inference/core/interfaces/stream_manager/manager_app/app.py
@@ -4,16 +4,23 @@ import socket
 import sys
 import time
 import uuid
-from dataclasses import dataclass
+from collections import deque
+from dataclasses import field, dataclass
 from functools import partial
 from multiprocessing import Process, Queue
 from socketserver import BaseRequestHandler, BaseServer
 from threading import Lock, Thread
 from types import FrameType
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Deque, Dict, List, Optional, Tuple
 from uuid import uuid4
 
+import psutil
+
 from inference.core import logger
+from inference.core.env import (
+    STREAM_MANAGER_MAX_RAM_MB,
+    STREAM_MANAGER_RAM_USAGE_QUEUE_SIZE,
+)
 from inference.core.interfaces.camera.video_source import StreamState
 from inference.core.interfaces.stream_manager.manager_app.communication import (
     receive_socket_data,
@@ -54,6 +61,9 @@ class ManagedInferencePipeline:
     responses_queue: Queue
     operation_lock: Lock
     is_idle: bool
+    ram_usage_queue: Deque = field(
+        default_factory=lambda: deque(maxlen=STREAM_MANAGER_RAM_USAGE_QUEUE_SIZE)
+    )
 
 
 PROCESSES_TABLE: Dict[str, ManagedInferencePipeline] = {}
@@ -303,48 +313,36 @@ def join_inference_pipeline(
 
 def check_process_health() -> None:
     while True:
-        for pipeline_id, managed_pipeline in list(PROCESSES_TABLE.items()):
-            process = managed_pipeline.pipeline_manager
-            if not process.is_alive():
-                logger.warning(
-                    "Process for pipeline_id=%s is not alive. Terminating...",
-                    pipeline_id,
+        total_ram_usage: int = _get_current_process_ram_usage_mb()
+        with PROCESSES_TABLE_LOCK:
+            for pipeline_id, managed_pipeline in list(PROCESSES_TABLE.items()):
+                process = managed_pipeline.pipeline_manager
+                process_ram_usage_mb = _get_process_memory_usage_mb(process=process)
+                managed_pipeline.ram_usage_queue.append(process_ram_usage_mb)
+
+                is_process_alive = process.is_alive()
+                is_process_above_ram_limit = (
+                    process_ram_usage_mb + total_ram_usage > STREAM_MANAGER_MAX_RAM_MB
                 )
-                process.terminate()
-                process.join()
-                del PROCESSES_TABLE[pipeline_id]
-                continue
-            if managed_pipeline.is_idle:
-                # skipping idle pipelines in status probing
-                continue
-            command = {
-                TYPE_KEY: CommandType.STATUS,
-                PIPELINE_ID_KEY: pipeline_id,
-            }
-            response = handle_command(
-                processes_table=PROCESSES_TABLE,
-                request_id=uuid.uuid4().hex,
-                pipeline_id=pipeline_id,
-                command=command,
-            )
-            if (
-                REPORT_KEY not in response
-                or SOURCES_METADATA_KEY not in response[REPORT_KEY]
-            ):
-                continue
-            all_sources_statues = set(
-                source_metadata[STATE_KEY]
-                for source_metadata in response[REPORT_KEY][SOURCES_METADATA_KEY]
-                if STATE_KEY in source_metadata
-            )
-            if not all_sources_statues:
-                continue
-            if all_sources_statues.issubset({StreamState.ENDED, StreamState.ERROR}):
-                logger.info(
-                    "All sources depleted in pipeline %s, terminating", pipeline_id
-                )
+                if not is_process_alive or is_process_above_ram_limit:
+                    msg = (
+                        f"Process for pipeline_id={pipeline_id} is not alive. Terminating..."
+                        if not is_process_alive
+                        else f"Process for pipeline_id={pipeline_id} is above RAM limit. Terminating..."
+                    )
+                    logger.warning(msg)
+                    process.terminate()
+                    process.join()
+                    del PROCESSES_TABLE[pipeline_id]
+                    continue
+
+                total_ram_usage += process_ram_usage_mb
+
+                if managed_pipeline.is_idle:
+                    # skipping idle pipelines in status probing
+                    continue
                 command = {
-                    TYPE_KEY: CommandType.TERMINATE,
+                    TYPE_KEY: CommandType.STATUS,
                     PIPELINE_ID_KEY: pipeline_id,
                 }
                 response = handle_command(
@@ -353,15 +351,46 @@ def check_process_health() -> None:
                     pipeline_id=pipeline_id,
                     command=command,
                 )
-                if not response.get(STATUS_KEY) == "success":
-                    logger.error(
-                        "Malformed response returned by termination command, '%s'",
-                        response,
-                    )
+                if (
+                    REPORT_KEY not in response
+                    or SOURCES_METADATA_KEY not in response[REPORT_KEY]
+                ):
                     continue
-                process.join()
-                del PROCESSES_TABLE[pipeline_id]
+                all_sources_statues = set(
+                    source_metadata[STATE_KEY]
+                    for source_metadata in response[REPORT_KEY][SOURCES_METADATA_KEY]
+                    if STATE_KEY in source_metadata
+                )
+                if not all_sources_statues:
+                    continue
+                if all_sources_statues.issubset({StreamState.ENDED, StreamState.ERROR}):
+                    total_ram_usage -= process_ram_usage_mb
+                    logger.info(
+                        "All sources depleted in pipeline %s, terminating", pipeline_id
+                    )
+                    command = {
+                        TYPE_KEY: CommandType.TERMINATE,
+                        PIPELINE_ID_KEY: pipeline_id,
+                    }
+                    response = handle_command(
+                        processes_table=PROCESSES_TABLE,
+                        request_id=uuid.uuid4().hex,
+                        pipeline_id=pipeline_id,
+                        command=command,
+                    )
+                    if not response.get(STATUS_KEY) == "success":
+                        logger.error(
+                            "Malformed response returned by termination command, '%s'",
+                            response,
+                        )
+                        continue
+                    process.join()
+                    del PROCESSES_TABLE[pipeline_id]
         time.sleep(1)
+
+
+def _get_current_process_ram_usage_mb() -> int:
+    return psutil.Process().memory_info().rss / (1024 * 1024)
 
 
 def get_or_spawn_pipeline_process(
@@ -373,6 +402,18 @@ def get_or_spawn_pipeline_process(
             chosen_pipeline = processes_table[idle_pipelines[0]]
             chosen_pipeline.is_idle = False
             return chosen_pipeline
+
+        pipelines_ram_usage = sum(
+            max(managed_pipeline.ram_usage_queue)
+            for managed_pipeline in processes_table.values()
+        )
+        if (
+            _get_current_process_ram_usage_mb() + pipelines_ram_usage
+            > STREAM_MANAGER_MAX_RAM_MB
+        ):
+            raise Exception(
+                f"Cannot spawn new pipeline due to insufficient RAM, current RAM usage: {pipelines_ram_usage}, max: {STREAM_MANAGER_MAX_RAM_MB}"
+            )
         new_pipeline_id = spawn_managed_pipeline_process(
             processes_table=processes_table,
             mark_as_idle=False,
@@ -423,8 +464,15 @@ def spawn_managed_pipeline_process(
         operation_lock=Lock(),
         is_idle=mark_as_idle,
     )
+    processes_table[pipeline_id].ram_usage_queue.append(
+        _get_process_memory_usage_mb(process=inference_pipeline_manager)
+    )
     logger.info(f"Spawned new InferencePipeline process with id: {pipeline_id}")
     return pipeline_id
+
+
+def _get_process_memory_usage_mb(process: Process) -> int:
+    return psutil.Process(process.pid).memory_info().rss / (1024 * 1024)
 
 
 def start(expected_warmed_up_pipelines: int = 0) -> None:

--- a/inference/core/interfaces/stream_manager/manager_app/app.py
+++ b/inference/core/interfaces/stream_manager/manager_app/app.py
@@ -417,12 +417,18 @@ def get_or_spawn_pipeline_process(
             )
             + _get_current_process_ram_usage_mb()
         )
-        highest_pipeline_ram_usage = max(
-            max(
-                managed_pipeline.ram_usage_queue
-                for managed_pipeline in processes_table.values()
+        highest_pipeline_ram_usage = 0
+        if processes_table:
+            highest_pipeline_ram_usage = max(
+                max(
+                    (
+                        managed_pipeline.ram_usage_queue
+                        if managed_pipeline.ram_usage_queue
+                        else 0
+                    )
+                    for managed_pipeline in processes_table.values()
+                )
             )
-        )
 
         if (
             STREAM_MANAGER_MAX_RAM_MB is not None

--- a/inference/core/interfaces/stream_manager/manager_app/inference_pipeline_manager.py
+++ b/inference/core/interfaces/stream_manager/manager_app/inference_pipeline_manager.py
@@ -7,7 +7,7 @@ from dataclasses import asdict
 from functools import partial
 from multiprocessing import Process, Queue
 from queue import Empty
-from threading import Event, Lock
+from threading import Event
 from types import FrameType
 from typing import Dict, Optional, Tuple
 


### PR DESCRIPTION
# Description

Prevent pipeline creation if there is insufficient memory available

## Type of change

-   [x] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?

CI passing
Manually tested on local deployment by setting `STREAM_MANAGER_MAX_RAM_MB=0`
Needs to be tested on dedicated deployment with sane RAM limit

## Any specific deployment considerations

N/A

## Docs

N/A