### PR TITLE
Added 60s cache expiry for invalid models

### DIFF
--- a/inference/core/models/roboflow.py
+++ b/inference/core/models/roboflow.py
@@ -790,7 +790,7 @@ class OnnxRoboflowInferenceModel(RoboflowInferenceModel):
             cache.set(
                 self.endpoint + "_validate_model_error_count",
                 validate_model_error_count + 1,
-                expire=60
+                expire=60,
             )
             raise ModelArtefactError(
                 "ONNX session not initialized. Check that the model weights are available."
@@ -801,7 +801,7 @@ class OnnxRoboflowInferenceModel(RoboflowInferenceModel):
             cache.set(
                 self.endpoint + "_validate_model_error_count",
                 validate_model_error_count + 1,
-                expire=60
+                expire=60,
             )
             raise ModelArtefactError(f"Unable to run test inference. Cause: {e}") from e
         try:
@@ -810,7 +810,7 @@ class OnnxRoboflowInferenceModel(RoboflowInferenceModel):
             cache.set(
                 self.endpoint + "_validate_model_error_count",
                 validate_model_error_count + 1,
-                expire=60
+                expire=60,
             )
             raise ModelArtefactError(
                 f"Unable to validate model classes. Cause: {e}"

--- a/inference/core/models/roboflow.py
+++ b/inference/core/models/roboflow.py
@@ -790,6 +790,7 @@ class OnnxRoboflowInferenceModel(RoboflowInferenceModel):
             cache.set(
                 self.endpoint + "_validate_model_error_count",
                 validate_model_error_count + 1,
+                expire=60
             )
             raise ModelArtefactError(
                 "ONNX session not initialized. Check that the model weights are available."
@@ -800,6 +801,7 @@ class OnnxRoboflowInferenceModel(RoboflowInferenceModel):
             cache.set(
                 self.endpoint + "_validate_model_error_count",
                 validate_model_error_count + 1,
+                expire=60
             )
             raise ModelArtefactError(f"Unable to run test inference. Cause: {e}") from e
         try:
@@ -808,6 +810,7 @@ class OnnxRoboflowInferenceModel(RoboflowInferenceModel):
             cache.set(
                 self.endpoint + "_validate_model_error_count",
                 validate_model_error_count + 1,
+                expire=60
             )
             raise ModelArtefactError(
                 f"Unable to validate model classes. Cause: {e}"

--- a/inference/usage_tracking/collector.py
+++ b/inference/usage_tracking/collector.py
@@ -691,6 +691,8 @@ class UsageCollector:
                 t1 = time.time()
                 res = func(*args, **kwargs)
                 t2 = time.time()
+                if <check for serverless>
+                THEN do max(100,t2-t1)
                 self.record_usage(
                     **self._extract_usage_params_from_func_kwargs(
                         usage_fps=usage_fps,
@@ -699,7 +701,7 @@ class UsageCollector:
                         usage_workflow_preview=usage_workflow_preview,
                         usage_inference_test_run=usage_inference_test_run,
                         usage_billable=usage_billable,
-                        execution_duration=(t2 - t1),
+                        execution_duration=max(t2 - t1, 100),
                         func=func,
                         category=category,
                         args=args,
@@ -730,7 +732,7 @@ class UsageCollector:
                         usage_workflow_preview=usage_workflow_preview,
                         usage_inference_test_run=usage_inference_test_run,
                         usage_billable=usage_billable,
-                        execution_duration=(t2 - t1),
+                        execution_duration=max(t2 - t1, 100),
                         func=func,
                         category=category,
                         args=args,

--- a/inference/usage_tracking/collector.py
+++ b/inference/usage_tracking/collector.py
@@ -691,8 +691,6 @@ class UsageCollector:
                 t1 = time.time()
                 res = func(*args, **kwargs)
                 t2 = time.time()
-                if <check for serverless>
-                THEN do max(100,t2-t1)
                 self.record_usage(
                     **self._extract_usage_params_from_func_kwargs(
                         usage_fps=usage_fps,
@@ -701,7 +699,7 @@ class UsageCollector:
                         usage_workflow_preview=usage_workflow_preview,
                         usage_inference_test_run=usage_inference_test_run,
                         usage_billable=usage_billable,
-                        execution_duration=max(t2 - t1, 100),
+                        execution_duration=(t2 - t1),
                         func=func,
                         category=category,
                         args=args,
@@ -732,7 +730,7 @@ class UsageCollector:
                         usage_workflow_preview=usage_workflow_preview,
                         usage_inference_test_run=usage_inference_test_run,
                         usage_billable=usage_billable,
-                        execution_duration=max(t2 - t1, 100),
+                        execution_duration=(t2 - t1),
                         func=func,
                         category=category,
                         args=args,


### PR DESCRIPTION
# Description

We currently have a permanent key in the cache which is set when model validation fails 3 times. We want to make this more flexible by expiring the key every minute instead. Sometimes errors can happen in bursts, and this leads to permanent model blocking in the current code.

## Type of change

Please delete options that are not relevant.

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Testing in staging

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
