### PR TITLE
handle versionless model id through legacy routes

### DIFF
--- a/inference/core/interfaces/http/http_api.py
+++ b/inference/core/interfaces/http/http_api.py
@@ -2509,7 +2509,17 @@ class HttpInterface(BaseInterface):
         app.mount(
             "/",
             StaticFiles(directory="./inference/landing/out", html=True),
+            name="root",
+        )
+        app.mount(
+            "/static",
+            StaticFiles(directory="./inference/landing/out/static", html=True),
             name="static",
+        )
+        app.mount(
+            "/_next/static",
+            StaticFiles(directory="./inference/landing/out/static", html=True),
+            name="_next_static",
         )
 
     def run(self):

--- a/inference/core/interfaces/http/http_api.py
+++ b/inference/core/interfaces/http/http_api.py
@@ -2378,6 +2378,7 @@ class HttpInterface(BaseInterface):
                         "Service secret is required to disable inference usage tracking"
                     )
                 if LAMBDA:
+                    logger.debug("request.scope: %s", request.scope)
                     request_model_id = (
                         request.scope["aws.event"]["requestContext"]["authorizer"][
                             "lambda"

--- a/inference/core/interfaces/http/http_api.py
+++ b/inference/core/interfaces/http/http_api.py
@@ -3,17 +3,15 @@ import base64
 import os
 import traceback
 from functools import partial, wraps
-from pathlib import Path as Pathlib
 from time import sleep
 from typing import Any, Dict, List, Optional, Union
 
 import asgi_correlation_id
 import uvicorn
 from fastapi import BackgroundTasks, Depends, FastAPI, Path, Query, Request
-from fastapi.responses import FileResponse, JSONResponse, RedirectResponse, Response
+from fastapi.responses import JSONResponse, RedirectResponse, Response
 from fastapi.staticfiles import StaticFiles
 from fastapi_cprofile.profiler import CProfileMiddleware
-from starlette.convertors import StringConvertor, register_url_convertor
 from starlette.middleware.base import BaseHTTPMiddleware
 
 from inference.core import logger

--- a/inference/core/interfaces/http/http_api.py
+++ b/inference/core/interfaces/http/http_api.py
@@ -555,12 +555,6 @@ class HttpInterface(BaseInterface):
             root_path=root_path,
         )
 
-        app.mount(
-            "/",
-            StaticFiles(directory="./inference/landing/out", html=True),
-            name="static",
-        )
-
         @app.on_event("shutdown")
         async def on_shutdown():
             logger.info("Shutting down %s", description)
@@ -2510,6 +2504,12 @@ class HttpInterface(BaseInterface):
                         "message": "inference session started from local memory.",
                     }
                 )
+
+        app.mount(
+            "/",
+            StaticFiles(directory="./inference/landing/out", html=True),
+            name="static",
+        )
 
     def run(self):
         uvicorn.run(self.app, host="127.0.0.1", port=8080)

--- a/inference/core/interfaces/http/http_api.py
+++ b/inference/core/interfaces/http/http_api.py
@@ -287,10 +287,10 @@ def with_route_exceptions(route):
                 },
             )
             traceback.print_exc()
-        except InvalidModelIDError:
+        except InvalidModelIDError as e:
             resp = JSONResponse(
                 status_code=400,
-                content={"message": "Invalid Model ID sent in request."},
+                content={"message": str(e)},
             )
             traceback.print_exc()
         except InvalidMaskDecodeArgument:

--- a/inference/core/interfaces/http/http_api.py
+++ b/inference/core/interfaces/http/http_api.py
@@ -408,9 +408,10 @@ def with_route_exceptions(route):
                 },
             )
             traceback.print_exc()
-        except ModelArtefactError:
+        except ModelArtefactError as error:
             resp = JSONResponse(
-                status_code=500, content={"message": "Model package is broken."}
+                status_code=500,
+                content={"message": f"Model package is broken: {error}"},
             )
             traceback.print_exc()
         except OnnxProviderNotAvailable:

--- a/inference/core/interfaces/http/http_api.py
+++ b/inference/core/interfaces/http/http_api.py
@@ -581,6 +581,17 @@ class HttpInterface(BaseInterface):
             root_path=root_path,
         )
 
+        app.mount(
+            "/static",
+            StaticFiles(directory="./inference/landing/out/static", html=True),
+            name="static",
+        )
+        app.mount(
+            "/_next/static",
+            StaticFiles(directory="./inference/landing/out/_next/static", html=True),
+            name="_next_static",
+        )
+
         @app.on_event("shutdown")
         async def on_shutdown():
             logger.info("Shutting down %s", description)
