### PR TITLE
Fix video pipeline race conditions

### DIFF
--- a/inference/core/interfaces/stream_manager/manager_app/entities.py
+++ b/inference/core/interfaces/stream_manager/manager_app/entities.py
@@ -12,6 +12,7 @@ from inference.core.interfaces.camera.video_source import (
 STATUS_KEY = "status"
 STATE_KEY = "state"
 SOURCES_METADATA_KEY = "sources_metadata"
+VIDEO_SOURCE_STATUS_UPDATES_KEY = "video_source_status_updates"
 REPORT_KEY = "report"
 TYPE_KEY = "type"
 ERROR_TYPE_KEY = "error_type"


### PR DESCRIPTION
# Description

Fix a few race conditions that causes the server to freeze when a stream pipeline is terminated:

- terminating a pipeline manually during a health check freezed the server
- having a pipeline time out during a health check also freezed it

https://github.com/user-attachments/assets/f33b0654-a4b6-43f4-8ba4-cf88bd2c194b

This PR makes sure that no status checks are run during termination and also that the health check doesn't try to terminate a pipeline that's already closed.

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Tested locally decreasing the pipeline timeout to 10s and starting/stoping streams multiple times, and also letting a pipeline timeout and get auto-terminated.

## Any specific deployment considerations

No