### PR TITLE
Fix overlap filter to use segmentation masks when available (#1987)

### DIFF
--- a/inference/core/workflows/core_steps/analytics/overlap/v1.py
+++ b/inference/core/workflows/core_steps/analytics/overlap/v1.py
@@ -149,6 +149,7 @@ class OverlapBlockV1(WorkflowBlock):
     def masks_overlap(
         cls,
         overlap_mask: np.ndarray,
+        overlap_bbox: list[int],
         other_mask: np.ndarray,
         other_bbox: list[int],
         overlap_type: Literal["Center Overlap", "Any Overlap"],
@@ -157,6 +158,7 @@ class OverlapBlockV1(WorkflowBlock):
 
         Args:
             overlap_mask: Boolean mask of the overlap-class detection.
+            overlap_bbox: Bounding box [x1, y1, x2, y2] of the overlap-class detection.
             other_mask: Boolean mask of the other detection.
             other_bbox: Bounding box [x1, y1, x2, y2] of the other detection.
             overlap_type: "Center Overlap" checks whether the center of
@@ -171,7 +173,20 @@ class OverlapBlockV1(WorkflowBlock):
                 return bool(overlap_mask[cy, cx])
             return False
         else:
-            return bool(np.logical_and(overlap_mask, other_mask).any())
+            # masks lie within their bboxes, so only the bbox intersection can
+            # share pixels - restrict logical_and there to skip a full (H, W) scan
+            h, w = overlap_mask.shape
+            x1 = max(int(np.floor(max(overlap_bbox[0], other_bbox[0]))), 0)
+            y1 = max(int(np.floor(max(overlap_bbox[1], other_bbox[1]))), 0)
+            x2 = min(int(np.ceil(min(overlap_bbox[2], other_bbox[2]))), w)
+            y2 = min(int(np.ceil(min(overlap_bbox[3], other_bbox[3]))), h)
+            if x1 >= x2 or y1 >= y2:
+                return False
+            return bool(
+                np.logical_and(
+                    overlap_mask[y1:y2, x1:x2], other_mask[y1:y2, x1:x2]
+                ).any()
+            )
 
     def run(
         self,
@@ -180,10 +195,8 @@ class OverlapBlockV1(WorkflowBlock):
         overlap_class_name: str,
     ) -> BlockResult:
 
-        has_masks = (
-            getattr(predictions, "mask", None) is not None
-            and len(predictions.mask) == len(predictions.xyxy)
-        )
+        mask = getattr(predictions, "mask", None)
+        has_masks = mask is not None and len(mask) == len(predictions.xyxy)
 
         overlap_indices = []
         others = {}
@@ -205,10 +218,11 @@ class OverlapBlockV1(WorkflowBlock):
                     k
                     for k in others
                     if OverlapBlockV1.masks_overlap(
-                        predictions.mask[oi],
-                        predictions.mask[k],
-                        predictions.xyxy[k],
-                        overlap_type,
+                        overlap_mask=predictions.mask[oi],
+                        overlap_bbox=predictions.xyxy[oi],
+                        other_mask=predictions.mask[k],
+                        other_bbox=predictions.xyxy[k],
+                        overlap_type=overlap_type,
                     )
                 }
             else:

--- a/tests/workflows/unit_tests/core_steps/analytics/test_coords_overlap_v1.py
+++ b/tests/workflows/unit_tests/core_steps/analytics/test_coords_overlap_v1.py
@@ -1,6 +1,11 @@
+import numpy as np
 import pytest
+import supervision as sv
 
-from inference.core.workflows.core_steps.analytics.overlap.v1 import OverlapBlockV1
+from inference.core.workflows.core_steps.analytics.overlap.v1 import (
+    OUTPUT_KEY,
+    OverlapBlockV1,
+)
 
 
 def test_coords_overlap():
@@ -16,3 +21,225 @@ def test_coords_overlap():
     assert OverlapBlockV1.coords_overlap(
         [0, 0, 20, 20], [15, 15, 35, 35], "Any Overlap"
     )
+
+
+def _make_segmentation_detections(
+    xyxy: np.ndarray,
+    masks: np.ndarray,
+    class_names: list,
+) -> sv.Detections:
+    """Helper to build sv.Detections with segmentation masks."""
+    n = len(xyxy)
+    return sv.Detections(
+        xyxy=xyxy,
+        mask=masks,
+        confidence=np.ones(n) * 0.9,
+        class_id=np.arange(n),
+        data={"class_name": np.array(class_names)},
+    )
+
+
+def test_overlap_run_masks_no_false_positive():
+    """
+    Regression test for GitHub Issue #1987:
+    https://github.com/roboflow/inference/issues/1987
+
+    When instance segmentation masks are present, the overlap block must
+    use pixel-level mask overlap — not just bounding-box overlap.
+
+    Scenario (100x100 image):
+      "container" — bbox [0,0,100,100], mask covers ONLY bottom-left
+                    quadrant (rows 50-99, cols 0-49)
+      "item"      — bbox [60,10,90,40], in the TOP-RIGHT area
+
+    Bounding boxes overlap, but masks do NOT.
+    The block should report NO overlap.
+    """
+    image_h, image_w = 100, 100
+
+    xyxy = np.array(
+        [
+            [0, 0, 100, 100],  # container — large bbox
+            [60, 10, 90, 40],  # item — top-right bbox
+        ],
+        dtype=np.float32,
+    )
+
+    masks = np.zeros((2, image_h, image_w), dtype=bool)
+    masks[0, 50:100, 0:50] = True  # container mask: bottom-left only
+    masks[1, 10:40, 60:90] = True  # item mask: top-right
+
+    detections = _make_segmentation_detections(
+        xyxy=xyxy, masks=masks, class_names=["container", "item"]
+    )
+
+    # Sanity check: masks do NOT overlap at the pixel level
+    assert not np.logical_and(masks[0], masks[1]).any(), (
+        "Sanity check failed: masks should not overlap"
+    )
+
+    block = OverlapBlockV1()
+
+    result_any = block.run(
+        predictions=detections,
+        overlap_type="Any Overlap",
+        overlap_class_name="container",
+    )
+    result_center = block.run(
+        predictions=detections,
+        overlap_type="Center Overlap",
+        overlap_class_name="container",
+    )
+
+    # Masks don't overlap, so no detections should be returned
+    assert len(result_any[OUTPUT_KEY]) == 0, (
+        "Expected no overlap — masks do not intersect"
+    )
+    assert len(result_center[OUTPUT_KEY]) == 0, (
+        "Expected no overlap — masks do not intersect"
+    )
+
+
+def test_masks_overlap():
+    """Unit tests for the masks_overlap classmethod, mirroring test_coords_overlap."""
+    image_h, image_w = 100, 100
+
+    # overlap mask: bottom-left quadrant
+    overlap_mask = np.zeros((image_h, image_w), dtype=bool)
+    overlap_mask[50:100, 0:50] = True
+
+    # other mask in top-right — no pixel overlap
+    other_mask_far = np.zeros((image_h, image_w), dtype=bool)
+    other_mask_far[10:40, 60:90] = True
+    other_bbox_far = [60, 10, 90, 40]
+
+    # other mask inside overlap — pixel overlap exists
+    other_mask_inside = np.zeros((image_h, image_w), dtype=bool)
+    other_mask_inside[60:80, 20:40] = True
+    other_bbox_inside = [20, 60, 40, 80]
+
+    # No overlap cases
+    assert not OverlapBlockV1.masks_overlap(
+        overlap_mask, other_mask_far, other_bbox_far, "Center Overlap"
+    )
+    assert not OverlapBlockV1.masks_overlap(
+        overlap_mask, other_mask_far, other_bbox_far, "Any Overlap"
+    )
+
+    # Overlap cases
+    assert OverlapBlockV1.masks_overlap(
+        overlap_mask, other_mask_inside, other_bbox_inside, "Center Overlap"
+    )
+    assert OverlapBlockV1.masks_overlap(
+        overlap_mask, other_mask_inside, other_bbox_inside, "Any Overlap"
+    )
+
+
+def test_overlap_run_bbox_fallback_without_masks():
+    """
+    When predictions have no masks (plain object detection), the block
+    falls back to bounding-box overlap — same behavior as before the fix.
+    """
+    xyxy = np.array(
+        [
+            [0, 0, 100, 100],  # container
+            [10, 10, 50, 50],  # item — bbox inside container
+        ],
+        dtype=np.float32,
+    )
+
+    detections = sv.Detections(
+        xyxy=xyxy,
+        confidence=np.array([0.9, 0.9]),
+        class_id=np.array([0, 1]),
+        data={"class_name": np.array(["container", "item"])},
+    )
+
+    block = OverlapBlockV1()
+    result = block.run(
+        predictions=detections,
+        overlap_type="Any Overlap",
+        overlap_class_name="container",
+    )
+
+    # No masks → bbox overlap is used; bboxes overlap → item is found
+    assert len(result[OUTPUT_KEY]) == 1
+    assert result[OUTPUT_KEY].data["class_name"][0] == "item"
+
+
+def test_overlap_run_with_masks_true_positive():
+    """
+    Control test: when masks DO overlap, the block should (and does)
+    report them as overlapping. This verifies the block works correctly
+    in the non-buggy case (where bbox overlap matches mask overlap).
+
+    Scenario (100x100 image):
+      "container" — bbox [0,0,100,100], mask covers bottom-left quadrant
+      "item"      — bbox [20,60,40,80], placed INSIDE the container mask
+    """
+    image_h, image_w = 100, 100
+
+    xyxy = np.array(
+        [
+            [0, 0, 100, 100],  # container
+            [20, 60, 40, 80],  # item — inside container's mask
+        ],
+        dtype=np.float32,
+    )
+
+    masks = np.zeros((2, image_h, image_w), dtype=bool)
+    masks[0, 50:100, 0:50] = True  # container mask: bottom-left
+    masks[1, 60:80, 20:40] = True  # item mask: inside container mask
+
+    detections = _make_segmentation_detections(
+        xyxy=xyxy, masks=masks, class_names=["container", "item"]
+    )
+
+    # Sanity check: masks DO overlap
+    assert np.logical_and(masks[0], masks[1]).any(), (
+        "Sanity check failed: masks should overlap"
+    )
+
+    block = OverlapBlockV1()
+    result = block.run(
+        predictions=detections,
+        overlap_type="Any Overlap",
+        overlap_class_name="container",
+    )
+
+    # This correctly reports overlap (both bbox and mask agree)
+    assert len(result[OUTPUT_KEY]) == 1
+    assert result[OUTPUT_KEY].data["class_name"][0] == "item"
+
+
+def test_overlap_run_no_overlap_at_all():
+    """
+    When neither bboxes nor masks overlap, the block correctly
+    reports no overlap. Baseline sanity test.
+    """
+    image_h, image_w = 100, 100
+
+    xyxy = np.array(
+        [
+            [0, 0, 30, 30],   # container — top-left
+            [70, 70, 90, 90],  # item — bottom-right, far away
+        ],
+        dtype=np.float32,
+    )
+
+    masks = np.zeros((2, image_h, image_w), dtype=bool)
+    masks[0, 0:30, 0:30] = True
+    masks[1, 70:90, 70:90] = True
+
+    detections = _make_segmentation_detections(
+        xyxy=xyxy, masks=masks, class_names=["container", "item"]
+    )
+
+    block = OverlapBlockV1()
+    result = block.run(
+        predictions=detections,
+        overlap_type="Any Overlap",
+        overlap_class_name="container",
+    )
+
+    assert len(result[OUTPUT_KEY]) == 0

--- a/tests/workflows/unit_tests/core_steps/analytics/test_coords_overlap_v1.py
+++ b/tests/workflows/unit_tests/core_steps/analytics/test_coords_overlap_v1.py
@@ -74,9 +74,9 @@ def test_overlap_run_masks_no_false_positive():
     )
 
     # Sanity check: masks do NOT overlap at the pixel level
