### PR TITLE
[codex] Add memory-optimized instance segmentation postprocess

### DIFF
--- a/inference/core/entities/responses/inference.py
+++ b/inference/core/entities/responses/inference.py
@@ -257,7 +257,9 @@ class InstanceSegmentationInferenceResponse(
         predictions (List[inference.core.entities.responses.inference.InstanceSegmentationPrediction]): List of instance segmentation predictions.
     """
 
-    predictions: List[InstanceSegmentationPrediction]
+    predictions: List[
+        Union[InstanceSegmentationPrediction, InstanceSegmentationRLEPrediction]
+    ]
 
 
 class SemanticSegmentationInferenceResponse(

--- a/inference/core/env.py
+++ b/inference/core/env.py
@@ -153,6 +153,25 @@ CONFIDENCE = float(os.getenv(CONFIDENCE_ENV, DEFAULT_CONFIDENCE))
 # Flag to enable core models, default is True
 CORE_MODELS_ENABLED = str2bool(os.getenv("CORE_MODELS_ENABLED", True))
 
+# When enabled, inference_models instance segmentation responses are serialized
+# directly from streamed masks instead of first materializing dense N x H x W masks.
+INFERENCE_MODELS_INSTANCE_SEGMENTATION_MEMORY_OPTIMIZED_POSTPROCESS = str2bool(
+    os.getenv(
+        "INFERENCE_MODELS_INSTANCE_SEGMENTATION_MEMORY_OPTIMIZED_POSTPROCESS", False
+    )
+)
+INFERENCE_MODELS_INSTANCE_SEGMENTATION_MEMORY_OPTIMIZED_FORMAT = os.getenv(
+    "INFERENCE_MODELS_INSTANCE_SEGMENTATION_MEMORY_OPTIMIZED_FORMAT", "polygon"
+).lower()
+if INFERENCE_MODELS_INSTANCE_SEGMENTATION_MEMORY_OPTIMIZED_FORMAT not in {
+    "polygon",
+    "rle",
+}:
+    raise ValueError(
+        "Invalid INFERENCE_MODELS_INSTANCE_SEGMENTATION_MEMORY_OPTIMIZED_FORMAT. "
+        "Expected one of: polygon, rle."
+    )
+
 # Flag to enable CLIP core model, default is True
 CORE_MODEL_CLIP_ENABLED = str2bool(os.getenv("CORE_MODEL_CLIP_ENABLED", True))
 

--- a/inference/core/models/inference_models_adapters.py
+++ b/inference/core/models/inference_models_adapters.py
@@ -2,11 +2,12 @@ import base64
 import io
 from io import BytesIO
 from time import perf_counter
-from typing import Any, List, Optional, Tuple, Union
+from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 
 import numpy as np
 import torch
 from PIL import Image, ImageDraw, ImageFont
+from torchvision.transforms import functional
 
 from inference.core.entities.requests import (
     ClassificationInferenceRequest,
@@ -84,9 +85,6 @@ from inference_models.models.base.semantic_segmentation import (
 from inference_models.models.base.types import PreprocessingMetadata
 from inference_models.models.common.roboflow.post_processing import (
     crop_masks_to_boxes,
-    iter_aligned_instance_segmentation_results,
-    mask_to_coco_rle,
-    mask_to_largest_polygon,
     post_process_nms_fused_model_output,
     preprocess_segmentation_masks,
     run_nms_for_instance_segmentation,
@@ -116,6 +114,157 @@ DEFAULT_COLOR_PALETTE = [
     "#FF97CA",
     "#FF39C9",
 ]
+
+
+def _resize_and_binarize_mask_for_serialization(
+    mask: torch.Tensor,
+    target_height: int,
+    target_width: int,
+    output_height: int,
+    output_width: int,
+    binarization_threshold: float,
+    output_offset_x: int = 0,
+    output_offset_y: int = 0,
+) -> torch.Tensor:
+    if output_offset_x > 0 or output_offset_y > 0:
+        aligned_mask = torch.zeros(
+            (output_height, output_width),
+            dtype=torch.bool,
+            device=mask.device,
+        )
+    else:
+        aligned_mask = torch.empty(
+            (output_height, output_width),
+            dtype=torch.bool,
+            device=mask.device,
+        )
+    resized_mask = functional.resize(
+        mask[None, ...],
+        [target_height, target_width],
+        interpolation=functional.InterpolationMode.BILINEAR,
+    )[0]
+    aligned_mask[
+        output_offset_y : output_offset_y + target_height,
+        output_offset_x : output_offset_x + target_width,
+    ] = resized_mask.gt_(binarization_threshold)
+    return aligned_mask
+
+
+def _iter_aligned_instance_segmentation_results(
+    image_bboxes: torch.Tensor,
+    masks: torch.Tensor,
+    padding: Tuple[int, int, int, int],
+    scale_width: float,
+    scale_height: float,
+    original_size: Any,
+    size_after_pre_processing: Any,
+    inference_size: Any,
+    static_crop_offset: Any,
+    binarization_threshold: float = 0.0,
+) -> Iterator[Tuple[torch.Tensor, torch.Tensor]]:
+    if image_bboxes.shape[0] == 0:
+        return
+    pad_left, pad_top, pad_right, pad_bottom = padding
+    offsets = torch.tensor(
+        [pad_left, pad_top, pad_left, pad_top],
+        device=image_bboxes.device,
+    )
+    image_bboxes[:, :4].sub_(offsets)
+    scale = torch.as_tensor(
+        [scale_width, scale_height, scale_width, scale_height],
+        dtype=image_bboxes.dtype,
+        device=image_bboxes.device,
+    )
+    image_bboxes[:, :4].div_(scale)
+    n, mh, mw = masks.shape
+    mask_h_scale = mh / inference_size.height
+    mask_w_scale = mw / inference_size.width
+    mask_pad_top, mask_pad_bottom, mask_pad_left, mask_pad_right = (
+        round(mask_h_scale * pad_top),
+        round(mask_h_scale * pad_bottom),
+        round(mask_w_scale * pad_left),
+        round(mask_w_scale * pad_right),
+    )
+    if (
+        mask_pad_top < 0
+        or mask_pad_bottom < 0
+        or mask_pad_left < 0
+        or mask_pad_right < 0
+    ):
+        masks = torch.nn.functional.pad(
+            masks,
+            (
+                abs(min(mask_pad_left, 0)),
+                abs(min(mask_pad_right, 0)),
+                abs(min(mask_pad_top, 0)),
+                abs(min(mask_pad_bottom, 0)),
+            ),
+            "constant",
+            0,
+        )
+        padded_mask_offset_top = max(mask_pad_top, 0)
+        padded_mask_offset_bottom = max(mask_pad_bottom, 0)
+        padded_mask_offset_left = max(mask_pad_left, 0)
+        padded_mask_offset_right = max(mask_pad_right, 0)
+        masks = masks[
+            :,
+            padded_mask_offset_top : masks.shape[1] - padded_mask_offset_bottom,
+            padded_mask_offset_left : masks.shape[2] - padded_mask_offset_right,
+        ]
+    else:
+        masks = masks[
+            :, mask_pad_top : mh - mask_pad_bottom, mask_pad_left : mw - mask_pad_right
+        ]
+
+    if static_crop_offset.offset_x > 0 or static_crop_offset.offset_y > 0:
+        static_crop_offsets = torch.as_tensor(
+            [
+                static_crop_offset.offset_x,
+                static_crop_offset.offset_y,
+                static_crop_offset.offset_x,
+                static_crop_offset.offset_y,
+            ],
+            dtype=image_bboxes.dtype,
+            device=image_bboxes.device,
+        )
+        image_bboxes[:, :4].add_(static_crop_offsets)
+
+    for mask_id in range(n):
+        if static_crop_offset.offset_x > 0 or static_crop_offset.offset_y > 0:
+            aligned_mask = _resize_and_binarize_mask_for_serialization(
+                mask=masks[mask_id],
+                target_height=size_after_pre_processing.height,
+                target_width=size_after_pre_processing.width,
+                output_height=original_size.height,
+                output_width=original_size.width,
+                binarization_threshold=binarization_threshold,
+                output_offset_x=static_crop_offset.offset_x,
+                output_offset_y=static_crop_offset.offset_y,
+            )
+        else:
+            aligned_mask = _resize_and_binarize_mask_for_serialization(
+                mask=masks[mask_id],
+                target_height=size_after_pre_processing.height,
+                target_width=size_after_pre_processing.width,
+                output_height=size_after_pre_processing.height,
+                output_width=size_after_pre_processing.width,
+                binarization_threshold=binarization_threshold,
+            )
+        yield image_bboxes[mask_id], aligned_mask
+
+
+def _mask_to_largest_polygon(mask: torch.Tensor) -> np.ndarray:
+    mask_np = mask.detach().cpu().numpy()
+    return masks2poly(mask_np[None, ...])[0]
+
+
+def _mask_to_coco_rle(mask: torch.Tensor) -> Dict[str, object]:
+    from pycocotools import mask as mask_utils
+
+    mask_np = mask.detach().cpu().numpy().astype(np.uint8)
+    rle = mask_utils.encode(np.asfortranarray(mask_np))
+    rle["counts"] = rle["counts"].decode("utf-8")
+    return rle
 
 
 class InferenceModelsObjectDetectionAdapter(Model):
@@ -653,7 +802,7 @@ class InferenceModelsInstanceSegmentationAdapter(Model):
             image_meta.pad_right,
             image_meta.pad_bottom,
         )
-        for aligned_box, aligned_mask in iter_aligned_instance_segmentation_results(
+        for aligned_box, aligned_mask in _iter_aligned_instance_segmentation_results(
             image_bboxes=image_bboxes,
             masks=masks,
             padding=padding,
@@ -702,10 +851,10 @@ class InferenceModelsInstanceSegmentationAdapter(Model):
             return InstanceSegmentationRLEPrediction(
                 **{
                     **prediction_kwargs,
-                    "rle": mask_to_coco_rle(mask=aligned_mask),
+                    "rle": _mask_to_coco_rle(mask=aligned_mask),
                 }
             )
-        polygon = mask_to_largest_polygon(mask=aligned_mask)
+        polygon = _mask_to_largest_polygon(mask=aligned_mask)
         return InstanceSegmentationPrediction(
             **{
                 **prediction_kwargs,

--- a/inference/core/models/inference_models_adapters.py
+++ b/inference/core/models/inference_models_adapters.py
@@ -18,6 +18,7 @@ from inference.core.entities.responses.inference import (
     InferenceResponseImage,
     InstanceSegmentationInferenceResponse,
     InstanceSegmentationPrediction,
+    InstanceSegmentationRLEPrediction,
     Keypoint,
     KeypointsDetectionInferenceResponse,
     KeypointsPrediction,
@@ -33,6 +34,8 @@ from inference.core.env import (
     ALLOW_INFERENCE_MODELS_UNTRUSTED_PACKAGES,
     API_KEY,
     DISABLED_INFERENCE_MODELS_BACKENDS,
+    INFERENCE_MODELS_INSTANCE_SEGMENTATION_MEMORY_OPTIMIZED_FORMAT,
+    INFERENCE_MODELS_INSTANCE_SEGMENTATION_MEMORY_OPTIMIZED_POSTPROCESS,
     RFDETR_ONNX_MAX_RESOLUTION,
     VALID_INFERENCE_MODELS_BACKENDS,
 )
@@ -57,10 +60,40 @@ from inference_models import (
     PreProcessingOverrides,
     SemanticSegmentationModel,
 )
+from inference_models.configuration import (
+    INFERENCE_MODELS_RFDETR_DEFAULT_CONFIDENCE,
+    INFERENCE_MODELS_YOLO26_DEFAULT_CONFIDENCE,
+    INFERENCE_MODELS_YOLO_ULTRALYTICS_DEFAULT_CLASS_AGNOSTIC_NMS,
+    INFERENCE_MODELS_YOLO_ULTRALYTICS_DEFAULT_CONFIDENCE,
+    INFERENCE_MODELS_YOLO_ULTRALYTICS_DEFAULT_IOU_THRESHOLD,
+    INFERENCE_MODELS_YOLO_ULTRALYTICS_DEFAULT_MASKS_BINARIZATION_THRESHOLD,
+    INFERENCE_MODELS_YOLO_ULTRALYTICS_DEFAULT_MASKS_SMOOTHING_ENABLED,
+    INFERENCE_MODELS_YOLO_ULTRALYTICS_DEFAULT_MAX_DETECTIONS,
+    INFERENCE_MODELS_YOLOV5_DEFAULT_CLASS_AGNOSTIC_NMS,
+    INFERENCE_MODELS_YOLOV5_DEFAULT_CONFIDENCE,
+    INFERENCE_MODELS_YOLOV5_DEFAULT_IOU_THRESHOLD,
+    INFERENCE_MODELS_YOLOV5_DEFAULT_MAX_DETECTIONS,
+    INFERENCE_MODELS_YOLOV7_DEFAULT_CLASS_AGNOSTIC_NMS,
+    INFERENCE_MODELS_YOLOV7_DEFAULT_CONFIDENCE,
+    INFERENCE_MODELS_YOLOV7_DEFAULT_IOU_THRESHOLD,
+    INFERENCE_MODELS_YOLOV7_DEFAULT_MAX_DETECTIONS,
+)
 from inference_models.models.base.semantic_segmentation import (
     SemanticSegmentationResult,
 )
 from inference_models.models.base.types import PreprocessingMetadata
+from inference_models.models.common.roboflow.post_processing import (
+    crop_masks_to_boxes,
+    iter_aligned_instance_segmentation_results,
+    mask_to_coco_rle,
+    mask_to_largest_polygon,
+    post_process_nms_fused_model_output,
+    preprocess_segmentation_masks,
+    run_nms_for_instance_segmentation,
+)
+from inference_models.models.yolov5.nms import (
+    run_yolov5_nms_for_instance_segmentation,
+)
 
 DEFAULT_COLOR_PALETTE = [
     "#A351FB",
@@ -298,6 +331,424 @@ class InferenceModelsInstanceSegmentationAdapter(Model):
         mapped_kwargs = self.map_inference_kwargs(kwargs)
         return self._model.forward(img_in, **mapped_kwargs)
 
+    def _postprocess_memory_optimized(
+        self,
+        predictions: Any,
+        preprocess_return_metadata: PreprocessingMetadata,
+        **kwargs,
+    ) -> Optional[List[InstanceSegmentationInferenceResponse]]:
+        post_process_stream = getattr(self._model, "_post_process_stream", None)
+        if post_process_stream is None:
+            return self._postprocess_memory_optimized_for_model(
+                predictions=predictions,
+                preprocess_return_metadata=preprocess_return_metadata,
+                **kwargs,
+            )
+        with torch.cuda.stream(post_process_stream):
+            self._record_predictions_to_stream(
+                predictions=predictions,
+                stream=post_process_stream,
+            )
+            optimized_response = self._postprocess_memory_optimized_for_model(
+                predictions=predictions,
+                preprocess_return_metadata=preprocess_return_metadata,
+                **kwargs,
+            )
+        post_process_stream.synchronize()
+        return optimized_response
+
+    def _postprocess_memory_optimized_for_model(
+        self,
+        predictions: Any,
+        preprocess_return_metadata: PreprocessingMetadata,
+        **kwargs,
+    ) -> Optional[List[InstanceSegmentationInferenceResponse]]:
+        model_class_name = self._model.__class__.__name__
+        if model_class_name.startswith("YOLOv5ForInstanceSegmentation"):
+            return self._postprocess_yolov5_memory_optimized(
+                predictions=predictions,
+                preprocess_return_metadata=preprocess_return_metadata,
+                **kwargs,
+            )
+        if model_class_name.startswith("YOLOv7ForInstanceSegmentation"):
+            return self._postprocess_yolov7_memory_optimized(
+                predictions=predictions,
+                preprocess_return_metadata=preprocess_return_metadata,
+                **kwargs,
+            )
+        if model_class_name.startswith("YOLOv8ForInstanceSegmentation"):
+            return self._postprocess_yolov8_memory_optimized(
+                predictions=predictions,
+                preprocess_return_metadata=preprocess_return_metadata,
+                **kwargs,
+            )
+        if model_class_name.startswith("YOLO26ForInstanceSegmentation"):
+            return self._postprocess_yolo26_memory_optimized(
+                predictions=predictions,
+                preprocess_return_metadata=preprocess_return_metadata,
+                **kwargs,
+            )
+        if model_class_name.startswith("RFDetrForInstanceSegmentation"):
+            return self._postprocess_rfdetr_memory_optimized(
+                predictions=predictions,
+                preprocess_return_metadata=preprocess_return_metadata,
+                **kwargs,
+            )
+        return None
+
+    def _record_predictions_to_stream(
+        self,
+        predictions: Any,
+        stream: torch.cuda.Stream,
+    ) -> None:
+        if isinstance(predictions, torch.Tensor):
+            predictions.record_stream(stream)
+            return
+        if isinstance(predictions, (list, tuple)):
+            for prediction in predictions:
+                self._record_predictions_to_stream(
+                    predictions=prediction,
+                    stream=stream,
+                )
+
+    def _postprocess_yolov5_memory_optimized(
+        self,
+        predictions: Tuple[torch.Tensor, torch.Tensor],
+        preprocess_return_metadata: PreprocessingMetadata,
+        confidence: float = INFERENCE_MODELS_YOLOV5_DEFAULT_CONFIDENCE,
+        iou_threshold: float = INFERENCE_MODELS_YOLOV5_DEFAULT_IOU_THRESHOLD,
+        max_detections: int = INFERENCE_MODELS_YOLOV5_DEFAULT_MAX_DETECTIONS,
+        class_agnostic_nms: bool = INFERENCE_MODELS_YOLOV5_DEFAULT_CLASS_AGNOSTIC_NMS,
+        **kwargs,
+    ) -> List[InstanceSegmentationInferenceResponse]:
+        instances, protos = predictions
+        nms_results = run_yolov5_nms_for_instance_segmentation(
+            output=instances.permute(0, 2, 1),
+            conf_thresh=confidence,
+            iou_thresh=iou_threshold,
+            max_detections=max_detections,
+            class_agnostic=class_agnostic_nms,
+        )
+        return self._build_memory_optimized_prototype_mask_response(
+            nms_results=nms_results,
+            protos=protos,
+            preprocess_return_metadata=preprocess_return_metadata,
+            binarization_threshold=0.0,
+            class_filter=kwargs.get("class_filter"),
+        )
+
+    def _postprocess_yolov7_memory_optimized(
+        self,
+        predictions: Tuple[torch.Tensor, torch.Tensor],
+        preprocess_return_metadata: PreprocessingMetadata,
+        confidence: float = INFERENCE_MODELS_YOLOV7_DEFAULT_CONFIDENCE,
+        iou_threshold: float = INFERENCE_MODELS_YOLOV7_DEFAULT_IOU_THRESHOLD,
+        max_detections: int = INFERENCE_MODELS_YOLOV7_DEFAULT_MAX_DETECTIONS,
+        class_agnostic_nms: bool = INFERENCE_MODELS_YOLOV7_DEFAULT_CLASS_AGNOSTIC_NMS,
+        **kwargs,
+    ) -> List[InstanceSegmentationInferenceResponse]:
+        instances, protos = predictions
+        nms_results = run_nms_for_instance_segmentation(
+            output=instances.permute(0, 2, 1),
+            conf_thresh=confidence,
+            iou_thresh=iou_threshold,
+            max_detections=max_detections,
+            class_agnostic=class_agnostic_nms,
+        )
+        return self._build_memory_optimized_prototype_mask_response(
+            nms_results=nms_results,
+            protos=protos,
+            preprocess_return_metadata=preprocess_return_metadata,
+            binarization_threshold=0.0,
+            class_filter=kwargs.get("class_filter"),
+        )
+
+    def _postprocess_yolov8_memory_optimized(
+        self,
+        predictions: Tuple[torch.Tensor, torch.Tensor],
+        preprocess_return_metadata: PreprocessingMetadata,
+        confidence: float = INFERENCE_MODELS_YOLO_ULTRALYTICS_DEFAULT_CONFIDENCE,
+        iou_threshold: float = INFERENCE_MODELS_YOLO_ULTRALYTICS_DEFAULT_IOU_THRESHOLD,
+        max_detections: int = INFERENCE_MODELS_YOLO_ULTRALYTICS_DEFAULT_MAX_DETECTIONS,
+        class_agnostic_nms: bool = (
+            INFERENCE_MODELS_YOLO_ULTRALYTICS_DEFAULT_CLASS_AGNOSTIC_NMS
+        ),
+        masks_smoothing_enabled: bool = (
+            INFERENCE_MODELS_YOLO_ULTRALYTICS_DEFAULT_MASKS_SMOOTHING_ENABLED
+        ),
+        masks_binarization_threshold: float = (
+            INFERENCE_MODELS_YOLO_ULTRALYTICS_DEFAULT_MASKS_BINARIZATION_THRESHOLD
+        ),
+        **kwargs,
+    ) -> List[InstanceSegmentationInferenceResponse]:
+        instances, protos = predictions
+        if self._model._inference_config.post_processing.fused:
+            nms_results = post_process_nms_fused_model_output(
+                output=instances, conf_thresh=confidence
+            )
+        else:
+            nms_results = run_nms_for_instance_segmentation(
+                output=instances,
+                conf_thresh=confidence,
+                iou_thresh=iou_threshold,
+                max_detections=max_detections,
+                class_agnostic=class_agnostic_nms,
+            )
+        return self._build_memory_optimized_prototype_mask_response(
+            nms_results=nms_results,
+            protos=protos,
+            preprocess_return_metadata=preprocess_return_metadata,
+            binarization_threshold=masks_binarization_threshold,
+            class_filter=kwargs.get("class_filter"),
+            masks_smoothing_enabled=masks_smoothing_enabled,
+        )
+
+    def _postprocess_yolo26_memory_optimized(
+        self,
+        predictions: Tuple[torch.Tensor, torch.Tensor],
+        preprocess_return_metadata: PreprocessingMetadata,
+        confidence: float = INFERENCE_MODELS_YOLO26_DEFAULT_CONFIDENCE,
+        **kwargs,
+    ) -> List[InstanceSegmentationInferenceResponse]:
+        instances, protos = predictions
+        nms_results = post_process_nms_fused_model_output(
+            output=instances, conf_thresh=confidence
+        )
+        return self._build_memory_optimized_prototype_mask_response(
+            nms_results=nms_results,
+            protos=protos,
+            preprocess_return_metadata=preprocess_return_metadata,
+            binarization_threshold=0.0,
+            class_filter=kwargs.get("class_filter"),
+        )
+
+    def _postprocess_rfdetr_memory_optimized(
+        self,
+        predictions: Tuple[torch.Tensor, torch.Tensor, torch.Tensor],
+        preprocess_return_metadata: PreprocessingMetadata,
+        confidence: float = INFERENCE_MODELS_RFDETR_DEFAULT_CONFIDENCE,
+        **kwargs,
+    ) -> List[InstanceSegmentationInferenceResponse]:
+        all_bboxes, all_logits, all_masks = predictions
+        all_logits = torch.nn.functional.sigmoid(all_logits)
+        responses = []
+        for image_bboxes, image_logits, image_masks, image_meta in zip(
+            all_bboxes, all_logits, all_masks, preprocess_return_metadata
+        ):
+            image_confidence, top_classes = image_logits.max(dim=1)
+            confidence_mask = image_confidence > confidence
+            image_confidence = image_confidence[confidence_mask]
+            top_classes = top_classes[confidence_mask]
+            selected_boxes = image_bboxes[confidence_mask]
+            selected_masks = image_masks[confidence_mask]
+            image_confidence, sorted_indices = torch.sort(
+                image_confidence, descending=True
+            )
+            top_classes = top_classes[sorted_indices]
+            selected_boxes = selected_boxes[sorted_indices]
+            selected_masks = selected_masks[sorted_indices]
+            classes_re_mapping = getattr(self._model, "_classes_re_mapping", None)
+            if classes_re_mapping is not None:
+                remapping_mask = torch.isin(
+                    top_classes, classes_re_mapping.remaining_class_ids
+                )
+                top_classes = classes_re_mapping.class_mapping[
+                    top_classes[remapping_mask]
+                ]
+                selected_boxes = selected_boxes[remapping_mask]
+                image_confidence = image_confidence[remapping_mask]
+                selected_masks = selected_masks[remapping_mask]
+            class_keep_mask = self._get_class_keep_mask(
+                class_ids=top_classes,
+                class_filter=kwargs.get("class_filter"),
+            )
+            top_classes = top_classes[class_keep_mask]
+            selected_boxes = selected_boxes[class_keep_mask]
+            image_confidence = image_confidence[class_keep_mask]
+            selected_masks = selected_masks[class_keep_mask]
+            cxcy = selected_boxes[:, :2]
+            wh = selected_boxes[:, 2:]
+            selected_boxes_xyxy_pct = torch.cat(
+                [cxcy - 0.5 * wh, cxcy + 0.5 * wh], dim=-1
+            )
+            denorm_size = (
+                image_meta.nonsquare_intermediate_size or image_meta.inference_size
+            )
+            denorm_size_whwh = torch.tensor(
+                [
+                    denorm_size.width,
+                    denorm_size.height,
+                    denorm_size.width,
+                    denorm_size.height,
+                ],
+                device=all_bboxes.device,
+            )
+            selected_boxes_xyxy = selected_boxes_xyxy_pct * denorm_size_whwh
+            image_bboxes_for_alignment = torch.cat(
+                [
+                    selected_boxes_xyxy,
+                    image_confidence[:, None],
+                    top_classes[:, None].float(),
+                ],
+                dim=1,
+            )
+            responses.append(
+                self._build_memory_optimized_image_response(
+                    image_bboxes=image_bboxes_for_alignment,
+                    masks=selected_masks,
+                    image_meta=image_meta,
+                    inference_size=denorm_size,
+                    binarization_threshold=0.0,
+                )
+            )
+        return responses
+
+    def _build_memory_optimized_prototype_mask_response(
+        self,
+        nms_results: List[torch.Tensor],
+        protos: torch.Tensor,
+        preprocess_return_metadata: PreprocessingMetadata,
+        binarization_threshold: float,
+        class_filter: Optional[List[str]],
+        masks_smoothing_enabled: bool = False,
+    ) -> List[InstanceSegmentationInferenceResponse]:
+        responses = []
+        for image_bboxes, image_protos, image_meta in zip(
+            nms_results, protos, preprocess_return_metadata
+        ):
+            image_bboxes = self._filter_image_bboxes_by_class(
+                image_bboxes=image_bboxes,
+                class_filter=class_filter,
+            )
+            pre_processed_masks = preprocess_segmentation_masks(
+                protos=image_protos,
+                masks_in=image_bboxes[:, 6:],
+            )
+            if masks_smoothing_enabled:
+                pre_processed_masks = torch.nn.functional.sigmoid(pre_processed_masks)
+            cropped_masks = crop_masks_to_boxes(
+                image_bboxes[:, :4], pre_processed_masks
+            )
+            responses.append(
+                self._build_memory_optimized_image_response(
+                    image_bboxes=image_bboxes,
+                    masks=cropped_masks,
+                    image_meta=image_meta,
+                    inference_size=image_meta.inference_size,
+                    binarization_threshold=binarization_threshold,
+                )
+            )
+        return responses
+
+    def _build_memory_optimized_image_response(
+        self,
+        image_bboxes: torch.Tensor,
+        masks: torch.Tensor,
+        image_meta: PreprocessingMetadata,
+        inference_size,
+        binarization_threshold: float,
+    ) -> InstanceSegmentationInferenceResponse:
+        response_predictions = []
+        padding = (
+            image_meta.pad_left,
+            image_meta.pad_top,
+            image_meta.pad_right,
+            image_meta.pad_bottom,
+        )
+        for aligned_box, aligned_mask in iter_aligned_instance_segmentation_results(
+            image_bboxes=image_bboxes,
+            masks=masks,
+            padding=padding,
+            scale_height=image_meta.scale_height,
+            scale_width=image_meta.scale_width,
+            original_size=image_meta.original_size,
+            size_after_pre_processing=image_meta.size_after_pre_processing,
+            inference_size=inference_size,
+            static_crop_offset=image_meta.static_crop_offset,
+            binarization_threshold=binarization_threshold,
+        ):
+            response_predictions.append(
+                self._build_serialized_instance_prediction(
+                    aligned_box=aligned_box,
+                    aligned_mask=aligned_mask,
+                )
+            )
+        return InstanceSegmentationInferenceResponse(
+            predictions=response_predictions,
+            image=InferenceResponseImage(
+                width=image_meta.original_size.width,
+                height=image_meta.original_size.height,
+            ),
+        )
+
+    def _build_serialized_instance_prediction(
+        self,
+        aligned_box: torch.Tensor,
+        aligned_mask: torch.Tensor,
+    ) -> Union[InstanceSegmentationPrediction, InstanceSegmentationRLEPrediction]:
+        aligned_box_cpu = aligned_box.detach().cpu()
+        x1, y1, x2, y2 = aligned_box_cpu[:4].round().int().tolist()
+        conf = float(aligned_box_cpu[4])
+        class_id_int = int(aligned_box_cpu[5])
+        class_name = self._class_name_for_id(class_id=class_id_int)
+        prediction_kwargs = {
+            "x": (float(x1) + float(x2)) / 2.0,
+            "y": (float(y1) + float(y2)) / 2.0,
+            "width": float(x2) - float(x1),
+            "height": float(y2) - float(y1),
+            "confidence": float(conf),
+            "class": class_name,
+            "class_id": class_id_int,
+        }
+        if INFERENCE_MODELS_INSTANCE_SEGMENTATION_MEMORY_OPTIMIZED_FORMAT == "rle":
+            return InstanceSegmentationRLEPrediction(
+                **{
+                    **prediction_kwargs,
+                    "rle": mask_to_coco_rle(mask=aligned_mask),
+                }
+            )
+        polygon = mask_to_largest_polygon(mask=aligned_mask)
+        return InstanceSegmentationPrediction(
+            **{
+                **prediction_kwargs,
+                "points": [Point(x=point[0], y=point[1]) for point in polygon],
+            }
+        )
+
+    def _filter_image_bboxes_by_class(
+        self,
+        image_bboxes: torch.Tensor,
+        class_filter: Optional[List[str]],
+    ) -> torch.Tensor:
+        keep_mask = self._get_class_keep_mask(
+            class_ids=image_bboxes[:, 5],
+            class_filter=class_filter,
+        )
+        return image_bboxes[keep_mask]
+
+    def _get_class_keep_mask(
+        self,
+        class_ids: torch.Tensor,
+        class_filter: Optional[List[str]],
+    ) -> torch.Tensor:
+        if not class_filter or class_ids.shape[0] == 0:
+            return torch.ones(
+                (class_ids.shape[0],),
+                dtype=torch.bool,
+                device=class_ids.device,
+            )
+        class_ids_list = class_ids.detach().cpu().int().tolist()
+        keep = [
+            self._class_name_for_id(class_id=class_id) in class_filter
+            for class_id in class_ids_list
+        ]
+        return torch.as_tensor(keep, dtype=torch.bool, device=class_ids.device)
+
+    def _class_name_for_id(self, class_id: int) -> str:
+        if 0 <= class_id < len(self.class_names):
+            return self.class_names[class_id]
+        return str(class_id)
+
     def postprocess(
         self,
         predictions: List[InstanceDetections],
@@ -305,6 +756,14 @@ class InferenceModelsInstanceSegmentationAdapter(Model):
         **kwargs,
     ) -> List[InstanceSegmentationInferenceResponse]:
         mapped_kwargs = self.map_inference_kwargs(kwargs)
+        if INFERENCE_MODELS_INSTANCE_SEGMENTATION_MEMORY_OPTIMIZED_POSTPROCESS:
+            optimized_response = self._postprocess_memory_optimized(
+                predictions=predictions,
+                preprocess_return_metadata=preprocess_return_metadata,
+                **mapped_kwargs,
+            )
+            if optimized_response is not None:
+                return optimized_response
         detections_list = self._model.post_process(
             predictions, preprocess_return_metadata, **mapped_kwargs
         )

--- a/inference/core/models/inference_models_adapters.py
+++ b/inference/core/models/inference_models_adapters.py
@@ -91,9 +91,7 @@ from inference_models.models.common.roboflow.post_processing import (
     preprocess_segmentation_masks,
     run_nms_for_instance_segmentation,
 )
-from inference_models.models.yolov5.nms import (
-    run_yolov5_nms_for_instance_segmentation,
-)
+from inference_models.models.yolov5.nms import run_yolov5_nms_for_instance_segmentation
 
 DEFAULT_COLOR_PALETTE = [
     "#A351FB",

--- a/inference_models/inference_models/models/common/roboflow/post_processing.py
+++ b/inference_models/inference_models/models/common/roboflow/post_processing.py
@@ -1,5 +1,6 @@
-from typing import List, Literal, Tuple
+from typing import Dict, Iterator, List, Literal, Tuple
 
+import numpy as np
 import torch
 import torchvision
 from torchvision.transforms import functional
@@ -9,6 +10,8 @@ from inference_models.models.common.roboflow.model_packages import (
     PreProcessingMetadata,
     StaticCropOffset,
 )
+
+MASK_ALIGNMENT_CHUNK_PIXEL_LIMIT = 4_000_000
 
 
 def run_nms_for_object_detection(
@@ -327,6 +330,208 @@ def crop_masks_to_boxes(
     return masks * crop_mask
 
 
+def _get_mask_alignment_chunk_size(
+    number_of_masks: int,
+    target_height: int,
+    target_width: int,
+) -> int:
+    pixels_per_mask = max(target_height * target_width, 1)
+    return max(
+        min(
+            number_of_masks,
+            MASK_ALIGNMENT_CHUNK_PIXEL_LIMIT // pixels_per_mask,
+        ),
+        1,
+    )
+
+
+def _resize_and_binarize_masks(
+    masks: torch.Tensor,
+    target_height: int,
+    target_width: int,
+    output_height: int,
+    output_width: int,
+    binarization_threshold: float,
+    output_offset_x: int = 0,
+    output_offset_y: int = 0,
+) -> torch.Tensor:
+    number_of_masks = masks.shape[0]
+    if output_offset_x > 0 or output_offset_y > 0:
+        resized_masks = torch.zeros(
+            (number_of_masks, output_height, output_width),
+            dtype=torch.bool,
+            device=masks.device,
+        )
+    else:
+        resized_masks = torch.empty(
+            (number_of_masks, output_height, output_width),
+            dtype=torch.bool,
+            device=masks.device,
+        )
+    output_y_slice = slice(output_offset_y, output_offset_y + target_height)
+    output_x_slice = slice(output_offset_x, output_offset_x + target_width)
+    chunk_size = _get_mask_alignment_chunk_size(
+        number_of_masks=number_of_masks,
+        target_height=target_height,
+        target_width=target_width,
+    )
+    for chunk_start in range(0, number_of_masks, chunk_size):
+        chunk_end = min(chunk_start + chunk_size, number_of_masks)
+        resized_chunk = functional.resize(
+            masks[chunk_start:chunk_end],
+            [target_height, target_width],
+            interpolation=functional.InterpolationMode.BILINEAR,
+        )
+        resized_masks[
+            chunk_start:chunk_end,
+            output_y_slice,
+            output_x_slice,
+        ] = resized_chunk.gt_(binarization_threshold)
+    return resized_masks
+
+
+def iter_aligned_instance_segmentation_results(
+    image_bboxes: torch.Tensor,
+    masks: torch.Tensor,
+    padding: Tuple[int, int, int, int],
+    scale_width: float,
+    scale_height: float,
+    original_size: ImageDimensions,
+    size_after_pre_processing: ImageDimensions,
+    inference_size: ImageDimensions,
+    static_crop_offset: StaticCropOffset,
+    binarization_threshold: float = 0.0,
+) -> Iterator[Tuple[torch.Tensor, torch.Tensor]]:
+    if image_bboxes.shape[0] == 0:
+        return
+    pad_left, pad_top, pad_right, pad_bottom = padding
+    offsets = torch.tensor(
+        [pad_left, pad_top, pad_left, pad_top],
+        device=image_bboxes.device,
+    )
+    image_bboxes[:, :4].sub_(offsets)
+    scale = torch.as_tensor(
+        [scale_width, scale_height, scale_width, scale_height],
+        dtype=image_bboxes.dtype,
+        device=image_bboxes.device,
+    )
+    image_bboxes[:, :4].div_(scale)
+    n, mh, mw = masks.shape
+    mask_h_scale = mh / inference_size.height
+    mask_w_scale = mw / inference_size.width
+    mask_pad_top, mask_pad_bottom, mask_pad_left, mask_pad_right = (
+        round(mask_h_scale * pad_top),
+        round(mask_h_scale * pad_bottom),
+        round(mask_w_scale * pad_left),
+        round(mask_w_scale * pad_right),
+    )
+    if (
+        mask_pad_top < 0
+        or mask_pad_bottom < 0
+        or mask_pad_left < 0
+        or mask_pad_right < 0
+    ):
+        masks = torch.nn.functional.pad(
+            masks,
+            (
+                abs(min(mask_pad_left, 0)),
+                abs(min(mask_pad_right, 0)),
+                abs(min(mask_pad_top, 0)),
+                abs(min(mask_pad_bottom, 0)),
+            ),
+            "constant",
+            0,
+        )
+        padded_mask_offset_top = max(mask_pad_top, 0)
+        padded_mask_offset_bottom = max(mask_pad_bottom, 0)
+        padded_mask_offset_left = max(mask_pad_left, 0)
+        padded_mask_offset_right = max(mask_pad_right, 0)
+        masks = masks[
+            :,
+            padded_mask_offset_top : masks.shape[1] - padded_mask_offset_bottom,
+            padded_mask_offset_left : masks.shape[2] - padded_mask_offset_right,
+        ]
+    else:
+        masks = masks[
+            :, mask_pad_top : mh - mask_pad_bottom, mask_pad_left : mw - mask_pad_right
+        ]
+
+    if static_crop_offset.offset_x > 0 or static_crop_offset.offset_y > 0:
+        static_crop_offsets = torch.as_tensor(
+            [
+                static_crop_offset.offset_x,
+                static_crop_offset.offset_y,
+                static_crop_offset.offset_x,
+                static_crop_offset.offset_y,
+            ],
+            dtype=image_bboxes.dtype,
+            device=image_bboxes.device,
+        )
+        image_bboxes[:, :4].add_(static_crop_offsets)
+
+    for mask_id in range(n):
+        if static_crop_offset.offset_x > 0 or static_crop_offset.offset_y > 0:
+            aligned_mask = _resize_and_binarize_masks(
+                masks=masks[mask_id : mask_id + 1],
+                target_height=size_after_pre_processing.height,
+                target_width=size_after_pre_processing.width,
+                output_height=original_size.height,
+                output_width=original_size.width,
+                binarization_threshold=binarization_threshold,
+                output_offset_x=static_crop_offset.offset_x,
+                output_offset_y=static_crop_offset.offset_y,
+            )[0]
+        else:
+            aligned_mask = _resize_and_binarize_masks(
+                masks=masks[mask_id : mask_id + 1],
+                target_height=size_after_pre_processing.height,
+                target_width=size_after_pre_processing.width,
+                output_height=size_after_pre_processing.height,
+                output_width=size_after_pre_processing.width,
+                binarization_threshold=binarization_threshold,
+            )[0]
+        yield image_bboxes[mask_id], aligned_mask
+
+
+def mask_to_largest_polygon(mask: torch.Tensor) -> np.ndarray:
+    import cv2
+
+    mask_np = mask.detach().cpu().numpy()
+    if mask_np.dtype == np.bool_:
+        if not mask_np.flags.c_contiguous:
+            mask_np = np.ascontiguousarray(mask_np)
+        mask_uint8 = mask_np.view(np.uint8)
+    elif mask_np.dtype == np.uint8:
+        mask_uint8 = (
+            mask_np
+            if mask_np.flags.c_contiguous
+            else np.ascontiguousarray(mask_np)
+        )
+    else:
+        mask_uint8 = np.ascontiguousarray(mask_np > 0).view(np.uint8)
+    if not np.any(mask_uint8):
+        return np.zeros((0, 2), dtype=np.float32)
+    contours = cv2.findContours(mask_uint8, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)[
+        0
+    ]
+    if not contours:
+        return np.zeros((0, 2), dtype=np.float32)
+    return (
+        np.array(contours[np.array([len(x) for x in contours]).argmax()])
+        .reshape(-1, 2)
+        .astype(np.float32)
+    )
+
+
+def mask_to_coco_rle(mask: torch.Tensor) -> Dict[str, object]:
+    from pycocotools import mask as mask_utils
+
+    mask_np = mask.detach().cpu().numpy().astype(np.uint8)
+    rle = mask_utils.encode(np.asfortranarray(mask_np))
+    rle["counts"] = rle["counts"].decode("utf-8")
+    return rle
+
+
 def align_instance_segmentation_results(
     image_bboxes: torch.Tensor,
     masks: torch.Tensor,
@@ -397,30 +602,17 @@ def align_instance_segmentation_results(
         masks = masks[
             :, mask_pad_top : mh - mask_pad_bottom, mask_pad_left : mw - mask_pad_right
         ]
-    masks = (
-        functional.resize(
-            masks,
-            [size_after_pre_processing.height, size_after_pre_processing.width],
-            interpolation=functional.InterpolationMode.BILINEAR,
-        )
-        .gt_(binarization_threshold)
-        .to(dtype=torch.bool)
-    )
     if static_crop_offset.offset_x > 0 or static_crop_offset.offset_y > 0:
-        mask_canvas = torch.zeros(
-            (
-                masks.shape[0],
-                original_size.height,
-                original_size.width,
-            ),
-            dtype=torch.bool,
-            device=masks.device,
+        masks = _resize_and_binarize_masks(
+            masks=masks,
+            target_height=size_after_pre_processing.height,
+            target_width=size_after_pre_processing.width,
+            output_height=original_size.height,
+            output_width=original_size.width,
+            binarization_threshold=binarization_threshold,
+            output_offset_x=static_crop_offset.offset_x,
+            output_offset_y=static_crop_offset.offset_y,
         )
-        mask_canvas[
-            :,
-            static_crop_offset.offset_y : static_crop_offset.offset_y + masks.shape[1],
-            static_crop_offset.offset_x : static_crop_offset.offset_x + masks.shape[2],
-        ] = masks
         static_crop_offsets = torch.as_tensor(
             [
                 static_crop_offset.offset_x,
@@ -432,5 +624,13 @@ def align_instance_segmentation_results(
             device=image_bboxes.device,
         )
         image_bboxes[:, :4].add_(static_crop_offsets)
-        masks = mask_canvas
+    else:
+        masks = _resize_and_binarize_masks(
+            masks=masks,
+            target_height=size_after_pre_processing.height,
+            target_width=size_after_pre_processing.width,
+            output_height=size_after_pre_processing.height,
+            output_width=size_after_pre_processing.width,
+            binarization_threshold=binarization_threshold,
+        )
     return image_bboxes, masks

--- a/inference_models/tests/unit_tests/models/common/roboflow/test_post_processing.py
+++ b/inference_models/tests/unit_tests/models/common/roboflow/test_post_processing.py
@@ -1,0 +1,179 @@
+import torch
+from torchvision.transforms import functional
+
+from inference_models.entities import ImageDimensions
+from inference_models.models.common.roboflow import post_processing
+from inference_models.models.common.roboflow.model_packages import StaticCropOffset
+
+
+def _legacy_resize_and_binarize_masks(
+    masks: torch.Tensor,
+    target_height: int,
+    target_width: int,
+    binarization_threshold: float,
+) -> torch.Tensor:
+    return (
+        functional.resize(
+            masks,
+            [target_height, target_width],
+            interpolation=functional.InterpolationMode.BILINEAR,
+        )
+        .gt_(binarization_threshold)
+        .to(dtype=torch.bool)
+    )
+
+
+def test_align_instance_segmentation_results_matches_legacy_resize_when_chunked(
+    monkeypatch,
+) -> None:
+    # given
+    monkeypatch.setattr(post_processing, "MASK_ALIGNMENT_CHUNK_PIXEL_LIMIT", 9)
+    masks = torch.linspace(-1.0, 1.0, steps=5 * 3 * 4).reshape(5, 3, 4)
+    image_bboxes = torch.tensor(
+        [
+            [0.0, 0.0, 8.0, 6.0, 0.9, 1.0],
+            [1.0, 1.0, 7.0, 5.0, 0.8, 2.0],
+            [2.0, 1.0, 6.0, 5.0, 0.7, 3.0],
+            [0.0, 2.0, 8.0, 4.0, 0.6, 4.0],
+            [3.0, 0.0, 5.0, 6.0, 0.5, 5.0],
+        ]
+    )
+    expected_masks = _legacy_resize_and_binarize_masks(
+        masks=masks.clone(),
+        target_height=6,
+        target_width=8,
+        binarization_threshold=0.2,
+    )
+
+    # when
+    aligned_boxes, aligned_masks = post_processing.align_instance_segmentation_results(
+        image_bboxes=image_bboxes.clone(),
+        masks=masks.clone(),
+        padding=(0, 0, 0, 0),
+        scale_height=1.0,
+        scale_width=1.0,
+        original_size=ImageDimensions(height=6, width=8),
+        size_after_pre_processing=ImageDimensions(height=6, width=8),
+        inference_size=ImageDimensions(height=6, width=8),
+        static_crop_offset=StaticCropOffset(
+            offset_x=0,
+            offset_y=0,
+            crop_width=0,
+            crop_height=0,
+        ),
+        binarization_threshold=0.2,
+    )
+
+    # then
+    assert torch.equal(aligned_masks, expected_masks)
+    assert torch.allclose(aligned_boxes, image_bboxes)
+
+
+def test_align_instance_segmentation_results_writes_static_crop_to_canvas_when_chunked(
+    monkeypatch,
+) -> None:
+    # given
+    monkeypatch.setattr(post_processing, "MASK_ALIGNMENT_CHUNK_PIXEL_LIMIT", 10)
+    masks = torch.linspace(-0.5, 0.8, steps=4 * 4 * 5).reshape(4, 4, 5)
+    image_bboxes = torch.tensor(
+        [
+            [0.0, 0.0, 10.0, 8.0, 0.9, 1.0],
+            [1.0, 1.0, 9.0, 7.0, 0.8, 2.0],
+            [2.0, 1.0, 8.0, 7.0, 0.7, 3.0],
+            [0.0, 2.0, 10.0, 6.0, 0.6, 4.0],
+        ]
+    )
+    expected_masks = torch.zeros((4, 13, 14), dtype=torch.bool)
+    expected_masks[:, 3:11, 2:12] = _legacy_resize_and_binarize_masks(
+        masks=masks.clone(),
+        target_height=8,
+        target_width=10,
+        binarization_threshold=0.3,
+    )
+    expected_boxes = image_bboxes.clone()
+    expected_boxes[:, :4] += torch.tensor([2.0, 3.0, 2.0, 3.0])
+
+    # when
+    aligned_boxes, aligned_masks = post_processing.align_instance_segmentation_results(
+        image_bboxes=image_bboxes.clone(),
+        masks=masks.clone(),
+        padding=(0, 0, 0, 0),
+        scale_height=1.0,
+        scale_width=1.0,
+        original_size=ImageDimensions(height=13, width=14),
+        size_after_pre_processing=ImageDimensions(height=8, width=10),
+        inference_size=ImageDimensions(height=8, width=10),
+        static_crop_offset=StaticCropOffset(
+            offset_x=2,
+            offset_y=3,
+            crop_width=10,
+            crop_height=8,
+        ),
+        binarization_threshold=0.3,
+    )
+
+    # then
+    assert torch.equal(aligned_masks, expected_masks)
+    assert torch.allclose(aligned_boxes, expected_boxes)
+
+
+def test_iter_aligned_instance_segmentation_results_matches_dense_alignment(
+    monkeypatch,
+) -> None:
+    # given
+    monkeypatch.setattr(post_processing, "MASK_ALIGNMENT_CHUNK_PIXEL_LIMIT", 12)
+    masks = torch.linspace(-0.3, 0.9, steps=3 * 4 * 6).reshape(3, 4, 6)
+    image_bboxes = torch.tensor(
+        [
+            [0.0, 0.0, 12.0, 8.0, 0.9, 1.0],
+            [2.0, 1.0, 11.0, 7.0, 0.8, 2.0],
+            [1.0, 2.0, 10.0, 6.0, 0.7, 3.0],
+        ]
+    )
+    (
+        expected_boxes,
+        expected_masks,
+    ) = post_processing.align_instance_segmentation_results(
+        image_bboxes=image_bboxes.clone(),
+        masks=masks.clone(),
+        padding=(0, 0, 0, 0),
+        scale_height=1.0,
+        scale_width=1.0,
+        original_size=ImageDimensions(height=8, width=12),
+        size_after_pre_processing=ImageDimensions(height=8, width=12),
+        inference_size=ImageDimensions(height=8, width=12),
+        static_crop_offset=StaticCropOffset(
+            offset_x=0,
+            offset_y=0,
+            crop_width=0,
+            crop_height=0,
+        ),
+        binarization_threshold=0.1,
+    )
+
+    # when
+    aligned_results = list(
+        post_processing.iter_aligned_instance_segmentation_results(
+            image_bboxes=image_bboxes.clone(),
+            masks=masks.clone(),
+            padding=(0, 0, 0, 0),
+            scale_height=1.0,
+            scale_width=1.0,
+            original_size=ImageDimensions(height=8, width=12),
+            size_after_pre_processing=ImageDimensions(height=8, width=12),
+            inference_size=ImageDimensions(height=8, width=12),
+            static_crop_offset=StaticCropOffset(
+                offset_x=0,
+                offset_y=0,
+                crop_width=0,
+                crop_height=0,
+            ),
+            binarization_threshold=0.1,
+        )
+    )
+
+    # then
+    aligned_boxes = torch.stack([box for box, _ in aligned_results])
+    aligned_masks = torch.stack([mask for _, mask in aligned_results])
+    assert torch.allclose(aligned_boxes, expected_boxes)
+    assert torch.equal(aligned_masks, expected_masks)


### PR DESCRIPTION
## Summary

This PR adds an opt-in memory-optimized post-processing path for `inference_models` instance segmentation models when they are served through `inference`.

The issue is that the current path materializes full-resolution dense masks for every retained detection before the server serializes the result. In `inference_models/inference_models/models/common/roboflow/post_processing.py`, mask alignment resizes the full `N x H x W` mask stack at once. With hosted defaults such as `max_detections=300`, a single 1920x1080 image can transiently allocate multiple GiB during post-processing, even when the final response is usually polygons or RLE rather than dense masks.

## What Changed

- Chunked the existing dense mask alignment helper so the current `InstanceDetections.mask` contract no longer creates one full `N x H x W` fp32 resize buffer at once.
- Added a streaming alignment iterator that yields one aligned full-resolution mask at a time.
- Added per-mask polygon and COCO RLE serializers.
- Added inference-server env toggles:
  - `INFERENCE_MODELS_INSTANCE_SEGMENTATION_MEMORY_OPTIMIZED_POSTPROCESS=true`
  - `INFERENCE_MODELS_INSTANCE_SEGMENTATION_MEMORY_OPTIMIZED_FORMAT=polygon|rle`
- Added an opt-in adapter path for YOLOv5/YOLOv7/YOLOv8/YOLO26 instance segmentation and RF-DETR instance segmentation.
- Moved class filtering before mask decode/serialization in the optimized adapter path.

## Expected Memory Difference

For an image with `N` retained detections and output size `H x W`:

- Existing dense alignment peak includes an interpolation buffer of roughly `N * H * W * 4` bytes for fp32, plus the final bool mask stack of roughly `N * H * W` bytes.
- The dense contract still requires `N * H * W` bytes for final bool masks, but this PR chunks the resize temp so it is bounded by the chunk size instead of all detections.
- The new opt-in server path avoids the final dense `N x H x W` mask stack entirely and serializes one aligned mask at a time.

Concrete worst-case examples at `N=300`:

- 1920x1080: old path can transiently require about 2.5 GiB for fp32 resize plus about 0.6 GiB for bool masks, before allocator overhead. The streaming path works on roughly one full-res mask at a time, about 8-10 MiB of mask data depending on dtype/temp lifetime.
- 3840x2160: old path can transiently require about 9.9 GiB for fp32 resize plus about 2.5 GiB for bool masks. The streaming path works on roughly one full-res mask at a time, about 33-42 MiB of mask data depending on dtype/temp lifetime.

## Future Direction

This PR intentionally keeps the new hosted behavior behind an inference-server opt-in, but the cleaner long-term interface probably belongs in `inference_models` itself. We should extend the model post-processing API while keeping the current dense API, for example by adding optional arguments for memory-optimized serialization or an iterator-style result API:

- `post_process(..., memory_optimized=True, output_format="polygon" | "rle")`
- or `iter_post_processed_instances(...)`

That would let the inference server call a model-owned memory-optimized implementation instead of reproducing model-specific decode steps in the adapter.

This also likely ties into the existing hosted mask decode knobs (`mask_decode_mode`, `tradeoff_factor`, and `max_candidates`). Those knobs were useful in the old `inference/core` path, but the current `inference_models` adapter path does not consume them. A follow-up could map `mask_decode_mode=tradeoff/fast` onto this memory-optimized path, use `tradeoff_factor` to choose chunking/serialization strategy, and use `max_candidates` to bound candidate masks before full-resolution decode.

## Validation

- `python -m py_compile inference/core/models/inference_models_adapters.py inference/core/env.py inference/core/entities/responses/inference.py inference_models/inference_models/models/common/roboflow/post_processing.py inference_models/tests/unit_tests/models/common/roboflow/test_post_processing.py`
- `git diff --check`

Targeted pytest was not run locally because this workspace Python does not have `pytest` installed (`No module named pytest`).