### PR TITLE
Fix CPU builds which are failing for no reason :)

### DIFF
--- a/docker/dockerfiles/Dockerfile.onnx.cpu
+++ b/docker/dockerfiles/Dockerfile.onnx.cpu
@@ -27,7 +27,8 @@ COPY requirements/requirements.sam.txt \
     requirements/_requirements.txt \
     ./
 
-RUN pip3 install --upgrade pip  && pip3 install \
+RUN pip3 install --upgrade pip && pip3 install "wheel>=0.45.0,<=0.45.1"
+RUN pip3 install \
     -r _requirements.txt \
     -r requirements.sam.txt \
     -r requirements.clip.txt \

--- a/docker/dockerfiles/Dockerfile.onnx.cpu.dev
+++ b/docker/dockerfiles/Dockerfile.onnx.cpu.dev
@@ -28,7 +28,8 @@ COPY requirements/requirements.sam.txt \
     requirements/_requirements.txt \
     ./
 
-RUN pip3 install --upgrade pip  && pip3 install \
+RUN pip3 install --upgrade pip && pip3 install "wheel>=0.45.0,<=0.45.1"
+RUN pip3 install \
     -r _requirements.txt \
     -r requirements.sam.txt \
     -r requirements.clip.txt \

--- a/docker/dockerfiles/Dockerfile.onnx.cpu.parallel
+++ b/docker/dockerfiles/Dockerfile.onnx.cpu.parallel
@@ -32,7 +32,8 @@ COPY requirements/requirements.sam.txt \
 
 RUN if [ "${TARGETPLATFORM}" = "linux/amd64" ]; then mv requirements.vino.txt requirements.cpu.txt; fi
 
-RUN pip3 install --upgrade pip  && pip3 install \
+RUN pip3 install --upgrade pip && pip3 install "wheel>=0.45.0,<=0.45.1"
+RUN pip3 install \
     -r _requirements.txt \
     -r requirements.sam.txt \
     -r requirements.clip.txt \

--- a/docker/dockerfiles/Dockerfile.onnx.cpu.slim
+++ b/docker/dockerfiles/Dockerfile.onnx.cpu.slim
@@ -27,7 +27,8 @@ COPY requirements/requirements.cpu.txt \
 
 RUN if [ "${TARGETPLATFORM}" = "linux/amd64" ]; then mv requirements.vino.txt requirements.cpu.txt; fi
 
-RUN pip3 install --upgrade pip  && pip3 install \
+RUN pip3 install --upgrade pip && pip3 install "wheel>=0.45.0,<=0.45.1"
+RUN pip3 install \
     -r _requirements.txt \
     -r requirements.cpu.txt \
     -r requirements.http.txt \

--- a/docker/dockerfiles/Dockerfile.onnx.cpu.stream_manager
+++ b/docker/dockerfiles/Dockerfile.onnx.cpu.stream_manager
@@ -21,7 +21,8 @@ COPY requirements/requirements.cpu.txt \
     requirements/_requirements.txt \
     ./
 
-RUN pip3 install --upgrade pip  && pip3 install \
+RUN pip3 install --upgrade pip && pip3 install "wheel>=0.45.0,<=0.45.1"
+RUN pip3 install \
     -r _requirements.txt \
     -r requirements.cpu.txt \
     -r requirements.http.txt \

--- a/inference/core/version.py
+++ b/inference/core/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.46.2"
+__version__ = "0.46.3"
 
 
 if __name__ == "__main__":

--- a/requirements/_requirements.txt
+++ b/requirements/_requirements.txt
@@ -17,7 +17,7 @@ supervision>=0.25.1,<=0.30.0
 pybase64~=1.0.0
 scikit-image>=0.19.0,<=0.25.2
 requests-toolbelt~=1.0.0
-wheel>=0.38.1,<=0.45.0
+wheel>=0.45.0,<=0.45.1
 setuptools>=70.0.0  # lack of upper-bound to ensure compatibility with Google Colab (builds to define one if needed)
 networkx>=3.0.0,<4.0.0
 pydantic>=2.8.0,<2.12.0


### PR DESCRIPTION
# Description

Some issue with `wheel` package - which now apparently must be available before pip install other packages using it.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

* build in CI

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
