### PR TITLE
use macos-14 for app bundle builder

### DIFF
--- a/.github/workflows/build-osx-bundle.yml
+++ b/.github/workflows/build-osx-bundle.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build_osx:
-    runs-on: macos-latest
+    runs-on: macos-14
     permissions:
       contents: write
     env:


### PR DESCRIPTION
# Description
github updated macos-latest to be macos-15, need to adjust build scripts before updating to that

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?
not yet

## Any specific deployment considerations
n/a

## Docs
n/a