### PR TITLE
Fix benchmark command to run with local images

### DIFF
--- a/inference_cli/lib/benchmark/dataset.py
+++ b/inference_cli/lib/benchmark/dataset.py
@@ -42,7 +42,7 @@ def load_images(
     file_paths = sorted(
         list(
             chain.from_iterable(
-                glob(os.path.join(directory, e)) for e in IMAGE_EXTENSIONS
+                glob(os.path.join(directory, f"*{e}")) for e in IMAGE_EXTENSIONS
             )
         )
     )


### PR DESCRIPTION
# Description

We had a bug in inference-cli making it impossible to benchmark from local dir.


## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

* e2e test

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
