### PR TITLE
Qwen3.5 Block Safety

### DIFF
--- a/inference/core/workflows/core_steps/models/foundation/qwen3_5vl/v1.py
+++ b/inference/core/workflows/core_steps/models/foundation/qwen3_5vl/v1.py
@@ -73,13 +73,14 @@ class BlockManifest(WorkflowBlockManifest):
         description="Optional text prompt to provide additional context to Qwen3.5-VL. Otherwise it will just be a default one, which may affect the desired model behavior.",
         examples=["What is in this image?"],
     )
-    model_version: Union[Selector(kind=[ROBOFLOW_MODEL_ID_KIND]), str] = Field(
+    model_version: Union[
+        Literal["qwen3_5-0.8b", "qwen3_5-2b"],
+        Selector(kind=[ROBOFLOW_MODEL_ID_KIND]),
+        str,
+    ] = Field(
         default="qwen3_5-0.8b",
         description="The Qwen3.5-VL model to be used for inference.",
         examples=["qwen3_5-0.8b", "qwen3_5-2b"],
-        json_schema_extra={
-            "predefined_options": ["qwen3_5-0.8b", "qwen3_5-2b"],
-        },
     )
 
     system_prompt: Optional[str] = Field(
@@ -91,6 +92,13 @@ class BlockManifest(WorkflowBlockManifest):
     enable_thinking: bool = Field(
         default=False,
         description="If true, enables Qwen3.5-VL's thinking mode, which allows the model to generate reasoning tokens before answering. The thinking output will be returned in the 'thinking' field.",
+        json_schema_extra={
+            "relevant_for": {
+                "model_version": {
+                    "values": ["qwen3_5-2b", "qwen3_5-2b-peft"],
+                },
+            },
+        },
     )
 
     max_new_tokens: Optional[int] = Field(


### PR DESCRIPTION
## What does this PR do?
Add selection ob base models fro inference_models-only aliases and drop thinking mode for 0.8 Qwen3.5 size due to token repetition.

<img width="1310" height="834" alt="Screenshot 2026-03-12 at 4 58 03 PM" src="https://github.com/user-attachments/assets/d3adb9c0-39cc-4799-b52d-3d8d4f633090" />
<img width="1203" height="838" alt="Screenshot 2026-03-12 at 4 58 10 PM" src="https://github.com/user-attachments/assets/ae7cd725-a2c5-4995-9b1c-b36e9b49ed4f" />


## Type of Change

<!-- Please select one and delete the others, or describe if Other -->

- Bug fix (non-breaking change that fixes an issue)

## Testing

<!-- Describe how you tested your changes -->

- [x] I have tested this change locally
- [x] I have added/updated tests for this change

**Test details:**
Tested locally

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)

## Additional Context

No
