### PR TITLE
Add model-instance level thread lock on accessing ONNX session to avoid GPU execution concurrency issues

### DIFF
--- a/inference/core/models/classification_base.py
+++ b/inference/core/models/classification_base.py
@@ -185,9 +185,10 @@ class ClassificationBaseOnnxRoboflowInferenceModel(OnnxRoboflowInferenceModel):
         )
 
     def predict(self, img_in: np.ndarray, **kwargs) -> Tuple[np.ndarray]:
-        predictions = run_session_via_iobinding(
-            self.onnx_session, self.input_name, img_in
-        )
+        with self._session_lock:
+            predictions = run_session_via_iobinding(
+                self.onnx_session, self.input_name, img_in
+            )
         return (predictions,)
 
     def preprocess(

--- a/inference/core/models/roboflow.py
+++ b/inference/core/models/roboflow.py
@@ -5,6 +5,7 @@ import random
 from collections import OrderedDict
 from concurrent.futures import ThreadPoolExecutor
 from functools import partial
+from threading import Lock
 from time import perf_counter
 from typing import Any, Dict, List, Optional, Tuple, Union
 
@@ -749,6 +750,7 @@ class OnnxRoboflowInferenceModel(RoboflowInferenceModel):
             self.onnxruntime_execution_providers = expanded_execution_providers
 
         self.image_loader_threadpool = ThreadPoolExecutor(max_workers=None)
+        self._session_lock = Lock()
         try:
             self.initialize_model()
             self.validate_model()

--- a/inference/models/gaze/gaze.py
+++ b/inference/models/gaze/gaze.py
@@ -1,4 +1,5 @@
 import math
+from threading import Lock
 from time import perf_counter
 from typing import List, Optional, Tuple, Union
 
@@ -67,6 +68,7 @@ class Gaze(OnnxRoboflowCoreModel):
                 "CPUExecutionProvider",
             ],
         )
+        self._gaze_session_lock = Lock()
 
         if REQUIRED_ONNX_PROVIDERS:
             available_providers = onnxruntime.get_available_providers()
@@ -138,8 +140,8 @@ class Gaze(OnnxRoboflowCoreModel):
 
             img_batch = np.concatenate(img_batch, axis=0)
             onnx_input_image = {self.gaze_onnx_session.get_inputs()[0].name: img_batch}
-            yaw, pitch = self.gaze_onnx_session.run(None, onnx_input_image)
-
+            with self._gaze_session_lock:
+                yaw, pitch = self.gaze_onnx_session.run(None, onnx_input_image)
             for j in range(len(img_batch)):
                 ret.append((yaw[j], pitch[j]))
 

--- a/inference/models/rfdetr/rfdetr.py
+++ b/inference/models/rfdetr/rfdetr.py
@@ -263,9 +263,10 @@ class RFDETRObjectDetection(ObjectDetectionBaseOnnxRoboflowInferenceModel):
         Returns:
             Tuple[np.ndarray]: NumPy array representing the predictions, including boxes, confidence scores, and class IDs.
         """
-        predictions = run_session_via_iobinding(
-            self.onnx_session, self.input_name, img_in
-        )
+        with self._session_lock:
+            predictions = run_session_via_iobinding(
+                self.onnx_session, self.input_name, img_in
+            )
         bboxes = predictions[0]
         logits = predictions[1]
 

--- a/inference/models/yolact/yolact_instance_segmentation.py
+++ b/inference/models/yolact/yolact_instance_segmentation.py
@@ -143,7 +143,8 @@ class YOLACT(OnnxRoboflowInferenceModel):
     def predict(
         self, img_in: np.ndarray, **kwargs
     ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
-        return run_session_via_iobinding(self.onnx_session, self.input_name, img_in)
+        with self._session_lock:
+            return run_session_via_iobinding(self.onnx_session, self.input_name, img_in)
 
     def postprocess(
         self,

--- a/inference/models/yolonas/yolonas_object_detection.py
+++ b/inference/models/yolonas/yolonas_object_detection.py
@@ -29,9 +29,10 @@ class YOLONASObjectDetection(ObjectDetectionBaseOnnxRoboflowInferenceModel):
         Returns:
             Tuple[np.ndarray]: NumPy array representing the predictions, including boxes, confidence scores, and class confidence scores.
         """
