### PR TITLE
fix instance segmentation filter

### DIFF
--- a/inference/core/models/instance_segmentation_base.py
+++ b/inference/core/models/instance_segmentation_base.py
@@ -247,7 +247,7 @@ class InstanceSegmentationBaseOnnxRoboflowInferenceModel(OnnxRoboflowInferenceMo
         for ind, (batch_predictions, batch_masks) in enumerate(zip(predictions, masks)):
             predictions = []
             for pred, mask in zip(batch_predictions, batch_masks):
-                if class_filter and self.class_names[int(pred[6])] in class_filter:
+                if class_filter and not self.class_names[int(pred[6])] in class_filter:
                     # TODO: logger.debug
                     continue
                 # Passing args as a dictionary here since one of the args is 'class' (a protected term in Python)


### PR DESCRIPTION
# Description

Instance segmentation class filter block did not filter the results. In fact, it made the results being empty.
<img width="394" height="722" alt="ac254a6f5344447915e79ac77361fbcd674766f7cc6880f1a73125ad2ab4b79c" src="https://github.com/user-attachments/assets/823dcfcc-e7d5-4616-b3b5-9e2ee527556c" />


The issue root cause was the instance segmentation base class that filtered to exclude all results with class_name in it

## Type of change

-   [X] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

locally

## Any specific deployment considerations

None

## Docs

-   [ ] Docs updated? What were the changes:
