### PR TITLE
Fix copy paste in local builder

### DIFF
--- a/inference/core/interfaces/http/builder/editor.html
+++ b/inference/core/interfaces/http/builder/editor.html
@@ -87,6 +87,6 @@
     </head>
     <body>
         <!-- The iframe where we load /workflows/local or /workflows/local/:id -->
-        <iframe id="workflow-iframe" allow="camera"></iframe>
+        <iframe id="workflow-iframe" allow="camera; clipboard-write; display-capture; microphone; fullscreen"></iframe>
     </body>
 </html>


### PR DESCRIPTION
# Description

Adds clipboard-write permission to the workflow editor iframe to enable copy/paste functionality in the local builder interface.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

- Verified copy/paste operations work in the local workflow builder
- Tested that clipboard interactions function correctly in the iframe

## Will the change affect Universe? If so was this change tested in universe?

No

## Any specific deployment considerations

None - frontend HTML change only (hosting)