### PR TITLE
Add keypoint detection to byte tracker inputs

### DIFF
--- a/inference/core/workflows/core_steps/transformations/byte_tracker/v3.py
+++ b/inference/core/workflows/core_steps/transformations/byte_tracker/v3.py
@@ -15,6 +15,7 @@ from inference.core.workflows.execution_engine.entities.types import (
     INSTANCE_SEGMENTATION_PREDICTION_KIND,
     INTEGER_KIND,
     OBJECT_DETECTION_PREDICTION_KIND,
+    KEYPOINT_DETECTION_PREDICTION_KIND,
     Selector,
 )
 from inference.core.workflows.prototypes.block import (
@@ -75,6 +76,7 @@ class ByteTrackerBlockManifest(WorkflowBlockManifest):
     detections: Selector(
         kind=[
             OBJECT_DETECTION_PREDICTION_KIND,
+            KEYPOINT_DETECTION_PREDICTION_KIND,
             INSTANCE_SEGMENTATION_PREDICTION_KIND,
         ]
     ) = Field(  # type: ignore

--- a/inference/core/workflows/core_steps/transformations/byte_tracker/v3.py
+++ b/inference/core/workflows/core_steps/transformations/byte_tracker/v3.py
@@ -14,8 +14,8 @@ from inference.core.workflows.execution_engine.entities.types import (
     IMAGE_KIND,
     INSTANCE_SEGMENTATION_PREDICTION_KIND,
     INTEGER_KIND,
-    OBJECT_DETECTION_PREDICTION_KIND,
     KEYPOINT_DETECTION_PREDICTION_KIND,
+    OBJECT_DETECTION_PREDICTION_KIND,
     Selector,
 )
 from inference.core.workflows.prototypes.block import (


### PR DESCRIPTION
# Description

Adding keypoint detection to the list of valid byte tracker inputs. Byte tracker appears to be working fine with keypoint data, which has all of the object detection data in it.

## Type of change

Please delete options that are not relevant.

-   [ X] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Ran unit tests, and tested a workflow with it

## Any specific deployment considerations

N/A

## Docs

No doc changes
