### PR TITLE
Cover center/bootom_left/bootom_right/top_left/top_right in property definition block

### DIFF
--- a/inference/core/workflows/core_steps/common/query_language/operations/detections/base.py
+++ b/inference/core/workflows/core_steps/common/query_language/operations/detections/base.py
@@ -36,6 +36,36 @@ PROPERTIES_EXTRACTORS = {
     DetectionsProperty.Y_MAX: lambda detections: detections.xyxy[:, 3].tolist(),
     DetectionsProperty.CLASS_ID: lambda detections: detections.class_id.tolist(),
     DetectionsProperty.SIZE: lambda detections: detections.box_area.tolist(),
+    DetectionsProperty.CENTER: lambda detections: detections.get_anchors_coordinates(
+        anchor=Position.CENTER
+    )
+    .round()
+    .astype(int)
+    .tolist(),
+    DetectionsProperty.TOP_LEFT: lambda detections: detections.get_anchors_coordinates(
+        anchor=Position.TOP_LEFT
+    )
+    .round()
+    .astype(int)
+    .tolist(),
+    DetectionsProperty.TOP_RIGHT: lambda detections: detections.get_anchors_coordinates(
+        anchor=Position.TOP_RIGHT
+    )
+    .round()
+    .astype(int)
+    .tolist(),
+    DetectionsProperty.BOTTOM_LEFT: lambda detections: detections.get_anchors_coordinates(
+        anchor=Position.BOTTOM_LEFT
+    )
+    .round()
+    .astype(int)
+    .tolist(),
+    DetectionsProperty.BOTTOM_RIGHT: lambda detections: detections.get_anchors_coordinates(
+        anchor=Position.BOTTOM_RIGHT
+    )
+    .round()
+    .astype(int)
+    .tolist(),
 }
 
 


### PR DESCRIPTION
# Description

Property definition block in UI lists `Center`, `Bottom Left`, `Bottom Right`, `Top Left`, `Top Right` in drop-down for `Extract Property`. Selecting any of these was resulting in error.

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

CI passing

## Any specific deployment considerations

N/A

## Docs

N/A
