### PR TITLE
Expose inference configuration flags for sam3-3d

### DIFF
--- a/inference/core/entities/requests/sam3_3d.py
+++ b/inference/core/entities/requests/sam3_3d.py
@@ -30,6 +30,28 @@ class Sam3_3D_Objects_InferenceRequest(BaseRequest):
         default="sam3-3d-objects", description="The model ID for SAM3_3D."
     )
 
+    output_meshes: Optional[bool] = Field(
+        default=True,
+        description="SAM3 3D always outputs object gaussians, and can optionally output object meshes if output_meshes is True.",
+    )
+
+    output_scene: Optional[bool] = Field(
+        default=True,
+        description="Output the combined scene reconstruction in addition to individual object reconstructions.",
+    )
+
+    with_mesh_postprocess: Optional[bool] = Field(
+        default=True, description="Enable mesh postprocessing."
+    )
+
+    with_texture_baking: Optional[bool] = Field(
+        default=True, description="Enable texture baking for meshes."
+    )
+
+    use_distillations: Optional[bool] = Field(
+        default=False, description="Use the distilled versions of the model components."
+    )
+
     @validator("model_id", always=True)
     def validate_model_id(cls, value):
         if value is not None:

--- a/inference_sdk/http/client.py
+++ b/inference_sdk/http/client.py
@@ -1858,6 +1858,12 @@ class InferenceHTTPClient:
         inference_input: ImagesReference,
         mask_input: Any,
         model_id: str = "sam3-3d-objects",
+        *,
+        output_meshes: bool = True,
+        output_scene: bool = True,
+        with_mesh_postprocess: bool = True,
+        with_texture_baking: bool = True,
+        use_distillations: bool = False,
     ) -> dict:
         """Generate 3D meshes and Gaussian splatting from a 2D image with mask prompts.
 
@@ -1873,14 +1879,21 @@ class InferenceHTTPClient:
                 - RLE dictionary
                 - List of any of the above for multiple masks
             model_id (str, optional): The SAM3 3D model to use. Defaults to "sam3-3d-objects".
+            output_meshes (bool, optional): SAM3 3D always outputs object gaussians, and can
+                optionally output object meshes if output_meshes is True. Defaults to True.
+            output_scene (bool, optional): Output the combined scene reconstruction in
+                addition to individual object reconstructions. Defaults to True.
+            with_mesh_postprocess (bool, optional): Enable mesh postprocessing. Defaults to True.
+            with_texture_baking (bool, optional): Enable texture baking for meshes. Defaults to True.
+            use_distillations (bool, optional): Use the distilled versions of the model components.
 
         Returns:
             dict: Response containing base64-encoded 3D outputs:
-                - mesh_glb: Scene mesh in GLB format (base64 encoded)
+                - mesh_glb: Scene mesh in GLB format (base64 encoded) if output_meshes=True, otherwise None.
                 - gaussian_ply: Combined Gaussian splatting in PLY format (base64 encoded)
                 - objects: List of individual objects, each containing:
-                    - mesh_glb: Object mesh (base64)
-                    - gaussian_ply: Object Gaussian (base64)
+                    - mesh_glb: Object mesh (base64) if output_scene=True and output_meshes=True, otherwise None.
+                    - gaussian_ply: Object Gaussian (base64) if output_scene=True, otherwise None.
                     - metadata: {"rotation": [...], "translation": [...], "scale": [...]}
                 - time: Inference time in seconds
 
@@ -1894,6 +1907,11 @@ class InferenceHTTPClient:
         payload = self.__initialise_payload()
         payload["model_id"] = model_id
         payload["mask_input"] = mask_input
+        payload["output_meshes"] = output_meshes
+        payload["output_scene"] = output_scene
+        payload["with_mesh_postprocess"] = with_mesh_postprocess
+        payload["with_texture_baking"] = with_texture_baking
+        payload["use_distillations"] = use_distillations
 
         url = self.__wrap_url_with_api_key(f"{self.__api_url}/sam3_3d/infer")
         requests_data = prepare_requests_data(
@@ -1918,6 +1936,12 @@ class InferenceHTTPClient:
         inference_input: ImagesReference,
         mask_input: Any,
         model_id: str = "sam3-3d-objects",
+        *,
+        output_meshes: bool = True,
+        output_scene: bool = True,
+        with_mesh_postprocess: bool = True,
+        with_texture_baking: bool = True,
+        use_distillations: bool = False,
     ) -> dict:
         """Generate 3D meshes and Gaussian splatting from a 2D image asynchronously.
 
@@ -1925,9 +1949,23 @@ class InferenceHTTPClient:
             inference_input (ImagesReference): Input image for 3D generation.
             mask_input (Any): Mask input in any supported format.
             model_id (str, optional): The SAM3 3D model to use. Defaults to "sam3-3d-objects".
+            output_meshes (bool, optional): SAM3 3D always outputs object gaussians, and can
+                optionally output object meshes if output_meshes is True. Defaults to True.
+            output_scene (bool, optional): Output the combined scene reconstruction in
+                addition to individual object reconstructions. Defaults to True.
+            with_mesh_postprocess (bool, optional): Enable mesh postprocessing. Defaults to True.
+            with_texture_baking (bool, optional): Enable texture baking for meshes. Defaults to True.
+            use_distillations (bool, optional): Use the distilled versions of the model components.
 
         Returns:
-            dict: Response containing base64-encoded 3D outputs.
+            dict: Response containing base64-encoded 3D outputs:
+                - mesh_glb: Scene mesh in GLB format (base64 encoded) if output_meshes=True, otherwise None.
+                - gaussian_ply: Combined Gaussian splatting in PLY format (base64 encoded)
+                - objects: List of individual objects, each containing:
+                    - mesh_glb: Object mesh (base64) if output_scene=True and output_meshes=True, otherwise None.
+                    - gaussian_ply: Object Gaussian (base64) if output_scene=True, otherwise None.
+                    - metadata: {"rotation": [...], "translation": [...], "scale": [...]}
+                - time: Inference time in seconds
 
         Raises:
             HTTPCallErrorError: If there is an error in the HTTP call.
@@ -1939,6 +1977,11 @@ class InferenceHTTPClient:
         payload = self.__initialise_payload()
         payload["model_id"] = model_id
         payload["mask_input"] = mask_input
+        payload["output_meshes"] = output_meshes
+        payload["output_scene"] = output_scene
+        payload["with_mesh_postprocess"] = with_mesh_postprocess
+        payload["with_texture_baking"] = with_texture_baking
+        payload["use_distillations"] = use_distillations
 
         url = self.__wrap_url_with_api_key(f"{self.__api_url}/sam3_3d/infer")
         requests_data = prepare_requests_data(


### PR DESCRIPTION
## What does this PR do?

<!-- Provide a clear and concise description of the changes -->

The SAM-3D inference pipeline offers some useful configuration flags that allow toggling certain pipeline steps on or off, and switching to a Meta-provided distillation of the model. See:

https://github.com/roboflow/tdfy/blob/main/tdfy/sam3d_v1/lidra/pipeline/inference_pipeline.py#L640-L654

They have some dependencies between them, for example the mesh decoder depends on the gaussian decoder so in practice `decode_formats = ["mesh"]` is an error. This PR exposes some new boolean flags offering some simplified control over these variables. The default settings are the "full fat" SAM-3D configuration.

I have intentionally not exposed a flag to enable `torch_compile` because in my experiments the compilation step takes ~20 min on first inference and does not noticeably speed up subsequent inferences.

## Type of Change

<!-- Please select one and delete the others, or describe if Other -->

- New feature (non-breaking change that adds functionality)

## Testing

<!-- Describe how you tested your changes -->

- [x] I have tested this change locally
- [ ] I have added/updated tests for this change <-- sam3-3d is experimental and does not currently have tests

**Test details:**
<!-- Describe what tests were added/updated and what they cover -->

Tested sam3_3d_infer() with these flags against local inference server on A100 VM built from Dockerfile.onnx.gpu.3d

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)

## Additional Context

<!-- Add any other context, screenshots, or notes about the PR here -->
