### PR TITLE
Add missing inference_sdk required when building cli (jetson 5.1.1 streaming Dockerfile)

### DIFF
--- a/docker/dockerfiles/Dockerfile.onnx.jetson.5.1.1.stream_manager
+++ b/docker/dockerfiles/Dockerfile.onnx.jetson.5.1.1.stream_manager
@@ -56,6 +56,7 @@ RUN python3.9 -m pip install onnxruntime_gpu-1.16.0-cp39-cp39-linux_aarch64.whl 
 
 WORKDIR /app/
 COPY inference_cli/ ./inference_cli/
+COPY inference_sdk/ ./inference_sdk/
 COPY inference inference
 COPY .release .release
 COPY requirements requirements


### PR DESCRIPTION
# Description

Add missing inference_sdk required when building cli (jetson 5.1.1 streaming Dockerfile)

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

 - [x] CI passing
 - [x] [Jetson 5.1.1 streaming Docker container is built without errors](https://github.com/roboflow/inference/actions/runs/16369172503)

## Any specific deployment considerations

N/A

## Docs

N/A