### PR TITLE
Fix/add default fallback to class replacement

### DIFF
--- a/inference/core/workflows/core_steps/fusion/detections_classes_replacement/v1.py
+++ b/inference/core/workflows/core_steps/fusion/detections_classes_replacement/v1.py
@@ -182,6 +182,8 @@ def extract_leading_class_from_prediction(
     prediction: dict,
 ) -> Optional[Tuple[str, int, float]]:
     if "top" in prediction:
+        if not prediction.get("predictions"):
+            return None
         class_name = prediction["top"]
         matching_class_ids = [
             (p["class_id"], p["confidence"])


### PR DESCRIPTION
# Description

Currently `detections_classes_replacement` fails with error when classification prediction batch element without predictions is passed to the block. This change fixes the problem by introducing optional `fallback_class_name` and `fallback_class_id` parameters. If parameters are not supplied, crops with no classification predictions are dropped. Otherwise `fallback_class_name` class is applied with `fallback_class_id` as ID. If `fallback_class_name` is provided however `fallback_class_id` is not provided or negative number provided, `sys.maxsize` is supplied as class ID.

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

CI passing

## Any specific deployment considerations

N/A

## Docs

N/A