### PR TITLE
Add Moondream2

### DIFF
--- a/docs/foundation/moondream2.md
+++ b/docs/foundation/moondream2.md
@@ -1,0 +1,50 @@
+<a href="https://github.com/vikhyat/moondream" target="_blank">Moondream2</a> is a multimodal model that supports image captioning, zero-shot object detection, point-prompt detection, and visual question answering.
+
+You can deploy Moondream2 with Inference.
+
+### Installation
+
+To install inference with the extra dependencies necessary to run Moondream2, run
+
+```pip install inference[transformers]```
+
+or
+
+```pip install inference-gpu[transformers]```
+
+### How to Use Moondream2
+
+Create a new Python file called `app.py` and add the following code:
+
+```python
+from PIL import Image
+
+from inference.models.moondream2.moondream2 import Moondream2
+
+pg = Moondream2(api_key="API_KEY")
+
+image = Image.open("dog.jpeg")
+
+prompt = "How many dogs are in this image?"
+
+result = pg.query(image, prompt)
+
+print(result)
+```
+
+In this code, we load Moondream2 run Moondream2 on an image, and annotate the image with the predictions from the model.
+
+Above, replace:
+
+1. `prompt` with the prompt for the model.
+2. `image.jpeg` with the path to the image that you want to run inference on.
+
+To use Moondream2 with Inference, you will need a Roboflow API key. If you don't already have a Roboflow account, <a href="https://app.roboflow.com" target="_blank">sign up for a free Roboflow account</a>.
+
+Then, run the Python script you have created:
+
+```
+python app.py
+```
+
+The result from your model will be printed to the console.

--- a/inference/core/env.py
+++ b/inference/core/env.py
@@ -151,6 +151,8 @@ QWEN_2_5_ENABLED = str2bool(os.getenv("QWEN_2_5_ENABLED", True))
 
 SMOLVLM2_ENABLED = str2bool(os.getenv("SMOLVLM2_ENABLED", True))
 
+MOONDREAM2_ENABLED = str2bool(os.getenv("MOONDREAM2_ENABLED", True))
+
 # Flag to enable YOLO-World core model, default is True
 CORE_MODEL_YOLO_WORLD_ENABLED = str2bool(
     os.getenv("CORE_MODEL_YOLO_WORLD_ENABLED", True)

--- a/inference/core/registries/roboflow.py
+++ b/inference/core/registries/roboflow.py
@@ -54,6 +54,7 @@ GENERIC_MODELS = {
     "yolo_world": ("object-detection", "yolo-world"),
     "owlv2": ("object-detection", "owlv2"),
     "smolvlm2": ("lmm", "smolvlm-2.2b-instruct"),
+    "moondream2": ("lmm", "moondream2"),
 }
 
 STUB_VERSION_ID = "0"

--- a/inference/core/utils/roboflow.py
+++ b/inference/core/utils/roboflow.py
@@ -24,6 +24,7 @@ def get_model_id_chunks(
         "trocr",
         "yolo_world",
         "smolvlm2",
+        "moondream2"
     }:
         return dataset_id, version_id
     try:

--- a/inference/core/workflows/core_steps/loader.py
+++ b/inference/core/workflows/core_steps/loader.py
@@ -200,6 +200,9 @@ from inference.core.workflows.core_steps.models.foundation.segment_anything2.v1 
 from inference.core.workflows.core_steps.models.foundation.smolvlm.v1 import (
     SmolVLM2BlockV1,
 )
+from inference.core.workflows.core_steps.models.foundation.moondream2.v1 import (
+    Moondream2BlockV1,
+)
 from inference.core.workflows.core_steps.models.foundation.stability_ai.image_gen.v1 import (
     StabilityAIImageGenBlockV1,
 )
@@ -632,6 +635,7 @@ def load_blocks() -> List[Type[WorkflowBlock]]:
         ImageSlicerBlockV2,
         Qwen25VLBlockV1,
         SmolVLM2BlockV1,
+        Moondream2BlockV1
     ]
 
 

