### PR TITLE
add missing extra-require

### DIFF
--- a/.release/pypi/inference.cli.setup.py
+++ b/.release/pypi/inference.cli.setup.py
@@ -65,6 +65,7 @@ setuptools.setup(
     },
     extras_require={
         "cloud-deploy": read_requirements("requirements/requirements.cloud_deploy.txt"),
+        "cloud-storage": read_requirements("requirements/requirements.cloud_storage.txt"),
     },
     package_data={"": ["configs/*.yml"]},
     install_requires=read_requirements([


### PR DESCRIPTION
# Description

add missing `extra-require` for `cloud-storage` so that `pip install 'inference-cli[cloud-storage]'"` works.

List any dependencies that are required for this change.

## Type of change

Please delete options that are not relevant.

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

unclear how I'd test this.

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
