### PR TITLE
Fix RTMP lack of smoothness

### DIFF
--- a/inference/core/interfaces/camera/video_source.py
+++ b/inference/core/interfaces/camera/video_source.py
@@ -1113,14 +1113,14 @@ def get_from_queue(
     queue.task_done() and on_successful_read(...) will be called on each received element.
     """
     result = None
-    if queue.empty() and not purge:
+    if queue.empty() or not purge:
         try:
             result = queue.get(timeout=timeout)
             queue.task_done()
             on_successful_read()
         except Empty:
             pass
-    while not queue.empty():
+    while not queue.empty() and purge:
         result = queue.get()
         queue.task_done()
         on_successful_read()

--- a/inference/core/interfaces/camera/video_source.py
+++ b/inference/core/interfaces/camera/video_source.py
@@ -1120,14 +1120,13 @@ def get_from_queue(
             on_successful_read()
         except Empty:
             pass
+    if not purge:
+        return result
     while not queue.empty() and purge:
         result = queue.get()
         queue.task_done()
         on_successful_read()
-        if purge:
-            break
     return result
-
 
 def drop_single_frame_from_buffer(
     buffer: Queue,

--- a/inference/core/interfaces/camera/video_source.py
+++ b/inference/core/interfaces/camera/video_source.py
@@ -553,7 +553,10 @@ class VideoSource:
         if not self._is_file:
             current_timestamp = time.time_ns()
             if (current_timestamp - self._last_frame_timestamp) / 1e9 < 1 / self._fps:
-                time.sleep((1 / self._fps) - (current_timestamp - self._last_frame_timestamp) / 1e9)
+                time.sleep(
+                    (1 / self._fps)
+                    - (current_timestamp - self._last_frame_timestamp) / 1e9
+                )
         video_frame: Optional[Union[VideoFrame, str]] = get_from_queue(
             queue=self._frames_buffer,
             on_successful_read=self._video_consumer.notify_frame_consumed,
@@ -1121,7 +1124,7 @@ def get_from_queue(
         result = queue.get()
         queue.task_done()
         on_successful_read()
-        if not purge:
+        if purge:
             break
     return result
 

--- a/inference/core/interfaces/camera/video_source.py
+++ b/inference/core/interfaces/camera/video_source.py
@@ -1110,16 +1110,19 @@ def get_from_queue(
     queue.task_done() and on_successful_read(...) will be called on each received element.
     """
     result = None
-    if queue.empty() or not purge:
+    if queue.empty() and not purge:
         try:
             result = queue.get(timeout=timeout)
             queue.task_done()
             on_successful_read()
         except Empty:
             pass
-    result = queue.get()
-    queue.task_done()
-    on_successful_read()
+    while not queue.empty():
+        result = queue.get()
+        queue.task_done()
+        on_successful_read()
+        if not purge:
+            break
     return result
 
 

--- a/inference/core/interfaces/camera/video_source.py
+++ b/inference/core/interfaces/camera/video_source.py
@@ -1128,6 +1128,7 @@ def get_from_queue(
         on_successful_read()
     return result
 
+
 def drop_single_frame_from_buffer(
     buffer: Queue,
     cause: str,

--- a/inference/core/interfaces/camera/video_source.py
+++ b/inference/core/interfaces/camera/video_source.py
@@ -671,7 +671,7 @@ class VideoSource:
 
     def _set_stream_mode_consumption_strategies(self) -> None:
         if self._buffer_consumption_strategy is None:
-            self._buffer_consumption_strategy = BufferConsumptionStrategy.EAGER
+            self._buffer_consumption_strategy = BufferConsumptionStrategy.LAZY
 
     def _consume_video(self) -> None:
         send_video_source_status_update(
@@ -926,7 +926,7 @@ class VideoConsumer:
 
     def _set_stream_mode_buffering_strategies(self) -> None:
         if self._buffer_filling_strategy is None:
-            self._buffer_filling_strategy = BufferFillingStrategy.ADAPTIVE_DROP_OLDEST
+            self._buffer_filling_strategy = BufferFillingStrategy.WAIT
 
     def _video_fps_should_be_sub_sampled(self) -> bool:
         if self._desired_fps is None:

--- a/inference/core/interfaces/camera/video_source.py
+++ b/inference/core/interfaces/camera/video_source.py
@@ -926,7 +926,7 @@ class VideoConsumer:
 
     def _set_stream_mode_buffering_strategies(self) -> None:
         if self._buffer_filling_strategy is None:
-            self._buffer_filling_strategy = BufferFillingStrategy.WAIT
+            self._buffer_filling_strategy = BufferFillingStrategy.DROP_OLDEST
 
     def _video_fps_should_be_sub_sampled(self) -> bool:
         if self._desired_fps is None:
@@ -1120,8 +1120,6 @@ def get_from_queue(
             on_successful_read()
         except Empty:
             pass
-    if not purge:
-        return result
     while not queue.empty() and purge:
         result = queue.get()
         queue.task_done()

--- a/inference/core/interfaces/stream_manager/manager_app/entities.py
+++ b/inference/core/interfaces/stream_manager/manager_app/entities.py
@@ -55,7 +55,7 @@ class VideoConfiguration(BaseModel):
         BufferFillingStrategy.DROP_OLDEST
     )
     source_buffer_consumption_strategy: Optional[BufferConsumptionStrategy] = (
-        BufferConsumptionStrategy.EAGER
+        BufferConsumptionStrategy.LAZY
     )
     video_source_properties: Optional[Dict[str, float]] = None
     batch_collection_timeout: Optional[float] = None


### PR DESCRIPTION
# Description

RTMP streaming is currently producing chunky footage, looking like below:

![chunky](https://github.com/user-attachments/assets/bb6c357e-47f8-4244-b266-429cd39178e3)

Fixed this by switching default strategy, ensuring proper output stream management when feeding frames and also spared function calls when it can be avoided early. Result. Queue filling strategy should result in dropping oldest frame, and queue consuming strategy should be picking one frame from the queue (and not purge the whole queue) to avoid chunky results on fast workflows but also to ensure pipeline performs well on slow workflows

![fixed-smooth](https://github.com/user-attachments/assets/118fef23-1a61-47e1-aecd-601d525d64fb)


## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

CI passing
Manually tested:

```python
import cv2 as cv

from inference.core.interfaces.camera.video_source import VideoSource, VideoFrame, BufferFillingStrategy, BufferConsumptionStrategy


rtmp_video_source: VideoSource = VideoSource.init(
    video_reference="rtsp://(...)",
)

rtmp_video_source.start()

while True:
    frame: VideoFrame = rtmp_video_source.read_frame()
    cv.imshow("Frame", frame.image)
    if cv.waitKey(1) & 0xFF == ord("q"):
        break

cv.destroyAllWindows()

rtmp_video_source.terminate(wait_on_frames_consumption=False)

```

Compared with output of below single-threaded streaming (used as reference):

```python
import cv2 as cv


while True:
    cap = cv.VideoCapture("rtsp://(...)")
    if not cap.isOpened():
        break
    exiting = False
    while True:
        ret, frame = cap.read()
        if not ret:
            break
        cv.imshow("", frame)
        if cv.waitKey(1) == ord("q"):
            exiting = True
            break
    if exiting:
        break

```

Also compared with the simple multi-threaded streaming:

```python
from queue import Queue
from threading import Event, Thread
import time

import cv2 as cv
import numpy as np


class VideoFrameProducer(Thread):
    def __init__(self, video_reference: str, max_queue_size: int = 10):
        super().__init__()
        self._video_reference = video_reference
        self._queue = Queue(maxsize=max_queue_size)
        self._stop_event = Event()
        self._fps = 30
        self._last_frame_timestamp = time.time_ns()

    def run(self) -> None:
        while not self._stop_event.is_set():
            cap = cv.VideoCapture(self._video_reference)
            self._fps = cap.get(cv.CAP_PROP_FPS)
            if 0 >= self._fps or self._fps > 60:
                self._fps = 30  # sane default
            while not self._stop_event.is_set():
                ret, frame = cap.read()
                if not ret:
                    break
                if not self._stop_event.is_set():
                    self._queue.put(frame)
                else:
                    break
            cap.release()
            print("Reconnecting!")

    def set_stop_event(self) -> None:
        self._stop_event.set()

    def get_frame(self) -> np.ndarray:
        current_timestamp = time.time_ns()
        if (current_timestamp - self._last_frame_timestamp) / 1e9 < 1 / self._fps:
            time.sleep((1 / self._fps) - (current_timestamp - self._last_frame_timestamp) / 1e9)
        frame = self._queue.get()
        self._last_frame_timestamp = time.time_ns()
        return frame


video_frame_producer = VideoFrameProducer("rtsp://(...)")
video_frame_producer.start()

while True:
    frame = video_frame_producer.get_frame()
    cv.imshow("", frame)
    if cv.waitKey(1) == ord("q"):
        break

video_frame_producer.set_stop_event()
video_frame_producer.join()

```

Test with simple pass-through workflow in the app:

```json
{
  "version": "1.0",
  "inputs": [
    {
      "type": "InferenceImage",
      "name": "image"
    }
  ],
  "steps": [
    {
      "type": "roboflow_core/image_preprocessing@v1",
      "name": "image_preprocessing",
      "image": "$inputs.image",
      "task_type": "flip",
      "flip_type": "horizontal"
    }
  ],
  "outputs": [
    {
      "type": "JsonField",
      "name": "image_preprocessing",
      "coordinates_system": "own",
      "selector": "$steps.image_preprocessing.image"
    }
  ]
}
```

Test with YOLOv8 nano (on CPU this model adds enough load to force pipeline to drop some frames)
```json
{
  "version": "1.0",
  "inputs": [
    {
      "type": "InferenceImage",
      "name": "image"
    }
  ],
  "steps": [
    {
      "type": "roboflow_core/roboflow_object_detection_model@v2",
      "name": "model",
      "images": "$inputs.image",
      "model_id": "yolov8n-640",
      "confidence": 0.1
    },
    {
      "type": "roboflow_core/bounding_box_visualization@v1",
      "name": "bounding_box_visualization",
      "image": "$inputs.image",
      "predictions": "$steps.model.predictions"
    }
  ],
  "outputs": [
    {
      "type": "JsonField",
      "name": "bounding_box_visualization",
      "coordinates_system": "own",
      "selector": "$steps.bounding_box_visualization.image"
    }
  ]
}
```

Above workflow when running on GPU - with consumption strategy set to eager:

![gpu_main](https://github.com/user-attachments/assets/7f5adbfd-9a15-4ee8-97e8-a81f0b3a1b8f)

consumption strategy set to lazy:

![gpu_branch](https://github.com/user-attachments/assets/808ec1bf-da92-473c-bbe6-631f56f5ba06)



## Any specific deployment considerations

N/A

## Docs

N/A