### PR TITLE
Wrap state-sensitive models with locks to make the execution of server handler thread safe

### DIFF
--- a/inference/models/yolo_world/yolo_world.py
+++ b/inference/models/yolo_world/yolo_world.py
@@ -1,4 +1,5 @@
 import os.path
+from threading import Lock
 from time import perf_counter
 from typing import Any, List, Optional
 
@@ -58,6 +59,7 @@ class YOLOWorld(RoboflowCoreModel):
         logger.debug("CLIP loaded")
         self.clip_model = clip_model
         self.class_names = None
+        self._state_lock = Lock()
 
     def preproc_image(self, image: Any):
         """Preprocesses an image.
@@ -78,8 +80,8 @@ class YOLOWorld(RoboflowCoreModel):
         """
         Perform inference based on the details provided in the request, and return the associated responses.
         """
-        result = self.infer(**request.dict())
-        return result
+        with self._state_lock:
+            return self.infer(**request.dict())
 
     def infer(
         self,


### PR DESCRIPTION
# Description

With releasing of server lock we introduced bug for models which maintain nuanced internal state during inference - this PR is meant to secure them at the price of sequential execution of multiple threads.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

* CI

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
