### PR TITLE
drop openvino

### DIFF
--- a/inference/models/rfdetr/rfdetr.py
+++ b/inference/models/rfdetr/rfdetr.py
@@ -334,12 +334,11 @@ class RFDETRObjectDetection(ObjectDetectionBaseOnnxRoboflowInferenceModel):
             # We exclude CoreMLExecutionProvider as it is showing worse performance than CPUExecutionProvider
             providers = [
                 "CUDAExecutionProvider",
-                "OpenVINOExecutionProvider",
                 "CPUExecutionProvider",
-            ]
+            ] #"OpenVINOExecutionProvider" dropped until further investigation is done
 
             if not self.load_weights:
-                providers = ["OpenVINOExecutionProvider", "CPUExecutionProvider"]
+                providers = ["CPUExecutionProvider"] #"OpenVINOExecutionProvider" dropped until further investigation is done
 
             try:
                 session_options = onnxruntime.SessionOptions()

--- a/inference/models/rfdetr/rfdetr.py
+++ b/inference/models/rfdetr/rfdetr.py
@@ -335,10 +335,12 @@ class RFDETRObjectDetection(ObjectDetectionBaseOnnxRoboflowInferenceModel):
             providers = [
                 "CUDAExecutionProvider",
                 "CPUExecutionProvider",
-            ] #"OpenVINOExecutionProvider" dropped until further investigation is done
+            ]  # "OpenVINOExecutionProvider" dropped until further investigation is done
 
             if not self.load_weights:
-                providers = ["CPUExecutionProvider"] #"OpenVINOExecutionProvider" dropped until further investigation is done
+                providers = [
+                    "CPUExecutionProvider"
+                ]  # "OpenVINOExecutionProvider" dropped until further investigation is done
 
             try:
                 session_options = onnxruntime.SessionOptions()


### PR DESCRIPTION
# Description

Dropping OpenVINO runtime for RF-DETR until we confirm its useful.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Tested locally

## Any specific deployment considerations

No

## Docs

-   [ ] Docs updated? What were the changes: No
