### PR TITLE
Extend Moondream2InferenceRequest to include 'prompt'

### DIFF
--- a/inference/core/entities/requests/moondream2.py
+++ b/inference/core/entities/requests/moondream2.py
@@ -9,4 +9,5 @@ class Moondream2InferenceRequest(DynamicClassBaseInferenceRequest):
     Attributes:
         text (List[str]): A list of strings.
     """
+
     prompt: str

--- a/inference/core/entities/requests/moondream2.py
+++ b/inference/core/entities/requests/moondream2.py
@@ -9,5 +9,4 @@ class Moondream2InferenceRequest(DynamicClassBaseInferenceRequest):
     Attributes:
         text (List[str]): A list of strings.
     """
-
-    pass
+    prompt: str

--- a/inference/core/workflows/core_steps/models/foundation/moondream2/v1.py
+++ b/inference/core/workflows/core_steps/models/foundation/moondream2/v1.py
@@ -166,7 +166,8 @@ class Moondream2BlockV1(WorkflowBlock):
                 api_key=self._api_key,
                 model_id=model_version,
                 image=image,
-                text=[single_prompt],
+                text=[],
+                prompt=single_prompt,
             )
             # Run inference.
             prediction = self._model_manager.infer_from_request_sync(


### PR DESCRIPTION
# Description

`moondream2` model expects 'prompt' as one of the params, 'text' is not recognized
`Moondream2InferenceRequest` inherits from `DynamicClassBaseInferenceRequest` which defines `text` as part of its interface; adding `prompt`

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

 - [x] CI passing
 - [ ] [Integration tests](https://github.com/roboflow/inference/actions/runs/17487765113) passing
 - [x] tested manually with below workflow:

```json
{
  "version": "1.0",
  "inputs": [
    {
      "type": "InferenceImage",
      "name": "image"
    }
  ],
  "steps": [
    {
      "type": "roboflow_core/moondream2@v1",
      "name": "moondream",
      "images": "$inputs.image",
      "prompt": "dog"
    },
    {
      "type": "roboflow_core/bounding_box_visualization@v1",
      "name": "bounding_box_visualization",
      "image": "$inputs.image",
      "predictions": "$steps.moondream.predictions"
    }
  ],
  "outputs": [
    {
      "type": "JsonField",
      "name": "bounding_box_visualization",
      "coordinates_system": "own",
      "selector": "$steps.bounding_box_visualization.image"
    },
    {
      "type": "JsonField",
      "name": "moondream",
      "coordinates_system": "own",
      "selector": "$steps.moondream.predictions"
    }
  ]
}
```

result:

<img width="577" height="663" alt="image" src="https://github.com/user-attachments/assets/a32f8458-b267-49e8-9cc9-0577bc4c2c83" />

Then switched workflow to cat:

<img width="577" height="663" alt="image" src="https://github.com/user-attachments/assets/4c624c2b-5f11-480e-9b9f-646d6f51d5b7" />

Before the fix, model returns below independently of what was passed as prompt:

<img width="577" height="663" alt="image" src="https://github.com/user-attachments/assets/6301316c-9a16-407c-991f-bfc1a37eccf7" />


## Any specific deployment considerations

N/A

## Docs

N/A