### PR TITLE
Preload hugginface IDs on inference startup

### DIFF
--- a/inference/core/env.py
+++ b/inference/core/env.py
@@ -98,7 +98,7 @@ OWLV2_CPU_IMAGE_CACHE_SIZE = int(os.getenv("OWLV2_CPU_IMAGE_CACHE_SIZE", 1000))
 # OWLv2 compile model, default is True
 OWLV2_COMPILE_MODEL = str2bool(os.getenv("OWLV2_COMPILE_MODEL", True))
 
-# Preload OWLv2 models
+# Preload comma separated list of Huggingface IDs for OWLv2 models
 PRELOAD_HF_IDS = os.getenv("PRELOAD_HF_IDS")
 if PRELOAD_HF_IDS:
     PRELOAD_HF_IDS = [id.strip() for id in PRELOAD_HF_IDS.split(",")]

--- a/inference/core/env.py
+++ b/inference/core/env.py
@@ -98,6 +98,11 @@ OWLV2_CPU_IMAGE_CACHE_SIZE = int(os.getenv("OWLV2_CPU_IMAGE_CACHE_SIZE", 1000))
 # OWLv2 compile model, default is True
 OWLV2_COMPILE_MODEL = str2bool(os.getenv("OWLV2_COMPILE_MODEL", True))
 
+# Preload OWLv2 models
+PRELOAD_HF_IDS = os.getenv("PRELOAD_HF_IDS")
+if PRELOAD_HF_IDS:
+    PRELOAD_HF_IDS = [id.strip() for id in PRELOAD_HF_IDS.split(",")]
+
 # Maximum batch size for GAZE, default is 8
 GAZE_MAX_BATCH_SIZE = int(os.getenv("GAZE_MAX_BATCH_SIZE", 8))
 

--- a/inference/core/env.py
+++ b/inference/core/env.py
@@ -99,6 +99,10 @@ OWLV2_CPU_IMAGE_CACHE_SIZE = int(os.getenv("OWLV2_CPU_IMAGE_CACHE_SIZE", 1000))
 OWLV2_COMPILE_MODEL = str2bool(os.getenv("OWLV2_COMPILE_MODEL", True))
 
 # Preload comma separated list of Huggingface IDs for OWLv2 models
+# NOTE: this will result in ALL inference processes to preload the models
+#       (e.g. InferencePipelineManager, InferencePipeline, etc.)
+#       Ensure NUM_WORKERS environmental variable is set to 1
+#       and also ENABLE_STREAM_API environmental variable is set to False
 PRELOAD_HF_IDS = os.getenv("PRELOAD_HF_IDS")
 if PRELOAD_HF_IDS:
     PRELOAD_HF_IDS = [id.strip() for id in PRELOAD_HF_IDS.split(",")]

--- a/inference/models/owlv2/owlv2.py
+++ b/inference/models/owlv2/owlv2.py
@@ -118,8 +118,10 @@ if PRELOAD_HF_IDS:
     if not isinstance(hf_ids, list):
         hf_ids = [hf_ids]
     for huggingface_id in hf_ids:
+        logger.info(f"Preloading OWLv2 model for {huggingface_id} (this may take a while)")
         try:
             Owlv2Singleton(huggingface_id)
+            logger.info(f"Preloaded OWLv2 model for {huggingface_id}")
         except Exception as exc:
             logger.error("Failed to preload OWLv2 model for %s: %s", huggingface_id, exc)
 

--- a/inference/models/owlv2/owlv2.py
+++ b/inference/models/owlv2/owlv2.py
@@ -119,11 +119,11 @@ if PRELOAD_HF_IDS:
         hf_ids = [hf_ids]
     for huggingface_id in hf_ids:
         logger.info(
-            f"Preloading OWLv2 model for {huggingface_id} (this may take a while)"
+            "Preloading OWLv2 model for %s (this may take a while)", huggingface_id
         )
         try:
             Owlv2Singleton(huggingface_id)
-            logger.info(f"Preloaded OWLv2 model for {huggingface_id}")
+            logger.info("Preloaded OWLv2 model for %s", huggingface_id)
         except Exception as exc:
             logger.error(
                 "Failed to preload OWLv2 model for %s: %s", huggingface_id, exc

--- a/inference/models/owlv2/owlv2.py
+++ b/inference/models/owlv2/owlv2.py
@@ -517,6 +517,9 @@ class OwlV2(RoboflowInferenceModel):
 
         # Explicitly delete temporary tensors to free memory.
         del pixel_values, np_image, image_features, image_embeds
+        gc.collect()
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
 
         if isinstance(image, LazyImageRetrievalWrapper):
             image.unload_numpy_image()  # Clears both _image_as_numpy and image if needed.

--- a/inference/models/owlv2/owlv2.py
+++ b/inference/models/owlv2/owlv2.py
@@ -25,12 +25,12 @@ from inference.core.env import (
     DEVICE,
     MAX_DETECTIONS,
     MODEL_CACHE_DIR,
-    PRELOAD_HF_IDS,
     OWLV2_COMPILE_MODEL,
     OWLV2_CPU_IMAGE_CACHE_SIZE,
     OWLV2_IMAGE_CACHE_SIZE,
     OWLV2_MODEL_CACHE_SIZE,
     OWLV2_VERSION_ID,
+    PRELOAD_HF_IDS,
 )
 from inference.core.exceptions import InvalidModelIDError, ModelArtefactError
 from inference.core.models.roboflow import (
@@ -118,12 +118,16 @@ if PRELOAD_HF_IDS:
     if not isinstance(hf_ids, list):
         hf_ids = [hf_ids]
     for huggingface_id in hf_ids:
-        logger.info(f"Preloading OWLv2 model for {huggingface_id} (this may take a while)")
+        logger.info(
+            f"Preloading OWLv2 model for {huggingface_id} (this may take a while)"
+        )
         try:
             Owlv2Singleton(huggingface_id)
             logger.info(f"Preloaded OWLv2 model for {huggingface_id}")
         except Exception as exc:
-            logger.error("Failed to preload OWLv2 model for %s: %s", huggingface_id, exc)
+            logger.error(
+                "Failed to preload OWLv2 model for %s: %s", huggingface_id, exc
+            )
 
 
 def preprocess_image(

--- a/inference/models/owlv2/owlv2.py
+++ b/inference/models/owlv2/owlv2.py
@@ -104,8 +104,13 @@ class Owlv2Singleton:
             instance.huggingface_id = huggingface_id
             # Load model directly in the instance
             logger.info(f"Loading OWLv2 model from {huggingface_id}")
+            dtype = torch.float16 if str(DEVICE).startswith("cuda") else torch.float32
             model = (
-                Owlv2ForObjectDetection.from_pretrained(huggingface_id)
+                Owlv2ForObjectDetection.from_pretrained(
+                    huggingface_id,
+                    torch_dtype=dtype,
+                    device_map=DEVICE if str(DEVICE).startswith("cuda") else None,
+                )
                 .eval()
                 .to(DEVICE)
             )
@@ -177,7 +182,7 @@ def dummy_infer(hf_id: str):
         1, 3, 1, 1
     )
 
-    np_image = np.zeros((image_size[0], image_size[1], 3))
+    np_image = np.zeros((image_size[0] // 2, image_size[1] // 2, 3))
     pixel_values = preprocess_image(np_image, image_size, image_mean, image_std)
 
     # Below code is copied from Owlv2.embed_image
@@ -185,7 +190,11 @@ def dummy_infer(hf_id: str):
     with torch.autocast(
         device_type=device_str, dtype=torch.float16, enabled=device_str == "cuda"
     ):
-        model.image_embedder(pixel_values=pixel_values)
+        image_embeds, _ = model.image_embedder(pixel_values=pixel_values)
+    del pixel_values, np_image, image_embeds
+    gc.collect()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
     return singleton
 
 
@@ -196,10 +205,21 @@ if PRELOAD_HF_IDS:
     for hf_id in hf_ids:
         logger.info("Preloading OWLv2 model for %s (this may take a while)", hf_id)
         try:
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
+                allocated_gpu_memory = torch.cuda.memory_allocated() / (1024**3)
+                logger.info(
+                    f"Allocated GPU memory before loading model: {allocated_gpu_memory:.2f} GB"
+                )
             t1 = time.time()
             singleton = dummy_infer(hf_id)
             t2 = time.time()
             logger.info("Preloaded OWLv2 model for %s in %0.2f seconds", hf_id, t2 - t1)
+            if torch.cuda.is_available():
+                allocated_gpu_memory = torch.cuda.memory_allocated() / (1024**3)
+                logger.info(
+                    f"Allocated GPU memory after loading model: {allocated_gpu_memory:.2f} GB"
+                )
             # Store the singleton instance directly in PRELOADED_HF_MODELS
             PRELOADED_HF_MODELS[hf_id] = singleton
         except Exception as exc:

--- a/inference/models/owlv2/owlv2.py
+++ b/inference/models/owlv2/owlv2.py
@@ -104,11 +104,11 @@ class Owlv2Singleton:
             instance.huggingface_id = huggingface_id
             # Load model directly in the instance
             logger.info(f"Loading OWLv2 model from {huggingface_id}")
-            dtype = torch.float16 if str(DEVICE).startswith("cuda") else torch.float32
+            # TODO: to further reduce GPU memory usage we could use torch.float16
+            # torch_dtype = torch.float16 if str(DEVICE).startswith("cuda") else torch.float32
             model = (
                 Owlv2ForObjectDetection.from_pretrained(
                     huggingface_id,
-                    torch_dtype=dtype,
                     device_map=DEVICE if str(DEVICE).startswith("cuda") else None,
                 )
                 .eval()

--- a/inference/models/owlv2/owlv2.py
+++ b/inference/models/owlv2/owlv2.py
@@ -25,6 +25,7 @@ from inference.core.env import (
     DEVICE,
     MAX_DETECTIONS,
     MODEL_CACHE_DIR,
+    PRELOAD_HF_IDS,
     OWLV2_COMPILE_MODEL,
     OWLV2_CPU_IMAGE_CACHE_SIZE,
     OWLV2_IMAGE_CACHE_SIZE,
@@ -110,6 +111,17 @@ class Owlv2Singleton:
             instance.model = model
             cls._instances[huggingface_id] = instance
         return cls._instances[huggingface_id]
+
+
+if PRELOAD_HF_IDS:
+    hf_ids = PRELOAD_HF_IDS
+    if not isinstance(hf_ids, list):
+        hf_ids = [hf_ids]
+    for huggingface_id in hf_ids:
+        try:
+            Owlv2Singleton(huggingface_id)
+        except Exception as exc:
+            logger.error("Failed to preload OWLv2 model for %s: %s", huggingface_id, exc)
 
 
 def preprocess_image(

--- a/inference/models/owlv2/owlv2.py
+++ b/inference/models/owlv2/owlv2.py
@@ -170,17 +170,15 @@ def dummy_infer(hf_id: str):
     model = singleton.model
     processor = Owlv2Processor.from_pretrained(hf_id)
     image_size = tuple(processor.image_processor.size.values())
-    image_mean = torch.tensor(
-        processor.image_processor.image_mean, device=DEVICE
-    ).view(1, 3, 1, 1)
-    image_std = torch.tensor(
-        processor.image_processor.image_std, device=DEVICE
-    ).view(1, 3, 1, 1)
+    image_mean = torch.tensor(processor.image_processor.image_mean, device=DEVICE).view(
+        1, 3, 1, 1
+    )
+    image_std = torch.tensor(processor.image_processor.image_std, device=DEVICE).view(
+        1, 3, 1, 1
+    )
 
     np_image = np.zeros((image_size[0], image_size[1], 3))
-    pixel_values = preprocess_image(
-        np_image, image_size, image_mean, image_std
-    )
+    pixel_values = preprocess_image(np_image, image_size, image_mean, image_std)
 
     # Below code is copied from Owlv2.embed_image
     device_str = "cuda" if str(DEVICE).startswith("cuda") else "cpu"
@@ -196,9 +194,7 @@ if PRELOAD_HF_IDS:
     if not isinstance(hf_ids, list):
         hf_ids = [hf_ids]
     for hf_id in hf_ids:
-        logger.info(
-            "Preloading OWLv2 model for %s (this may take a while)", hf_id
-        )
+        logger.info("Preloading OWLv2 model for %s (this may take a while)", hf_id)
         try:
             t1 = time.time()
             singleton = dummy_infer(hf_id)
@@ -207,9 +203,7 @@ if PRELOAD_HF_IDS:
             # Store the singleton instance directly in PRELOADED_HF_MODELS
             PRELOADED_HF_MODELS[hf_id] = singleton
         except Exception as exc:
-            logger.error(
-                "Failed to preload OWLv2 model for %s: %s", hf_id, exc
-            )
+            logger.error("Failed to preload OWLv2 model for %s: %s", hf_id, exc)
 
 
 def filter_tensors_by_objectness(


### PR DESCRIPTION
# Description

In order to speed up client requests (including first request), preload set of huggingface IDs on inference startup.

## Type of change

Please delete options that are not relevant.

-   [x] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?

 - [ ] tested on roboflow serverless

## Any specific deployment considerations

This option may result in failure for multiple potential reasons, i.e. lack of GPU or RAM - in such case error will be logged out and inference will start without preloaded HF ID's

## Docs

N/A