### PR TITLE
inference-exp compile model script

### DIFF
--- a/inference_experimental/development/compilation/core.py
+++ b/inference_experimental/development/compilation/core.py
@@ -87,6 +87,8 @@ def select_matching_model_packages(
         api_key=roboflow_api_key,
     )
     matching_model_packages = negotiate_model_packages(
+        model_architecture=model_metadata.model_architecture,
+        task_type=model_metadata.task_type,
         model_packages=model_metadata.model_packages,
         requested_backends=BackendType.ONNX,
         requested_quantization=Quantization.FP32,

--- a/inference_experimental/development/compile_model.py
+++ b/inference_experimental/development/compile_model.py
@@ -1,0 +1,68 @@
+import os
+
+from compilation.core import compile_model
+
+MODELS_OUTPUT_DIR = os.getenv("MODELS_OUTPUT_DIR", "/model-compilation")
+WORKSPACE_SIZE_IN_GB = int(os.getenv("WORKSPACE_SIZE_GB", "15"))
+
+model_id = os.getenv("MODEL_ID") or os.getenv("MODEL")
+if not model_id:
+    raise RuntimeError("MODEL_ID environment variable is required")
+
+precisions_env = os.getenv("PRECISIONS", "fp16,fp32")
+precisions = [p.strip() for p in precisions_env.split(",") if p.strip()]
+
+
+def parse_int_from_env(var_name: str) -> int:
+    value = os.getenv(var_name)
+    if value is None or value == "":
+        return None
+    return int(value)
+
+
+def parse_model_input_size_from_env() -> tuple:
+    value = os.getenv("MODEL_INPUT_SIZE")
+    if value is None or value == "":
+        return None
+    normalized = value.lower().replace(" ", "").replace("x", ",")
+    parts = [p for p in normalized.split(",") if p]
+    if len(parts) == 1:
+        n = int(parts[0])
+        return (n, n)
+    if len(parts) == 2:
+        h = int(parts[0])
+        w = int(parts[1])
+        return (h, w)
+    raise RuntimeError("MODEL_INPUT_SIZE must be like '640', '640x640', or '640,640'")
+
+
+model_input_size = parse_model_input_size_from_env()
+
+min_batch_size = parse_int_from_env("MIN_BATCH_SIZE")
+opt_batch_size = parse_int_from_env("OPT_BATCH_SIZE")
+max_batch_size = parse_int_from_env("MAX_BATCH_SIZE")
+
+if any(v is None for v in [min_batch_size, opt_batch_size, max_batch_size]):
+    # Fall back to previous defaults when not fully provided
+    min_batch_size = 1 if min_batch_size is None else min_batch_size
+    opt_batch_size = 8 if opt_batch_size is None else opt_batch_size
+    max_batch_size = 16 if max_batch_size is None else max_batch_size
+
+for precision in precisions:
+    target_path = os.path.join(MODELS_OUTPUT_DIR, f"{model_id}-{precision}")
+    # try:
+    compile_model(
+        model_id,
+        target_path=target_path,
+        precision=precision,
+        min_batch_size=min_batch_size,
+        opt_batch_size=opt_batch_size,
+        max_batch_size=max_batch_size,
+        workspace_size_gb=WORKSPACE_SIZE_IN_GB,
+        model_input_size=model_input_size,
+    )
+    # except Exception as error:
+    #     print(f"Could not finish compilation for {model_id} ({precision}): {error}")
+
+
+# TODO: register model in registry

--- a/inference_experimental/inference_exp/configuration.py
+++ b/inference_experimental/inference_exp/configuration.py
@@ -34,6 +34,12 @@ ROBOFLOW_API_HOST = os.getenv(
         else "https://api.roboflow.one"
     ),
 )
+# extra headers expected to be serialised json
+ROBOFLOW_API_EXTRA_HEADERS = os.getenv("ROBOFLOW_API_EXTRA_HEADERS")
+ROBOFLOW_API_MODEL_REGISTRY_ENDPOINT = os.getenv(
+    "ROBOFLOW_API_MODEL_REGISTRY_ENDPOINT", "/models/v1/external/weights"
+)
+
 RUNNING_ON_JETSON = os.getenv("RUNNING_ON_JETSON")
 L4T_VERSION = os.getenv("L4T_VERSION")
 INFERENCE_HOME = os.getenv("INFERENCE_HOME", "/tmp/cache")

--- a/inference_experimental/tests/integration_tests/basic_library_features/test_auto_model.py
+++ b/inference_experimental/tests/integration_tests/basic_library_features/test_auto_model.py
@@ -7,7 +7,10 @@ from unittest.mock import MagicMock
 import numpy as np
 import pytest
 from inference_exp import AutoModel, ClassificationPrediction
