### PR TITLE
Fix small bug in motion detection

### DIFF
--- a/inference/core/workflows/core_steps/classical_cv/motion_detection/v1.py
+++ b/inference/core/workflows/core_steps/classical_cv/motion_detection/v1.py
@@ -190,7 +190,7 @@ class MotionDetectionBlockV1(WorkflowBlock):
         mask = self.back_sub.apply(frame)
 
         # if frames aren't initialized yet, return no motion
-        if self.frame_count <= history and suppress_first_detections:
+        if self.frame_count < history and suppress_first_detections:
             self.frame_count += 1
             return {
                 "motion": False,


### PR DESCRIPTION
# Description

Motion detection has an option to not start detection motion until the background is initialized. The order of the code however was actually preventing the background from initializing until the time limit hit. This is a very small change to fix the issue. Also filtering out contours of < 3 points earlier rather than hold onto them.

## Type of change

Please delete options that are not relevant.

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Tested locally and with test cases

## Any specific deployment considerations

N/A

## Docs

N/A
