### PR TITLE
Add pipeline termination when processing is over

### DIFF
--- a/inference_cli/lib/workflows/video_adapter.py
+++ b/inference_cli/lib/workflows/video_adapter.py
@@ -64,6 +64,7 @@ def process_video_with_workflow(
     progress_sink.start()
     pipeline.start(use_main_thread=True)
     pipeline.join()
+    pipeline.terminate()
     progress_sink.stop()
     structured_results_file = structured_sink.flush()[0]
     video_outputs = None


### PR DESCRIPTION
# Description

We had a bug in batch processing leading processes to hang in a situation when there is error in inference thread - then Inference pipeline shuts down all of the internal threads apart from video sources - which are closed only when `.terminate(...)` is called.

This solution is just bug-fix - in new iteration of `InferencePipeline` we need to design it better to handle such cases.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

* e2e test against problematic workflow

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
