### PR TITLE
Fix: Add psutil dependency to resolve slim Docker image startup failures

### DIFF
--- a/requirements/_requirements.txt
+++ b/requirements/_requirements.txt
@@ -10,6 +10,7 @@ opencv-python>=4.8.1.78,<=4.10.0.84
 opencv-contrib-python>=4.8.1.78,<=4.10.0.84  # Note: opencv-python considers this as a bad practice, but since our dependencies rely on both we pin both here
 pillow>=11.0,<12.0
 prometheus-fastapi-instrumentator<=6.0.0
+psutil==7.1.0
 redis~=5.0.0
 requests>=2.32.0,<3.0.0
 rich>=13.0.0,<13.10.0


### PR DESCRIPTION
## What was done

Added `psutil==7.1.0` to the `requirements/_requirements.txt` file to fix Docker container startup failures in the slim CPU inference image.

## Why this was necessary

The slim Docker image (`Dockerfile.onnx.cpu.slim`) was failing to start because the `cpu_http.py` server code imports `psutil` for system monitoring, but this dependency wasn't included in the slim version's requirements. This caused import errors and prevented the inference server from starting properly.

## Why `_requirements.txt` was chosen specifically

The `_requirements.txt` file contains the core dependencies used by all Docker variants, including the slim version. Since `psutil` is used by the core HTTP server functionality (not model-specific features), it belongs in the base requirements rather than in specialised requirement files like `requirements.transformers.txt` or `requirements.sam.txt`. 

The slim Dockerfile specifically installs from:
- `_requirements.txt` (core dependencies)
- `requirements.cpu.txt` 
- `requirements.http.txt`
- `requirements.cli.txt`
- `requirements.sdk.http.txt`

Adding it to `_requirements.txt` ensures it's available across all Docker variants whilst maintaining the lightweight nature of the slim build.