### PR TITLE
Fix: Updated aiohttp to >=3.13.3 to address CVEs (#1949)

### DIFF
--- a/requirements/requirements.cli.txt
+++ b/requirements/requirements.cli.txt
@@ -9,7 +9,7 @@ opencv-python>=4.8.1.78,<=4.10.0.84
 tqdm>=4.0.0,<5.0.0
 nvidia-ml-py<13.0.0
 py-cpuinfo~=9.0.0
-aiohttp>=3.9.0,<=3.10.11
+aiohttp>=3.13.3
 backoff~=2.2.0
 pandas>=2.2.3,<3.0.0
 pybase64~=1.0.0

--- a/requirements/requirements.sdk.http.txt
+++ b/requirements/requirements.sdk.http.txt
@@ -4,6 +4,6 @@ opencv-python>=4.8.1.78,<=4.10.0.84
 pillow>=11.0,<12.0
 supervision>=0.26
 numpy>=2.0.0,<2.4.0
-aiohttp>=3.9.0,<=3.10.11
+aiohttp>=3.13.3
 backoff~=2.2.0
 py-cpuinfo~=9.0.0


### PR DESCRIPTION
## What does this PR do?

- Updates the `aiohttp` dependency to allow patched versions that fix multiple published CVEs.

**Related Issue(s):** Fixes #1949

## Type of Change

- Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] I have tested this change locally
- [ ] I have added/updated tests for this change

**Test details:**

- Installed the project with the updated `aiohttp` constraint.
- Ran SDK HTTP tests:

  pytest tests/inference_sdk/unit_tests/http/ -q

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)

## Additional Context

<!-- Add any other context, screenshots, or notes about the PR here -->
