### PR TITLE
Pin OTel packages to fix CPU Docker build resolution

### DIFF
--- a/requirements/requirements.http.txt
+++ b/requirements/requirements.http.txt
@@ -3,9 +3,9 @@ python-multipart==0.0.19
 fastapi-cprofile<=0.0.2
 orjson>=3.9.10,<=3.10.11
 asgi_correlation_id~=4.3.1
-opentelemetry-api>=1.20.0,<2.0.0
-opentelemetry-sdk>=1.20.0,<2.0.0
-opentelemetry-exporter-otlp-proto-grpc>=1.20.0,<2.0.0
-opentelemetry-exporter-otlp-proto-http>=1.20.0,<2.0.0
-opentelemetry-instrumentation-fastapi>=0.41b0,<1.0.0
-opentelemetry-instrumentation-requests>=0.41b0,<1.0.0
+opentelemetry-api~=1.27.0
+opentelemetry-sdk~=1.27.0
+opentelemetry-exporter-otlp-proto-grpc~=1.27.0
+opentelemetry-exporter-otlp-proto-http~=1.27.0
+opentelemetry-instrumentation-fastapi~=0.48b0
+opentelemetry-instrumentation-requests~=0.48b0


### PR DESCRIPTION
## Summary

Fixes `resolution-too-deep` error when building CPU Parallel and CPU Slim Docker images.

The wide OTel version ranges (`>=1.20.0,<2.0.0`) caused pip to backtrack through dozens of releases. GPU images don't hit this because they pre-resolve dependencies via `uv sync --locked` from the inference-models lock file. CPU images resolve everything from scratch with pip, which can't handle the combinatorial explosion.

## Change

Pin to compatible-release (`~=`) of the versions we've tested with:

```
opentelemetry-api~=1.27.0
opentelemetry-sdk~=1.27.0
opentelemetry-exporter-otlp-proto-grpc~=1.27.0
opentelemetry-exporter-otlp-proto-http~=1.27.0
opentelemetry-instrumentation-fastapi~=0.48b0
opentelemetry-instrumentation-requests~=0.48b0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)