### PR TITLE
Fix post-processing for instance-segmentation in `inference-exp`

### DIFF
--- a/inference_experimental/inference_exp/models/common/roboflow/post_processing.py
+++ b/inference_experimental/inference_exp/models/common/roboflow/post_processing.py
@@ -275,6 +275,13 @@ def align_instance_segmentation_results(
     original_size: ImageDimensions,
     inference_size: ImageDimensions,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
+    if image_bboxes.shape[0] == 0:
+        empty_masks = torch.empty(
+            size=(0, original_size.height, original_size.width),
+            dtype=torch.bool,
+            device=image_bboxes.device,
+        )
+        return image_bboxes, empty_masks
     pad_left, pad_top, pad_right, pad_bottom = padding
     offsets = torch.tensor(
         [pad_left, pad_top, pad_left, pad_top],
@@ -303,5 +310,5 @@ def align_instance_segmentation_results(
         masks,
         [original_size.height, original_size.width],
         interpolation=functional.InterpolationMode.BILINEAR,
-    ).gt_(0.0)
+    ).gt_(0.0).to(dtype=torch.bool)
     return image_bboxes, masks

--- a/inference_experimental/pyproject.toml
+++ b/inference_experimental/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inference-exp"
-version = "0.12.0"
+version = "0.13.0"
 description = "Experimental vresion of inference package which is supposed to evolve into inference 1.0"
 readme = "README.md"
 requires-python = ">=3.10,<3.13"


### PR DESCRIPTION
# Description

There was a bug in `inference-exp` post-processing for instance segmentation causing error when empty predictions were hitting the function.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

* CI
* e2e test

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
