### PR TITLE
Fix rf-detr to ignore predictions of background class

### DIFF
--- a/inference/core/version.py
+++ b/inference/core/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.46.5"
+__version__ = "0.46.6"
 
 
 if __name__ == "__main__":

--- a/inference/models/rfdetr/rfdetr.py
+++ b/inference/models/rfdetr/rfdetr.py
@@ -264,7 +264,6 @@ class RFDETRObjectDetection(ObjectDetectionBaseOnnxRoboflowInferenceModel):
         try:
             background_class_index = self.class_names.index(background_class_name)
         except ValueError:
-            print(f"Background class {background_class_name} not found in class_names")
             pass
 
         for batch_idx in range(batch_size):

--- a/inference/models/rfdetr/rfdetr.py
+++ b/inference/models/rfdetr/rfdetr.py
@@ -287,7 +287,7 @@ class RFDETRObjectDetection(ObjectDetectionBaseOnnxRoboflowInferenceModel):
 
                 topk_scores = topk_scores[class_filter_mask]
                 topk_labels = topk_labels[class_filter_mask]
-                topk_boxes_indices = topk_boxes_indices[class_filter_mask]
+                topk_boxes = topk_boxes[class_filter_mask]
 
             selected_boxes = bboxes[batch_idx, topk_boxes]
 

--- a/inference/models/rfdetr/rfdetr.py
+++ b/inference/models/rfdetr/rfdetr.py
@@ -259,7 +259,7 @@ class RFDETRObjectDetection(ObjectDetectionBaseOnnxRoboflowInferenceModel):
 
         processed_predictions = []
 
-        background_class_index = -1 # Default to -1 (won't match valid indices)
+        background_class_index = -1  # Default to -1 (won't match valid indices)
         background_class_name = "background_class8342"
         try:
             background_class_index = self.class_names.index(background_class_name)
@@ -283,7 +283,7 @@ class RFDETRObjectDetection(ObjectDetectionBaseOnnxRoboflowInferenceModel):
             topk_labels = sorted_indices % num_classes
 
             if background_class_index != -1:
-                class_filter_mask = (topk_labels != background_class_index)
+                class_filter_mask = topk_labels != background_class_index
 
                 topk_scores = topk_scores[class_filter_mask]
                 topk_labels = topk_labels[class_filter_mask]

--- a/inference/models/rfdetr/rfdetr.py
+++ b/inference/models/rfdetr/rfdetr.py
@@ -260,7 +260,7 @@ class RFDETRObjectDetection(ObjectDetectionBaseOnnxRoboflowInferenceModel):
         processed_predictions = []
 
         background_class_index = -1  # Default to -1 (won't match valid indices)
-        background_class_name = "background_class8342"
+        background_class_name = "background_class83422"
         try:
             background_class_index = self.class_names.index(background_class_name)
         except ValueError:

--- a/inference/models/rfdetr/rfdetr.py
+++ b/inference/models/rfdetr/rfdetr.py
@@ -259,6 +259,14 @@ class RFDETRObjectDetection(ObjectDetectionBaseOnnxRoboflowInferenceModel):
 
         processed_predictions = []
 
+        background_class_index = -1 # Default to -1 (won't match valid indices)
+        background_class_name = "background_class8342"
+        try:
+            background_class_index = self.class_names.index(background_class_name)
+        except ValueError:
+            print(f"Background class {background_class_name} not found in class_names")
+            pass
+
         for batch_idx in range(batch_size):
             orig_h, orig_w = img_dims[batch_idx]
 
@@ -273,6 +281,13 @@ class RFDETRObjectDetection(ObjectDetectionBaseOnnxRoboflowInferenceModel):
 
             topk_boxes = sorted_indices // num_classes
             topk_labels = sorted_indices % num_classes
+
+            if background_class_index != -1:
+                class_filter_mask = (topk_labels != background_class_index)
+
+                topk_scores = topk_scores[class_filter_mask]
+                topk_labels = topk_labels[class_filter_mask]
+                topk_boxes_indices = topk_boxes_indices[class_filter_mask]
 
             selected_boxes = bboxes[batch_idx, topk_boxes]
 


### PR DESCRIPTION
# Description

Fixing rf-detr to ignore predictions of background class, to make metrics work in the app

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
- 
## How has this change been tested, please provide a testcase or example of how you tested the change?

Tested locally

## Any specific deployment considerations

No

## Docs

-   [ ] Docs updated? What were the changes: No
