### PR TITLE
Fix issue with OWLv2 serialisation and deserialisation

### DIFF
--- a/inference/core/version.py
+++ b/inference/core/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.63.1"
+__version__ = "0.63.2"
 
 
 if __name__ == "__main__":

--- a/inference/models/__init__.py
+++ b/inference/models/__init__.py
@@ -1,14 +1,19 @@
 import importlib
 from typing import Any
-#Preinit nvdiffrast for SAM3D as it breaks if any flash attn model is loaded in first
+
+# Preinit nvdiffrast for SAM3D as it breaks if any flash attn model is loaded in first
 try:
-    import torch 
+    import torch
+
     if torch.cuda.is_available():
         import utils3d.torch
-        _nvdiffrast_ctx = utils3d.torch.RastContext(backend='cuda')
-        _dummy_verts = torch.zeros(1, 3, 3, device='cuda')
-        _dummy_faces = torch.tensor([[0, 1, 2]], dtype=torch.int32, device='cuda')
-        _ = utils3d.torch.rasterize_triangle_faces(_nvdiffrast_ctx, _dummy_verts, _dummy_faces, 64, 64)
+
+        _nvdiffrast_ctx = utils3d.torch.RastContext(backend="cuda")
+        _dummy_verts = torch.zeros(1, 3, 3, device="cuda")
+        _dummy_faces = torch.tensor([[0, 1, 2]], dtype=torch.int32, device="cuda")
+        _ = utils3d.torch.rasterize_triangle_faces(
+            _nvdiffrast_ctx, _dummy_verts, _dummy_faces, 64, 64
+        )
         del _dummy_verts, _dummy_faces, _
 except:
     pass
@@ -36,7 +41,10 @@ CORE_MODELS = {
     "SegmentAnything": ("inference.models.sam", CORE_MODEL_SAM_ENABLED),
     "SegmentAnything2": ("inference.models.sam2", CORE_MODEL_SAM2_ENABLED),
     "SegmentAnything3": ("inference.models.sam3", CORE_MODEL_SAM3_ENABLED),
-    "SegmentAnything3_3D_Objects": ("inference.models.sam3_3d", SAM3_3D_OBJECTS_ENABLED),
+    "SegmentAnything3_3D_Objects": (
+        "inference.models.sam3_3d",
+        SAM3_3D_OBJECTS_ENABLED,
+    ),
     "Sam3ForInteractiveImageSegmentation": (
         "inference.models.sam3",
         CORE_MODEL_SAM3_ENABLED,

--- a/inference/models/owlv2/owlv2.py
+++ b/inference/models/owlv2/owlv2.py
@@ -867,7 +867,13 @@ class SerializedOwlV2(RoboflowInferenceModel):
                 model_data = torch.load(previous_embeddings_file, weights_only=False)
 
             train_data_dict = model_data["train_data_dict"]
-            owlv2.cpu_image_embed_cache = model_data["image_embeds"]
+            if isinstance(model_data["image_embeds"], LimitedSizeDict):
+                owlv2.cpu_image_embed_cache = model_data["image_embeds"]
+            else:
+                cache = LimitedSizeDict(size_limit=CPU_IMAGE_EMBED_CACHE_SIZE)
+                for key, value in model_data["image_embeds"].items():
+                    cache[key] = value
+                owlv2.cpu_image_embed_cache = cache
 
         train_data_dict, image_embeds = owlv2.make_class_embeddings_dict(
             training_data, iou_threshold, return_image_embeds=True
@@ -1001,7 +1007,13 @@ class SerializedOwlV2(RoboflowInferenceModel):
         self.roboflow_id = self.model_data["roboflow_id"]
         # Use the same cached OwlV2 instance mechanism to avoid creating duplicates
         self.owlv2 = self.__class__.get_or_create_owlv2_instance(self.roboflow_id)
-        self.owlv2.cpu_image_embed_cache = self.model_data["image_embeds"]
+        if isinstance(self.model_data["image_embeds"], LimitedSizeDict):
+            self.owlv2.cpu_image_embed_cache = self.model_data["image_embeds"]
+        else:
+            cache = LimitedSizeDict(size_limit=CPU_IMAGE_EMBED_CACHE_SIZE)
+            for key, value in self.model_data["image_embeds"].items():
+                cache[key] = value
+            self.owlv2.cpu_image_embed_cache = cache
 
     weights_file_path = "weights.pt"
 
@@ -1049,6 +1061,6 @@ class SerializedOwlV2(RoboflowInferenceModel):
             self.huggingface_id,
             self.roboflow_id,
             self.train_data_dict,
-            self.owlv2.cpu_image_embed_cache,
+            {},
             save_dir,
         )

--- a/inference/models/sam3_3d/__init__.py
+++ b/inference/models/sam3_3d/__init__.py
@@ -1,1 +1,3 @@
-from inference.models.sam3_3d.segment_anything_3d import SegmentAnything3_3D_Objects #, SegmentAnything3_3D_Body
+from inference.models.sam3_3d.segment_anything_3d import (  # , SegmentAnything3_3D_Body
+    SegmentAnything3_3D_Objects,
+)


### PR DESCRIPTION
# Description

There was an issue with dragging hard `inference` dependency into serialized owlv2 models - fixed the problem by serilizing empty cache in light-weight artefacts and adjusting loader code to deserialize properly

List any dependencies that are required for this change.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

* e2e
* CI

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
