### PR TITLE
Accelerate mask conversion to RLE

### DIFF
--- a/inference_models/inference_models/models/common/rle_utils.py
+++ b/inference_models/inference_models/models/common/rle_utils.py
@@ -8,8 +8,20 @@ from inference_models.models.base.types import InstancesRLEMasks
 
 
 def torch_mask_to_coco_rle(mask: torch.Tensor) -> dict:
-    np_mask = np.asfortranarray(mask.detach().cpu().numpy().astype(np.uint8))
-    return mask_utils.encode(np_mask)
+    # Convert to uncompressed run length encoding in GPU
+    # coco tools expect fortran order (column-wise)
+    mask_flat = mask.permute(1, 0).reshape(-1)
+    values, lengths = torch.unique_consecutive(mask_flat, return_counts=True)
+    counts = lengths.cpu().tolist()
+
+    if values[0] == 1:
+        counts.insert(0, 0)
+
+    h, w = mask.shape
+    # compress
+    rle = mask_utils.frPyObjects({"counts": counts, "size": [h, w]}, h, w)
+    rle["counts"] = rle["counts"].decode("utf-8")
+    return rle
 
 
 def coco_rle_masks_to_numpy_mask(instances_masks: InstancesRLEMasks) -> np.ndarray:

--- a/inference_models/inference_models/models/common/rle_utils.py
+++ b/inference_models/inference_models/models/common/rle_utils.py
@@ -20,7 +20,6 @@ def torch_mask_to_coco_rle(mask: torch.Tensor) -> dict:
     h, w = mask.shape
     # compress
     rle = mask_utils.frPyObjects({"counts": counts, "size": [h, w]}, h, w)
-    rle["counts"] = rle["counts"].decode("utf-8")
     return rle
 
 


### PR DESCRIPTION
## What does this PR do?

Improves conversion speed of gpu masks to cpu pycocotools RLE.

## Type of Change

- New feature (non-breaking change that adds functionality)

## Testing

<!-- Describe how you tested your changes -->

- [ ] I have tested this change locally
- [ ] I have added/updated tests for this change

**Test details:**
<!-- Describe what tests were added/updated and what they cover -->

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where necessary, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have updated the documentation accordingly (if applicable)

## Additional Context

<!-- Add any other context, screenshots, or notes about the PR here -->
