### PR TITLE
feat(cicd): switch to per-repo SA

### DIFF
--- a/.github/workflows/docker.cpu.yml
+++ b/.github/workflows/docker.cpu.yml
@@ -66,7 +66,7 @@ jobs:
         id: auth
         with:
           workload_identity_provider: 'projects/391662651862/locations/global/workloadIdentityPools/github-actions/providers/github'
-          service_account: 'github-gcloud-deployer@roboflow-artifacts.iam.gserviceaccount.com'
+          service_account: 'gha-inference@roboflow-artifacts.iam.gserviceaccount.com'
           token_format: 'access_token'
       - name: Login to Google Artifact Registry
         uses: docker/login-action@v3

--- a/.github/workflows/docker.gpu.yml
+++ b/.github/workflows/docker.gpu.yml
@@ -64,7 +64,7 @@ jobs:
         id: auth
         with:
           workload_identity_provider: 'projects/391662651862/locations/global/workloadIdentityPools/github-actions/providers/github'
-          service_account: 'github-gcloud-deployer@roboflow-artifacts.iam.gserviceaccount.com'
+          service_account: 'gha-inference@roboflow-artifacts.iam.gserviceaccount.com'
           token_format: 'access_token'
       - name: Login to Google Artifact Registry
         uses: docker/login-action@v3


### PR DESCRIPTION
# Description

CI change

## Type of change

-   [x] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?

- [ ] After Terraform is applied, dispatch a workflow targeting staging to verify the new SA works
- [ ] Check GCP audit logs for `gha-<repo>@roboflow-staging.iam.gserviceaccount.com` activity

## Any specific deployment considerations

**DO NOT MERGE** until the per-repo SA has been created via Terraform in roboflow-infra. The SA must exist and have the correct WIF binding before this workflow change takes effect, otherwise deploys will fail with authentication errors.

## Docs

-   [ ] Docs updated? No docs changes needed.