### PR TITLE
Remove retired Claude version and add new ones

### DIFF
--- a/inference/core/workflows/core_steps/models/foundation/anthropic_claude/v1.py
+++ b/inference/core/workflows/core_steps/models/foundation/anthropic_claude/v1.py
@@ -164,7 +164,12 @@ class BlockManifest(WorkflowBlockManifest):
     model_version: Union[
         Selector(kind=[STRING_KIND]),
         Literal[
-            "claude-3-5-sonnet", "claude-3-opus", "claude-3-sonnet", "claude-3-haiku"
+            "claude-3-7-sonnet",
+            "claude-3-5-sonnet-v2",
+            "claude-3-5-haiku",
+            "claude-3-5-sonnet",
+            "claude-3-opus",
+            "claude-3-haiku",
         ],
     ] = Field(
         default="claude-3-5-sonnet",
@@ -357,9 +362,11 @@ def execute_claude_requests(
 
 
 EXACT_MODELS_VERSIONS_MAPPING = {
+    "claude-3-7-sonnet": "claude-3-7-sonnet-20250219",
+    "claude-3-5-sonnet-v2": "claude-3-5-sonnet-20241022",
+    "claude-3-5-haiku": "claude-3-5-haiku-20241022",
     "claude-3-5-sonnet": "claude-3-5-sonnet-20240620",
     "claude-3-opus": "claude-3-opus-20240229",
-    "claude-3-sonnet": "claude-3-sonnet-20240229",
     "claude-3-haiku": "claude-3-haiku-20240307",
 }
 


### PR DESCRIPTION
# Description

Anthropic removed `claude-3-sonnet-20240229` from their API (even though it's still marked as deprecated for another month).

This PR removes the deprecated model version, that errors like this:

```sh
curl -s https://api.anthropic.com/v1/messages \
     --header "x-api-key: $ANTHROPIC_API_KEY" \
     --header "anthropic-version: 2023-06-01" \
     --header "content-type: application/json" \
     --data \
'{
    "model": "claude-3-sonnet-20240229",
    "max_tokens": 1024,
    "messages": [
        {"role": "user", "content": "Hello, world"}
    ]
}' | jq .
{
  "type": "error",
  "error": {
    "type": "not_found_error",
    "message": "model: claude-3-sonnet-20240229"
  }
}
```

The PR also adds the new model versions from Anthropic. More context on:

- https://docs.anthropic.com/en/docs/resources/model-deprecations#model-status
- https://docs.anthropic.com/en/docs/about-claude/models/all-models

The default is kept as `claude-3-5-sonnet` to avoid creating a breaking change.

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Tested locally, with workflows pointing to localhost. Used all the current model versions to describe an image and run detection as VLM.

## Any specific deployment considerations

No