### PR TITLE
Refactor middleware: separate structured logging from GCP serverless

### DIFF
--- a/inference/core/interfaces/http/http_api.py
+++ b/inference/core/interfaces/http/http_api.py
@@ -172,6 +172,7 @@ from inference.core.env import (
     ROBOFLOW_INTERNAL_SERVICE_SECRET,
     ROBOFLOW_SERVICE_SECRET,
     SAM3_EXEC_MODE,
+    STRUCTURED_LOGGING_ENABLED,
     WEBRTC_WORKER_ENABLED,
     WORKFLOWS_MAX_CONCURRENT_STEPS,
     WORKFLOWS_PROFILER_BUFFER_SIZE,
@@ -291,21 +292,20 @@ class LambdaMiddleware(BaseHTTPMiddleware):
         return response
 
 
-class GCPServerlessMiddleware(BaseHTTPMiddleware):
-    async def dispatch(self, request, call_next):
-        if execution_id is not None:
-            execution_id_value = request.headers.get(EXECUTION_ID_HEADER)
-            if not execution_id_value:
-                execution_id_value = f"{time.time_ns()}_{uuid4().hex[:4]}"
-            execution_id.set(execution_id_value)
+class StructuredLoggingMiddleware(BaseHTTPMiddleware):
+    """Middleware to set up structured logging request context.
 
-        # Set up structured logging context
+    Sets up RequestContext with request_id (from correlation ID) and hashed api_key.
+    Only active when STRUCTURED_LOGGING_ENABLED=True.
+    """
+
+    async def dispatch(self, request, call_next):
         from inference.core.structured_logging import (
             RequestContext,
             clear_request_context,
-            structured_event_logger,
             hash_api_key,
             set_request_context,
+            structured_event_logger,
         )
 
         if structured_event_logger.enabled:
@@ -326,13 +326,31 @@ class GCPServerlessMiddleware(BaseHTTPMiddleware):
             )
             set_request_context(context)
 
-        t1 = time.time()
         try:
             response = await call_next(request)
         finally:
             if structured_event_logger.enabled:
                 clear_request_context()
 
+        return response
+
+
+class GCPServerlessMiddleware(BaseHTTPMiddleware):
+    """Middleware for GCP-specific serverless concerns.
+
+    Handles execution_id header and processing time header.
+    Only active when GCP_SERVERLESS=True.
+    """
+
+    async def dispatch(self, request, call_next):
+        if execution_id is not None:
+            execution_id_value = request.headers.get(EXECUTION_ID_HEADER)
+            if not execution_id_value:
+                execution_id_value = f"{time.time_ns()}_{uuid4().hex[:4]}"
+            execution_id.set(execution_id_value)
+
+        t1 = time.time()
+        response = await call_next(request)
         t2 = time.time()
         response.headers[PROCESSING_TIME_HEADER] = str(t2 - t1)
         if execution_id is not None:
@@ -414,6 +432,8 @@ class HttpInterface(BaseInterface):
             app.add_middleware(LambdaMiddleware)
         if GCP_SERVERLESS:
             app.add_middleware(GCPServerlessMiddleware)
+        if STRUCTURED_LOGGING_ENABLED:
+            app.add_middleware(StructuredLoggingMiddleware)
 
         if len(ALLOW_ORIGINS) > 0:
             # Add CORS Middleware (but not for /build**, which is controlled separately)


### PR DESCRIPTION
## Summary
Refactored HTTP middleware to separate concerns by extracting structured logging functionality into its own dedicated middleware class. This improves code organization and allows structured logging to be independently enabled/disabled via the `STRUCTURED_LOGGING_ENABLED` configuration flag.

## Key Changes
- **Created `StructuredLoggingMiddleware`**: New middleware class dedicated to setting up structured logging request context with request_id and hashed api_key
- **Refactored `GCPServerlessMiddleware`**: Removed structured logging logic; now focuses solely on GCP-specific concerns (execution_id header and processing time tracking)
- **Added conditional middleware registration**: Both middlewares are now conditionally added based on their respective feature flags (`STRUCTURED_LOGGING_ENABLED` and `GCP_SERVERLESS`)
- **Improved code documentation**: Added docstrings to both middleware classes explaining their purpose and activation conditions
- **Cleaned up imports**: Reorganized imports in `StructuredLoggingMiddleware` for consistency

## Implementation Details
- The `StructuredLoggingMiddleware` is only active when `STRUCTURED_LOGGING_ENABLED=True`, allowing it to be toggled independently
- Processing time measurement remains in `GCPServerlessMiddleware` where it belongs
- Both middlewares properly handle cleanup (context clearing) in their respective domains
- The middleware registration order in the app initialization ensures proper execution flow

https://claude.ai/code/session_01XHjBRQV5q7Nyq7eNEiTAaH