### PR TITLE
rename from perception_encoder to perception-encoder

### DIFF
--- a/inference_experimental/inference_exp/models/auto_loaders/models_registry.py
+++ b/inference_experimental/inference_exp/models/auto_loaders/models_registry.py
@@ -121,7 +121,7 @@ REGISTERED_MODELS: Dict[Tuple[ModelArchitecture, TaskType, BackendType], LazyCla
         module_name="inference_exp.models.paligemma.paligemma_hf",
         class_name="PaliGemmaHF",
     ),
-    ("perception_encoder", EMBEDDING_TASK, BackendType.TORCH): LazyClass(
+    ("perception-encoder", EMBEDDING_TASK, BackendType.TORCH): LazyClass(
         module_name="inference_exp.models.perception_encoder.perception_encoder_pytorch",
         class_name="PerceptionEncoderTorch",
     ),

--- a/inference_experimental/tests/integration_tests/e2e/test_perception_encoder_e2e.py
+++ b/inference_experimental/tests/integration_tests/e2e/test_perception_encoder_e2e.py
@@ -7,7 +7,7 @@ from inference_exp import AutoModel
 @pytest.mark.e2e_model_inference
 def test_perception_encoder_text_embedding():
     # GIVEN
-    model = AutoModel.from_pretrained("perception_encoder/PE-Core-B16-224")
+    model = AutoModel.from_pretrained("perception-encoder/PE-Core-B16-224")
 
     # WHEN
     embeddings = model.embed_text("hello world")
@@ -20,7 +20,7 @@ def test_perception_encoder_text_embedding():
 @pytest.mark.e2e_model_inference
 def test_perception_encoder_image_embedding_with_numpy_inputs():
     # GIVEN
-    model = AutoModel.from_pretrained("perception_encoder/PE-Core-B16-224")
+    model = AutoModel.from_pretrained("perception-encoder/PE-Core-B16-224")
 
     # WHEN & THEN
 
@@ -42,7 +42,7 @@ def test_perception_encoder_image_embedding_with_numpy_inputs():
 @pytest.mark.e2e_model_inference
 def test_perception_encoder_image_embedding_with_tensor_inputs():
     # GIVEN
-    model = AutoModel.from_pretrained("perception_encoder/PE-Core-B16-224")
+    model = AutoModel.from_pretrained("perception-encoder/PE-Core-B16-224")
 
     # WHEN & THEN
 


### PR DESCRIPTION
# Description
renames `perception_encoder` to `perception-encoder` for model architechture / use in model ids.  registry has already been updated on staging and prod with new models.

this is for new inference-exp

## Type of change
maintenance

## How has this change been tested, please provide a testcase or example of how you tested the change?
locally running e2e tests

## Any specific deployment considerations
n/a

## Docs
n/a