### PR TITLE
Add missing 'engine_host_code_allowed' flag for YOLOv10 implementation in TRT

### DIFF
--- a/inference_experimental/inference_exp/models/yolov10/yolov10_object_detection_trt.py
+++ b/inference_experimental/inference_exp/models/yolov10/yolov10_object_detection_trt.py
@@ -66,6 +66,7 @@ class YOLOv10ForObjectDetectionTRT(
         cls,
         model_name_or_path: str,
         device: torch.device = DEFAULT_DEVICE,
+        engine_host_code_allowed: bool = False,
         **kwargs,
     ) -> "YOLOv10ForObjectDetectionTRT":
         if device.type != "cuda":
@@ -100,7 +101,10 @@ class YOLOv10ForObjectDetectionTRT(
         cuda.init()
         cuda_device = cuda.Device(device.index or 0)
         with use_primary_cuda_context(cuda_device=cuda_device) as cuda_context:
-            engine = load_model(model_path=model_package_content["engine.plan"])
+            engine = load_model(
+                model_path=model_package_content["engine.plan"],
+                engine_host_code_allowed=engine_host_code_allowed,
+            )
             execution_context = engine.create_execution_context()
         inputs, outputs = get_engine_inputs_and_outputs(engine=engine)
         if len(inputs) != 1:


### PR DESCRIPTION
# Description

Adding missing flag `engine_host_code_allowed` to YoloV10 TRT implementation to align with rest of TRT models.

List any dependencies that are required for this change.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

* CI
* e2e

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
