### PR TITLE
Fix base detection docstrings default confidence and IOU

### DIFF
--- a/inference/core/models/instance_segmentation_base.py
+++ b/inference/core/models/instance_segmentation_base.py
@@ -69,8 +69,8 @@ class InstanceSegmentationBaseOnnxRoboflowInferenceModel(OnnxRoboflowInferenceMo
             image (Any): An image or a list of images for processing.
                 - can be a BGR numpy array, filepath, InferenceRequestImage, PIL Image, byte-string, etc.
             class_agnostic_nms (bool, optional): Whether to use class-agnostic non-maximum suppression. Defaults to False.
-            confidence (float, optional): Confidence threshold for predictions. Defaults to 0.5.
-            iou_threshold (float, optional): IoU threshold for non-maximum suppression. Defaults to 0.5.
+            confidence (float, optional): Confidence threshold for predictions. Defaults to 0.4.
+            iou_threshold (float, optional): IoU threshold for non-maximum suppression. Defaults to 0.3.
             mask_decode_mode (str, optional): Decoding mode for masks. Choices are "accurate", "tradeoff", and "fast". Defaults to "accurate".
             max_candidates (int, optional): Maximum number of candidate detections. Defaults to 3000.
             max_detections (int, optional): Maximum number of detections after non-maximum suppression. Defaults to 300.

--- a/inference/core/models/object_detection_base.py
+++ b/inference/core/models/object_detection_base.py
@@ -62,8 +62,8 @@ class ObjectDetectionBaseOnnxRoboflowInferenceModel(OnnxRoboflowInferenceModel):
             image (Any): The input image or a list of images to process.
                 - can be a BGR numpy array, filepath, InferenceRequestImage, PIL Image, byte-string, etc.
             class_agnostic_nms (bool, optional): Whether to use class-agnostic non-maximum suppression. Defaults to False.
-            confidence (float, optional): Confidence threshold for predictions. Defaults to 0.5.
-            iou_threshold (float, optional): IoU threshold for non-maximum suppression. Defaults to 0.5.
+            confidence (float, optional): Confidence threshold for predictions. Defaults to 0.4.
+            iou_threshold (float, optional): IoU threshold for non-maximum suppression. Defaults to 0.3.
             fix_batch_size (bool, optional): If True, fix the batch size for predictions. Useful when the model requires a fixed batch size. Defaults to False.
             max_candidates (int, optional): Maximum number of candidate detections. Defaults to 3000.
             max_detections (int, optional): Maximum number of detections after non-maximum suppression. Defaults to 300.


### PR DESCRIPTION
# Description

Fixes the incorrect docstrings from #1658. It does not currently use the `CONFIDENCE` environment variable for the default, though these changes are small so it wouldn't be hard to switch them over but could cause issues for people since it doesn't currently apply

Object detection defaults
https://github.com/roboflow/inference/blob/e2ab42bd847c1b822df9473b47f6a938848c181e/inference/core/models/defaults.py#L1-L5

Separate instance segmenetation defaults
https://github.com/roboflow/inference/blob/e2ab42bd847c1b822df9473b47f6a938848c181e/inference/core/models/instance_segmentation_base.py#L27-L33

List any dependencies that are required for this change.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

N/A

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
