### PR TITLE
Initial overlap block filter commit

### DIFF
--- a/inference/core/workflows/core_steps/analytics/overlap/v1.py
+++ b/inference/core/workflows/core_steps/analytics/overlap/v1.py
@@ -85,21 +85,6 @@ class OverlapManifest(WorkflowBlockManifest):
         return ">=1.3.0,<2.0.0"
 
 
-def test_coords_overlap():
-    assert not OverlapBlockV1.coords_overlap(
-        [0, 0, 20, 20], [15, 15, 35, 35], "Center Overlap"
-    )
-    assert not OverlapBlockV1.coords_overlap(
-        [10, 10, 20, 20], [30, 30, 40, 40], "Any Overlap"
-    )
-    assert OverlapBlockV1.coords_overlap(
-        [20, 20, 30, 30], [15, 15, 35, 35], "Center Overlap"
-    )
-    assert OverlapBlockV1.coords_overlap(
-        [0, 0, 20, 20], [15, 15, 35, 35], "Any Overlap"
-    )
-
-
 class OverlapBlockV1(WorkflowBlock):
     def __init__(self):
         pass

--- a/inference/core/workflows/core_steps/analytics/overlap/v1.py
+++ b/inference/core/workflows/core_steps/analytics/overlap/v1.py
@@ -1,0 +1,160 @@
+from typing import List, Optional, Union
+
+import numpy as np
+import supervision as sv
+from pydantic import ConfigDict, Field
+from supervision.detection.utils import get_data_item
+from typing_extensions import Literal, Type
+
+from inference.core.workflows.execution_engine.entities.base import (
+    OutputDefinition,
+    WorkflowImageData,
+)
+from inference.core.workflows.execution_engine.entities.types import (
+    OBJECT_DETECTION_PREDICTION_KIND,
+    Selector,
+    WorkflowImageSelector,
+)
+from inference.core.workflows.prototypes.block import (
+    BlockResult,
+    WorkflowBlock,
+    WorkflowBlockManifest,
+)
+
+OUTPUT_KEY: str = "overlaps"
+SHORT_DESCRIPTION = "Filter objects overlapping some other class"
+LONG_DESCRIPTION = """
+The `OverlapFilter` is an analytics block that filters out objects overlapping instances of some other class
+"""
+
+
+class OverlapManifest(WorkflowBlockManifest):
+    model_config = ConfigDict(
+        json_schema_extra={
+            "name": "Overlap Filter",
+            "version": "v1",
+            "short_description": SHORT_DESCRIPTION,
+            "long_description": LONG_DESCRIPTION,
+            "license": "Apache-2.0",
+            "block_type": "analytics",
+            "ui_manifest": {
+                "icon": "far fa-square-o",
+                "blockPriority": 1,
+            },
+        }
+    )
+    type: Literal["roboflow_core/overlap@v1", "Overlap"]
+    image: Union[WorkflowImageSelector] = Field(
+        title="Image",
+        description="The input image for this step.",
+        examples=["$inputs.image", "$steps.cropping.crops"],
+    )
+    predictions: Selector(
+        kind=[
+            OBJECT_DETECTION_PREDICTION_KIND,
+        ]
+    ) = Field(  # type: ignore
+        description="Object predictions",
+        examples=["$steps.object_detection_model.predictions"],
+    )
+    overlap_type: Literal["Center Overlap", "Any Overlap"] = Field(
+        default="Center Overlap",
+        description="Overlap Type.",
+        examples=["Center Overlap", "Any Overlap"],
+    )
+    overlap_class_name: Union[str] = Field(
+        description="Overlap Class Name",
+        json_schema_extra={
+            "hide_description": True,
+        },
+    )
+
+    @classmethod
+    def describe_outputs(cls) -> List[OutputDefinition]:
+        return [
+            OutputDefinition(
+                name=OUTPUT_KEY,
+                kind=[
+                    OBJECT_DETECTION_PREDICTION_KIND,
+                ],
+            ),
+        ]
+
+    @classmethod
+    def get_execution_engine_compatibility(cls) -> Optional[str]:
+        return ">=1.3.0,<2.0.0"
+
+
+def test_coords_overlap():
+    assert not OverlapBlockV1.coords_overlap(
+        [0, 0, 20, 20], [15, 15, 35, 35], "Center Overlap"
+    )
+    assert not OverlapBlockV1.coords_overlap(
+        [10, 10, 20, 20], [30, 30, 40, 40], "Any Overlap"
+    )
+    assert OverlapBlockV1.coords_overlap(
+        [20, 20, 30, 30], [15, 15, 35, 35], "Center Overlap"
+    )
+    assert OverlapBlockV1.coords_overlap(
+        [0, 0, 20, 20], [15, 15, 35, 35], "Any Overlap"
+    )
+
+
+class OverlapBlockV1(WorkflowBlock):
+    def __init__(self):
+        pass
+
+    @classmethod
+    def get_manifest(cls) -> Type[WorkflowBlockManifest]:
+        return OverlapManifest
+
+    @classmethod
+    def coords_overlap(cls, overlap, other, overlap_type):
+
+        # coords are [x1, y1, x2, y2]
+        if overlap_type == "Center Overlap":
+            size = [other[2] - other[0], other[3] - other[1]]
+            (x, y) = [other[0] + size[0] / 2, other[1] + size[1] / 2]
+            return (
+                x > overlap[0] and x < overlap[2] and y > overlap[1] and y < overlap[3]
+            )
+        else:
+            return not (
+                other[2] < overlap[0]
+                or other[0] > overlap[2]
+                or other[3] < overlap[1]
+                or other[1] > overlap[3]
+            )
+
+    def run(
+        self,
+        image: WorkflowImageData,
+        predictions: sv.Detections,
+        overlap_type: str,
+        overlap_class_name: str,
+    ) -> BlockResult:
+
+        overlaps = []
+        others = []
+        for i in range(len(predictions.xyxy)):
+            data = get_data_item(predictions.data, i)
+            if data["class_name"] == overlap_class_name:
+                overlaps.append(predictions.xyxy[i])
+            else:
+                others.append((predictions.xyxy[i], i))
+
+        idx = set()
+        for overlap in overlaps:
+            if not others:
+                break
+            idx = idx.union(
+                {
+                    other[1]
+                    for other in others
+                    if OverlapBlockV1.coords_overlap(overlap, other[0], overlap_type)
+                }
+            )
+            # once it's overlapped we don't need to check again
+            others = [o for o in others if o[1] not in idx]
+
+        return {OUTPUT_KEY: predictions[list(idx)]}

