### PR TITLE
filter out detections that cant be serialized for instance seg block

### DIFF
--- a/inference/core/workflows/core_steps/common/utils.py
+++ b/inference/core/workflows/core_steps/common/utils.py
@@ -332,6 +332,19 @@ def filter_out_unwanted_classes_from_sv_detections_batch(
     return filtered_predictions
 
 
+def filter_out_sv_incompatible_instance_seg_predictions(
+    predictions: List[sv.Detections],
+) -> List[sv.Detections]:
+    processed_predictions = []
+    for p in predictions:
+        if p.mask is None or len(p) == 0:
+            processed_predictions.append(p)
+            continue
+        keep_mask = np.array([poly.shape[0] >= 3 for poly in p.mask])
+        processed_predictions.append(p[keep_mask])
+    return processed_predictions
+
+
 def grab_batch_parameters(
     operations_parameters: Dict[str, Any],
     main_batch_size: int,

--- a/inference/core/workflows/core_steps/models/roboflow/instance_segmentation/v2.py
+++ b/inference/core/workflows/core_steps/models/roboflow/instance_segmentation/v2.py
@@ -19,6 +19,7 @@ from inference.core.workflows.core_steps.common.utils import (
     attach_prediction_type_info_to_sv_detections_batch,
     convert_inference_detections_batch_to_sv_detections,
     filter_out_unwanted_classes_from_sv_detections_batch,
+    filter_out_sv_incompatible_instance_seg_predictions,
 )
 from inference.core.workflows.execution_engine.constants import INFERENCE_ID_KEY
 from inference.core.workflows.execution_engine.entities.base import (
@@ -363,6 +364,9 @@ class RoboflowInstanceSegmentationModelBlockV2(WorkflowBlock):
         predictions = filter_out_unwanted_classes_from_sv_detections_batch(
             predictions=predictions,
             classes_to_accept=class_filter,
+        )
+        predictions = filter_out_sv_incompatible_instance_seg_predictions(
+            predictions=predictions
         )
         predictions = attach_parents_coordinates_to_batch_of_sv_detections(
             images=images,


### PR DESCRIPTION

# Description
In workflows we end up serializing detections using supervision.  However some instance seg models can produce very small detection that somehow end up with less than 3 points in a polygon mask.  These cannot be serialized and cause whole workflow run to crash.

So I think the block should filter them out categorically.  Mayve we should even this at model level, but I since the isue only happens when serializing with supervision in workflows this seems like minimally invasive change in behavior to fix the problem.


## Type of change

Please delete options that are not relevant.
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?
not yet, currently dont have a reproducable model/image pair, but have record of having that from [user bug reports](https://github.com/roboflow/roboflow-bugtracker/issues/1031)

## Any specific deployment considerations
n/a

## Docs
-   [ ] Docs updated? What were the changes:
