### PR TITLE
When dynamic zone was not found, return empty result

### DIFF
--- a/inference/core/workflows/core_steps/transformations/dynamic_zones/v1.py
+++ b/inference/core/workflows/core_steps/transformations/dynamic_zones/v1.py
@@ -312,4 +312,12 @@ class DynamicZonesBlockV1(WorkflowBlock):
                     OUTPUT_KEY_SIMPLIFICATION_CONVERGED: all_converged,
                 }
             )
+        if not result:
+            result.append(
+                {
+                    OUTPUT_KEY: [],
+                    OUTPUT_KEY_DETECTIONS: None,
+                    OUTPUT_KEY_SIMPLIFICATION_CONVERGED: False,
+                }
+            )
         return result


### PR DESCRIPTION
# Description

In case when no dynamic zone is found, this block fails with error due to missing output keys in block result. When dynamic zone was not found, return empty result with all keys.

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

CI passing

## Any specific deployment considerations

N/A

## Docs

N/A