### PR TITLE
DO-NOT-MERGE inference-sdk pass images as numpy

### DIFF
--- a/inference/core/interfaces/http/http_api.py
+++ b/inference/core/interfaces/http/http_api.py
@@ -787,6 +787,7 @@ class HttpInterface(BaseInterface):
             Returns:
                 InferenceResponse: The response containing the inference results.
             """
+            t1 = time.time()
             de_aliased_model_id = resolve_roboflow_model_alias(
                 model_id=inference_request.model_id
             )
@@ -799,6 +800,8 @@ class HttpInterface(BaseInterface):
             resp = await self.model_manager.infer_from_request(
                 de_aliased_model_id, inference_request, **kwargs
             )
+            t2 = time.time()
+            logger.error(f"################################## {t2 - t1:.2f}s")
             return orjson_response(resp)
 
         def process_workflow_inference_request(

--- a/inference_cli/benchmark.py
+++ b/inference_cli/benchmark.py
@@ -144,6 +144,13 @@ def api_speed(
             "return non-success error code. Expected percentage values in range 0.0-100.0",
         ),
     ] = None,
+    use_numpy_format: Annotated[
+        bool,
+        typer.Option(
+            "--numpy/--no-numpy",
+            help="Use numpy format for image transmission instead of base64. Requires server to have ALLOW_NUMPY_INPUT=True.",
+        ),
+    ] = False,
 ):
     if "roboflow.com" in host and not proceed_automatically:
         proceed = input(
@@ -167,6 +174,7 @@ def api_speed(
                 output_location=output_location,
                 enforce_legacy_endpoints=enforce_legacy_endpoints,
                 max_error_rate=max_error_rate,
+                use_numpy_format=use_numpy_format,
             )
         else:
             if workflow_specification:
@@ -189,6 +197,7 @@ def api_speed(
                 model_configuration=model_configuration,
                 output_location=output_location,
                 max_error_rate=max_error_rate,
+                use_numpy_format=use_numpy_format,
             )
     except Exception as error:
         typer.echo(f"Command failed. Cause: {error}")

--- a/inference_cli/lib/benchmark_adapter.py
+++ b/inference_cli/lib/benchmark_adapter.py
@@ -36,6 +36,7 @@ def run_infer_api_speed_benchmark(
     output_location: Optional[str] = None,
     enforce_legacy_endpoints: bool = False,
     max_error_rate: Optional[float] = None,
+    use_numpy_format: bool = False,
 ) -> None:
     dataset_images = load_dataset_images(
         dataset_reference=dataset_reference,
@@ -47,6 +48,7 @@ def run_infer_api_speed_benchmark(
         disable_active_learning=True,
         max_concurrent_requests=1,
         max_batch_size=request_batch_size,
+        use_numpy_format=use_numpy_format,
     )
     client.select_model(model_id=model_id)
     if enforce_legacy_endpoints:
@@ -105,6 +107,7 @@ def run_workflow_api_speed_benchmark(
     model_configuration: Optional[str] = None,
     output_location: Optional[str] = None,
     max_error_rate: Optional[float] = None,
+    use_numpy_format: bool = False,
 ) -> None:
     dataset_images = load_dataset_images(
         dataset_reference=dataset_reference,
@@ -116,6 +119,7 @@ def run_workflow_api_speed_benchmark(
         disable_active_learning=True,
         max_concurrent_requests=1,
         max_batch_size=request_batch_size,
+        use_numpy_format=use_numpy_format,
     )
     benchmark_results = coordinate_workflow_api_speed_benchmark(
         client=client,

--- a/inference_cli/lib/utils.py
+++ b/inference_cli/lib/utils.py
@@ -138,13 +138,14 @@ def dump_jsonl(path: str, content: Iterable[dict]) -> None:
 
 
 def initialise_client(
-    host: str, api_key: Optional[str], model_configuration: Optional[str], **kwargs
+    host: str, api_key: Optional[str], model_configuration: Optional[str], use_numpy_format: Optional[bool] = None, **kwargs
 ) -> InferenceHTTPClient:
     if api_key is None:
         api_key = ROBOFLOW_API_KEY
     client = InferenceHTTPClient(
         api_url=host,
         api_key=api_key,
+        use_numpy_format=use_numpy_format,
     )
     raw_configuration = {}
     if model_configuration is not None:

--- a/inference_sdk/http/client.py
+++ b/inference_sdk/http/client.py
@@ -189,18 +189,22 @@ class InferenceHTTPClient:
         self,
         api_url: str,
         api_key: Optional[str] = None,
+        use_numpy_format: bool = False,
     ):
         """Initialize a new InferenceHTTPClient instance.
 
         Args:
             api_url (str): The base URL for the inference API.
             api_key (Optional[str], optional): API key for authentication. Defaults to None.
+            use_numpy_format (Optional[bool], optional): Whether to use numpy format for 
+                image transmission instead of base64
         """
         self.__api_url = api_url
         self.__api_key = api_key
         self.__inference_configuration = InferenceConfiguration.init_default()
         self.__client_mode = _determine_client_mode(api_url=api_url)
         self.__selected_model: Optional[str] = None
+        self.__use_numpy_format = use_numpy_format
 
     @property
     def inference_configuration(self) -> InferenceConfiguration:
@@ -228,6 +232,15 @@ class InferenceHTTPClient:
             Optional[str]: The identifier of the currently selected model, if any.
         """
         return self.__selected_model
+
+    @property
+    def use_numpy_format(self) -> bool:
+        """Get whether numpy format is enabled for image transmission.
+
+        Returns:
+            bool: True if numpy format is enabled, False otherwise.
+        """
+        return self.__use_numpy_format
 
     @contextmanager
     def use_configuration(
@@ -472,6 +485,7 @@ class InferenceHTTPClient:
             inference_input=inference_input,
             max_height=max_height,
             max_width=max_width,
+            use_numpy_format=self.__use_numpy_format,
         )
         params = {
             "api_key": self.__api_key,
@@ -550,6 +564,7 @@ class InferenceHTTPClient:
             inference_input=inference_input,
             max_height=max_height,
             max_width=max_width,
+            use_numpy_format=self.__use_numpy_format,
         )
         params = {
             "api_key": self.__api_key,
@@ -614,6 +629,7 @@ class InferenceHTTPClient:
             inference_input=inference_input,
             max_height=max_height,
             max_width=max_width,
+            use_numpy_format=self.__use_numpy_format,
         )
         payload = {
             "api_key": self.__api_key,
@@ -687,6 +703,7 @@ class InferenceHTTPClient:
             inference_input=inference_input,
             max_height=max_height,
             max_width=max_width,
+            use_numpy_format=self.__use_numpy_format,
         )
         payload = {
             "api_key": self.__api_key,
@@ -1016,6 +1033,7 @@ class InferenceHTTPClient:
         """
         encoded_inference_inputs = load_static_inference_input(
             inference_input=inference_input,
+            use_numpy_format=self.__use_numpy_format,
         )
         payload = self.__initialise_payload()
         if version:
@@ -1064,6 +1082,7 @@ class InferenceHTTPClient:
         """
         encoded_inference_inputs = await load_static_inference_input_async(
             inference_input=inference_input,
+            use_numpy_format=self.__use_numpy_format,
         )
         payload = self.__initialise_payload()
         if version:
@@ -1300,18 +1319,20 @@ class InferenceHTTPClient:
         if subject_type == "image":
             encoded_image = load_static_inference_input(
                 inference_input=subject,
+                use_numpy_format=self.__use_numpy_format,
             )
             payload = inject_images_into_payload(
-                payload=payload, encoded_images=encoded_image, key="subject"
+                payload=payload, encoded_images=encoded_image, key="subject", use_numpy_format=self.__use_numpy_format
             )
         else:
             payload["subject"] = subject
         if prompt_type == "image":
             encoded_inference_inputs = load_static_inference_input(
                 inference_input=prompt,
+                use_numpy_format=self.__use_numpy_format,
             )
             payload = inject_images_into_payload(
-                payload=payload, encoded_images=encoded_inference_inputs, key="prompt"
+                payload=payload, encoded_images=encoded_inference_inputs, key="prompt", use_numpy_format=self.__use_numpy_format
             )
         else:
             payload["prompt"] = prompt
@@ -1364,18 +1385,20 @@ class InferenceHTTPClient:
         if subject_type == "image":
             encoded_image = await load_static_inference_input_async(
                 inference_input=subject,
+                use_numpy_format=self.__use_numpy_format,
             )
             payload = inject_images_into_payload(
-                payload=payload, encoded_images=encoded_image, key="subject"
+                payload=payload, encoded_images=encoded_image, key="subject", use_numpy_format=self.__use_numpy_format
             )
         else:
             payload["subject"] = subject
         if prompt_type == "image":
             encoded_inference_inputs = await load_static_inference_input_async(
                 inference_input=prompt,
+                use_numpy_format=self.__use_numpy_format,
             )
             payload = inject_images_into_payload(
-                payload=payload, encoded_images=encoded_inference_inputs, key="prompt"
+                payload=payload, encoded_images=encoded_inference_inputs, key="prompt", use_numpy_format=self.__use_numpy_format
             )
         else:
             payload["prompt"] = prompt
@@ -1652,6 +1675,7 @@ class InferenceHTTPClient:
         """
         encoded_inference_inputs = load_static_inference_input(
             inference_input=inference_input,
+            use_numpy_format=self.__use_numpy_format,
         )
         payload = self.__initialise_payload()
         payload["text"] = class_names
@@ -1706,6 +1730,7 @@ class InferenceHTTPClient:
         """
         encoded_inference_inputs = await load_static_inference_input_async(
             inference_input=inference_input,
+            use_numpy_format=self.__use_numpy_format,
         )
         payload = self.__initialise_payload()
         payload["text"] = class_names
@@ -2022,6 +2047,7 @@ class InferenceHTTPClient:
     ) -> Union[dict, List[dict]]:
         encoded_inference_inputs = load_static_inference_input(
             inference_input=inference_input,
+            use_numpy_format=self.__use_numpy_format,
         )
         payload = self.__initialise_payload()
         if model_id is not None:

--- a/inference_sdk/http/client.py
+++ b/inference_sdk/http/client.py
@@ -499,6 +499,7 @@ class InferenceHTTPClient:
             payload=None,
             max_batch_size=1,
             image_placement=ImagePlacement.DATA,
+            use_numpy_format=self.__use_numpy_format,
         )
         responses = execute_requests_packages(
             requests_data=requests_data,
@@ -578,6 +579,7 @@ class InferenceHTTPClient:
             payload=None,
             max_batch_size=1,
             image_placement=ImagePlacement.DATA,
+            use_numpy_format=self.__use_numpy_format,
         )
         responses = await execute_requests_packages_async(
             requests_data=requests_data,
@@ -650,6 +652,7 @@ class InferenceHTTPClient:
             payload=payload,
             max_batch_size=self.__inference_configuration.max_batch_size,
             image_placement=ImagePlacement.JSON,
+            use_numpy_format=self.__use_numpy_format,
         )
         responses = execute_requests_packages(
             requests_data=requests_data,
@@ -724,6 +727,7 @@ class InferenceHTTPClient:
             payload=payload,
             max_batch_size=self.__inference_configuration.max_batch_size,
             image_placement=ImagePlacement.JSON,
+            use_numpy_format=self.__use_numpy_format,
         )
         responses = await execute_requests_packages_async(
             requests_data=requests_data,
@@ -1049,6 +1053,7 @@ class InferenceHTTPClient:
             payload=payload,
             max_batch_size=1,
             image_placement=ImagePlacement.JSON,
+            use_numpy_format=self.__use_numpy_format,
         )
         responses = execute_requests_packages(
             requests_data=requests_data,
@@ -1098,6 +1103,7 @@ class InferenceHTTPClient:
             payload=payload,
             max_batch_size=1,
             image_placement=ImagePlacement.JSON,
+            use_numpy_format=self.__use_numpy_format,
         )
         responses = await execute_requests_packages_async(
             requests_data=requests_data,
@@ -1692,6 +1698,7 @@ class InferenceHTTPClient:
             payload=payload,
             max_batch_size=1,
             image_placement=ImagePlacement.JSON,
+            use_numpy_format=self.__use_numpy_format,
         )
         responses = execute_requests_packages(
             requests_data=requests_data,
@@ -1747,6 +1754,7 @@ class InferenceHTTPClient:
             payload=payload,
             max_batch_size=1,
             image_placement=ImagePlacement.JSON,
+            use_numpy_format=self.__use_numpy_format,
         )
         return await execute_requests_packages_async(
             requests_data=requests_data,
@@ -2063,6 +2071,7 @@ class InferenceHTTPClient:
             payload=payload,
             max_batch_size=self.__inference_configuration.max_batch_size,
             image_placement=ImagePlacement.JSON,
+            use_numpy_format=self.__use_numpy_format,
         )
         responses = execute_requests_packages(
             requests_data=requests_data,
@@ -2081,6 +2090,7 @@ class InferenceHTTPClient:
     ) -> Union[dict, List[dict]]:
         encoded_inference_inputs = await load_static_inference_input_async(
             inference_input=inference_input,
+            use_numpy_format=self.__use_numpy_format,
         )
         payload = self.__initialise_payload()
         if model_id is not None:
@@ -2096,6 +2106,7 @@ class InferenceHTTPClient:
             payload=payload,
             max_batch_size=self.__inference_configuration.max_batch_size,
             image_placement=ImagePlacement.JSON,
+            use_numpy_format=self.__use_numpy_format,
         )
         responses = await execute_requests_packages_async(
             requests_data=requests_data,

--- a/inference_sdk/http/utils/encoding.py
+++ b/inference_sdk/http/utils/encoding.py
@@ -1,4 +1,5 @@
 import base64
+import pickle
 from io import BytesIO
 from typing import Union
 
@@ -49,6 +50,22 @@ def encode_base_64(payload: bytes) -> str:
         The base64 string.
     """
     return base64.b64encode(payload).decode("utf-8")
+
+
+def pickle_numpy_array(image: np.ndarray) -> bytes:
+    """pickle numpy array.
+
+    This format is used when ALLOW_NUMPY_INPUT is enabled on the server.
+    WARNING: This should only be used with trusted servers as pickle
+    deserialization can execute arbitrary code.
+
+    Args:
+        image: The numpy array to encode.
+
+    Returns:
+        The pickled numpy array.
+    """
+    return pickle.dumps(image)
 
 
 def bytes_to_opencv_image(

--- a/inference_sdk/http/utils/encoding.py
+++ b/inference_sdk/http/utils/encoding.py
@@ -56,16 +56,15 @@ def pickle_numpy_array(image: np.ndarray) -> bytes:
     """pickle numpy array.
 
     This format is used when ALLOW_NUMPY_INPUT is enabled on the server.
-    WARNING: This should only be used with trusted servers as pickle
-    deserialization can execute arbitrary code.
 
     Args:
-        image: The numpy array to encode.
+        image: The numpy array to pickle and represent as latin-1 string.
 
     Returns:
         The pickled numpy array.
     """
-    return pickle.dumps(image)
+    # latin-1 represents all 256 values of the byte and is faster than base64
+    return pickle.dumps(image).decode("latin-1")
 
 
 def bytes_to_opencv_image(

--- a/inference_sdk/http/utils/loaders.py
+++ b/inference_sdk/http/utils/loaders.py
@@ -15,6 +15,7 @@ from inference_sdk.http.utils.encoding import (
     bytes_to_opencv_image,
     encode_base_64,
     numpy_array_to_base64_jpeg,
+    pickle_numpy_array,
     pillow_image_to_base64_jpeg,
 )
 from inference_sdk.http.utils.pre_processing import (
@@ -74,6 +75,7 @@ def load_nested_batches_of_inference_input(
     inference_input: Union[list, ImagesReference],
     max_height: Optional[int] = None,
     max_width: Optional[int] = None,
+    use_numpy_format: bool = False,
 ) -> Union[Tuple[str, Optional[float]], list]:
     """Load a nested batch of inference input.
 
@@ -81,6 +83,7 @@ def load_nested_batches_of_inference_input(
         inference_input: The inference input.
         max_height: The maximum height of the image.
         max_width: The maximum width of the image.
+        use_numpy_format: Whether to use numpy format instead of base64.
 
     Returns:
         The nested batch of inference input.
@@ -90,6 +93,7 @@ def load_nested_batches_of_inference_input(
             inference_input=inference_input,
             max_height=max_height,
             max_width=max_width,
+            use_numpy_format=use_numpy_format,
         )[0]
     result = []
     for element in inference_input:
@@ -98,6 +102,7 @@ def load_nested_batches_of_inference_input(
                 inference_input=element,
                 max_height=max_height,
                 max_width=max_width,
+                use_numpy_format=use_numpy_format,
             )
         )
     return result
@@ -107,6 +112,7 @@ def load_static_inference_input(
     inference_input: Union[ImagesReference, List[ImagesReference]],
     max_height: Optional[int] = None,
     max_width: Optional[int] = None,
+    use_numpy_format: bool = False,
 ) -> List[Tuple[str, Optional[float]]]:
     """Load a static inference input.
 
@@ -114,6 +120,7 @@ def load_static_inference_input(
         inference_input: The inference input.
         max_height: The maximum height of the image.
         max_width: The maximum width of the image.
+        use_numpy_format: Whether to use numpy format instead of base64.
 
     Returns:
         The list of the inference input.
@@ -126,6 +133,7 @@ def load_static_inference_input(
                     inference_input=element,
                     max_height=max_height,
                     max_width=max_width,
+                    use_numpy_format=use_numpy_format,
                 )
             )
         return results
@@ -141,7 +149,10 @@ def load_static_inference_input(
             max_height=max_height,
             max_width=max_width,
         )
-        return [(numpy_array_to_base64_jpeg(image=image), scaling_factor)]
+        if use_numpy_format:
+            return [(pickle_numpy_array(image=image), scaling_factor)]
+        else:
+            return [(numpy_array_to_base64_jpeg(image=image), scaling_factor)]
     if issubclass(type(inference_input), Image.Image):
         image, scaling_factor = resize_pillow_image(
             image=inference_input,
@@ -158,6 +169,7 @@ async def load_static_inference_input_async(
     inference_input: Union[ImagesReference, List[ImagesReference]],
     max_height: Optional[int] = None,
     max_width: Optional[int] = None,
+    use_numpy_format: bool = False,
 ) -> List[Tuple[str, Optional[float]]]:
     """Load a static inference input asynchronously.
 
@@ -165,6 +177,7 @@ async def load_static_inference_input_async(
         inference_input: The inference input.
         max_height: The maximum height of the image.
         max_width: The maximum width of the image.
+        use_numpy_format: Whether to use numpy format instead of base64.
 
     Returns:
         The list of the inference input.
@@ -177,6 +190,7 @@ async def load_static_inference_input_async(
                     inference_input=element,
                     max_height=max_height,
                     max_width=max_width,
+                    use_numpy_format=use_numpy_format,
                 )
             )
         return results
@@ -192,7 +206,10 @@ async def load_static_inference_input_async(
             max_height=max_height,
             max_width=max_width,
         )
-        return [(numpy_array_to_base64_jpeg(image=image), scaling_factor)]
+        if use_numpy_format:
+            return [(pickle_numpy_array(image=image), scaling_factor)]
+        else:
+            return [(numpy_array_to_base64_jpeg(image=image), scaling_factor)]
     if issubclass(type(inference_input), Image.Image):
         image, scaling_factor = resize_pillow_image(
             image=inference_input,

--- a/inference_sdk/http/utils/request_building.py
+++ b/inference_sdk/http/utils/request_building.py
@@ -43,6 +43,7 @@ def prepare_requests_data(
     payload: Optional[Dict[str, Any]],
     max_batch_size: int,
     image_placement: ImagePlacement,
+    use_numpy_format: bool = False,
 ) -> List[RequestData]:
     """Prepare requests data.
 
@@ -54,6 +55,7 @@ def prepare_requests_data(
         payload: The payload of the request.
         max_batch_size: The maximum batch size.
         image_placement: The image placement.
+        use_numpy_format: Whether to use numpy format instead of base64.
 
     Returns:
         The list of request data.
@@ -73,6 +75,7 @@ def prepare_requests_data(
             parameters=parameters,
             payload=payload,
             image_placement=image_placement,
+            use_numpy_format=use_numpy_format,
         )
         requests_data.append(request_data)
     return requests_data
@@ -85,6 +88,7 @@ def assembly_request_data(
     parameters: Optional[Dict[str, Union[str, List[str]]]],
     payload: Optional[Dict[str, Any]],
     image_placement: ImagePlacement,
+    use_numpy_format: bool = False,
 ) -> RequestData:
     """Assemble request data.
 
@@ -109,6 +113,7 @@ def assembly_request_data(
         payload = inject_images_into_payload(
             payload=payload,
             encoded_images=batch_inference_inputs,
+            use_numpy_format=use_numpy_format,
         )
     elif image_placement is ImagePlacement.DATA:
         data = batch_inference_inputs[0][0]

--- a/inference_sdk/http/utils/requests.py
+++ b/inference_sdk/http/utils/requests.py
@@ -70,7 +70,7 @@ def inject_images_into_payload(
     if len(encoded_images) == 0:
         return payload
     
-    image_type = "numpy" if use_numpy_format else "base64"
+    image_type = "latin-1" if use_numpy_format else "base64"
     
     if len(encoded_images) > 1:
         images_payload = [

--- a/inference_sdk/http/utils/requests.py
+++ b/inference_sdk/http/utils/requests.py
@@ -54,6 +54,7 @@ def inject_images_into_payload(
     payload: dict,
     encoded_images: List[Tuple[str, Optional[float]]],
     key: str = "image",
+    use_numpy_format: bool = False,
 ) -> dict:
     """Inject images into the payload.
 
@@ -61,19 +62,23 @@ def inject_images_into_payload(
         payload: The payload to inject the images into.
         encoded_images: The encoded images.
         key: The key of the images.
+        use_numpy_format: Whether to use numpy format instead of base64.
 
     Returns:
         The payload with the images injected.
     """
     if len(encoded_images) == 0:
         return payload
+    
+    image_type = "numpy" if use_numpy_format else "base64"
+    
     if len(encoded_images) > 1:
         images_payload = [
-            {"type": "base64", "value": image} for image, _ in encoded_images
+            {"type": image_type, "value": image} for image, _ in encoded_images
         ]
         payload[key] = images_payload
     else:
-        payload[key] = {"type": "base64", "value": encoded_images[0][0]}
+        payload[key] = {"type": image_type, "value": encoded_images[0][0]}
     return payload
 
 
@@ -81,6 +86,7 @@ def inject_nested_batches_of_images_into_payload(
     payload: dict,
     encoded_images: Union[list, Tuple[str, Optional[float]]],
     key: str = "image",
+    use_numpy_format: bool = False,
 ) -> dict:
     """Inject nested batches of images into the payload.
 
@@ -88,12 +94,14 @@ def inject_nested_batches_of_images_into_payload(
         payload: The payload to inject the images into.
         encoded_images: The encoded images.
         key: The key of the images.
+        use_numpy_format: Whether to use numpy format instead of base64.
 
     Returns:
         The payload with the images injected.
     """
     payload_value = _batch_of_images_into_inference_format(
         encoded_images=encoded_images,
+        use_numpy_format=use_numpy_format,
     )
     payload[key] = payload_value
     return payload
@@ -101,22 +109,26 @@ def inject_nested_batches_of_images_into_payload(
 
 def _batch_of_images_into_inference_format(
     encoded_images: Union[list, Tuple[str, Optional[float]]],
+    use_numpy_format: bool = False,
 ) -> Union[dict, list]:
     """Batch of images into inference format.
 
     Args:
         encoded_images: The encoded images.
+        use_numpy_format: Whether to use numpy format instead of base64.
 
     Returns:
         The images in inference format.
     """
     if not isinstance(encoded_images, list):
-        return {"type": "base64", "value": encoded_images[0]}
+        image_type = "numpy" if use_numpy_format else "base64"
+        return {"type": image_type, "value": encoded_images[0]}
     result = []
     for element in encoded_images:
         result.append(
             _batch_of_images_into_inference_format(
                 encoded_images=element,
+                use_numpy_format=use_numpy_format,
             )
         )
     return result


### PR DESCRIPTION
# Description

inference-sdk - add support for sending raw numpy array avoiding base64 encoding

## Type of change

-   [x] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?

CI passing

## Any specific deployment considerations

N/A

## Docs

N/A