### PR TITLE
Fault tolerant redis calls for model monitoring

### DIFF
--- a/inference/core/managers/base.py
+++ b/inference/core/managers/base.py
@@ -162,51 +162,61 @@ class ModelManager:
             )
             finish_time = time.time()
             if not DISABLE_INFERENCE_CACHE:
-                logger.debug(
-                    f"ModelManager - caching inference request started for model_id={model_id}"
-                )
-                cache.zadd(
-                    f"models",
-                    value=f"{GLOBAL_INFERENCE_SERVER_ID}:{request.api_key}:{model_id}",
-                    score=finish_time,
-                    expire=METRICS_INTERVAL * 2,
-                )
-                if (
-                    hasattr(request, "image")
-                    and hasattr(request.image, "type")
-                    and request.image.type == "numpy"
-                ):
-                    request.image.value = str(request.image.value)
-                cache.zadd(
-                    f"inference:{GLOBAL_INFERENCE_SERVER_ID}:{model_id}",
-                    value=to_cachable_inference_item(request, rtn_val),
-                    score=finish_time,
-                    expire=METRICS_INTERVAL * 2,
-                )
-                logger.debug(
-                    f"ModelManager - caching inference request finished for model_id={model_id}"
-                )
+                try:
+                    logger.debug(
+                        f"ModelManager - caching inference request started for model_id={model_id}"
+                    )
+                    cache.zadd(
+                        f"models",
+                        value=f"{GLOBAL_INFERENCE_SERVER_ID}:{request.api_key}:{model_id}",
+                        score=finish_time,
+                        expire=METRICS_INTERVAL * 2,
+                    )
+                    if (
+                        hasattr(request, "image")
+                        and hasattr(request.image, "type")
+                        and request.image.type == "numpy"
+                    ):
+                        request.image.value = str(request.image.value)
+                    cache.zadd(
+                        f"inference:{GLOBAL_INFERENCE_SERVER_ID}:{model_id}",
+                        value=to_cachable_inference_item(request, rtn_val),
+                        score=finish_time,
+                        expire=METRICS_INTERVAL * 2,
+                    )
+                    logger.debug(
+                        f"ModelManager - caching inference request finished for model_id={model_id}"
+                    )
+                except Exception as cache_error:
+                    logger.warning(
+                        f"Failed to cache inference data for model {model_id}: {cache_error}"
+                    )
             return rtn_val
         except Exception as e:
             finish_time = time.time()
             if not DISABLE_INFERENCE_CACHE:
-                cache.zadd(
-                    f"models",
-                    value=f"{GLOBAL_INFERENCE_SERVER_ID}:{request.api_key}:{model_id}",
-                    score=finish_time,
-                    expire=METRICS_INTERVAL * 2,
-                )
-                cache.zadd(
-                    f"error:{GLOBAL_INFERENCE_SERVER_ID}:{model_id}",
-                    value={
-                        "request": jsonable_encoder(
-                            request.dict(exclude={"image", "subject", "prompt"})
-                        ),
-                        "error": str(e),
-                    },
-                    score=finish_time,
-                    expire=METRICS_INTERVAL * 2,
-                )
+                try:
+                    cache.zadd(
+                        f"models",
+                        value=f"{GLOBAL_INFERENCE_SERVER_ID}:{request.api_key}:{model_id}",
+                        score=finish_time,
+                        expire=METRICS_INTERVAL * 2,
+                    )
+                    cache.zadd(
+                        f"error:{GLOBAL_INFERENCE_SERVER_ID}:{model_id}",
+                        value={
+                            "request": jsonable_encoder(
+                                request.dict(exclude={"image", "subject", "prompt"})
+                            ),
+                            "error": str(e),
+                        },
+                        score=finish_time,
+                        expire=METRICS_INTERVAL * 2,
+                    )
+                except Exception as cache_error:
+                    logger.warning(
+                        f"Failed to cache error data for model {model_id}: {cache_error}"
+                    )
             raise
 
     def infer_from_request_sync(
@@ -236,51 +246,61 @@ class ModelManager:
             )
             finish_time = time.time()
             if not DISABLE_INFERENCE_CACHE:
