### PR TITLE
Fix/force numpy 1.26.4 on jetson dockers

### DIFF
--- a/docker/dockerfiles/Dockerfile.onnx.jetson.4.6.1
+++ b/docker/dockerfiles/Dockerfile.onnx.jetson.4.6.1
@@ -66,13 +66,6 @@ RUN python3.9 -m pip install --upgrade pip "h5py<=3.10.0" && python3.9 -m pip in
     --upgrade \
     && rm -rf ~/.cache/pip
 
-# BE CAREFUL, WE ENFORCE numpy 1.x for the sake of compatibility with onnxruntime
-RUN python3.9 -m pip uninstall --yes onnxruntime numpy
-RUN wget https://nvidia.box.com/shared/static/jmomlpcctmjojz14zbwa12lxmeh2h6o5.whl -O onnxruntime_gpu-1.11.0-cp39-cp39-linux_aarch64.whl
-RUN python3.9 -m pip install "numpy<=1.26.4" onnxruntime_gpu-1.11.0-cp39-cp39-linux_aarch64.whl \
-    && rm -rf ~/.cache/pip \
-    && rm onnxruntime_gpu-1.11.0-cp39-cp39-linux_aarch64.whl
-
 WORKDIR /app/
 COPY inference inference
 COPY inference_cli inference_cli
@@ -84,6 +77,13 @@ COPY Makefile Makefile
 
 RUN make create_inference_cli_whl PYTHON=python3.9
 RUN python3.9 -m pip install dist/inference_cli*.whl
+
+# BE CAREFUL, WE ENFORCE numpy 1.x for the sake of compatibility with onnxruntime
+RUN python3.9 -m pip uninstall --yes onnxruntime numpy
+RUN wget https://nvidia.box.com/shared/static/jmomlpcctmjojz14zbwa12lxmeh2h6o5.whl -O onnxruntime_gpu-1.11.0-cp39-cp39-linux_aarch64.whl
+RUN python3.9 -m pip install "numpy<=1.26.4" onnxruntime_gpu-1.11.0-cp39-cp39-linux_aarch64.whl \
+    && rm -rf ~/.cache/pip \
+    && rm onnxruntime_gpu-1.11.0-cp39-cp39-linux_aarch64.whl
 
 ENV VERSION_CHECK_MODE=continuous \
     PROJECT=roboflow-platform \

--- a/docker/dockerfiles/Dockerfile.onnx.jetson.5.1.1
+++ b/docker/dockerfiles/Dockerfile.onnx.jetson.5.1.1
@@ -57,13 +57,6 @@ RUN python3.9 -m pip install --upgrade pip  && python3.9 -m pip install \
     --upgrade \
     && rm -rf ~/.cache/pip
 
-# BE CAREFUL, WE ENFORCE numpy 1.x for the sake of compatibility with onnxruntime
-RUN python3.9 -m pip uninstall --yes onnxruntime numpy
-RUN wget https://nvidia.box.com/shared/static/67zek28z497hs9aev7xg2c1wngdeyv4h.whl -O onnxruntime_gpu-1.16.0-cp39-cp39-linux_aarch64.whl
-RUN python3.9 -m pip install "numpy<=1.26.4" onnxruntime_gpu-1.16.0-cp39-cp39-linux_aarch64.whl "opencv-python-headless>4,<=4.10.0.84" \
-    && rm -rf ~/.cache/pip \
-    && rm onnxruntime_gpu-1.16.0-cp39-cp39-linux_aarch64.whl
-
 WORKDIR /app/
 COPY inference inference
 COPY inference_cli inference_cli
@@ -75,6 +68,13 @@ COPY Makefile Makefile
 
 RUN make create_inference_cli_whl PYTHON=python3.9
 RUN python3.9 -m pip install dist/inference_cli*.whl
+
+# BE CAREFUL, WE ENFORCE numpy 1.x for the sake of compatibility with onnxruntime
+RUN python3.9 -m pip uninstall --yes onnxruntime numpy
+RUN wget https://nvidia.box.com/shared/static/67zek28z497hs9aev7xg2c1wngdeyv4h.whl -O onnxruntime_gpu-1.16.0-cp39-cp39-linux_aarch64.whl
+RUN python3.9 -m pip install "numpy<=1.26.4" onnxruntime_gpu-1.16.0-cp39-cp39-linux_aarch64.whl "opencv-python-headless>4,<=4.10.0.84" \
+    && rm -rf ~/.cache/pip \
+    && rm onnxruntime_gpu-1.16.0-cp39-cp39-linux_aarch64.whl
 
 ENV VERSION_CHECK_MODE=continuous \
     PROJECT=roboflow-platform \

--- a/docker/dockerfiles/Dockerfile.onnx.jetson.5.1.1.stream_manager
+++ b/docker/dockerfiles/Dockerfile.onnx.jetson.5.1.1.stream_manager
@@ -48,12 +48,6 @@ RUN python3.9 -m pip install --upgrade pip  && python3.9 -m pip install \
     --upgrade \
     && rm -rf ~/.cache/pip
 
-RUN python3.9 -m pip uninstall --yes onnxruntime
-RUN wget https://nvidia.box.com/shared/static/67zek28z497hs9aev7xg2c1wngdeyv4h.whl -O onnxruntime_gpu-1.16.0-cp39-cp39-linux_aarch64.whl
-RUN python3.9 -m pip install onnxruntime_gpu-1.16.0-cp39-cp39-linux_aarch64.whl "opencv-python-headless>4,<=4.10.0.84" \
-    && rm -rf ~/.cache/pip \
-    && rm onnxruntime_gpu-1.16.0-cp39-cp39-linux_aarch64.whl
-
 WORKDIR /app/
 COPY inference_cli/ ./inference_cli/
 COPY inference_sdk/ ./inference_sdk/
