### PR TITLE
Fall back to 'Fit (grey edges) in' when 'Fit (reflect edges) in' / 'Fit within' / 'Fill (with center crop) in' is passed as resize method

### DIFF
--- a/inference/core/models/roboflow.py
+++ b/inference/core/models/roboflow.py
@@ -457,14 +457,31 @@ class RoboflowInferenceModel(Model):
             self.preproc = json.loads(self.environment["PREPROCESSING"])
         if self.preproc.get("resize"):
             self.resize_method = self.preproc["resize"].get("format", "Stretch to")
+            if self.resize_method in [
+                "Fit (reflect edges) in",
+                "Fit within",
+                "Fill (with center crop) in",
+            ]:
+                logger.error(
+                    "Unsupported resize method '%s', defaulting to 'Fit (grey edges) in' - this may result in degraded model performance.",
+                    self.resize_method,
+                )
+                self.resize_method = "Fit (grey edges) in"
             if self.resize_method not in [
                 "Stretch to",
                 "Fit (black edges) in",
-                "Fit (white edges) in",
                 "Fit (grey edges) in",
+                "Fit (white edges) in",
             ]:
+                logger.error(
+                    "Unsupported resize method '%s', defaulting to 'Stretch to' - this may result in degraded model performance.",
+                    self.resize_method,
+                )
                 self.resize_method = "Stretch to"
         else:
+            logger.error(
+                "Unknown resize method, defaulting to 'Stretch to' - this may result in degraded model performance."
+            )
             self.resize_method = "Stretch to"
         logger.debug(f"Resize method is '{self.resize_method}'")
         self.multiclass = self.environment.get("MULTICLASS", False)


### PR DESCRIPTION
# Description

Following resize methods were defaulting to 'Stretch to':
 * 'Fit (reflect edges) in'
 * 'Fit within'
 * 'Fill (with center crop) in'
This change is logging error when this happens, and is defaulting these methods to 'Fit (grey edges) in'

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

CI passing
Tested manually

## Any specific deployment considerations

N/A

## Docs

N/A