### PR TITLE
Treat corrupted downloads at root

### DIFF
--- a/inference/core/roboflow_api.py
+++ b/inference/core/roboflow_api.py
@@ -723,6 +723,16 @@ def _get_from_url(url: str, json_response: bool = True) -> Union[Response, dict]
             headers=build_roboflow_api_headers(),
             timeout=ROBOFLOW_API_REQUEST_TIMEOUT,
         )
+        content_length_header = None
+        for k in response.headers.keys():
+            if k.lower() == "content-length":
+                content_length_header = k
+                break
+        if not content_length_header or not response.headers[content_length_header].isnumeric():
+            raise(RoboflowAPIUnsuccessfulRequestError("Content-Length header not found or malformed"))
+        if int(response.headers.get(k)) != response.content:
+            raise RoboflowAPIUnsuccessfulRequestError("Content-Length header does not match response content length")
+
     except (ConnectionError, Timeout, requests.exceptions.ConnectionError) as error:
         if RETRY_CONNECTION_ERRORS_TO_ROBOFLOW_API:
             raise RetryRequestError(


### PR DESCRIPTION
# Description

Proposing changes:
 - original change covers real root cause - if request results in status 200 however results are corrupted, then either source file is corrupted (in which case we do want the pipeline to fail) or response was truncated  (this is where we want retry)
 - bottom `_get_from_url` is already handling retries, so there is no need to add extra layer of retries above

## Type of change

-   [ ] Code review

## How has this change been tested, please provide a testcase or example of how you tested the change?

CI passing

## Any specific deployment considerations

N/A

## Docs

N/A