### PR TITLE
fix task name for instance seg api endpoint

### DIFF
--- a/docs/quickstart/http_inference.md
+++ b/docs/quickstart/http_inference.md
@@ -74,7 +74,7 @@ There are two generations of routes in a Roboflow inference server To see what r
         2. `image_url`: The URL of the image you want to run inference on.
         3. `confidence`: The confidence threshold for predictions. Predictions with a confidence score below this threshold will be filtered out.
         4. `api_key`: Your Roboflow API key. <a href="https://docs.roboflow.com/api-reference/authentication#retrieve-an-api-key" target="_blank">Learn how to retrieve your Roboflow API key</a>.
-        5. `task`: The type of task you want to run. Choose from `object_detection`, `classification`, or `segmentation`.
+        5. `task`: The type of task you want to run. Choose from `object_detection`, `classification`, or `instance_segmentation`.
 
         Then, run the Python script:
 
@@ -134,7 +134,7 @@ There are two generations of routes in a Roboflow inference server To see what r
         1. `project_id`, `model_version`: Your project ID and model version number. <a href="https://docs.roboflow.com/api-reference/workspace-and-project-ids" target="_blank">Learn how to retrieve your project ID and model version number</a>.
         2. `confidence`: The confidence threshold for predictions. Predictions with a confidence score below this threshold will be filtered out.
         3. `api_key`: Your Roboflow API key. <a href="https://docs.roboflow.com/api-reference/authentication#retrieve-an-api-key" target="_blank">Learn how to retrieve your Roboflow API key</a>.
-        4. `task`: The type of task you want to run. Choose from `object_detection`, `classification`, or `segmentation`.
+        4. `task`: The type of task you want to run. Choose from `object_detection`, `classification`, or `instance_segmentation`.
         5. `filename`: The path to the image you want to run inference on.
 
         Then, run the Python script:
@@ -205,7 +205,7 @@ There are two generations of routes in a Roboflow inference server To see what r
         1. `project_id`, `model_version`: Your project ID and model version number. <a href="https://docs.roboflow.com/api-reference/workspace-and-project-ids" target="_blank">Learn how to retrieve your project ID and model version number</a>.
         2. `confidence`: The confidence threshold for predictions. Predictions with a confidence score below this threshold will be filtered out.
         3. `api_key`: Your Roboflow API key. <a href="https://docs.roboflow.com/api-reference/authentication#retrieve-an-api-key" target="_blank">Learn how to retrieve your Roboflow API key</a>.
-        4. `task`: The type of task you want to run. Choose from `object_detection`, `classification`, or `segmentation`.
+        4. `task`: The type of task you want to run. Choose from `object_detection`, `classification`, or `instance_segmentation`.
         5. `filename`: The path to the image you want to run inference on.
 
         Then, run the Python script:
@@ -262,7 +262,7 @@ There are two generations of routes in a Roboflow inference server To see what r
         1. `project_id`, `model_version`: Your project ID and model version number. <a href="https://docs.roboflow.com/api-reference/workspace-and-project-ids" target="_blank">Learn how to retrieve your project ID and model version number</a>.
         2. `confidence`: The confidence threshold for predictions. Predictions with a confidence score below this threshold will be filtered out.
         3. `api_key`: Your Roboflow API key. <a href="https://docs.roboflow.com/api-reference/authentication#retrieve-an-api-key" target="_blank">Learn how to retrieve your Roboflow API key</a>.
-        4. `task`: The type of task you want to run. Choose from `object_detection`, `classification`, or `segmentation`.
+        4. `task`: The type of task you want to run. Choose from `object_detection`, `classification`, or `instance_segmentation`.
         5. `filename`: The path to the image you want to run inference on.
 
         Then, run the Python script:
@@ -305,7 +305,7 @@ There are two generations of routes in a Roboflow inference server To see what r
         1. `project_id`, `model_version`: Your project ID and model version number. <a href="https://docs.roboflow.com/api-reference/workspace-and-project-ids" target="_blank">Learn how to retrieve your project ID and model version number</a>.
         2. `confidence`: The confidence threshold for predictions. Predictions with a confidence score below this threshold will be filtered out.
         3. `api_key`: Your Roboflow API key. <a href="https://docs.roboflow.com/api-reference/authentication#retrieve-an-api-key" target="_blank">Learn how to retrieve your Roboflow API key</a>.
-        4. `task`: The type of task you want to run. Choose from `object_detection`, `classification`, or `segmentation`.
+        4. `task`: The type of task you want to run. Choose from `object_detection`, `classification`, or `instance_segmentation`.
         5. `filename`: The path to the image you want to run inference on.
 
         Then, run the Python script:
@@ -355,7 +355,7 @@ There are two generations of routes in a Roboflow inference server To see what r
         1. `project_id`, `model_version`: Your project ID and model version number. <a href="https://docs.roboflow.com/api-reference/workspace-and-project-ids" target="_blank">Learn how to retrieve your project ID and model version number</a>.
         2. `confidence`: The confidence threshold for predictions. Predictions with a confidence score below this threshold will be filtered out.
         3. `api_key`: Your Roboflow API key. <a href="https://docs.roboflow.com/api-reference/authentication#retrieve-an-api-key" target="_blank">Learn how to retrieve your Roboflow API key</a>.
