### PR TITLE
Increase default rfdetr resolution limit

### DIFF
--- a/inference/core/env.py
+++ b/inference/core/env.py
@@ -665,4 +665,8 @@ HOT_MODELS_QUEUE_LOCK_ACQUIRE_TIMEOUT = float(
 )
 
 # RFDETR input resolution limit for models loaded through onnx runtime
-RFDETR_ONNX_MAX_RESOLUTION = int(os.getenv("RFDETR_ONNX_MAX_RESOLUTION", "1280"))
+# 1280 -> ~3.5G
+# 1440 -> ~5G
+# 1600 -> ~10G
+# 2048 -> ~22G
+RFDETR_ONNX_MAX_RESOLUTION = int(os.getenv("RFDETR_ONNX_MAX_RESOLUTION", "1600"))

--- a/inference/core/version.py
+++ b/inference/core/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.57.3"
+__version__ = "0.57.4"
 
 
 if __name__ == "__main__":

--- a/inference/models/rfdetr/rfdetr.py
+++ b/inference/models/rfdetr/rfdetr.py
@@ -405,7 +405,7 @@ class RFDETRObjectDetection(ObjectDetectionBaseOnnxRoboflowInferenceModel):
             and input_resolution >= RFDETR_ONNX_MAX_RESOLUTION
         ):
             logger.error(
-                "NOT loading '%s' model, input resolution is '%s', ONNX max resolution limit set to '%s'",
+                "NOT loading '%s' model, input resolution is '%s', ONNX max resolution limit set to '%s' (limit can be increased via RFDETR_ONNX_MAX_RESOLUTION env variable)",
                 self.endpoint,
                 input_resolution,
                 RFDETR_ONNX_MAX_RESOLUTION,


### PR DESCRIPTION
# Description

Based on measured vRAM usage:
1280 -> ~3.5G
1440 -> ~5G
1600 -> ~10G
2048 -> ~22G

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

CI passing

## Any specific deployment considerations

N/A

## Docs

N/A