### PR TITLE
asyncua moved User and UserRole definition to asyncua.crypto.permission_rules

### DIFF
--- a/tests/workflows/integration_tests/execution/test_workflow_with_opc_writer.py
+++ b/tests/workflows/integration_tests/execution/test_workflow_with_opc_writer.py
@@ -6,7 +6,10 @@ from typing import Optional, Union
 import pytest
 from asyncua import Server
 from asyncua.client import Client as AsyncClient
-from asyncua.server.users import User, UserRole
+try:
+    from asyncua.server.users import User, UserRole
+except ImportError:
+    from asyncua.crypto.permission_rules import User, UserRole
 from asyncua.sync import Client, sync_async_client_method
 from asyncua.ua.uaerrors import BadNoMatch, BadTypeMismatch, BadUserAccessDenied
 


### PR DESCRIPTION
# Description

Fix CI failing due to asyncua moved User and UserRole definition to asyncua.crypto.permission_rules

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

CI passing

## Any specific deployment considerations

N/A

## Docs

N/A