### PR TITLE
Fix test_rfdetr_base_with_background_class - 

### DIFF
--- a/inference/core/models/roboflow.py
+++ b/inference/core/models/roboflow.py
@@ -466,7 +466,7 @@ class RoboflowInferenceModel(Model):
                     "Unsupported resize method '%s', defaulting to 'Fit (grey edges) in' - this may result in degraded model performance.",
                     self.resize_method,
                 )
-                self.resize_method = "Fit (grey edges) in"
+                self.resize_method = "Fit (black edges) in"
             if self.resize_method not in [
                 "Stretch to",
                 "Fit (black edges) in",


### PR DESCRIPTION
# Description

'Fit (black edges) in' yields better result than 'Fit (grey edges) in'

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

 - [x] CI passing
 - [x] [Integration tests passing](https://github.com/roboflow/inference/actions/runs/18003221746)
 - [x] [Regression tests passing](https://github.com/roboflow/inference/actions/runs/18003243953)

## Any specific deployment considerations

N/A

## Docs

N/A