### PR TITLE
Claude opus 4.6 in Claude block

### DIFF
--- a/inference/core/workflows/core_steps/models/foundation/anthropic_claude/v1.py
+++ b/inference/core/workflows/core_steps/models/foundation/anthropic_claude/v1.py
@@ -164,6 +164,7 @@ class BlockManifest(WorkflowBlockManifest):
     model_version: Union[
         Selector(kind=[STRING_KIND]),
         Literal[
+            "claude-opus-4-6",
             "claude-opus-4-5",
             "claude-sonnet-4-5",
             "claude-haiku-4-5",
@@ -368,6 +369,7 @@ def execute_claude_requests(
 
 
 EXACT_MODELS_VERSIONS_MAPPING = {
+    "claude-opus-4-6": "claude-opus-4-6",
     "claude-opus-4-5": "claude-opus-4-5-20251101",
     "claude-sonnet-4-5": "claude-sonnet-4-5-20250929",
     "claude-haiku-4-5": "claude-haiku-4-5-20251001",

--- a/inference/core/workflows/core_steps/models/foundation/anthropic_claude/v2.py
+++ b/inference/core/workflows/core_steps/models/foundation/anthropic_claude/v2.py
@@ -37,6 +37,12 @@ from inference.core.workflows.prototypes.block import (
 
 CLAUDE_MODELS = [
     {
+        "id": "claude-opus-4-6",
+        "name": "Claude Opus 4.6",
+        "exact_version": "claude-opus-4-6",
+        "max_output_tokens": 128000,
+    },
+    {
         "id": "claude-sonnet-4-5",
         "name": "Claude Sonnet 4.5",
         "exact_version": "claude-sonnet-4-5-20250929",

--- a/inference/core/workflows/core_steps/models/foundation/anthropic_claude/v3.py
+++ b/inference/core/workflows/core_steps/models/foundation/anthropic_claude/v3.py
@@ -40,6 +40,12 @@ from inference.core.workflows.prototypes.block import (
 
 CLAUDE_MODELS = [
     {
+        "id": "claude-opus-4-6",
+        "name": "Claude Opus 4.6",
+        "exact_version": "claude-opus-4-6",
+        "max_output_tokens": 128000,
+    },
+    {
         "id": "claude-sonnet-4-5",
         "name": "Claude Sonnet 4.5",
         "exact_version": "claude-sonnet-4-5-20250929",


### PR DESCRIPTION
added claude opus 4.6 to the claude block. Not sure which version of the code block workflows actually use, so i just updated all of them to support it.

## Type of Change

- New feature (non-breaking change that adds functionality)

## Testing

- [ ] I have tested this change locally
- [ ] I have added/updated tests for this change

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where necessary, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have updated the documentation accordingly (if applicable)


