### PR TITLE
Investigate and fix broken cicd tests

### DIFF
--- a/inference/core/workflows/core_steps/transformations/dynamic_zones/v1.py
+++ b/inference/core/workflows/core_steps/transformations/dynamic_zones/v1.py
@@ -235,8 +235,8 @@ def scale_polygon(polygon: np.ndarray, scale: float) -> np.ndarray:
     return result.round().astype(np.int32)
 
 
-def convert_from_np_types(zone: np.ndarray) -> List[Tuple[int, int]]:
-    return [(int(x), int(y)) for each in zone for x, y in each]
+def convert_from_np_types(zones: List[np.ndarray]) -> List[List[Tuple[int, int]]]:
+    return [[(int(x), int(y)) for x, y in polygon] for polygon in zones]
 
 
 class DynamicZonesBlockV1(WorkflowBlock):
@@ -304,12 +304,12 @@ class DynamicZonesBlockV1(WorkflowBlock):
                     simplified_polygon = simplified_polygon[
                         :required_number_of_vertices
                     ]
-                updated_detection[POLYGON_KEY_IN_SV_DETECTIONS] = np.array(
-                    [simplified_polygon]
-                )
                 simplified_polygon = scale_polygon(
                     polygon=simplified_polygon,
                     scale=scale_ratio,
+                )
+                updated_detection[POLYGON_KEY_IN_SV_DETECTIONS] = np.array(
+                    [simplified_polygon]
                 )
                 simplified_polygons.append(simplified_polygon)
                 updated_detection.mask = np.array(


### PR DESCRIPTION
Corrected dynamic zone output structure and ensured scaled polygons are stored in detections to fix CI failures.

The `convert_from_np_types` function was flattening polygon coordinates, leading to an incorrect `List[Tuple[int, int]]` structure instead of `List[List[Tuple[int, int]]]` expected by downstream consumers. Additionally, the detection polygon was being stored before scaling, resulting in inconsistent data between output zones and detection masks. This PR addresses both issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-4cd4f9bc-c788-4aa5-9783-ce21c0597096">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4cd4f9bc-c788-4aa5-9783-ce21c0597096">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

