### PR TITLE
Support max detections for OWLv2 models

### DIFF
--- a/tests/inference/unit_tests/models/test_owlv2_max_detections.py
+++ b/tests/inference/unit_tests/models/test_owlv2_max_detections.py
@@ -1,0 +1,29 @@
+import torch
+from unittest.mock import MagicMock
+
+from inference.models.owlv2 import owlv2
+
+
+def test_infer_from_embed_respects_max_detections(monkeypatch):
+    model = owlv2.OwlV2.__new__(owlv2.OwlV2)
+    image_boxes = torch.tensor(
+        [[0, 0, 1, 1], [0, 0, 2, 2], [0, 0, 3, 3], [0, 0, 4, 4]],
+        dtype=torch.float32,
+    )
+    image_class_embeds = torch.zeros((4, 2))
+    model.get_image_embeds = MagicMock(return_value=(None, image_boxes, image_class_embeds, None, None))
+
+    def fake_get_class_preds_from_embeds(*args, **kwargs):
+        boxes = image_boxes
+        classes = torch.zeros(4, dtype=torch.int64)
+        scores = torch.tensor([0.9, 0.8, 0.7, 0.6])
+        return boxes, classes, scores
+
+    monkeypatch.setattr(owlv2, "get_class_preds_from_embeds", fake_get_class_preds_from_embeds)
+    monkeypatch.setattr(owlv2.torchvision.ops, "nms", lambda boxes, scores, iou: torch.arange(boxes.shape[0]))
+
+    query_embeddings = {"a": {"positive": torch.zeros((1, 2)), "negative": None}}
+    predictions = model.infer_from_embed(
+        "hash", query_embeddings, confidence=0.5, iou_threshold=0.5, max_detections=2
+    )
+    assert len(predictions) == 2


### PR DESCRIPTION
# Description

Add support for limiting the number of detections returned by OWLv2 models. The `max_detections` parameter is now properly enforced after NMS by trimming results to the specified limit.

## Type of change

-   [x] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?

- Added unit test to verify max_detections enforcement after NMS
- Test validates that results are correctly trimmed to specified limit

## Any specific deployment considerations

N/A

## Docs

N/A
