### PR TITLE
Output predictions for Dynamic Crop

### DIFF
--- a/inference/core/workflows/core_steps/transformations/dynamic_crop/v1.py
+++ b/inference/core/workflows/core_steps/transformations/dynamic_crop/v1.py
@@ -226,12 +226,12 @@ def crop_image(
             ),
         )
 
-        if KEYPOINTS_XY_KEY_IN_SV_DETECTIONS in detections:
-            translated_detection[KEYPOINTS_XY_KEY_IN_SV_DETECTIONS] = detections[
+        if KEYPOINTS_XY_KEY_IN_SV_DETECTIONS in detections.data:
+            translated_detection[KEYPOINTS_XY_KEY_IN_SV_DETECTIONS] = selected_detection[
                 KEYPOINTS_XY_KEY_IN_SV_DETECTIONS
             ] - np.array([x_min, y_min])
-        if POLYGON_KEY_IN_SV_DETECTIONS in detections:
-            translated_detection[POLYGON_KEY_IN_SV_DETECTIONS] = detections[
+        if POLYGON_KEY_IN_SV_DETECTIONS in detections.data:
+            translated_detection[POLYGON_KEY_IN_SV_DETECTIONS] = selected_detection[
                 POLYGON_KEY_IN_SV_DETECTIONS
             ] - np.array([x_min, y_min])
 

--- a/inference/core/workflows/core_steps/transformations/dynamic_crop/v1.py
+++ b/inference/core/workflows/core_steps/transformations/dynamic_crop/v1.py
@@ -6,11 +6,13 @@ import numpy as np
 import supervision as sv
 from pydantic import AliasChoices, ConfigDict, Field
 
-from inference.core.workflows.execution_engine.constants import DETECTION_ID_KEY
+from inference.core.workflows.execution_engine.constants import (
+    DETECTION_ID_KEY,
+    KEYPOINTS_XY_KEY_IN_SV_DETECTIONS,
+    POLYGON_KEY_IN_SV_DETECTIONS,
+)
 from inference.core.workflows.execution_engine.entities.base import (
     Batch,
-    ImageParentMetadata,
-    OriginCoordinatesSystem,
     OutputDefinition,
     WorkflowImageData,
 )
@@ -224,9 +226,13 @@ def crop_image(
             ),
         )
 
-        if "keypoints_xy" in detections:
-            translated_detection["keypoints_xy"] = detections[
-                "keypoints_xy"
+        if KEYPOINTS_XY_KEY_IN_SV_DETECTIONS in detections:
+            translated_detection[KEYPOINTS_XY_KEY_IN_SV_DETECTIONS] = detections[
+                KEYPOINTS_XY_KEY_IN_SV_DETECTIONS
+            ] - np.array([x_min, y_min])
+        if POLYGON_KEY_IN_SV_DETECTIONS in detections:
+            translated_detection[POLYGON_KEY_IN_SV_DETECTIONS] = detections[
+                POLYGON_KEY_IN_SV_DETECTIONS
             ] - np.array([x_min, y_min])
 
         crops.append(

--- a/inference/core/workflows/core_steps/transformations/dynamic_crop/v1.py
+++ b/inference/core/workflows/core_steps/transformations/dynamic_crop/v1.py
@@ -227,9 +227,10 @@ def crop_image(
         )
 
         if KEYPOINTS_XY_KEY_IN_SV_DETECTIONS in detections.data:
-            translated_detection[KEYPOINTS_XY_KEY_IN_SV_DETECTIONS] = selected_detection[
-                KEYPOINTS_XY_KEY_IN_SV_DETECTIONS
-            ] - np.array([x_min, y_min])
+            translated_detection[KEYPOINTS_XY_KEY_IN_SV_DETECTIONS] = (
+                selected_detection[KEYPOINTS_XY_KEY_IN_SV_DETECTIONS]
+                - np.array([x_min, y_min])
+            )
         if POLYGON_KEY_IN_SV_DETECTIONS in detections.data:
             translated_detection[POLYGON_KEY_IN_SV_DETECTIONS] = selected_detection[
                 POLYGON_KEY_IN_SV_DETECTIONS

--- a/inference/core/workflows/core_steps/transformations/dynamic_crop/v1.py
+++ b/inference/core/workflows/core_steps/transformations/dynamic_crop/v1.py
@@ -217,17 +217,25 @@ def crop_image(
         translated_detection = replace(
             selected_detection,
             xyxy=sv.move_boxes(xyxy=selected_detection.xyxy, offset=(-x_min, -y_min)),
-            mask=selected_detection.mask[:, y_min:y_max, x_min:x_max] if selected_detection.mask is not None else None,
+            mask=(
+                selected_detection.mask[:, y_min:y_max, x_min:x_max]
+                if selected_detection.mask is not None
+                else None
+            ),
         )
 
         if "keypoints_xy" in detections:
-            translated_detection["keypoints_xy"] = detections["keypoints_xy"] - np.array([x_min, y_min])
+            translated_detection["keypoints_xy"] = detections[
+                "keypoints_xy"
+            ] - np.array([x_min, y_min])
 
-        crops.append({
-            "crops": result,
-            # preserve all masks, keypoints, and metadata if present
-            "predictions": translated_detection
-        })
+        crops.append(
+            {
+                "crops": result,
+                # preserve all masks, keypoints, and metadata if present
+                "predictions": translated_detection,
+            }
+        )
     return crops
 
 

--- a/tests/workflows/integration_tests/execution/test_workflow_with_keypoints_detections_and_dynamic_crop.py
+++ b/tests/workflows/integration_tests/execution/test_workflow_with_keypoints_detections_and_dynamic_crop.py
@@ -1,0 +1,104 @@
+import numpy as np
+
+from inference.core.env import WORKFLOWS_MAX_CONCURRENT_STEPS
+from inference.core.managers.base import ModelManager
+from inference.core.workflows.core_steps.common.entities import StepExecutionMode
+from inference.core.workflows.execution_engine.core import ExecutionEngine
+from tests.workflows.integration_tests.execution.workflows_gallery_collector.decorators import (
+    add_to_workflows_gallery,
+)
+
+WORKFLOW = {
+    "version": "1.0",
+    "inputs": [{"type": "InferenceImage", "name": "image"}],
+    "steps": [
+        {
+            "type": "roboflow_core/roboflow_keypoint_detection_model@v2",
+            "name": "model",
+            "images": "$inputs.image",
+            "model_id": "yolov8n-pose-640",
+        },
+        {
+            "type": "roboflow_core/dynamic_crop@v1",
+            "name": "dynamic_crop",
+            "images": "$inputs.image",
+            "predictions": "$steps.model.predictions",
+        },
+        {
+            "type": "roboflow_core/keypoint_visualization@v1",
+            "name": "model_keypoint_visualization",
+            "image": "$inputs.image",
+            "predictions": "$steps.model.predictions",
+        },
+        {
+            "type": "roboflow_core/keypoint_visualization@v1",
+            "name": "dynamic_crops_keypoint_visualization",
+            "image": "$steps.dynamic_crop.crops",
+            "predictions": "$steps.dynamic_crop.predictions",
+        },
+    ],
+    "outputs": [
+        {
+            "type": "JsonField",
+            "name": "model_keypoint_visualization",
+            "coordinates_system": "own",
+            "selector": "$steps.model_keypoint_visualization.image",
+        },
+        {
+            "type": "JsonField",
+            "name": "dynamic_crops_keypoint_visualization",
+            "coordinates_system": "own",
+            "selector": "$steps.dynamic_crops_keypoint_visualization.image",
+        },
+        {
+            "type": "JsonField",
+            "name": "dynamic_crop_predictions",
+            "selector": "$steps.dynamic_crop.predictions",
+        },
+    ],
+}
+
+
+def test_workflow_with_keypoints_and_dynamic_crop(
+    model_manager: ModelManager,
+    crowd_image: np.ndarray,
+) -> None:
+    # given
+    workflow_init_parameters = {
+        "workflows_core.model_manager": model_manager,
+        "workflows_core.api_key": None,
+        "workflows_core.step_execution_mode": StepExecutionMode.LOCAL,
+    }
+    execution_engine = ExecutionEngine.init(
+        workflow_definition=WORKFLOW,
+        init_parameters=workflow_init_parameters,
+        max_concurrent_steps=WORKFLOWS_MAX_CONCURRENT_STEPS,
+    )
+
+    # when
+    result = execution_engine.run(
+        runtime_parameters={
+            "image": crowd_image,
+        }
+    )
+
+    # then
+    assert isinstance(result, list), "Expected result to be list"
+    assert len(result) == 1, "One set of images provided, so one output expected"
+    assert set(result[0].keys()) == {
+        "model_keypoint_visualization",
+        "dynamic_crops_keypoint_visualization",
+        "dynamic_crop_predictions",
+    }, "Expected all declared outputs to be delivered"
+    assert (
+        len(result[0]["dynamic_crops_keypoint_visualization"]) == 8
+    ), "Expected 8 crops"
+    assert (
+        result[0]["model_keypoint_visualization"].numpy_image.shape == crowd_image.shape
+    ), "Expected visualization of model predictions to be of the same shape as original image"
+    assert (
+        type(result[0]["dynamic_crop_predictions"]) == list
+    ), "Expected dynamic crops predictions to be a list"
+    assert (
+        len(result[0]["dynamic_crop_predictions"]) == 8
+    ), "Expected 8-elements list containing sv.Detections for each crop"


### PR DESCRIPTION
# Description

For each cropped image, also output the detection that goes along with it (including class, mask, keypoints, other metadata). This helps so that you have matching detections in the same dimensionality to work with after the crop.

## Type of change

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Locally so far.

## Any specific deployment considerations

Didn't bump the version since it shouldn't be a breaking change but could see an argument that changing the output signature should mean we bump dynamic crop block to v2.

## Docs

-   [ ] Docs updated? What were the changes: Not yet
