### PR TITLE
allow cuda execution provider

### DIFF
--- a/inference/models/rfdetr/rfdetr.py
+++ b/inference/models/rfdetr/rfdetr.py
@@ -391,11 +391,6 @@ class RFDETRObjectDetection(ObjectDetectionBaseOnnxRoboflowInferenceModel):
                 ONNXRUNTIME_EXECUTION_PROVIDERS
             )
 
-            if not self.load_weights:
-                providers = [
-                    "CPUExecutionProvider"
-                ]  # "OpenVINOExecutionProvider" dropped until further investigation is done
-
             try:
                 session_options = onnxruntime.SessionOptions()
                 session_options.log_severity_level = 3
@@ -404,7 +399,7 @@ class RFDETRObjectDetection(ObjectDetectionBaseOnnxRoboflowInferenceModel):
                     session_options.graph_optimization_level = (
                         onnxruntime.GraphOptimizationLevel.ORT_DISABLE_ALL
                     )
-                expanded_execution_providers = []
+                expanded_execution_providers = providers
                 for ep in self.onnxruntime_execution_providers:
                     if ep == "TensorrtExecutionProvider":
                         ep = (
@@ -422,6 +417,10 @@ class RFDETRObjectDetection(ObjectDetectionBaseOnnxRoboflowInferenceModel):
                             },
                         )
                 expanded_execution_providers.append(ep)
+
+                if "OpenVINOExecutionProvider" in expanded_execution_providers:
+                    expanded_execution_providers.remove("OpenVINOExecutionProvider")
+
                 self.onnx_session = onnxruntime.InferenceSession(
                     self.cache_file(self.weights_file),
                     providers=expanded_execution_providers,


### PR DESCRIPTION
# Description

CUDAExecutionProvider couldn't make its way into ONNX session for RFDETR. Fixed.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

tested locally, confirmed using CUDA 

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
