### PR TITLE
Fix Moondream2 Workflow long_description. Should be string, not tuple.

### DIFF
--- a/inference/core/workflows/core_steps/models/foundation/moondream2/v1.py
+++ b/inference/core/workflows/core_steps/models/foundation/moondream2/v1.py
@@ -50,9 +50,7 @@ class BlockManifest(WorkflowBlockManifest):
             "name": "Moondream2",
             "version": "v1",
             "short_description": "Run Moondream2 on an image.",
-            "long_description": (
-                "This workflow block runs Moondream2, a multimodal vision-language model. You can use this block to run zero-shot object detection.",
-            ),
+            "long_description": "This workflow block runs Moondream2, a multimodal vision-language model. You can use this block to run zero-shot object detection.",
             "license": "Apache-2.0",
             "block_type": "model",
             "search_keywords": [


### PR DESCRIPTION
# Description

Change Moondream2 Workflow `long_description` property from tuple to string. Otherwise it doesn't show up in the workflow editor:

![CleanShot 2025-05-13 at 18 10 10@2x](https://github.com/user-attachments/assets/85423178-f98b-440e-9ca6-0ff5242dd7ad)

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Ran inference locally and pointed the editor to localhost, to validate that the description shows up properly.

## Any specific deployment considerations

No