### PR TITLE
Add change to avoid pushing latest tag for rc release

### DIFF
--- a/.github/actions/determine-tags/action.yml
+++ b/.github/actions/determine-tags/action.yml
@@ -84,7 +84,7 @@ runs:
           # Logic for release events
           if [ "$EVENT_NAME" == "release" ]; then
             IMAGE_TAGS="$BASE_IMAGE:$NORMALIZED_RELEASE"
-            if [ "$VERSION" == "$NORMALIZED_RELEASE" ] && [ "$NORMALIZED_RELEASE" == "$NORMALIZED_LATEST_RELEASE" ]; then
+            if [ "$VERSION" == "$NORMALIZED_RELEASE" ] && [ "$NORMALIZED_RELEASE" == "$NORMALIZED_LATEST_RELEASE" ] && [[ "$NORMALIZED_RELEASE" != *rc* ]]; then
               IMAGE_TAGS="$IMAGE_TAGS,$BASE_IMAGE:latest"
             fi
           fi


### PR DESCRIPTION
## What does this PR do?

Adding exclusion from our GHA to determine docker tag - if release has `rc` in tag - we will not publish latest
## Type of Change

<!-- Please select one and delete the others, or describe if Other -->

- Bug fix (non-breaking change that fixes an issue)

## Testing

<!-- Describe how you tested your changes -->

- [x] I have tested this change locally
- [ ] I have added/updated tests for this change

**Test details:**
<!-- Describe what tests were added/updated and what they cover -->

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)

## Additional Context

<!-- Add any other context, screenshots, or notes about the PR here -->
