### PR TITLE
Use a generator for instance segmentation masks

### DIFF
--- a/inference/models/yolact/yolact_instance_segmentation.py
+++ b/inference/models/yolact/yolact_instance_segmentation.py
@@ -272,11 +272,11 @@ class YOLACT(OnnxRoboflowInferenceModel):
         """
         responses = [
             InstanceSegmentationInferenceResponse(
-                predictions=[
+                predictions=(
                     InstanceSegmentationPrediction(**p)
                     for p in batch_pred
                     if not class_filter or p["class_name"] in class_filter
-                ],
+                ),
                 image=InferenceResponseImage(
                     width=img_dims[i][1], height=img_dims[i][0]
                 ),


### PR DESCRIPTION
# Description

I am currently testing this changeset, but I notice a significant slowdown when loading large instance segmentation masks in memory - currently, it is not possible to access the class or confidence without also loading the entire mask as well. By using a generator, this code reduces memory usage by enabling access to the labels and classes of predictions without requiring the entire mask to be loaded also.

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Currently profiling the change to see if it improves performance on edge devices (Jetson Orin 16GB)

## Any specific deployment considerations

This does change the type from a list to a generator, but should not change any APIs or dependencies.

## Docs

N/A