### PR TITLE
WithFixedSizeCache memory pressure - prevent from attempts to remove from epty _key_queue

### DIFF
--- a/inference/core/managers/decorators/fixed_size_cache.py
+++ b/inference/core/managers/decorators/fixed_size_cache.py
@@ -46,6 +46,11 @@ class WithFixedSizeCache(ModelManagerDecorator):
         while len(self) >= self.max_size or (
             MEMORY_FREE_THRESHOLD and self.memory_pressure_detected()
         ):
+            if not self._key_queue:
+                logger.error(
+                    "Tried to remove model from cache even though key queue is already empty!"
+                )
+                break
             to_remove_model_id = self._key_queue.popleft()
             super().remove(
                 to_remove_model_id, delete_from_disk=DISK_CACHE_CLEANUP

--- a/inference/core/managers/decorators/fixed_size_cache.py
+++ b/inference/core/managers/decorators/fixed_size_cache.py
@@ -49,6 +49,10 @@ class WithFixedSizeCache(ModelManagerDecorator):
             if not self._key_queue:
                 logger.error(
                     "Tried to remove model from cache even though key queue is already empty!"
+                    "(max_size: %s, len(self): %s, MEMORY_FREE_THRESHOLD: %s)",
+                    self.max_size,
+                    len(self),
+                    MEMORY_FREE_THRESHOLD,
                 )
                 break
             to_remove_model_id = self._key_queue.popleft()

--- a/inference/core/version.py
+++ b/inference/core/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.47.0"
+__version__ = "0.47.1"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

Following error was observed on serverless deployment:

```
  File "/app/inference/core/interfaces/http/http_api.py", line 273, in wrapped_route
    return await route(*args, **kwargs)
  File "/app/inference/usage_tracking/collector.py", line 723, in async_wrapper
    res = await func(*args, **kwargs)
  File "/app/inference/core/interfaces/http/http_api.py", line 2512, in legacy_infer_from_request
    self.model_manager.add_model(
  File "/app/inference/core/managers/decorators/fixed_size_cache.py", line 49, in add_model
    to_remove_model_id = self._key_queue.popleft()
IndexError: pop from an empty deque
```

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Manually tested

## Any specific deployment considerations

N/A

## Docs

N/A