### PR TITLE
handle buffer filling / consumption strategy params when passed as str

### DIFF
--- a/inference/core/interfaces/stream/utils.py
+++ b/inference/core/interfaces/stream/utils.py
@@ -80,6 +80,14 @@ def initialise_video_sources(
     desired_source_fps: Optional[Union[float, int]] = None,
     decoding_buffer_size: int = DEFAULT_BUFFER_SIZE,
 ) -> List[VideoSource]:
+    if isinstance(source_buffer_filling_strategy, str):
+        source_buffer_filling_strategy = BufferFillingStrategy(
+            source_buffer_filling_strategy
+        )
+    if isinstance(source_buffer_consumption_strategy, str):
+        source_buffer_consumption_strategy = BufferConsumptionStrategy(
+            source_buffer_consumption_strategy
+        )
     return [
         VideoSource.init(
             video_reference=reference,


### PR DESCRIPTION
# Description

When source_buffer_filling_strategy or source_buffer_consumption_strategy are passed as instance of str, cast them to BufferFillingStrategy / BufferConsumptionStrategy

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

CI passing
Manually tested, below script results in dropping most of the frames when executed with code on main, but consumes all frames (as expected) when executed with this fix.

```python
import cv2

from inference import InferencePipeline
from inference.core.interfaces.camera.entities import VideoFrame


def my_sink(result, video_frame: VideoFrame):
    cv2.imshow("Workflow Image", video_frame.image)
    cv2.waitKey(1)

    print(f"Frame {video_frame.frame_id}: {result}")


pipeline = InferencePipeline.init_with_workflow(
    api_key="<SECRET>",
    workspace_name="<workspace>",
    workflow_id="<workflow ID>",
    video_reference="/path/to/file.mp4",
    on_prediction=my_sink,
    source_buffer_filling_strategy="WAIT",
    source_buffer_consumption_strategy="LAZY",
    predictions_queue_size=2,
    decoding_buffer_size=2,
)
pipeline.start()
pipeline.join()


```

## Any specific deployment considerations

N/A

## Docs

N/A