### PR TITLE
fix windows download url for florence ending up with \ in url

### DIFF
--- a/inference/models/transformers/transformers.py
+++ b/inference/models/transformers/transformers.py
@@ -279,6 +279,9 @@ class LoRATransformerModel(TransformerModel):
         )
 
     def get_lora_base_from_roboflow(self, repo, revision) -> str:
+        # Normalize potential Windows path separators in repo and revision
+        repo = repo.replace("\\", "/")
+        revision = revision.replace("\\", "/")
         base_dir = os.path.join("lora-bases", repo, revision)
         cache_dir = get_cache_dir(base_dir)
         if os.path.exists(cache_dir):


### PR DESCRIPTION
# Description

Florence model fails to load on windows.  I think because the way we construct the download url based on file path in windows including "\"

## Type of change

Please delete options that are not relevant.
-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?
not yet.  Need to test this on a windows machine!  This is purely best guess at how to fix it at this point.

## Any specific deployment considerations
n/a

## Docs
n/a
