### PR TITLE
Catch ZeroDivisionError in video source

### DIFF
--- a/inference/core/interfaces/camera/video_source.py
+++ b/inference/core/interfaces/camera/video_source.py
@@ -1190,7 +1190,17 @@ def get_fps_if_tick_happens_now(fps_monitor: sv.FPSMonitor) -> float:
     min_reader_timestamp = fps_monitor.all_timestamps[0]
     now = time.monotonic()
     reader_taken_time = now - min_reader_timestamp
-    return (len(fps_monitor.all_timestamps) + 1) / reader_taken_time
+    try:
+        calculated_fps = (len(fps_monitor.all_timestamps) + 1) / reader_taken_time
+        return calculated_fps
+    except ZeroDivisionError:
+        state = {
+            "fps_monitor": fps_monitor,
+            "reader_taken_time": reader_taken_time,
+            "now": now,
+        }
+        logger.warning(f"ZeroDivisionError in get_fps_if_tick_happens_now: {state}")
+        return 0.0
 
 
 def calculate_video_file_stride(

--- a/inference/core/interfaces/camera/video_source.py
+++ b/inference/core/interfaces/camera/video_source.py
@@ -1189,18 +1189,9 @@ def get_fps_if_tick_happens_now(fps_monitor: sv.FPSMonitor) -> float:
         return 0.0
     min_reader_timestamp = fps_monitor.all_timestamps[0]
     now = time.monotonic()
-    reader_taken_time = now - min_reader_timestamp
-    try:
-        calculated_fps = (len(fps_monitor.all_timestamps) + 1) / reader_taken_time
-        return calculated_fps
-    except ZeroDivisionError:
-        state = {
-            "fps_monitor": fps_monitor,
-            "reader_taken_time": reader_taken_time,
-            "now": now,
-        }
-        logger.warning(f"ZeroDivisionError in get_fps_if_tick_happens_now: {state}")
-        return 0.0
+    epsilon = 1e-8
+    reader_taken_time = (now - min_reader_timestamp) + epsilon
+    return (len(fps_monitor.all_timestamps) + 1) / reader_taken_time
 
 
 def calculate_video_file_stride(


### PR DESCRIPTION
# Description

- User running into ZeroDivisionErrors when running multiplexed video inputs. This change adds an epsilon to the denominator to prevent zero division

User's Code:
```python
from inference.core.interfaces.stream.inference_pipeline import InferencePipeline
from inference.core.interfaces.stream.sinks import UDPSink
udp_sink = UDPSink.init(ip_address="localhost", port=8080)
InferencePipeline.init(
   api_key="***",
   model_id="coco/34",
   class_agnostic_nms=False,
   confidence=0.3,
   iou_threshold=0.50,
   max_detections=100,
   video_reference=[0, 1, 2, 3],
   active_learning_enabled = False,
   video_source_properties ={"frame_width": 1280, "frame_height": 720},
   on_prediction=udp_sink.send_predictions
).start()
```

Error:
```
get_fps_if_tick_happens_now
                                 return (len(fps_monitor.all_timestamps) + 1) / reader_taken_time
                             ZeroDivisionError: float division by zero
                    ERROR    Encountered error in video consumption thread  video_source.py:701
```

## Type of change

Please delete options that are not relevant.

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

- Ran the function in isolation and unit/integration tests passing

## Any specific deployment considerations

- N/A

## Docs

-   N/A
