### PR TITLE
Add OTel spans around model manager inference cache writes

### DIFF
--- a/inference/core/managers/base.py
+++ b/inference/core/managers/base.py
@@ -218,62 +218,64 @@ class ModelManager:
                 )
                 finish_time = time.time()
                 if not DISABLE_INFERENCE_CACHE and enable_model_monitoring:
-                    try:
-                        logger.debug(
-                            f"ModelManager - caching inference request started for model_id={model_id}"
-                        )
-                        cache.zadd(
-                            f"models",
-                            value=f"{GLOBAL_INFERENCE_SERVER_ID}:{request.api_key}:{model_id}",
-                            score=finish_time,
-                            expire=METRICS_INTERVAL * 2,
-                        )
-                        if (
-                            hasattr(request, "image")
-                            and hasattr(request.image, "type")
-                            and request.image.type == "numpy"
-                        ):
-                            request.image.value = str(request.image.value)
-                        cache.zadd(
-                            f"inference:{GLOBAL_INFERENCE_SERVER_ID}:{model_id}",
-                            value=to_cachable_inference_item(request, rtn_val),
-                            score=finish_time,
-                            expire=METRICS_INTERVAL * 2,
-                        )
-                        logger.debug(
-                            f"ModelManager - caching inference request finished for model_id={model_id}"
-                        )
-                    except Exception as cache_error:
-                        logger.warning(
-                            f"Failed to cache inference data for model {model_id}: {cache_error}"
-                        )
+                    with start_span("model.infer.cache"):
+                        try:
+                            logger.debug(
+                                f"ModelManager - caching inference request started for model_id={model_id}"
+                            )
+                            cache.zadd(
+                                f"models",
+                                value=f"{GLOBAL_INFERENCE_SERVER_ID}:{request.api_key}:{model_id}",
+                                score=finish_time,
+                                expire=METRICS_INTERVAL * 2,
+                            )
+                            if (
+                                hasattr(request, "image")
+                                and hasattr(request.image, "type")
+                                and request.image.type == "numpy"
+                            ):
+                                request.image.value = str(request.image.value)
+                            cache.zadd(
+                                f"inference:{GLOBAL_INFERENCE_SERVER_ID}:{model_id}",
+                                value=to_cachable_inference_item(request, rtn_val),
+                                score=finish_time,
+                                expire=METRICS_INTERVAL * 2,
+                            )
+                            logger.debug(
+                                f"ModelManager - caching inference request finished for model_id={model_id}"
+                            )
+                        except Exception as cache_error:
+                            logger.warning(
+                                f"Failed to cache inference data for model {model_id}: {cache_error}"
+                            )
                 return rtn_val
             except Exception as e:
                 record_error(e)
                 finish_time = time.time()
                 if not DISABLE_INFERENCE_CACHE and enable_model_monitoring:
-                    try:
-                        cache.zadd(
-                            f"models",
-                            value=f"{GLOBAL_INFERENCE_SERVER_ID}:{request.api_key}:{model_id}",
-                            score=finish_time,
-                            expire=METRICS_INTERVAL * 2,
-                        )
-                        cache.zadd(
-                            f"error:{GLOBAL_INFERENCE_SERVER_ID}:{model_id}",
-                            value={
-                                "request": jsonable_encoder(
-                                    request.dict(exclude={"image", "subject", "prompt"})
-                                ),
-                                "error": str(e),
-                            },
-                            score=finish_time,
-                            expire=METRICS_INTERVAL * 2,
-                        )
-                    except Exception as cache_error:
-                        logger.warning(
-                            f"Failed to cache error data for model {model_id}: {cache_error}"
-                        )
+                    with start_span("model.infer.cache_error"):
+                        try:
+                            cache.zadd(
+                                f"models",
+                                value=f"{GLOBAL_INFERENCE_SERVER_ID}:{request.api_key}:{model_id}",
+                                score=finish_time,
+                                expire=METRICS_INTERVAL * 2,
+                            )
+                            cache.zadd(
+                                f"error:{GLOBAL_INFERENCE_SERVER_ID}:{model_id}",
+                                value={
+                                    "request": jsonable_encoder(
+                                        request.dict(exclude={"image", "subject", "prompt"})
+                                    ),
+                                    "error": str(e),
+                                },
+                                score=finish_time,
+                                expire=METRICS_INTERVAL * 2,
+                            )
+                        except Exception as cache_error:
+                            logger.warning(
+                                f"Failed to cache error data for model {model_id}: {cache_error}"
+                            )
                 raise
 
     def infer_from_request_sync(
@@ -312,62 +314,64 @@ class ModelManager:
                 )
                 finish_time = time.time()
                 if not DISABLE_INFERENCE_CACHE and enable_model_monitoring:
-                    try:
-                        logger.debug(
-                            f"ModelManager - caching inference request started for model_id={model_id}"
-                        )
-                        cache.zadd(
-                            f"models",
-                            value=f"{GLOBAL_INFERENCE_SERVER_ID}:{request.api_key}:{model_id}",
-                            score=finish_time,
-                            expire=METRICS_INTERVAL * 2,
-                        )
-                        if (
-                            hasattr(request, "image")
-                            and hasattr(request.image, "type")
-                            and request.image.type == "numpy"
-                        ):
-                            request.image.value = str(request.image.value)
-                        cache.zadd(
-                            f"inference:{GLOBAL_INFERENCE_SERVER_ID}:{model_id}",
-                            value=to_cachable_inference_item(request, rtn_val),
-                            score=finish_time,
-                            expire=METRICS_INTERVAL * 2,
-                        )
-                        logger.debug(
-                            f"ModelManager - caching inference request finished for model_id={model_id}"
-                        )
-                    except Exception as cache_error:
-                        logger.warning(
-                            f"Failed to cache inference data for model {model_id}: {cache_error}"
-                        )
+                    with start_span("model.infer.cache"):
+                        try:
+                            logger.debug(
+                                f"ModelManager - caching inference request started for model_id={model_id}"
+                            )
+                            cache.zadd(
+                                f"models",
+                                value=f"{GLOBAL_INFERENCE_SERVER_ID}:{request.api_key}:{model_id}",
+                                score=finish_time,
+                                expire=METRICS_INTERVAL * 2,
+                            )
+                            if (
+                                hasattr(request, "image")
+                                and hasattr(request.image, "type")
+                                and request.image.type == "numpy"
+                            ):
+                                request.image.value = str(request.image.value)
+                            cache.zadd(
+                                f"inference:{GLOBAL_INFERENCE_SERVER_ID}:{model_id}",
+                                value=to_cachable_inference_item(request, rtn_val),
+                                score=finish_time,
+                                expire=METRICS_INTERVAL * 2,
+                            )
+                            logger.debug(
+                                f"ModelManager - caching inference request finished for model_id={model_id}"
+                            )
+                        except Exception as cache_error:
+                            logger.warning(
+                                f"Failed to cache inference data for model {model_id}: {cache_error}"
+                            )
                 return rtn_val
             except Exception as e:
                 record_error(e)
                 finish_time = time.time()
                 if not DISABLE_INFERENCE_CACHE and enable_model_monitoring:
-                    try:
-                        cache.zadd(
-                            f"models",
-                            value=f"{GLOBAL_INFERENCE_SERVER_ID}:{request.api_key}:{model_id}",
-                            score=finish_time,
-                            expire=METRICS_INTERVAL * 2,
-                        )
-                        cache.zadd(
-                            f"error:{GLOBAL_INFERENCE_SERVER_ID}:{model_id}",
-                            value={
-                                "request": jsonable_encoder(
-                                    request.dict(exclude={"image", "subject", "prompt"})
-                                ),
-                                "error": str(e),
-                            },
-                            score=finish_time,
-                            expire=METRICS_INTERVAL * 2,
-                        )
-                    except Exception as cache_error:
-                        logger.warning(
-                            f"Failed to cache error data for model {model_id}: {cache_error}"
-                        )
+                    with start_span("model.infer.cache_error"):
+                        try:
+                            cache.zadd(
+                                f"models",
+                                value=f"{GLOBAL_INFERENCE_SERVER_ID}:{request.api_key}:{model_id}",
+                                score=finish_time,
+                                expire=METRICS_INTERVAL * 2,
+                            )
+                            cache.zadd(
+                                f"error:{GLOBAL_INFERENCE_SERVER_ID}:{model_id}",
+                                value={
+                                    "request": jsonable_encoder(
+                                        request.dict(exclude={"image", "subject", "prompt"})
+                                    ),
+                                    "error": str(e),
+                                },
+                                score=finish_time,
+                                expire=METRICS_INTERVAL * 2,
+                            )
+                        except Exception as cache_error:
+                            logger.warning(
+                                f"Failed to cache error data for model {model_id}: {cache_error}"
+                            )
                 raise
 
     async def model_infer(self, model_id: str, request: InferenceRequest, **kwargs):


### PR DESCRIPTION
Wraps the cache.zadd + to_cachable_inference_item calls in both async and sync infer_from_request paths with model.infer.cache spans to surface how much time is spent on post-inference serialization/caching inside the model.infer parent span.

https://claude.ai/code/session_01VTsKHtHrPeKzeCxe5EZnug

## What does this PR do?

<!-- Provide a clear and concise description of the changes -->

**Related Issue(s):** <!-- Link to related issues, e.g., Fixes #123 or Related to #456 -->

## Type of Change

<!-- Please select one and delete the others, or describe if Other -->

- Bug fix (non-breaking change that fixes an issue)
- New feature (non-breaking change that adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
- Refactoring (no functional changes)
- Other:

## Testing

<!-- Describe how you tested your changes -->

- [ ] I have tested this change locally
- [ ] I have added/updated tests for this change

**Test details:**
<!-- Describe what tests were added/updated and what they cover -->

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where necessary, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have updated the documentation accordingly (if applicable)

## Additional Context

<!-- Add any other context, screenshots, or notes about the PR here -->
