### PR TITLE
Extend PropertyDefinition block to expose ExtractFrameMetadata operation

### DIFF
--- a/inference/core/interfaces/camera/entities.py
+++ b/inference/core/interfaces/camera/entities.py
@@ -78,6 +78,7 @@ class SourceProperties:
     is_file: bool
     fps: float
     is_reconnectable: Optional[bool] = None
+    timestamp_created: Optional[datetime] = None
 
 
 class VideoFrameProducer:

--- a/inference/core/interfaces/camera/video_source.py
+++ b/inference/core/interfaces/camera/video_source.py
@@ -860,7 +860,9 @@ class VideoConsumer:
             self._timestamp_created = source_properties.timestamp_created
 
         if self._timestamp_created:
-            frame_timestamp = self._timestamp_created + timedelta(seconds=self._frame_counter / self._declared_source_fps)
+            frame_timestamp = self._timestamp_created + timedelta(
+                seconds=self._frame_counter / self._declared_source_fps
+            )
         else:
             frame_timestamp = datetime.now()
 

--- a/inference/core/interfaces/camera/video_source.py
+++ b/inference/core/interfaces/camera/video_source.py
@@ -1,7 +1,8 @@
+import os
 import random
 import time
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timedelta
 from enum import Enum
 from queue import Empty, Queue
 from threading import Event, Lock, Thread
@@ -134,6 +135,7 @@ def lock_state_transition(
 
 class CV2VideoFrameProducer(VideoFrameProducer):
     def __init__(self, video: Union[str, int]):
+        self._source_ref = video
         if _consumes_camera_on_jetson(video=video):
             self.stream = cv2.VideoCapture(video, cv2.CAP_V4L2)
         else:
@@ -158,12 +160,20 @@ class CV2VideoFrameProducer(VideoFrameProducer):
         height = int(self.stream.get(cv2.CAP_PROP_FRAME_HEIGHT))
         fps = self.stream.get(cv2.CAP_PROP_FPS)
         total_frames = int(self.stream.get(cv2.CAP_PROP_FRAME_COUNT))
+        is_file = total_frames > 0
+        timestamp_created = None
+        if is_file:
+            file_length_seconds = total_frames / fps
+            last_modified = datetime.fromtimestamp(os.path.getmtime(self._source_ref))
+            timestamp_created = last_modified - timedelta(seconds=file_length_seconds)
+
         return SourceProperties(
             width=width,
             height=height,
             total_frames=total_frames,
-            is_file=total_frames > 0,
+            is_file=is_file,
             fps=fps,
+            timestamp_created=timestamp_created,
         )
 
     def release(self):
@@ -809,6 +819,7 @@ class VideoConsumer:
         self._desired_fps = desired_fps
         self._declared_source_fps = None
         self._is_source_video_file = None
+        self._timestamp_created: Optional[datetime] = None
         self._status_update_handlers = status_update_handlers
         self._next_frame_from_video_to_accept = 1
 
@@ -846,7 +857,13 @@ class VideoConsumer:
             source_properties = video.discover_source_properties()
             self._is_source_video_file = source_properties.is_file
             self._declared_source_fps = source_properties.fps
-        frame_timestamp = datetime.now()
+            self._timestamp_created = source_properties.timestamp_created
+
+        if self._timestamp_created:
+            frame_timestamp = self._timestamp_created + timedelta(seconds=self._frame_counter / self._declared_source_fps)
+        else:
+            frame_timestamp = datetime.now()
+
         success = video.grab()
         self._stream_consumption_pace_monitor.tick()
         if not success:

--- a/inference/core/interfaces/camera/video_source.py
+++ b/inference/core/interfaces/camera/video_source.py
@@ -160,7 +160,7 @@ class CV2VideoFrameProducer(VideoFrameProducer):
         height = int(self.stream.get(cv2.CAP_PROP_FRAME_HEIGHT))
         fps = self.stream.get(cv2.CAP_PROP_FPS)
         total_frames = int(self.stream.get(cv2.CAP_PROP_FRAME_COUNT))
-        is_file = total_frames > 0
+        is_file = total_frames > 0 and os.path.exists(self._source_ref)
         timestamp_created = None
         if is_file:
             file_length_seconds = total_frames / fps

--- a/inference/core/version.py
+++ b/inference/core/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.45.0"
+__version__ = "0.45.1"
 
 
 if __name__ == "__main__":

--- a/inference/core/workflows/core_steps/common/query_language/entities/enums.py
+++ b/inference/core/workflows/core_steps/common/query_language/entities/enums.py
@@ -103,6 +103,11 @@ class ImageProperty(Enum):
     ASPECT_RATIO = "aspect_ratio"
 
 
+class FrameMetadataProperty(Enum):
+    FRAME_NUMBER = "frame_number"
+    FRAME_TIMESTAMP = "frame_timestamp"
+
+
 class DetectionsSelectionMode(Enum):
     LEFT_MOST = "left_most"
     RIGHT_MOST = "right_most"

--- a/inference/core/workflows/core_steps/common/query_language/entities/operations.py
+++ b/inference/core/workflows/core_steps/common/query_language/entities/operations.py
@@ -8,6 +8,7 @@ from inference.core.workflows.core_steps.common.query_language.entities.enums im
     DetectionsProperty,
     DetectionsSelectionMode,
     DetectionsSortProperties,
+    FrameMetadataProperty,
     ImageProperty,
     NumberCastingMode,
     SequenceAggregationFunction,
@@ -395,6 +396,18 @@ class ExtractImageProperty(OperationDefinition):
     property_name: ImageProperty
 
 
+class ExtractFrameMetadata(OperationDefinition):
+    model_config = ConfigDict(
+        json_schema_extra={
+            "description": "Extracts specific property of frame (frame number, timestamp)",
+            "input_kind": [IMAGE_KIND],
+            "output_kind": [INTEGER_KIND],
+        },
+    )
+    type: Literal["ExtractFrameMetadata"]
+    property_name: FrameMetadataProperty
+
+
 class ConvertImageToJPEG(OperationDefinition):
     model_config = ConfigDict(
         json_schema_extra={
@@ -595,6 +608,7 @@ AllOperationsType = Annotated[
         RandomNumber,
         StringMatches,
         ExtractImageProperty,
+        ExtractFrameMetadata,
         SequenceLength,
         SequenceElementsCount,
         Multiply,

--- a/inference/core/workflows/core_steps/common/query_language/operations/core.py
+++ b/inference/core/workflows/core_steps/common/query_language/operations/core.py
@@ -47,6 +47,9 @@ from inference.core.workflows.core_steps.common.query_language.operations.images
     encode_image_to_jpeg,
     extract_image_property,
 )
+from inference.core.workflows.core_steps.common.query_language.operations.frame_metadata.base import (
+    extract_frame_metadata,
+)
 from inference.core.workflows.core_steps.common.query_language.operations.numbers.base import (
     divide,
     multiply,
@@ -192,6 +195,7 @@ REGISTERED_SIMPLE_OPERATIONS = {
     "SequenceLength": get_sequence_length,
     "SequenceElementsCount": get_sequence_elements_count,
     "ExtractImageProperty": extract_image_property,
+    "ExtractFrameMetadata": extract_frame_metadata,
     "Multiply": multiply,
     "Divide": divide,
     "DetectionsSelection": select_detections,

--- a/inference/core/workflows/core_steps/common/query_language/operations/core.py
+++ b/inference/core/workflows/core_steps/common/query_language/operations/core.py
@@ -38,6 +38,9 @@ from inference.core.workflows.core_steps.common.query_language.operations.detect
 from inference.core.workflows.core_steps.common.query_language.operations.dictionaries.base import (
     dictionary_to_json,
 )
+from inference.core.workflows.core_steps.common.query_language.operations.frame_metadata.base import (
+    extract_frame_metadata,
+)
 from inference.core.workflows.core_steps.common.query_language.operations.generic.base import (
     apply_lookup,
     generate_random_number,
@@ -46,9 +49,6 @@ from inference.core.workflows.core_steps.common.query_language.operations.images
     encode_image_to_base64,
     encode_image_to_jpeg,
     extract_image_property,
-)
-from inference.core.workflows.core_steps.common.query_language.operations.frame_metadata.base import (
-    extract_frame_metadata,
 )
 from inference.core.workflows.core_steps.common.query_language.operations.numbers.base import (
     divide,

--- a/inference/core/workflows/core_steps/common/query_language/operations/frame_metadata/base.py
+++ b/inference/core/workflows/core_steps/common/query_language/operations/frame_metadata/base.py
@@ -1,0 +1,39 @@
+from typing import Any
+
+from inference.core.workflows.core_steps.common.query_language.entities.enums import (
+    FrameMetadataProperty,
+)
+from inference.core.workflows.core_steps.common.query_language.errors import (
+    InvalidInputTypeError,
+    OperationError,
+)
+from inference.core.workflows.core_steps.common.query_language.operations.utils import (
+    safe_stringify,
+)
+from inference.core.workflows.execution_engine.entities.base import WorkflowImageData
+
+PROPERTY_EXTRACTORS = {
+    FrameMetadataProperty.FRAME_NUMBER: lambda image: image.video_metadata.frame_number,
+    FrameMetadataProperty.FRAME_TIMESTAMP: lambda image: image.video_metadata.frame_timestamp,
+}
+
+
+def extract_frame_metadata(
+    value: Any, property_name: FrameMetadataProperty, execution_context: str, **kwargs
+):
+    if not isinstance(value, WorkflowImageData):
+        value_as_str = safe_stringify(value=value)
+        raise InvalidInputTypeError(
+            public_message=f"Executing extract_frame_metadata(...) in context {execution_context}, "
+            f"expected WorkflowImageData object as value, got {value_as_str} of type {type(value)}",
+            context=f"step_execution | roboflow_query_language_evaluation | {execution_context}",
+        )
+    try:
+        return PROPERTY_EXTRACTORS[property_name](value)
+    except Exception as e:
+        raise OperationError(
+            public_message=f"While Using operation extract_frame_metadata(...) in context {execution_context} "
+            f"encountered error: {e}",
+            context=f"step_execution | roboflow_query_language_evaluation | {execution_context}",
+            inner_error=e,
+        )

--- a/inference/usage_tracking/__init__.py
+++ b/inference/usage_tracking/__init__.py
@@ -1,5 +1,5 @@
 """
 Inference utilizes Roboflow's cloud services and requires telemetry during deployment.
-Customers with an offline deployment can turn the telemetry off by setting TELEMETRY_OPT_OUT environment variable to True.
+Telemetry is automatically turned on if Roboflow API key is provided.
 For more information please consult our licensing page [roboflow.com/licensing] or contact sales [roboflow.com/sales].
 """

--- a/inference/usage_tracking/collector.py
+++ b/inference/usage_tracking/collector.py
@@ -408,8 +408,6 @@ class UsageCollector:
     ):
         if not api_key:
             return
-        if self._settings.opt_out and not api_key:
-            return
         self.record_system_info()
         self.record_resource_details(
             category=category,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,13 @@
 import os
 
-os.environ["TELEMETRY_OPT_OUT"] = "True"
+import pytest
+
+
+ASSETS_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "inference", "unit_tests", "core", "interfaces", "assets"))
+
 os.environ["ONNXRUNTIME_EXECUTION_PROVIDERS"] = "[CUDAExecutionProvider,CPUExecutionProvider]"
+
+
+@pytest.fixture
+def local_video_path() -> str:
+    return os.path.join(ASSETS_DIR, "example_video.mp4")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ import pytest
 
 ASSETS_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "inference", "unit_tests", "core", "interfaces", "assets"))
 
+os.environ["TELEMETRY_OPT_OUT"] = "True"
 os.environ["ONNXRUNTIME_EXECUTION_PROVIDERS"] = "[CUDAExecutionProvider,CPUExecutionProvider]"
 
 

--- a/tests/inference/unit_tests/core/interfaces/camera/test_video_source.py
+++ b/tests/inference/unit_tests/core/interfaces/camera/test_video_source.py
@@ -1352,7 +1352,6 @@ def test_source_properties_initialized_on_video_source_using_string_values(
 ) -> None:
     mock_video = MagicMock()
     mock_video.retrieve.return_value = (False, None)
-    mock_video.get.return_value = 0  # Simulate stream
     mock_video_capture.return_value = mock_video
 
     # given

--- a/tests/inference/unit_tests/core/interfaces/camera/test_video_source.py
+++ b/tests/inference/unit_tests/core/interfaces/camera/test_video_source.py
@@ -65,7 +65,7 @@ def test_get_from_queue_when_non_empty_queue_given_and_purge_disabled() -> None:
 
     # then
     assert (
-        result is 1
+        result == 1
     ), "As a result of non-empty queue purge - last inserted value should be returned"
     assert (
         queue.empty() is False
@@ -84,7 +84,7 @@ def test_get_from_queue_when_non_empty_queue_given_and_purge_enabled() -> None:
 
     # then
     assert (
-        result is 3
+        result == 3
     ), "As a result of non-empty queue purge - last inserted value should be returned"
     assert (
         queue.empty() is True
@@ -228,6 +228,10 @@ def test_pausing_video_stream(local_video_path: str) -> None:
     try:
         # when
         source.start()
+        source.read_frame()
+        source.pause()
+        source._video_consumer._timestamp_created = None  # simulate stream
+        source.resume()
         last_frame_before_resume = source.read_frame()
         source.pause()
         time.sleep(pause_resume_delay)
@@ -246,6 +250,36 @@ def test_pausing_video_stream(local_video_path: str) -> None:
             first_frame_after_resume.frame_timestamp
             - last_frame_before_resume.frame_timestamp
         ).total_seconds() >= pause_resume_delay, "Between first frame decoded after resume and last before pause must a break - at least as long as in between of .pause() and .resume() operations"
+    finally:
+        tear_down_source(source=source)
+
+
+@pytest.mark.timeout(90)
+@pytest.mark.slow
+def test_pausing_video_file(local_video_path: str) -> None:
+    # given
+    source = VideoSource.init(video_reference=local_video_path)
+    pause_resume_delay = 0.2
+
+    try:
+        # when
+        source.start()
+        last_frame_before_resume = source.read_frame()
+        source.pause()
+        time.sleep(pause_resume_delay)
+        source.resume()
+
+        while True:
+            frame = source.read_frame()
+            if frame.frame_id != last_frame_before_resume.frame_id:
+                first_frame_after_resume = frame
+                break
+            last_frame_before_resume = frame
+
+        # then
+        assert (
+            first_frame_after_resume.frame_id - last_frame_before_resume.frame_id
+        ) == 1, "Pausing and resuming video file must not result in missing frames"
     finally:
         tear_down_source(source=source)
 
@@ -288,6 +322,10 @@ def test_restart_paused_stream_for_video_preserves_frames_continuity(
     try:
         # when
         source.start()
+        source.read_frame()
+        source.pause()
+        source._video_consumer._timestamp_created = None  # simulate stream
+        source.resume()
         frame = source.read_frame()
         last_id_before_restart = frame.frame_id
         capture_thread.start()
@@ -328,6 +366,10 @@ def test_restart_muted_stream_completes_successfully(local_video_path: str) -> N
     try:
         # when
         source.start()
+        source.read_frame()
+        source.pause()
+        source._video_consumer._timestamp_created = None  # simulate stream
+        source.resume()
         _ = source.read_frame()
         capture_thread.start()
         source.mute()
@@ -364,6 +406,10 @@ def test_restart_running_stream_preserves_frame_id_continuity(
     try:
         # when
         source.start()
+        source.read_frame()
+        source.pause()
+        source._video_consumer._timestamp_created = None  # simulate stream
+        source.resume()
         frame = source.read_frame()
         last_id_before_restart = frame.frame_id
         capture_thread.start()
@@ -779,6 +825,7 @@ def test_stream_consumption_when_frame_cannot_be_grabbed() -> None:
     video = MagicMock()
     video.grab.return_value = False
     source_properties = assembly_dummy_source_properties(is_file=True, fps=16.0)
+    video.discover_source_properties.return_value = source_properties
     buffer = Queue()
 
     # when
@@ -811,6 +858,7 @@ def test_stream_consumption_when_buffering_not_allowed() -> None:
     video = MagicMock()
     video.grab.return_value = True
     source_properties = assembly_dummy_source_properties(is_file=True, fps=16.0)
+    video.discover_source_properties.return_value = source_properties
     buffer = Queue()
 
     # when
@@ -848,6 +896,7 @@ def test_stream_consumption_when_buffer_is_ready_to_accept_frame_but_decoding_fa
     video.grab.return_value = True
     video.retrieve.return_value = (False, None)
     source_properties = assembly_dummy_source_properties(is_file=True, fps=16.0)
+    video.discover_source_properties.return_value = source_properties
     buffer = Queue()
 
     # when
@@ -886,6 +935,7 @@ def test_stream_consumption_when_buffer_is_ready_to_accept_frame_and_decoding_su
     image = np.zeros((128, 128, 3), dtype=np.uint8)
     video.retrieve.return_value = (True, image)
     source_properties = assembly_dummy_source_properties(is_file=True, fps=16.0)
+    video.discover_source_properties.return_value = source_properties
     buffer = Queue()
     buffer.put(VideoFrame(image=image, frame_timestamp=datetime.now(), frame_id=-2))
 
@@ -928,6 +978,7 @@ def test_stream_consumption_when_buffer_full_and_latest_frames_to_be_dropped() -
     image = np.zeros((128, 128, 3), dtype=np.uint8)
     video.retrieve.return_value = (True, image)
     source_properties = assembly_dummy_source_properties(is_file=True, fps=16.0)
+    video.discover_source_properties.return_value = source_properties
     buffer = Queue(maxsize=1)
     buffer.put(VideoFrame(image=image, frame_timestamp=datetime.now(), frame_id=-2))
 
@@ -963,6 +1014,7 @@ def test_stream_consumption_when_buffer_full_and_oldest_frames_to_be_dropped() -
     image = np.zeros((128, 128, 3), dtype=np.uint8)
     video.retrieve.return_value = (True, image)
     source_properties = assembly_dummy_source_properties(is_file=True, fps=16.0)
+    video.discover_source_properties.return_value = source_properties
     buffer = Queue(maxsize=2)
     buffer.put(VideoFrame(image=image, frame_timestamp=datetime.now(), frame_id=-2))
     buffer.put(VideoFrame(image=image, frame_timestamp=datetime.now(), frame_id=-1))
@@ -1011,6 +1063,7 @@ def test_stream_consumption_when_adaptive_strategy_does_not_prevent_decoding_due
     image = np.zeros((128, 128, 3), dtype=np.uint8)
     video.retrieve.return_value = (True, image)
     source_properties = assembly_dummy_source_properties(is_file=True, fps=16.0)
+    video.discover_source_properties.return_value = source_properties
     buffer = Queue(maxsize=2)
     buffer.put(VideoFrame(image=image, frame_timestamp=datetime.now(), frame_id=-2))
     buffer.put(VideoFrame(image=image, frame_timestamp=datetime.now(), frame_id=-1))
@@ -1060,6 +1113,7 @@ def test_stream_consumption_when_adaptive_strategy_eventually_stops_preventing_d
     image = np.zeros((128, 128, 3), dtype=np.uint8)
     video.retrieve.return_value = (True, image)
     source_properties = assembly_dummy_source_properties(is_file=True, fps=200)
+    video.discover_source_properties.return_value = source_properties
     buffer = Queue(maxsize=2)
     buffer.put(VideoFrame(image=image, frame_timestamp=datetime.now(), frame_id=-2))
     buffer.put(VideoFrame(image=image, frame_timestamp=datetime.now(), frame_id=-1))
@@ -1133,6 +1187,7 @@ def test_stream_consumption_when_adaptive_strategy_is_disabled_as_announced_fps_
     image = np.zeros((128, 128, 3), dtype=np.uint8)
     video.retrieve.return_value = (True, image)
     source_properties = assembly_dummy_source_properties(is_file=True, fps=200)
+    video.discover_source_properties.return_value = source_properties
     buffer = Queue(maxsize=2)
     buffer.put(VideoFrame(image=image, frame_timestamp=datetime.now(), frame_id=-2))
     buffer.put(VideoFrame(image=image, frame_timestamp=datetime.now(), frame_id=-1))
@@ -1207,6 +1262,7 @@ def test_stream_consumption_when_adaptive_strategy_drops_frames_due_to_reader_la
     image = np.zeros((128, 128, 3), dtype=np.uint8)
     video.retrieve.return_value = (True, image)
     source_properties = assembly_dummy_source_properties(is_file=True, fps=100)
+    video.discover_source_properties.return_value = source_properties
     buffer = Queue()
 
     # when
@@ -1296,6 +1352,7 @@ def test_source_properties_initialized_on_video_source_using_string_values(
 ) -> None:
     mock_video = MagicMock()
     mock_video.retrieve.return_value = (False, None)
+    mock_video.get.return_value = 0  # Simulate stream
     mock_video_capture.return_value = mock_video
 
     # given

--- a/tests/inference/unit_tests/core/interfaces/conftest.py
+++ b/tests/inference/unit_tests/core/interfaces/conftest.py
@@ -1,15 +1,7 @@
-import os.path
 import tempfile
 from typing import Generator
 
 import pytest
-
-ASSETS_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "assets"))
-
-
-@pytest.fixture
-def local_video_path() -> str:
-    return os.path.join(ASSETS_DIR, "example_video.mp4")
 
 
 @pytest.fixture(scope="function")

--- a/tests/inference/unit_tests/usage_tracking/test_collector.py
+++ b/tests/inference/unit_tests/usage_tracking/test_collector.py
@@ -928,12 +928,15 @@ def test_record_malformed_usage():
     )
 
     # then
-    assert "fake" in collector._usage
-    assert "model:None" in collector._usage["fake"]
-    assert collector._usage["fake"]["model:None"]["processed_frames"] == 0
-    assert collector._usage["fake"]["model:None"]["fps"] == 0
-    assert collector._usage["fake"]["model:None"]["source_duration"] == 0
-    assert collector._usage["fake"]["model:None"]["category"] == "model"
-    assert collector._usage["fake"]["model:None"]["resource_id"] == None
-    assert collector._usage["fake"]["model:None"]["resource_details"] == "{}"
-    assert collector._usage["fake"]["model:None"]["api_key_hash"] == "fake"
+    hashed_api_key = hashlib.sha256("fake".encode()).hexdigest()[:5]
+    assert hashed_api_key in collector._usage
+    assert "model:None" in collector._usage[hashed_api_key]
+    assert collector._usage[hashed_api_key]["model:None"]["processed_frames"] == 0
+    assert collector._usage[hashed_api_key]["model:None"]["fps"] == 0
+    assert collector._usage[hashed_api_key]["model:None"]["source_duration"] == 0
+    assert collector._usage[hashed_api_key]["model:None"]["category"] == "model"
+    assert collector._usage[hashed_api_key]["model:None"]["resource_id"] == None
+    assert collector._usage[hashed_api_key]["model:None"]["resource_details"] == "{}"
+    assert (
+        collector._usage[hashed_api_key]["model:None"]["api_key_hash"] == hashed_api_key
+    )

--- a/tests/inference/unit_tests/usage_tracking/test_collector.py
+++ b/tests/inference/unit_tests/usage_tracking/test_collector.py
@@ -928,15 +928,15 @@ def test_record_malformed_usage():
     )
 
     # then
-    hashed_api_key = hashlib.sha256("fake".encode()).hexdigest()[:5]
-    assert hashed_api_key in collector._usage
-    assert "model:None" in collector._usage[hashed_api_key]
-    assert collector._usage[hashed_api_key]["model:None"]["processed_frames"] == 0
-    assert collector._usage[hashed_api_key]["model:None"]["fps"] == 0
-    assert collector._usage[hashed_api_key]["model:None"]["source_duration"] == 0
-    assert collector._usage[hashed_api_key]["model:None"]["category"] == "model"
-    assert collector._usage[hashed_api_key]["model:None"]["resource_id"] == None
-    assert collector._usage[hashed_api_key]["model:None"]["resource_details"] == "{}"
+    api_key = "fake"
+    assert api_key in collector._usage
+    assert "model:None" in collector._usage[api_key]
+    assert collector._usage[api_key]["model:None"]["processed_frames"] == 0
+    assert collector._usage[api_key]["model:None"]["fps"] == 0
+    assert collector._usage[api_key]["model:None"]["source_duration"] == 0
+    assert collector._usage[api_key]["model:None"]["category"] == "model"
+    assert collector._usage[api_key]["model:None"]["resource_id"] == None
+    assert collector._usage[api_key]["model:None"]["resource_details"] == "{}"
     assert (
-        collector._usage[hashed_api_key]["model:None"]["api_key_hash"] == hashed_api_key
+        collector._usage[api_key]["model:None"]["api_key_hash"] == api_key
     )

--- a/tests/workflows/integration_tests/execution/test_workflow_with_property_extraction.py
+++ b/tests/workflows/integration_tests/execution/test_workflow_with_property_extraction.py
@@ -894,6 +894,7 @@ def test_workflow_with_timestamp_extraction_from_photo(
     assert len(result) == 1, "Expected 1 element in the output for one input image"
     assert set(result[0].keys()) == {
         "frame_timestamp",
+        "frame_number",
     }, "Expected all declared outputs to be delivered"
 
 

--- a/tests/workflows/integration_tests/execution/test_workflow_with_property_extraction.py
+++ b/tests/workflows/integration_tests/execution/test_workflow_with_property_extraction.py
@@ -1,7 +1,15 @@
+import datetime
+import os
+
+import cv2 as cv
 import numpy as np
 import pytest
 
 from inference.core.env import WORKFLOWS_MAX_CONCURRENT_STEPS
+from inference.core.interfaces.stream.inference_pipeline import InferencePipeline
+from inference.core.interfaces.stream.watchdog import BasePipelineWatchDog
+from inference.core.interfaces.camera.video_source import VideoSource
+from inference.core.interfaces.stream.entities import VideoFrame
 from inference.core.managers.base import ModelManager
 from inference.core.workflows.core_steps.common.entities import StepExecutionMode
 from inference.core.workflows.errors import StepOutputLineageError
@@ -775,3 +783,164 @@ def test_workflow_with_aspect_ratio_extraction_with_valid_input(
         "aspect_ratio",
     }, "Expected all declared outputs to be delivered"
     assert result[0]["aspect_ratio"] == 1.5, "Expected aspect ratio to be 1.5"
+
+
+WORKFLOW_WITH_FRAME_NUMBER_EXTRACTION = {
+    "version": "1.0",
+    "inputs": [{"type": "WorkflowImage", "name": "image"}],
+    "steps": [
+        {
+            "type": "PropertyDefinition",
+            "name": "property_extraction",
+            "data": "$inputs.image",
+            "operations": [
+                {"type": "ExtractFrameMetadata", "property_name": "frame_number"}
+            ],
+        },
+    ],
+    "outputs": [
+        {
+            "type": "JsonField",
+            "name": "frame_number",
+            "selector": "$steps.property_extraction.output",
+        },
+    ],
+}
+
+
+def test_workflow_with_frame_number_extraction_from_photo(
+    license_plate_image: np.ndarray,
+) -> None:
+    # given
+    workflow_init_parameters = {
+        "workflows_core.api_key": None,
+        "workflows_core.step_execution_mode": StepExecutionMode.LOCAL,
+    }
+    execution_engine = ExecutionEngine.init(
+        workflow_definition=WORKFLOW_WITH_FRAME_NUMBER_EXTRACTION,
+        init_parameters=workflow_init_parameters,
+        max_concurrent_steps=WORKFLOWS_MAX_CONCURRENT_STEPS,
+    )
+
+    # when
+    result = execution_engine.run(runtime_parameters={"image": license_plate_image})
+
+    # then
+    assert isinstance(result, list), "Expected list to be delivered"
+    assert len(result) == 1, "Expected 1 element in the output for one input image"
+    assert set(result[0].keys()) == {
+        "frame_number",
+    }, "Expected all declared outputs to be delivered"
+    assert result[0]["frame_number"] == 0, "Expected frame number to be 0 (for photos there is always only one frame)"
+
+
+WORKFLOW_WITH_FRAME_TIMESTAMP_EXTRACTION = {
+    "version": "1.0",
+    "inputs": [{"type": "WorkflowImage", "name": "image"}],
+    "steps": [
+        {
+            "type": "PropertyDefinition",
+            "name": "frame_timestamp",
+            "data": "$inputs.image",
+            "operations": [
+                {"type": "ExtractFrameMetadata", "property_name": "frame_timestamp"}
+            ],
+        },
+        {
+            "type": "PropertyDefinition",
+            "name": "frame_number",
+            "data": "$inputs.image",
+            "operations": [
+                {"type": "ExtractFrameMetadata", "property_name": "frame_number"}
+            ],
+        },
+    ],
+    "outputs": [
+        {
+            "type": "JsonField",
+            "name": "frame_timestamp",
+            "selector": "$steps.frame_timestamp.output",
+        },
+        {
+            "type": "JsonField",
+            "name": "frame_number",
+            "selector": "$steps.frame_number.output",
+        },
+    ],
+}
+
+
+def test_workflow_with_timestamp_extraction_from_photo(
+    license_plate_image: np.ndarray,
+) -> None:
+    # given
+    workflow_init_parameters = {
+        "workflows_core.api_key": None,
+        "workflows_core.step_execution_mode": StepExecutionMode.LOCAL,
+    }
+    execution_engine = ExecutionEngine.init(
+        workflow_definition=WORKFLOW_WITH_FRAME_TIMESTAMP_EXTRACTION,
+        init_parameters=workflow_init_parameters,
+        max_concurrent_steps=WORKFLOWS_MAX_CONCURRENT_STEPS,
+    )
+
+    # when
+    result = execution_engine.run(runtime_parameters={"image": license_plate_image})
+
+    # then
+    assert isinstance(result, list), "Expected list to be delivered"
+    assert len(result) == 1, "Expected 1 element in the output for one input image"
+    assert set(result[0].keys()) == {
+        "frame_timestamp",
+    }, "Expected all declared outputs to be delivered"
+
+
+@pytest.mark.timeout(90)
+@pytest.mark.slow
+def test_workflow_with_timestamp_extraction_from_video(
+    local_video_path: str,
+) -> None:
+    # given
+    video_capture = cv.VideoCapture(local_video_path)
+    frames_count = int(round(video_capture.get(cv.CAP_PROP_FRAME_COUNT)))
+    fps = video_capture.get(cv.CAP_PROP_FPS)
+    video_capture.release()
+    last_modified = datetime.datetime.fromtimestamp(os.path.getmtime(local_video_path))
+    timestamp_created = last_modified - datetime.timedelta(seconds=frames_count / fps)
+
+    video_source = VideoSource.init(video_reference=local_video_path)
+    watchdog = BasePipelineWatchDog()
+    watchdog.register_video_sources(video_sources=[video_source])
+    predictions = []
+
+    def on_prediction(prediction: dict, video_frame: VideoFrame) -> None:
+        predictions.append(prediction)
+
+    workflow_init_parameters = {
+        "workflows_core.api_key": None,
+        "workflows_core.step_execution_mode": StepExecutionMode.LOCAL,
+    }
+
+    inference_pipeline = InferencePipeline.init_with_workflow(
+        workflow_specification=WORKFLOW_WITH_FRAME_TIMESTAMP_EXTRACTION,
+        workflow_init_parameters=workflow_init_parameters,
+        video_reference=local_video_path,
+        on_prediction=on_prediction,
+        max_fps=200,
+        watchdog=watchdog,
+    )
+
+    # when
+    inference_pipeline.start()
+    inference_pipeline.join()
+
+    # then
+    assert len(predictions) == frames_count
+    assert set(predictions[0].keys()) == {
+        "frame_timestamp", "frame_number"
+    }, "Expected all declared outputs to be delivered"
+    
+    for i in range(1, frames_count + 1):
+        assert predictions[i - 1]["frame_number"] == i
+        assert predictions[i - 1]["frame_timestamp"] == timestamp_created + datetime.timedelta(seconds=(i - 1) / fps)
+

--- a/tests/workflows/integration_tests/execution/test_workflow_with_property_extraction.py
+++ b/tests/workflows/integration_tests/execution/test_workflow_with_property_extraction.py
@@ -831,7 +831,9 @@ def test_workflow_with_frame_number_extraction_from_photo(
     assert set(result[0].keys()) == {
         "frame_number",
     }, "Expected all declared outputs to be delivered"
-    assert result[0]["frame_number"] == 0, "Expected frame number to be 0 (for photos there is always only one frame)"
+    assert (
+        result[0]["frame_number"] == 0
+    ), "Expected frame number to be 0 (for photos there is always only one frame)"
 
 
 WORKFLOW_WITH_FRAME_TIMESTAMP_EXTRACTION = {
@@ -937,10 +939,12 @@ def test_workflow_with_timestamp_extraction_from_video(
     # then
     assert len(predictions) == frames_count
     assert set(predictions[0].keys()) == {
-        "frame_timestamp", "frame_number"
+        "frame_timestamp",
+        "frame_number",
     }, "Expected all declared outputs to be delivered"
-    
+
     for i in range(1, frames_count + 1):
         assert predictions[i - 1]["frame_number"] == i
-        assert predictions[i - 1]["frame_timestamp"] == timestamp_created + datetime.timedelta(seconds=(i - 1) / fps)
-
+        assert predictions[i - 1][
+            "frame_timestamp"
+        ] == timestamp_created + datetime.timedelta(seconds=(i - 1) / fps)


### PR DESCRIPTION
# Description

Extend CV2VideoFrameProducer to return timestamp_created when calling discover_source_properties Extend VideoSource and VideoConsumer to pass frame timestamp related to file creation date within WorkflowImageData.video_metadata

## Type of change

-   [x] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?

CI passing
New tests introduced

## Any specific deployment considerations

N/A

## Docs

N/A