### PR TITLE
fix: resolve input image sub-property selector in workflow compiler (…

### DIFF
--- a/inference/core/workflows/execution_engine/v1/compiler/graph_constructor.py
+++ b/inference/core/workflows/execution_engine/v1/compiler/graph_constructor.py
@@ -74,6 +74,7 @@ from inference.core.workflows.execution_engine.v1.compiler.utils import (
     construct_output_selector,
     construct_step_selector,
     get_last_chunk_of_selector,
+    get_input_selector_base,
     get_nodes_of_specific_category,
     get_step_selector_from_its_output,
     identify_lineage,
@@ -282,7 +283,7 @@ def add_edge_for_step(
     if is_input_selector(target_step_parsed_selector.value):
         input_node_compilation_data = node_as(
             execution_graph=execution_graph,
-            node=target_step_parsed_selector.value,
+            node=get_input_selector_base(target_step_parsed_selector.value),
             expected_type=InputNode,
         )
         actual_input_kind = input_node_compilation_data.input_manifest.kind

--- a/inference/core/workflows/execution_engine/v1/compiler/utils.py
+++ b/inference/core/workflows/execution_engine/v1/compiler/utils.py
@@ -85,6 +85,16 @@ def get_last_chunk_of_selector(selector: str) -> str:
     return selector.split(".")[-1]
 
 
+def get_input_selector_base(selector: str) -> str:
+    """Strip sub-property suffix from input selector.
+    e.g. $inputs.image.name -> $inputs.image
+    """
+    parts = selector.split(".")
+    if len(parts) > 2:
+        return ".".join(parts[:2])
+    return selector
+
+
 def is_control_flow_step(execution_graph: DiGraph, node: str) -> bool:
     if not is_step_node(execution_graph=execution_graph, node=node):
         return False

--- a/tests/workflows/unit_tests/execution_engine/compiler/test_utils.py
+++ b/tests/workflows/unit_tests/execution_engine/compiler/test_utils.py
@@ -364,3 +364,15 @@ def test_is_selector_when_not_a_selector_given(value: Any) -> None:
 
     # then
     assert result is False
+
+
+def test_get_input_selector_base_with_sub_property():
+    # $inputs.image.name should be stripped to $inputs.image
+    from inference.core.workflows.execution_engine.v1.compiler.utils import get_input_selector_base
+    assert get_input_selector_base("$inputs.image.name") == "$inputs.image"
+
+
+def test_get_input_selector_base_without_sub_property():
+    # $inputs.image should remain unchanged
+    from inference.core.workflows.execution_engine.v1.compiler.utils import get_input_selector_base
+    assert get_input_selector_base("$inputs.image") == "$inputs.image"


### PR DESCRIPTION
…#2113)

## What does this PR do?

Fixes the workflow compiler error when binding `$inputs.image.name` 
to the Dataset Upload block's image name field.

**Root cause:** When a selector like `$inputs.image.name` was used, 
the compiler passed the full string to `node_as()` for graph lookup, 
but only `$inputs.image` exists as a node — causing an `AssumptionError`.

**Fix:** Added `get_input_selector_base()` helper in `compiler/utils.py` 
that strips sub-property suffixes from input selectors before graph 
node lookup. Used in `graph_constructor.py` when resolving input 
selector bindings.

**Related Issue(s):** Fixes #2113

## Type of Change
- Bug fix (non-breaking change that fixes an issue)

## Tests
Added two unit tests in `test_utils.py` covering:
- `$inputs.image.name` → stripped to `$inputs.image`
- `$inputs.image` → unchanged