### PR TITLE
Install libsqlite3-dev before building python3.9 on jetson 4.6.1

### DIFF
--- a/docker/dockerfiles/Dockerfile.onnx.jetson.4.6.1
+++ b/docker/dockerfiles/Dockerfile.onnx.jetson.4.6.1
@@ -12,6 +12,7 @@ RUN apt-get update -y && apt-get upgrade -y && apt-get install -y \
     libssl-dev \ 
     libreadline-dev \
     libffi-dev \
+    libsqlite3-dev \
     curl \
     libbz2-dev \
     software-properties-common \
@@ -29,7 +30,6 @@ RUN apt-get update -y && apt-get upgrade -y && apt-get install -y \
     python3-pip \
     python3-matplotlib \
     gfortran \
-    build-essential \
     libatlas-base-dev \
     libsm6 \
     libxext6 \

--- a/docker/dockerfiles/Dockerfile.onnx.jetson.4.6.1
+++ b/docker/dockerfiles/Dockerfile.onnx.jetson.4.6.1
@@ -61,6 +61,7 @@ RUN python3.9 -m pip install --upgrade pip "h5py<=3.10.0" && python3.9 -m pip in
     -r requirements.yolo_world.txt \
     jupyterlab \
     "setuptools<=75.5.0" \
+    "pydantic<=2.10.6" \
     --upgrade \
     && rm -rf ~/.cache/pip
 


### PR DESCRIPTION
# Description

Install libsqlite3-dev before building python3.9 on jetson 4.6.1

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

CI passing
Test manually by running `docker run -it --rm roboflow/roboflow-inference-server-jetson-4.6.1:latest`

## Any specific deployment considerations

N/A

## Docs

N/A