### PR TITLE
Fix workflow endpoints to always record exactly 100ms for usage tracking

### DIFF
--- a/inference/core/env.py
+++ b/inference/core/env.py
@@ -289,6 +289,14 @@ LAMBDA = str2bool(os.getenv("LAMBDA", False))
 # Whether is's GCP serverless service
 GCP_SERVERLESS = str2bool(os.getenv("GCP_SERVERLESS", "False"))
 
+# Fixed usage duration for billing/tracking (in seconds). When set, overrides actual execution time.
+COUNT_FIXED_USAGE = os.getenv("COUNT_FIXED_USAGE")
+if COUNT_FIXED_USAGE:
+    try:
+        COUNT_FIXED_USAGE = float(COUNT_FIXED_USAGE)
+    except (ValueError, TypeError):
+        COUNT_FIXED_USAGE = None
+
 GET_MODEL_REGISTRY_ENABLED = str2bool(os.getenv("GET_MODEL_REGISTRY_ENABLED", "True"))
 
 # Flag to enable API logging, default is False

--- a/inference/core/interfaces/http/http_api.py
+++ b/inference/core/interfaces/http/http_api.py
@@ -1253,7 +1253,6 @@ class HttpInterface(BaseInterface):
                 workflow_id: str,
                 workflow_request: PredefinedWorkflowInferenceRequest,
                 background_tasks: BackgroundTasks,
-                usage_fixed_duration: float = 0.1,
             ) -> WorkflowInferenceResponse:
                 # TODO: get rid of async: https://github.com/roboflow/inference/issues/569
                 if ENABLE_WORKFLOWS_PROFILING and workflow_request.enable_profiling:
@@ -1306,7 +1305,6 @@ class HttpInterface(BaseInterface):
             def infer_from_workflow(
                 workflow_request: WorkflowSpecificationInferenceRequest,
                 background_tasks: BackgroundTasks,
-                usage_fixed_duration: float = 0.1,
             ) -> WorkflowInferenceResponse:
                 # TODO: get rid of async: https://github.com/roboflow/inference/issues/569
                 if ENABLE_WORKFLOWS_PROFILING and workflow_request.enable_profiling:

--- a/inference/usage_tracking/collector.py
+++ b/inference/usage_tracking/collector.py
@@ -27,6 +27,7 @@ from typing_extensions import ParamSpec
 
 from inference.core.env import (
     API_KEY,
+    COUNT_FIXED_USAGE,
     DEDICATED_DEPLOYMENT_ID,
     DEVICE_ID,
     GCP_SERVERLESS,
@@ -708,15 +709,14 @@ class UsageCollector:
                 usage_workflow_preview: bool = False,
                 usage_inference_test_run: bool = False,
                 usage_billable: bool = True,
-                usage_fixed_duration: Optional[float] = None,
                 **kwargs: P.kwargs,
             ) -> T:
                 try:
                     t1 = time.time()
                     res = func(*args, **kwargs)
                     t2 = time.time()
-                    if usage_fixed_duration is not None:
-                        execution_duration = usage_fixed_duration
+                    if COUNT_FIXED_USAGE is not None:
+                        execution_duration = COUNT_FIXED_USAGE
                     elif GCP_SERVERLESS is True:
                         execution_duration = max(t2 - t1, 0.1)
                     else:
@@ -739,8 +739,8 @@ class UsageCollector:
                     )
                 except Exception as exc:
                     t2 = time.time()
-                    if usage_fixed_duration is not None:
-                        execution_duration = usage_fixed_duration
+                    if COUNT_FIXED_USAGE is not None:
+                        execution_duration = COUNT_FIXED_USAGE
                     elif GCP_SERVERLESS is True:
                         execution_duration = max(t2 - t1, 0.1)
                     else:
@@ -777,15 +777,14 @@ class UsageCollector:
                 usage_workflow_preview: bool = False,
                 usage_inference_test_run: bool = False,
                 usage_billable: bool = True,
-                usage_fixed_duration: Optional[float] = None,
                 **kwargs: P.kwargs,
             ) -> T:
                 try:
                     t1 = time.time()
                     res = await func(*args, **kwargs)
                     t2 = time.time()
-                    if usage_fixed_duration is not None:
-                        execution_duration = usage_fixed_duration
+                    if COUNT_FIXED_USAGE is not None:
+                        execution_duration = COUNT_FIXED_USAGE
                     elif GCP_SERVERLESS is True:
                         execution_duration = max(t2 - t1, 0.1)
                     else:
@@ -808,8 +807,8 @@ class UsageCollector:
                     )
                 except Exception as exc:
                     t2 = time.time()
-                    if usage_fixed_duration is not None:
-                        execution_duration = usage_fixed_duration
+                    if COUNT_FIXED_USAGE is not None:
+                        execution_duration = COUNT_FIXED_USAGE
                     elif GCP_SERVERLESS is True:
                         execution_duration = max(t2 - t1, 0.1)
                     else:


### PR DESCRIPTION
## What does this PR do?

This PR modifies workflow endpoints to always record exactly 100ms execution duration for usage tracking/billing purposes via an env var.
**Related Issue(s):** <!-- Link to related issues, e.g., Fixes #123 or Related to #456 -->

## Type of Change

<!-- Please select one and delete the others, or describe if Other -->

- Enhancement to usage collection

## Testing

<!-- Describe how you tested your changes -->

- [ ] I have tested this change locally
- [ ] I have added/updated tests for this change

**Test details:**
<!-- Describe what tests were added/updated and what they cover -->

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where necessary, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have updated the documentation accordingly (if applicable)

## Additional Context

Added an env var for fixing the usage.