### PR TITLE
Honor mask decode args for rf-detr seg model

### DIFF
--- a/inference/models/rfdetr/rfdetr.py
+++ b/inference/models/rfdetr/rfdetr.py
@@ -628,19 +628,29 @@ class RFDETRInstanceSegmentation(
                     target_res = (orig_w, orig_h)
                     new_masks = []
                     for mask in selected_masks:
-                        new_masks.append(cv2.resize(mask, target_res, interpolation=cv2.INTER_LINEAR))
+                        new_masks.append(
+                            cv2.resize(mask, target_res, interpolation=cv2.INTER_LINEAR)
+                        )
                     selected_masks = np.stack(new_masks, axis=0)
                 elif kwargs.get("mask_decode_mode", "accurate") == "tradeoff":
                     tradeoff_factor = kwargs.get("tradeoff_factor", 0.0)
                     mask_res = (selected_masks.shape[2], selected_masks.shape[1])
                     full_res = (orig_w, orig_h)
                     target_res = (
-                        int(mask_res[0] * (1 - tradeoff_factor) + full_res[0] * tradeoff_factor),
-                        int(mask_res[1] * (1 - tradeoff_factor) + full_res[1] * tradeoff_factor),
+                        int(
+                            mask_res[0] * (1 - tradeoff_factor)
+                            + full_res[0] * tradeoff_factor
+                        ),
+                        int(
+                            mask_res[1] * (1 - tradeoff_factor)
+                            + full_res[1] * tradeoff_factor
+                        ),
                     )
                     new_masks = []
                     for mask in selected_masks:
-                        new_masks.append(cv2.resize(mask, target_res, interpolation=cv2.INTER_LINEAR))
+                        new_masks.append(
+                            cv2.resize(mask, target_res, interpolation=cv2.INTER_LINEAR)
+                        )
                     selected_masks = np.stack(new_masks, axis=0)
 
             selected_masks = selected_masks > 0


### PR DESCRIPTION
# Description

Honor mask decode args for rf-detr seg model. With my test image, tradeoff factor 0.5 led to 28 fps, accurate mode was 23 fps, and fast mode was 32 fps.

@PawelPeczek-Roboflow I'm not sure how this will play with the padding argument.

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

locally

## Any specific deployment considerations

no

## Docs

-   [ ] Docs updated? What were the changes:
