### PR TITLE
Add new Moondream2 model

### DIFF
--- a/inference/core/workflows/core_steps/models/foundation/moondream2/v1.py
+++ b/inference/core/workflows/core_steps/models/foundation/moondream2/v1.py
@@ -71,9 +71,9 @@ class BlockManifest(WorkflowBlockManifest):
     type: Literal["roboflow_core/moondream2@v1"]
 
     model_version: Union[Selector(kind=[ROBOFLOW_MODEL_ID_KIND]), str] = Field(
-        default="moondream2/moondream2-2b",
+        default="moondream2/moondream2_2b_jul24",
         description="The Moondream2 model to be used for inference.",
-        examples=["moondream2/moondream2-2b"],
+        examples=["moondream2/moondream2_2b_jul24", "moondream2/moondream2-2b"],
     )
 
     @classmethod


### PR DESCRIPTION
# Description

This PR adds the 2025-06-21 checkpoint of Moondream2 to Inference. (reference: https://huggingface.co/vikhyatk/moondream2).

@Matvezy has already added the weights to our server.

Let me know if any more changes are needed to make this work.

<img width="790" alt="Screenshot 2025-06-25 at 15 41 09" src="https://github.com/user-attachments/assets/f882cecd-a262-401e-93be-421d5fdce7a7" />
<img width="796" alt="Screenshot 2025-06-25 at 15 41 13" src="https://github.com/user-attachments/assets/6233cea5-fb80-4485-a290-188e7389f3bf" />

## Type of change

- [X] New model

## How has this change been tested, please provide a testcase or example of how you tested the change?

This change was tested by adding a Moondream2 Workflow block and running the model on an image.

## Any specific deployment considerations

N/A

## Docs

N/A
