### PR TITLE
fix url construction for get_roboflow_base_lora to be OS agnostic

### DIFF
--- a/inference/core/roboflow_api.py
+++ b/inference/core/roboflow_api.py
@@ -303,7 +303,7 @@ def get_roboflow_instant_model_data(
 def get_roboflow_base_lora(
     api_key: str, repo: str, revision: str, device_id: str
 ) -> dict:
-    full_path = os.path.join(repo, revision)
+    full_path = f"{repo.strip('/')}/{revision.strip('/')}"
     api_data_cache_key = f"roboflow_api_data:lora-bases:{full_path}"
     api_data = cache.get(api_data_cache_key)
     if api_data is not None:


### PR DESCRIPTION
# Description
the function `get_roboflow_base_lora` was using `os.path.join` to construct an `api_data_cache_key` which later was used for url / weight download purposes.  This broke on windows because it was being concatenated with `\` instead of `/`.

Since we are not dealing with filesystem here, the correct method of constructing the api cache key is to strip trailing slashes and then concatenate with `/` explicitly.

## Type of change
-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?
locally on windows machine using a workflow with fine tuned Florence2 weights

## Any specific deployment considerations
n/a 

## Docs
n/a