### PR TITLE
communicate failed pipeline over webrtc

### DIFF
--- a/inference/core/interfaces/stream/watchdog.py
+++ b/inference/core/interfaces/stream/watchdog.py
@@ -8,8 +8,8 @@ from collections import deque
 from datetime import datetime
 from typing import Any, Deque, Dict, Iterable, List, Optional, TypeVar
 
-from aiortc import RTCPeerConnection
 import supervision as sv
+from aiortc import RTCPeerConnection
 
 from inference.core.interfaces.camera.entities import (
     StatusUpdate,


### PR DESCRIPTION
# Description

Improve webrtc stability on malformed workflow or when workflow terminates abnormally

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Tested manually:
 - workflow containing syntax error (used string instead of float when specifying model confidence)
 - workflow containing model user does not have access to use

## Any specific deployment considerations

N/A

## Docs

N/A