### PR TITLE
When wildcard output is specified, `None` is sent as stream output - pick first video output

### DIFF
--- a/inference/core/interfaces/stream_manager/manager_app/inference_pipeline_manager.py
+++ b/inference/core/interfaces/stream_manager/manager_app/inference_pipeline_manager.py
@@ -266,7 +266,8 @@ class InferencePipelineManager(Process):
 
             stream_output = None
             if parsed_payload.stream_output:
-                stream_output = parsed_payload.stream_output[0]
+                # TODO: UI sends None as stream_output for wildcard outputs
+                stream_output = parsed_payload.stream_output[0] or ""
             data_output = None
             if parsed_payload.data_output:
                 data_output = parsed_payload.data_output[0]
@@ -368,7 +369,7 @@ class InferencePipelineManager(Process):
                             f"Selected data output '{peer_connection.data_output}' not found in workflow outputs"
                         )
 
-                if peer_connection.stream_output:
+                if peer_connection.stream_output is not None:
                     frame: Optional[np.ndarray] = get_frame_from_workflow_output(
                         workflow_output=prediction,
                         frame_output_key=peer_connection.stream_output,


### PR DESCRIPTION
# Description

If `None` is sent as selected stream output, pick first available stream output and provide on-stream error message

example workflow:

```json
{
  "version": "1.0",
  "inputs": [
    {
      "type": "InferenceImage",
      "name": "image"
    }
  ],
  "steps": [
    {
      "type": "roboflow_core/perspective_correction@v1",
      "name": "perspective_correction",
      "images": "$inputs.image",
      "perspective_polygons": [
        [
          332,
          457
        ],
        [
          163,
          131
        ],
        [
          547,
          130
        ],
        [
          379,
          459
        ]
      ],
      "warp_image": true
    }
  ],
  "outputs": [
    {
      "type": "JsonField",
      "name": "perspective_correction",
      "coordinates_system": "own",
      "selector": "$steps.perspective_correction.*"
    }
  ]
}
```

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

CI passing

## Any specific deployment considerations

N/A

## Docs

N/A