### PR TITLE
Improve artifact download reliability

### DIFF
--- a/tests/inference/unit_tests/core/cache/test_model_artifacts.py
+++ b/tests/inference/unit_tests/core/cache/test_model_artifacts.py
@@ -19,6 +19,7 @@ from inference.core.cache.model_artifacts import (
     save_json_in_cache,
     save_text_lines_in_cache,
 )
+from inference.core.exceptions import ModelArtefactError
 from tests.inference.unit_tests.core.utils.test_file_system import (
     assert_bytes_file_content_correct,
     assert_text_file_content_correct,
@@ -169,6 +170,23 @@ def test_load_json_from_cache(
     # then
     assert result == {"some": "key"}
     get_cache_dir_mock.assert_called_once_with(model_id="some/3")
+
+
+@mock.patch.object(model_artifacts, "get_cache_dir")
+def test_load_json_from_cache_when_file_is_corrupted(
+    get_cache_dir_mock: MagicMock,
+    empty_local_dir: str,
+) -> None:
+    # given
+    cache_dir = os.path.join(empty_local_dir, "some", "3")
+    get_cache_dir_mock.return_value = cache_dir
+    os.makedirs(cache_dir, exist_ok=True)
+    with open(os.path.join(cache_dir, "a.json"), "w") as f:
+        f.write("NOT JSON")
+
+    # when / then
+    with pytest.raises(ModelArtefactError):
+        _ = load_json_from_cache(file="a.json", model_id="some/3")
 
 
 @mock.patch.object(model_artifacts, "get_cache_dir")

--- a/tests/inference/unit_tests/core/models/test_roboflow.py
+++ b/tests/inference/unit_tests/core/models/test_roboflow.py
@@ -194,3 +194,34 @@ def test_get_class_names_from_environment_file() -> None:
         "class_k",
         "class_l",
     ]
+
+
+@mock.patch.object(roboflow.RoboflowInferenceModel, "clear_cache")
+@mock.patch.object(roboflow.RoboflowInferenceModel, "load_model_artifacts_from_cache")
+@mock.patch.object(roboflow.RoboflowInferenceModel, "cache_model_artefacts")
+@mock.patch.object(roboflow, "initialise_cache")
+@mock.patch.object(roboflow, "MODELS_CACHE_AUTH_ENABLED", False)
+def test_get_model_artifacts_redownloads_after_corruption(
+    models_cache_auth_enabled_mock: MagicMock,
+    initialise_cache_mock: MagicMock,
+    cache_model_artefacts_mock: MagicMock,
+    load_model_artifacts_from_cache_mock: MagicMock,
+    clear_cache_mock: MagicMock,
+) -> None:
+    # given
+    load_model_artifacts_from_cache_mock.side_effect = [
+        ModelArtefactError("corrupted"),
+        None,
+    ]
+    model = roboflow.RoboflowInferenceModel(
+        model_id="project/1",
+        load_weights=False,
+    )
+
+    # when
+    model.get_model_artifacts()
+
+    # then
+    assert cache_model_artefacts_mock.call_count == 2
+    assert load_model_artifacts_from_cache_mock.call_count == 2
+    clear_cache_mock.assert_called_once_with(delete_from_disk=True)

--- a/tests/inference/unit_tests/enterprise/stream_management/api/test_stream_manager_client.py
+++ b/tests/inference/unit_tests/enterprise/stream_management/api/test_stream_manager_client.py
@@ -276,7 +276,8 @@ async def test_send_message_when_communication_problem_arises() -> None:
 @pytest.mark.asyncio
 async def test_send_message_when_communication_succeeds() -> None:
     # given
-    writer = AsyncMock()
+    writer = mock.MagicMock()
+    writer.drain = AsyncMock()
     message = {"data": "some"}
     serialised_message = json.dumps(message).encode("utf-8")
     expected_payload = (


### PR DESCRIPTION
## Summary
- retry downloading model artifacts when loading fails
- raise `ModelArtefactError` when cached JSON is invalid
- test corrupted cache handling
- add test covering successful retry after corrupted download
- remove stray noqa comments
- fix writer mock in async send message test

## Testing
- `make style`
- `make check_code_quality` *(fails: flake8 not installed)*
- `pytest tests/inference/unit_tests/` *(fails: ModuleNotFoundError: No module named 'cv2')*


------
https://chatgpt.com/codex/tasks/task_e_685ef744ebf4832aa2219ee565056ced