--- a/inference/core/workflows/core_steps/analytics/overlap/v1.py
+++ b/inference/core/workflows/core_steps/analytics/overlap/v1.py
@@ -1,3 +1,4 @@
+from functools import lru_cache
 from typing import List, Optional, Union
 
 import numpy as np
@@ -17,7 +18,6 @@ from inference.core.workflows.prototypes.block import (
     WorkflowBlock,
     WorkflowBlockManifest,
 )
-from functools import lru_cache
 
 OUTPUT_KEY: str = "overlaps"
 SHORT_DESCRIPTION = "Filter objects overlapping some other class"

--- a/inference/core/workflows/core_steps/loader.py
+++ b/inference/core/workflows/core_steps/loader.py
@@ -17,6 +17,7 @@ from inference.core.workflows.core_steps.analytics.line_counter.v1 import (
 from inference.core.workflows.core_steps.analytics.line_counter.v2 import (
     LineCounterBlockV2,
 )
+from inference.core.workflows.core_steps.analytics.overlap.v1 import OverlapBlockV1
 from inference.core.workflows.core_steps.analytics.path_deviation.v1 import (
     PathDeviationAnalyticsBlockV1,
 )
@@ -30,9 +31,6 @@ from inference.core.workflows.core_steps.analytics.time_in_zone.v2 import (
     TimeInZoneBlockV2,
 )
 from inference.core.workflows.core_steps.analytics.velocity.v1 import VelocityBlockV1
-from inference.core.workflows.core_steps.analytics.overlap.v1 import (
-    OverlapBlockV1,
-)
 from inference.core.workflows.core_steps.cache.cache_get.v1 import CacheGetBlockV1
 from inference.core.workflows.core_steps.cache.cache_set.v1 import CacheSetBlockV1
 from inference.core.workflows.core_steps.classical_cv.camera_focus.v1 import (

--- a/inference/core/workflows/core_steps/loader.py
+++ b/inference/core/workflows/core_steps/loader.py
@@ -30,6 +30,9 @@ from inference.core.workflows.core_steps.analytics.time_in_zone.v2 import (
     TimeInZoneBlockV2,
 )
 from inference.core.workflows.core_steps.analytics.velocity.v1 import VelocityBlockV1
+from inference.core.workflows.core_steps.analytics.overlap.v1 import (
+    OverlapBlockV1,
+)
 from inference.core.workflows.core_steps.cache.cache_get.v1 import CacheGetBlockV1
 from inference.core.workflows.core_steps.cache.cache_set.v1 import CacheSetBlockV1
 from inference.core.workflows.core_steps.classical_cv.camera_focus.v1 import (
@@ -641,6 +644,7 @@ def load_blocks() -> List[Type[WorkflowBlock]]:
         Qwen25VLBlockV1,
         SmolVLM2BlockV1,
         Moondream2BlockV1,
+        OverlapBlockV1,
     ]
 
 

--- a/tests/workflows/integration_tests/execution/test_workflow_with_overlap.py
+++ b/tests/workflows/integration_tests/execution/test_workflow_with_overlap.py
@@ -1,0 +1,108 @@
+import numpy as np
+
+from inference.core.env import WORKFLOWS_MAX_CONCURRENT_STEPS
+from inference.core.managers.base import ModelManager
+from inference.core.workflows.core_steps.common.entities import StepExecutionMode
+
+from inference.core.workflows.execution_engine.core import ExecutionEngine
+from tests.workflows.integration_tests.execution.workflows_gallery_collector.decorators import (
+    add_to_workflows_gallery,
+)
+
+# check both overlap types
+OVERLAP_WORKFLOW = {
+    "version": "1.0",
+    "inputs": [{"type": "InferenceImage", "name": "image"}],
+    "steps": [
+        {
+            "type": "roboflow_core/roboflow_object_detection_model@v1",
+            "name": "model",
+            "images": "$inputs.image",
+            "model_id": "yolov8n-640"
+        },
+        {
+            "type": "roboflow_core/overlap@v1",
+            "name": "any_overlap",
+            "predictions": "$steps.model.predictions",
+            "overlap_class_name": "banana",
+            "overlap_type": "Any Overlap",
+            "image": "$inputs.image"
+        },
+        {
+            "type": "roboflow_core/overlap@v1",
+            "name": "center_overlap",
+            "predictions": "$steps.model.predictions",
+            "overlap_class_name": "banana",
+            "overlap_type": "Center Overlap",
+            "image": "$inputs.image"
+        }
+    ],
+    "outputs": [
+        {
+            "type": "JsonField",
+            "name": "center_predictions",
+            "coordinates_system": "own",
+            "selector": "$steps.center_overlap.overlaps"
+        },
+        {
+            "type": "JsonField",
+            "name": "any_predictions",
+            "coordinates_system": "own",
+            "selector": "$steps.any_overlap.overlaps"
+        }
+    ],
+}
+
+'''
+@add_to_workflows_gallery(
+    category="Workflows with classical Computer Vision methods",
+    use_case_title="Workflow with dynamic zone and perspective converter",
+    use_case_description="""
+In this example dynamic zone with 4 vertices is calculated from detected segmentations.
+Perspective correction is applied to the input image as well as to detected segmentations based on this zone.
+    """,
+    workflow_definition=OVERLAP_WORKFLOW,
+    workflow_name_in_app="dynamic_zone_and_perspective_converter",
+)
+'''
+def test_workflow_with_overlap_all(
+    model_manager: ModelManager,
+    fruit_image: np.ndarray,
+) -> None:
+    # given
+    workflow_init_parameters = {
+        "workflows_core.model_manager": model_manager,
+        "workflows_core.api_key": None,
+        "workflows_core.step_execution_mode": StepExecutionMode.LOCAL,
+    }
+    execution_engine = ExecutionEngine.init(
+        workflow_definition=OVERLAP_WORKFLOW,
+        init_parameters=workflow_init_parameters,
+        max_concurrent_steps=WORKFLOWS_MAX_CONCURRENT_STEPS,
+    )
+
+    # when
+    result = execution_engine.run(
+        runtime_parameters={
+            "image": fruit_image,
+        }
+    )
+
+    assert len(result)==1, "One set of images provided, so one output expected"
+
+    # if overlap_type is "Any Overlap", both the apples and orange will overlap the banana
+    any_redictions = result[0]["any_predictions"]    
+    assert len(any_redictions.class_id)==4
+    class_names = any_redictions.data["class_name"]
+    assert "banana" not in class_names
+    assert "apple" in class_names
+    assert "orange" in class_names
+
+    # if overlap_type is "Center Overlap" only the orange will overlap the banana
+    any_redictions = result[0]["center_predictions"]    
+    assert len(any_redictions.class_id)==1
+    class_names = any_redictions.data["class_name"]
+    assert "banana" not in class_names
+    assert "apple" not in class_names
+    assert "orange" in class_names
+

--- a/tests/workflows/integration_tests/execution/test_workflow_with_overlap.py
+++ b/tests/workflows/integration_tests/execution/test_workflow_with_overlap.py
@@ -26,7 +26,6 @@ OVERLAP_WORKFLOW = {
             "predictions": "$steps.model.predictions",
             "overlap_class_name": "banana",
             "overlap_type": "Any Overlap",
-            "image": "$inputs.image"
         },
         {
             "type": "roboflow_core/overlap@v1",
@@ -34,7 +33,6 @@ OVERLAP_WORKFLOW = {
             "predictions": "$steps.model.predictions",
             "overlap_class_name": "banana",
             "overlap_type": "Center Overlap",
-            "image": "$inputs.image"
         }
     ],
     "outputs": [

--- a/tests/workflows/unit_tests/core_steps/analytics/test_coords_overlap_v1.py
+++ b/tests/workflows/unit_tests/core_steps/analytics/test_coords_overlap_v1.py
@@ -1,0 +1,19 @@
+import pytest
+
+from inference.core.workflows.core_steps.analytics.overlap.v1 import (
+    OverlapBlockV1,
+)
+
+def test_coords_overlap():
+    assert not OverlapBlockV1.coords_overlap(
+        [0, 0, 20, 20], [15, 15, 35, 35], "Center Overlap"
+    )
+    assert not OverlapBlockV1.coords_overlap(
+        [10, 10, 20, 20], [30, 30, 40, 40], "Any Overlap"
+    )
+    assert OverlapBlockV1.coords_overlap(
+        [20, 20, 30, 30], [15, 15, 35, 35], "Center Overlap"
+    )
+    assert OverlapBlockV1.coords_overlap(
+        [0, 0, 20, 20], [15, 15, 35, 35], "Any Overlap"
+    )


### PR DESCRIPTION
# Description

Adds an overlap block filter, which filters out all classes that overlap some other filter class. Ex. person on a bicycle, widget on a pallet, person in a car, etc.

No dependency changes required - this is a very simple, but extremely useful block.

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   X New feature (non-breaking change which adds functionality)
-   X This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Both unit and workflow test cases are included, in addition to my own testing.

## Any specific deployment considerations

The block will need to be documented once the PR is approved.

## Docs

-   [ ] Docs updated? What were the changes: (doc updates TBD once the PR is approved - I need to make sure we're ok with merging this first)
