### PR TITLE
Add gpt-5.5 to OpenAI workflow block

### DIFF
--- a/inference/core/workflows/core_steps/models/foundation/openai/v1.py
+++ b/inference/core/workflows/core_steps/models/foundation/openai/v1.py
@@ -95,7 +95,14 @@ class BlockManifest(WorkflowBlockManifest):
     )
     openai_model: Union[
         Selector(kind=[STRING_KIND]),
-        Literal["gpt-4o", "gpt-4o-mini", "gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano"],
+        Literal[
+            "gpt-4o",
+            "gpt-4o-mini",
+            "gpt-5.4",
+            "gpt-5.4-mini",
+            "gpt-5.4-nano",
+            "gpt-5.5",
+        ],
     ] = Field(
         default="gpt-4o",
         description="Model to be used",

--- a/inference/core/workflows/core_steps/models/foundation/openai/v2.py
+++ b/inference/core/workflows/core_steps/models/foundation/openai/v2.py
@@ -173,6 +173,7 @@ class BlockManifest(WorkflowBlockManifest):
             "gpt-5.4",
             "gpt-5.4-mini",
             "gpt-5.4-nano",
+            "gpt-5.5",
         ],
     ] = Field(
         default="gpt-4o",

--- a/inference/core/workflows/core_steps/models/foundation/openai/v3.py
+++ b/inference/core/workflows/core_steps/models/foundation/openai/v3.py
@@ -181,6 +181,7 @@ class BlockManifest(WorkflowBlockManifest):
             "gpt-5.4",
             "gpt-5.4-mini",
             "gpt-5.4-nano",
+            "gpt-5.5",
             "o3",
             "o4-mini",
         ],

--- a/inference/core/workflows/core_steps/models/foundation/openai/v4.py
+++ b/inference/core/workflows/core_steps/models/foundation/openai/v4.py
@@ -38,6 +38,11 @@ from inference.core.workflows.prototypes.block import (
 
 OPENAI_MODELS = [
     {
+        "id": "gpt-5.5",
+        "name": "GPT-5.5",
+        "reasoning_effort_values": ["none", "low", "medium", "high", "xhigh"],
+    },
+    {
         "id": "gpt-5.4",
         "name": "GPT-5.4",
         "reasoning_effort_values": ["none", "low", "medium", "high", "xhigh"],

--- a/inference/models/owlv2/owlv2.py
+++ b/inference/models/owlv2/owlv2.py
@@ -123,9 +123,7 @@ class Owlv2Singleton:
 
             if OWLV2_COMPILE_MODEL:
                 torch._dynamo.config.suppress_errors = True
-                model = monkey_patch_vision_encoder_before_compilation(
-                    model
-                )
+                model = monkey_patch_vision_encoder_before_compilation(model)
                 model.owlv2.vision_model = torch.compile(model.owlv2.vision_model)
             instance.model = model
             cls._instances[huggingface_id] = instance


### PR DESCRIPTION
## Summary
- Adds `gpt-5.5` as a selectable model across all four versions of the OpenAI workflow block (v1–v4)
- v4 entry uses reasoning-effort values `[none, low, medium, high, xhigh]`, matching the OpenAI docs
- API proxy support for gpt-5.5 was already added separately

## Test plan
- [ ] Confirm `gpt-5.5` appears as an option in each OpenAI block version in the workflows UI
- [ ] Run an OpenAI block with `model_version=gpt-5.5` end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)