### PR TITLE
Add fixes for TRT error handling

### DIFF
--- a/inference_experimental/inference_exp/models/common/trt.py
+++ b/inference_experimental/inference_exp/models/common/trt.py
@@ -196,8 +196,18 @@ def execute_trt_engine(
         )
         context.set_tensor_address(output, result.data_ptr())
         results.append(result)
-    context.set_input_shape(input_name, tuple(pre_processed_images.shape))
-    context.set_tensor_address(input_name, pre_processed_images.data_ptr())
+    status = context.set_input_shape(input_name, tuple(pre_processed_images.shape))
+    if not status:
+        raise ModelRuntimeError(
+            message="Failed to set TRT model input shape during forward pass from the model.",
+            help_url="https://todo",
+        )
+    status = context.set_tensor_address(input_name, pre_processed_images.data_ptr())
+    if not status:
+        raise ModelRuntimeError(
+            message="Failed to set input tensor data pointer during forward pass from the model.",
+            help_url="https://todo",
+        )
     stream = torch.cuda.Stream(device=device)
     status = context.execute_async_v3(stream_handle=stream.cuda_stream)
     if not status:


### PR DESCRIPTION
# Description

We had silent errors in `inference-exp` for TRT models - addes operation statuses verification (based on docs: https://developer.nvidia.com/docs/drive/drive-os/6.0.8/public/drive-os-tensorrt/api-reference/docs/python/infer/Core/ExecutionContext.html) 

Below, the example of faulty model package causing silent errors (only logs, no exception)
<img width="1653" height="295" alt="image" src="https://github.com/user-attachments/assets/7fee9e86-1303-430c-bfe4-a70cd6d68a86" />



List any dependencies that are required for this change.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

* CI
* e2e

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
