### PR TITLE
fixing memory leak and variable not associated value on PolygonZoneBlock

### DIFF
--- a/inference/core/workflows/core_steps/visualizations/polygon_zone/v1.py
+++ b/inference/core/workflows/core_steps/visualizations/polygon_zone/v1.py
@@ -85,7 +85,7 @@ class PolygonZoneVisualizationManifest(VisualizationManifest):
 class PolygonZoneVisualizationBlockV1(VisualizationBlock):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._cache: OrderedDict[str, np.ndarray] = OrderedDict(maxsize=200)
+        self._cache: OrderedDict[str, np.ndarray] = OrderedDict()
 
     @classmethod
     def get_manifest(cls) -> Type[WorkflowBlockManifest]:

--- a/inference/core/workflows/core_steps/visualizations/polygon_zone/v1.py
+++ b/inference/core/workflows/core_steps/visualizations/polygon_zone/v1.py
@@ -1,6 +1,6 @@
 import hashlib
 from collections import OrderedDict
-from typing import Dict, List, Literal, Optional, Tuple, Type, Union
+from typing import List, Literal, Optional, Tuple, Type, Union
 
 import cv2 as cv
 import numpy as np
@@ -81,7 +81,9 @@ class PolygonZoneVisualizationManifest(VisualizationManifest):
     def get_execution_engine_compatibility(cls) -> Optional[str]:
         return ">=1.3.0,<2.0.0"
 
+
 CACHE_MAXSIZE = 200
+
 
 class PolygonZoneVisualizationBlockV1(VisualizationBlock):
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
# Description

While testing video processing locally, I got an exception on PolygonZoneBlock about an undefined variable.
The exception said:
<img width="960" height="77" alt="image" src="https://github.com/user-attachments/assets/d20e010a-cb2f-49fe-9dfe-f23e1c442d70" />


`File "/Users/digao/dev/inference/inference/core/workflows/core_steps/visualizations/polygon_zone/v1.py", line 124, in run                                                                                         
                                 img=mask,                                                                                                                                                                                                       
                                     ^^^^                                                                                                                                                                                                        
                             UnboundLocalError: cannot access local variable 'mask' where it is not associated with a value      `

While fixing this, I noticed that the cache length was unlimited. So also fixed that.

## Type of change

-   [X] Bug fix (non-breaking change which fixes an issue)


## How has this change been tested, please provide a testcase or example of how you tested the change?

locally

## Any specific deployment considerations

None

## Docs

-   [ ] Docs updated? What were the changes:
