### PR TITLE
Handle core models when MODELS_CACHE_AUTH_ENABLED is set

### DIFF
--- a/inference/__init__.py
+++ b/inference/__init__.py
@@ -1,10 +1,10 @@
-from typing import Any, Callable, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Callable
 
 if TYPE_CHECKING:
     from inference.core.interfaces.stream.inference_pipeline import InferencePipeline
     from inference.core.interfaces.stream.stream import Stream
-    from inference.models.utils import get_model, get_roboflow_model
     from inference.core.models.base import Model
+    from inference.models.utils import get_model, get_roboflow_model
 
 _LAZY_ATTRIBUTES: dict[str, Callable[[], Any]] = {
     "Stream": lambda: _import_from("inference.core.interfaces.stream.stream", "Stream"),

--- a/inference/core/registries/roboflow.py
+++ b/inference/core/registries/roboflow.py
@@ -92,6 +92,7 @@ class RoboflowModelRegistry(ModelRegistry):
 def _check_if_api_key_has_access_to_model(
     api_key: str,
     model_id: str,
+    endpoint_type: ModelEndpointType = ModelEndpointType.ORT,
 ) -> bool:
     model_id = resolve_roboflow_model_alias(model_id=model_id)
     _, version_id = get_model_id_chunks(model_id=model_id)
@@ -100,9 +101,9 @@ def _check_if_api_key_has_access_to_model(
             get_roboflow_model_data(
                 api_key=api_key,
                 model_id=model_id,
-                endpoint_type=ModelEndpointType.ORT,
+                endpoint_type=endpoint_type,
                 device_id=GLOBAL_DEVICE_ID,
-            ).get("ort")
+            )
         else:
             get_roboflow_instant_model_data(
                 api_key=api_key,

--- a/inference/core/version.py
+++ b/inference/core/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.48.4"
+__version__ = "0.49.0"
 
 
 if __name__ == "__main__":

--- a/inference/core/version.py
+++ b/inference/core/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.48.3"
+__version__ = "0.48.4"
 
 
 if __name__ == "__main__":

--- a/tests/inference/hosted_platform_tests/test_core_models.py
+++ b/tests/inference/hosted_platform_tests/test_core_models.py
@@ -3,12 +3,27 @@ import requests
 
 from inference_sdk import InferenceHTTPClient
 from inference_sdk.http.errors import HTTPCallErrorError
-from tests.inference.hosted_platform_tests.conftest import IMAGE_URL, ROBOFLOW_API_KEY
+from tests.inference.hosted_platform_tests.conftest import (
+    IMAGE_URL,
+    ROBOFLOW_API_KEY,
+    PlatformEnvironment,
+)
+
+
+EXPECTED_AUTH_ERROR_FOR_ENVIRONMENT = {
+    PlatformEnvironment.ROBOFLOW_STAGING_LAMBDA: 403,
+    PlatformEnvironment.ROBOFLOW_PLATFORM_LAMBDA: 403,
+    PlatformEnvironment.ROBOFLOW_STAGING_SERVERLESS: 401,
+    PlatformEnvironment.ROBOFLOW_PLATFORM_SERVERLESS: 401,
+    PlatformEnvironment.ROBOFLOW_STAGING_LOCALHOST: 403,
+    PlatformEnvironment.ROBOFLOW_PLATFORM_LOCALHOST: 403,
+}
 
 
 @pytest.mark.flaky(retries=4, delay=1)
 def test_infer_from_core_model_without_api_key(
     core_models_service_url: str,
+    platform_environment: PlatformEnvironment,
 ) -> None:
     # given
     client = InferenceHTTPClient(
@@ -20,12 +35,13 @@ def test_infer_from_core_model_without_api_key(
         _ = client.ocr_image(IMAGE_URL)
 
     # then
-    assert error.value.status_code == 403, "Expected to see unauthorised error"
+    assert error.value.status_code == EXPECTED_AUTH_ERROR_FOR_ENVIRONMENT[platform_environment], "Expected to see unauthorised error"
 
 
 @pytest.mark.flaky(retries=4, delay=1)
 def test_infer_from_core_model_with_invalid_api_key(
     core_models_service_url: str,
+    platform_environment: PlatformEnvironment,
 ) -> None:
     # given
     client = InferenceHTTPClient(
@@ -37,7 +53,7 @@ def test_infer_from_core_model_with_invalid_api_key(
         _ = client.ocr_image(IMAGE_URL)
 
     # then
-    assert error.value.status_code == 403, "Expected to see unauthorised error"
+    assert error.value.status_code == EXPECTED_AUTH_ERROR_FOR_ENVIRONMENT[platform_environment], "Expected to see unauthorised error"
 
 
 @pytest.mark.flaky(retries=4, delay=1)


### PR DESCRIPTION
# Description

Handle core models when MODELS_CACHE_AUTH_ENABLED is set

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

CI passing
E2E tests on staging against serverless passing

## Any specific deployment considerations

N/A

## Docs

N/A