### PR TITLE
Fix video frame count estimation by detecting actual FPS from uploaded video

### DIFF
--- a/inference/core/interfaces/webrtc_worker/utils.py
+++ b/inference/core/interfaces/webrtc_worker/utils.py
@@ -280,7 +280,9 @@ def get_video_fps(filepath: str) -> Optional[float]:
                         if int(den) != 0:
                             fps = int(num) / int(den)
                             if fps > 0:
-                                logger.info("Video FPS detected: %.2f from %s", fps, rate_key)
+                                logger.info(
+                                    "Video FPS detected: %.2f from %s", fps, rate_key
+                                )
                                 return fps
         else:
             logger.warning("ffprobe FPS detection failed: %s", result.stderr.strip())

--- a/inference/core/interfaces/webrtc_worker/webrtc.py
+++ b/inference/core/interfaces/webrtc_worker/webrtc.py
@@ -1156,13 +1156,13 @@ async def init_rtc_peer_connection_with_loop(
                         logger.info(
                             "FPS detection: detected=%.2f, previous=%s",
                             detected_fps,
-                            video_processor._declared_fps
+                            video_processor._declared_fps,
                         )
                         video_processor._declared_fps = detected_fps
                     else:
                         logger.warning(
                             "FPS detection failed, keeping default: %s",
-                            video_processor._declared_fps
+                            video_processor._declared_fps,
                         )
 
                     if webrtc_request.webrtc_realtime_processing:


### PR DESCRIPTION
Resolves DG-252

## What does this PR do?


Previously, FPS was assumed to be 30 for all videos. This caused incorrect frame counts in the frontend preview when videos had higher or lower frame rates. This PR uses the actual FPS to calculate frames correctly.


**Related Issue(s):** <!-- Link to related issues, e.g., Fixes #123 or Related to #456 -->

## Type of Change

<!-- Please select one and delete the others, or describe if Other -->

- Bug fix (non-breaking change that fixes an issue)

## Testing

<!-- Describe how you tested your changes -->

- [x] I have tested this change locally
- [ ] I have added/updated tests for this change

**Test details:**
<!-- Describe what tests were added/updated and what they cover -->

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where necessary, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have updated the documentation accordingly (if applicable)

## Additional Context

Before and after:

<img width="221" height="86" alt="image" src="https://github.com/user-attachments/assets/830a7076-fee0-4d88-8269-a838c457c74b" />


<img width="217" height="77" alt="image" src="https://github.com/user-attachments/assets/8d896b0c-5ccb-4b71-ae4f-b2be83f6b3cb" />

