### PR TITLE
Add fix for the problem with JSON object as default vaule for `WorkflowParameter`

### DIFF
--- a/inference/core/workflows/execution_engine/entities/base.py
+++ b/inference/core/workflows/execution_engine/entities/base.py
@@ -102,7 +102,7 @@ class WorkflowParameter(WorkflowInput):
     type: Literal["WorkflowParameter", "InferenceParameter"]
     name: str
     kind: List[Union[str, Kind]] = Field(default_factory=lambda: [WILDCARD_KIND])
-    default_value: Optional[Union[float, int, str, bool, list, set]] = Field(
+    default_value: Optional[Union[float, int, str, bool, list, set, dict]] = Field(
         default=None
     )
     dimensionality: int = Field(default=0, ge=0, le=0)


### PR DESCRIPTION
# Description

Add fix for the problem with setting default value of `WorkflowParameter` as dict which was not passing validation

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

* e2e locally

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
