### PR TITLE
Fix PyTorch clobbering in Jetson 6.2 build

### DIFF
--- a/docker/dockerfiles/Dockerfile.onnx.jetson.6.2.0
+++ b/docker/dockerfiles/Dockerfile.onnx.jetson.6.2.0
@@ -205,7 +205,7 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python && \
 RUN cd /usr/local/lib/python3.10/dist-packages && \
     find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true && \
     rm -rf debugpy* jupyterlab* jupyter_* notebook* ipython* ipykernel* || true && \
-    rm -rf torch/bin torch/include || true && \
+    rm -rf torch/include || true && \
     rm -rf onnx/backend/test onnx/test || true && \
     rm -rf scipy/*/tests pandas/tests || true && \
     rm -rf */examples */benchmarks */docs || true && \

--- a/requirements/requirements.sam.txt
+++ b/requirements/requirements.sam.txt
@@ -2,6 +2,5 @@ rf-segment-anything==1.0
 samv2==0.0.4
 rasterio~=1.4.0
 pycocotools>=2.0.10
-# TODO: update to 2.8.0 once pre-built flashattn is available
-torch>=2.0.1,<2.7.0
+torch>=2.0.1,<2.9.0
 torchvision>=0.15.2

--- a/requirements/requirements.transformers.txt
+++ b/requirements/requirements.transformers.txt
@@ -1,5 +1,4 @@
-# TODO: update to 2.8.0 once pre-built flashattn is available
-torch>=2.0.1,<2.7.0
+torch>=2.0.1,<2.9.0
 torchvision>=0.15.0
 transformers>=4.53.3,<4.57.0
 timm~=1.0.0


### PR DESCRIPTION
## Summary
- Bump torch constraint from `<2.7.0` to `<2.9.0` to prevent uv from replacing compiled torch 2.8.0 with CPU-only 2.6.0
- Keep `torch/bin` directory to preserve `torch_shm_manager` needed at runtime

## Test plan
- [ ] Build Dockerfile.onnx.jetson.6.2.0 on Jetson
- [ ] Verify `import torch` works
- [ ] Verify `torch.cuda.is_available()` returns True