### PR TITLE
use Windows-2022 runner for windows build

### DIFF
--- a/.github/workflows/build-windows-installer.yml
+++ b/.github/workflows/build-windows-installer.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build_windows:
-    runs-on: windows-latest
+    runs-on: Windows-2022
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
# Description

github runner runs Wondows 2025 as latest windows runner as of Sept 2. which breaks our build as seen here: https://github.com/roboflow/inference/actions/runs/17493688863

This sets the runner to use the previous runner version which will remain supported for another 3 years 

## Type of change
build fix

## How has this change been tested, please provide a testcase or example of how you tested the change?
running build of of branch

## Any specific deployment considerations
n/a

## Docs
n/a