-    assert not np.logical_and(masks[0], masks[1]).any(), (
-        "Sanity check failed: masks should not overlap"
-    )
+    assert not np.logical_and(
+        masks[0], masks[1]
+    ).any(), "Sanity check failed: masks should not overlap"
 
     block = OverlapBlockV1()
 
@@ -92,46 +92,64 @@ def test_overlap_run_masks_no_false_positive():
     )
 
     # Masks don't overlap, so no detections should be returned
-    assert len(result_any[OUTPUT_KEY]) == 0, (
-        "Expected no overlap — masks do not intersect"
-    )
-    assert len(result_center[OUTPUT_KEY]) == 0, (
-        "Expected no overlap — masks do not intersect"
-    )
+    assert (
+        len(result_any[OUTPUT_KEY]) == 0
+    ), "Expected no overlap — masks do not intersect"
+    assert (
+        len(result_center[OUTPUT_KEY]) == 0
+    ), "Expected no overlap — masks do not intersect"
 
 
 def test_masks_overlap():
     """Unit tests for the masks_overlap classmethod, mirroring test_coords_overlap."""
     image_h, image_w = 100, 100
 
-    # overlap mask: bottom-left quadrant
+    # overlap mask: bottom-left quadrant. Coords are float32 to mirror real
+    # sv.Detections.xyxy, which guards against integer-only mask slicing.
     overlap_mask = np.zeros((image_h, image_w), dtype=bool)
     overlap_mask[50:100, 0:50] = True
