### PR TITLE
Migrate to `logger.warning` usage

### DIFF
--- a/inference/core/active_learning/configuration.py
+++ b/inference/core/active_learning/configuration.py
@@ -55,7 +55,7 @@ def prepare_active_learning_configuration(
             cache=cache,
         )
     except Exception as e:
-        logger.warn(
+        logger.warning(
             f"Failed to initialise Active Learning configuration. Active Learning will not be enabled for this session. Cause: {str(e)}"
         )
         return None
@@ -267,7 +267,7 @@ def initialize_sampling_methods(
     for sampling_strategy_config in sampling_strategies_configs:
         sampling_type = sampling_strategy_config["type"]
         if sampling_type not in TYPE2SAMPLING_INITIALIZERS:
-            logger.warn(
+            logger.warning(
                 f"Could not identify sampling method `{sampling_type}` - skipping initialisation."
             )
             continue

--- a/inference/core/interfaces/camera/camera.py
+++ b/inference/core/interfaces/camera/camera.py
@@ -45,13 +45,13 @@ class WebcamStream:
                     self.vcap.set(opencv_constant, value)
                     logger.info(f"set {opencv_prop} to {value}")
                 else:
-                    logger.warn(f"Property {opencv_prop} not found in cv2")
+                    logger.warning(f"Property {opencv_prop} not found in cv2")
 
         self.width = int(self.vcap.get(cv2.CAP_PROP_FRAME_WIDTH))
         self.height = int(self.vcap.get(cv2.CAP_PROP_FRAME_HEIGHT))
         self.file_mode = self.vcap.get(cv2.CAP_PROP_FRAME_COUNT) > 0
         if self.enforce_fps and not self.file_mode:
-            logger.warn(
+            logger.warning(
                 "Ignoring enforce_fps flag for this stream. It is not compatible with streams and will cause the process to crash"
             )
             self.enforce_fps = False


### PR DESCRIPTION
# Description

This small PR resolves the deprecation warnings of `logger.warn`:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

