### PR TITLE
Prevent accepting 0 as confidence due to resulting high memory requirement

### DIFF
--- a/inference/core/env.py
+++ b/inference/core/env.py
@@ -670,3 +670,8 @@ HOT_MODELS_QUEUE_LOCK_ACQUIRE_TIMEOUT = float(
 # 1600 -> ~10G
 # 2048 -> ~22G
 RFDETR_ONNX_MAX_RESOLUTION = int(os.getenv("RFDETR_ONNX_MAX_RESOLUTION", "1600"))
+
+# Confidence lower bound to prevent OOM when inferring on instance segmentation models
+CONFIDENCE_LOWER_BOUND_OOM_PREVENTION = float(
+    os.getenv("CONFIDENCE_LOWER_BOUND_OOM_PREVENTION", "0.01")
+)

--- a/inference/core/interfaces/http/http_api.py
+++ b/inference/core/interfaces/http/http_api.py
@@ -122,6 +122,7 @@ from inference.core.env import (
     API_KEY,
     API_LOGGING_ENABLED,
     BUILDER_ORIGIN,
+    CONFIDENCE_LOWER_BOUND_OOM_PREVENTION,
     CORE_MODEL_CLIP_ENABLED,
     CORE_MODEL_DOCTR_ENABLED,
     CORE_MODEL_EASYOCR_ENABLED,
@@ -2690,8 +2691,9 @@ class HttpInterface(BaseInterface):
                 model_id = f"{dataset_id}/{version_id}"
                 if confidence >= 1:
                     confidence /= 100
-                elif confidence < 0:
-                    confidence = 0
+                elif confidence < CONFIDENCE_LOWER_BOUND_OOM_PREVENTION:
+                    # allowing lower confidence results in RAM usage explosion
+                    confidence = CONFIDENCE_LOWER_BOUND_OOM_PREVENTION
 
                 if overlap >= 1:
                     overlap /= 100

--- a/inference/core/version.py
+++ b/inference/core/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.58.0"
+__version__ = "0.58.1"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

In [this change](https://github.com/roboflow/inference/pull/1546/commits/8694051d019e4171c8257309b174190df2362b95) the lower bound limit on confidence was removed in order to ensure correct MAP calculation. This has adverse effect of high RAM usage when running model evaluation.

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

CI passing

## Any specific deployment considerations

N/A

## Docs

N/A