+    overlap_bbox = np.array([0, 50, 50, 100], dtype=np.float32)
 
-    # other mask in top-right — no pixel overlap
+    # other mask in top-right — no pixel overlap (and disjoint bounding boxes)
     other_mask_far = np.zeros((image_h, image_w), dtype=bool)
     other_mask_far[10:40, 60:90] = True
-    other_bbox_far = [60, 10, 90, 40]
+    other_bbox_far = np.array([60, 10, 90, 40], dtype=np.float32)
 
     # other mask inside overlap — pixel overlap exists
     other_mask_inside = np.zeros((image_h, image_w), dtype=bool)
     other_mask_inside[60:80, 20:40] = True
-    other_bbox_inside = [20, 60, 40, 80]
+    other_bbox_inside = np.array([20, 60, 40, 80], dtype=np.float32)
 
     # No overlap cases
     assert not OverlapBlockV1.masks_overlap(
-        overlap_mask, other_mask_far, other_bbox_far, "Center Overlap"
+        overlap_mask=overlap_mask,
+        overlap_bbox=overlap_bbox,
+        other_mask=other_mask_far,
+        other_bbox=other_bbox_far,
+        overlap_type="Center Overlap",
     )
     assert not OverlapBlockV1.masks_overlap(
-        overlap_mask, other_mask_far, other_bbox_far, "Any Overlap"
+        overlap_mask=overlap_mask,
+        overlap_bbox=overlap_bbox,
+        other_mask=other_mask_far,
+        other_bbox=other_bbox_far,
+        overlap_type="Any Overlap",
     )
 
     # Overlap cases
     assert OverlapBlockV1.masks_overlap(
-        overlap_mask, other_mask_inside, other_bbox_inside, "Center Overlap"
+        overlap_mask=overlap_mask,
+        overlap_bbox=overlap_bbox,
+        other_mask=other_mask_inside,
+        other_bbox=other_bbox_inside,
+        overlap_type="Center Overlap",
     )
     assert OverlapBlockV1.masks_overlap(
-        overlap_mask, other_mask_inside, other_bbox_inside, "Any Overlap"
+        overlap_mask=overlap_mask,
+        overlap_bbox=overlap_bbox,
+        other_mask=other_mask_inside,
+        other_bbox=other_bbox_inside,
+        overlap_type="Any Overlap",
     )
 
 
