### PR TITLE
silcence libav swscaler warnings

### DIFF
--- a/inference/core/interfaces/stream_manager/manager_app/webrtc.py
+++ b/inference/core/interfaces/stream_manager/manager_app/webrtc.py
@@ -14,9 +14,8 @@ from aiortc import (
     VideoStreamTrack,
 )
 from aiortc.contrib.media import MediaRelay
-from aiortc.mediastreams import MediaStreamError
 from aiortc.rtcrtpreceiver import RemoteStreamTrack
-from av import VideoFrame
+from av import logging as av_logging, VideoFrame
 
 from inference.core import logger
 from inference.core.interfaces.camera.entities import (
@@ -87,6 +86,8 @@ class VideoTransformTrack(VideoStreamTrack):
         self._max_consecutive_timeouts: Optional[int] = max_consecutive_timeouts
         self._min_consecutive_on_time: int = min_consecutive_on_time
 
+        self._av_logging_set: bool = False
+
     def set_track(self, track: RemoteStreamTrack):
         if not self.track:
             self.track = track
@@ -95,6 +96,10 @@ class VideoTransformTrack(VideoStreamTrack):
         self._track_active = False
 
     async def recv(self):
+        # Silencing swscaler warnings in multi-threading environment
+        if not self._av_logging_set:
+            av_logging.set_libav_level(av_logging.ERROR)
+            self._av_logging_set = True
         frame: VideoFrame = await self.track.recv()
         self._processed += 1
         if not self.incoming_stream_fps:

--- a/inference/core/interfaces/stream_manager/manager_app/webrtc.py
+++ b/inference/core/interfaces/stream_manager/manager_app/webrtc.py
@@ -15,7 +15,8 @@ from aiortc import (
 )
 from aiortc.contrib.media import MediaRelay
 from aiortc.rtcrtpreceiver import RemoteStreamTrack
-from av import logging as av_logging, VideoFrame
+from av import VideoFrame
+from av import logging as av_logging
 
 from inference.core import logger
 from inference.core.interfaces.camera.entities import (


### PR DESCRIPTION
# Description

Silence 'swscaler No accelerated colorspace conversion found from yuv420p to bgr24' warnings

## Type of change

-   [x] QoL

## How has this change been tested, please provide a testcase or example of how you tested the change?

CI passing
Manually tested

When running webrtc pipeline, warnings below are no longer produced:

```log
[swscaler @ 0x118060000] No accelerated colorspace conversion found from yuv420p to bgr24.
```

## Any specific deployment considerations

N/A

## Docs

N/A