### PR TITLE
Recalculate perspective transformation matrix for each frame if extended

### DIFF
--- a/inference/core/workflows/core_steps/transformations/perspective_correction/v1.py
+++ b/inference/core/workflows/core_steps/transformations/perspective_correction/v1.py
@@ -706,7 +706,8 @@ class PerspectiveCorrectionBlockV1(WorkflowBlock):
         if not predictions:
             predictions = [None] * len(images)
 
-        if not self.perspective_transformers:
+        if not self.perspective_transformers or extend_perspective_polygon_by_detections_anchor:
+            self.perspective_transformers = []
             largest_perspective_polygons = pick_largest_perspective_polygons(
                 perspective_polygons
             )

--- a/inference/core/workflows/core_steps/transformations/perspective_correction/v1.py
+++ b/inference/core/workflows/core_steps/transformations/perspective_correction/v1.py
@@ -706,7 +706,10 @@ class PerspectiveCorrectionBlockV1(WorkflowBlock):
         if not predictions:
             predictions = [None] * len(images)
 
-        if not self.perspective_transformers or extend_perspective_polygon_by_detections_anchor:
+        if (
+            not self.perspective_transformers
+            or extend_perspective_polygon_by_detections_anchor
+        ):
             self.perspective_transformers = []
             largest_perspective_polygons = pick_largest_perspective_polygons(
                 perspective_polygons

--- a/requirements/requirements.transformers.txt
+++ b/requirements/requirements.transformers.txt
@@ -1,6 +1,6 @@
 torch>=2.0.1,<2.7.0
 torchvision>=0.15.0
-transformers>=4.50.0
+transformers>=4.50.0,<4.52.0
 timm~=1.0.0
 accelerate>=0.25.0,<=0.32.1
 einops>=0.7.0,<=0.8.0


### PR DESCRIPTION
# Description

When running perspective correction on video with option to extend perspective polygon, perspective transformation matrix should be recalculated for each frame.

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

CI passing

## Any specific deployment considerations

N/A

## Docs

N/A