### PR TITLE
Bug/dg 306 wrong workflow that doesnt raise error and provokes 500

### DIFF
--- a/inference/core/interfaces/http/http_api.py
+++ b/inference/core/interfaces/http/http_api.py
@@ -248,7 +248,7 @@ from inference.core.roboflow_api import (
 from inference.core.utils.container import is_docker_socket_mounted
 from inference.core.utils.notebooks import start_notebook
 from inference.core.workflows.core_steps.common.entities import StepExecutionMode
-from inference.core.workflows.errors import WorkflowSyntaxError
+from inference.core.workflows.errors import WorkflowError, WorkflowSyntaxError
 from inference.core.workflows.execution_engine.core import (
     ExecutionEngine,
     get_available_versions,
@@ -1638,13 +1638,12 @@ class HttpInterface(BaseInterface):
                         raise WorkflowSyntaxError(
                             public_message=worker_result.error_message,
                             context=worker_result.error_context,
-                            inner_error=None,
+                            inner_error=worker_result.inner_error,
                         )
                     if worker_result.exception_type == "WorkflowError":
                         raise WorkflowError(
                             public_message=worker_result.error_message,
                             context=worker_result.error_context,
-                            inner_error=None,
                         )
                     expected_exceptions = {
                         "Exception": Exception,


### PR DESCRIPTION
## What does this PR do?

fixed bug returning 400 error instead of saying exactly what was wrong

**Related Issue(s):** <!-- Link to related issues, e.g., Fixes #123 or Related to #456 -->

## Type of Change

<!-- Please select one and delete the others, or describe if Other -->

- Bug fix (non-breaking change that fixes an issue)
 

## Testing

<!-- Describe how you tested your changes -->

- [x] I have tested this change locally
- [ ] I have added/updated tests for this change

**Test details:**
<!-- Describe what tests were added/updated and what they cover -->

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where necessary, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have updated the documentation accordingly (if applicable)

## Additional Context
 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small change limited to error mapping for the WebRTC worker HTTP endpoint; behavior change is confined to how certain worker failures are surfaced to clients.
> 
> **Overview**
> Fixes WebRTC workflow error propagation by explicitly importing and re-raising `WorkflowError` (in addition to `WorkflowSyntaxError`) when returned from the WebRTC worker.
> 
> This prevents generic exception handling from turning known workflow failures into less-informative 500s, improving client-visible error messages/context for invalid workflow executions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dd9199a475d199df92e32dd7e7572e7807d62e04. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->