### PR TITLE
Fix: widen confidence type in legacy HTTP API

### DIFF
--- a/inference/core/interfaces/http/http_api.py
+++ b/inference/core/interfaces/http/http_api.py
@@ -328,6 +328,7 @@ import time
 
 from inference.core.roboflow_api import ModelEndpointType
 from inference.core.version import __version__
+from inference_sdk.http.entities import Confidence
 
 try:
     from inference_sdk.config import EXECUTION_ID_HEADER, execution_id
@@ -3845,9 +3846,14 @@ class HttpInterface(BaseInterface):
                     None,
                     description="Roboflow API Key that will be passed to the model during initialization for artifact retrieval",
                 ),
-                confidence: float = Query(
+                confidence: Confidence = Query(
                     0.4,
-                    description="The confidence threshold used to filter out predictions",
+                    description=(
+                        "The confidence threshold used to filter out predictions. "
+                        'Pass a float in [0, 1], or "best" to use F1-optimal '
+                        'thresholds from model evaluation, or "default" to use '
+                        "the model's built-in default."
+                    ),
                 ),
                 keypoint_confidence: float = Query(
                     0.0,
@@ -3955,11 +3961,12 @@ class HttpInterface(BaseInterface):
                     f"Reached legacy route /:dataset_id/:version_id with {dataset_id}/{version_id}"
                 )
                 model_id = f"{dataset_id}/{version_id}"
-                if confidence >= 1:
-                    confidence /= 100
-                if confidence < CONFIDENCE_LOWER_BOUND_OOM_PREVENTION:
-                    # allowing lower confidence results in RAM usage explosion
-                    confidence = CONFIDENCE_LOWER_BOUND_OOM_PREVENTION
+                if isinstance(confidence, (int, float)):
+                    if confidence >= 1:
+                        confidence /= 100
+                    if confidence < CONFIDENCE_LOWER_BOUND_OOM_PREVENTION:
+                        # allowing lower confidence results in RAM usage explosion
+                        confidence = CONFIDENCE_LOWER_BOUND_OOM_PREVENTION
 
                 if overlap >= 1:
                     overlap /= 100

--- a/inference/core/version.py
+++ b/inference/core/version.py
@@ -1,4 +1,4 @@
-__version__ = "1.2.5"
+__version__ = "1.2.6"
 
 
 if __name__ == "__main__":

--- a/tests/inference/unit_tests/core/interfaces/http/test_legacy_http_route_accepts_confidence_modes.py
+++ b/tests/inference/unit_tests/core/interfaces/http/test_legacy_http_route_accepts_confidence_modes.py
@@ -1,0 +1,121 @@
+"""Regression test for the legacy ``POST /{dataset_id}/{version_id}`` route.
+
+The route's ``confidence`` query param backs ``Confidence = Union[float,
+Literal["best", "default"]]`` request entities. Earlier the param was typed as
+``float`` and FastAPI rejected ``confidence=best`` with a 422 — only manifesting
+in remote workflow execution mode where the v3 model blocks select the v0 API
+(``WORKFLOWS_REMOTE_API_TARGET=hosted``). This test spins up the FastAPI app
+with a mocked model manager and confirms each task type accepts the same
+confidence-mode values the v3 blocks send.
+"""
+from typing import Optional, Union
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pydantic import BaseModel
+from starlette.testclient import TestClient
+
+
+class _DummyInstrumentator:
+    def __init__(self, app, model_manager, endpoint="/metrics"):
+        self.app = app
+        self.model_manager = model_manager
+        self.endpoint = endpoint
+
+    def set_stream_manager_client(self, stream_manager_client) -> None:
+        self.stream_manager_client = stream_manager_client
+
+
+class _DummyResponse(BaseModel):
+    visualization: Optional[bytes] = None
+
+
+def _build_interface(monkeypatch, task_type: str):
+    import inference.core.interfaces.http.http_api as http_api
+
+    monkeypatch.setattr(http_api, "InferenceInstrumentator", _DummyInstrumentator)
+    monkeypatch.setattr(
+        http_api.usage_collector,
+        "async_push_usage_payloads",
+        AsyncMock(),
+    )
+    monkeypatch.setattr(http_api, "DEDICATED_DEPLOYMENT_WORKSPACE_URL", None)
+    model_manager = MagicMock()
+    model_manager.pingback = None
+    model_manager.num_errors = 0
+    model_manager.get_task_type.return_value = task_type
+    model_manager.infer_from_request_sync.return_value = _DummyResponse()
+
+    interface = http_api.HttpInterface(model_manager=model_manager)
+    return interface, model_manager
+
+
+# task_type -> set of confidence values the corresponding request entity is
+# expected to accept. "best"/"default" are the two non-float modes v3 blocks
+# can serialize; semseg and keypoint-detection reject "best" via field
+# validators because model eval doesn't yet produce thresholds for those
+# tasks.
+_ACCEPTED_CONFIDENCE_MODES = {
+    "object-detection": ["best", "default", 0.5],
+    "instance-segmentation": ["best", "default", 0.5],
+    "keypoint-detection": ["default", 0.5],
+    "classification": ["best", "default", 0.5],
+    "semantic-segmentation": ["default", 0.5],
+}
+
+
+@pytest.mark.parametrize(
+    "task_type, confidence",
+    [
+        (task, conf)
+        for task, modes in _ACCEPTED_CONFIDENCE_MODES.items()
+        for conf in modes
+    ],
+)
+def test_legacy_route_accepts_confidence_mode(
+    monkeypatch,
+    task_type: str,
+    confidence: Union[str, float],
+) -> None:
+    interface, model_manager = _build_interface(monkeypatch, task_type=task_type)
+
+    with TestClient(interface.app) as client:
+        response = client.post(
+            "/dummy-dataset/1",
+            params={
+                "api_key": "query-api-key",
+                "confidence": confidence,
+                "image": "https://example.com/test.jpg",
+            },
+        )
+
+    assert (
+        response.status_code == 200
+    ), f"task={task_type} confidence={confidence!r} body={response.text}"
+    inference_request = model_manager.infer_from_request_sync.call_args.args[1]
+    assert inference_request.confidence == confidence
+
+
+@pytest.mark.parametrize(
+    "task_type",
+    ["semantic-segmentation", "keypoint-detection"],
+)
+def test_legacy_route_rejects_best_confidence_for_unsupported_tasks(
+    monkeypatch,
+    task_type: str,
+) -> None:
+    """Tasks whose request entities reject ``confidence="best"`` should
+    surface a 4xx, not silently fall back."""
+    interface, _ = _build_interface(monkeypatch, task_type=task_type)
+
+    with TestClient(interface.app) as client:
+        response = client.post(
+            "/dummy-dataset/1",
+            params={
+                "api_key": "query-api-key",
+                "confidence": "best",
+                "image": "https://example.com/test.jpg",
+            },
+        )
+
+    assert response.status_code >= 400, response.text


### PR DESCRIPTION
## What does this PR do?

<!-- Provide a clear and concise description of the changes -->

Fix for v3 workflow blocks 422 errors on remote execution path only: https://roboflow.slack.com/archives/C06BD36S37A/p1777316040643609

## Type of Change

<!-- Please select one and delete the others, or describe if Other -->

- Bug fix (non-breaking change that fixes an issue)

## Testing

<!-- Describe how you tested your changes -->

- [x] I have tested this change locally
- [x] I have added/updated tests for this change

**Test details:**

New unit test: test legacy http API with string-valued confidence modes

Integration testing:
* Force `self._step_execution_mode = ExecutionMode.REMOTE` in v3 instance seg workflow block
* Run local inference server forcing v0 API via
```
docker run --rm -p 9001:9001 \
    -e ROBOFLOW_API_KEY=${ROBOFLOW_API_KEY} \
    -e WORKFLOWS_REMOTE_API_TARGET=hosted \
    -e HOSTED_INSTANCE_SEGMENTATION_URL=http://localhost:9001 \
    -e LOG_LEVEL=DEBUG \
    --gpus=all \
    --name inference-test \
    roboflow/roboflow-inference-server-gpu:dev
```
- [x] Reproduced 422 error on main with `confidence=best`
```
HTTPCallErrorError(description='422 Client Error: Unprocessable Entity for url: http://localhost:9001/bouldering-holds-9wavr-wrfb4/2?api_key=EW***Ap&confidence=best&mask_decode_mode=accurate&tradeoff_factor=0.0&max_detections=300&overlap=0.3&disable_active_learning=True&source=workflow-execution', api_message='N/A',status_code=422)
```
- [x] Verified this PR fixes the 422 error and workflow succeeds with model block `confidence="best"`
<img width="1600" height="900" alt="image" src="https://github.com/user-attachments/assets/a8de3d7b-7227-4cd3-9ba6-2e4536a128d8" />


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)

## Additional Context

<!-- Add any other context, screenshots, or notes about the PR here -->
