### PR TITLE
Bump peft with fixed dependencies

### DIFF
--- a/inference/models/depth_estimation/__init__.py
+++ b/inference/models/depth_estimation/__init__.py
@@ -1,1 +1,1 @@
-from inference.models.smolvlm.smolvlm import SmolVLM
+from inference.models.depth_estimation.depthestimation import DepthEstimator

--- a/requirements/requirements.transformers.txt
+++ b/requirements/requirements.transformers.txt
@@ -3,9 +3,9 @@ torch>=2.0.1,<2.7.0
 torchvision>=0.15.0
 transformers>=4.50.0,<4.52.0
 timm~=1.0.0
-accelerate>=0.25.0,<=0.32.1
+accelerate>=0.32,<1.0.0
 einops>=0.7.0,<=0.8.0
-peft~=0.11.1
+peft~=0.15.0
 num2words~=0.5.14
 bitsandbytes>=0.42.0,<0.46.0
 num2words~=0.5.14


### PR DESCRIPTION
# Description

The depth estimator test was breaking bc the depth estimator init was importing smolvlm2, which was broken. Now both things are fixed. Accelerate==0.31 was breaking things. This fix is necessary to make sure florence2 models run successfully in inference after https://github.com/roboflow/roboflow-train/pull/555 was merged.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Built locally and linked actions

## Any specific deployment considerations

no

## Docs

-   [ ] Docs updated? What were the changes:
