### PR TITLE
Limit rfdetr input resolution when loading through onnx

### DIFF
--- a/inference/core/env.py
+++ b/inference/core/env.py
@@ -665,4 +665,4 @@ HOT_MODELS_QUEUE_LOCK_ACQUIRE_TIMEOUT = float(
 )
 
 # RFDETR input resolution limit for models loaded through onnx runtime
-RFDETR_ONNX_MAX_RESOLUTION = int(os.getenv("RFDETR_MAX_RESOLUTION", "2048"))
+RFDETR_ONNX_MAX_RESOLUTION = int(os.getenv("RFDETR_ONNX_MAX_RESOLUTION", "1280"))

--- a/inference/core/env.py
+++ b/inference/core/env.py
@@ -663,3 +663,6 @@ MODEL_LOCK_ACQUIRE_TIMEOUT = float(os.getenv("MODEL_LOCK_ACQUIRE_TIMEOUT", "60.0
 HOT_MODELS_QUEUE_LOCK_ACQUIRE_TIMEOUT = float(
     os.getenv("HOT_MODELS_QUEUE_LOCK_ACQUIRE_TIMEOUT", "5.0")
 )
+
+# RFDETR input resolution limit for models loaded through onnx runtime
+RFDETR_ONNX_MAX_RESOLUTION = int(os.getenv("RFDETR_MAX_RESOLUTION", "2048"))

--- a/inference/core/models/roboflow.py
+++ b/inference/core/models/roboflow.py
@@ -463,7 +463,7 @@ class RoboflowInferenceModel(Model):
                 "Fill (with center crop) in",
             ]:
                 fallback_resize_method = "Fit (black edges) in"
-                logger.error(
+                logger.warning(
                     "Unsupported resize method '%s', defaulting to '%s' - this may result in degraded model performance.",
                     self.resize_method,
                     fallback_resize_method,

--- a/inference/core/models/roboflow.py
+++ b/inference/core/models/roboflow.py
@@ -462,11 +462,13 @@ class RoboflowInferenceModel(Model):
                 "Fit within",
                 "Fill (with center crop) in",
             ]:
+                fallback_resize_method = "Fit (black edges) in"
                 logger.error(
-                    "Unsupported resize method '%s', defaulting to 'Fit (grey edges) in' - this may result in degraded model performance.",
+                    "Unsupported resize method '%s', defaulting to '%s' - this may result in degraded model performance.",
                     self.resize_method,
+                    fallback_resize_method,
                 )
-                self.resize_method = "Fit (black edges) in"
+                self.resize_method = fallback_resize_method
             if self.resize_method not in [
                 "Stretch to",
                 "Fit (black edges) in",

--- a/inference/core/version.py
+++ b/inference/core/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.57.2"
+__version__ = "0.57.3"
 
 
 if __name__ == "__main__":

--- a/inference/models/rfdetr/rfdetr.py
+++ b/inference/models/rfdetr/rfdetr.py
@@ -15,6 +15,7 @@ from inference.core.env import (
     MAX_BATCH_SIZE,
     ONNXRUNTIME_EXECUTION_PROVIDERS,
     REQUIRED_ONNX_PROVIDERS,
+    RFDETR_ONNX_MAX_RESOLUTION,
     TENSORRT_CACHE_PATH,
     USE_PYTORCH_FOR_PREPROCESSING,
 )
@@ -385,6 +386,14 @@ class RFDETRObjectDetection(ObjectDetectionBaseOnnxRoboflowInferenceModel):
         """Initializes the ONNX model, setting up the inference session and other necessary properties."""
         logger.debug("Getting model artefacts")
         self.get_model_artifacts(**kwargs)
+        if self.environment.get("RESOLUTION") >= RFDETR_ONNX_MAX_RESOLUTION:
+            logger.error(
+                "NOT loading '%s' model, input resolution is '%s', ONNX max resolution limit set to '%s'",
+                self.endpoint,
+                self.environment.get("RESOLUTION"),
+                RFDETR_ONNX_MAX_RESOLUTION,
+            )
+            raise ModelArtefactError(f"Resolution too high for RFDETR")
         logger.debug("Creating inference session")
         if self.load_weights or not self.has_model_metadata:
             t1_session = perf_counter()

--- a/inference/models/rfdetr/rfdetr.py
+++ b/inference/models/rfdetr/rfdetr.py
@@ -19,7 +19,11 @@ from inference.core.env import (
     TENSORRT_CACHE_PATH,
     USE_PYTORCH_FOR_PREPROCESSING,
 )
-from inference.core.exceptions import ModelArtefactError, OnnxProviderNotAvailable
+from inference.core.exceptions import (
+    CannotInitialiseModelError,
+    ModelArtefactError,
+    OnnxProviderNotAvailable,
+)
 from inference.core.logger import logger
 from inference.core.models.defaults import DEFAULT_CONFIDENCE, DEFAUlT_MAX_DETECTIONS
 from inference.core.models.object_detection_base import (
@@ -393,7 +397,7 @@ class RFDETRObjectDetection(ObjectDetectionBaseOnnxRoboflowInferenceModel):
                 self.environment.get("RESOLUTION"),
                 RFDETR_ONNX_MAX_RESOLUTION,
             )
-            raise ModelArtefactError(f"Resolution too high for RFDETR")
+            raise CannotInitialiseModelError(f"Resolution too high for RFDETR")
         logger.debug("Creating inference session")
         if self.load_weights or not self.has_model_metadata:
             t1_session = perf_counter()


### PR DESCRIPTION
# Description

RFDetr models take up lots of RAM when input resolution is high and when running through ONNX runtime. Limiting RFDetr input resolution to ensure sane RAM usage.

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

CI passing
Tested manually

## Any specific deployment considerations

N/A

## Docs

N/A