### PR TITLE
Route all API calls through Secure Gateway proxy and rename LICENSE_SERVER

### DIFF
--- a/docs/quickstart/docker_configuration_options.md
+++ b/docs/quickstart/docker_configuration_options.md
@@ -59,11 +59,13 @@ Sets the max batch size accepted by the clip model inference functions.
 
 If true, the batch size will be fixed to the maximum batch size configured for this server.
 
-## License Server
+## Secure Gateway
 
-**LICENSE_SERVER**: String (default = None)
+**SECURE_GATEWAY**: String (default = None)
 
-Sets the address of a Roboflow license server.
+Sets the address of a Roboflow Secure Gateway for air-gapped deployments. All API and model download traffic will be routed through this proxy.
+
+The legacy `LICENSE_SERVER` environment variable is still accepted but deprecated.
 
 ## Maximum Active Models
 

--- a/inference/core/env.py
+++ b/inference/core/env.py
@@ -367,8 +367,16 @@ CORRELATION_ID_LOG_KEY = os.getenv("CORRELATION_ID_LOG_KEY", "request_id")
 # Flag to enable legacy route, default is True
 LEGACY_ROUTE_ENABLED = str2bool(os.getenv("LEGACY_ROUTE_ENABLED", True))
 
-# License server, default is None
-LICENSE_SERVER = os.getenv("LICENSE_SERVER", None)
+# Secure gateway address for air-gapped deployments.
+# Accepts SECURE_GATEWAY (preferred) or LICENSE_SERVER (legacy).
+_legacy_license_server = os.getenv("LICENSE_SERVER")
+SECURE_GATEWAY = os.getenv("SECURE_GATEWAY") or _legacy_license_server or None
+if _legacy_license_server and not os.getenv("SECURE_GATEWAY"):
+    warnings.warn(
+        "LICENSE_SERVER is deprecated, use SECURE_GATEWAY instead",
+        DeprecationWarning,
+        stacklevel=1,
+    )
 
 # Log level, default is "WARNING"
 LOG_LEVEL = os.getenv("LOG_LEVEL", "WARNING")

--- a/inference/core/env.py
+++ b/inference/core/env.py
@@ -373,7 +373,8 @@ _legacy_license_server = os.getenv("LICENSE_SERVER")
 SECURE_GATEWAY = os.getenv("SECURE_GATEWAY") or _legacy_license_server or None
 if _legacy_license_server and not os.getenv("SECURE_GATEWAY"):
     warnings.warn(
-        "LICENSE_SERVER is deprecated, use SECURE_GATEWAY instead",
+        "`LICENSE_SERVER` env variable is deprecated, use `SECURE_GATEWAY` instead. "
+        "`LICENSE_SERVER` will be removed end of Q3 2026.",
         DeprecationWarning,
         stacklevel=1,
     )

--- a/inference/core/interfaces/http/http_api.py
+++ b/inference/core/interfaces/http/http_api.py
@@ -287,6 +287,7 @@ from inference.core.telemetry import (
 )
 from inference.core.utils.container import is_docker_socket_mounted
 from inference.core.utils.notebooks import start_notebook
