### PR TITLE
Adding a floor of 100ms for GCP_SERVERLESS

### DIFF
--- a/inference/usage_tracking/collector.py
+++ b/inference/usage_tracking/collector.py
@@ -691,7 +691,7 @@ class UsageCollector:
                 t1 = time.time()
                 res = func(*args, **kwargs)
                 t2 = time.time()
-                if GCP_SERVERLESS == True:
+                if GCP_SERVERLESS is True:
                     execution_duration = max(t2 - t1, 100)
                 else:
                     execution_duration = t2 - t1
@@ -726,7 +726,7 @@ class UsageCollector:
                 t1 = time.time()
                 res = await func(*args, **kwargs)
                 t2 = time.time()
-                if GCP_SERVERLESS == True:
+                if GCP_SERVERLESS is True:
                     execution_duration = max(t2 - t1, 100)
                 else:
                     execution_duration = t2 - t1

--- a/inference/usage_tracking/collector.py
+++ b/inference/usage_tracking/collector.py
@@ -33,7 +33,6 @@ from inference.core.env import (
     REDIS_HOST,
     ROBOFLOW_INTERNAL_SERVICE_NAME,
     ROBOFLOW_INTERNAL_SERVICE_SECRET,
-    GCP_SERVERLESS,
 )
 from inference.core.logger import logger
 from inference.core.version import __version__ as inference_version

--- a/inference/usage_tracking/collector.py
+++ b/inference/usage_tracking/collector.py
@@ -692,7 +692,7 @@ class UsageCollector:
                 res = func(*args, **kwargs)
                 t2 = time.time()
                 if GCP_SERVERLESS is True:
-                    execution_duration = max(t2 - t1, 100)
+                    execution_duration = max(t2 - t1, 0.1)
                 else:
                     execution_duration = t2 - t1
                 self.record_usage(
@@ -727,7 +727,7 @@ class UsageCollector:
                 res = await func(*args, **kwargs)
                 t2 = time.time()
                 if GCP_SERVERLESS is True:
-                    execution_duration = max(t2 - t1, 100)
+                    execution_duration = max(t2 - t1, 0.1)
                 else:
                     execution_duration = t2 - t1
                 await self.async_record_usage(

--- a/inference/usage_tracking/collector.py
+++ b/inference/usage_tracking/collector.py
@@ -33,6 +33,7 @@ from inference.core.env import (
     REDIS_HOST,
     ROBOFLOW_INTERNAL_SERVICE_NAME,
     ROBOFLOW_INTERNAL_SERVICE_SECRET,
+    GCP_SERVERLESS,
 )
 from inference.core.logger import logger
 from inference.core.version import __version__ as inference_version
@@ -691,6 +692,10 @@ class UsageCollector:
                 t1 = time.time()
                 res = func(*args, **kwargs)
                 t2 = time.time()
+                if GCP_SERVERLESS == True:
+                    execution_duration = max(t2 - t1, 100)
+                else:
+                    execution_duration = t2 - t1
                 self.record_usage(
                     **self._extract_usage_params_from_func_kwargs(
                         usage_fps=usage_fps,
@@ -699,7 +704,7 @@ class UsageCollector:
                         usage_workflow_preview=usage_workflow_preview,
                         usage_inference_test_run=usage_inference_test_run,
                         usage_billable=usage_billable,
-                        execution_duration=(t2 - t1),
+                        execution_duration=execution_duration,
                         func=func,
                         category=category,
                         args=args,
@@ -722,6 +727,10 @@ class UsageCollector:
                 t1 = time.time()
                 res = await func(*args, **kwargs)
                 t2 = time.time()
+                if GCP_SERVERLESS == True:
+                    execution_duration = max(t2 - t1, 100)
+                else:
+                    execution_duration = t2 - t1
                 await self.async_record_usage(
                     **self._extract_usage_params_from_func_kwargs(
                         usage_fps=usage_fps,
@@ -730,7 +739,7 @@ class UsageCollector:
                         usage_workflow_preview=usage_workflow_preview,
                         usage_inference_test_run=usage_inference_test_run,
                         usage_billable=usage_billable,
-                        execution_duration=(t2 - t1),
+                        execution_duration=execution_duration,
                         func=func,
                         category=category,
                         args=args,


### PR DESCRIPTION
# Description

Adding a floor for the recorded execution duration of a frame for usage purposes on Roboflow's hosted serverless platform.

## Type of change

Please delete options that are not relevant.

Operational change

## How has this change been tested, please provide a testcase or example of how you tested the change?

Testing in staging and running tests first. Then checking usage tables.

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
