### PR TITLE
Show pip install inference-sdk more prominently in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,9 +149,13 @@ You can use its API to run models and workflows on images and video streams.
 By default, the server is running locally on
 [`localhost:9001`](http://localhost:9001).
 
-To interface with your server via Python, use our SDK.
-`pip install inference-sdk` then run
-[an example model comparison Workflow](https://app.roboflow.com/workflows/embed/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ3b3JrZmxvd0lkIjoiSHhIODdZR0FGUWhaVmtOVWNEeVUiLCJ3b3Jrc3BhY2VJZCI6IlhySm9BRVFCQkFPc2ozMmpYZ0lPIiwidXNlcklkIjoiNXcyMFZ6UU9iVFhqSmhUanE2a2FkOXVicm0zMyIsImlhdCI6MTczNTIzNDA4Mn0.AA78pZnlivFs5pBPVX9cMigFAOIIMZk0dA4gxEF5tj4)
+To interface with your server via Python, use our SDK:
+
+```
+pip install inference-sdk
+```
+
+Then run [an example model comparison Workflow](https://app.roboflow.com/workflows/embed/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ3b3JrZmxvd0lkIjoiSHhIODdZR0FGUWhaVmtOVWNEeVUiLCJ3b3Jrc3BhY2VJZCI6IlhySm9BRVFCQkFPc2ozMmpYZ0lPIiwidXNlcklkIjoiNXcyMFZ6UU9iVFhqSmhUanE2a2FkOXVicm0zMyIsImlhdCI6MTczNTIzNDA4Mn0.AA78pZnlivFs5pBPVX9cMigFAOIIMZk0dA4gxEF5tj4)
 like this:
 
 ```python


### PR DESCRIPTION
This PR updates the README to show the `pip install inference-sdk` command more prominently.

I'm new to supervision and inference and wanted to run the example from here:
https://supervision.roboflow.com/latest/how_to/detect_and_annotate/
which has
```
from inference import get_model
```

I overlooked the `pip install inference-sdk` in your README which is very far down and wasn't very prominent. Looking on PyPI I was confused whether I need the `inference` or `inference-sdk` package and with both got cryptic "No solution found ..." errors from `uv add` because of version constraints between supervision, inference and openCV. Is it possible that you simplify and moving forward just offer one instead of two inference packages and consistently in the inference/supervision/all docs recommend to use that one?
