### PR TITLE
Make model unsupported message more descriptive

### DIFF
--- a/inference/core/registries/roboflow.py
+++ b/inference/core/registries/roboflow.py
@@ -84,7 +84,7 @@ class RoboflowModelRegistry(ModelRegistry):
         logger.debug(f"Model type: {model_type}")
 
         if model_type not in self.registry_dict:
-            raise ModelNotRecognisedError(f"Model type not supported: {model_type}")
+            raise ModelNotRecognisedError(f"Model type not supported, you may want to try a different inference server configuration or endpoint: {model_type}")
         return self.registry_dict[model_type]
 
 


### PR DESCRIPTION
# Description

Instead of saying "Model type not supported" say "Model type not supported, you may want to try a different inference server configuration or endpoint". THis is useful when models like SMOVLM or QWEN are disabled.

## Type of change

Please delete options that are not relevant.

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Tested in staging

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
