### PR TITLE
Gzip workflows schema

### DIFF
--- a/inference/core/interfaces/http/http_api.py
+++ b/inference/core/interfaces/http/http_api.py
@@ -1224,8 +1224,11 @@ class HttpInterface(BaseInterface):
                 "used to validate workflow definitions and suggest syntax in the JSON editor.",
             )
             @with_route_exceptions
-            def get_workflow_schema() -> WorkflowsBlocksSchemaDescription:
-                return get_workflow_schema_description()
+            def get_workflow_schema(
+                request: Request,
+            ) -> WorkflowsBlocksSchemaDescription:
+                result = get_workflow_schema_description()
+                return gzip_response_if_requested(request, response=result)
 
             @app.post(
                 "/workflows/blocks/dynamic_outputs",


### PR DESCRIPTION
# Description

Serve workflows schema gzipped.

Schema is a ~1.9MB text file. Compressed it'll be ~140KB.

## Type of change

-   [x] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Manually checked the page and compared output sizes with curl: 141kb x 1839kb.

```
iurisilvio@Mac functions % curl "http://localhost:9001/workflows/definition/schema" --compressed > /dev/n
ull
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  141k  100  141k    0     0   977k      0 --:--:-- --:--:-- --:--:--  981k

iurisilvio@Mac functions % curl "http://localhost:9001/workflows/definition/schema" > /dev/null
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 1839k  100 1839k    0     0  13.1M      0 --:--:-- --:--:-- --:--:-- 13.2M
```

## Any specific deployment considerations

No.
