### PR TITLE
Add optional models cache authorization

### DIFF
--- a/inference/core/env.py
+++ b/inference/core/env.py
@@ -257,6 +257,15 @@ MAX_DETECTIONS = int(os.getenv(MAX_DETECTIONS_ENV, DEFAULT_MAX_DETECTIONS))
 # Loop interval for expiration of memory cache, default is 5
 MEMORY_CACHE_EXPIRE_INTERVAL = int(os.getenv("MEMORY_CACHE_EXPIRE_INTERVAL", 5))
 
+# Enable models cache auth
+MODELS_CACHE_AUTH_ENABLED = str2bool(os.getenv("MODELS_CACHE_AUTH_ENABLED", False))
+
+# Models cache auth cache ttl, default is 15 minutes
+MODELS_CACHE_AUTH_CACHE_TTL = int(os.getenv("MODELS_CACHE_AUTH_CACHE_TTL", 15 * 60))
+
+# Models cache auth cache max size, default is 0 (unlimited)
+MODELS_CACHE_AUTH_CACHE_MAX_SIZE = int(os.getenv("MODELS_CACHE_AUTH_CACHE_MAX_SIZE", 0))
+
 # Metrics enabled flag, default is True
 METRICS_ENABLED = str2bool(os.getenv("METRICS_ENABLED", True))
 if LAMBDA or GCP_SERVERLESS:

--- a/inference/core/registries/roboflow.py
+++ b/inference/core/registries/roboflow.py
@@ -12,8 +12,6 @@ from inference.core.entities.types import (
     TaskType,
     VersionID,
 )
-
-from inference.core.exceptions import RoboflowAPINotAuthorizedError
 from inference.core.env import (
     LAMBDA,
     MODEL_CACHE_DIR,
@@ -25,6 +23,7 @@ from inference.core.exceptions import (
     MissingApiKeyError,
     ModelArtefactError,
     ModelNotRecognisedError,
+    RoboflowAPINotAuthorizedError,
 )
 from inference.core.logger import logger
 from inference.core.models.base import Model

--- a/inference/core/registries/roboflow.py
+++ b/inference/core/registries/roboflow.py
@@ -1,5 +1,7 @@
 import os
-from typing import Optional, Tuple, Union
+from typing import Any, Dict, Optional, Tuple, Union
+
+from cachetools.func import ttl_cache
 
 from inference.core.cache import cache
 from inference.core.devices.utils import GLOBAL_DEVICE_ID
@@ -10,7 +12,15 @@ from inference.core.entities.types import (
     TaskType,
     VersionID,
 )
-from inference.core.env import LAMBDA, MODEL_CACHE_DIR
+
+from inference.core.exceptions import RoboflowAPINotAuthorizedError
+from inference.core.env import (
+    LAMBDA,
+    MODEL_CACHE_DIR,
+    MODELS_CACHE_AUTH_CACHE_MAX_SIZE,
+    MODELS_CACHE_AUTH_CACHE_TTL,
+    MODELS_CACHE_AUTH_ENABLED,
+)
 from inference.core.exceptions import (
     MissingApiKeyError,
     ModelArtefactError,
@@ -75,6 +85,30 @@ class RoboflowModelRegistry(ModelRegistry):
         return self.registry_dict[model_type]
 
 
+@ttl_cache(ttl=MODELS_CACHE_AUTH_CACHE_TTL, maxsize=MODELS_CACHE_AUTH_CACHE_MAX_SIZE)
+def _check_if_api_key_has_access_to_model(
+    api_key: str,
+    model_id: str,
+) -> bool:
+    _, version_id = get_model_id_chunks(model_id=model_id)
+    try:
+        if version_id is not None:
+            get_roboflow_model_data(
+                api_key=api_key,
+                model_id=model_id,
+                endpoint_type=ModelEndpointType.ORT,
+                device_id=GLOBAL_DEVICE_ID,
+            ).get("ort")
+        else:
+            get_roboflow_instant_model_data(
+                api_key=api_key,
+                model_id=model_id,
+            )
+    except RoboflowAPINotAuthorizedError:
+        return False
+    return True
+
+
 def get_model_type(
     model_id: ModelID,
     api_key: Optional[str] = None,
@@ -99,6 +133,15 @@ def get_model_type(
     if dataset_id in GENERIC_MODELS:
         logger.debug(f"Loading generic model: {dataset_id}.")
         return GENERIC_MODELS[dataset_id]
+
+    if MODELS_CACHE_AUTH_ENABLED:
+        if not _check_if_api_key_has_access_to_model(
+            api_key=api_key, model_id=model_id
+        ):
+            raise RoboflowAPINotAuthorizedError(
+                f"API key {api_key} does not have access to model {model_id}"
+            )
+
     cached_metadata = get_model_metadata_from_cache(
         dataset_id=dataset_id, version_id=version_id
     )

--- a/inference/core/version.py
+++ b/inference/core/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.42.0"
+__version__ = "0.42.1"
 
 
 if __name__ == "__main__":

--- a/requirements/_requirements.txt
+++ b/requirements/_requirements.txt
@@ -1,6 +1,7 @@
 aiortc~=1.9.0
 APScheduler>=3.10.1,<4.0.0
 asyncua~=1.1.5
+cachetools<6.0.0
 cython~=3.0.0
 python-dotenv~=1.0.0
 fastapi>=0.100,<0.111  # be careful with upper pin - fastapi might remove support for on_event


### PR DESCRIPTION
# Description

Add optional models cache authorization. Feature is turned on with MODELS_CACHE_AUTH_ENABLED environmental variable. Authorization result is cached for MODELS_CACHE_AUTH_CACHE_TTL seconds.

## Type of change

-   [x] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?

CI passing

## Any specific deployment considerations

N/A

## Docs

N/A