### PR TITLE
Security: Outbound HTTP request at import time without timeout

### DIFF
--- a/inference/core/__init__.py
+++ b/inference/core/__init__.py
@@ -21,7 +21,8 @@ def get_latest_release_version():
         try:
             logger.debug("Checking for latest inference release version...")
             response = requests.get(
-                "https://api.github.com/repos/roboflow/inference/releases/latest"
+                "https://api.github.com/repos/roboflow/inference/releases/latest",
+                timeout=3,
             )
             response.raise_for_status()
             latest_release = response.json()["tag_name"].lstrip("v")


### PR DESCRIPTION
## Summary

Security: Outbound HTTP request at import time without timeout

## Problem

**Severity**: `Low` | **File**: `inference/core/__init__.py:L20`

The package performs a network call to GitHub during import/version check and does not set a timeout. This can block startup indefinitely in constrained networks and can be abused for availability degradation (slow or hung connections).

## Solution

Set a short timeout (e.g., `requests.get(..., timeout=3)`) and ensure failures are non-blocking. Consider deferring the check to a background task only.

## Changes

- `inference/core/__init__.py` (modified)