### PR TITLE
Fix "Getting Started" python version requirement

### DIFF
--- a/docs/start/getting-started.md
+++ b/docs/start/getting-started.md
@@ -1,6 +1,6 @@
 # Installation
 
-You can install `inference` in a [Python>=3.8](https://www.python.org/) environment.
+You can install `inference` in a [Python>=3.9,<3.13](https://www.python.org/) environment.
 
 !!! example "Installation Command"
 


### PR DESCRIPTION
# Description

Fix "Getting Started" docs to display correct Python version requirement. Use the `python_requires` value from the `.release/pypi` release scripts, that are used to created the actual pypi package.

## Type of change

-   [x] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Locally

## Any specific deployment considerations

n/a

## Docs

-   [x] Docs updated? What were the changes: fix python version in getting started page