@@ -196,9 +214,9 @@ def test_overlap_run_with_masks_true_positive():
     )
 
     # Sanity check: masks DO overlap
-    assert np.logical_and(masks[0], masks[1]).any(), (
-        "Sanity check failed: masks should overlap"
-    )
+    assert np.logical_and(
+        masks[0], masks[1]
+    ).any(), "Sanity check failed: masks should overlap"
 
     block = OverlapBlockV1()
     result = block.run(
@@ -221,7 +239,7 @@ def test_overlap_run_no_overlap_at_all():
 
     xyxy = np.array(
         [
-            [0, 0, 30, 30],   # container — top-left
+            [0, 0, 30, 30],  # container — top-left
             [70, 70, 90, 90],  # item — bottom-right, far away
         ],
         dtype=np.float32,


### PR DESCRIPTION
## What does this PR do?

This PR fixes the `Overlap Filter` workflow block (`roboflow_core/overlap@v1`) so that **instance segmentation predictions use masks for overlap checks**, rather than implicitly falling back to bounding-box-only overlap.

Before this change, `OverlapBlockV1.run()` only used `predictions.xyxy`, which could produce **false positives** for segmented objects with irregular shapes (their bounding boxes overlap even when the masks do not).

This PR:
- Uses **pixel-level mask overlap** when segmentation masks are present (and consistent with detection length)
- Keeps the existing bbox overlap behavior as a **fallback** when masks are not present
- Makes output ordering deterministic by sorting indices before indexing into `sv.Detections`
- Adds/updates unit tests covering the regression and both mask/bbox code paths

**Related Issue(s):** Fixes #1987

## Type of Change

- Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] I have tested this change locally
- [x] I have added/updated tests for this change

**Test details:**
- Updated/expanded unit tests for the overlap block to include:
  - A regression test demonstrating the original false-positive case for instance segmentation (bbox overlap but masks do not overlap)
  - Direct tests for the new mask overlap helper (`Center Overlap` and `Any Overlap`)
  - A fallback test verifying bbox-only behavior still works when masks are absent
  - Existing sanity tests for true-positive overlap and no-overlap scenarios

Example command run locally:
- `pytest tests/workflows/unit_tests/core_steps/analytics/test_coords_overlap_v1.py -v`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)

## Additional Context

I’m new to the repo, so please let me know if you’d prefer this behavior behind a new version (e.g. `@v2`) or if the current approach (fixing `@v1` since it already accepts instance segmentation predictions) is aligned with the project’s versioning expectations. Happy to adjust based on maintainer feedback.