### PR TITLE
Extend dynamic zone block with dynamic zone fitting of edges produced by convex hull

### DIFF
--- a/inference/core/workflows/core_steps/transformations/dynamic_zones/v1.py
+++ b/inference/core/workflows/core_steps/transformations/dynamic_zones/v1.py
@@ -1,4 +1,4 @@
-from typing import List, Literal, Optional, Type, Union
+from typing import List, Literal, Optional, Tuple, Type, Union
 
 import cv2 as cv
 import numpy as np
@@ -15,6 +15,7 @@ from inference.core.workflows.execution_engine.entities.base import (
 from inference.core.workflows.execution_engine.entities.types import (
     BOOLEAN_KIND,
     FLOAT_KIND,
+    FLOAT_ZERO_TO_ONE_KIND,
     INSTANCE_SEGMENTATION_PREDICTION_KIND,
     INTEGER_KIND,
     LIST_OF_VALUES_KIND,
@@ -78,6 +79,17 @@ class DynamicZonesManifest(WorkflowBlockManifest):
         description="Expand resulting polygon along imaginary line from centroid to edge by this ratio",
         examples=[1.05, "$inputs.scale_ratio"],
     )
+    apply_least_squares: Union[bool, Selector(kind=[BOOLEAN_KIND])] = Field(  # type: ignore
+        default=False,
+        description="Apply least squares algorithm to fit resulting polygon edges to base contour",
+        examples=[True, "$inputs.apply_least_squares"],
+    )
+    midpoint_fraction: Union[float, Selector(kind=[FLOAT_ZERO_TO_ONE_KIND])] = Field(  # type: ignore
+        default=1,
+        description="Fraction of vertices to keep in the middle of each edge before fitting least squares line. "
+        "This parameter is useful when vertices of convex polygon are not aligned with edge that would be otherwise fitted to points closer to the center of each edge.",
+        examples=[0.9, "$inputs.midpoint_fraction"],
+    )
 
     @classmethod
     def get_parameters_accepting_batches(cls) -> List[str]:
@@ -101,9 +113,8 @@ class DynamicZonesManifest(WorkflowBlockManifest):
 
 
 def calculate_simplified_polygon(
-    mask: np.ndarray, required_number_of_vertices: int, max_steps: int = 1000
-) -> np.ndarray:
-    contours = sv.mask_to_polygons(mask)
+    contours: List[np.ndarray], required_number_of_vertices: int, max_steps: int = 1000
+) -> Tuple[np.ndarray, np.ndarray]:
     largest_contour = max(contours, key=len)
 
     # https://docs.opencv.org/4.x/d3/dc0/group__imgproc__shape.html#ga014b28e56cb8854c0de4a211cb2be656
@@ -134,7 +145,78 @@ def calculate_simplified_polygon(
         )
     while len(simplified_polygon.shape) > 2:
         simplified_polygon = np.concatenate(simplified_polygon)
