### PR TITLE
Add line number and function name information to dynamic block errors

### DIFF
--- a/inference/core/workflows/execution_engine/v1/dynamic_blocks/block_scaffolding.py
+++ b/inference/core/workflows/execution_engine/v1/dynamic_blocks/block_scaffolding.py
@@ -1,5 +1,5 @@
-import types
 import traceback
+import types
 from typing import List, Type
 
 from inference.core.env import ALLOW_CUSTOM_PYTHON_EXECUTION_IN_WORKFLOWS
@@ -65,7 +65,9 @@ def assembly_custom_python_block(
             tb = traceback.extract_tb(error.__traceback__)
             if tb:
                 frame = tb[-1]
-                line_number = frame.lineno - len(_get_python_code_imports(python_code).splitlines())
+                line_number = frame.lineno - len(
+                    _get_python_code_imports(python_code).splitlines()
+                )
                 function_name = frame.name
                 message = f"Error in line {line_number}, in {function_name}: {error.__class__.__name__}: {error}"
             else:


### PR DESCRIPTION
# Description

When a dynamic python block breaks execution, enrich the error message with the proper breaking line number and function name.

Follows the python standard:

```
File "<string>", line 22, in my_bad_func
ZeroDivisionError: division by zero
```

But without filename, since it's just a string.

## Type of change

-   [x] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Locally using a miscoded python block in workflows. And also with a proper working one to ensure valid blocks still work.

Python block:

<img width="1564" height="633" alt="CleanShot 2025-08-04 at 13 24 52@2x" src="https://github.com/user-attachments/assets/3c58f366-914c-4a54-84a5-88ff144dc94f" />

Current error message:

<img width="1020" height="550" alt="CleanShot 2025-08-04 at 14 09 53@2x" src="https://github.com/user-attachments/assets/ddd5496c-d8f2-4a99-9661-1281127f4c73" />

Improved error message:

<img width="1033" height="581" alt="CleanShot 2025-08-04 at 13 20 38@2x" src="https://github.com/user-attachments/assets/b52331d4-2829-4c75-8142-ed4cf1e82a5c" />

## Any specific deployment considerations

none