### PR TITLE
Fix JSON parser for direct strings

### DIFF
--- a/inference/core/workflows/core_steps/formatters/json_parser/v1.py
+++ b/inference/core/workflows/core_steps/formatters/json_parser/v1.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import re
-from typing import List, Literal, Optional, Tuple, Type
+from typing import List, Literal, Optional, Tuple, Type, Union
 
 from pydantic import AfterValidator, ConfigDict, Field
 from typing_extensions import Annotated
@@ -68,9 +68,9 @@ class BlockManifest(WorkflowBlockManifest):
         }
     )
     type: Literal["roboflow_core/json_parser@v1"]
-    raw_json: Selector(kind=[LANGUAGE_MODEL_OUTPUT_KIND]) = Field(
+    raw_json: Union[str, Selector(kind=[LANGUAGE_MODEL_OUTPUT_KIND])] = Field(
         description="The string with raw JSON to parse.",
-        examples=[["$steps.lmm.output"]],
+        examples=[["$steps.lmm.output"], ['{"key": "value"}']],
     )
     expected_fields: Annotated[List[str], AfterValidator(validate_reserved_fields)] = (
         Field(

--- a/tests/workflows/integration_tests/execution/test_workflow_json_parser_config.py
+++ b/tests/workflows/integration_tests/execution/test_workflow_json_parser_config.py
@@ -1,0 +1,73 @@
+import numpy as np
+import supervision as sv
+
+from inference.core.env import WORKFLOWS_MAX_CONCURRENT_STEPS
+from inference.core.managers.base import ModelManager
+from inference.core.workflows.core_steps.common.entities import StepExecutionMode
+from inference.core.workflows.execution_engine.core import ExecutionEngine
+
+JSON_PARSER_WORKFLOW = {
+    "version": "1.0",
+    "inputs": [
+        {
+            "type": "WorkflowParameter",
+            "name": "config",
+            "default_value": "{\"model_id\": \"yolov8n-640\"}",
+        },
+        {"type": "WorkflowImage", "name": "image"},
+    ],
+    "steps": [
+        {
+            "type": "roboflow_core/json_parser@v1",
+            "name": "json_parser",
+            "raw_json": "$inputs.config",
+            "expected_fields": ["model_id"],
+        },
+        {
+            "type": "roboflow_core/roboflow_object_detection_model@v2",
+            "name": "model",
+            "images": "$inputs.image",
+            "model_id": "$steps.json_parser.model_id",
+        },
+    ],
+    "outputs": [
+        {
+            "type": "JsonField",
+            "name": "json_parser",
+            "selector": "$steps.json_parser.model_id",
+        },
+        {
+            "type": "JsonField",
+            "name": "model_predictions",
+            "selector": "$steps.model.predictions",
+        },
+    ],
+}
+
+
+def test_workflow_with_json_parameter(
+    model_manager: ModelManager,
+    dogs_image: np.ndarray,
+) -> None:
+    workflow_init_parameters = {
+        "workflows_core.model_manager": model_manager,
+        "workflows_core.api_key": None,
+        "workflows_core.step_execution_mode": StepExecutionMode.LOCAL,
+    }
+    execution_engine = ExecutionEngine.init(
+        workflow_definition=JSON_PARSER_WORKFLOW,
+        init_parameters=workflow_init_parameters,
+        max_concurrent_steps=WORKFLOWS_MAX_CONCURRENT_STEPS,
+    )
+
+    result = execution_engine.run(
+        runtime_parameters={
+            "image": dogs_image,
+            "config": "{\"model_id\": \"yolov8n-640\"}",
+        }
+    )
+
+    assert len(result) == 1
+    assert set(result[0].keys()) == {"json_parser", "model_predictions"}
+    assert result[0]["json_parser"] == "yolov8n-640"
+    assert isinstance(result[0]["model_predictions"], sv.Detections)

--- a/tests/workflows/unit_tests/core_steps/formatters/test_json_parser.py
+++ b/tests/workflows/unit_tests/core_steps/formatters/test_json_parser.py
@@ -32,6 +32,27 @@ def test_parsing_manifest_when_input_is_valid() -> None:
     )
 
 
+def test_parsing_manifest_when_raw_json_is_plain_string() -> None:
+    # given
+    raw_manifest = {
+        "name": "parser",
+        "type": "roboflow_core/json_parser@v1",
+        "raw_json": "{\"a\": 1}",
+        "expected_fields": ["a"],
+    }
+
+    # when
+    result = BlockManifest.model_validate(raw_manifest)
+
+    # then
+    assert result == BlockManifest(
+        name="parser",
+        type="roboflow_core/json_parser@v1",
+        raw_json="{\"a\": 1}",
+        expected_fields=["a"],
+    )
+
+
 def test_parsing_manifest_when_input_is_invalid() -> None:
     # given
     raw_manifest = {


### PR DESCRIPTION
This PR is generated by OpenAI Codex

I don't think it actually resolved the issue that the input selector isn't properly getting converted to the json from that ref, but might be a good starting point to try to fix the issue.  More context on the bug and request for it on roboflow internal slack here: https://roboflow.slack.com/archives/C06BD36S37A/p1746462559704149

## Summary
- allow JSON Parser to accept raw strings or selectors
- test manifest handling of plain string input
- exercise json_parser block in integration test

## Testing
- `make style`
- `make check_code_quality` *(fails: flake8 missing)*
- `pytest tests/workflows/unit_tests/core_steps/formatters/test_json_parser.py::test_parsing_manifest_when_raw_json_is_plain_string` *(fails: pytest not installed)*
- `pytest tests/workflows/integration_tests/execution/test_workflow_json_parser_config.py::test_workflow_with_json_parameter` *(fails: pytest not installed)*