### PR TITLE
Switch webrtc from multiprocessing to threading

### DIFF
--- a/inference/core/interfaces/webrtc_worker/__init__.py
+++ b/inference/core/interfaces/webrtc_worker/__init__.py
@@ -1,5 +1,5 @@
 import asyncio
-import multiprocessing
+import threading
 import uuid
 
 from inference.core.env import (
@@ -11,7 +11,6 @@ from inference.core.env import (
     WEBRTC_WORKSPACE_STREAM_TTL_SECONDS,
 )
 from inference.core.exceptions import CreditsExceededError, WorkspaceStreamQuotaError
-from inference.core.interfaces.webrtc_worker.cpu import rtc_peer_connection_process
 from inference.core.interfaces.webrtc_worker.entities import (
     RTCIceServer,
     WebRTCConfig,
@@ -105,23 +104,41 @@ async def start_worker(
         )
         return result
     else:
-        ctx = multiprocessing.get_context("spawn")
-        parent_conn, child_conn = ctx.Pipe(duplex=False)
-        p = ctx.Process(
-            target=rtc_peer_connection_process,
-            kwargs={
-                "webrtc_request": webrtc_request,
-                "answer_conn": child_conn,
-            },
-            daemon=False,
+        from inference.core.interfaces.webrtc_worker.webrtc import (
+            init_rtc_peer_connection_with_loop,
         )
-        p.start()
-        child_conn.close()
 
-        loop = asyncio.get_running_loop()
-        answer = WebRTCWorkerResult.model_validate(
-            await loop.run_in_executor(None, parent_conn.recv)
+        main_loop = asyncio.get_running_loop()
+        answer_future: asyncio.Future[WebRTCWorkerResult] = main_loop.create_future()
+        worker_loop: asyncio.AbstractEventLoop = asyncio.new_event_loop()
+
+        def _send_answer(obj: WebRTCWorkerResult) -> None:
+            main_loop.call_soon_threadsafe(answer_future.set_result, obj)
+
+        def _run_worker() -> None:
+            try:
+                worker_loop.run_until_complete(
+                    init_rtc_peer_connection_with_loop(
+                        webrtc_request=webrtc_request,
+                        send_answer=_send_answer,
+                        asyncio_loop=worker_loop,
+                    )
+                )
+            except Exception as exc:
+                logger.exception("WebRTC worker thread crashed: %s", exc)
+                try:
+                    _send_answer(
+                        WebRTCWorkerResult(
+                            exception_type=exc.__class__.__name__,
+                            error_message=str(exc),
+                        )
+                    )
+                except Exception:
+                    pass
+
+        worker_thread = threading.Thread(
+            target=_run_worker, daemon=True, name="webrtc-worker"
         )
-        parent_conn.close()
+        worker_thread.start()
 
-        return answer
+        return await answer_future

--- a/inference/core/interfaces/webrtc_worker/cpu.py
+++ b/inference/core/interfaces/webrtc_worker/cpu.py
@@ -19,10 +19,22 @@ def rtc_peer_connection_process(
         answer_conn.send(obj)
         answer_conn.close()
 
-    asyncio.run(
-        init_rtc_peer_connection_with_loop(
-            webrtc_request=webrtc_request,
-            send_answer=send_answer,
+    try:
+        asyncio.run(
+            init_rtc_peer_connection_with_loop(
+                webrtc_request=webrtc_request,
+                send_answer=send_answer,
+            )
         )
-    )
-    logger.info("WebRTC process terminated")
+        logger.info("WebRTC process terminated")
+    except Exception as exc:
+        logger.exception("WebRTC worker process crashed: %s", exc)
+        try:
+            send_answer(
+                WebRTCWorkerResult(
+                    exception_type=exc.__class__.__name__,
+                    error_message=str(exc),
+                )
+            )
+        except Exception:
+            pass


### PR DESCRIPTION
## What does this PR do?

The local WebRTC worker (`/initialise_webrtc_worker`) was crashing with SIGSEGV on macOS because `multiprocessing.get_context("spawn")` forces a child process to re-import and re-initialize all C extensions (PyTorch, av, aiortc), which segfaults in native code.

**Fix:** Replace the multiprocessing subprocess with a `threading.Thread` running its own `asyncio.new_event_loop()` for the local (non-Modal) code path. The SDP answer is communicated back via `asyncio.Future` + `call_soon_threadsafe`. This avoids subprocess spawn entirely, eliminating the segfault. The Modal (production) path is unchanged.

Also added defensive error handling in `cpu.py` so that if the multiprocessing path is ever used, unhandled exceptions are logged and sent back through the pipe instead of silently killing the child process.

## Type of Change

- Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] I have tested this change locally

**Test details:**
- Verified `/initialise_webrtc_worker` no longer crashes with SIGSEGV on macOS
- Confirmed WebRTC peer connection establishes successfully via the threaded worker

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors