### PR TITLE
Add inference cli to jetson dockers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,12 +51,20 @@ create_wheels:
 
 create_wheels_for_gpu_notebook:
 	python -m pip install --upgrade pip
-	python -m pip install wheel twine requests 
+	python -m pip install wheel twine requests
 	rm -f dist/*
 	python .release/pypi/inference.core.setup.py bdist_wheel
 	python .release/pypi/inference.gpu.setup.py bdist_wheel
 	python .release/pypi/inference.sdk.setup.py bdist_wheel
 	python .release/pypi/inference.cli.setup.py bdist_wheel
+
+
+create_inference_cli_whl:
+	python -m pip install --upgrade pip
+	python -m pip install wheel twine requests
+	rm -f dist/*
+	python .release/pypi/inference.cli.setup.py bdist_wheel
+
 
 upload_wheels:
 	twine upload dist/*.whl

--- a/docker/dockerfiles/Dockerfile.onnx.jetson.4.6.1
+++ b/docker/dockerfiles/Dockerfile.onnx.jetson.4.6.1
@@ -75,8 +75,12 @@ RUN python3.9 -m pip install "numpy<=1.26.4" onnxruntime_gpu-1.11.0-cp39-cp39-li
 
 WORKDIR /app/
 COPY inference inference
+COPY inference_cli inference_cli
 COPY inference_sdk inference_sdk
 COPY docker/config/gpu_http.py gpu_http.py
+
+RUN make create_inference_cli_whl
+RUN pip3 install dist/inference_cli*.whl
 
 ENV VERSION_CHECK_MODE=continuous
 ENV PROJECT=roboflow-platform

--- a/docker/dockerfiles/Dockerfile.onnx.jetson.5.1.1
+++ b/docker/dockerfiles/Dockerfile.onnx.jetson.5.1.1
@@ -66,8 +66,12 @@ RUN python3.9 -m pip install "numpy<=1.26.4" onnxruntime_gpu-1.16.0-cp39-cp39-li
 
 WORKDIR /app/
 COPY inference inference
+COPY inference_cli inference_cli
 COPY inference_sdk inference_sdk
 COPY docker/config/gpu_http.py gpu_http.py
+
+RUN make create_inference_cli_whl
+RUN pip3 install dist/inference_cli*.whl
 
 ENV VERSION_CHECK_MODE=continuous
 ENV PROJECT=roboflow-platform

--- a/docker/dockerfiles/Dockerfile.onnx.jetson.6.0.0
+++ b/docker/dockerfiles/Dockerfile.onnx.jetson.6.0.0
@@ -45,8 +45,12 @@ RUN python3 -m pip uninstall -y numpy && python3 -m pip install "numpy<=1.26.4" 
 # Set up the application runtime
 WORKDIR /app
 COPY inference/ ./inference/
+COPY inference_cli/ ./inference_cli/
 COPY inference_sdk/ ./inference_sdk/
 COPY docker/config/gpu_http.py ./gpu_http.py
+
+RUN make create_inference_cli_whl
+RUN pip3 install dist/inference_cli*.whl
 
 # Set environment variables
 ENV VERSION_CHECK_MODE=continuous \

--- a/docker/dockerfiles/Dockerfile.onnx.jetson.6.2.0
+++ b/docker/dockerfiles/Dockerfile.onnx.jetson.6.2.0
@@ -50,8 +50,12 @@ RUN python3 -m pip install "numpy<=1.26.4"
 # Set up the application runtime
 WORKDIR /app
 COPY inference/ ./inference/
+COPY inference_cli/ ./inference_cli/
 COPY inference_sdk/ ./inference_sdk/
 COPY docker/config/gpu_http.py ./gpu_http.py
+
+RUN make create_inference_cli_whl
+RUN pip3 install dist/inference_cli*.whl
 
 # Set environment variables
 ENV VERSION_CHECK_MODE=continuous \


### PR DESCRIPTION
# Description

Add inference_cli installation step on jetson Dockerfiles
Remove empty Dockerfile.onnx.jetson.4.5.0

## Type of change

-   [x] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?

CI passing
Relevant docker images are built without error
 - [ ] Dockerfile.onnx.jetson.4.6.1
 - [ ] Dockerfile.onnx.jetson.5.1.1
 - [ ] Dockerfile.onnx.jetson.6.0.0
 - [ ] Dockerfile.onnx.jetson.6.2.0

## Any specific deployment considerations

N/A

## Docs

N/A