### PR TITLE
Validate workflow accepts api key

### DIFF
--- a/inference/core/interfaces/http/http_api.py
+++ b/inference/core/interfaces/http/http_api.py
@@ -1415,12 +1415,16 @@ class HttpInterface(BaseInterface):
             @with_route_exceptions
             def validate_workflow(
                 specification: dict,
+                api_key: Optional[str] = Query(
+                    None,
+                    description="Roboflow API Key that will be passed to the model during initialization for artifact retrieval",
+                ),
             ) -> WorkflowValidationStatus:
                 # TODO: get rid of async: https://github.com/roboflow/inference/issues/569
                 step_execution_mode = StepExecutionMode(WORKFLOWS_STEP_EXECUTION_MODE)
                 workflow_init_parameters = {
                     "workflows_core.model_manager": model_manager,
-                    "workflows_core.api_key": None,
+                    "workflows_core.api_key": api_key,
                     "workflows_core.background_tasks": None,
                     "workflows_core.step_execution_mode": step_execution_mode,
                 }


### PR DESCRIPTION
# Description

Add `api_key` as query param to the `/validate/workflow` endpoint. Necessary for validating custom python blocks when modal executor is enabled, and anonymous modal execution is disabled.

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Tested on staging with several workflows.

## Any specific deployment considerations

none

## Docs

-   [ ] Docs updated? What were the changes:
