### PR TITLE
Add Google Gemma workflow block via OpenRouter

### DIFF
--- a/inference/core/workflows/core_steps/loader.py
+++ b/inference/core/workflows/core_steps/loader.py
@@ -233,6 +233,9 @@ from inference.core.workflows.core_steps.models.foundation.google_gemini.v2 impo
 from inference.core.workflows.core_steps.models.foundation.google_gemini.v3 import (
     GoogleGeminiBlockV3,
 )
+from inference.core.workflows.core_steps.models.foundation.google_gemma.v1 import (
+    GoogleGemmaBlockV1,
+)
 from inference.core.workflows.core_steps.models.foundation.google_vision_ocr.v1 import (
     GoogleVisionOCRBlockV1,
 )
@@ -897,6 +900,7 @@ def load_blocks() -> List[Type[WorkflowBlock]]:
         TwilioSMSNotificationBlockV2,
         GazeBlockV1,
         LlamaVisionBlockV1,
+        GoogleGemmaBlockV1,
         ImageSlicerBlockV2,
         Qwen25VLBlockV1,
         Qwen3VLBlockV1,

--- a/inference/core/workflows/core_steps/models/foundation/google_gemma/v1.py
+++ b/inference/core/workflows/core_steps/models/foundation/google_gemma/v1.py
@@ -21,6 +21,7 @@ from inference.core.workflows.execution_engine.entities.types import (
     IMAGE_KIND,
     LANGUAGE_MODEL_OUTPUT_KIND,
     LIST_OF_VALUES_KIND,
+    SECRET_KIND,
     STRING_KIND,
     ImageInputField,
     Selector,
@@ -182,7 +183,7 @@ class BlockManifest(WorkflowBlockManifest):
             },
         },
     )
-    api_key: Union[Selector(kind=[STRING_KIND]), str] = Field(
+    api_key: Union[Selector(kind=[STRING_KIND, SECRET_KIND]), str] = Field(
         description="Your OpenRouter API key",
         examples=["xxx-xxx", "$inputs.open_router_api_key"],
         private=True,

--- a/inference/core/workflows/core_steps/models/foundation/google_gemma/v1.py
+++ b/inference/core/workflows/core_steps/models/foundation/google_gemma/v1.py
@@ -1,0 +1,648 @@
+import base64
+import json
+from functools import partial
+from typing import Any, Dict, List, Literal, Optional, Type, Union
+
+from openai import OpenAI
+from pydantic import ConfigDict, Field, field_validator, model_validator
+
+from inference.core.env import WORKFLOWS_REMOTE_EXECUTION_MAX_STEP_CONCURRENT_REQUESTS
+from inference.core.managers.base import ModelManager
+from inference.core.utils.image_utils import encode_image_to_jpeg_bytes, load_image
+from inference.core.workflows.core_steps.common.utils import run_in_parallel
+from inference.core.workflows.core_steps.common.vlms import VLM_TASKS_METADATA
+from inference.core.workflows.execution_engine.entities.base import (
+    Batch,
+    OutputDefinition,
+    WorkflowImageData,
+)
+from inference.core.workflows.execution_engine.entities.types import (
+    FLOAT_KIND,
+    IMAGE_KIND,
+    LANGUAGE_MODEL_OUTPUT_KIND,
+    LIST_OF_VALUES_KIND,
+    STRING_KIND,
+    ImageInputField,
+    Selector,
+)
+from inference.core.workflows.prototypes.block import (
+    AirGappedAvailability,
+    BlockResult,
+    WorkflowBlock,
+    WorkflowBlockManifest,
+)
+
+MODEL_VERSION_MAPPING = {
+    "Gemma 4 31B - OpenRouter": "google/gemma-4-31b-it",
+    "Gemma 4 26B A4B - OpenRouter": "google/gemma-4-26b-a4b-it",
+}
+
+ModelVersion = Literal[
+    "Gemma 4 31B - OpenRouter",
+    "Gemma 4 26B A4B - OpenRouter",
+]
+
+SUPPORTED_TASK_TYPES_LIST = [
+    "unconstrained",
+    "ocr",
+    "structured-answering",
+    "classification",
+    "multi-label-classification",
+    "visual-question-answering",
+    "caption",
+    "detailed-caption",
+    "object-detection",
+]
+SUPPORTED_TASK_TYPES = set(SUPPORTED_TASK_TYPES_LIST)
+
+RELEVANT_TASKS_METADATA = {
+    k: v for k, v in VLM_TASKS_METADATA.items() if k in SUPPORTED_TASK_TYPES
+}
+RELEVANT_TASKS_DOCS_DESCRIPTION = "\n\n".join(
+    f"* **{v['name']}** (`{k}`) - {v['description']}"
+    for k, v in RELEVANT_TASKS_METADATA.items()
+)
+
+
+LONG_DESCRIPTION = f"""
+Ask a question to Google's Gemma model with vision capabilities.
+
+You can specify arbitrary text prompts or predefined ones, the block supports the following types of prompt:
+
+{RELEVANT_TASKS_DOCS_DESCRIPTION}
+
+#### 🛠️ API providers and model variants
+
+Gemma is exposed via [OpenRouter API](https://openrouter.ai/) and we require
+passing an [OpenRouter API Key](https://openrouter.ai/docs/api-keys) to run.
+
+Pick a specific model version from the `model_version` dropdown - new Gemma releases
+will be added to this list as they become available on OpenRouter.
+
+!!! warning "API Usage Charges"
+
+    OpenRouter is an external third party providing access to the model and incurring charges on the usage.
+    Please check pricing on [openrouter.ai](https://openrouter.ai/) before use.
+
+#### 💡 Further reading and Acceptable Use Policy
+
+!!! warning "Model license"
+
+    Check the [Gemma Terms of Use](https://ai.google.dev/gemma/terms) before use.
+"""
+
+
+TaskType = Literal[tuple(SUPPORTED_TASK_TYPES_LIST)]
+
+TASKS_REQUIRING_PROMPT = {
+    "unconstrained",
+    "visual-question-answering",
+}
+
+TASKS_REQUIRING_CLASSES = {
+    "classification",
+    "multi-label-classification",
+    "object-detection",
+}
+
+TASKS_REQUIRING_OUTPUT_STRUCTURE = {
+    "structured-answering",
+}
+
+
+class BlockManifest(WorkflowBlockManifest):
+    model_config = ConfigDict(
+        json_schema_extra={
+            "name": "Google Gemma",
+            "version": "v1",
+            "short_description": "Run Google's Gemma model with vision capabilities.",
+            "long_description": LONG_DESCRIPTION,
+            "license": "Gemma Terms of Use",
+            "block_type": "model",
+            "search_keywords": ["LMM", "VLM", "Gemma", "Google", "OpenRouter"],
+            "is_vlm_block": True,
+            "task_type_property": "task_type",
+            "ui_manifest": {
+                "section": "model",
+                "icon": "fa-brands fa-google",
+            },
+        },
+        protected_namespaces=(),
+    )
+    type: Literal["roboflow_core/google_gemma@v1"]
+    images: Selector(kind=[IMAGE_KIND]) = ImageInputField
+    task_type: TaskType = Field(
+        default="unconstrained",
+        description="Task type to be performed by model. Value determines required parameters and output response.",
+        json_schema_extra={
+            "values_metadata": RELEVANT_TASKS_METADATA,
+            "recommended_parsers": {
+                "structured-answering": "roboflow_core/json_parser@v1",
+                "classification": "roboflow_core/vlm_as_classifier@v2",
+                "multi-label-classification": "roboflow_core/vlm_as_classifier@v2",
+                "object-detection": "roboflow_core/vlm_as_detector@v2",
+            },
+            "always_visible": True,
+        },
+    )
+    prompt: Optional[Union[Selector(kind=[STRING_KIND]), str]] = Field(
+        default=None,
+        description="Text prompt to the Gemma model",
+        examples=["my prompt", "$inputs.prompt"],
+        json_schema_extra={
+            "relevant_for": {
+                "task_type": {"values": TASKS_REQUIRING_PROMPT, "required": True},
+            },
+            "multiline": True,
+        },
+    )
+    output_structure: Optional[Dict[str, str]] = Field(
+        default=None,
+        description="Dictionary with structure of expected JSON response",
+        examples=[{"my_key": "description"}, "$inputs.output_structure"],
+        json_schema_extra={
+            "relevant_for": {
+                "task_type": {
+                    "values": TASKS_REQUIRING_OUTPUT_STRUCTURE,
+                    "required": True,
+                },
+            },
+        },
+    )
+    classes: Optional[Union[Selector(kind=[LIST_OF_VALUES_KIND]), List[str]]] = Field(
+        default=None,
+        description="List of classes to be used",
+        examples=[["class-a", "class-b"], "$inputs.classes"],
+        json_schema_extra={
+            "relevant_for": {
+                "task_type": {
+                    "values": TASKS_REQUIRING_CLASSES,
+                    "required": True,
+                },
+            },
+        },
+    )
+    api_key: Union[Selector(kind=[STRING_KIND]), str] = Field(
+        description="Your OpenRouter API key",
+        examples=["xxx-xxx", "$inputs.open_router_api_key"],
+        private=True,
+    )
+    model_version: Union[
+        Selector(kind=[STRING_KIND]),
+        Literal[
+            "Gemma 4 31B - OpenRouter",
+            "Gemma 4 26B A4B - OpenRouter",
+        ],
+    ] = Field(
+        default="Gemma 4 31B - OpenRouter",
+        description="Model to be used",
+        examples=["Gemma 4 31B - OpenRouter", "$inputs.gemma_model"],
+    )
+    max_tokens: int = Field(
+        default=500,
+        description="Maximum number of tokens the model can generate in it's response.",
+        gt=1,
+    )
+    temperature: Union[float, Selector(kind=[FLOAT_KIND])] = Field(
+        default=0.1,
+        description="Temperature to sample from the model - value in range 0.0-2.0, the higher - the more "
+        'random / "creative" the generations are.',
+    )
+    max_concurrent_requests: Optional[int] = Field(
+        default=None,
+        description="Number of concurrent requests that can be executed by block when batch of input images provided. "
+        "If not given - block defaults to value configured globally in Workflows Execution Engine. "
+        "Please restrict if you hit limits.",
+    )
+
+    @model_validator(mode="after")
+    def validate(self) -> "BlockManifest":
+        if self.task_type in TASKS_REQUIRING_PROMPT and self.prompt is None:
+            raise ValueError(
+                f"`prompt` parameter required to be set for task `{self.task_type}`"
+            )
+        if self.task_type in TASKS_REQUIRING_CLASSES and self.classes is None:
+            raise ValueError(
+                f"`classes` parameter required to be set for task `{self.task_type}`"
+            )
+        if (
+            self.task_type in TASKS_REQUIRING_OUTPUT_STRUCTURE
+            and self.output_structure is None
+        ):
+            raise ValueError(
+                f"`output_structure` parameter required to be set for task `{self.task_type}`"
+            )
+        return self
+
+    @classmethod
+    def get_air_gapped_availability(cls) -> AirGappedAvailability:
+        return AirGappedAvailability(available=False, reason="requires_internet")
+
+    @field_validator("temperature")
+    @classmethod
+    def validate_temperature(cls, value: Union[str, float]) -> Union[str, float]:
+        if isinstance(value, str):
+            return value
+        if value < 0.0 or value > 2.0:
+            raise ValueError(
+                "'temperature' parameter required to be in range [0.0, 2.0]"
+            )
+        return value
+
+    @classmethod
+    def get_parameters_accepting_batches(cls) -> List[str]:
+        return ["images"]
+
+    @classmethod
+    def describe_outputs(cls) -> List[OutputDefinition]:
+        return [
+            OutputDefinition(
+                name="output", kind=[STRING_KIND, LANGUAGE_MODEL_OUTPUT_KIND]
+            ),
+            OutputDefinition(name="classes", kind=[LIST_OF_VALUES_KIND]),
+        ]
+
+    @classmethod
+    def get_execution_engine_compatibility(cls) -> Optional[str]:
+        return ">=1.3.0,<2.0.0"
+
+
+class GoogleGemmaBlockV1(WorkflowBlock):
+
+    def __init__(
+        self,
+        model_manager: ModelManager,
+    ):
+        self._model_manager = model_manager
+
+    @classmethod
+    def get_init_parameters(cls) -> List[str]:
+        return ["model_manager"]
+
+    @classmethod
+    def get_manifest(cls) -> Type[WorkflowBlockManifest]:
+        return BlockManifest
+
+    @classmethod
+    def get_execution_engine_compatibility(cls) -> Optional[str]:
+        return ">=1.3.0,<2.0.0"
+
+    def run(
+        self,
+        images: Batch[WorkflowImageData],
+        task_type: TaskType,
+        prompt: Optional[str],
+        output_structure: Optional[Dict[str, str]],
+        classes: Optional[List[str]],
+        api_key: str,
+        model_version: ModelVersion,
+        max_tokens: int,
+        temperature: float,
+        max_concurrent_requests: Optional[int],
+    ) -> BlockResult:
+        inference_images = [i.to_inference_format() for i in images]
+        raw_outputs = run_gemma_llm_prompting(
+            images=inference_images,
+            task_type=task_type,
+            prompt=prompt,
+            output_structure=output_structure,
+            classes=classes,
+            gemma_api_key=api_key,
+            gemma_model_version=model_version,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            max_concurrent_requests=max_concurrent_requests,
+        )
+        return [
+            {"output": raw_output, "classes": classes} for raw_output in raw_outputs
+        ]
+
+
+def run_gemma_llm_prompting(
+    images: List[Dict[str, Any]],
+    task_type: TaskType,
+    prompt: Optional[str],
+    output_structure: Optional[Dict[str, str]],
+    classes: Optional[List[str]],
+    gemma_api_key: Optional[str],
+    gemma_model_version: ModelVersion,
+    max_tokens: int,
+    temperature: float,
+    max_concurrent_requests: Optional[int],
+) -> List[str]:
+    if task_type not in PROMPT_BUILDERS:
+        raise ValueError(f"Task type: {task_type} not supported.")
+    model_version_id = MODEL_VERSION_MAPPING.get(gemma_model_version)
+    if model_version_id is None:
+        raise ValueError(
+            f"Invalid model name: '{gemma_model_version}'. Please use one of {list(MODEL_VERSION_MAPPING.keys())}."
+        )
+    gemma_prompts = []
+    for image in images:
+        loaded_image, _ = load_image(image)
+        base64_image = base64.b64encode(
+            encode_image_to_jpeg_bytes(loaded_image)
+        ).decode("ascii")
+        generated_prompt = PROMPT_BUILDERS[task_type](
+            base64_image=base64_image,
+            prompt=prompt,
+            output_structure=output_structure,
+            classes=classes,
+        )
+        gemma_prompts.append(generated_prompt)
+    return execute_gemma_requests(
+        gemma_api_key=gemma_api_key,
+        gemma_prompts=gemma_prompts,
+        model_version_id=model_version_id,
+        max_tokens=max_tokens,
+        temperature=temperature,
+        max_concurrent_requests=max_concurrent_requests,
+    )
+
+
+def execute_gemma_requests(
+    gemma_api_key: str,
+    gemma_prompts: List[List[dict]],
+    model_version_id: str,
+    max_tokens: int,
+    temperature: float,
+    max_concurrent_requests: Optional[int],
+) -> List[str]:
+    client = OpenAI(base_url="https://openrouter.ai/api/v1", api_key=gemma_api_key)
+    tasks = [
+        partial(
+            execute_gemma_request,
+            client=client,
+            prompt=prompt,
+            gemma_model_version=model_version_id,
+            max_tokens=max_tokens,
+            temperature=temperature,
+        )
+        for prompt in gemma_prompts
+    ]
+    max_workers = (
+        max_concurrent_requests
+        or WORKFLOWS_REMOTE_EXECUTION_MAX_STEP_CONCURRENT_REQUESTS
+    )
+    return run_in_parallel(
+        tasks=tasks,
+        max_workers=max_workers,
+    )
+
+
+def execute_gemma_request(
+    client: OpenAI,
+    prompt: List[dict],
+    gemma_model_version: str,
+    max_tokens: int,
+    temperature: float,
+) -> str:
+    response = client.chat.completions.create(
+        model=gemma_model_version,
+        messages=prompt,
+        max_tokens=max_tokens,
+        temperature=temperature,
+    )
+    if response.choices is None:
+        error_detail = getattr(response, "error", {}).get("message", "N/A")
+        raise RuntimeError(
+            "OpenRouter provider failed in delivering response. This issue happens from time "
+            "to time - raise issue to OpenRouter if that's problematic for you. "
+            f"Details: {error_detail}"
+        )
+    return response.choices[0].message.content
+
+
+def prepare_unconstrained_prompt(
+    base64_image: str,
+    prompt: str,
+    **kwargs,
+) -> List[dict]:
+    return [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": prompt},
+                {
+                    "type": "image_url",
+                    "image_url": {
+                        "url": f"data:image/jpeg;base64,{base64_image}",
+                    },
+                },
+            ],
+        }
+    ]
+
+
+def prepare_classification_prompt(
+    base64_image: str, classes: List[str], **kwargs
+) -> List[dict]:
+    serialised_classes = ", ".join(classes)
+    return [
+        {
+            "role": "system",
+            "content": "You act as single-class classification model. You must provide reasonable predictions. "
+            "You are only allowed to produce JSON document in Markdown ```json [...]``` markers. "
+            'Expected structure of json: {"class_name": "class-name", "confidence": 0.4}. '
+            "`class-name` must be one of the class names defined by user. You are only allowed to return "
+            "single JSON document, even if there are potentially multiple classes. You are not allowed to return list. "
+            "You cannot discuss the result, you are only allowed to return JSON document.",
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": f"List of all classes to be recognised by model: {serialised_classes}",
+                },
+                {
+                    "type": "image_url",
+                    "image_url": {
+                        "url": f"data:image/jpeg;base64,{base64_image}",
+                    },
+                },
+            ],
+        },
+    ]
+
+
+def prepare_multi_label_classification_prompt(
+    base64_image: str, classes: List[str], **kwargs
+) -> List[dict]:
+    serialised_classes = ", ".join(classes)
+    return [
+        {
+            "role": "system",
+            "content": "You act as multi-label classification model. You must provide reasonable predictions. "
+            "You are only allowed to produce JSON document in Markdown ```json``` markers. "
+            'Expected structure of json: {"predicted_classes": [{"class": "class-name-1", "confidence": 0.9}, '
+            '{"class": "class-name-2", "confidence": 0.7}]}. '
+            "`class-name-X` must be one of the class names defined by user and `confidence` is a float value in range "
+            "0.0-1.0 that represent how sure you are that the class is present in the image. Only return class names "
+            "that are visible. You cannot discuss the result, you are only allowed to return JSON document.",
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": f"List of all classes to be recognised by model: {serialised_classes}",
+                },
+                {
+                    "type": "image_url",
+                    "image_url": {
+                        "url": f"data:image/jpeg;base64,{base64_image}",
+                    },
+                },
+            ],
+        },
+    ]
+
+
+def prepare_vqa_prompt(base64_image: str, prompt: str, **kwargs) -> List[dict]:
+    return [
+        {
+            "role": "system",
+            "content": "You act as Visual Question Answering model. Your task is to provide answer to question"
+            "submitted by user. If this is open-question - answer with few sentences, for ABCD question, "
+            "return only the indicator of the answer.",
+        },
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": f"Question: {prompt}"},
+                {
+                    "type": "image_url",
+                    "image_url": {
+                        "url": f"data:image/jpeg;base64,{base64_image}",
+                    },
+                },
+            ],
+        },
+    ]
+
+
+def prepare_ocr_prompt(base64_image: str, **kwargs) -> List[dict]:
+    return [
+        {
+            "role": "system",
+            "content": "You act as OCR model. Your task is to read text from the image and return it in "
+            "paragraphs representing the structure of texts in the image. You should only return "
+            "recognised text, nothing else.",
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image_url",
+                    "image_url": {
+                        "url": f"data:image/jpeg;base64,{base64_image}",
+                    },
+                },
+            ],
+        },
+    ]
+
+
+def prepare_caption_prompt(
+    base64_image: str, short_description: bool, **kwargs
+) -> List[dict]:
+    caption_detail_level = "Caption should be short."
+    if not short_description:
+        caption_detail_level = "Caption should be extensive."
+    return [
+        {
+            "role": "system",
+            "content": f"You act as image caption model. Your task is to provide description of the image. "
+            f"{caption_detail_level}",
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image_url",
+                    "image_url": {
+                        "url": f"data:image/jpeg;base64,{base64_image}",
+                    },
+                },
+            ],
+        },
+    ]
+
+
+def prepare_structured_answering_prompt(
+    base64_image: str, output_structure: Dict[str, str], **kwargs
+) -> List[dict]:
+    output_structure_serialised = json.dumps(output_structure, indent=4)
+    return [
+        {
+            "role": "system",
+            "content": "You are supposed to produce responses in JSON wrapped in Markdown markers: "
+            "```json\nyour-response\n```. User is to provide you dictionary with keys and values. "
+            "Each key must be present in your response. Values in user dictionary represent "
+            "descriptions for JSON fields to be generated. Provide only JSON Markdown in response.",
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": f"Specification of requirements regarding output fields: \n"
+                    f"{output_structure_serialised}",
+                },
+                {
+                    "type": "image_url",
+                    "image_url": {
+                        "url": f"data:image/jpeg;base64,{base64_image}",
+                    },
+                },
+            ],
+        },
+    ]
+
+
+def prepare_object_detection_prompt(
+    base64_image: str, classes: List[str], **kwargs
+) -> List[dict]:
+    serialised_classes = ", ".join(classes)
+    return [
+        {
+            "role": "system",
+            "content": "You act as object-detection model. You must provide reasonable predictions. "
+            "You are only allowed to produce JSON document in Markdown ```json``` markers. "
+            'Expected structure of json: {"detections": [{"x_min": 0.1, "y_min": 0.2, "x_max": 0.3, "y_max": 0.4, '
+            '"class_name": "my-class-X", "confidence": 0.7}]}. '
+            "`my-class-X` must be one of the class names defined by user. All coordinates must be in range 0.0-1.0, "
+            "representing percentage of image dimensions. `confidence` is a value in range 0.0-1.0 representing your "
+            "confidence in prediction. You should detect all instances of classes provided by user. "
+            "You cannot discuss the result, you are only allowed to return JSON document.",
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": f"List of all classes to be recognised by model: {serialised_classes}",
+                },
+                {
+                    "type": "image_url",
+                    "image_url": {
+                        "url": f"data:image/jpeg;base64,{base64_image}",
+                    },
+                },
+            ],
+        },
+    ]
+
+
+PROMPT_BUILDERS = {
+    "unconstrained": prepare_unconstrained_prompt,
+    "ocr": prepare_ocr_prompt,
+    "visual-question-answering": prepare_vqa_prompt,
+    "caption": partial(prepare_caption_prompt, short_description=True),
+    "detailed-caption": partial(prepare_caption_prompt, short_description=False),
+    "classification": prepare_classification_prompt,
+    "multi-label-classification": prepare_multi_label_classification_prompt,
+    "structured-answering": prepare_structured_answering_prompt,
+    "object-detection": prepare_object_detection_prompt,
+}

