### PR TITLE
switch modal to app cls

### DIFF
--- a/inference/core/interfaces/webrtc_worker/modal.py
+++ b/inference/core/interfaces/webrtc_worker/modal.py
@@ -166,7 +166,8 @@ if modal is not None:
             app.deploy(name=WEBRTC_MODAL_APP_NAME, client=client)
         # https://modal.com/docs/reference/modal.Cls#from_name
         deployed_cls = modal.Cls.from_name(
-            app_name=app.name, name=RTCPeerConnectionModal.__name__,
+            app_name=app.name,
+            name=RTCPeerConnectionModal.__name__,
         )
         deployed_cls.hydrate(client=client)
         rtc_modal_obj: RTCPeerConnectionModal = deployed_cls()


### PR DESCRIPTION
# Description

Modal worker is currently based on modal.function, this is limiting functionalities like parametrized function or modal.Cls.from_options; modal.Cls is also allowing to specify @enter and @exit methods

## Type of change

-   [x] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Tested manually

## Any specific deployment considerations

N/A

## Docs

N/A