### PR TITLE
Revert timeout when waiting for response from inference pipeline

### DIFF
--- a/inference/core/interfaces/stream_manager/manager_app/app.py
+++ b/inference/core/interfaces/stream_manager/manager_app/app.py
@@ -8,7 +8,6 @@ from collections import deque
 from dataclasses import dataclass, field
 from functools import partial
 from multiprocessing import Process, Queue
-from queue import Empty
 from socketserver import BaseRequestHandler, BaseServer
 from threading import Lock, Thread
 from types import FrameType
@@ -298,10 +297,7 @@ def get_response_ignoring_thrash(
     responses_queue: Queue, matching_request_id: str
 ) -> dict:
     while True:
-        try:
-            response = responses_queue.get(timeout=SOCKET_TIMEOUT)
-        except Empty:
-            return {}
+        response = responses_queue.get(timeout=SOCKET_TIMEOUT)
         if response[0] == matching_request_id:
             return response[1]
         logger.warning(


### PR DESCRIPTION
# Description

Revert timeout when waiting for response from inference pipeline

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Tested manually

## Any specific deployment considerations

N/A

## Docs

N/A