### PR TITLE
bump base cpu images from python3.9 -> 3.11

### DIFF
--- a/docker/dockerfiles/Dockerfile.onnx.cpu
+++ b/docker/dockerfiles/Dockerfile.onnx.cpu
@@ -1,4 +1,4 @@
-FROM python:3.9-bookworm as base
+FROM python:3.11-bookworm as base
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/docker/dockerfiles/Dockerfile.onnx.cpu.dev
+++ b/docker/dockerfiles/Dockerfile.onnx.cpu.dev
@@ -1,4 +1,4 @@
-FROM python:3.9-bookworm as base
+FROM python:3.11-bookworm as base
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/docker/dockerfiles/Dockerfile.onnx.cpu.parallel
+++ b/docker/dockerfiles/Dockerfile.onnx.cpu.parallel
@@ -1,4 +1,4 @@
-FROM python:3.9-bookworm as base
+FROM python:3.11-bookworm as base
 
 WORKDIR /app
 

--- a/docker/dockerfiles/Dockerfile.onnx.cpu.slim
+++ b/docker/dockerfiles/Dockerfile.onnx.cpu.slim
@@ -1,4 +1,4 @@
-FROM python:3.9-bookworm as base
+FROM python:3.11-bookworm as base
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG TARGETPLATFORM

--- a/docker/dockerfiles/Dockerfile.onnx.cpu.stream_manager
+++ b/docker/dockerfiles/Dockerfile.onnx.cpu.stream_manager
@@ -1,4 +1,4 @@
-FROM python:3.9-bookworm
+FROM python:3.11-bookworm
 
 WORKDIR /app
 

--- a/docker/dockerfiles/Dockerfile.onnx.gpu
+++ b/docker/dockerfiles/Dockerfile.onnx.gpu
@@ -1,4 +1,5 @@
 FROM nvcr.io/nvidia/cuda:12.4.1-cudnn-devel-ubuntu22.04 as builder
+#has python 3.10
 
 WORKDIR /app
 

--- a/docker/dockerfiles/Dockerfile.onnx.gpu.dev
+++ b/docker/dockerfiles/Dockerfile.onnx.gpu.dev
@@ -1,4 +1,5 @@
 FROM nvcr.io/nvidia/cuda:12.4.1-cudnn-devel-ubuntu22.04 as base
+#has python 3.10
 
 WORKDIR /app
 

--- a/docker/dockerfiles/Dockerfile.onnx.gpu.parallel
+++ b/docker/dockerfiles/Dockerfile.onnx.gpu.parallel
@@ -1,4 +1,5 @@
 FROM nvcr.io/nvidia/cuda:12.4.1-cudnn-devel-ubuntu22.04 as base
+#has python 3.10
 
 WORKDIR /app
 

--- a/docker/dockerfiles/Dockerfile.onnx.gpu.slim
+++ b/docker/dockerfiles/Dockerfile.onnx.gpu.slim
@@ -1,4 +1,5 @@
 FROM nvcr.io/nvidia/cuda:12.4.1-cudnn-runtime-ubuntu22.04 as base
+#has python 3.10
 
 WORKDIR /app
 

--- a/docker/dockerfiles/Dockerfile.onnx.gpu.stream_manager
+++ b/docker/dockerfiles/Dockerfile.onnx.gpu.stream_manager
@@ -1,4 +1,5 @@
 FROM nvcr.io/nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu22.04
+#has python 3.10
 
 WORKDIR /app
 

--- a/docker/dockerfiles/Dockerfile.onnx.jetson.4.6.1
+++ b/docker/dockerfiles/Dockerfile.onnx.jetson.4.6.1
@@ -1,4 +1,5 @@
 FROM nvcr.io/nvidia/l4t-ml:r32.7.1-py3
+#has python 3.8 we manually install python 3.9  in here
 
 ARG DEBIAN_FRONTEND=noninteractive
 ENV LANG en_US.UTF-8 

--- a/docker/dockerfiles/Dockerfile.onnx.jetson.5.1.1
+++ b/docker/dockerfiles/Dockerfile.onnx.jetson.5.1.1
@@ -1,4 +1,5 @@
 FROM nvcr.io/nvidia/l4t-ml:r35.2.1-py3
+#installs python 3.9
 
 ARG DEBIAN_FRONTEND=noninteractive
 ENV LANG en_US.UTF-8 

--- a/docker/dockerfiles/Dockerfile.onnx.jetson.5.1.1.stream_manager
+++ b/docker/dockerfiles/Dockerfile.onnx.jetson.5.1.1.stream_manager
@@ -1,4 +1,5 @@
 FROM nvcr.io/nvidia/l4t-ml:r35.2.1-py3
+#installs python 3.9
 
 ARG DEBIAN_FRONTEND=noninteractive
 ENV LANG en_US.UTF-8 

--- a/docker/dockerfiles/Dockerfile.onnx.jetson.6.0.0
+++ b/docker/dockerfiles/Dockerfile.onnx.jetson.6.0.0
@@ -1,4 +1,6 @@
 FROM nvcr.io/nvidia/l4t-jetpack:r36.3.0
+#probably Python 3.10 or 3.12 based on ubuntu 22.04
+
 
 ARG DEBIAN_FRONTEND=noninteractive
 ENV LANG=en_US.UTF-8

--- a/docker/dockerfiles/Dockerfile.onnx.jetson.6.2.0
+++ b/docker/dockerfiles/Dockerfile.onnx.jetson.6.2.0
@@ -1,4 +1,5 @@
 FROM nvcr.io/nvidia/l4t-jetpack:r36.4.0
+#probably Python 3.10 or 3.12 based on ubuntu 22.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 ENV LANG=en_US.UTF-8

--- a/docker/dockerfiles/Dockerfile.onnx.trt
+++ b/docker/dockerfiles/Dockerfile.onnx.trt
@@ -1,4 +1,6 @@
 FROM nvcr.io/nvidia/tensorrt:25.03-py3
+#Python 3.12.3
+
 WORKDIR /app
 
 RUN apt-get update -y && apt-get install -y \

--- a/docker/dockerfiles/Dockerfile.onnx.udp.gpu
+++ b/docker/dockerfiles/Dockerfile.onnx.udp.gpu
@@ -1,4 +1,5 @@
 FROM nvcr.io/nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu22.04
+#probably Python 3.10 based on ubuntu 22.04
 
 WORKDIR /app
 

--- a/docker/dockerfiles/Dockerfile.stream_management_api
+++ b/docker/dockerfiles/Dockerfile.stream_management_api
@@ -1,4 +1,4 @@
-FROM python:3.9-bookworm
+FROM python:3.11-bookworm
 
 WORKDIR /app
 


### PR DESCRIPTION
# Description
bumps base cpu python docker images to python 3.11

gpu images already come with python 3.10

only thing < python 3.10 after this is jetson 4.6 and 5.11 images.  we already install python 3.9 manually in those (they come with 3.8 out of box)...so maybe can change that to 3.10 or 3.11 but will need to also adjust other installed dependencies compiled specifically for 3.9 on there like:
  - onnxruntime_gpu-1.16.0-cp39-cp39-linux_aarch64.whl
  - zxing_cpp_library_compiled_for_inference_v0.12.1.tar.gz (5.11)

## Type of change
maintanance

## How has this change been tested, please provide a testcase or example of how you tested the change?
WIP

## Any specific deployment considerations
n/a

## Docs
n/a