@@ -64,6 +58,12 @@ COPY Makefile Makefile
 
 RUN make create_inference_cli_whl PYTHON=python3.9
 RUN python3.9 -m pip install dist/inference_cli*.whl
+
+RUN python3.9 -m pip uninstall --yes onnxruntime
+RUN wget https://nvidia.box.com/shared/static/67zek28z497hs9aev7xg2c1wngdeyv4h.whl -O onnxruntime_gpu-1.16.0-cp39-cp39-linux_aarch64.whl
+RUN python3.9 -m pip install onnxruntime_gpu-1.16.0-cp39-cp39-linux_aarch64.whl "opencv-python-headless>4,<=4.10.0.84" \
+    && rm -rf ~/.cache/pip \
+    && rm onnxruntime_gpu-1.16.0-cp39-cp39-linux_aarch64.whl
 
 ENV ORT_TENSORRT_FP16_ENABLE=1 \
     ORT_TENSORRT_ENGINE_CACHE_ENABLE=1 \

--- a/docker/dockerfiles/Dockerfile.onnx.jetson.5.1.1.stream_manager
+++ b/docker/dockerfiles/Dockerfile.onnx.jetson.5.1.1.stream_manager
@@ -59,9 +59,10 @@ COPY Makefile Makefile
 RUN make create_inference_cli_whl PYTHON=python3.9
 RUN python3.9 -m pip install dist/inference_cli*.whl
 
-RUN python3.9 -m pip uninstall --yes onnxruntime
+# BE CAREFUL, WE ENFORCE numpy 1.x for the sake of compatibility with onnxruntime
+RUN python3.9 -m pip uninstall --yes onnxruntime numpy
 RUN wget https://nvidia.box.com/shared/static/67zek28z497hs9aev7xg2c1wngdeyv4h.whl -O onnxruntime_gpu-1.16.0-cp39-cp39-linux_aarch64.whl
-RUN python3.9 -m pip install onnxruntime_gpu-1.16.0-cp39-cp39-linux_aarch64.whl "opencv-python-headless>4,<=4.10.0.84" \
+RUN python3.9 -m pip install "numpy<=1.26.4" onnxruntime_gpu-1.16.0-cp39-cp39-linux_aarch64.whl "opencv-python-headless>4,<=4.10.0.84" \
     && rm -rf ~/.cache/pip \
     && rm onnxruntime_gpu-1.16.0-cp39-cp39-linux_aarch64.whl
 

--- a/docker/dockerfiles/Dockerfile.onnx.jetson.6.0.0
+++ b/docker/dockerfiles/Dockerfile.onnx.jetson.6.0.0
@@ -37,11 +37,6 @@ RUN python3 -m pip install --upgrade pip && \
     -r requirements/requirements.jetson.txt \
     "setuptools<=75.5.0"
 
-RUN wget https://nvidia.box.com/shared/static/6l0u97rj80ifwkk8rqbzj1try89fk26z.whl -O onnxruntime_gpu-1.19.0-cp310-cp310-linux_aarch64.whl
-RUN python3 -m pip uninstall -y numpy && python3 -m pip install "numpy<=1.26.4" onnxruntime_gpu-1.19.0-cp310-cp310-linux_aarch64.whl \
-    && rm -rf ~/.cache/pip \
-    && rm onnxruntime_gpu-1.19.0-cp310-cp310-linux_aarch64.whl
-
 # Set up the application runtime
 WORKDIR /app
 COPY inference/ ./inference/
@@ -54,6 +49,11 @@ COPY Makefile Makefile
 
 RUN make create_inference_cli_whl PYTHON=python3
 RUN pip3 install dist/inference_cli*.whl
+
+RUN wget https://nvidia.box.com/shared/static/6l0u97rj80ifwkk8rqbzj1try89fk26z.whl -O onnxruntime_gpu-1.19.0-cp310-cp310-linux_aarch64.whl
+RUN python3 -m pip uninstall -y numpy && python3 -m pip install "numpy<=1.26.4" onnxruntime_gpu-1.19.0-cp310-cp310-linux_aarch64.whl \
+    && rm -rf ~/.cache/pip \
+    && rm onnxruntime_gpu-1.19.0-cp310-cp310-linux_aarch64.whl
 
 # Set environment variables
 ENV VERSION_CHECK_MODE=continuous \

--- a/inference/core/version.py
+++ b/inference/core/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.51.8"
+__version__ = "0.51.9"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

On jetsons we need to force numpy 1.26.4 installation due to inference-cli installation

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

CI passing
 - [x] [jetson 4.6.1 docker image is building without error](https://github.com/roboflow/inference/actions/runs/16575334520)
 - [x] [jetson 5.1.1 docker image is building without error](https://github.com/roboflow/inference/actions/runs/16575337840)
 - [x] [jetson 6.0.0 docker image is building without error](https://github.com/roboflow/inference/actions/runs/16575340416)
 - [x] [jetson 5.1.1 stream-manager docker container is building without error](https://github.com/roboflow/inference/actions/runs/16575343147)

## Any specific deployment considerations

N/A

## Docs

N/A