### PR TITLE
Fix selector types for CLIP block

### DIFF
--- a/inference/core/workflows/core_steps/models/foundation/clip/v1.py
+++ b/inference/core/workflows/core_steps/models/foundation/clip/v1.py
@@ -61,8 +61,7 @@ class BlockManifest(WorkflowBlockManifest):
     type: Literal["roboflow_core/clip@v1"]
     name: str = Field(description="Unique name of step in workflows")
     data: Union[
-        Selector(kind=[IMAGE_KIND]),
-        Selector(kind=[STRING_KIND]),
+        Selector(kind=[IMAGE_KIND, STRING_KIND]),
         str,
     ] = Field(
         title="Data",

--- a/inference/core/workflows/core_steps/models/foundation/perception_encoder/v1.py
+++ b/inference/core/workflows/core_steps/models/foundation/perception_encoder/v1.py
@@ -60,8 +60,7 @@ class BlockManifest(WorkflowBlockManifest):
     type: Literal["roboflow_core/perception_encoder@v1"]
     name: str = Field(description="Unique name of step in workflows")
     data: Union[
-        Selector(kind=[IMAGE_KIND]),
-        Selector(kind=[STRING_KIND]),
+        Selector(kind=[IMAGE_KIND, STRING_KIND]),
         str,
     ] = Field(
         title="Data",


### PR DESCRIPTION
## Summary
- allow Perception Encoder block to accept string selectors by splitting the `data` union
- apply the same selector change on the CLIP block

## Testing
- `make style`
- `make check_code_quality` *(fails: flake8 not installed)*
- `pytest tests/workflows/unit_tests/core_steps/models/foundation/test_clip.py::test_manifest_parsing_valid -q` *(fails: ModuleNotFoundError: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_685972d8ad988327be10b3fd63f9ed22