### PR TITLE
allow app bundle actions to write to release

### DIFF
--- a/.github/workflows/build-osx-bundle.yml
+++ b/.github/workflows/build-osx-bundle.yml
@@ -12,6 +12,8 @@ on:
 jobs:
   build_osx:
     runs-on: macos-latest
+    permissions:
+      contents: write
     env:
       KEYCHAIN_NAME: "build-keychain.keychain"
       CODESIGN_IDENTITY_STRING: "Developer ID Application: Roboflow, LLC (7SBQ39NG7G)"

--- a/.github/workflows/build-windows-installer.yml
+++ b/.github/workflows/build-windows-installer.yml
@@ -12,6 +12,8 @@ on:
 jobs:
   build_windows:
     runs-on: windows-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
# Description
App bundle release trigger works fine to build the app bundles/installer, but the last step to upload to release was failing because the action didnt have write access to repo.  This fixes that.

I uploaded the build artifacts from latest release manually, so this should fix it so for the next release it will happen autoamtically

## Type of change

Please delete options that are not relevant.
-   [X] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?
n/a

## Any specific deployment considerations
n/a

## Docs
n/a