### PR TITLE
Feat/remove UUID validator from request correlation middleware for gcp and dd

### DIFF
--- a/inference/core/env.py
+++ b/inference/core/env.py
@@ -231,6 +231,9 @@ LAMBDA = str2bool(os.getenv("LAMBDA", False))
 # Whether is's GCP serverless service
 GCP_SERVERLESS = str2bool(os.getenv("GCP_SERVERLESS", "False"))
 
+# Header where correlaction ID for logging is stored
+CORRELACTION_ID_HEADER = os.getenv("CORRELACTION_ID_HEADER", "X-Request-ID")
+
 # Flag to enable legacy route, default is True
 LEGACY_ROUTE_ENABLED = str2bool(os.getenv("LEGACY_ROUTE_ENABLED", True))
 

--- a/inference/core/interfaces/http/http_api.py
+++ b/inference/core/interfaces/http/http_api.py
@@ -108,6 +108,7 @@ from inference.core.env import (
     CORE_MODEL_TROCR_ENABLED,
     CORE_MODEL_YOLO_WORLD_ENABLED,
     CORE_MODELS_ENABLED,
+    DEDICATED_DEPLOYMENT_ID,
     DEDICATED_DEPLOYMENT_WORKSPACE_URL,
     DISABLE_WORKFLOW_ENDPOINTS,
     DOCKER_SOCKET_PATH,
@@ -630,7 +631,17 @@ class HttpInterface(BaseInterface):
                 strip_dirs=False,
                 sort_by="cumulative",
             )
-        app.add_middleware(asgi_correlation_id.CorrelationIdMiddleware)
+        if DEDICATED_DEPLOYMENT_ID or GCP_SERVERLESS:
+            app.add_middleware(
+                asgi_correlation_id.CorrelationIdMiddleware,
+                header_name="X-Request-ID",
+                update_request_header=True,
+                generator=lambda: uuid4().hex,
+                validator=lambda a: True,
+                transformer=lambda a: a,
+            )
+        else:
+            app.add_middleware(asgi_correlation_id.CorrelationIdMiddleware)
 
         if METRICS_ENABLED:
 

--- a/inference/core/interfaces/http/http_api.py
+++ b/inference/core/interfaces/http/http_api.py
@@ -108,6 +108,7 @@ from inference.core.env import (
     CORE_MODEL_TROCR_ENABLED,
     CORE_MODEL_YOLO_WORLD_ENABLED,
     CORE_MODELS_ENABLED,
+    CORRELACTION_ID_HEADER,
     DEDICATED_DEPLOYMENT_ID,
     DEDICATED_DEPLOYMENT_WORKSPACE_URL,
     DISABLE_WORKFLOW_ENDPOINTS,
@@ -634,7 +635,7 @@ class HttpInterface(BaseInterface):
         if DEDICATED_DEPLOYMENT_ID or GCP_SERVERLESS:
             app.add_middleware(
                 asgi_correlation_id.CorrelationIdMiddleware,
-                header_name="X-Request-ID",
+                header_name=CORRELACTION_ID_HEADER,
                 update_request_header=True,
                 generator=lambda: uuid4().hex,
                 validator=lambda a: True,


### PR DESCRIPTION
# Description

When running on GCP or DD add CorrelationIdMiddleware with permissive validator
Parametrize header

## Type of change

Please delete options that are not relevant.

-   [x] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?

CI passing
Tested on staging

## Any specific deployment considerations

N/A

## Docs

N/A