-        predictions = run_session_via_iobinding(
-            self.onnx_session, self.input_name, img_in
-        )
+        with self._session_lock:
+            predictions = run_session_via_iobinding(
+                self.onnx_session, self.input_name, img_in
+            )
         boxes = predictions[0]
         class_confs = predictions[1]
         confs = np.expand_dims(np.max(class_confs, axis=2), axis=2)

--- a/inference/models/yolov10/yolov10_object_detection.py
+++ b/inference/models/yolov10/yolov10_object_detection.py
@@ -45,9 +45,10 @@ class YOLOv10ObjectDetection(ObjectDetectionBaseOnnxRoboflowInferenceModel):
         Returns:
             Tuple[np.ndarray]: NumPy array representing the predictions, including boxes, confidence scores, and class confidence scores.
         """
-        predictions = run_session_via_iobinding(
-            self.onnx_session, self.input_name, img_in
-        )[0]
+        with self._session_lock:
+            predictions = run_session_via_iobinding(
+                self.onnx_session, self.input_name, img_in
+            )[0]
 
         return (predictions,)
 

--- a/inference/models/yolov5/yolov5_instance_segmentation.py
+++ b/inference/models/yolov5/yolov5_instance_segmentation.py
@@ -36,7 +36,8 @@ class YOLOv5InstanceSegmentation(InstanceSegmentationBaseOnnxRoboflowInferenceMo
         Returns:
             Tuple[np.ndarray, np.ndarray]: Tuple containing two NumPy arrays representing the predictions.
         """
-        predictions = run_session_via_iobinding(
-            self.onnx_session, self.input_name, img_in
-        )
+        with self._session_lock:
+            predictions = run_session_via_iobinding(
+                self.onnx_session, self.input_name, img_in
+            )
         return predictions[0], predictions[1]

--- a/inference/models/yolov5/yolov5_object_detection.py
+++ b/inference/models/yolov5/yolov5_object_detection.py
@@ -36,7 +36,8 @@ class YOLOv5ObjectDetection(ObjectDetectionBaseOnnxRoboflowInferenceModel):
         Returns:
             Tuple[np.ndarray]: NumPy array representing the predictions.
         """
-        predictions = run_session_via_iobinding(
-            self.onnx_session, self.input_name, img_in
-        )[0]
+        with self._session_lock:
+            predictions = run_session_via_iobinding(
+                self.onnx_session, self.input_name, img_in
+            )[0]
         return (predictions,)

--- a/inference/models/yolov7/yolov7_instance_segmentation.py
+++ b/inference/models/yolov7/yolov7_instance_segmentation.py
@@ -27,9 +27,10 @@ class YOLOv7InstanceSegmentation(InstanceSegmentationBaseOnnxRoboflowInferenceMo
         Returns:
             Tuple[np.ndarray, np.ndarray]: Tuple containing two NumPy arrays representing the predictions and protos.
         """
-        predictions = run_session_via_iobinding(
-            self.onnx_session, self.input_name, img_in
-        )
+        with self._session_lock:
+            predictions = run_session_via_iobinding(
+                self.onnx_session, self.input_name, img_in
+            )
         protos = predictions[4]
         predictions = predictions[0]
         return predictions, protos

--- a/inference/models/yolov8/yolov8_instance_segmentation.py
+++ b/inference/models/yolov8/yolov8_instance_segmentation.py
@@ -39,9 +39,10 @@ class YOLOv8InstanceSegmentation(InstanceSegmentationBaseOnnxRoboflowInferenceMo
         Returns:
             Tuple[np.ndarray, np.ndarray]: Tuple containing two NumPy arrays representing the predictions and protos. The predictions include boxes, confidence scores, class confidence scores, and masks.
         """
-        predictions, protos = run_session_via_iobinding(
-            self.onnx_session, self.input_name, img_in
-        )
+        with self._session_lock:
+            predictions, protos = run_session_via_iobinding(
+                self.onnx_session, self.input_name, img_in
+            )
         predictions = predictions.transpose(0, 2, 1)
         boxes = predictions[:, :, :4]
         class_confs = predictions[:, :, 4:-32]

--- a/inference/models/yolov8/yolov8_keypoints_detection.py
+++ b/inference/models/yolov8/yolov8_keypoints_detection.py
@@ -41,9 +41,10 @@ class YOLOv8KeypointsDetection(KeypointsDetectionBaseOnnxRoboflowInferenceModel)
         Returns:
             Tuple[np.ndarray]: NumPy array representing the predictions, including boxes, confidence scores, and class confidence scores.
         """
-        predictions = run_session_via_iobinding(
-            self.onnx_session, self.input_name, img_in
-        )[0]
+        with self._session_lock:
+            predictions = run_session_via_iobinding(
+                self.onnx_session, self.input_name, img_in
+            )[0]
         predictions = predictions.transpose(0, 2, 1)
         boxes = predictions[:, :, :4]
         number_of_classes = len(self.get_class_names)

--- a/inference/models/yolov8/yolov8_object_detection.py
+++ b/inference/models/yolov8/yolov8_object_detection.py
@@ -41,9 +41,10 @@ class YOLOv8ObjectDetection(ObjectDetectionBaseOnnxRoboflowInferenceModel):
         Returns:
             Tuple[np.ndarray]: NumPy array representing the predictions, including boxes, confidence scores, and class confidence scores.
         """
-        predictions = run_session_via_iobinding(
-            self.onnx_session, self.input_name, img_in
-        )[0]
+        with self._session_lock:
+            predictions = run_session_via_iobinding(
+                self.onnx_session, self.input_name, img_in
+            )[0]
         predictions = predictions.transpose(0, 2, 1)
         boxes = predictions[:, :, :4]
         class_confs = predictions[:, :, 4:]

--- a/inference/models/yolov9/yolov9_object_detection.py
+++ b/inference/models/yolov9/yolov9_object_detection.py
@@ -37,9 +37,10 @@ class YOLOv9ObjectDetection(ObjectDetectionBaseOnnxRoboflowInferenceModel):
             Tuple[np.ndarray]: NumPy array representing the predictions.
         """
         # (b x 8 x 8000)
-        predictions = run_session_via_iobinding(
-            self.onnx_session, self.input_name, img_in
-        )[0]
+        with self._session_lock:
+            predictions = run_session_via_iobinding(
+                self.onnx_session, self.input_name, img_in
+            )[0]
         predictions = predictions.transpose(0, 2, 1)
         boxes = predictions[:, :, :4]
         class_confs = predictions[:, :, 4:]

--- a/tests/inference/unit_tests/models/test_owlv2_max_detections.py
+++ b/tests/inference/unit_tests/models/test_owlv2_max_detections.py
@@ -1,5 +1,6 @@
-import torch
 from unittest.mock import MagicMock
+
+import torch
 
 from inference.models.owlv2 import owlv2
 

--- a/tests/inference/unit_tests/usage_tracking/test_collector.py
+++ b/tests/inference/unit_tests/usage_tracking/test_collector.py
@@ -1,9 +1,9 @@
 import hashlib
 import json
 import sys
+from unittest import mock
 
 import pytest
-from unittest import mock
 
 from inference.core.env import LAMBDA
 from inference.core.version import __version__ as inference_version

--- a/tests/workflows/unit_tests/core_steps/transformations/test_qr_code_generator.py
+++ b/tests/workflows/unit_tests/core_steps/transformations/test_qr_code_generator.py
@@ -1,5 +1,5 @@
-import pytest
 import numpy as np
+import pytest
 
 from inference.core.workflows.core_steps.transformations.qr_code_generator.v1 import (
     QRCodeGeneratorBlockV1,

--- a/tests/workflows/unit_tests/core_steps/visualizations/test_icon_alpha.py
+++ b/tests/workflows/unit_tests/core_steps/visualizations/test_icon_alpha.py
@@ -1,8 +1,10 @@
+import base64
+
+import cv2
 import numpy as np
 import pytest
 import supervision as sv
-import base64
-import cv2
+
 from inference.core.workflows.core_steps.visualizations.icon.v1 import (
     IconVisualizationBlockV1,
 )


### PR DESCRIPTION
# Description

In the core of inference, we were exposed on unsafe multi-thread execution of operations against ONNX sessions - which on GPU could lead to CUDA runtime errors. This PR is adding instance-level thread locks on all ONNX sessions of all inference models.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

* CI

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
