### PR TITLE
fix(serverless-auth): fail closed on unexpected upstream status

### DIFF
--- a/inference/core/interfaces/http/http_api.py
+++ b/inference/core/interfaces/http/http_api.py
@@ -716,6 +716,16 @@ class HttpInterface(BaseInterface):
                             402,
                             cached_api_keys[api_key].message,
                         )
+                    else:
+                        logger.warning(
+                            "Unexpected status %s from serverless usage check; "
+                            "failing closed without caching.",
+                            usage_check_result.status_code,
+                        )
+                        return _authorization_error_response(
+                            503,
+                            "Authorization service temporarily unavailable. Please retry.",
+                        )
 
                 response = await call_next(request)
                 if workspace_id:

--- a/tests/inference/unit_tests/core/interfaces/http/test_http_api.py
+++ b/tests/inference/unit_tests/core/interfaces/http/test_http_api.py
@@ -98,9 +98,7 @@ def test_infer_lmm_with_model_id_uses_alias_registry_key(monkeypatch) -> None:
         service_secret=None,
     )
     model_manager.infer_from_request_sync.assert_called_once()
-    assert (
-        model_manager.infer_from_request_sync.call_args.args[0] == "florence-2-base"
-    )
+    assert model_manager.infer_from_request_sync.call_args.args[0] == "florence-2-base"
     inference_request = model_manager.infer_from_request_sync.call_args.args[1]
     assert inference_request.model_id == "florence-2-base"
     assert inference_request.api_key == "query-api-key"
@@ -202,5 +200,38 @@ def test_serverless_auth_middleware_caches_payment_required_response(
     assert second_response.json() == first_response.json()
     assert WORKSPACE_ID_HEADER not in first_response.headers
     assert usage_check_mock.await_count == 1
+    model_manager.add_model.assert_not_called()
+    model_manager.infer_from_request_sync.assert_not_called()
+
+
+def test_serverless_auth_middleware_fails_closed_on_unexpected_upstream_status(
+    monkeypatch,
+) -> None:
+    interface, model_manager, usage_check_mock = _build_serverless_interface(
+        monkeypatch=monkeypatch,
+        usage_check_result=ServerlessUsageCheckResponse(status_code=503),
+    )
+
+    with TestClient(interface.app) as client:
+        first_response = client.post(
+            "/infer/lmm/florence-2-base",
+            params={"api_key": "query-api-key"},
+            json=_make_inference_request(),
+        )
+        second_response = client.post(
+            "/infer/lmm/florence-2-base",
+            params={"api_key": "query-api-key"},
+            json=_make_inference_request(),
+        )
+
+    assert first_response.status_code == 503
+    assert second_response.status_code == 503
+    assert (
+        first_response.json()["message"]
+        == "Authorization service temporarily unavailable. Please retry."
+    )
+    assert WORKSPACE_ID_HEADER not in first_response.headers
+    # Unexpected upstream statuses must not be cached, so every request re-queries.
+    assert usage_check_mock.await_count == 2
     model_manager.add_model.assert_not_called()
     model_manager.infer_from_request_sync.assert_not_called()


### PR DESCRIPTION
## What does this PR do?

Fixes a silent-authorization bug in `check_authorization_serverless`. When `get_serverless_usage_check_async` returned any status other than 200/401/402 (e.g. 429, 500, 503), the if/elif chain fell through and the request was served with `workspace_id = None`, bypassing billing verification.

Now any unrecognized upstream status:
- Returns HTTP 503 (`"Authorization service temporarily unavailable. Please retry."`)
- Logs a warning with the unexpected status
- Is deliberately **not cached**, so the next request retries the upstream once it recovers

**Related Issue(s):** N/A

## Type of Change

- Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] I have tested this change locally
- [x] I have added/updated tests for this change

**Test details:**
Added `test_serverless_auth_middleware_fails_closed_on_unexpected_upstream_status` in `tests/inference/unit_tests/core/interfaces/http/test_http_api.py`. It mocks the usage check to return status 503 and asserts the middleware:
- Responds with 503 and the expected message
- Does not set `WORKSPACE_ID_HEADER`
- Does not invoke `model_manager.add_model` / `infer_from_request_sync`
- Re-queries the upstream on every request (no caching of the failure)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [ ] I have updated the documentation accordingly (if applicable)

## Additional Context

Fails closed rather than open on transient upstream errors. The previous behavior also caused OTel spans to report `auth.result="authorized"` for these requests, masking upstream failures in traces.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes serverless authorization/billing gate behavior: unexpected upstream statuses now block requests with a 503, which could impact availability but closes a potential authorization bypass.
> 
> **Overview**
> Prevents serverless requests from being treated as authorized when `get_serverless_usage_check_async` returns an unrecognized status code (e.g. 429/5xx).
> 
> `check_authorization_serverless` now logs a warning and returns `503` with a retryable message, and deliberately **does not cache** these failures so each request re-checks upstream; adds a unit test asserting this fail-closed, no-caching behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe521ce9b109373241baf9fc58bb46b596c63215. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->