### PR TITLE
Fix single return in get_system_info

### DIFF
--- a/inference/core/managers/metrics.py
+++ b/inference/core/managers/metrics.py
@@ -72,7 +72,6 @@ def get_system_info() -> dict:
         info["ip_address"] = socket.gethostbyname(socket.gethostname())
         info["mac_address"] = ":".join(re.findall("..", "%012x" % uuid.getnode()))
         info["processor"] = platform.processor()
-        return info
     except Exception as e:
         logger.exception(e)
     finally:

--- a/tests/inference/unit_tests/core/managers/test_metrics.py
+++ b/tests/inference/unit_tests/core/managers/test_metrics.py
@@ -1,0 +1,17 @@
+from unittest import mock
+
+from inference.core.managers import metrics
+
+
+def test_get_system_info_returns_info() -> None:
+    info = metrics.get_system_info()
+    assert isinstance(info, dict)
+    assert "platform" in info
+
+
+@mock.patch.object(metrics.platform, "system", side_effect=RuntimeError("fail"))
+def test_get_system_info_returns_info_even_on_exception(system_mock: mock.MagicMock) -> None:
+    info = metrics.get_system_info()
+    assert isinstance(info, dict)
+    assert info == {}
+    system_mock.assert_called_once_with()


### PR DESCRIPTION
## Summary
- ensure `get_system_info` has one return statement
- add tests for `get_system_info`

## Testing
- `python3 -m pytest tests/inference/unit_tests/core/managers/test_metrics.py -q` *(fails: No module named pytest)*