### PR TITLE
feat: gate structured access logging behind STRUCTURED_API_LOGGING env var

### DIFF
--- a/inference/core/env.py
+++ b/inference/core/env.py
@@ -320,6 +320,10 @@ GET_MODEL_REGISTRY_ENABLED = str2bool(os.getenv("GET_MODEL_REGISTRY_ENABLED", "T
 # Flag to enable API logging, default is False
 API_LOGGING_ENABLED = str2bool(os.getenv("API_LOGGING_ENABLED", "False"))
 
+# Flag to enable structured access logging (JSON access logs replacing uvicorn's
+# default access log). Requires API_LOGGING_ENABLED=True. Default is False.
+STRUCTURED_API_LOGGING = str2bool(os.getenv("STRUCTURED_API_LOGGING", "False"))
+
 # Header where correlaction ID for logging is stored
 CORRELATION_ID_HEADER = os.getenv("CORRELATION_ID_HEADER", "X-Request-ID")
 
@@ -332,7 +336,7 @@ LEGACY_ROUTE_ENABLED = str2bool(os.getenv("LEGACY_ROUTE_ENABLED", True))
 # License server, default is None
 LICENSE_SERVER = os.getenv("LICENSE_SERVER", None)
 
-# Log level, default is "INFO"
+# Log level, default is "WARNING"
 LOG_LEVEL = os.getenv("LOG_LEVEL", "WARNING")
 
 # Maximum number of active models, default is 8

--- a/inference/core/interfaces/http/http_api.py
+++ b/inference/core/interfaces/http/http_api.py
@@ -186,6 +186,7 @@ from inference.core.env import (
     ROBOFLOW_SERVICE_SECRET,
     SAM3_EXEC_MODE,
     SAM3_FINE_TUNED_MODELS_ENABLED,
+    STRUCTURED_API_LOGGING,
     USE_INFERENCE_MODELS,
     WEBRTC_WORKER_ENABLED,
     WORKFLOWS_MAX_CONCURRENT_STEPS,
@@ -490,11 +491,12 @@ class HttpInterface(BaseInterface):
                 validator=lambda a: True,
                 transformer=lambda a: a,
             )
-            # Suppress uvicorn's default access log to avoid duplicate
-            # unstructured entries — we replace it with a structured
-            # access log middleware (see structured_access_log below).
-            logging.getLogger("uvicorn.access").handlers = []
-            logging.getLogger("uvicorn.access").propagate = False
+            if STRUCTURED_API_LOGGING:
+                # Suppress uvicorn's default access log to avoid duplicate
+                # unstructured entries — we replace it with a structured
+                # access log middleware (see structured_access_log below).
+                logging.getLogger("uvicorn.access").handlers = []
+                logging.getLogger("uvicorn.access").propagate = False
         else:
             app.add_middleware(asgi_correlation_id.CorrelationIdMiddleware)
 
@@ -748,7 +750,7 @@ class HttpInterface(BaseInterface):
                 response.headers[WORKFLOW_ID_HEADER] = wf_id
             return response
 
-        if API_LOGGING_ENABLED:
+        if API_LOGGING_ENABLED and STRUCTURED_API_LOGGING:
 
             @app.middleware("http")
             async def structured_access_log(request: Request, call_next):
@@ -780,7 +782,10 @@ class HttpInterface(BaseInterface):
                     if value is not None:
                         log_fields[field_name] = value
 
-                logger.info("access", **log_fields)
+                logger.info(
+                    f"{request.method} {request.url.path} {response.status_code}",
+                    **log_fields,
+                )
                 return response
 
         self.app = app


### PR DESCRIPTION
## Summary

- Introduces `STRUCTURED_API_LOGGING` env var (default: `False`) to gate the structured access logging changes from PR #2053
- When `API_LOGGING_ENABLED=True` alone (no `STRUCTURED_API_LOGGING`), behavior reverts to pre-#2053: uvicorn access logs work normally
- When both `API_LOGGING_ENABLED=True` and `STRUCTURED_API_LOGGING=True`: structured JSON access logs, uvicorn access logs suppressed
- Additive changes from #2053 (execution_id structlog processor, correlation_id thread propagation) remain always active when `API_LOGGING_ENABLED=True`
- Improves structured access log event message from `"access"` to `"METHOD /path STATUS"` for better readability in GCP log viewer
- Fixes misleading comment on `LOG_LEVEL` default (said "INFO", actual default is "WARNING")

### Why

PR #2053 broke the local Docker experience: structured logs were filtered by `LOG_LEVEL=WARNING` (the default) while uvicorn's access logs were also suppressed, resulting in zero access logs when running Docker images locally. Existing users rely on the pre-PR behavior when `API_LOGGING_ENABLED=True`.

## Test plan

- [ ] Run Docker image locally with `API_LOGGING_ENABLED=True` (default in Dockerfiles), no `STRUCTURED_API_LOGGING` → verify uvicorn access logs appear
- [ ] Run with `API_LOGGING_ENABLED=True` + `STRUCTURED_API_LOGGING=True` + `LOG_LEVEL=INFO` → verify structured JSON access logs appear, uvicorn suppressed
- [ ] Run `pytest tests/workflows/unit_tests/core_steps/common/test_run_in_parallel_context.py` → 7 tests pass ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)