### PR TITLE
Weights download speedup

### DIFF
--- a/inference/core/roboflow_api.py
+++ b/inference/core/roboflow_api.py
@@ -808,6 +808,7 @@ def get_weights_from_url_optimally(url: str) -> Response:
     Returns:
         Response: A requests.Response object with the content of the downloaded file.
     """
+    logger.debug("Downloading weights from url: %s", url)
     try:
         head_response = requests.head(
             wrap_url(url),
@@ -848,6 +849,7 @@ def _serial_download(url: str, total_size: int) -> Response:
     content = bytearray()
     downloaded_size = 0
     last_logged_percentage = -1
+    start_time = time.time()
     last_log_time = time.time()
     bytes_since_last_log = 0
 

--- a/inference/core/roboflow_api.py
+++ b/inference/core/roboflow_api.py
@@ -868,7 +868,7 @@ def _serial_download(url: str, total_size: int) -> Response:
                     bytes_since_last_log = 0
 
 
-    
+    logger.info("Download complete. Downloaded %d bytes in %d seconds. Speed: %d Mbps", downloaded_size, time.time() - start_time, downloaded_size * 8 / (time.time() - start_time) / 1024 / 1024)
 
     final_response = Response()
     final_response.status_code = response.status_code
@@ -920,6 +920,8 @@ def _parallel_download(url: str, total_size: int) -> Response:
                     speed_mbps = (downloaded_bytes * 8) / (elapsed_time * 1024 * 1024) if elapsed_time > 0 else 0
                     logger.debug(f"Download progress: {percentage}%, Speed: {speed_mbps:.2f} Mbps")
                     last_logged_percentage = percentage
+
+    logger.info("Download complete. Downloaded %d bytes in %d seconds. Speed: %d Mbps", downloaded_bytes, time.time() - start_time, downloaded_bytes * 8 / (time.time() - start_time) / 1024 / 1024)
 
     final_response = Response()
     final_response.status_code = 200

--- a/inference/models/transformers/transformers.py
+++ b/inference/models/transformers/transformers.py
@@ -344,11 +344,12 @@ class LoRATransformerModel(TransformerModel):
                 f"`weights` key not available in Roboflow API response while downloading model weights."
             )
 
+        weights_url = api_data["weights"]["model"]
         filename = weights_url.split("?")[0].split("/")[-1]
         assert filename.endswith("tar.gz")
 
         logger.info("Fetching transformer model weights from Roboflow API: %s", filename)
-        weights_url = api_data["weights"]["model"]
+        
         model_weights_response = get_weights_from_url_optimally(weights_url)
         
         save_bytes_in_cache(

--- a/inference/models/transformers/transformers.py
+++ b/inference/models/transformers/transformers.py
@@ -27,6 +27,7 @@ from inference.core.roboflow_api import (
     get_roboflow_base_lora,
     get_roboflow_instant_model_data,
     get_roboflow_model_data,
+    get_weights_from_url_optimally,
 )
 from inference.core.utils.image_utils import load_image_rgb
 
@@ -228,7 +229,8 @@ class TransformerModel(RoboflowInferenceModel):
             filename = weights_url.split("?")[0].split("/")[-1]
             if filename.endswith(".npz"):
                 continue
-            model_weights_response = get_from_url(weights_url, json_response=False)
+            logger.info("Fetching transformer model weights from Roboflow API: %s", filename)
+            model_weights_response = get_weights_from_url_optimally(weights_url)
             save_bytes_in_cache(
                 content=model_weights_response.content,
                 file=filename,
@@ -342,10 +344,13 @@ class LoRATransformerModel(TransformerModel):
                 f"`weights` key not available in Roboflow API response while downloading model weights."
             )
 
-        weights_url = api_data["weights"]["model"]
-        model_weights_response = get_from_url(weights_url, json_response=False)
         filename = weights_url.split("?")[0].split("/")[-1]
         assert filename.endswith("tar.gz")
+
+        logger.info("Fetching transformer model weights from Roboflow API: %s", filename)
+        weights_url = api_data["weights"]["model"]
+        model_weights_response = get_weights_from_url_optimally(weights_url)
+        
         save_bytes_in_cache(
             content=model_weights_response.content,
             file=filename,


### PR DESCRIPTION
# Description

This adds anew download method to be used for downloading weights.  I was basically unable to download perception encoder (2.5GB) or even clip weights (250MB). because it would go so slow (I used naive chinking and measured at ~5Mbps and slower..although partially that chunking might have been worse than what requests does by default).  Either way with previous implementation I was waiting 30 minutes and still weights weren't done, now it downloads in seconds.

This implements parralell or serialized chunked downloads with BytesIO buffer and adds some basic logging about file size when model weights are fetched (with debug logs it will print download progress and speed at 10% intervals also)

Ideally we don't need to buffer entire weight file in memory at al...but we cant just stream to a file because at least need to be careful I think since cache implementation differences in various envs so will need some more refactoring for that.

## Type of change

Please delete options that are not relevant.
maintenance / speed improvement

## How has this change been tested, please provide a testcase or example of how you tested the change?
locally

## Any specific deployment considerations
no

## Docs
-   [ ] Docs updated? What were the changes:
