### PR TITLE
Retain empty 'parent_id' field in OCR response

### DIFF
--- a/inference/core/entities/responses/ocr.py
+++ b/inference/core/entities/responses/ocr.py
@@ -23,7 +23,8 @@ class OCRInferenceResponse(BaseModel):
         description="Metadata about input image dimensions", default=None
     )
     predictions: Optional[List[ObjectDetectionPrediction]] = Field(
-        description="List of objects detected by OCR", default=None
+        description="List of objects detected by OCR",
+        default=None,
     )
     time: float = Field(
         description="The time in seconds it took to produce the inference including preprocessing."

--- a/inference/core/interfaces/http/http_api.py
+++ b/inference/core/interfaces/http/http_api.py
@@ -184,7 +184,10 @@ from inference.core.interfaces.http.handlers.workflows import (
 )
 from inference.core.interfaces.http.middlewares.cors import PathAwareCORSMiddleware
 from inference.core.interfaces.http.middlewares.gzip import gzip_response_if_requested
-from inference.core.interfaces.http.orjson_utils import orjson_response
+from inference.core.interfaces.http.orjson_utils import (
+    orjson_response,
+    orjson_response_keeping_parent_id,
+)
 from inference.core.interfaces.stream_manager.api.entities import (
     CommandResponse,
     ConsumePipelineResponse,
@@ -1994,7 +1997,9 @@ class HttpInterface(BaseInterface):
 
                 @app.post(
                     "/doctr/ocr",
-                    response_model=OCRInferenceResponse | List[OCRInferenceResponse],
+                    response_model=Union[
+                        OCRInferenceResponse, List[OCRInferenceResponse]
+                    ],
                     summary="DocTR OCR response",
                     description="Run the DocTR OCR model to retrieve text in an image.",
                 )
@@ -2036,13 +2041,15 @@ class HttpInterface(BaseInterface):
                             "authorizer"
                         ]["lambda"]["actor"]
                         trackUsage(doctr_model_id, actor)
-                    return orjson_response(response)
+                    return orjson_response_keeping_parent_id(response)
 
             if CORE_MODEL_EASYOCR_ENABLED:
 
                 @app.post(
                     "/easy_ocr/ocr",
-                    response_model=OCRInferenceResponse | List[OCRInferenceResponse],
+                    response_model=Union[
+                        OCRInferenceResponse, List[OCRInferenceResponse]
+                    ],
                     summary="EasyOCR OCR response",
                     description="Run the EasyOCR model to retrieve text in an image.",
                 )
@@ -2084,7 +2091,7 @@ class HttpInterface(BaseInterface):
                             "authorizer"
                         ]["lambda"]["actor"]
                         trackUsage(easy_ocr_model_id, actor)
-                    return orjson_response(response)
+                    return orjson_response_keeping_parent_id(response)
 
             if CORE_MODEL_SAM_ENABLED:
 
@@ -2472,7 +2479,7 @@ class HttpInterface(BaseInterface):
                             "authorizer"
                         ]["lambda"]["actor"]
                         trackUsage(trocr_model_id, actor)
-                    return orjson_response(response)
+                    return orjson_response_keeping_parent_id(response)
 
         if not (LAMBDA or GCP_SERVERLESS):
 

--- a/inference/core/interfaces/http/orjson_utils.py
+++ b/inference/core/interfaces/http/orjson_utils.py
@@ -41,6 +41,23 @@ def orjson_response(
     return ORJSONResponseBytes(content=content)
 
 
+def orjson_response_keeping_parent_id(
+    response: Union[List[InferenceResponse], InferenceResponse, BaseModel],
+) -> ORJSONResponseBytes:
+    if isinstance(response, list):
+        content = []
+        for r in response:
+            serialised = r.model_dump(by_alias=True, exclude_none=True)
+            if "parent_id" not in serialised:
+                serialised["parent_id"] = None
+            content.append(serialised)
+    else:
+        content = response.model_dump(by_alias=True, exclude_none=True)
+        if "parent_id" not in content:
+            content["parent_id"] = None
+    return ORJSONResponseBytes(content=content)
+
+
 @deprecated(
     reason="Function serialise_workflow_result(...) will be removed from `inference` end of Q1 2025. "
     "Workflows ecosystem shifted towards internal serialization - see Workflows docs: "

--- a/inference/core/version.py
+++ b/inference/core/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.57.1"
+__version__ = "0.57.2"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

Yet another fix to 0.57.x release - this time with retaining parent id response

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

* ci
* e2e test

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
