### PR TITLE
Webrtc latency for heavy workflows

### DIFF
--- a/inference/core/interfaces/stream_manager/manager_app/inference_pipeline_manager.py
+++ b/inference/core/interfaces/stream_manager/manager_app/inference_pipeline_manager.py
@@ -280,8 +280,6 @@ class InferencePipelineManager(Process):
                     from_inference_queue=from_inference_queue,
                     asyncio_loop=loop,
                     webcam_fps=webcam_fps,
-                    max_consecutive_timeouts=parsed_payload.max_consecutive_timeouts,
-                    min_consecutive_on_time=parsed_payload.min_consecutive_on_time,
                     processing_timeout=parsed_payload.processing_timeout,
                     fps_probe_frames=parsed_payload.fps_probe_frames,
                     data_output=data_output,

--- a/inference/core/interfaces/stream_manager/manager_app/webrtc.py
+++ b/inference/core/interfaces/stream_manager/manager_app/webrtc.py
@@ -63,14 +63,27 @@ def get_frame_from_workflow_output(
 ) -> Optional[np.ndarray]:
     step_output = workflow_output.get(frame_output_key)
     if isinstance(step_output, WorkflowImageData):
-        latency = datetime.datetime.now() - step_output.video_metadata.frame_timestamp
-        logger.info("Processing latency: %ss", latency.total_seconds())
+        if (
+            step_output.video_metadata
+            and step_output.video_metadata.frame_timestamp is not None
+        ):
+            latency = (
+                datetime.datetime.now() - step_output.video_metadata.frame_timestamp
+            )
+            logger.info("Processing latency: %ss", latency.total_seconds())
         return step_output.numpy_image
     elif isinstance(step_output, dict):
         for frame_output in step_output.values():
             if isinstance(frame_output, WorkflowImageData):
-                latency = datetime.datetime.now() - frame_output.video_metadata.frame_timestamp
-                logger.info("Processing latency: %ss", latency.total_seconds())
+                if (
+                    frame_output.video_metadata
+                    and frame_output.video_metadata.frame_timestamp is not None
+                ):
+                    latency = (
+                        datetime.datetime.now()
+                        - frame_output.video_metadata.frame_timestamp
+                    )
+                    logger.info("Processing latency: %ss", latency.total_seconds())
                 return frame_output.numpy_image
 
 

--- a/inference/core/version.py
+++ b/inference/core/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.51.5"
+__version__ = "0.51.6"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

Remove 'Workflow is heavy' message
add latency logging
Use incoming frame time when sending resulting frame back

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

CI passing
manually tested on localhost and on DD

## Any specific deployment considerations

N/A

## Docs

N/A