-        4. `task`: The type of task you want to run. Choose from `object_detection`, `classification`, or `segmentation`.
+        4. `task`: The type of task you want to run. Choose from `object_detection`, `classification`, or `instance_segmentation`.
         5. `filename`: The path to the image you want to run inference on.
 
         Then, run the Python script:
@@ -397,7 +397,7 @@ There are two generations of routes in a Roboflow inference server To see what r
         1. `project_id`, `model_version`: Your project ID and model version number. <a href="https://docs.roboflow.com/api-reference/workspace-and-project-ids" target="_blank">Learn how to retrieve your project ID and model version number</a>.
         2. `confidence`: The confidence threshold for predictions. Predictions with a confidence score below this threshold will be filtered out.
         3. `api_key`: Your Roboflow API key. <a href="https://docs.roboflow.com/api-reference/authentication#retrieve-an-api-key" target="_blank">Learn how to retrieve your Roboflow API key</a>.
-        4. `task`: The type of task you want to run. Choose from `object_detection`, `classification`, or `segmentation`.
+        4. `task`: The type of task you want to run. Choose from `object_detection`, `classification`, or `instance_segmentation`.
         5. `filename`: The path to the image you want to run inference on.
 
         Then, run the Python script:

--- a/docs/quickstart/run_model_on_image.md
+++ b/docs/quickstart/run_model_on_image.md
@@ -221,7 +221,7 @@ There are two generations of routes in a Roboflow inference server To see what r
         1. `project_id`, `model_version`: Your project ID and model version number. <a href="https://docs.roboflow.com/api-reference/workspace-and-project-ids" target="_blank">Learn how to retrieve your project ID and model version number</a>.
         2. `confidence`: The confidence threshold for predictions. Predictions with a confidence score below this threshold will be filtered out.
         3. `api_key`: Your Roboflow API key. <a href="https://docs.roboflow.com/api-reference/authentication#retrieve-an-api-key" target="_blank">Learn how to retrieve your Roboflow API key</a>.
-        4. `task`: The type of task you want to run. Choose from `object_detection`, `classification`, or `segmentation`.
+        4. `task`: The type of task you want to run. Choose from `object_detection`, `classification`, or `instance_segmentation`.
         5. `filename`: The path to the image you want to run inference on.
 
         Then, run the Python script:
@@ -267,7 +267,7 @@ There are two generations of routes in a Roboflow inference server To see what r
         1. `project_id`, `model_version`: Your project ID and model version number. <a href="https://docs.roboflow.com/api-reference/workspace-and-project-ids" target="_blank">Learn how to retrieve your project ID and model version number</a>.
         2. `confidence`: The confidence threshold for predictions. Predictions with a confidence score below this threshold will be filtered out.
         3. `api_key`: Your Roboflow API key. <a href="https://docs.roboflow.com/api-reference/authentication#retrieve-an-api-key" target="_blank">Learn how to retrieve your Roboflow API key</a>.
-        4. `task`: The type of task you want to run. Choose from `object_detection`, `classification`, or `segmentation`.
+        4. `task`: The type of task you want to run. Choose from `object_detection`, `classification`, or `instance_segmentation`.
         5. `filename`: The path to the image you want to run inference on.
 
         Then, run the Python script:
@@ -317,7 +317,7 @@ There are two generations of routes in a Roboflow inference server To see what r
         1. `project_id`, `model_version`: Your project ID and model version number. <a href="https://docs.roboflow.com/api-reference/workspace-and-project-ids" target="_blank">Learn how to retrieve your project ID and model version number</a>.
         2. `confidence`: The confidence threshold for predictions. Predictions with a confidence score below this threshold will be filtered out.
         3. `api_key`: Your Roboflow API key. <a href="https://docs.roboflow.com/api-reference/authentication#retrieve-an-api-key" target="_blank">Learn how to retrieve your Roboflow API key</a>.
-        4. `task`: The type of task you want to run. Choose from `object_detection`, `classification`, or `segmentation`.
+        4. `task`: The type of task you want to run. Choose from `object_detection`, `classification`, or `instance_segmentation`.
         5. `filename`: The path to the image you want to run inference on.
 
         Then, run the Python script:
@@ -359,7 +359,7 @@ There are two generations of routes in a Roboflow inference server To see what r
         1. `project_id`, `model_version`: Your project ID and model version number. <a href="https://docs.roboflow.com/api-reference/workspace-and-project-ids" target="_blank">Learn how to retrieve your project ID and model version number</a>.
         2. `confidence`: The confidence threshold for predictions. Predictions with a confidence score below this threshold will be filtered out.
         3. `api_key`: Your Roboflow API key. <a href="https://docs.roboflow.com/api-reference/authentication#retrieve-an-api-key" target="_blank">Learn how to retrieve your Roboflow API key</a>.
-        4. `task`: The type of task you want to run. Choose from `object_detection`, `classification`, or `segmentation`.
+        4. `task`: The type of task you want to run. Choose from `object_detection`, `classification`, or `instance_segmentation`.
         5. `filename`: The path to the image you want to run inference on.
 
         Then, run the Python script:


### PR DESCRIPTION
# Description
User noticed that we were suggesting `segmentation` here when actually the endpoint is `/infer/insatnce_segmentation`

## Type of change
Docs update

## How has this change been tested, please provide a testcase or example of how you tested the change?
n/a

## Any specific deployment considerations
n/a

## Docs
-   [X] Docs updated? What were the changes: fixed segmentation -> instance_segmentation for task name in example
