### PR TITLE
Fix dots in block names

### DIFF
--- a/inference/core/workflows/core_steps/models/foundation/llama_vision/v1.py
+++ b/inference/core/workflows/core_steps/models/foundation/llama_vision/v1.py
@@ -140,7 +140,7 @@ TASKS_REQUIRING_OUTPUT_STRUCTURE = {
 class BlockManifest(WorkflowBlockManifest):
     model_config = ConfigDict(
         json_schema_extra={
-            "name": "Llama 3.2 Vision",
+            "name": "Llama 3_2 Vision",
             "version": "v1",
             "short_description": "Run Llama model with Vision capabilities",
             "long_description": LONG_DESCRIPTION,

--- a/inference/core/workflows/core_steps/models/foundation/qwen/v1.py
+++ b/inference/core/workflows/core_steps/models/foundation/qwen/v1.py
@@ -49,7 +49,7 @@ class BlockManifest(WorkflowBlockManifest):
     # Standard model configuration for UI, schema, etc.
     model_config = ConfigDict(
         json_schema_extra={
-            "name": "Qwen2.5-VL",
+            "name": "Qwen2_5-VL",
             "version": "v1",
             "short_description": "Run Qwen2.5-VL on an image.",
             "long_description": (


### PR DESCRIPTION
Replaced a dot with an underscore for qwen 2.5 and llama 3.2 (default) block name as it messes with workflows.
What's the best github action to add this "dot in a block name is not ok" test to?

## What does this PR do?

**Before**
<img width="1194" height="766" alt="image" src="https://github.com/user-attachments/assets/83288022-4a9e-43e3-9b49-83e368eb7ea5" />

**After**
<img width="1262" height="810" alt="image" src="https://github.com/user-attachments/assets/2d0cfebd-3a91-44ab-ad8c-89e926e2d297" />

okok it still doesn't work but it will once we have serverless async:)
