### PR TITLE
Revert change with making inference models default backend

### DIFF
--- a/.github/workflows/integration_tests_inference_models.yml
+++ b/.github/workflows/integration_tests_inference_models.yml
@@ -44,4 +44,4 @@ jobs:
           pip install --extra-index-url https://download.pytorch.org/whl/cpu -r requirements/_requirements.txt -r requirements/requirements.cpu.txt -r requirements/requirements.sdk.http.txt -r requirements/requirements.test.unit.txt -r requirements/requirements.http.txt -r requirements/requirements.yolo_world.txt -r requirements/requirements.sam.txt -r requirements/requirements.transformers.txt
       - name: 🧪 Integration Tests of Inference models
         timeout-minutes: 45
-        run: MAX_BATCH_SIZE=6 python -m pytest tests/inference/models_predictions_tests
+        run: USE_INFERENCE_MODELS=False MAX_BATCH_SIZE=6 python -m pytest tests/inference/models_predictions_tests

--- a/inference/core/env.py
+++ b/inference/core/env.py
@@ -226,7 +226,7 @@ CORE_MODEL_YOLO_WORLD_ENABLED = str2bool(
 )
 
 # Enable experimental RFDETR backend (inference_models) rollout, default is True
-USE_INFERENCE_MODELS = str2bool(os.getenv("USE_INFERENCE_MODELS", "True"))
+USE_INFERENCE_MODELS = str2bool(os.getenv("USE_INFERENCE_MODELS", "False"))
 ALLOW_INFERENCE_MODELS_UNTRUSTED_PACKAGES = str2bool(
     os.getenv("ALLOW_INFERENCE_MODELS_UNTRUSTED_PACKAGES", "False")
 )

--- a/inference/core/version.py
+++ b/inference/core/version.py
@@ -1,4 +1,4 @@
-__version__ = "1.2.0"
+__version__ = "1.1.2"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What does this PR do?

<!-- Provide a clear and concise description of the changes -->

We needed to make old inference deafult, as some dependencies of old inference must be adjusted to properly install python package - will be done next week to save todays release.

## Type of Change

<!-- Please select one and delete the others, or describe if Other -->

- Bug fix (non-breaking change that fixes an issue)

## Testing

<!-- Describe how you tested your changes -->
- ci
- [ ] I have tested this change locally
- [ ] I have added/updated tests for this change

**Test details:**
<!-- Describe what tests were added/updated and what they cover -->

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)

## Additional Context

<!-- Add any other context, screenshots, or notes about the PR here -->
