### PR TITLE
add benchmark configuration and case for codeflash

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 # All paths are relative to this pyproject.toml's directory.
 module-root = "inference"
 tests-root = "tests/inference/unit_tests"
+benchmarks-root = "tests/inference/unit_tests/benchmarks"
 test-framework = "pytest"
 ignore-paths = []
 formatter-cmds = ["black $file"]

--- a/tests/inference/unit_tests/benchmarks/core/test_speed_benchmark.py
+++ b/tests/inference/unit_tests/benchmarks/core/test_speed_benchmark.py
@@ -1,0 +1,35 @@
+from inference_cli.lib.benchmark.dataset import load_dataset_images
+import numpy as np
+import pytest
+
+
+from inference import get_model
+
+
+@pytest.fixture
+def dataset_reference() -> tuple[list[np.ndarray], set[tuple[int, int]]]:
+    dataset_images = load_dataset_images(
+        dataset_reference="coco",
+    )
+    return dataset_images, {i.shape[:2] for i in dataset_images}
+
+
+# args of inference benchmark python-package-speed -m yolov8n-seg-640 -bi 10000 command
+args = {
+    "model_id": "yolov8n-seg-640",
+    "dataset_reference": "coco",
+    "warm_up_inferences": 10,
+    "benchmark_inferences": 10000,
+    "batch_size": 1,
+    "api_key": None,
+    "model_configuration": None,
+    "output_location": None,
+}
+
+
+def test_benchmark_equivalent(benchmark, dataset_reference):
+    images, image_sizes = dataset_reference
+
+    model = get_model(model_id="yolov8n-seg-640", api_key=None)
+
+    benchmark(model.infer, images[0])


### PR DESCRIPTION
Hi @grzegorz-roboflow,

We've implemented a benchmark that exercises an end-to-end workflow using the existing inference benchmark:
inference benchmark python-package-speed -m yolov8n-seg-640 -bi 10000.

That said, we believe Codeflash would benefit from having a broader set of end-to-end benchmarks that reflect real workflows. To support this, we'd like to ask Roboflow to define benchmarks for workflows you consider important to optimize.

These benchmarks should be lightweight enough not to take too long to run, and follow the pytest-benchmark format as the interface. (Note: the actual plugin isn't used — Codeflash runs them through its own pytest plugin.)

Let us know if you have any questions or need help setting this up!