### PR TITLE
don't auth /model/registry endpoint via api_key on serverless

### DIFF
--- a/inference/core/interfaces/http/http_api.py
+++ b/inference/core/interfaces/http/http_api.py
@@ -423,8 +423,7 @@ class HttpInterface(BaseInterface):
                         "/docs",
                         "/info",
                         "/openapi.json",  # needed for /docs and /redoc
-                        # "/workflows/blocks/describe",
-                        # "/workflows/definition/schema",
+                        "/model/registry",  # dont auth this route, usually not used on serverlerless, but queue based serverless uses it internally (not accessible from outside)
                     ]
                     or request.url.path.startswith("/static/")
                     or request.url.path.startswith("/_next/")


### PR DESCRIPTION
# Description
This endpoint should not be require api key

## Type of change

Please delete options that are not relevant.
-   [X] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?
locally

## Any specific deployment considerations
n/a

## Docs
n/a