-                logger.debug(
-                    f"ModelManager - caching inference request started for model_id={model_id}"
-                )
-                cache.zadd(
-                    f"models",
-                    value=f"{GLOBAL_INFERENCE_SERVER_ID}:{request.api_key}:{model_id}",
-                    score=finish_time,
-                    expire=METRICS_INTERVAL * 2,
-                )
-                if (
-                    hasattr(request, "image")
-                    and hasattr(request.image, "type")
-                    and request.image.type == "numpy"
-                ):
-                    request.image.value = str(request.image.value)
-                cache.zadd(
-                    f"inference:{GLOBAL_INFERENCE_SERVER_ID}:{model_id}",
-                    value=to_cachable_inference_item(request, rtn_val),
-                    score=finish_time,
-                    expire=METRICS_INTERVAL * 2,
-                )
-                logger.debug(
-                    f"ModelManager - caching inference request finished for model_id={model_id}"
-                )
+                try:
+                    logger.debug(
+                        f"ModelManager - caching inference request started for model_id={model_id}"
+                    )
+                    cache.zadd(
+                        f"models",
+                        value=f"{GLOBAL_INFERENCE_SERVER_ID}:{request.api_key}:{model_id}",
+                        score=finish_time,
+                        expire=METRICS_INTERVAL * 2,
+                    )
+                    if (
+                        hasattr(request, "image")
+                        and hasattr(request.image, "type")
+                        and request.image.type == "numpy"
+                    ):
+                        request.image.value = str(request.image.value)
+                    cache.zadd(
+                        f"inference:{GLOBAL_INFERENCE_SERVER_ID}:{model_id}",
+                        value=to_cachable_inference_item(request, rtn_val),
+                        score=finish_time,
+                        expire=METRICS_INTERVAL * 2,
+                    )
+                    logger.debug(
+                        f"ModelManager - caching inference request finished for model_id={model_id}"
+                    )
+                except Exception as cache_error:
+                    logger.warning(
+                        f"Failed to cache inference data for model {model_id}: {cache_error}"
+                    )
             return rtn_val
         except Exception as e:
             finish_time = time.time()
             if not DISABLE_INFERENCE_CACHE:
-                cache.zadd(
-                    f"models",
-                    value=f"{GLOBAL_INFERENCE_SERVER_ID}:{request.api_key}:{model_id}",
-                    score=finish_time,
-                    expire=METRICS_INTERVAL * 2,
-                )
-                cache.zadd(
-                    f"error:{GLOBAL_INFERENCE_SERVER_ID}:{model_id}",
-                    value={
-                        "request": jsonable_encoder(
-                            request.dict(exclude={"image", "subject", "prompt"})
-                        ),
-                        "error": str(e),
-                    },
-                    score=finish_time,
-                    expire=METRICS_INTERVAL * 2,
-                )
+                try:
+                    cache.zadd(
+                        f"models",
+                        value=f"{GLOBAL_INFERENCE_SERVER_ID}:{request.api_key}:{model_id}",
+                        score=finish_time,
+                        expire=METRICS_INTERVAL * 2,
+                    )
+                    cache.zadd(
+                        f"error:{GLOBAL_INFERENCE_SERVER_ID}:{model_id}",
+                        value={
+                            "request": jsonable_encoder(
+                                request.dict(exclude={"image", "subject", "prompt"})
+                            ),
+                            "error": str(e),
+                        },
+                        score=finish_time,
+                        expire=METRICS_INTERVAL * 2,
+                    )
+                except Exception as cache_error:
+                    logger.warning(
+                        f"Failed to cache error data for model {model_id}: {cache_error}"
+                    )
             raise
 
     async def model_infer(self, model_id: str, request: InferenceRequest, **kwargs):


### PR DESCRIPTION
# Description

Enhance error handling in ModelManager caching logic by adding try-except blocks to log failures when caching inference and error data. This improves robustness and provides better insights into potential issues during caching operations. We had an issue previously where this Redis instance filled up and it was causing inference to fail. This prevents that from happening. We'd rather have model monitoring be missing some data than inference fail entirely.

[ENT-200](https://linear.app/roboflow/issue/ENT-200/make-model-monitoring-redis-cache-storage-fault-tolerant)

List any dependencies that are required for this change.

## Type of change

Please delete options that are not relevant.

-   [X] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

This should be a low level change. Tested locally by running inference locally

## Any specific deployment considerations

N/A

## Docs

N/A