### PR TITLE
temporarily pin z3-solver version

### DIFF
--- a/.github/workflows/static_code_analysis.yml
+++ b/.github/workflows/static_code_analysis.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on:
       labels: depot-ubuntu-24.04-small
       group: public-depot
-    timeout-minutes: 10
+    timeout-minutes: 5
     steps:
       - name: 🛎️ Checkout
         uses: actions/checkout@v4

--- a/requirements/requirements.code_analysis.txt
+++ b/requirements/requirements.code_analysis.txt
@@ -1,3 +1,4 @@
+z3-solver<=4.15.4.0
 black==24.3.0
 isort==5.13.2
 flake8==7.0.0


### PR DESCRIPTION
## What does this PR do?

static code analysis fails due to error when building z3-solver, pinning z3-solver version to `4.15.4.0` brings back the CI to life

in [static code analysis](https://github.com/roboflow/inference/actions/runs/21860239990/workflow?pr=1990#L13) we use [depot-ubuntu-22.04-small](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md) which happens to have gcc 11 baked into it. According to [this issue](https://github.com/Z3Prover/z3/issues/8536#issuecomment-3867611170) gcc 14 would be preferable for production-ready builds.

Updating depot to [depot-ubuntu-24.04-small](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md) which has gcc 13 (not exactly what we want but according to above mentioned issue features introduced into z3-solver are available starting from gcc 12, with stability in gcc 14) does not fix the problem - z3-solver takes excessive time when building the wheel.

Pinning to `4.15.4.0` is currently the only viable option.

## Type of Change

- Bug fix (non-breaking change that fixes an issue)

## Testing

CI passing

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)

## Additional Context

N/A