--- a/inference/core/workflows/core_steps/models/foundation/moondream2/v1.py
+++ b/inference/core/workflows/core_steps/models/foundation/moondream2/v1.py
@@ -1,0 +1,168 @@
+from typing import List, Literal, Optional, Type, Union
+
+from pydantic import ConfigDict, Field
+
+from inference.core.entities.requests.inference import LMMInferenceRequest
+from inference.core.managers.base import ModelManager
+from inference.core.workflows.core_steps.common.entities import StepExecutionMode
+from inference.core.workflows.execution_engine.entities.base import (
+    Batch,
+    OutputDefinition,
+    WorkflowImageData,
+)
+from inference.core.workflows.execution_engine.entities.types import (
+    DICTIONARY_KIND,
+    IMAGE_KIND,
+    ROBOFLOW_MODEL_ID_KIND,
+    ImageInputField,
+    Selector,
+)
+from inference.core.workflows.prototypes.block import (
+    BlockResult,
+    WorkflowBlock,
+    WorkflowBlockManifest,
+)
+
+
+class BlockManifest(WorkflowBlockManifest):
+    # SmolVLM needs an image and a text prompt.
+    images: Selector(kind=[IMAGE_KIND]) = ImageInputField
+    prompt: Optional[str] = Field(
+        default=None,
+        description="Optional text prompt to provide additional context to Moondream2. Otherwise it will just be None",
+        examples=["What is in this image?"],
+    )
+
+    # Standard model configuration for UI, schema, etc.
+    model_config = ConfigDict(
+        json_schema_extra={
+            "name": "Moondream2",
+            "version": "v1",
+            "short_description": "Run Moondream2 on an image.",
+            "long_description": (
+                "This workflow block runs Moondream2, a multimodal vision-language model. You can ask questions about images"
+                " -- including documents and photos -- and get answers in natural language."
+            ),
+            "license": "Apache-2.0",
+            "block_type": "model",
+            "search_keywords": [
+                "Moondream2",
+                "moondream",
+                "vision language model",
+                "VLM",
+            ],
+            "is_vlm_block": True,
+            "ui_manifest": {
+                "section": "model",
+                "icon": "fal fa-atom",
+                "blockPriority": 5.5,
+            },
+        },
+        protected_namespaces=(),
+    )
+    type: Literal["roboflow_core/moondream2@v1"]
+
+    model_version: Union[Selector(kind=[ROBOFLOW_MODEL_ID_KIND]), str] = Field(
+        default="moondream2/moondream2",
+        description="The Moondream2 model to be used for inference.",
+        examples=["moondream2/moondream2"],
+    )
+
+    @classmethod
+    def describe_outputs(cls) -> List[OutputDefinition]:
+        return [
+            OutputDefinition(
+                name="parsed_output",
+                kind=[DICTIONARY_KIND],
+                description="A parsed version of the output, provided as a dictionary containing the text.",
+            ),
+        ]
+
+    @classmethod
+    def get_parameters_accepting_batches(cls) -> List[str]:
+        # Only images can be passed in as a list/batch
+        return ["images"]
+
+    @classmethod
+    def get_execution_engine_compatibility(cls) -> Optional[str]:
+        return ">=1.3.0,<2.0.0"
+
+
+class Moondream2BlockV1(WorkflowBlock):
+    def __init__(
+        self,
+        model_manager: ModelManager,
+        api_key: Optional[str],
+        step_execution_mode: StepExecutionMode,
+    ):
+        self._model_manager = model_manager
+        self._api_key = api_key
+        self._step_execution_mode = step_execution_mode
+
+    @classmethod
+    def get_init_parameters(cls) -> List[str]:
+        return ["model_manager", "api_key", "step_execution_mode"]
+
+    @classmethod
+    def get_manifest(cls) -> Type[WorkflowBlockManifest]:
+        return BlockManifest
+
+    def run(
+        self,
+        images: Batch[WorkflowImageData],
+        model_version: str,
+        prompt: Optional[str],
+    ) -> BlockResult:
+        if self._step_execution_mode == StepExecutionMode.LOCAL:
+            return self.run_locally(
+                images=images,
+                model_version=model_version,
+                prompt=prompt,
+            )
+        elif self._step_execution_mode == StepExecutionMode.REMOTE:
+            raise NotImplementedError(
+                "Remote execution is not supported for moondream2. Please use a local or dedicated inference server."
+            )
+        else:
+            raise ValueError(
+                f"Unknown step execution mode: {self._step_execution_mode}"
+            )
+
+    def run_locally(
+        self,
+        images: Batch[WorkflowImageData],
+        model_version: str,
+        prompt: Optional[str],
+    ) -> BlockResult:
+        # Convert each image to the format required by the model.
+        inference_images = [
+            i.to_inference_format(numpy_preferred=False) for i in images
+        ]
+        # Use the provided prompt (or an empty string if None) for every image.
+        prompt = prompt or ""
+        prompts = [prompt] * len(inference_images)
+
+        # Register SmolVLM2 with the model manager.
+        self._model_manager.add_model(model_id=model_version, api_key=self._api_key)
+
+        predictions = []
+        for image, single_prompt in zip(inference_images, prompts):
+            # Build an LMMInferenceRequest with both prompt and image.
+            request = LMMInferenceRequest(
+                api_key=self._api_key,
+                model_id=model_version,
+                image=image,
+                source="workflow-execution",
+                prompt=single_prompt,
+            )
+            # Run inference.
+            prediction = self._model_manager.infer_from_request_sync(
+                model_id=model_version, request=request
+            )
+            response_text = prediction.response
+            predictions.append(
+                {
+                    "parsed_output": response_text,
+                }
+            )
+        return predictions

