### PR TITLE
fix DD and Serverless auth for legacy endpoints

### DIFF
--- a/inference/core/interfaces/http/http_api.py
+++ b/inference/core/interfaces/http/http_api.py
@@ -461,17 +461,20 @@ class HttpInterface(BaseInterface):
                         },
                     )
 
-                # check api_key
                 req_params = request.query_params
                 json_params = dict()
+                api_key = req_params.get("api_key", None)
                 if (
-                    request.headers.get("content-type", None) == "application/json"
+                    api_key is None
+                    and request.headers.get("content-type", None) == "application/json"
                     and int(request.headers.get("content-length", 0)) > 0
                 ):
-                    json_params = await request.json()
-                api_key = req_params.get("api_key", None) or json_params.get(
-                    "api_key", None
-                )
+                    # have to try catch here, because some legacy endpoints that abuse Content-Type header but dont actually receive json
+                    try:
+                        json_params = await request.json()
+                    except Exception:
+                        pass
+                api_key = json_params.get("api_key", api_key)
 
                 if api_key is None:
                     return _unauthorized_response("Unauthorized api_key")
@@ -520,14 +523,21 @@ class HttpInterface(BaseInterface):
                 # check api_key
                 req_params = request.query_params
                 json_params = dict()
+                api_key = req_params.get("api_key", None)
                 if (
-                    request.headers.get("content-type", None) == "application/json"
+                    api_key is None
+                    and request.headers.get("content-type", None) == "application/json"
                     and int(request.headers.get("content-length", 0)) > 0
                 ):
-                    json_params = await request.json()
-                api_key = req_params.get("api_key", None) or json_params.get(
-                    "api_key", None
-                )
+                    # have to try catch here, because some legacy endpoints that abuse Content-Type header but dont actually receive json
+                    try:
+                        json_params = await request.json()
+                    except Exception:
+                        pass
+                api_key = json_params.get("api_key", api_key)
+
+                if api_key is None:
+                    return _unauthorized_response("Unauthorized api_key")
 
                 if cached_api_keys.get(api_key, 0) < time.time():
                     try:


### PR DESCRIPTION
# Description
The auth check middelware for dedicated and serverless deployments failed for legacy endpoints because we try to parse the json body on requests with content-type `application/json`...however, some legacy endpoints mistreat this and expect both this content type and then actual non json data in the body.  In this case we only want to auth based on url params, but we need to handle ths json body not being parsable without crashing

## Type of change

Please delete options that are not relevant.
-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?
locally with load tests running against legacy endpoints

## Any specific deployment considerations
n/a

## Docs
n/a