+from inference.core.utils.url_utils import wrap_url
 from inference.core.workflows.core_steps.common.entities import StepExecutionMode
 from inference.core.workflows.errors import (
     WorkflowBlockError,
@@ -3354,7 +3355,7 @@ class HttpInterface(BaseInterface):
                             )
 
                             response = requests.post(
-                                f"{endpoint}?api_key={api_key}",
+                                wrap_url(f"{endpoint}?api_key={api_key}"),
                                 json=payload,
                                 headers=headers,
                                 timeout=60,
@@ -3455,7 +3456,7 @@ class HttpInterface(BaseInterface):
                             )
 
                             response = requests.post(
-                                f"{endpoint}?api_key={api_key}",
+                                wrap_url(f"{endpoint}?api_key={api_key}"),
                                 json=payload,
                                 headers=headers,
                                 timeout=60,

--- a/inference/core/interfaces/webrtc_worker/watchdog.py
+++ b/inference/core/interfaces/webrtc_worker/watchdog.py
@@ -11,6 +11,7 @@ from inference.core.env import (
 )
 from inference.core.interfaces.webrtc_worker.utils import is_over_quota
 from inference.core.logger import logger
+from inference.core.utils.url_utils import wrap_url
 
 
 class Watchdog:
@@ -87,7 +88,7 @@ class Watchdog:
 
         try:
             response = requests.post(
-                self._heartbeat_url,
+                wrap_url(self._heartbeat_url),
                 json={
                     "session_id": self._session_id,
                     "api_key": self._api_key,
@@ -116,7 +117,7 @@ class Watchdog:
         url = self._heartbeat_url + "/end"
         try:
             response = requests.post(
-                url,
+                wrap_url(url),
                 json={
                     "session_id": self._session_id,
                     "api_key": self._api_key,

--- a/inference/core/roboflow_api.py
+++ b/inference/core/roboflow_api.py
@@ -20,6 +20,7 @@ import requests
 from cachetools.func import ttl_cache
 from requests import Response, Timeout
 from requests_toolbelt import MultipartEncoder
+from yarl import URL
 
 from inference.core import logger
 from inference.core.cache import cache
@@ -290,10 +291,15 @@ def get_roboflow_workspace(api_key: str) -> WorkspaceID:
 async def get_roboflow_workspace_async(api_key: str) -> WorkspaceID:
     try:
         headers = build_roboflow_api_headers()
+        full_url = wrap_url(
+            _add_params_to_url(
+                url=f"{API_BASE_URL}/",
+                params=[("api_key", api_key), ("nocache", "true")],
+            )
+        )
         async with aiohttp.ClientSession() as session:
             async with session.get(
-                f"{API_BASE_URL}/",
-                params={"api_key": api_key, "nocache": "true"},
+                URL(full_url, encoded=True),
                 headers=headers,
                 timeout=ROBOFLOW_API_REQUEST_TIMEOUT,
             ) as response:
@@ -332,10 +338,15 @@ async def get_serverless_usage_check_async(
 ) -> ServerlessUsageCheckResponse:
     try:
         headers = build_roboflow_api_headers()
+        full_url = wrap_url(
+            _add_params_to_url(
+                url=f"{API_BASE_URL}/serverless/usage-check",
+                params=[("api_key", api_key), ("nocache", "true")],
+            )
+        )
         async with aiohttp.ClientSession() as session:
             async with session.get(
-                f"{API_BASE_URL}/serverless/usage-check",
-                params={"api_key": api_key, "nocache": "true"},
+                URL(full_url, encoded=True),
                 headers=headers,
                 timeout=ROBOFLOW_API_REQUEST_TIMEOUT,
             ) as response:
@@ -389,9 +400,11 @@ def add_custom_metadata(
     field_name: str,
     field_value: str,
 ):
-    api_url = _add_params_to_url(
-        url=f"{API_BASE_URL}/{workspace_id}/inference-stats/metadata",
-        params=[("api_key", api_key), ("nocache", "true")],
+    api_url = wrap_url(
+        _add_params_to_url(
+            url=f"{API_BASE_URL}/{workspace_id}/inference-stats/metadata",
+            params=[("api_key", api_key), ("nocache", "true")],
+        )
     )
     response = requests.post(
         url=api_url,
@@ -1126,7 +1139,9 @@ def _test_range_request(url: str, timeout: int = 10) -> bool:
     """
     try:
         headers = {"Range": "bytes=0-0"}
-        response = requests.get(url, headers=headers, stream=True, timeout=timeout)
+        response = requests.get(
+            wrap_url(url), headers=headers, stream=True, timeout=timeout
+        )
         response.close()
         if response.status_code == 206:
             return True
@@ -1200,9 +1215,11 @@ def send_inference_results_to_model_monitoring(
     workspace_id: WorkspaceID,
     inference_data: dict,
 ):
-    api_url = _add_params_to_url(
-        url=f"{API_BASE_URL}/{workspace_id}/inference-stats",
-        params=[("api_key", api_key)],
+    api_url = wrap_url(
+        _add_params_to_url(
+            url=f"{API_BASE_URL}/{workspace_id}/inference-stats",
+            params=[("api_key", api_key)],
+        )
     )
     response = requests.post(
         url=api_url,

--- a/inference/core/utils/url_utils.py
+++ b/inference/core/utils/url_utils.py
@@ -1,11 +1,11 @@
 import urllib
 
-from inference.core.env import LICENSE_SERVER
+from inference.core.env import SECURE_GATEWAY
 
 
 def wrap_url(url: str) -> str:
-    if not LICENSE_SERVER:
+    if not SECURE_GATEWAY:
         return url
-    return f"http://{LICENSE_SERVER}/proxy?url=" + urllib.parse.quote(
+    return f"http://{SECURE_GATEWAY}/proxy?url=" + urllib.parse.quote(
         url, safe="~()*!'"
     )

--- a/inference/core/workflows/core_steps/models/foundation/seg_preview/v1.py
+++ b/inference/core/workflows/core_steps/models/foundation/seg_preview/v1.py
@@ -18,6 +18,7 @@ from inference.core.env import (
 )
 from inference.core.managers.base import ModelManager
 from inference.core.roboflow_api import build_roboflow_api_headers
+from inference.core.utils.url_utils import wrap_url
 from inference.core.workflows.core_steps.common.entities import StepExecutionMode
 from inference.core.workflows.core_steps.common.utils import (
     attach_parents_coordinates_to_batch_of_sv_detections,
@@ -200,7 +201,7 @@ class SegPreviewBlockV1(WorkflowBlock):
                 headers = build_roboflow_api_headers(explicit_headers=headers)
 
                 response = requests.post(
-                    f"{endpoint}?api_key={api_key}",
+                    wrap_url(f"{endpoint}?api_key={api_key}"),
                     json=payload,
                     headers=headers,
                     timeout=60,

--- a/inference/core/workflows/core_steps/models/foundation/segment_anything3/v1.py
+++ b/inference/core/workflows/core_steps/models/foundation/segment_anything3/v1.py
@@ -26,6 +26,7 @@ from inference.core.env import (
 )
 from inference.core.managers.base import ModelManager
 from inference.core.roboflow_api import build_roboflow_api_headers
+from inference.core.utils.url_utils import wrap_url
 from inference.core.workflows.core_steps.common.entities import StepExecutionMode
 from inference.core.workflows.core_steps.common.utils import (
     attach_parents_coordinates_to_batch_of_sv_detections,
@@ -404,7 +405,7 @@ class SegmentAnything3BlockV1(WorkflowBlock):
                 headers = build_roboflow_api_headers(explicit_headers=headers)
 
                 response = requests.post(
-                    f"{endpoint}?api_key={api_key}",
+                    wrap_url(f"{endpoint}?api_key={api_key}"),
                     json=payload,
                     headers=headers,
                     timeout=60,

--- a/inference/core/workflows/core_steps/models/foundation/segment_anything3/v2.py
+++ b/inference/core/workflows/core_steps/models/foundation/segment_anything3/v2.py
@@ -26,6 +26,7 @@ from inference.core.env import (
 )
 from inference.core.managers.base import ModelManager
 from inference.core.roboflow_api import build_roboflow_api_headers
+from inference.core.utils.url_utils import wrap_url
 from inference.core.workflows.core_steps.common.entities import StepExecutionMode
 from inference.core.workflows.core_steps.common.utils import (
     attach_parents_coordinates_to_batch_of_sv_detections,
@@ -493,7 +494,7 @@ class SegmentAnything3BlockV2(WorkflowBlock):
                 headers = build_roboflow_api_headers(explicit_headers=headers)
 
                 response = requests.post(
-                    f"{endpoint}?api_key={api_key}",
+                    wrap_url(f"{endpoint}?api_key={api_key}"),
                     json=payload,
                     headers=headers,
                     timeout=60,

--- a/inference/core/workflows/core_steps/models/foundation/segment_anything3/v3.py
+++ b/inference/core/workflows/core_steps/models/foundation/segment_anything3/v3.py
@@ -26,6 +26,7 @@ from inference.core.env import (
 )
 from inference.core.managers.base import ModelManager
 from inference.core.roboflow_api import build_roboflow_api_headers
+from inference.core.utils.url_utils import wrap_url
 from inference.core.workflows.core_steps.common.entities import StepExecutionMode
 from inference.core.workflows.core_steps.common.utils import (
     attach_parents_coordinates_to_batch_of_sv_detections,
@@ -536,7 +537,7 @@ class SegmentAnything3BlockV3(WorkflowBlock):
                 headers = build_roboflow_api_headers(explicit_headers=headers)
 
                 response = requests.post(
-                    f"{endpoint}?api_key={api_key}",
+                    wrap_url(f"{endpoint}?api_key={api_key}"),
                     json=payload,
                     headers=headers,
                     timeout=60,

--- a/inference/core/workflows/core_steps/sinks/roboflow/vision_events/v1.py
+++ b/inference/core/workflows/core_steps/sinks/roboflow/vision_events/v1.py
@@ -13,6 +13,7 @@ from pydantic import ConfigDict, Field
 from inference.core.env import API_BASE_URL
 from inference.core.logger import logger
 from inference.core.utils.image_utils import encode_image_to_jpeg_bytes
+from inference.core.utils.url_utils import wrap_url
 from inference.core.workflows.core_steps.common.serializers import mask_to_polygon
 from inference.core.workflows.execution_engine.constants import (
     KEYPOINTS_CLASS_ID_KEY_IN_SV_DETECTIONS,
@@ -745,7 +746,7 @@ def _upload_image(
         image_data.numpy_image, jpeg_quality=jpeg_quality
     )
     response = requests.post(
-        f"{api_base_url}/vision-events/upload",
+        wrap_url(f"{api_base_url}/vision-events/upload"),
         headers={"Authorization": f"Bearer {api_key}"},
         files={"file": ("image.jpg", image_bytes, "image/jpeg")},
         timeout=30,
@@ -797,7 +798,7 @@ def _send_event(
     """
     try:
         response = requests.post(
-            f"{api_base_url}/vision-events",
+            wrap_url(f"{api_base_url}/vision-events"),
             headers={
                 "Authorization": f"Bearer {api_key}",
                 "Content-Type": "application/json",

--- a/inference/models/grounding_dino/grounding_dino.py
+++ b/inference/models/grounding_dino/grounding_dino.py
@@ -1,5 +1,4 @@
 import os
-import urllib.request
 from time import perf_counter
 from typing import Any, List, Optional
 
@@ -81,16 +80,15 @@ class GroundingDINO(RoboflowCoreModel):
 
         GROUNDING_DINO_CACHE_DIR = os.path.join(MODEL_CACHE_DIR, model_id)
 
+        import groundingdino.config as _gd_config
+
         GROUNDING_DINO_CONFIG_PATH = os.path.join(
-            GROUNDING_DINO_CACHE_DIR, "GroundingDINO_SwinT_OGC.py"
+            os.path.dirname(_gd_config.__file__),
+            "GroundingDINO_SwinT_OGC.py",
         )
 
         if not os.path.exists(GROUNDING_DINO_CACHE_DIR):
             os.makedirs(GROUNDING_DINO_CACHE_DIR)
-
-        if not os.path.exists(GROUNDING_DINO_CONFIG_PATH):
-            url = "https://raw.githubusercontent.com/roboflow/GroundingDINO/main/groundingdino/config/GroundingDINO_SwinT_OGC.py"
-            urllib.request.urlretrieve(url, GROUNDING_DINO_CONFIG_PATH)
 
         self.model = Model(
             model_config_path=GROUNDING_DINO_CONFIG_PATH,

--- a/inference_models/docs/changelog.md
+++ b/inference_models/docs/changelog.md
@@ -96,7 +96,7 @@ problem with loading is recoverable.
 
 ### Added
 
-- Support for Roboflow License Server proxy in Roboflow weights provider 
+- Support for Roboflow Secure Gateway proxy in Roboflow weights provider
 
 ---
 

--- a/inference_models/docs/changelog.md
+++ b/inference_models/docs/changelog.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## `0.26.1`
+
+### Changed
+- For Roboflow weights provider, Roboflow License Server proxy transitioned into 
+Roboflow Secure Gateway, altering naming conventions of all helper functions which are 
+considered private interface of weights provider (hence should not be considered breaking 
+for any clients). Along with this change, `LICENSE_SERVER` environmental variable controlling 
+the proxy address was replaced to be `SECURE_GATEWAY` - old variable will be deleted in the
+release following after the end of Q3 2026.
+
+---
+
 ## `0.26.0` 
 
 ### Added
@@ -96,7 +108,7 @@ problem with loading is recoverable.
 
 ### Added
 
-- Support for Roboflow Secure Gateway proxy in Roboflow weights provider
+- Support for Roboflow License Server proxy in Roboflow weights provider
 
 ---
 

--- a/inference_models/inference_models/configuration.py
+++ b/inference_models/inference_models/configuration.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 
 import torch
 
@@ -43,7 +44,14 @@ ROBOFLOW_API_HOST = os.getenv(
         else "https://api.roboflow.one"
     ),
 )
-ROBOFLOW_LICENSE_SERVER = os.getenv("LICENSE_SERVER", None)
+_legacy_license_server = os.getenv("LICENSE_SERVER")
+SECURE_GATEWAY = os.getenv("SECURE_GATEWAY") or _legacy_license_server or None
+if _legacy_license_server and not os.getenv("SECURE_GATEWAY"):
+    warnings.warn(
+        "LICENSE_SERVER is deprecated, use SECURE_GATEWAY instead",
+        DeprecationWarning,
+        stacklevel=1,
+    )
 RUNNING_ON_JETSON = os.getenv("RUNNING_ON_JETSON")
 L4T_VERSION = os.getenv("L4T_VERSION")
 INFERENCE_HOME = os.getenv("INFERENCE_HOME", "/tmp/cache")

--- a/inference_models/inference_models/configuration.py
+++ b/inference_models/inference_models/configuration.py
@@ -48,7 +48,8 @@ _legacy_license_server = os.getenv("LICENSE_SERVER")
 SECURE_GATEWAY = os.getenv("SECURE_GATEWAY") or _legacy_license_server or None
 if _legacy_license_server and not os.getenv("SECURE_GATEWAY"):
     warnings.warn(
-        "LICENSE_SERVER is deprecated, use SECURE_GATEWAY instead",
+        "`LICENSE_SERVER` env variable is deprecated, use `SECURE_GATEWAY` instead. "
+        "`LICENSE_SERVER` will be removed end of Q3 2026.",
         DeprecationWarning,
         stacklevel=1,
     )

--- a/inference_models/inference_models/weights_providers/roboflow.py
+++ b/inference_models/inference_models/weights_providers/roboflow.py
@@ -14,7 +14,7 @@ from inference_models.configuration import (
     IDEMPOTENT_API_REQUEST_CODES_TO_RETRY,
     ROBOFLOW_API_HOST,
     ROBOFLOW_API_KEY,
-    ROBOFLOW_LICENSE_SERVER,
+    SECURE_GATEWAY,
 )
 
 LOCAL_API_KEY = "local"
@@ -107,8 +107,8 @@ def get_roboflow_model(
     **kwargs,
 ) -> ModelMetadata:
     proxy_url_builder = None
-    if ROBOFLOW_LICENSE_SERVER:
-        proxy_url_builder = roboflow_license_server_proxy_url_builder
+    if SECURE_GATEWAY:
+        proxy_url_builder = roboflow_secure_gateway_proxy_url_builder
     model_metadata = get_model_metadata(
         model_id=model_id,
         api_key=api_key,
@@ -147,7 +147,7 @@ def get_roboflow_model(
     )
 
 
-def roboflow_license_server_proxy_url_builder(
+def roboflow_secure_gateway_proxy_url_builder(
     url: str, query: Optional[Dict[str, Union[str, List[str]]]]
 ) -> str:
     """
@@ -156,9 +156,9 @@ def roboflow_license_server_proxy_url_builder(
     """
     if query is not None:
         url = _add_query_params_to_url(url=url, query=query)
-    if not ROBOFLOW_LICENSE_SERVER:
+    if not SECURE_GATEWAY:
         return url
-    return f"http://{ROBOFLOW_LICENSE_SERVER}/proxy?url=" + urllib.parse.quote(
+    return f"http://{SECURE_GATEWAY}/proxy?url=" + urllib.parse.quote(
         url, safe="~()*!'"
     )
 

--- a/inference_models/pyproject.toml
+++ b/inference_models/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inference-models"
-version = "0.26.0"
+version = "0.26.1"
 description = "The new inference engine for Computer Vision models"
 readme = "README.md"
 requires-python = ">=3.10,<3.13"

--- a/inference_models/tests/unit_tests/weights_providers/test_roboflow.py
+++ b/inference_models/tests/unit_tests/weights_providers/test_roboflow.py
@@ -41,10 +41,10 @@ from inference_models.weights_providers.roboflow import (
     get_roboflow_model,
     handle_response_errors,
     parse_model_package_metadata,
-    roboflow_license_server_proxy_url_builder,
+    roboflow_secure_gateway_proxy_url_builder,
 )
 
-DUMMY_PROXY_PREFIX = "http://license.local/proxy?url="
+DUMMY_PROXY_PREFIX = "http://gateway.local/proxy?url="
 
 
 def test_as_version_when_valid_version_provided() -> None:
@@ -1702,12 +1702,12 @@ def test_get_roboflow_model_drops_unknown_recommended_parameters_keys(
     assert result.recommended_parameters == RecommendedParameters(confidence=0.42)
 
 
-@patch.object(roboflow_module, "ROBOFLOW_LICENSE_SERVER", "license.local")
+@patch.object(roboflow_module, "SECURE_GATEWAY", "gateway.local")
 def test_get_roboflow_model_with_proxy(requests_mock: Mocker) -> None:
     # given
     requests_mock.register_uri(
         "GET",
-        re.compile(r"http://license\.local/proxy"),
+        re.compile(r"http://gateway\.local/proxy"),
         [
             {
                 "status_code": 200,
@@ -1811,7 +1811,7 @@ def test_get_roboflow_model_with_proxy(requests_mock: Mocker) -> None:
     for history_entry in requests_mock.request_history:
         parsed = urllib.parse.urlparse(history_entry.url)
         assert parsed.scheme == "http"
-        assert parsed.netloc == "license.local"
+        assert parsed.netloc == "gateway.local"
         assert parsed.path == "/proxy"
         outer_params = urllib.parse.parse_qs(parsed.query)
         assert "url" in outer_params
@@ -1823,21 +1823,21 @@ def test_get_roboflow_model_with_proxy(requests_mock: Mocker) -> None:
     for package in result.model_packages:
         for artefact in package.package_artefacts:
             parsed = urllib.parse.urlparse(artefact.download_url)
-            assert parsed.netloc == "license.local"
+            assert parsed.netloc == "gateway.local"
             assert parsed.path == "/proxy"
             inner_url = urllib.parse.parse_qs(parsed.query)["url"][0]
             assert inner_url == "https://link.com"
 
 
-@patch.object(roboflow_module, "ROBOFLOW_LICENSE_SERVER", "license.local:8080")
+@patch.object(roboflow_module, "SECURE_GATEWAY", "gateway.local:8080")
 def test_basic_url_no_query():
-    result = roboflow_license_server_proxy_url_builder(
+    result = roboflow_secure_gateway_proxy_url_builder(
         url="https://api.roboflow.com/models/v1/weights",
         query=None,
     )
     outer = _parse_proxy_result(result)
     assert outer.scheme == "http"
-    assert outer.netloc == "license.local:8080"
+    assert outer.netloc == "gateway.local:8080"
     assert outer.path == "/proxy"
 
     inner_url = _extract_proxied_url(result)
@@ -1848,9 +1848,9 @@ def test_basic_url_no_query():
     assert inner.query == ""
 
 
-@patch.object(roboflow_module, "ROBOFLOW_LICENSE_SERVER", "license.local:8080")
+@patch.object(roboflow_module, "SECURE_GATEWAY", "gateway.local:8080")
 def test_query_params_are_embedded_in_proxied_url():
-    result = roboflow_license_server_proxy_url_builder(
+    result = roboflow_secure_gateway_proxy_url_builder(
         url="https://api.roboflow.com/weights",
         query={"modelId": "my-model", "api_key": "abc123"},
     )
@@ -1859,9 +1859,9 @@ def test_query_params_are_embedded_in_proxied_url():
     assert inner_params["api_key"] == ["abc123"]
 
 
-@patch.object(roboflow_module, "ROBOFLOW_LICENSE_SERVER", "license.local:8080")
+@patch.object(roboflow_module, "SECURE_GATEWAY", "gateway.local:8080")
 def test_query_with_list_values():
-    result = roboflow_license_server_proxy_url_builder(
+    result = roboflow_secure_gateway_proxy_url_builder(
         url="https://api.roboflow.com/weights",
         query={"tag": ["a", "b"]},
     )
@@ -1869,9 +1869,9 @@ def test_query_with_list_values():
     assert inner_params["tag"] == ["a", "b"]
 
 
-@patch.object(roboflow_module, "ROBOFLOW_LICENSE_SERVER", "license.local:8080")
+@patch.object(roboflow_module, "SECURE_GATEWAY", "gateway.local:8080")
 def test_empty_query_dict_no_params_in_proxied_url():
-    result = roboflow_license_server_proxy_url_builder(
+    result = roboflow_secure_gateway_proxy_url_builder(
         url="https://api.roboflow.com/weights",
         query={},
     )
@@ -1880,9 +1880,9 @@ def test_empty_query_dict_no_params_in_proxied_url():
     assert inner.query == ""
 
 
-@patch.object(roboflow_module, "ROBOFLOW_LICENSE_SERVER", None)
-def test_no_license_server_returns_plain_url():
-    result = roboflow_license_server_proxy_url_builder(
+@patch.object(roboflow_module, "SECURE_GATEWAY", None)
+def test_no_secure_gateway_returns_plain_url():
+    result = roboflow_secure_gateway_proxy_url_builder(
         url="https://api.roboflow.com/weights",
         query=None,
     )
@@ -1893,9 +1893,9 @@ def test_no_license_server_returns_plain_url():
     assert parsed.query == ""
 
 
-@patch.object(roboflow_module, "ROBOFLOW_LICENSE_SERVER", None)
-def test_no_license_server_with_query_returns_url_with_params():
-    result = roboflow_license_server_proxy_url_builder(
+@patch.object(roboflow_module, "SECURE_GATEWAY", None)
+def test_no_secure_gateway_with_query_returns_url_with_params():
+    result = roboflow_secure_gateway_proxy_url_builder(
         url="https://api.roboflow.com/weights",
         query={"modelId": "my-model"},
     )
@@ -1907,9 +1907,9 @@ def test_no_license_server_with_query_returns_url_with_params():
     assert params["modelId"] == ["my-model"]
 
 
-@patch.object(roboflow_module, "ROBOFLOW_LICENSE_SERVER", "")
-def test_empty_string_license_server_returns_plain_url():
-    result = roboflow_license_server_proxy_url_builder(
+@patch.object(roboflow_module, "SECURE_GATEWAY", "")
+def test_empty_string_secure_gateway_returns_plain_url():
+    result = roboflow_secure_gateway_proxy_url_builder(
         url="https://api.roboflow.com/weights",
         query=None,
     )
@@ -1919,9 +1919,9 @@ def test_empty_string_license_server_returns_plain_url():
     assert parsed.query == ""
 
 
-@patch.object(roboflow_module, "ROBOFLOW_LICENSE_SERVER", "proxy.internal")
+@patch.object(roboflow_module, "SECURE_GATEWAY", "proxy.internal")
 def test_url_with_existing_params_preserved_after_proxying():
-    result = roboflow_license_server_proxy_url_builder(
+    result = roboflow_secure_gateway_proxy_url_builder(
         url="https://api.roboflow.com/weights?existing=val&other=123",
         query=None,
     )
@@ -1930,9 +1930,9 @@ def test_url_with_existing_params_preserved_after_proxying():
     assert inner_params["other"] == ["123"]
 
 
-@patch.object(roboflow_module, "ROBOFLOW_LICENSE_SERVER", "proxy.internal:9090")
+@patch.object(roboflow_module, "SECURE_GATEWAY", "proxy.internal:9090")
 def test_proxy_url_structure():
-    result = roboflow_license_server_proxy_url_builder(
+    result = roboflow_secure_gateway_proxy_url_builder(
         url="https://api.roboflow.com/weights",
         query=None,
     )
@@ -1943,9 +1943,9 @@ def test_proxy_url_structure():
     assert "url" in urllib.parse.parse_qs(outer.query)
 
 
-@patch.object(roboflow_module, "ROBOFLOW_LICENSE_SERVER", "proxy.internal")
+@patch.object(roboflow_module, "SECURE_GATEWAY", "proxy.internal")
 def test_proxy_uses_http_not_https():
-    result = roboflow_license_server_proxy_url_builder(
+    result = roboflow_secure_gateway_proxy_url_builder(
         url="https://api.roboflow.com/weights",
         query=None,
     )
@@ -1953,9 +1953,9 @@ def test_proxy_uses_http_not_https():
     assert outer.scheme == "http"
 
 
-@patch.object(roboflow_module, "ROBOFLOW_LICENSE_SERVER", "proxy.internal")
+@patch.object(roboflow_module, "SECURE_GATEWAY", "proxy.internal")
 def test_roundtrip_preserves_query_with_special_characters():
-    result = roboflow_license_server_proxy_url_builder(
+    result = roboflow_secure_gateway_proxy_url_builder(
         url="https://api.roboflow.com/weights",
         query={"modelId": "workspace/model", "api_key": "key=with=equals"},
     )
@@ -1964,9 +1964,9 @@ def test_roundtrip_preserves_query_with_special_characters():
     assert inner_params["api_key"] == ["key=with=equals"]
 
 
-@patch.object(roboflow_module, "ROBOFLOW_LICENSE_SERVER", "proxy.internal")
+@patch.object(roboflow_module, "SECURE_GATEWAY", "proxy.internal")
 def test_proxy_url_param_does_not_leak_into_inner_url():
-    result = roboflow_license_server_proxy_url_builder(
+    result = roboflow_secure_gateway_proxy_url_builder(
         url="https://api.roboflow.com/weights",
         query={"modelId": "test"},
     )
@@ -1980,9 +1980,9 @@ def test_proxy_url_param_does_not_leak_into_inner_url():
     assert "modelId" in inner_params
 
 
-@patch.object(roboflow_module, "ROBOFLOW_LICENSE_SERVER", "proxy.internal")
+@patch.object(roboflow_module, "SECURE_GATEWAY", "proxy.internal")
 def test_params_from_url_and_query_are_both_preserved():
-    result = roboflow_license_server_proxy_url_builder(
+    result = roboflow_secure_gateway_proxy_url_builder(
         url="https://api.roboflow.com/weights?existing=from_url&page=1",
         query={"modelId": "my-model", "api_key": "abc123"},
     )
@@ -1995,18 +1995,18 @@ def test_params_from_url_and_query_are_both_preserved():
     assert inner_params["api_key"] == ["abc123"]
 
 
-@patch.object(roboflow_module, "ROBOFLOW_LICENSE_SERVER", "proxy.internal")
+@patch.object(roboflow_module, "SECURE_GATEWAY", "proxy.internal")
 def test_overlapping_params_from_url_and_query():
     with pytest.raises(AssumptionError):
-        _ = roboflow_license_server_proxy_url_builder(
+        _ = roboflow_secure_gateway_proxy_url_builder(
             url="https://api.roboflow.com/weights?key=from_url",
             query={"key": "from_query"},
         )
 
 
-@patch.object(roboflow_module, "ROBOFLOW_LICENSE_SERVER", None)
+@patch.object(roboflow_module, "SECURE_GATEWAY", None)
 def test_params_from_url_and_query_are_both_preserved_without_proxy():
-    result = roboflow_license_server_proxy_url_builder(
+    result = roboflow_secure_gateway_proxy_url_builder(
         url="https://api.roboflow.com/weights?existing=from_url",
         query={"modelId": "my-model"},
     )

--- a/inference_models/uv.lock
+++ b/inference_models/uv.lock
@@ -917,7 +917,7 @@ wheels = [
 
 [[package]]
 name = "inference-models"
-version = "0.26.0"
+version = "0.26.1"
 source = { virtual = "." }
 dependencies = [
     { name = "accelerate" },

--- a/requirements/requirements.cpu.txt
+++ b/requirements/requirements.cpu.txt
@@ -1,3 +1,3 @@
 onnxruntime>=1.15.1,<1.22.0
 nvidia-ml-py<13.0.0
-inference-models[torch-cpu,onnx-cpu]~=0.26.0  # keep in sync between requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt
+inference-models[torch-cpu,onnx-cpu]~=0.26.1  # keep in sync between requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt

--- a/requirements/requirements.gpu.txt
+++ b/requirements/requirements.gpu.txt
@@ -1,2 +1,2 @@
 onnxruntime-gpu>=1.15.1,<1.22.0
-inference-models[torch-cu124,onnx-cu12]~=0.26.0  # keep in sync between requirements.jetson requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt
+inference-models[torch-cu124,onnx-cu12]~=0.26.1  # keep in sync between requirements.jetson requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt

--- a/requirements/requirements.jetson.txt
+++ b/requirements/requirements.jetson.txt
@@ -1,4 +1,4 @@
 pypdfium2>=4.11.0,<5.0.0
 jupyterlab>=4.3.0,<5.0.0
 PyYAML~=6.0.0
-inference-models~=0.26.0  # keep in sync between requirements.jetson requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt
+inference-models~=0.26.1  # keep in sync between requirements.jetson requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt

--- a/requirements/requirements.vino.txt
+++ b/requirements/requirements.vino.txt
@@ -1,2 +1,2 @@
 onnxruntime-openvino>=1.15.0,<1.22.0
-inference-models[torch-cpu]~=0.26.0  # keep in sync between requirements.jetson requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt
+inference-models[torch-cpu]~=0.26.1  # keep in sync between requirements.jetson requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt

--- a/tests/inference/unit_tests/core/test_roboflow_api.py
+++ b/tests/inference/unit_tests/core/test_roboflow_api.py
@@ -33,6 +33,7 @@ from inference.core.exceptions import (
 from inference.core.roboflow_api import (
     ModelEndpointType,
     ServerlessUsageCheckResponse,
+    add_custom_metadata,
     annotate_image_at_roboflow,
     build_roboflow_api_headers,
     delete_cached_workflow_response_if_exists,
@@ -50,9 +51,11 @@ from inference.core.roboflow_api import (
     get_workflow_specification,
     raise_from_lambda,
     register_image_at_roboflow,
+    send_inference_results_to_model_monitoring,
     wrap_roboflow_api_errors,
     wrap_roboflow_api_errors_async,
 )
+from inference.core.utils import url_utils
 from inference.core.utils.url_utils import wrap_url
 from inference.core.version import __version__
 
@@ -3156,3 +3159,148 @@ def test_get_workflow_specification_raises_timeout_when_no_cache(
             workflow_id="timeout_no_cache_workflow",
             use_cache=False,
         )
+
+
+# --- LICENSE_SERVER / wrap_url proxy tests ---
+# These verify that all API calls route through the license server proxy
+# when LICENSE_SERVER is configured (air-gapped deployment support).
+
+SECURE_GATEWAY_HOST = "gateway.local"
+PROXY_PREFIX = f"http://{SECURE_GATEWAY_HOST}/proxy?url="
+
+
+@mock.patch.object(url_utils, "SECURE_GATEWAY", SECURE_GATEWAY_HOST)
+@pytest.mark.asyncio
+async def test_get_roboflow_workspace_async_routes_through_secure_gateway() -> None:
+    """When LICENSE_SERVER is set, async workspace lookup goes through the proxy."""
+    expected_proxy_url = wrap_url(f"{API_BASE_URL}/?api_key=my_api_key&nocache=true")
+    assert expected_proxy_url.startswith(PROXY_PREFIX)
+
+    with aioresponses() as request_mock:
+        request_mock.get(
+            expected_proxy_url,
+            payload={"workspace": "my_workspace"},
+        )
+
+        result = await get_roboflow_workspace_async(api_key="my_api_key")
+
+        assert result == "my_workspace"
+        # Verify the request went to the proxy URL, not directly to API_BASE_URL
+        called_urls = [str(k[1]) for k in request_mock.requests.keys()]
+        assert any(
+            PROXY_PREFIX in u for u in called_urls
+        ), f"Expected request through proxy ({PROXY_PREFIX}), got: {called_urls}"
+
+
+@mock.patch.object(url_utils, "SECURE_GATEWAY", SECURE_GATEWAY_HOST)
+@pytest.mark.asyncio
+async def test_get_serverless_usage_check_async_routes_through_secure_gateway() -> None:
+    """When LICENSE_SERVER is set, async usage check goes through the proxy."""
+    expected_proxy_url = wrap_url(
+        f"{API_BASE_URL}/serverless/usage-check?api_key=my_api_key&nocache=true"
+    )
+    assert expected_proxy_url.startswith(PROXY_PREFIX)
+
+    with aioresponses() as request_mock:
+        request_mock.get(
+            expected_proxy_url,
+            payload={
+                "workspace": "my-workspace",
+                "workspaceId": "ws-id",
+                "underCap": True,
+            },
+        )
+
+        result = await get_serverless_usage_check_async(api_key="my_api_key")
+
+        assert result.status_code == 200
+        assert result.workspace_id == "my-workspace"
+        called_urls = [str(k[1]) for k in request_mock.requests.keys()]
+        assert any(
+            PROXY_PREFIX in u for u in called_urls
+        ), f"Expected request through proxy ({PROXY_PREFIX}), got: {called_urls}"
+
+
+@mock.patch.object(url_utils, "SECURE_GATEWAY", SECURE_GATEWAY_HOST)
+def test_add_custom_metadata_routes_through_secure_gateway(
+    requests_mock: Mocker,
+) -> None:
+    """When LICENSE_SERVER is set, custom metadata POST goes through the proxy."""
+    expected_proxy_url = wrap_url(
+        f"{API_BASE_URL}/my-workspace/inference-stats/metadata?api_key=my_api_key&nocache=true"
+    )
+    assert expected_proxy_url.startswith(PROXY_PREFIX)
+
+    requests_mock.post(expected_proxy_url, json={"status": "ok"})
+
+    add_custom_metadata(
+        api_key="my_api_key",
+        workspace_id="my-workspace",
+        inference_ids=["inf-1"],
+        field_name="label",
+        field_value="cat",
+    )
+
+    assert requests_mock.called
+    assert requests_mock.last_request.url.startswith(PROXY_PREFIX)
+
+
+@mock.patch.object(url_utils, "SECURE_GATEWAY", SECURE_GATEWAY_HOST)
+def test_send_inference_results_to_model_monitoring_routes_through_secure_gateway(
+    requests_mock: Mocker,
+) -> None:
+    """When LICENSE_SERVER is set, model monitoring POST goes through the proxy."""
+    expected_proxy_url = wrap_url(
+        f"{API_BASE_URL}/my-workspace/inference-stats?api_key=my_api_key"
+    )
+    assert expected_proxy_url.startswith(PROXY_PREFIX)
+
+    requests_mock.post(expected_proxy_url, json={"status": "ok"})
+
+    send_inference_results_to_model_monitoring(
+        api_key="my_api_key",
+        workspace_id="my-workspace",
+        inference_data={"predictions": []},
+    )
+
+    assert requests_mock.called
+    assert requests_mock.last_request.url.startswith(PROXY_PREFIX)
+
+
+@mock.patch.object(url_utils, "SECURE_GATEWAY", None)
+@pytest.mark.asyncio
+async def test_get_roboflow_workspace_async_direct_when_no_secure_gateway() -> None:
+    """Without LICENSE_SERVER, async workspace lookup goes directly to the API."""
+    with aioresponses() as request_mock:
+        request_mock.get(
+            f"{API_BASE_URL}/?api_key=my_api_key&nocache=true",
+            payload={"workspace": "my_workspace"},
+        )
+
+        result = await get_roboflow_workspace_async(api_key="my_api_key")
+
+        assert result == "my_workspace"
+        called_urls = [str(k[1]) for k in request_mock.requests.keys()]
+        assert all("proxy" not in u for u in called_urls)
+
+
+@mock.patch.object(url_utils, "SECURE_GATEWAY", None)
+def test_add_custom_metadata_direct_when_no_secure_gateway(
+    requests_mock: Mocker,
+) -> None:
+    """Without LICENSE_SERVER, custom metadata POST goes directly to the API."""
+    requests_mock.post(
+        f"{API_BASE_URL}/my-workspace/inference-stats/metadata",
+        json={"status": "ok"},
+    )
+
+    add_custom_metadata(
+        api_key="my_api_key",
+        workspace_id="my-workspace",
+        inference_ids=["inf-1"],
+        field_name="label",
+        field_value="cat",
+    )
+
+    assert requests_mock.called
+    assert "proxy" not in requests_mock.last_request.url

--- a/tests/inference/unit_tests/core/utils/test_url_utils.py
+++ b/tests/inference/unit_tests/core/utils/test_url_utils.py
@@ -5,8 +5,8 @@ from inference.core.utils import url_utils
 from inference.core.utils.url_utils import wrap_url
 
 
-@mock.patch.object(url_utils, "LICENSE_SERVER", "licence-server.com")
-def test_wrap_url_when_license_server_is_provided() -> None:
+@mock.patch.object(url_utils, "SECURE_GATEWAY", "gateway.local")
+def test_wrap_url_when_secure_gateway_is_provided() -> None:
     # given
     original_url = "https://detection.roboflow.com/eye-detection/1?api_key=X"
 
@@ -16,13 +16,13 @@ def test_wrap_url_when_license_server_is_provided() -> None:
     # then
     assert (
         result
-        == "http://licence-server.com/proxy?url=https%3A%2F%2Fdetection.roboflow.com%2Feye-detection%2F1%3Fapi_key%3DX"
+        == "http://gateway.local/proxy?url=https%3A%2F%2Fdetection.roboflow.com%2Feye-detection%2F1%3Fapi_key%3DX"
     )
     assert parse_qs(urlparse(result).query)["url"][0] == original_url
 
 
-@mock.patch.object(url_utils, "LICENSE_SERVER", None)
-def test_wrap_url_when_license_server_is_not_provided() -> None:
+@mock.patch.object(url_utils, "SECURE_GATEWAY", None)
+def test_wrap_url_when_secure_gateway_is_not_provided() -> None:
     # given
     original_url = "https://detection.roboflow.com/eye-detection/1?api_key=X"
 


### PR DESCRIPTION
## Summary
- Wrap all external HTTP requests with `wrap_url()` so every outbound call routes through the secure gateway in air-gapped deployments
- Rename `LICENSE_SERVER` to `SECURE_GATEWAY` everywhere (env var, constants, functions, tests, docs) with deprecation fallback for the old name
- Remove runtime GitHub download of GroundingDINO config file, resolving the path from the installed package instead

## What changed

### Core proxy wrapping (`roboflow_api.py`)
4 async/sync functions that were making direct calls to `api.roboflow.com`:
- `get_roboflow_workspace_async`
- `get_serverless_usage_check_async`
- `add_custom_metadata`
- `send_inference_results_to_model_monitoring`

Also fixed `_test_range_request` which probes URLs for range support without going through the gateway.

### Other call sites now wrapped
- SAM3 / seg-preview workflow blocks (`seg_preview/v1`, `segment_anything3/v1-v3`)
- HTTP API SAM3 endpoints (`http_api.py`)
- Vision events sink (`vision_events/v1.py`)
- WebRTC session heartbeat (`watchdog.py`)

### GroundingDINO config file
Removed the runtime `urllib.request.urlretrieve` call that downloaded a config file from `raw.githubusercontent.com`. The file already exists in the installed `groundingdino` package, so we resolve the path from there instead.

### Rename: LICENSE_SERVER -> SECURE_GATEWAY
- `LICENSE_SERVER` env var -> `SECURE_GATEWAY` (legacy var still accepted with deprecation warning)
- `ROBOFLOW_LICENSE_SERVER` -> `SECURE_GATEWAY` in inference_models
- `roboflow_license_server_proxy_url_builder` -> `roboflow_secure_gateway_proxy_url_builder`
- All tests and docs updated

## Test plan
- [x] 6 new tests verify proxy routing for the roboflow_api.py functions
- [x] All 140 existing `test_roboflow_api.py` tests pass
- [x] `test_url_utils.py` tests pass with renamed constant
- [x] black, isort, flake8 all pass
- [ ] Manual: set `SECURE_GATEWAY=gateway:80`, verify all requests route through gateway
- [ ] Manual: set `LICENSE_SERVER=gateway:80` (no SECURE_GATEWAY), verify deprecation warning and functionality
- [ ] Manual: verify GroundingDINO loads config from installed package without network access