### PR TITLE
Fix CodeQL scan

### DIFF
--- a/app_bundles/osx/launcher.c.txt
+++ b/app_bundles/osx/launcher.c.txt
@@ -1,3 +1,8 @@
+// this is the source code for the binary checked in to the repo.  
+// renamed to .txt to make code scanning ignore it 
+// TODO:  change CodeQL config to advanced mode in github and make it explicitly ignore this file or figure out how to tell it to build it
+// it currently complains that: Exit code was 32 and last log line was: CodeQL detected code written in C/C++ but could not automatically build any of it
+
 #include <stdlib.h>
 #include <unistd.h>
 #include <libgen.h>


### PR DESCRIPTION
# Description
as part of app bundling code we added a c source file.  its just in the repo for reference (tiny binary compiled from it is also included for the build)

however, this makes the autpomated codeQL scanner unhappy, which fails with error:
```
Exit code was 32 and last log line was: CodeQL detected code written in C/C++ but could not automatically build any of it
```

We can probably change the github repo settings to do manual/advanced config for the code scanning tool, but for right now I think easier to just rename this file so it gets ignored since its just here for reference and resolves the issue that CI is reporting error on main 

## Type of change

Please delete options that are not relevant.
-   [X] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?
n/a

## Any specific deployment considerations
n/a

## Docs
n/a