### PR TITLE
Add notice about custom python support in batch processing

### DIFF
--- a/docs/workflows/batch_processing/about.md
+++ b/docs/workflows/batch_processing/about.md
@@ -300,7 +300,9 @@ potential costs.
 
 ## Known limitations
 
-* Batch Processing service cannot run Custom Python blocks.
+<div style="border: 2px solid #059669; background: #D1FAE5; color: #065F46; padding: 1em; border-radius: 8px; text-align: center; margin-bottom: 1em; font-weight: bold;">
+  🚀 <b>Update:</b> Batch Processing service <b>now supports running Custom Python blocks.</b>
+</div>
 
 * Certain Workflow blocks requiring access to env variables and local storage (like File Sink and Environment 
 Secret Store) are blacklisted and will not execute.


### PR DESCRIPTION
# Description

Updates docs to show that custom python blocks are supported in batch processing.

<img width="654" height="400" alt="image" src="https://github.com/user-attachments/assets/92b2d4a5-204f-4491-868d-0e40b5614b9e" />

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Tested locally.

## Any specific deployment considerations

None, can go out with next release.

## Docs

-   [ ] Docs updated? What were the changes:
