### PR TITLE
Forward service_secret and countinference from InferenceConfig to v1 API

### DIFF
--- a/inference_sdk/http/client.py
+++ b/inference_sdk/http/client.py
@@ -743,13 +743,13 @@ class InferenceHTTPClient:
             "model_id": model_id_to_be_used,
         }
         endpoint = NEW_INFERENCE_ENDPOINTS[model_description.task_type]
-        body_params, query_params = (
+        payload.update(
             self.__inference_configuration.to_api_call_parameters(
                 client_mode=self.__client_mode,
                 task_type=model_description.task_type,
             )
         )
-        payload.update(body_params)
+        query_params = self.__inference_configuration.to_api_v1_query_parameters()
         requests_data = prepare_requests_data(
             url=f"{self.__api_url}{endpoint}",
             encoded_inference_inputs=encoded_inference_inputs,
@@ -792,13 +792,13 @@ class InferenceHTTPClient:
             "model_id": model_id_to_be_used,
         }
         endpoint = NEW_INFERENCE_ENDPOINTS[model_description.task_type]
-        body_params, query_params = (
+        payload.update(
             self.__inference_configuration.to_api_call_parameters(
                 client_mode=self.__client_mode,
                 task_type=model_description.task_type,
             )
         )
-        payload.update(body_params)
+        query_params = self.__inference_configuration.to_api_v1_query_parameters()
         requests_data = prepare_requests_data(
             url=f"{self.__api_url}{endpoint}",
             encoded_inference_inputs=encoded_inference_inputs,

--- a/inference_sdk/http/client.py
+++ b/inference_sdk/http/client.py
@@ -743,17 +743,18 @@ class InferenceHTTPClient:
             "model_id": model_id_to_be_used,
         }
         endpoint = NEW_INFERENCE_ENDPOINTS[model_description.task_type]
-        payload.update(
+        body_params, query_params = (
             self.__inference_configuration.to_api_call_parameters(
                 client_mode=self.__client_mode,
                 task_type=model_description.task_type,
             )
         )
+        payload.update(body_params)
         requests_data = prepare_requests_data(
             url=f"{self.__api_url}{endpoint}",
             encoded_inference_inputs=encoded_inference_inputs,
             headers=DEFAULT_HEADERS,
-            parameters=None,
+            parameters=query_params,
             payload=payload,
             max_batch_size=self.__inference_configuration.max_batch_size,
             image_placement=ImagePlacement.JSON,
@@ -791,17 +792,18 @@ class InferenceHTTPClient:
             "model_id": model_id_to_be_used,
         }
         endpoint = NEW_INFERENCE_ENDPOINTS[model_description.task_type]
-        payload.update(
+        body_params, query_params = (
             self.__inference_configuration.to_api_call_parameters(
                 client_mode=self.__client_mode,
                 task_type=model_description.task_type,
             )
         )
+        payload.update(body_params)
         requests_data = prepare_requests_data(
             url=f"{self.__api_url}{endpoint}",
             encoded_inference_inputs=encoded_inference_inputs,
             headers=DEFAULT_HEADERS,
-            parameters=None,
+            parameters=query_params,
             payload=payload,
             max_batch_size=self.__inference_configuration.max_batch_size,
             image_placement=ImagePlacement.JSON,

--- a/inference_sdk/http/entities.py
+++ b/inference_sdk/http/entities.py
@@ -157,35 +157,43 @@ class InferenceConfiguration:
 
     def to_api_call_parameters(
         self, client_mode: HTTPClientMode, task_type: TaskType
-    ) -> Tuple[Dict[str, Any], Optional[Dict[str, Any]]]:
-        """Return (body_params, query_params) for the given client mode and task.
+    ) -> Dict[str, Any]:
+        """Convert the current configuration to API call parameters.
 
-        v0 places everything on the URL query string. v1 splits: task-specific
-        config goes in the JSON body, and `service_secret` / `countinference`
-        go on the query string (the FastAPI handlers bind them from query).
-        Returns None for query_params when there's nothing to send.
+        Args:
+            client_mode: The HTTP client mode.
+            task_type: The type of task the model is designed for.
+
+        Returns:
+            Dict[str, Any]: The API call parameters.
         """
         if client_mode is HTTPClientMode.V0:
-            return {}, self.to_legacy_call_parameters() or None
+            return self.to_legacy_call_parameters()
         if task_type == OBJECT_DETECTION_TASK:
-            body = self.to_object_detection_parameters()
-        elif task_type == INSTANCE_SEGMENTATION_TASK:
-            body = self.to_instance_segmentation_parameters()
-        elif task_type == CLASSIFICATION_TASK:
-            body = self.to_classification_parameters()
-        elif task_type == KEYPOINTS_DETECTION_TASK:
-            body = self.to_keypoints_detection_parameters()
-        else:
-            raise ModelTaskTypeNotSupportedError(
-                f"Model task {task_type} is not supported by API v1 client."
-            )
+            return self.to_object_detection_parameters()
+        if task_type == INSTANCE_SEGMENTATION_TASK:
+            return self.to_instance_segmentation_parameters()
+        if task_type == CLASSIFICATION_TASK:
+            return self.to_classification_parameters()
+        if task_type == KEYPOINTS_DETECTION_TASK:
+            return self.to_keypoints_detection_parameters()
+        raise ModelTaskTypeNotSupportedError(
+            f"Model task {task_type} is not supported by API v1 client."
+        )
+
+    def to_api_v1_query_parameters(self) -> Optional[Dict[str, Any]]:
+        """Extract v1 API query-string parameters from the current configuration.
+
+        Returns:
+            Optional[Dict[str, Any]]: The query parameters, or None if unset.
+        """
         query = remove_empty_values(
             {
                 "service_secret": self.service_secret,
                 "countinference": self.count_inference,
             }
         )
-        return body, (query or None)
+        return query or None
 
     def to_object_detection_parameters(self) -> Dict[str, Any]:
         """Convert the current configuration to object detection parameters.

--- a/inference_sdk/http/entities.py
+++ b/inference_sdk/http/entities.py
@@ -157,29 +157,35 @@ class InferenceConfiguration:
 
     def to_api_call_parameters(
         self, client_mode: HTTPClientMode, task_type: TaskType
-    ) -> Dict[str, Any]:
-        """Convert the current configuration to API call parameters.
+    ) -> Tuple[Dict[str, Any], Optional[Dict[str, Any]]]:
+        """Return (body_params, query_params) for the given client mode and task.
 
-        Args:
-            client_mode: The HTTP client mode.
-            task_type: The type of task the model is designed for.
-
-        Returns:
-            Dict[str, Any]: The API call parameters.
+        v0 places everything on the URL query string. v1 splits: task-specific
+        config goes in the JSON body, and `service_secret` / `countinference`
+        go on the query string (the FastAPI handlers bind them from query).
+        Returns None for query_params when there's nothing to send.
         """
         if client_mode is HTTPClientMode.V0:
-            return self.to_legacy_call_parameters()
+            return {}, self.to_legacy_call_parameters() or None
         if task_type == OBJECT_DETECTION_TASK:
-            return self.to_object_detection_parameters()
-        if task_type == INSTANCE_SEGMENTATION_TASK:
-            return self.to_instance_segmentation_parameters()
-        if task_type == CLASSIFICATION_TASK:
-            return self.to_classification_parameters()
-        if task_type == KEYPOINTS_DETECTION_TASK:
-            return self.to_keypoints_detection_parameters()
-        raise ModelTaskTypeNotSupportedError(
-            f"Model task {task_type} is not supported by API v1 client."
+            body = self.to_object_detection_parameters()
+        elif task_type == INSTANCE_SEGMENTATION_TASK:
+            body = self.to_instance_segmentation_parameters()
+        elif task_type == CLASSIFICATION_TASK:
+            body = self.to_classification_parameters()
+        elif task_type == KEYPOINTS_DETECTION_TASK:
+            body = self.to_keypoints_detection_parameters()
+        else:
+            raise ModelTaskTypeNotSupportedError(
+                f"Model task {task_type} is not supported by API v1 client."
+            )
+        query = remove_empty_values(
+            {
+                "service_secret": self.service_secret,
+                "countinference": self.count_inference,
+            }
         )
+        return body, (query or None)
 
     def to_object_detection_parameters(self) -> Dict[str, Any]:
         """Convert the current configuration to object detection parameters.

--- a/tests/inference_sdk/unit_tests/http/test_client.py
+++ b/tests/inference_sdk/unit_tests/http/test_client.py
@@ -1850,6 +1850,50 @@ def test_infer_from_api_v1_when_request_succeed_for_object_detection_with_batch_
     }
 
 
+@mock.patch.object(client, "load_static_inference_input")
+def test_infer_from_api_v1_threads_service_secret_and_countinference_as_query_params(
+    load_static_inference_input_mock: MagicMock,
+    requests_mock: Mocker,
+) -> None:
+    # given
+    api_url = "http://some.com"
+    http_client = InferenceHTTPClient(api_key="my-api-key", api_url=api_url)
+    http_client.get_model_description = MagicMock()
+    http_client.get_model_description.return_value = ModelDescription(
+        model_id="coco/3",
+        task_type="object-detection",
+        input_height=480,
+        input_width=640,
+    )
+    load_static_inference_input_mock.return_value = [("base64_image", None)]
+    configuration = InferenceConfiguration(
+        confidence_threshold=0.5,
+        service_secret="internal-secret",
+        count_inference=False,
+    )
+    http_client.configure(inference_configuration=configuration)
+    requests_mock.post(
+        f"{api_url}/infer/object_detection",
+        json={"image": {"height": 480, "width": 640}, "predictions": []},
+    )
+
+    # when
+    http_client.infer_from_api_v1(
+        inference_input="https://some/image.jpg",
+        model_id="coco/3",
+    )
+
+    # then — credentials live on the URL query string, where FastAPI binds them
+    qs = requests_mock.request_history[0].qs
+    assert qs.get("service_secret") == ["internal-secret"]
+    assert qs.get("countinference") == ["false"]
+    # and they must NOT leak into the JSON body (the Pydantic body model would drop them anyway)
+    body = requests_mock.request_history[0].json()
+    assert "service_secret" not in body
+    assert "countinference" not in body
+    assert "count_inference" not in body
+
+
 @pytest.mark.asyncio
 @mock.patch.object(client, "load_static_inference_input_async")
 @pytest.mark.parametrize("model_id_to_use", ["coco/3", "yolov8n-640"])

--- a/tests/inference_sdk/unit_tests/http/test_entities.py
+++ b/tests/inference_sdk/unit_tests/http/test_entities.py
@@ -82,13 +82,12 @@ def test_source_attributes() -> None:
 
 def test_to_api_call_parameters_for_api_v0() -> None:
     # when
-    body, query = REFERENCE_IMAGE_CONFIGURATION.to_api_call_parameters(
+    result = REFERENCE_IMAGE_CONFIGURATION.to_api_call_parameters(
         client_mode=HTTPClientMode.V0, task_type="does-not-matter"
     )
 
-    # then — v0 puts everything on the URL query string
-    assert body == {}
-    assert query == {
+    # then
+    assert result == {
         "confidence": 0.5,
         "format": "json",
         "labels": True,
@@ -111,13 +110,13 @@ def test_to_api_call_parameters_for_api_v0() -> None:
 
 def test_to_api_call_parameters_for_api_v1_classification() -> None:
     # when
-    body, query = REFERENCE_IMAGE_CONFIGURATION.to_api_call_parameters(
+    result = REFERENCE_IMAGE_CONFIGURATION.to_api_call_parameters(
         client_mode=HTTPClientMode.V1,
         task_type=CLASSIFICATION_TASK,
     )
 
     # then
-    assert body == {
+    assert result == {
         "confidence": 0.5,
         "visualize_predictions": False,
         "visualization_stroke_width": 1,
@@ -129,17 +128,16 @@ def test_to_api_call_parameters_for_api_v1_classification() -> None:
         "source": "config-test",
         "source_info": "config-test-source-info",
     }
-    assert query == {"service_secret": "xxx", "countinference": True}
 
 
 def test_to_api_call_parameters_for_api_v1_object_detection() -> None:
     # when
-    body, query = REFERENCE_IMAGE_CONFIGURATION.to_api_call_parameters(
+    result = REFERENCE_IMAGE_CONFIGURATION.to_api_call_parameters(
         client_mode=HTTPClientMode.V1, task_type=OBJECT_DETECTION_TASK
     )
 
     # then
-    assert body == {
+    assert result == {
         "disable_preproc_auto_orient": True,
         "disable_preproc_contrast": False,
         "disable_preproc_grayscale": True,
@@ -158,32 +156,44 @@ def test_to_api_call_parameters_for_api_v1_object_detection() -> None:
         "source": "config-test",
         "source_info": "config-test-source-info",
     }
+
+
+def test_to_api_v1_query_parameters_when_both_set() -> None:
+    # when
+    query = REFERENCE_IMAGE_CONFIGURATION.to_api_v1_query_parameters()
+
+    # then
     assert query == {"service_secret": "xxx", "countinference": True}
 
 
-def test_to_api_call_parameters_for_api_v1_when_credentials_unset() -> None:
+def test_to_api_v1_query_parameters_when_credentials_unset() -> None:
     # given
     configuration = InferenceConfiguration(confidence_threshold=0.5)
 
     # when
-    body, query = configuration.to_api_call_parameters(
-        client_mode=HTTPClientMode.V1, task_type=OBJECT_DETECTION_TASK
-    )
+    query = configuration.to_api_v1_query_parameters()
 
-    # then — no creds set means None query, no leakage into body
+    # then — no creds set means None so request builders skip the query string
     assert query is None
-    assert "service_secret" not in body
-    assert "countinference" not in body
 
 
-def test_to_api_call_parameters_for_api_v1_when_only_service_secret_set() -> None:
+def test_to_api_v1_query_parameters_when_only_service_secret_set() -> None:
     # given
     configuration = InferenceConfiguration(service_secret="abc")
 
     # when
-    _, query = configuration.to_api_call_parameters(
-        client_mode=HTTPClientMode.V1, task_type=OBJECT_DETECTION_TASK
-    )
+    query = configuration.to_api_v1_query_parameters()
 
     # then
     assert query == {"service_secret": "abc"}
+
+
+def test_to_api_v1_query_parameters_when_only_count_inference_set() -> None:
+    # given
+    configuration = InferenceConfiguration(count_inference=True)
+
+    # when
+    query = configuration.to_api_v1_query_parameters()
+
+    # then
+    assert query == {"countinference": True}

--- a/tests/inference_sdk/unit_tests/http/test_entities.py
+++ b/tests/inference_sdk/unit_tests/http/test_entities.py
@@ -82,12 +82,13 @@ def test_source_attributes() -> None:
 
 def test_to_api_call_parameters_for_api_v0() -> None:
     # when
-    result = REFERENCE_IMAGE_CONFIGURATION.to_api_call_parameters(
+    body, query = REFERENCE_IMAGE_CONFIGURATION.to_api_call_parameters(
         client_mode=HTTPClientMode.V0, task_type="does-not-matter"
     )
 
-    # then
-    assert result == {
+    # then — v0 puts everything on the URL query string
+    assert body == {}
+    assert query == {
         "confidence": 0.5,
         "format": "json",
         "labels": True,
@@ -110,13 +111,13 @@ def test_to_api_call_parameters_for_api_v0() -> None:
 
 def test_to_api_call_parameters_for_api_v1_classification() -> None:
     # when
-    result = REFERENCE_IMAGE_CONFIGURATION.to_api_call_parameters(
+    body, query = REFERENCE_IMAGE_CONFIGURATION.to_api_call_parameters(
         client_mode=HTTPClientMode.V1,
         task_type=CLASSIFICATION_TASK,
     )
 
     # then
-    assert result == {
+    assert body == {
         "confidence": 0.5,
         "visualize_predictions": False,
         "visualization_stroke_width": 1,
@@ -128,16 +129,17 @@ def test_to_api_call_parameters_for_api_v1_classification() -> None:
         "source": "config-test",
         "source_info": "config-test-source-info",
     }
+    assert query == {"service_secret": "xxx", "countinference": True}
 
 
 def test_to_api_call_parameters_for_api_v1_object_detection() -> None:
     # when
-    result = REFERENCE_IMAGE_CONFIGURATION.to_api_call_parameters(
+    body, query = REFERENCE_IMAGE_CONFIGURATION.to_api_call_parameters(
         client_mode=HTTPClientMode.V1, task_type=OBJECT_DETECTION_TASK
     )
 
     # then
-    assert result == {
+    assert body == {
         "disable_preproc_auto_orient": True,
         "disable_preproc_contrast": False,
         "disable_preproc_grayscale": True,
@@ -156,3 +158,32 @@ def test_to_api_call_parameters_for_api_v1_object_detection() -> None:
         "source": "config-test",
         "source_info": "config-test-source-info",
     }
+    assert query == {"service_secret": "xxx", "countinference": True}
+
+
+def test_to_api_call_parameters_for_api_v1_when_credentials_unset() -> None:
+    # given
+    configuration = InferenceConfiguration(confidence_threshold=0.5)
+
+    # when
+    body, query = configuration.to_api_call_parameters(
+        client_mode=HTTPClientMode.V1, task_type=OBJECT_DETECTION_TASK
+    )
+
+    # then — no creds set means None query, no leakage into body
+    assert query is None
+    assert "service_secret" not in body
+    assert "countinference" not in body
+
+
+def test_to_api_call_parameters_for_api_v1_when_only_service_secret_set() -> None:
+    # given
+    configuration = InferenceConfiguration(service_secret="abc")
+
+    # when
+    _, query = configuration.to_api_call_parameters(
+        client_mode=HTTPClientMode.V1, task_type=OBJECT_DETECTION_TASK
+    )
+
+    # then
+    assert query == {"service_secret": "abc"}


### PR DESCRIPTION
## What does this PR do?

<!-- Provide a clear and concise description of the changes -->

v1 API supports `service_secret` and `countinference` query params (https://github.com/roboflow/inference/pull/1373), however the SDK does not forward them from InferenceConfig for v1, only for v0. 

## Type of Change

<!-- Please select one and delete the others, or describe if Other -->

- Bug fix (non-breaking change that fixes an issue)

## Testing

<!-- Describe how you tested your changes -->

- [x] I have tested this change locally - unit tests
- [x] I have added/updated tests for this change

**Test details:**
<!-- Describe what tests were added/updated and what they cover -->

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)

## Additional Context

<!-- Add any other context, screenshots, or notes about the PR here -->
