### PR TITLE
Add device ID to usage tracking

### DIFF
--- a/inference/usage_tracking/collector.py
+++ b/inference/usage_tracking/collector.py
@@ -25,6 +25,7 @@ from uuid import uuid4
 
 from typing_extensions import ParamSpec
 
+from inference.core.devices.utils import GLOBAL_DEVICE_ID
 from inference.core.env import (
     API_KEY,
     DEDICATED_DEPLOYMENT_ID,
@@ -160,6 +161,7 @@ class UsageCollector:
             "exec_session_id": exec_session_id,
             "hostname": "",
             "ip_address_hash": "",
+            "device_id": "",
             "processed_frames": 0,
             "fps": 0,
             "source_duration": 0,
@@ -299,6 +301,7 @@ class UsageCollector:
             "hostname": hostname,
             "ip_address_hash": ip_address_hash_hex,
             "is_gpu_available": False,  # TODO
+            "device_id": GLOBAL_DEVICE_ID,
         }
 
     def record_system_info(
@@ -362,6 +365,7 @@ class UsageCollector:
         with self._system_info_lock:
             ip_address_hash = self._system_info["ip_address_hash"]
             is_gpu_available = self._system_info["is_gpu_available"]
+            device_id = self._system_info["device_id"]
             hostname = self._system_info["hostname"]
         with UsageCollector._lock:
             source_usage = self._usage[api_key_hash][f"{category}:{resource_id}"]
@@ -380,6 +384,7 @@ class UsageCollector:
             source_usage["hostname"] = hostname
             source_usage["ip_address_hash"] = ip_address_hash
             source_usage["is_gpu_available"] = is_gpu_available
+            source_usage["device_id"] = device_id
             source_usage["execution_duration"] += execution_duration
             if (
                 roboflow_service_name

--- a/inference/usage_tracking/collector.py
+++ b/inference/usage_tracking/collector.py
@@ -25,7 +25,10 @@ from uuid import uuid4
 
 from typing_extensions import ParamSpec
 
-from inference.core.devices.utils import GLOBAL_DEVICE_ID
+from inference.core.devices.utils import (
+    GLOBAL_DEVICE_ID,
+    GLOBAL_INFERENCE_SERVER_ID,
+)
 from inference.core.env import (
     API_KEY,
     DEDICATED_DEPLOYMENT_ID,
@@ -162,6 +165,7 @@ class UsageCollector:
             "hostname": "",
             "ip_address_hash": "",
             "device_id": "",
+            "inference_server_id": "",
             "processed_frames": 0,
             "fps": 0,
             "source_duration": 0,
@@ -302,6 +306,7 @@ class UsageCollector:
             "ip_address_hash": ip_address_hash_hex,
             "is_gpu_available": False,  # TODO
             "device_id": GLOBAL_DEVICE_ID,
+            "inference_server_id": GLOBAL_INFERENCE_SERVER_ID,
         }
 
     def record_system_info(
@@ -366,6 +371,7 @@ class UsageCollector:
             ip_address_hash = self._system_info["ip_address_hash"]
             is_gpu_available = self._system_info["is_gpu_available"]
             device_id = self._system_info["device_id"]
+            inference_server_id = self._system_info["inference_server_id"]
             hostname = self._system_info["hostname"]
         with UsageCollector._lock:
             source_usage = self._usage[api_key_hash][f"{category}:{resource_id}"]
@@ -385,6 +391,7 @@ class UsageCollector:
             source_usage["ip_address_hash"] = ip_address_hash
             source_usage["is_gpu_available"] = is_gpu_available
             source_usage["device_id"] = device_id
+            source_usage["inference_server_id"] = inference_server_id
             source_usage["execution_duration"] += execution_duration
             if (
                 roboflow_service_name

--- a/tests/inference/unit_tests/usage_tracking/test_collector.py
+++ b/tests/inference/unit_tests/usage_tracking/test_collector.py
@@ -6,6 +6,7 @@ import pytest
 
 from inference.core.env import LAMBDA
 from inference.core.version import __version__ as inference_version
+from inference.core.devices.utils import GLOBAL_DEVICE_ID
 from inference.usage_tracking.collector import UsageCollector
 from inference.usage_tracking.payload_helpers import (
     get_api_key_usage_containing_resource,
@@ -35,6 +36,7 @@ def test_create_empty_usage_dict():
                     "exec_session_id": "exec_session_id",
                     "hostname": "",
                     "ip_address_hash": "",
+                    "device_id": "",
                     "processed_frames": 0,
                     "fps": 0,
                     "source_duration": 0,
@@ -890,6 +892,7 @@ def test_system_info_with_dedicated_deployment_id():
         "hostname": f"deployment01:hostname01",
         "ip_address_hash": hashlib.sha256("w.x.y.z".encode()).hexdigest()[:5],
         "is_gpu_available": False,
+        "device_id": GLOBAL_DEVICE_ID,
     }
     for k, v in expected_system_info.items():
         assert system_info[k] == v
@@ -906,6 +909,7 @@ def test_system_info_with_no_dedicated_deployment_id():
         "hostname": "5aacc",
         "ip_address_hash": hashlib.sha256("w.x.y.z".encode()).hexdigest()[:5],
         "is_gpu_available": False,
+        "device_id": GLOBAL_DEVICE_ID,
     }
     for k, v in expected_system_info.items():
         assert system_info[k] == v

--- a/tests/inference/unit_tests/usage_tracking/test_collector.py
+++ b/tests/inference/unit_tests/usage_tracking/test_collector.py
@@ -6,7 +6,10 @@ import pytest
 
 from inference.core.env import LAMBDA
 from inference.core.version import __version__ as inference_version
-from inference.core.devices.utils import GLOBAL_DEVICE_ID
+from inference.core.devices.utils import (
+    GLOBAL_DEVICE_ID,
+    GLOBAL_INFERENCE_SERVER_ID,
+)
 from inference.usage_tracking.collector import UsageCollector
 from inference.usage_tracking.payload_helpers import (
     get_api_key_usage_containing_resource,
@@ -37,6 +40,7 @@ def test_create_empty_usage_dict():
                     "hostname": "",
                     "ip_address_hash": "",
                     "device_id": "",
+                    "inference_server_id": "",
                     "processed_frames": 0,
                     "fps": 0,
                     "source_duration": 0,
@@ -893,6 +897,7 @@ def test_system_info_with_dedicated_deployment_id():
         "ip_address_hash": hashlib.sha256("w.x.y.z".encode()).hexdigest()[:5],
         "is_gpu_available": False,
         "device_id": GLOBAL_DEVICE_ID,
+        "inference_server_id": GLOBAL_INFERENCE_SERVER_ID,
     }
     for k, v in expected_system_info.items():
         assert system_info[k] == v
@@ -910,6 +915,7 @@ def test_system_info_with_no_dedicated_deployment_id():
         "ip_address_hash": hashlib.sha256("w.x.y.z".encode()).hexdigest()[:5],
         "is_gpu_available": False,
         "device_id": GLOBAL_DEVICE_ID,
+        "inference_server_id": GLOBAL_INFERENCE_SERVER_ID,
     }
     for k, v in expected_system_info.items():
         assert system_info[k] == v


### PR DESCRIPTION
## Summary
- include device_id in usage tracking payloads
- update system info helpers
- adjust usage tracking tests for device_id

## Testing
- `make style`
- `make check_code_quality` *(fails: flake8 missing)*
- `pytest tests/inference/unit_tests/usage_tracking/test_collector.py` *(fails: ModuleNotFoundError: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_6848a7ec3ff4832a8bd90a378a4e72bd