### PR TITLE
Fix OSX app build / windows installer dependency issue introduced in 0.51

### DIFF
--- a/app_bundles/osx/inference-app.spec
+++ b/app_bundles/osx/inference-app.spec
@@ -13,6 +13,8 @@ peft_datas, peft_bins, peft_hiddenimports                     = collect_all('pef
 cython_datas, cython_bins, cython_hiddenimports               = collect_all('Cython')
 tldextract_datas, tldextract_binaries, tldextract_hidden      = collect_all("tldextract")
 inference_datas, inference_bins, inference_hidden = collect_all('inference', include_py_files=True)
+scipy_datas, scipy_binaries, scipy_hiddenimports              = collect_all('scipy')
+
 
 # ---------------------------------------------------------------------------
 opensslnames = ("libcrypto.3.dylib", "libssl.3.dylib")
@@ -29,6 +31,7 @@ a = Analysis(
         *cython_bins,
         *tldextract_binaries,
         *inference_bins,
+        *scipy_binaries,
     ],
     datas=[
         *clip_datas,
@@ -38,6 +41,7 @@ a = Analysis(
         *cython_datas,
         *tldextract_datas,
         *inference_datas,
+        *scipy_datas,
         # Manually include editor.html for the builder interface
         ('../../inference/core/interfaces/http/builder/editor.html', 'inference/core/interfaces/http/builder'),
     ],
@@ -47,6 +51,7 @@ a = Analysis(
         *transformers_hiddenimports,
         *peft_hiddenimports,
         *cython_hiddenimports,
+        *scipy_hiddenimports,
         'psutil',
         'rasterio',
         'rasterio.sample',
@@ -61,6 +66,11 @@ a = Analysis(
         'Cython',
         'inference',
         'pyvips',
+        'scipy',
+        'scipy.linalg.cython_lapack',
+        'scipy.linalg.cython_blas',
+        'scipy.linalg.cython_overflow',
+        'scipy._lib.messagestream',
         *inference_hidden,
     ],
     hookspath=['hooks'],     # place custom hooks here if you like

--- a/app_bundles/windows/inference.spec
+++ b/app_bundles/windows/inference.spec
@@ -13,6 +13,7 @@ peft_datas, peft_bins, peft_hiddenimports                     = collect_all('pef
 cython_datas, cython_bins, cython_hiddenimports               = collect_all('Cython')
 tldextract_datas, tldextract_binaries, tldextract_hidden      = collect_all("tldextract")
 inference_datas, inference_bins, inference_hidden = collect_all('inference', include_py_files=True)
+scipy_datas, scipy_binaries, scipy_hiddenimports              = collect_all('scipy')
 
 a = Analysis(
     ['run_inference.py'],
@@ -23,16 +24,18 @@ binaries=[
         *peft_bins,
         *cython_bins,
         *tldextract_binaries,
-        *inference_bins
+        *inference_bins,
+        *scipy_binaries
     ],
     datas=[
-        *clip_datas, 
-        *rasterio_datas, 
+        *clip_datas,
+        *rasterio_datas,
         *transformers_datas,
         *peft_datas,
         *cython_datas,
         *tldextract_datas,
         *inference_datas,
+        *scipy_datas,
         ('../../inference/core/interfaces/http/builder/editor.html', 'inference/core/interfaces/http/builder')
     ],
     hiddenimports=[
@@ -41,6 +44,7 @@ binaries=[
         *transformers_hiddenimports,
         *peft_hiddenimports,
         *cython_hiddenimports,
+        *scipy_hiddenimports,
         'psutil',
         'rasterio',
         'rasterio.sample',


### PR DESCRIPTION
# Description
Looks like there was a dependency change introduced via supervision -> scipy that didn't get picked up properly by pyinstaller.  Adding the scipy package to the pyinstaller app spec fixed the problem.

hard to catch thankfully users reported issue here: https://github.com/roboflow/inference/issues/1409

I will also look at  whether we can add a integration test or extra step to the build to make sure the inferene server will at least start fully (although takes a while to run) to make sure the build is completely sane

## Type of change

Please delete options that are not relevant.

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?
I build off of the branch and tested the resulting DMG [here](https://github.com/roboflow/inference/actions/runs/16157313050)
Windows build currently still running (I did confirm that latest installer ended up with exactly the same error so fairly certain the same change will fix it there also) 

## Any specific deployment considerations
will update user and link to manual build if they want to use this version and update the release artifacts manually after window build is finished

## Docs
n/a
