### PR TITLE
When version number is aa.bb.cc, script was not removing leading 'v'

### DIFF
--- a/.github/actions/determine-tags/action.yml
+++ b/.github/actions/determine-tags/action.yml
@@ -60,7 +60,7 @@ runs:
           # Fetch the latest release tag for release events
           if [ "$EVENT_NAME" == "release" ]; then
             RELEASE=$BRANCH
-            NORMALIZED_RELEASE=$(if echo "$RELEASE" | grep -Eq '^v?[0-9]+\.[0-9]+\.[0-9]$'; then echo "$RELEASE" | sed 's/^v//'; else echo "$RELEASE"; fi)
+            NORMALIZED_RELEASE=$(if echo "$RELEASE" | grep -Eq '^v?[0-9]+\.[0-9]+\.[0-9]+$'; then echo "$RELEASE" | sed 's/^v//'; else echo "$RELEASE"; fi)
             echo "Normalized release: $NORMALIZED_RELEASE"
 
             LATEST_RELEASE=$(curl -s -H "Authorization: Bearer $TOKEN" \


### PR DESCRIPTION
# Description

.github/actions/determine-tags/action.yml was not handling `vaa.bb.cc` correctly (but was handling `vaa.bb.c`) - adjusting regular expression.

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

CI passing

## Any specific deployment considerations

N/A

## Docs

N/A