### PR TITLE
Add CORRELATION_ID_LOG_KEY; fix typo for CORRELATION_ID_HEADER; control logging across modules with single env variable API_LOGGING_ENABLED

### DIFF
--- a/inference/core/env.py
+++ b/inference/core/env.py
@@ -243,7 +243,10 @@ LAMBDA = str2bool(os.getenv("LAMBDA", False))
 GCP_SERVERLESS = str2bool(os.getenv("GCP_SERVERLESS", "False"))
 
 # Header where correlaction ID for logging is stored
-CORRELACTION_ID_HEADER = os.getenv("CORRELACTION_ID_HEADER", "X-Request-ID")
+CORRELATION_ID_HEADER = os.getenv("CORRELATION_ID_HEADER", "X-Request-ID")
+
+# Header where correlaction ID for logging is stored
+CORRELATION_ID_LOG_KEY = os.getenv("CORRELATION_ID_LOG_KEY", "request_id")
 
 # Flag to enable legacy route, default is True
 LEGACY_ROUTE_ENABLED = str2bool(os.getenv("LEGACY_ROUTE_ENABLED", True))

--- a/inference/core/env.py
+++ b/inference/core/env.py
@@ -242,6 +242,9 @@ LAMBDA = str2bool(os.getenv("LAMBDA", False))
 # Whether is's GCP serverless service
 GCP_SERVERLESS = str2bool(os.getenv("GCP_SERVERLESS", "False"))
 
+# Flag to enable API logging, default is False
+API_LOGGING_ENABLED = str2bool(os.getenv("API_LOGGING_ENABLED", "False"))
+
 # Header where correlaction ID for logging is stored
 CORRELATION_ID_HEADER = os.getenv("CORRELATION_ID_HEADER", "X-Request-ID")
 

--- a/inference/core/interfaces/http/http_api.py
+++ b/inference/core/interfaces/http/http_api.py
@@ -100,6 +100,7 @@ from inference.core.entities.responses.workflows import (
 from inference.core.env import (
     ALLOW_ORIGINS,
     API_KEY,
+    API_LOGGING_ENABLED,
     BUILDER_ORIGIN,
     CORE_MODEL_CLIP_ENABLED,
     CORE_MODEL_DOCTR_ENABLED,
@@ -112,7 +113,6 @@ from inference.core.env import (
     CORE_MODEL_YOLO_WORLD_ENABLED,
     CORE_MODELS_ENABLED,
     CORRELATION_ID_HEADER,
-    DEDICATED_DEPLOYMENT_ID,
     DEDICATED_DEPLOYMENT_WORKSPACE_URL,
     DEPTH_ESTIMATION_ENABLED,
     DISABLE_WORKFLOW_ENDPOINTS,
@@ -636,7 +636,7 @@ class HttpInterface(BaseInterface):
                 strip_dirs=False,
                 sort_by="cumulative",
             )
-        if DEDICATED_DEPLOYMENT_ID or GCP_SERVERLESS:
+        if API_LOGGING_ENABLED:
             app.add_middleware(
                 asgi_correlation_id.CorrelationIdMiddleware,
                 header_name=CORRELATION_ID_HEADER,

--- a/inference/core/interfaces/http/http_api.py
+++ b/inference/core/interfaces/http/http_api.py
@@ -111,7 +111,7 @@ from inference.core.env import (
     CORE_MODEL_TROCR_ENABLED,
     CORE_MODEL_YOLO_WORLD_ENABLED,
     CORE_MODELS_ENABLED,
-    CORRELACTION_ID_HEADER,
+    CORRELATION_ID_HEADER,
     DEDICATED_DEPLOYMENT_ID,
     DEDICATED_DEPLOYMENT_WORKSPACE_URL,
     DEPTH_ESTIMATION_ENABLED,
@@ -639,7 +639,7 @@ class HttpInterface(BaseInterface):
         if DEDICATED_DEPLOYMENT_ID or GCP_SERVERLESS:
             app.add_middleware(
                 asgi_correlation_id.CorrelationIdMiddleware,
-                header_name=CORRELACTION_ID_HEADER,
+                header_name=CORRELATION_ID_HEADER,
                 update_request_header=True,
                 generator=lambda: uuid4().hex,
                 validator=lambda a: True,

--- a/inference/core/logger.py
+++ b/inference/core/logger.py
@@ -6,7 +6,7 @@ from typing import Any, Dict
 from rich.logging import RichHandler
 from structlog.processors import CallsiteParameter
 
-from inference.core.env import CORRELATION_ID_LOG_KEY, LOG_LEVEL
+from inference.core.env import API_LOGGING_ENABLED, CORRELATION_ID_LOG_KEY, LOG_LEVEL
 from inference.core.utils.environment import str2bool
 
 if LOG_LEVEL == "ERROR" or LOG_LEVEL == "FATAL":
@@ -24,7 +24,7 @@ def add_correlation(
     return event_dict
 
 
-if str2bool(os.getenv("API_LOGGING_ENABLED", "False")):
+if API_LOGGING_ENABLED:
     import structlog
 
     structlog.configure(

--- a/inference/core/logger.py
+++ b/inference/core/logger.py
@@ -6,7 +6,7 @@ from typing import Any, Dict
 from rich.logging import RichHandler
 from structlog.processors import CallsiteParameter
 
-from inference.core.env import LOG_LEVEL
+from inference.core.env import CORRELATION_ID_LOG_KEY, LOG_LEVEL
 from inference.core.utils.environment import str2bool
 
 if LOG_LEVEL == "ERROR" or LOG_LEVEL == "FATAL":
@@ -20,7 +20,7 @@ def add_correlation(
 
     request_id = correlation_id.get()
     if request_id:
-        event_dict["request_id"] = request_id
+        event_dict[CORRELATION_ID_LOG_KEY] = request_id
     return event_dict
 
 


### PR DESCRIPTION
# Description

Add CORRELATION_ID_LOG_KEY; fix typo for CORRELATION_ID_HEADER

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

CI passing

started docker like below:

```
docker run \
    --rm \
    -p 9001:9001 \
    -e LOG_LEVEL=INFO \
    -e API_LOGGING_ENABLED=True \
    --name=hosted_inference \
    roboflow/roboflow-inference-server-cpu:test
```

then made request like below:

```
base64 -i /path/to/file.jpg | curl -H "X-Request-ID: test-correlation-id-123" -d @- \
  "http://127.0.0.1:9001/chess-pieces-and-chess-board-object-detection/6?api_key=secret"
```

got log like below:

```
INFO:inference:{"event": "Fetching active learning configuration.", "request_id": "test-correlation-id-123", "timestamp": "2025-04-18 08:53.13", "filename": "configuration.py", "func_name": "get_roboflow_project_metadata", "lineno": 121}
```

NOTE:

Some logs, that are not related to request, are logged without correlation id, including below:

```
UserWarning: Specified provider 'OpenVINOExecutionProvider' is not in available provider names.Available providers: 'AzureExecutionProvider, CPUExecutionProvider'
UserWarning: Specified provider 'CoreMLExecutionProvider' is not in available provider names.Available providers: 'AzureExecutionProvider, CPUExecutionProvider'
```

## Any specific deployment considerations

N/A

## Docs

N/A