### PR TITLE
Fix JP7.1 container build OOM during ORT compilation

### DIFF
--- a/docker/dockerfiles/Dockerfile.onnx.jetson.7.1.0
+++ b/docker/dockerfiles/Dockerfile.onnx.jetson.7.1.0
@@ -7,7 +7,7 @@ ARG CMAKE_VERSION=4.2.0
 ARG PYTORCH_VERSION=2.10.0
 ARG TORCHVISION_VERSION=0.25.0
 ARG OPENCV_VERSION=4.10.0
-ARG ONNXRUNTIME_VERSION=1.21.0
+ARG ONNXRUNTIME_VERSION=1.24.2
 ENV LANG=en_US.UTF-8
 
 WORKDIR /build
@@ -132,7 +132,7 @@ RUN for i in 1 2 3; do \
     python3 -m pip install --break-system-packages dist/torchvision-*.whl
 
 # Build ONNX Runtime GPU from source with CUDA 13 and TensorRT 10.13 support
-# Pinned to v1.21.0 release tag for reproducible builds
+# Pinned to v1.24.2 release tag (includes CUDA 13 fix PR #26153 and TensorRT 10.13 support)
 # No prebuilt ARM64 CUDA 13 packages available - must build from source
 # Parallel jobs limited to 8 to prevent OOM during flash attention CUDA kernel compilation
 WORKDIR /build/onnxruntime


### PR DESCRIPTION
## Summary
- Pin ONNX Runtime to `v1.21.0` release tag instead of cloning unpinned `main` — makes builds reproducible and avoids breaking changes
- Limit parallel build jobs from 32 (default) to 8 to prevent the Linux OOM killer from terminating `nvcc` processes during flash attention CUDA kernel compilation (`flash_fwd_hdim*_sm80.cu`)

All 10 recent CI builds were failing at the same step with `Error 137` (SIGKILL/OOM) while compiling `onnxruntime_providers_cuda`.

## Test plan
- [ ] JP7.1 container build workflow passes (triggered on this branch)