### PR TITLE
Fix rfdetr instance segmentation and object detection postprocessing error

### DIFF
--- a/inference/core/version.py
+++ b/inference/core/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.64.2"
+__version__ = "0.64.3"
 
 
 if __name__ == "__main__":

--- a/inference/models/rfdetr/rfdetr.py
+++ b/inference/models/rfdetr/rfdetr.py
@@ -315,12 +315,15 @@ class RFDETRObjectDetection(ObjectDetectionBaseOnnxRoboflowInferenceModel):
             logits_flat = logits_sigmoid[batch_idx].reshape(-1)
 
             # Use argpartition for better performance when max_detections is smaller than logits_flat
-            partition_indices = np.argpartition(-logits_flat, max_detections)[
-                :max_detections
-            ]
-            sorted_indices = partition_indices[
-                np.argsort(-logits_flat[partition_indices])
-            ]
+            if len(logits_flat) > max_detections:
+                partition_indices = np.argpartition(-logits_flat, max_detections)[
+                    :max_detections
+                ]
+                sorted_indices = partition_indices[
+                    np.argsort(-logits_flat[partition_indices])
+                ]
+            else:
+                sorted_indices = np.argsort(-logits_flat)
             topk_scores = logits_flat[sorted_indices]
 
             conf_mask = topk_scores > confidence
@@ -601,12 +604,15 @@ class RFDETRInstanceSegmentation(
             logits_flat = logits_sigmoid[batch_idx].reshape(-1)
 
             # Use argpartition for better performance when max_detections is smaller than logits_flat
-            partition_indices = np.argpartition(-logits_flat, max_detections)[
-                :max_detections
-            ]
-            sorted_indices = partition_indices[
-                np.argsort(-logits_flat[partition_indices])
-            ]
+            if len(logits_flat) > max_detections:
+                partition_indices = np.argpartition(-logits_flat, max_detections)[
+                    :max_detections
+                ]
+                sorted_indices = partition_indices[
+                    np.argsort(-logits_flat[partition_indices])
+                ]
+            else:
+                sorted_indices = np.argsort(-logits_flat)
             topk_scores = logits_flat[sorted_indices]
 
             conf_mask = topk_scores > confidence


### PR DESCRIPTION
## What does this PR do?

Fix rfdetr instance segmentation and object detection postprocessing unhandled error caused by  argpartition crash when max_detections exceeds logits length

## Type of Change

- Bug fix (non-breaking change that fixes an issue)

## Testing

I tested manually to confirm bug is fixed

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)

## Additional Context

N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes RFDETR postprocessing crash when `max_detections` can exceed logits length.
> 
> - In both `RFDETRObjectDetection.postprocess` and `RFDETRInstanceSegmentation.postprocess`, conditionally use `np.argpartition` only when `len(logits_flat) > max_detections`; otherwise fall back to `np.argsort` to select top scores
> - Bumps `__version__` to `0.64.3`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 476534e6570d2cab9fe737c52248c9e90a546f9d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->