### PR TITLE
Fix zone filter anchor extraction for non-center detection reference points

### DIFF
--- a/inference/core/workflows/core_steps/common/query_language/operations/detection/base.py
+++ b/inference/core/workflows/core_steps/common/query_language/operations/detection/base.py
@@ -46,10 +46,10 @@ DETECTION_PROPERTY_EXTRACTION = {
         x[0][0] + (x[0][2] - x[0][0]) / 2,
         x[0][1] + (x[0][3] - x[0][1]) / 2,
     ),
-    DetectionsProperty.TOP_LEFT: lambda xyxy: (xyxy[0], xyxy[1]),
-    DetectionsProperty.TOP_RIGHT: lambda xyxy: (xyxy[2], xyxy[1]),
-    DetectionsProperty.BOTTOM_LEFT: lambda xyxy: (xyxy[0], xyxy[3]),
-    DetectionsProperty.BOTTOM_RIGHT: lambda xyxy: (xyxy[2], xyxy[3]),
+    DetectionsProperty.TOP_LEFT: lambda x: (x[0][0].item(), x[0][1].item()),
+    DetectionsProperty.TOP_RIGHT: lambda x: (x[0][2].item(), x[0][1].item()),
+    DetectionsProperty.BOTTOM_LEFT: lambda x: (x[0][0].item(), x[0][3].item()),
+    DetectionsProperty.BOTTOM_RIGHT: lambda x: (x[0][2].item(), x[0][3].item()),
     DetectionsProperty.IN_OUT: lambda x: x[5].get(DETECTIONS_IN_OUT_PARAM),
     DetectionsProperty.PATH_DEVIATION: lambda x: x[5].get(
         PATH_DEVIATION_KEY_IN_SV_DETECTIONS


### PR DESCRIPTION
## Summary
- correct detection anchor property extraction

## Testing
- `make style`
- `make check_code_quality` *(fails: flake8 not found)*
- `pytest tests/workflows/unit_tests/core_steps/formatters/test_property_extraction.py::test_property_extraction_block_with_top_left -q` *(fails: ModuleNotFoundError: No module named 'cv2')*


------
https://chatgpt.com/codex/tasks/task_b_68530b3d87e883249c888420bbc44798