--- a/inference/models/owlv2/owlv2.py
+++ b/inference/models/owlv2/owlv2.py
@@ -123,9 +123,7 @@ class Owlv2Singleton:
 
             if OWLV2_COMPILE_MODEL:
                 torch._dynamo.config.suppress_errors = True
-                model = monkey_patch_vision_encoder_before_compilation(
-                    model
-                )
+                model = monkey_patch_vision_encoder_before_compilation(model)
                 model.owlv2.vision_model = torch.compile(model.owlv2.vision_model)
             instance.model = model
             cls._instances[huggingface_id] = instance

--- a/tests/workflows/unit_tests/core_steps/models/foundation/test_google_gemma.py
+++ b/tests/workflows/unit_tests/core_steps/models/foundation/test_google_gemma.py
@@ -1,0 +1,312 @@
+import time
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from openai.types.chat import ChatCompletion, ChatCompletionMessage
+from openai.types.chat.chat_completion import Choice
+from pydantic import ValidationError
+
+from inference.core.workflows.core_steps.models.foundation.google_gemma.v1 import (
+    BlockManifest,
+    execute_gemma_request,
+)
+
+
+@pytest.mark.parametrize("value", [None, 1, "a", True])
+def test_google_gemma_step_validation_when_image_is_invalid(
+    value: Any,
+) -> None:
+    # given
+    specification = {
+        "type": "roboflow_core/google_gemma@v1",
+        "name": "step_1",
+        "images": value,
+        "prompt": "$inputs.prompt",
+        "api_key": "$inputs.open_router_api_key",
+    }
+
+    # when
+    with pytest.raises(ValidationError):
+        _ = BlockManifest.model_validate(specification)
+
+
+def test_google_gemma_step_validation_when_prompt_is_given_directly() -> None:
+    # given
+    specification = {
+        "type": "roboflow_core/google_gemma@v1",
+        "name": "step_1",
+        "images": "$inputs.image",
+        "prompt": "This is my prompt",
+        "api_key": "$inputs.open_router_api_key",
+    }
+
+    # when
+    result = BlockManifest.model_validate(specification)
+
+    # then
+    assert result == BlockManifest(
+        type="roboflow_core/google_gemma@v1",
+        name="step_1",
+        images="$inputs.image",
+        prompt="This is my prompt",
+        api_key="$inputs.open_router_api_key",
+    )
+
+
+@pytest.mark.parametrize("value", [None, []])
+def test_google_gemma_step_validation_when_prompt_is_invalid(
+    value: Any,
+) -> None:
+    # given
+    specification = {
+        "type": "roboflow_core/google_gemma@v1",
+        "name": "step_1",
+        "images": "$inputs.image",
+        "prompt": value,
+        "api_key": "$inputs.open_router_api_key",
+    }
+
+    # when
+    with pytest.raises(ValidationError):
+        _ = BlockManifest.model_validate(specification)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "$inputs.model",
+        "Gemma 4 31B - OpenRouter",
+        "Gemma 4 26B A4B - OpenRouter",
+    ],
+)
+def test_google_gemma_step_validation_when_model_type_valid(
+    value: str,
+) -> None:
+    # given
+    specification = {
+        "type": "roboflow_core/google_gemma@v1",
+        "name": "step_1",
+        "images": "$inputs.image",
+        "prompt": "This is my prompt",
+        "api_key": "$inputs.open_router_api_key",
+        "model_version": value,
+    }
+
+    # when
+    result = BlockManifest.model_validate(specification)
+
+    assert result == BlockManifest(
+        type="roboflow_core/google_gemma@v1",
+        name="step_1",
+        images="$inputs.image",
+        prompt="This is my prompt",
+        api_key="$inputs.open_router_api_key",
+        model_version=value,
+    )
+
+
+@pytest.mark.parametrize("value", ["some", None])
+def test_google_gemma_step_validation_when_model_type_invalid(
+    value: Any,
+) -> None:
+    # given
+    specification = {
+        "type": "roboflow_core/google_gemma@v1",
+        "name": "step_1",
+        "images": "$inputs.image",
+        "prompt": "This is my prompt",
+        "api_key": "$inputs.open_router_api_key",
+        "model_version": value,
+    }
+
+    # when
+    with pytest.raises(ValidationError):
+        _ = BlockManifest.model_validate(specification)
+
+
+def test_google_gemma_step_validation_when_api_key_not_given() -> None:
+    # given
+    specification = {
+        "type": "roboflow_core/google_gemma@v1",
+        "name": "step_1",
+        "images": "$inputs.image",
+        "prompt": "This is my prompt",
+    }
+
+    # when
+    with pytest.raises(ValidationError):
+        _ = BlockManifest.model_validate(specification)
+
+
+def test_google_gemma_step_validation_when_output_structure_invalid() -> None:
+    # given
+    specification = {
+        "type": "roboflow_core/google_gemma@v1",
+        "name": "step_1",
+        "images": "$inputs.image",
+        "prompt": "This is my prompt",
+        "api_key": "$inputs.open_router_api_key",
+        "output_structure": "INVALID",
+    }
+
+    # when
+    with pytest.raises(ValidationError):
+        _ = BlockManifest.model_validate(specification)
+
+
+@pytest.mark.parametrize("value", [-0.5, 3.0])
+def test_google_gemma_step_validation_when_temperature_is_invalid(
+    value: float,
+) -> None:
+    # given
+    specification = {
+        "type": "roboflow_core/google_gemma@v1",
+        "name": "step_1",
+        "images": "$inputs.image",
+        "prompt": "This is my prompt",
+        "api_key": "$inputs.open_router_api_key",
+        "temperature": value,
+    }
+
+    # when
+    with pytest.raises(ValidationError):
+        _ = BlockManifest.model_validate(specification)
+
+
+@pytest.mark.parametrize("value", ["unconstrained", "visual-question-answering"])
+def test_google_gemma_when_prompt_not_delivered_when_required(value: str) -> None:
+    # given
+    specification = {
+        "type": "roboflow_core/google_gemma@v1",
+        "task_type": value,
+        "name": "step_1",
+        "images": "$inputs.image",
+        "api_key": "$inputs.open_router_api_key",
+    }
+
+    # when
+    with pytest.raises(ValidationError) as e:
+        _ = BlockManifest.model_validate(specification)
+
+    # then
+    assert "`prompt`" in str(e.value)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "classification",
+        "multi-label-classification",
+        "object-detection",
+    ],
+)
+def test_google_gemma_when_classes_not_delivered_when_required(
+    value: str,
+) -> None:
+    # given
+    specification = {
+        "type": "roboflow_core/google_gemma@v1",
+        "task_type": value,
+        "name": "step_1",
+        "images": "$inputs.image",
+        "api_key": "$inputs.open_router_api_key",
+    }
+
+    # when
+    with pytest.raises(ValidationError) as e:
+        _ = BlockManifest.model_validate(specification)
+
+    # then
+    assert "`classes`" in str(e.value)
+
+
+def test_google_gemma_when_output_structure_not_delivered_when_required() -> None:
+    # given
+    specification = {
+        "type": "roboflow_core/google_gemma@v1",
+        "task_type": "structured-answering",
+        "name": "step_1",
+        "images": "$inputs.image",
+        "api_key": "$inputs.open_router_api_key",
+    }
+
+    # when
+    with pytest.raises(ValidationError) as e:
+        _ = BlockManifest.model_validate(specification)
+
+    # then
+    assert "`output_structure`" in str(e.value)
+
+
+def test_execute_gemma_request_when_request_succeeds() -> None:
+    # given
+    client = MagicMock()
+    client.chat.completions.create.return_value = ChatCompletion(
+        id="38",
+        choices=[
+            Choice(
+                finish_reason="stop",
+                index=0,
+                message=ChatCompletionMessage(
+                    role="assistant",
+                    content="This is content from Gemma",
+                ),
+            )
+        ],
+        created=int(time.time()),
+        model="google/gemma-4-31b-it",
+        object="chat.completion",
+    )
+
+    # when
+    result = execute_gemma_request(
+        client=client,
+        prompt=[{"content": [{"text": "prompt"}]}],
+        gemma_model_version="google/gemma-4-31b-it",
+        max_tokens=300,
+        temperature=0.5,
+    )
+
+    # then
+    assert result == "This is content from Gemma"
+    call_kwargs = client.chat.completions.create.call_args[1]
+    assert call_kwargs["model"] == "google/gemma-4-31b-it"
+    assert call_kwargs["max_tokens"] == 300
+    assert (
+        len(call_kwargs["messages"]) == 1
+    ), "Only single message is expected to be prompted"
+    assert (
+        call_kwargs["messages"][0]["content"][0]["text"] == "prompt"
+    ), "Text prompt is expected to be injected without modification"
+
+
+def test_execute_gemma_request_when_request_fails() -> None:
+    # given
+    client = MagicMock()
+    return_value = MagicMock()
+    return_value.choices = None
+    return_value.error = {"message": "Error MSG"}
+    client.chat.completions.create.return_value = return_value
+
+    # when
+    with pytest.raises(RuntimeError) as e:
+        _ = execute_gemma_request(
+            client=client,
+            prompt=[{"content": [{"text": "prompt"}]}],
+            gemma_model_version="google/gemma-4-31b-it",
+            max_tokens=300,
+            temperature=0.5,
+        )
+
+    # then
+    call_kwargs = client.chat.completions.create.call_args[1]
+    assert call_kwargs["model"] == "google/gemma-4-31b-it"
+    assert call_kwargs["max_tokens"] == 300
+    assert (
+        len(call_kwargs["messages"]) == 1
+    ), "Only single message is expected to be prompted"
+    assert (
+        call_kwargs["messages"][0]["content"][0]["text"] == "prompt"
+    ), "Text prompt is expected to be injected without modification"
+    assert "Details: Error MSG" in str(e.value)


### PR DESCRIPTION
Tested locally. ATM user needs to pass openrouter api key manually, in the future we could udpate this so it uses apiproxy. 
<img width="1533" height="1002" alt="image" src="https://github.com/user-attachments/assets/e134f365-7d29-49f9-b9aa-694837b55bd2" />


## Summary
- Adds a new `roboflow_core/google_gemma@v1` workflow block that exposes Google's Gemma vision-language models (Gemma 4 31B and Gemma 4 26B A4B) through OpenRouter, using the same OpenAI-compatible client pattern as the existing Llama Vision block.
- Supports the full VLM task surface (matches Google Gemini v3): unconstrained, OCR, structured answering, single/multi-label classification, VQA, short/long captioning, and unprompted object detection.
- Requires a user-supplied OpenRouter API key — there is no `apiproxy/openrouter` proxy on the platform side yet, so `rf_key:account` is intentionally not wired in.
- Adds 24 unit tests mirroring `test_llama_3_2_vision.py`, including mocked happy/error paths for the `choices=None` failure mode that OpenRouter occasionally returns.

## Test plan
- [x] `pytest tests/workflows/unit_tests/core_steps/models/foundation/test_google_gemma.py` — 24 passed
- [x] Block loads in the workflow registry (`/workflows/blocks/describe` shows `roboflow_core/google_gemma@v1` with all 9 tasks)
- [x] End-to-end smoke test against OpenRouter once the Gemma 4 model IDs are live

🤖 Generated with [Claude Code](https://claude.com/claude-code)