### PR TITLE
When serializing sv.Detections produced by segmentation model, use sv.Detections['polygon'] as vertices for points if available

### DIFF
--- a/inference/core/workflows/core_steps/common/serializers.py
+++ b/inference/core/workflows/core_steps/common/serializers.py
@@ -63,7 +63,10 @@ def serialise_sv_detections(detections: sv.Detections) -> dict:
         detection_dict[CONFIDENCE_KEY] = float(confidence)
         detection_dict[CLASS_ID_KEY] = int(class_id)
         if mask is not None:
-            polygon = sv.mask_to_polygons(mask=mask)
+            if POLYGON_KEY_IN_SV_DETECTIONS in data:
+                polygon = data[POLYGON_KEY_IN_SV_DETECTIONS]
+            else:
+                polygon = sv.mask_to_polygons(mask=mask)
             detection_dict[POLYGON_KEY] = []
             for x, y in polygon[0]:
                 detection_dict[POLYGON_KEY].append(

--- a/inference/core/workflows/core_steps/common/serializers.py
+++ b/inference/core/workflows/core_steps/common/serializers.py
@@ -64,7 +64,7 @@ def serialise_sv_detections(detections: sv.Detections) -> dict:
         detection_dict[CLASS_ID_KEY] = int(class_id)
         if mask is not None:
             if POLYGON_KEY_IN_SV_DETECTIONS in data:
-                polygon = data[POLYGON_KEY_IN_SV_DETECTIONS]
+                polygon = [data[POLYGON_KEY_IN_SV_DETECTIONS]]
             else:
                 polygon = sv.mask_to_polygons(mask=mask)
             detection_dict[POLYGON_KEY] = []
@@ -88,9 +88,13 @@ def serialise_sv_detections(detections: sv.Detections) -> dict:
                 TIME_IN_ZONE_KEY_IN_SV_DETECTIONS
             ]
         if POLYGON_KEY_IN_SV_DETECTIONS in data:
-            detection_dict[POLYGON_KEY_IN_INFERENCE_RESPONSE] = data[
-                POLYGON_KEY_IN_SV_DETECTIONS
-            ]
+            detection_dict[POLYGON_KEY_IN_INFERENCE_RESPONSE] = (
+                data[POLYGON_KEY_IN_SV_DETECTIONS]
+                .astype(float)
+                .round()
+                .astype(int)
+                .tolist()
+            )
         if (
             BOUNDING_RECT_ANGLE_KEY_IN_SV_DETECTIONS in data
             and BOUNDING_RECT_RECT_KEY_IN_SV_DETECTIONS in data

--- a/inference/core/workflows/core_steps/transformations/dynamic_zones/v1.py
+++ b/inference/core/workflows/core_steps/transformations/dynamic_zones/v1.py
@@ -191,20 +191,19 @@ class DynamicZonesBlockV1(WorkflowBlock):
                 updated_detection[POLYGON_KEY_IN_SV_DETECTIONS] = np.array(
                     [simplified_polygon]
                 )
-                if len(simplified_polygon) == required_number_of_vertices:
-                    simplified_polygon = scale_polygon(
-                        polygon=simplified_polygon,
-                        scale=scale_ratio,
-                    )
-                    simplified_polygons.append(simplified_polygon)
-                    updated_detection.mask = np.array(
-                        [
-                            sv.polygon_to_mask(
-                                polygon=simplified_polygon,
-                                resolution_wh=mask.shape[::-1],
-                            )
-                        ]
-                    )
+                simplified_polygon = scale_polygon(
+                    polygon=simplified_polygon,
+                    scale=scale_ratio,
+                )
+                simplified_polygons.append(simplified_polygon)
+                updated_detection.mask = np.array(
+                    [
+                        sv.polygon_to_mask(
+                            polygon=simplified_polygon,
+                            resolution_wh=mask.shape[::-1],
+                        )
+                    ]
+                )
                 updated_detections.append(updated_detection)
             result.append(
                 {


### PR DESCRIPTION
# Description

The goal is to serve back simplified polygon
Currently, due to the fact that contour is stored as mask, simplification is lost when calling `polygon_to_mask` to store the polygon and then `mask_to_polygons` when serializing.
In order not to lose the simplification of polygon, `sv.Detections["polygon"]` should be used if available.

## Type of change

-   [x] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?

CI passing
Manually tested

## Any specific deployment considerations

N/A

## Docs

N/A