### PR TITLE
Add x-processing-time header to response when running on GCP_SERVERLESS

### DIFF
--- a/inference/core/interfaces/http/http_api.py
+++ b/inference/core/interfaces/http/http_api.py
@@ -531,6 +531,15 @@ class LambdaMiddleware(BaseHTTPMiddleware):
         return response
 
 
+class GCPServerlessMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request, call_next):
+        t1 = time.time()
+        response = await call_next(request)
+        t2 = time.time()
+        response.headers["X-Processing-Time"] = str(t2 - t1)
+        return response
+
+
 class HttpInterface(BaseInterface):
     """Roboflow defined HTTP interface for a general-purpose inference server.
 
@@ -604,6 +613,8 @@ class HttpInterface(BaseInterface):
             )
         if LAMBDA:
             app.add_middleware(LambdaMiddleware)
+        if GCP_SERVERLESS:
+            app.add_middleware(GCPServerlessMiddleware)
 
         if len(ALLOW_ORIGINS) > 0:
             # Add CORS Middleware (but not for /build**, which is controlled separately)


### PR DESCRIPTION
# Description

Add x-processing-time header to response when running on GCP_SERVERLESS

## Type of change

-   [x] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?

CI passing

## Any specific deployment considerations

N/A

## Docs

N/A