### PR TITLE
fix sam2 test

### DIFF
--- a/tests/inference/models_predictions_tests/test_sam2.py
+++ b/tests/inference/models_predictions_tests/test_sam2.py
@@ -288,7 +288,7 @@ def test_sam2_segment_with_rle_format(sam2_small_model: str, truck_image: np.nda
     resp = turn_segmentation_results_into_rle_response(
         masks=masks,
         scores=scores,
-        mask_threshold=model.predictor.mask_threshold,
+        mask_threshold=0.0,
         inference_start_timestamp=t1,
     )
 


### PR DESCRIPTION
# Description
Fixes sam2 test that was failing because sam2 predictor is no longer part of the public interface (not needed as member on class anymore)

## Type of change

Please delete options that are not relevant.

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?
CI

## Any specific deployment considerations
n/a

## Docs
n/a