### PR TITLE
Fix docs build: skip empty block sections in SUMMARY.md

### DIFF
--- a/development/docs/build_block_docs.py
+++ b/development/docs/build_block_docs.py
@@ -389,7 +389,10 @@ def write_blocks_summary_md(block_families):
     for block_section in BLOCK_SECTIONS:
         section_title = block_section['title']
         section_id = block_section['id']
-        
+
+        if not block_families_by_section[section_id]:
+            continue
+
         lines.append(f"* {section_title}")
         for family_name in sorted(block_families_by_section[section_id], key=lambda x: block_families[x][0].block_schema.get("ui_manifest", {}).get("blockPriority", 99)):
             # Suppose you had a function slugify_block_name:

--- a/requirements/requirements.docs.txt
+++ b/requirements/requirements.docs.txt
@@ -1,4 +1,4 @@
-zensical
+zensical==0.0.31
 mkdocstrings[python]
 mkdocs-gen-files
 mkdocs-literate-nav

--- a/requirements/requirements.docs.txt
+++ b/requirements/requirements.docs.txt
@@ -1,4 +1,4 @@
-zensical==0.0.31
+zensical==0.0.33
 mkdocstrings[python]
 mkdocs-gen-files
 mkdocs-literate-nav


### PR DESCRIPTION
## Summary
Docs builds have been failing since v1.2.2 with:
```
TypeError: Unknown nav item value type: <class 'NoneType'>
```

### Root cause
Commit [ff64c93e7](https://github.com/roboflow/inference/commit/ff64c93e7) added an `Industrial` entry to `BLOCK_SECTIONS` in `development/docs/build_block_docs.py`. No blocks in the non-enterprise codebase (nor in `workflows-enterprise-blocks`) declare `ui_manifest.section = "industrial"`, so the section ends up empty.

`write_blocks_summary_md` iterated all `BLOCK_SECTIONS` unconditionally and wrote `* Industrial` with no children. Then `docs/scripts/expand_literate_nav.py` expanded that into mkdocs.yml as:
```yaml
- Industrial:
```
which YAML parses as a `None` value, and zensical's nav parser raises on it.

### Fix
- Skip empty sections in `write_blocks_summary_md` so no `* Section` is emitted without children
- Pin `zensical==0.0.33` (was unpinned) for reproducible docs builds

## Test plan
- [x] Reproduced the exact CI error locally by appending `* Industrial` to `SUMMARY.md` and running `expand_literate_nav.py` + `zensical build`
- [x] Confirmed docs build passes locally with the fix applied (zensical 0.0.31 and 0.0.33)
- [ ] Verify the docs workflow passes on this branch (triggered via workflow_dispatch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)