### PR TITLE
Fix ModelConfig incorrect confidence environment variable

### DIFF
--- a/inference/core/interfaces/stream/entities.py
+++ b/inference/core/interfaces/stream/entities.py
@@ -4,6 +4,7 @@ from typing import Any, Callable, Dict, List, Optional, Union
 
 from inference.core.env import (
     CLASS_AGNOSTIC_NMS_ENV,
+    CONFIDENCE_ENV,
     DEFAULT_CLASS_AGNOSTIC_NMS,
     DEFAULT_CONFIDENCE,
     DEFAULT_IOU_THRESHOLD,
@@ -50,7 +51,7 @@ class ModelConfig:
             )
         if confidence is None:
             confidence = safe_env_to_type(
-                variable_name=CLASS_AGNOSTIC_NMS_ENV,
+                variable_name=CONFIDENCE_ENV,
                 default_value=DEFAULT_CONFIDENCE,
                 type_constructor=float,
             )


### PR DESCRIPTION
# Description

Fixes the incorrect  environment variable name from #1658 

 
List any dependencies that are required for this change.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)

It could break things if people have the variable set but are not currently expecting it to work?

## How has this change been tested, please provide a testcase or example of how you tested the change?

```python
from inference.core.interfaces.stream.entities import ModelConfig
import os

os.environ["CONFIDENCE"] = "0.5"
os.environ["CLASS_AGNOSTIC_NMS"] = "True"

m = ModelConfig.init()
print(m.confidence)
```

Before, this would be 0.4. Now, it properly uses the environment variable and does not fail to parse the `CLASS_AGNOSITC_NMS` variable.

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