--- a/inference/models/README.md
+++ b/inference/models/README.md
@@ -28,6 +28,7 @@ The models supported by Roboflow Inference have their own licenses. View the lic
 | `inference/models/yolov12`        | [AGPL-3.0](https://github.com/sunsmarterjie/yolov12?tab=AGPL-3.0-1-ov-file)          | ✅ |
 | `inference/models/smolvlm2`        | [Apache 2.0](https://huggingface.co/HuggingFaceTB/SmolVLM2-2.2B-Instruct)          | 👍 |
 | `inference/models/rfdetr`         | [Apache 2.0](https://github.com/roboflow/rf-detr/blob/main/LICENSE)                  | 👍 |
+| `inference/models/moondream2`        | [Apache 2.0](https://github.com/vikhyat/moondream/blob/main/LICENSE)          | 👍 |
 
 ## Commercial Licenses
 

--- a/inference/models/__init__.py
+++ b/inference/models/__init__.py
@@ -77,6 +77,11 @@ try:
 except:
     pass
 
+try:
+    from inference.models.moondream2 import Moondream2
+except:
+    pass
+
 from inference.models.resnet import ResNetClassification
 from inference.models.rfdetr import RFDETRObjectDetection
 from inference.models.vit import VitClassification

--- a/inference/models/moondream2/LICENSE.txt
+++ b/inference/models/moondream2/LICENSE.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/inference/models/moondream2/__init__.py
+++ b/inference/models/moondream2/__init__.py
@@ -1,0 +1,1 @@
+from inference.models.moondream2.moondream2 import Moondream2

--- a/inference/models/moondream2/moondream2.py
+++ b/inference/models/moondream2/moondream2.py
@@ -1,0 +1,63 @@
+import torch
+from PIL import Image
+from transformers import AutoModelForCausalLM
+
+from inference.models.transformers import TransformerModel
+from inference.core.entities.responses.inference import (
+    InferenceResponseImage,
+    ObjectDetectionInferenceResponse,
+    ObjectDetectionPrediction,
+)
+
+class Moondream2(TransformerModel):
+    generation_includes_input = True
+    transformers_class = AutoModelForCausalLM
+    load_base_from_roboflow = True
+    version_id = None
+    default_dtype = torch.bfloat16
+    load_weights_as_transformers = True
+    endpoint = "moondream2/moondream2"
+    trust_remote_code = True
+    revision = "2025-03-27"
+
+    def __init__(self, *args, **kwargs):
+        if not "model_id" in kwargs:
+            kwargs["model_id"] = self.endpoint
+        print("Loading model from:", self.endpoint)
+        super().__init__(*args, **kwargs)
+
+    def caption(self, image_in: Image.Image, history=None, **kwargs):
+        return self.model.caption(image_in, length="normal", stream=True)["caption"]
+    
+    def query(self, image_in: Image.Image, prompt="", history=None, **kwargs):
+        return self.model.query(image_in, prompt)["answer"]
+    
+    def detect(self, image_in: Image.Image, prompt="", history=None, **kwargs):
+        return self.make_response(self.model.detect(image_in, prompt)["objects"], 
+                             image_in.size)
+    
+    def make_response(self, predictions, image_sizes):
+        responses = [
+            ObjectDetectionInferenceResponse(
+                predictions=[
+                    ObjectDetectionPrediction(
+                        # Passing args as a dictionary here since one of the args is 'class' (a protected term in Python)
+                        **{
+                            "x": pred["x"] * max(image_sizes[ind]),
+                            "y": pred["y"] * max(image_sizes[ind]),
+                            "width": pred["w"] * max(image_sizes[ind]),
+                            "height": pred["h"] * max(image_sizes[ind]),
+                            "confidence": pred["confidence"],
+                            "class": pred["class_name"],
+                            "class_id": class_names.index(pred["class_name"]),
+                        }
+                    )
+                    for pred in batch_predictions
+                ],
+                image=InferenceResponseImage(
+                    width=image_sizes[ind][0], height=image_sizes[ind][1]
+                ),
+            )
+            for ind, batch_predictions in enumerate(predictions)
+        ]
+        return responses

--- a/inference/models/transformers/transformers.py
+++ b/inference/models/transformers/transformers.py
@@ -82,6 +82,16 @@ class TransformerModel(RoboflowInferenceModel):
         else:
             model_id = self.cache_dir
 
+        if hasattr(self, "revision") and self.revision is not None:
+            revision = self.revision
+        else:
+            revision = None
+
+        if hasattr(self, "trust_remote_code") and self.trust_remote_code:
+            trust_remote_code = True
+        else:
+            trust_remote_code = False
+
         self.model = (
             self.transformers_class.from_pretrained(
                 model_id,
@@ -89,6 +99,8 @@ class TransformerModel(RoboflowInferenceModel):
                 device_map=DEVICE,
                 token=self.huggingface_token,
                 torch_dtype=self.default_dtype,
+                revision=revision,
+                trust_remote_code=trust_remote_code,
             )
             .eval()
             .to(self.dtype)

--- a/inference/models/utils.py
+++ b/inference/models/utils.py
@@ -5,6 +5,7 @@ from inference.core.env import (
     API_KEY_ENV_NAMES,
     QWEN_2_5_ENABLED,
     SMOLVLM2_ENABLED,
+    MOONDREAM2_ENABLED
 )
 from inference.core.exceptions import MissingApiKeyError
 from inference.core.models.base import Model
@@ -404,6 +405,18 @@ try:
 except:
     warnings.warn(
         f"Your `inference` configuration does not support SmolVLM2."
+        f"Use pip install 'inference[transformers]' to install missing requirements.",
+        category=ModelDependencyMissing,
+    )
+
+try:
+    if MOONDREAM2_ENABLED:
+        from inference.models.moondream2.moondream2 import Moondream2
+
+        ROBOFLOW_MODEL_TYPES[("lmm", "moondream2")] = Moondream2
+except:
+    warnings.warn(
+        f"Your `inference` configuration does not support Moondream2."
         f"Use pip install 'inference[transformers]' to install missing requirements.",
         category=ModelDependencyMissing,
     )

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -107,6 +107,7 @@ nav:
           - TrOCR (OCR): foundation/trocr.md
           - Grounding DINO (Object Detection): foundation/grounding_dino.md
           - L2CS-Net (Gaze Detection): foundation/gaze.md
+          - Moondream2: foundation/moondream2.md
           - PaliGemma: foundation/paligemma.md
           - Segment Anything (Segmentation): foundation/sam.md
           - Segment Anything 2 (Segmentation): foundation/sam2.md

--- a/requirements/requirements.transformers.txt
+++ b/requirements/requirements.transformers.txt
@@ -8,3 +8,4 @@ peft~=0.11.1
 num2words~=0.5.14
 bitsandbytes>=0.42.0,<0.46.0
 num2words~=0.5.14
+pyvips>=2.2.3


### PR DESCRIPTION
# Description

This PR adds Moondream2 to Inference and Workflows.

## Type of change

-   [X] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?

TK

## Any specific deployment considerations

Model weights will need to be uploaded to production when the PR is ready.

## Docs

A new docs page for Moondream2 is in the `foundation` folder of the docs.