-    return simplified_polygon
+    return simplified_polygon, largest_contour
+
+
+def calculate_least_squares_polygon(
+    contour: np.ndarray, polygon: np.ndarray, midpoint_fraction: float = 1
+) -> np.ndarray:
+    def find_closest_index(point: np.ndarray, contour: np.ndarray) -> int:
+        dists = np.linalg.norm(contour - point, axis=1)
+        return np.argmin(dists)
+
+    def pick_contour_points_between_vertices(
+        point_1: np.ndarray, point_2: np.ndarray, contour: np.ndarray
+    ) -> np.ndarray:
+        i1 = find_closest_index(point_1, contour)
+        i2 = find_closest_index(point_2, contour)
+
+        if i1 <= i2:
+            return contour[i1 : i2 + 1]
+        else:
+            return np.concatenate((contour[i1:], contour[: i2 + 1]), axis=0)
+
+    def least_squares_line(points: np.ndarray) -> Optional[Tuple[float, float]]:
+        if len(points) < 2:
+            return None
+        x = points[:, 0]
+        y = points[:, 1]
+        A = np.vstack([x, np.ones_like(x)]).T
+        a, b = np.linalg.lstsq(A, y, rcond=None)[0]
+        return (a, b)
+
+    def intersect_lines(
+        line_1: Optional[Tuple[float, float]], line_2: Optional[Tuple[float, float]]
+    ) -> Optional[np.ndarray]:
+        if line_1 is None or line_2 is None:
+            return None
+        a_1, b_1 = line_1
+        a_2, b_2 = line_2
+        if np.isclose(a_1, a_2):
+            return None
+        x = (b_2 - b_1) / (a_1 - a_2)
+        y = a_1 * x + b_1
+        return np.array([x, y])
+
+    pairs = list(zip(polygon[:-1], polygon[1:]))
+    pairs.append((polygon[-1], polygon[0]))
+
+    lines = []
+    for point_1, point_2 in pairs:
+        segment_points = pick_contour_points_between_vertices(point_1, point_2, contour)
+        if midpoint_fraction < 1:
+            number_of_points = int(round(len(segment_points) * midpoint_fraction))
+            if number_of_points > 2:
+                number_of_points_to_discard = (
+                    len(segment_points) - number_of_points
+                ) // 2
+                segment_points = segment_points[
+                    number_of_points_to_discard : len(segment_points)
+                    - number_of_points_to_discard
+                ]
+        line_params = least_squares_line(segment_points)
+        lines.append(line_params)
+
+    intersections = []
+    for i in range(len(lines)):
+        line_1 = lines[i]
+        line_2 = lines[(i + 1) % len(lines)]
+        pt = intersect_lines(line_1, line_2)
+        intersections.append(pt)
+
+    intersections = [intersections[-1]] + intersections[:-1]
+
+    return np.array(intersections, dtype=float).round().astype(int)
 
 
 def scale_polygon(polygon: np.ndarray, scale: float) -> np.ndarray:
@@ -165,7 +247,9 @@ class DynamicZonesBlockV1(WorkflowBlock):
         self,
         predictions: Batch[sv.Detections],
         required_number_of_vertices: int,
-        scale_ratio: float,
+        scale_ratio: float = 1,
+        apply_least_squares: bool = False,
+        midpoint_fraction: float = 1,
     ) -> BlockResult:
         result = []
         for detections in predictions:
@@ -182,10 +266,17 @@ class DynamicZonesBlockV1(WorkflowBlock):
                 # copy
                 updated_detection = detections[i]
 
-                simplified_polygon = calculate_simplified_polygon(
-                    mask=mask,
+                contours = sv.mask_to_polygons(mask)
+                simplified_polygon, largest_contour = calculate_simplified_polygon(
+                    contours=contours,
                     required_number_of_vertices=required_number_of_vertices,
                 )
+                if apply_least_squares:
+                    simplified_polygon = calculate_least_squares_polygon(
+                        contour=largest_contour,
+                        polygon=simplified_polygon,
+                        midpoint_fraction=midpoint_fraction,
+                    )
                 vertices_count, _ = simplified_polygon.shape
                 if vertices_count < required_number_of_vertices:
                     all_converged = False


### PR DESCRIPTION
# Description

Currently dynamic zones block produces simplified polygon based on cv convex hull. In some cases this might produce result that is not very accurate:

![Screenshot 2025-05-21 at 23 44 40](https://github.com/user-attachments/assets/2398441d-4073-4691-90f1-1337dba99a96)

Introducing extra parameter: `apply_least_squares`, setting this parameter to `True` will enable fine tuning of edges based on least squares algorithm.
Introducing extra parameter: `midpoint_fraction`, setting this parameter to any number below `1` (100%) will result in taking under account subset of points from the middle of the edge.

Result:

![Screenshot 2025-05-21 at 23 45 02](https://github.com/user-attachments/assets/17127a06-6460-406e-8111-7c0958c5e144)


## Type of change

Please delete options that are not relevant.

-   [x] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?

CI passing

## Any specific deployment considerations

N/A

## Docs

N/A