### PR TITLE
Update RF-DETR docs

### DIFF
--- a/docs/fine-tuned/rfdetr.md
+++ b/docs/fine-tuned/rfdetr.md
@@ -1,4 +1,15 @@
-RF-DETR is Roboflow's new Real-Time SOTA Object Detector.
+[RF-DETR](https://blog.roboflow.com/rf-detr/) is a real-time object detection transformer-based architecture designed to transfer well to both a wide variety of domains and to datasets big and small.
+
+RF-DETR is the first real-time model to exceed 60 AP on the Microsoft COCO benchmark alongside competitive performance at base sizes. It also achieves state-of-the-art performance on RF100-VL, an object detection benchmark that measures model domain adaptability to real world problems. RF-DETR is comparable speed to current real-time objection models.
+
+![](https://media.roboflow.com/rf-detr/charts.png)
+
+The model comes in two variants:
+
+- RF-DETR Base, which has 29M parameters, and;
+- RF-DETR Large, which has 129M parameters.
+
+The RF-DETR source code and COCO checkpoint weights is available under an Apache 2.0 license.
 
 ## Supported Model Types
 
@@ -8,11 +19,15 @@ You can deploy the following RF-DETR model types with Inference:
 
 ## Model Overview
 
-- [Read More About RF-DETR](https://blog.roboflow.com/rf-detr/)
+- [RF-DETR background and architecture overview](https://blog.roboflow.com/rf-detr/)
+- [Train an RF-DETR model on a custom dataset](https://blog.roboflow.com/train-rf-detr-on-a-custom-dataset/)
+- [Train and deploy an RF-DETR model on Roboflow](https://blog.roboflow.com/train-deploy-rf-detr/)
 
 ## Usage Example
 
-```
+You can use RF-DETR with the following code:
+
+```python
 import os
 import supervision as sv
 from inference import get_model
@@ -59,6 +74,10 @@ sv.plot_image(annotated_image)
 
 annotated_image.save("annotated_image_large.jpg")
 ```
+
+
+
+If you have [fine-tuned an RF-DETR model on Roboflow](https://blog.roboflow.com/train-deploy-rf-detr/), you can deploy it by replacing the `rfdetr-base` model ID in the `get_model()` function call above with the ID of your trained model on Roboflow. This model ID will look like `model-name/1`, where `model-name` is the name of the model and `1` is your model version. [Learn how to find your model ID](https://docs.roboflow.com/api-reference/workspace-and-project-ids)
 
 ## License
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -89,6 +89,7 @@ nav:
       - Predict on a Video, Webcam or RTSP Stream: quickstart/run_model_on_rtsp_webcam.md
       - 'Fine-Tuned Models':
           - quickstart/explore_models.md
+          - RF-DETR: fine-tuned/rfdetr.md
           - YOLOv11: fine-tuned/yolov11.md
           - YOLOv10: fine-tuned/yolov10.md
           - YOLOv9: fine-tuned/yolov9.md


### PR DESCRIPTION
# Description

This PR expands the RF-DETR documentation with a more detailed description of the model, links to new content, and more context around the code snippet.

This PR also adds the RF-DETR docs to the mkdocs table of contents.

## Type of change

- [X] Documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

You can test this change by building the documentation and checking the `fine-tuned/rfdetr` page.

## Any specific deployment considerations

N/A

## Docs

N/A
