### PR TITLE
Fix compatibility typos

### DIFF
--- a/docs/quickstart/devices.md
+++ b/docs/quickstart/devices.md
@@ -48,4 +48,4 @@ The installation and setup instructions are the same as for any edge device, onc
 
 You can also run your models in the cloud with the <a href="https://docs.roboflow.com/deploy/hosted-api" target="_blank">Roboflow hosted inference offering</a>. The Roboflow hosted inference solution enables you to deploy your models in the cloud without having to manage your own infrastructure. Roboflow's hosted solution does not support all features available in Inference that you can run on your own infrastructure.
 
-To learn more about device compatability with different models, refer to the [model compatability matrix](./compatability_matrix.md).
+To learn more about device compatibility with different models, refer to the [model compatibility matrix](./compatability_matrix.md).

--- a/inference/core/interfaces/http/http_api.py
+++ b/inference/core/interfaces/http/http_api.py
@@ -2283,7 +2283,7 @@ class HttpInterface(BaseInterface):
             app.include_router(builder_router, prefix="/build", tags=["builder"])
 
         if LEGACY_ROUTE_ENABLED:
-            # Legacy object detection inference path for backwards compatability
+            # Legacy object detection inference path for backwards compatibility
             @app.get(
                 "/{dataset_id}/{version_id:str}",
                 # Order matters in this response model Union. It will use the first matching model. For example, Object Detection Inference Response is a subset of Instance segmentation inference response, so instance segmentation must come first in order for the matching logic to work.
@@ -2551,7 +2551,7 @@ class HttpInterface(BaseInterface):
                     return orjson_response(inference_response)
 
         if not (LAMBDA or GCP_SERVERLESS):
-            # Legacy clear cache endpoint for backwards compatability
+            # Legacy clear cache endpoint for backwards compatibility
             @app.get("/clear_cache", response_model=str)
             async def legacy_clear_cache():
                 """
@@ -2566,7 +2566,7 @@ class HttpInterface(BaseInterface):
                 await model_clear()
                 return "Cache Cleared"
 
-            # Legacy add model endpoint for backwards compatability
+            # Legacy add model endpoint for backwards compatibility
             @app.get("/start/{dataset_id}/{version_id}")
             async def model_add_legacy(
                 dataset_id: str, version_id: str, api_key: str = None


### PR DESCRIPTION
## Summary
- fix `compatibility` spelling in HTTP API comments
- update `devices.md` text to use `compatibility`

## Testing
- `make check_code_quality` *(fails: flake8 not installed)*
- `pytest tests/inference/unit_tests` *(fails: pytest not installed)*