@@ -2536,16 +2547,6 @@ class HttpInterface(BaseInterface):
             "/",
             StaticFiles(directory="./inference/landing/out", html=True),
             name="root",
-        )
-        app.mount(
-            "/static",
-            StaticFiles(directory="./inference/landing/out/static", html=True),
-            name="static",
-        )
-        app.mount(
-            "/_next/static",
-            StaticFiles(directory="./inference/landing/out/static", html=True),
-            name="_next_static",
         )
 
     def run(self):

--- a/inference/core/interfaces/http/http_api.py
+++ b/inference/core/interfaces/http/http_api.py
@@ -265,7 +265,8 @@ def with_route_exceptions(route):
     async def wrapped_route(*args, **kwargs):
         try:
             return await route(*args, **kwargs)
-        except ContentTypeInvalid:
+        except ContentTypeInvalid as error:
+            logger.error("%s: %s", type(error).__name__, error)
             resp = JSONResponse(
                 status_code=400,
                 content={
@@ -273,27 +274,31 @@ def with_route_exceptions(route):
                 },
             )
             traceback.print_exc()
-        except ContentTypeMissing:
+        except ContentTypeMissing as error:
+            logger.error("%s: %s", type(error).__name__, error)
             resp = JSONResponse(
                 status_code=400,
                 content={"message": "Content-Type header not provided with request."},
             )
             traceback.print_exc()
-        except InputImageLoadError as e:
+        except InputImageLoadError as error:
+            logger.error("%s: %s", type(error).__name__, error)
             resp = JSONResponse(
                 status_code=400,
                 content={
-                    "message": f"Could not load input image. Cause: {e.get_public_error_details()}"
+                    "message": f"Could not load input image. Cause: {error.get_public_error_details()}"
                 },
             )
             traceback.print_exc()
-        except InvalidModelIDError as e:
+        except InvalidModelIDError as error:
+            logger.error("%s: %s", type(error).__name__, error)
             resp = JSONResponse(
                 status_code=400,
-                content={"message": str(e)},
+                content={"message": "Invalid Model ID sent in request."},
             )
             traceback.print_exc()
-        except InvalidMaskDecodeArgument:
+        except InvalidMaskDecodeArgument as error:
+            logger.error("%s: %s", type(error).__name__, error)
             resp = JSONResponse(
                 status_code=400,
                 content={
@@ -302,7 +307,8 @@ def with_route_exceptions(route):
                 },
             )
             traceback.print_exc()
-        except MissingApiKeyError:
+        except MissingApiKeyError as error:
+            logger.error("%s: %s", type(error).__name__, error)
             resp = JSONResponse(
                 status_code=400,
                 content={
@@ -317,6 +323,7 @@ def with_route_exceptions(route):
             ExecutionGraphStructureError,
             StepInputDimensionalityError,
         ) as error:
+            logger.error("%s: %s", type(error).__name__, error)
             content = WorkflowErrorResponse(
                 message=str(error.public_message),
                 error_type=error.__class__.__name__,
@@ -336,6 +343,7 @@ def with_route_exceptions(route):
             WorkflowExecutionEngineVersionError,
             NotSupportedExecutionEngineError,
         ) as error:
+            logger.error("%s: %s", type(error).__name__, error)
             resp = JSONResponse(
                 status_code=400,
                 content={
@@ -351,6 +359,7 @@ def with_route_exceptions(route):
             MalformedPayloadError,
             MessageToBigError,
         ) as error:
+            logger.error("%s: %s", type(error).__name__, error)
             resp = JSONResponse(
                 status_code=400,
                 content={
@@ -359,7 +368,11 @@ def with_route_exceptions(route):
                     "inner_error_type": error.inner_error_type,
                 },
             )
-        except (RoboflowAPINotAuthorizedError, ProcessesManagerAuthorisationError):
+        except (
+            RoboflowAPINotAuthorizedError,
+            ProcessesManagerAuthorisationError,
+        ) as error:
+            logger.error("%s: %s", type(error).__name__, error)
             resp = JSONResponse(
                 status_code=401,
                 content={
@@ -369,7 +382,8 @@ def with_route_exceptions(route):
                 },
             )
             traceback.print_exc()
-        except (RoboflowAPINotNotFoundError, InferenceModelNotFound):
+        except (RoboflowAPINotNotFoundError, InferenceModelNotFound) as error:
+            logger.error("%s: %s", type(error).__name__, error)
             resp = JSONResponse(
                 status_code=404,
                 content={
@@ -379,6 +393,7 @@ def with_route_exceptions(route):
             )
             traceback.print_exc()
         except ProcessesManagerNotFoundError as error:
+            logger.error("%s: %s", type(error).__name__, error)
             resp = JSONResponse(
                 status_code=404,
                 content={
@@ -392,7 +407,8 @@ def with_route_exceptions(route):
             InvalidEnvironmentVariableError,
             MissingServiceSecretError,
             ServiceConfigurationError,
-        ):
+        ) as error:
+            logger.error("%s: %s", type(error).__name__, error)
             resp = JSONResponse(
                 status_code=500, content={"message": "Service misconfiguration."}
             )
@@ -400,7 +416,8 @@ def with_route_exceptions(route):
         except (
             PreProcessingError,
             PostProcessingError,
-        ):
+        ) as error:
+            logger.error("%s: %s", type(error).__name__, error)
             resp = JSONResponse(
                 status_code=500,
                 content={
@@ -409,12 +426,13 @@ def with_route_exceptions(route):
             )
             traceback.print_exc()
         except ModelArtefactError as error:
+            logger.error("%s: %s", type(error).__name__, error)
             resp = JSONResponse(
-                status_code=500,
-                content={"message": f"Model package is broken: {error}"},
+                status_code=500, content={"message": "Model package is broken."}
             )
             traceback.print_exc()
-        except OnnxProviderNotAvailable:
+        except OnnxProviderNotAvailable as error:
+            logger.error("%s: %s", type(error).__name__, error)
             resp = JSONResponse(
                 status_code=501,
                 content={
@@ -428,13 +446,15 @@ def with_route_exceptions(route):
             RoboflowAPIUnsuccessfulRequestError,
             WorkspaceLoadError,
             MalformedWorkflowResponseError,
-        ):
+        ) as error:
+            logger.error("%s: %s", type(error).__name__, error)
             resp = JSONResponse(
                 status_code=502,
                 content={"message": "Internal error. Request to Roboflow API failed."},
             )
             traceback.print_exc()
-        except RoboflowAPIConnectionError:
+        except RoboflowAPIConnectionError as error:
+            logger.error("%s: %s", type(error).__name__, error)
             resp = JSONResponse(
                 status_code=503,
                 content={
@@ -442,7 +462,8 @@ def with_route_exceptions(route):
                 },
             )
             traceback.print_exc()
-        except RoboflowAPITimeoutError:
+        except RoboflowAPITimeoutError as error:
+            logger.error("%s: %s", type(error).__name__, error)
             resp = JSONResponse(
                 status_code=504,
                 content={
@@ -451,6 +472,7 @@ def with_route_exceptions(route):
             )
             traceback.print_exc()
         except StepExecutionError as error:
+            logger.error("%s: %s", type(error).__name__, error)
             content = WorkflowErrorResponse(
                 message=str(error.public_message),
                 error_type=error.__class__.__name__,
@@ -470,6 +492,7 @@ def with_route_exceptions(route):
             )
             traceback.print_exc()
         except WorkflowError as error:
+            logger.error("%s: %s", type(error).__name__, error)
             resp = JSONResponse(
                 status_code=500,
                 content={
@@ -485,6 +508,7 @@ def with_route_exceptions(route):
             ProcessesManagerClientError,
             CommunicationProtocolError,
         ) as error:
+            logger.error("%s: %s", type(error).__name__, error)
             resp = JSONResponse(
                 status_code=500,
                 content={
@@ -494,7 +518,8 @@ def with_route_exceptions(route):
                 },
             )
             traceback.print_exc()
-        except Exception:
+        except Exception as error:
+            logger.error("%s: %s", type(error).__name__, error)
             resp = JSONResponse(status_code=500, content={"message": "Internal error."})
             traceback.print_exc()
         return resp

--- a/inference/core/version.py
+++ b/inference/core/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.44.0"
+__version__ = "0.44.1rc1"
 
 
 if __name__ == "__main__":

--- a/inference/core/version.py
+++ b/inference/core/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.44.1rc3"
+__version__ = "0.44.1"
 
 
 if __name__ == "__main__":

--- a/inference/core/version.py
+++ b/inference/core/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.44.1rc1"
+__version__ = "0.44.1rc2"
 
 
 if __name__ == "__main__":

--- a/inference/core/version.py
+++ b/inference/core/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.44.1rc2"
+__version__ = "0.44.1rc3"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

Versionless models pass non-numeric `version_id` as part of route path, hence are not handled by [legacy routes](https://github.com/roboflow/inference/blob/main/inference/core/interfaces/http/http_api.py#L2208)

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

CI passing
http://127.0.0.1:9001 manually tested and confirmed to work

## Any specific deployment considerations

N/A

## Docs

N/A