-from inference_exp.configuration import ROBOFLOW_API_HOST
+from inference_exp.configuration import (
+    ROBOFLOW_API_HOST,
+    ROBOFLOW_API_MODEL_REGISTRY_ENDPOINT,
+)
 from inference_exp.errors import (
     DirectLocalStorageAccessError,
     ModelLoadingError,
@@ -282,7 +285,7 @@ def test_auto_loading_with_weights_provider_in_base_scenario(
         )
     )
     requests_mock.get(
-        f"{ROBOFLOW_API_HOST}/models/v1/external/weights",
+        f"{ROBOFLOW_API_HOST}{ROBOFLOW_API_MODEL_REGISTRY_ENDPOINT}",
         [
             {
                 "status_code": 200,
@@ -373,7 +376,7 @@ def test_auto_loading_with_weights_provider_when_cache_for_the_exact_model_and_a
         )
     )
     requests_mock.get(
-        f"{ROBOFLOW_API_HOST}/models/v1/external/weights",
+        f"{ROBOFLOW_API_HOST}{ROBOFLOW_API_MODEL_REGISTRY_ENDPOINT}",
         [
             {
                 "status_code": 200,
@@ -439,7 +442,7 @@ def test_auto_loading_with_weights_provider_when_cache_for_the_exact_model_but_d
         )
     )
     requests_mock.get(
-        f"{ROBOFLOW_API_HOST}/models/v1/external/weights",
+        f"{ROBOFLOW_API_HOST}{ROBOFLOW_API_MODEL_REGISTRY_ENDPOINT}",
         [
             {
                 "status_code": 200,
@@ -512,7 +515,7 @@ def test_auto_loading_with_weights_provider_when_api_denoted_forbidden(
         )
     )
     requests_mock.get(
-        f"{ROBOFLOW_API_HOST}/models/v1/external/weights",
+        f"{ROBOFLOW_API_HOST}{ROBOFLOW_API_MODEL_REGISTRY_ENDPOINT}",
         [
             {
                 "status_code": 401,
@@ -579,7 +582,7 @@ def test_auto_loading_with_weights_provider_when_api_denoted_forbidden_for_one_k
         )
     )
     requests_mock.get(
-        f"{ROBOFLOW_API_HOST}/models/v1/external/weights",
+        f"{ROBOFLOW_API_HOST}{ROBOFLOW_API_MODEL_REGISTRY_ENDPOINT}",
         [
             {
                 "status_code": 200,
@@ -679,7 +682,7 @@ def test_auto_loading_from_cached_local_path(
         )
     )
     requests_mock.get(
-        f"{ROBOFLOW_API_HOST}/models/v1/external/weights",
+        f"{ROBOFLOW_API_HOST}{ROBOFLOW_API_MODEL_REGISTRY_ENDPOINT}",
         [
             {
                 "status_code": 200,

--- a/inference_experimental/tests/unit_tests/weights_providers/test_roboflow.py
+++ b/inference_experimental/tests/unit_tests/weights_providers/test_roboflow.py
@@ -3,7 +3,11 @@ import urllib.parse
 from typing import Optional
 
 import pytest
-from inference_exp.configuration import API_CALLS_MAX_TRIES, ROBOFLOW_API_HOST
+from inference_exp.configuration import (
+    API_CALLS_MAX_TRIES,
+    ROBOFLOW_API_HOST,
+    ROBOFLOW_API_MODEL_REGISTRY_ENDPOINT,
+)
 from inference_exp.errors import (
     ModelMetadataConsistencyError,
     ModelRetrievalError,
@@ -1042,7 +1046,7 @@ def test_get_one_page_of_model_metadata_when_retry_not_needed_and_parsable_respo
     requests_mock: Mocker,
 ) -> None:
     requests_mock.get(
-        f"{ROBOFLOW_API_HOST}/models/v1/external/weights",
+        f"{ROBOFLOW_API_HOST}{ROBOFLOW_API_MODEL_REGISTRY_ENDPOINT}",
         json={
             "modelMetadata": {
                 "type": "external-model-metadata-v1",
@@ -1111,7 +1115,8 @@ def test_get_one_page_of_model_metadata_when_retry_not_needed_and_not_parsable_r
     requests_mock: Mocker,
 ) -> None:
     requests_mock.get(
-        f"{ROBOFLOW_API_HOST}/models/v1/external/weights", json={"status": "ok"}
+        f"{ROBOFLOW_API_HOST}{ROBOFLOW_API_MODEL_REGISTRY_ENDPOINT}",
+        json={"status": "ok"},
     )
 
     # when
@@ -1123,7 +1128,7 @@ def test_get_one_page_of_model_metadata_when_retry_needed_and_parsable_response(
     requests_mock: Mocker,
 ) -> None:
     requests_mock.get(
-        f"{ROBOFLOW_API_HOST}/models/v1/external/weights",
+        f"{ROBOFLOW_API_HOST}{ROBOFLOW_API_MODEL_REGISTRY_ENDPOINT}",
         [
             {"status_code": 429},
             {
@@ -1194,7 +1199,7 @@ def test_get_one_page_of_model_metadata_when_retries_exceeded(
 ) -> None:
     # given
     requests_mock.get(
-        f"{ROBOFLOW_API_HOST}/models/v1/external/weights",
+        f"{ROBOFLOW_API_HOST}{ROBOFLOW_API_MODEL_REGISTRY_ENDPOINT}",
         [
             {"status_code": 429},
         ]
@@ -1213,7 +1218,7 @@ def test_get_one_page_of_model_metadata_when_retries_exceeded(
 
 def test_get_model_metadata_with_pagination(requests_mock: Mocker) -> None:
     requests_mock.get(
-        f"{ROBOFLOW_API_HOST}/models/v1/external/weights",
+        f"{ROBOFLOW_API_HOST}{ROBOFLOW_API_MODEL_REGISTRY_ENDPOINT}",
         [
             {
                 "status_code": 200,
@@ -1308,7 +1313,7 @@ def test_get_model_metadata_with_pagination(requests_mock: Mocker) -> None:
 
 def test_get_roboflow_model(requests_mock: Mocker) -> None:
     requests_mock.get(
-        f"{ROBOFLOW_API_HOST}/models/v1/external/weights",
+        f"{ROBOFLOW_API_HOST}{ROBOFLOW_API_MODEL_REGISTRY_ENDPOINT}",
         [
             {
                 "status_code": 200,


### PR DESCRIPTION
# Description
adds a script to compile a single model

also adds env vars for ROBOFLOW_API_EXTRA_HEADERS, ROBOFLOW_API_MODEL_REGISTRY_ENDPOINT to configure the model registration api cals 

## Type of change

Please delete options that are not relevant.
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?
locally

## Any specific deployment considerations
n/a

## Docs
n/a