### PR TITLE
Pin dockerfiles built on top of Python 3.9 to bookworm due to recent debian trixie release

### DIFF
--- a/docker/dockerfiles/Dockerfile.onnx.cpu
+++ b/docker/dockerfiles/Dockerfile.onnx.cpu
@@ -1,4 +1,4 @@
-FROM python:3.9 as base
+FROM python:3.9-bookworm as base
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/docker/dockerfiles/Dockerfile.onnx.cpu.dev
+++ b/docker/dockerfiles/Dockerfile.onnx.cpu.dev
@@ -1,4 +1,4 @@
-FROM python:3.9 as base
+FROM python:3.9-bookworm as base
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/docker/dockerfiles/Dockerfile.onnx.cpu.parallel
+++ b/docker/dockerfiles/Dockerfile.onnx.cpu.parallel
@@ -1,4 +1,4 @@
-FROM python:3.9 as base
+FROM python:3.9-bookworm as base
 
 WORKDIR /app
 

--- a/docker/dockerfiles/Dockerfile.onnx.cpu.slim
+++ b/docker/dockerfiles/Dockerfile.onnx.cpu.slim
@@ -1,4 +1,4 @@
-FROM python:3.9 as base
+FROM python:3.9-bookworm as base
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG TARGETPLATFORM

--- a/docker/dockerfiles/Dockerfile.onnx.cpu.stream_manager
+++ b/docker/dockerfiles/Dockerfile.onnx.cpu.stream_manager
@@ -1,4 +1,4 @@
-FROM python:3.9
+FROM python:3.9-bookworm
 
 WORKDIR /app
 

--- a/docker/dockerfiles/Dockerfile.stream_management_api
+++ b/docker/dockerfiles/Dockerfile.stream_management_api
@@ -1,4 +1,4 @@
-FROM python:3.9
+FROM python:3.9-bookworm
 
 WORKDIR /app
 


### PR DESCRIPTION
# Description

Recent release of Debian trixie causes some images building process to fail, pin to bookworm for the time being

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

CI passing

## Any specific deployment considerations

N/A

## Docs

N/A