### PR TITLE
timm 1.0.23 introduces error: …

### DIFF
--- a/requirements/requirements.transformers.txt
+++ b/requirements/requirements.transformers.txt
@@ -2,7 +2,7 @@
 torch>=2.0.1,<2.7.0
 torchvision>=0.15.0
 transformers>=4.57.3,<5.0.0
-timm~=1.0.0
+timm<1.0.23
 #accelerate>=0.32,<1.0.0
 accelerate>=1.0.0,<2.0.0
 einops>=0.7.0,<=0.8.0


### PR DESCRIPTION
# Description

[CI failure log](https://github.com/roboflow/inference/actions/runs/20750507749/job/59578364414) shows error: `cannot import name 'RotaryEmbedding' from 'timm.layers.attention_pool2d'`

Temporarily add pin in requirements to cut off `tim==1.0.23`

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

CI passing

## Any specific deployment considerations

N/A

## Docs

N/A