### PR TITLE
feat(workflows): add Image Stack block for frame accumulation

### DIFF
--- a/inference/core/workflows/core_steps/fusion/image_stack/v1.py
+++ b/inference/core/workflows/core_steps/fusion/image_stack/v1.py
@@ -56,9 +56,7 @@ out-of-memory conditions.
 - **Event buffering**: keep a rolling window of frames around an event of interest.
 """
 
-SHORT_DESCRIPTION = (
-    "Accumulate compressed video frames into a fixed-size FIFO stack."
-)
+SHORT_DESCRIPTION = "Accumulate compressed video frames into a fixed-size FIFO stack."
 
 
 class BlockManifest(WorkflowBlockManifest):
@@ -120,9 +118,7 @@ class BlockManifest(WorkflowBlockManifest):
     @classmethod
     def validate_stack_size(cls, value: Any) -> Any:
         if isinstance(value, int) and not (1 <= value <= MAX_STACK_SIZE):
-            raise ValueError(
-                f"`stack_size` must be between 1 and {MAX_STACK_SIZE}."
-            )
+            raise ValueError(f"`stack_size` must be between 1 and {MAX_STACK_SIZE}.")
         return value
 
     @field_validator("resolution_width")

--- a/inference/core/workflows/core_steps/fusion/image_stack/v1.py
+++ b/inference/core/workflows/core_steps/fusion/image_stack/v1.py
@@ -1,0 +1,226 @@
+from collections import deque
+from typing import Any, Dict, List, Literal, Optional, Type, Union
+
+import cv2
+import numpy as np
+from pydantic import ConfigDict, Field, field_validator
+
+from inference.core.utils.image_utils import encode_image_to_jpeg_bytes
+from inference.core.workflows.execution_engine.entities.base import (
+    OutputDefinition,
+    WorkflowImageData,
+)
+from inference.core.workflows.execution_engine.entities.types import (
+    BOOLEAN_KIND,
+    IMAGE_KIND,
+    INTEGER_KIND,
+    LIST_OF_VALUES_KIND,
+    Selector,
+)
+from inference.core.workflows.prototypes.block import (
+    BlockResult,
+    WorkflowBlock,
+    WorkflowBlockManifest,
+)
+
+MAX_STACK_SIZE = 64
+MAX_RESOLUTION_WIDTH = 1920
+MAX_RESOLUTION_HEIGHT = 1080
+JPEG_QUALITY = 75
+
+LONG_DESCRIPTION = """
+Accumulate compressed video frames into a fixed-size stack, returning the most recent
+N frames as JPEG-encoded binary blobs. Designed for shared-hosting safety: frames are
+always JPEG-compressed and downsampled to fit within resolution limits, preventing
+out-of-memory conditions.
+
+## How This Block Works
+
+1. Receives a video frame (WorkflowImageData) each workflow cycle.
+2. Downsamples the frame if it exceeds the configured resolution limits (default
+   1920x1080), preserving aspect ratio.
+3. JPEG-encodes the frame at quality 75 and stores the resulting bytes.
+4. Maintains a per-camera FIFO buffer (deque) of up to `stack_size` compressed frames.
+   When the buffer is full the oldest frame is automatically evicted.
+5. If `stack_size` changes between calls (e.g. via a dynamic selector), the buffer is
+   resized and existing frames are preserved up to the new limit.
+6. If the `clear` input is True the buffer is flushed before the current frame is added.
+7. Outputs the list of JPEG byte blobs (newest first) and the current frame count.
+
+## Common Use Cases
+
+- **Action / activity recognition**: accumulate a clip of N frames and pass them to a
+  vision-language model (e.g. Google Gemini, Qwen) that can reason over multiple images
+  to classify actions, detect events, or describe what is happening in a scene.
+- **Time-lapse snapshots**: collect the last N frames for periodic visual comparison.
+- **Event buffering**: keep a rolling window of frames around an event of interest.
+"""
+
+SHORT_DESCRIPTION = (
+    "Accumulate compressed video frames into a fixed-size FIFO stack."
+)
+
+
+class BlockManifest(WorkflowBlockManifest):
+    model_config = ConfigDict(
+        json_schema_extra={
+            "name": "Image Stack",
+            "version": "v1",
+            "short_description": SHORT_DESCRIPTION,
+            "long_description": LONG_DESCRIPTION,
+            "license": "Apache-2.0",
+            "block_type": "fusion",
+            "ui_manifest": {
+                "section": "video",
+                "icon": "far fa-layer-group",
+            },
+        }
+    )
+    type: Literal["roboflow_core/image_stack@v1"]
+
+    image: Selector(kind=[IMAGE_KIND]) = Field(
+        title="Input Image",
+        description="Video frame to add to the stack.",
+        examples=["$inputs.image", "$steps.preprocessing.image"],
+    )
+    stack_size: Union[int, Selector(kind=[INTEGER_KIND])] = Field(  # type: ignore
+        default=10,
+        description=(
+            f"Maximum number of frames to keep in the stack (1-{MAX_STACK_SIZE}). "
+            "When the stack is full the oldest frame is evicted."
+        ),
+        examples=[5, 10, "$inputs.stack_size"],
+    )
+    resolution_width: Union[int, Selector(kind=[INTEGER_KIND])] = Field(  # type: ignore
+        default=MAX_RESOLUTION_WIDTH,
+        description=(
+            f"Maximum frame width in pixels (64-{MAX_RESOLUTION_WIDTH}). "
+            "Frames wider than this are downsampled preserving aspect ratio."
+        ),
+        examples=[640, 1280, "$inputs.resolution_width"],
+    )
+    resolution_height: Union[int, Selector(kind=[INTEGER_KIND])] = Field(  # type: ignore
+        default=MAX_RESOLUTION_HEIGHT,
+        description=(
+            f"Maximum frame height in pixels (64-{MAX_RESOLUTION_HEIGHT}). "
+            "Frames taller than this are downsampled preserving aspect ratio."
+        ),
+        examples=[480, 720, "$inputs.resolution_height"],
+    )
+    clear: Union[bool, Selector(kind=[BOOLEAN_KIND])] = Field(
+        default=False,
+        description=(
+            "When True the entire frame buffer is flushed before the current "
+            "frame is added. Useful for resetting state on scene changes."
+        ),
+        examples=[False, "$inputs.clear_buffer"],
+    )
+
+    @field_validator("stack_size")
+    @classmethod
+    def validate_stack_size(cls, value: Any) -> Any:
+        if isinstance(value, int) and not (1 <= value <= MAX_STACK_SIZE):
+            raise ValueError(
+                f"`stack_size` must be between 1 and {MAX_STACK_SIZE}."
+            )
+        return value
+
+    @field_validator("resolution_width")
+    @classmethod
+    def validate_resolution_width(cls, value: Any) -> Any:
+        if isinstance(value, int) and not (64 <= value <= MAX_RESOLUTION_WIDTH):
+            raise ValueError(
+                f"`resolution_width` must be between 64 and {MAX_RESOLUTION_WIDTH}."
+            )
+        return value
+
+    @field_validator("resolution_height")
+    @classmethod
+    def validate_resolution_height(cls, value: Any) -> Any:
+        if isinstance(value, int) and not (64 <= value <= MAX_RESOLUTION_HEIGHT):
+            raise ValueError(
+                f"`resolution_height` must be between 64 and {MAX_RESOLUTION_HEIGHT}."
+            )
+        return value
+
+    @classmethod
+    def describe_outputs(cls) -> List[OutputDefinition]:
+        return [
+            OutputDefinition(
+                name="frames",
+                kind=[LIST_OF_VALUES_KIND],
+            ),
+            OutputDefinition(
+                name="frames_count",
+                kind=[INTEGER_KIND],
+            ),
+        ]
+
+    @classmethod
+    def get_execution_engine_compatibility(cls) -> Optional[str]:
+        return ">=1.3.0,<2.0.0"
+
+
+def _compress_frame(
+    numpy_image: np.ndarray,
+    max_width: int,
+    max_height: int,
+) -> bytes:
+    h, w = numpy_image.shape[:2]
+    if w > max_width or h > max_height:
+        scale = min(max_width / w, max_height / h)
+        new_w = int(w * scale)
+        new_h = int(h * scale)
+        numpy_image = cv2.resize(
+            numpy_image, (new_w, new_h), interpolation=cv2.INTER_AREA
+        )
+    return encode_image_to_jpeg_bytes(numpy_image, jpeg_quality=JPEG_QUALITY)
+
+
+class ImageStackBlockV1(WorkflowBlock):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._buffers: Dict[str, deque] = {}
+
+    @classmethod
+    def get_manifest(cls) -> Type[WorkflowBlockManifest]:
+        return BlockManifest
+
+    def run(
+        self,
+        image: WorkflowImageData,
+        stack_size: int,
+        resolution_width: int,
+        resolution_height: int,
+        clear: bool,
+    ) -> BlockResult:
+        stack_size = max(1, min(stack_size, MAX_STACK_SIZE))
+        resolution_width = max(64, min(resolution_width, MAX_RESOLUTION_WIDTH))
+        resolution_height = max(64, min(resolution_height, MAX_RESOLUTION_HEIGHT))
+
+        video_id = image.video_metadata.video_identifier
+
+        buf = self._buffers.get(video_id)
+        if buf is None:
+            buf = deque(maxlen=stack_size)
+            self._buffers[video_id] = buf
+        elif buf.maxlen != stack_size:
+            new_buf = deque(buf, maxlen=stack_size)
+            buf = new_buf
+            self._buffers[video_id] = buf
+
+        if clear:
+            buf.clear()
+
+        compressed = _compress_frame(
+            image.numpy_image,
+            max_width=resolution_width,
+            max_height=resolution_height,
+        )
+        buf.appendleft(compressed)
+
+        frames = list(buf)
+        return {
+            "frames": frames,
+            "frames_count": len(frames),
+        }

--- a/inference/core/workflows/core_steps/loader.py
+++ b/inference/core/workflows/core_steps/loader.py
@@ -178,6 +178,7 @@ from inference.core.workflows.core_steps.formatters.vlm_as_detector.v2 import (
     VLMAsDetectorBlockV2,
 )
 from inference.core.workflows.core_steps.fusion.buffer.v1 import BufferBlockV1
+from inference.core.workflows.core_steps.fusion.image_stack.v1 import ImageStackBlockV1
 from inference.core.workflows.core_steps.fusion.detections_classes_replacement.v1 import (
     DetectionsClassesReplacementBlockV1,
 )
@@ -771,6 +772,7 @@ def load_blocks() -> List[Type[WorkflowBlock]]:
         DynamicZonesBlockV1,
         SizeMeasurementBlockV1,
         BufferBlockV1,
+        ImageStackBlockV1,
         DetectionsClassesReplacementBlockV1,
         ExpressionBlockV1,
         PropertyDefinitionBlockV1,

--- a/inference/core/workflows/core_steps/loader.py
+++ b/inference/core/workflows/core_steps/loader.py
@@ -178,7 +178,6 @@ from inference.core.workflows.core_steps.formatters.vlm_as_detector.v2 import (
     VLMAsDetectorBlockV2,
 )
 from inference.core.workflows.core_steps.fusion.buffer.v1 import BufferBlockV1
-from inference.core.workflows.core_steps.fusion.image_stack.v1 import ImageStackBlockV1
 from inference.core.workflows.core_steps.fusion.detections_classes_replacement.v1 import (
     DetectionsClassesReplacementBlockV1,
 )
@@ -194,6 +193,7 @@ from inference.core.workflows.core_steps.fusion.detections_stitch.v1 import (
 from inference.core.workflows.core_steps.fusion.dimension_collapse.v1 import (
     DimensionCollapseBlockV1,
 )
+from inference.core.workflows.core_steps.fusion.image_stack.v1 import ImageStackBlockV1
 from inference.core.workflows.core_steps.math.cosine_similarity.v1 import (
     CosineSimilarityBlockV1,
 )

--- a/tests/workflows/integration_tests/execution/test_workflow_with_image_stack.py
+++ b/tests/workflows/integration_tests/execution/test_workflow_with_image_stack.py
@@ -1,0 +1,104 @@
+import numpy as np
+
+from inference.core.env import WORKFLOWS_MAX_CONCURRENT_STEPS
+from inference.core.workflows.execution_engine.core import ExecutionEngine
+
+IMAGE_STACK_WORKFLOW = {
+    "version": "1.0",
+    "inputs": [
+        {"type": "InferenceImage", "name": "image"},
+        {"type": "InferenceParameter", "name": "stack_size", "default_value": 3},
+        {"type": "InferenceParameter", "name": "clear", "default_value": False},
+    ],
+    "steps": [
+        {
+            "type": "roboflow_core/image_stack@v1",
+            "name": "image_stack",
+            "image": "$inputs.image",
+            "stack_size": "$inputs.stack_size",
+            "clear": "$inputs.clear",
+        }
+    ],
+    "outputs": [
+        {
+            "type": "JsonField",
+            "name": "frames",
+            "selector": "$steps.image_stack.frames",
+        },
+        {
+            "type": "JsonField",
+            "name": "frames_count",
+            "selector": "$steps.image_stack.frames_count",
+        },
+    ],
+}
+
+
+def test_image_stack_accumulates_frames(
+    dogs_image: np.ndarray,
+) -> None:
+    # given
+    execution_engine = ExecutionEngine.init(
+        workflow_definition=IMAGE_STACK_WORKFLOW,
+        init_parameters={},
+        max_concurrent_steps=WORKFLOWS_MAX_CONCURRENT_STEPS,
+    )
+
+    # when — feed 3 frames
+    for _ in range(3):
+        result = execution_engine.run(
+            runtime_parameters={"image": dogs_image}
+        )
+
+    # then
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert result[0]["frames_count"] == 3
+    assert len(result[0]["frames"]) == 3
+    for frame in result[0]["frames"]:
+        assert isinstance(frame, bytes)
+        assert frame[:2] == b"\xff\xd8"  # JPEG magic bytes
+
+
+def test_image_stack_evicts_oldest_when_full(
+    dogs_image: np.ndarray,
+) -> None:
+    # given
+    execution_engine = ExecutionEngine.init(
+        workflow_definition=IMAGE_STACK_WORKFLOW,
+        init_parameters={},
+        max_concurrent_steps=WORKFLOWS_MAX_CONCURRENT_STEPS,
+    )
+
+    # when — feed 5 frames with stack_size=3
+    for _ in range(5):
+        result = execution_engine.run(
+            runtime_parameters={"image": dogs_image, "stack_size": 3}
+        )
+
+    # then — only 3 most recent kept
+    assert result[0]["frames_count"] == 3
+    assert len(result[0]["frames"]) == 3
+
+
+def test_image_stack_clear_resets_buffer(
+    dogs_image: np.ndarray,
+) -> None:
+    # given
+    execution_engine = ExecutionEngine.init(
+        workflow_definition=IMAGE_STACK_WORKFLOW,
+        init_parameters={},
+        max_concurrent_steps=WORKFLOWS_MAX_CONCURRENT_STEPS,
+    )
+
+    # when — fill buffer
+    for _ in range(3):
+        execution_engine.run(
+            runtime_parameters={"image": dogs_image}
+        )
+
+    # then — clear and add one
+    result = execution_engine.run(
+        runtime_parameters={"image": dogs_image, "clear": True}
+    )
+    assert result[0]["frames_count"] == 1

--- a/tests/workflows/unit_tests/core_steps/fusion/test_image_stack.py
+++ b/tests/workflows/unit_tests/core_steps/fusion/test_image_stack.py
@@ -1,0 +1,446 @@
+from datetime import datetime
+
+import cv2
+import numpy as np
+import pytest
+from pydantic import ValidationError
+
+from inference.core.workflows.core_steps.fusion.image_stack.v1 import (
+    BlockManifest,
+    ImageStackBlockV1,
+    MAX_RESOLUTION_HEIGHT,
+    MAX_RESOLUTION_WIDTH,
+    MAX_STACK_SIZE,
+    _compress_frame,
+)
+from inference.core.workflows.execution_engine.entities.base import (
+    ImageParentMetadata,
+    VideoMetadata,
+    WorkflowImageData,
+)
+
+
+def _make_image(
+    width: int = 320,
+    height: int = 240,
+    video_id: str = "cam-1",
+    frame_number: int = 0,
+) -> WorkflowImageData:
+    return WorkflowImageData(
+        parent_metadata=ImageParentMetadata(parent_id=video_id),
+        numpy_image=np.random.randint(0, 255, (height, width, 3), dtype=np.uint8),
+        video_metadata=VideoMetadata(
+            video_identifier=video_id,
+            frame_number=frame_number,
+            frame_timestamp=datetime.now(),
+            fps=30,
+            comes_from_video_file=None,
+        ),
+    )
+
+
+# ── Manifest validation ─────────────────────────────────────────────
+
+
+def test_manifest_with_defaults() -> None:
+    raw = {
+        "type": "roboflow_core/image_stack@v1",
+        "name": "stack1",
+        "image": "$inputs.image",
+    }
+    result = BlockManifest.model_validate(raw)
+    assert result.stack_size == 10
+    assert result.resolution_width == MAX_RESOLUTION_WIDTH
+    assert result.resolution_height == MAX_RESOLUTION_HEIGHT
+    assert result.clear is False
+
+
+def test_manifest_with_custom_values() -> None:
+    raw = {
+        "type": "roboflow_core/image_stack@v1",
+        "name": "stack1",
+        "image": "$inputs.image",
+        "stack_size": 5,
+        "resolution_width": 640,
+        "resolution_height": 480,
+        "clear": "$inputs.reset",
+    }
+    result = BlockManifest.model_validate(raw)
+    assert result.stack_size == 5
+    assert result.resolution_width == 640
+    assert result.resolution_height == 480
+
+
+def test_manifest_rejects_stack_size_too_large() -> None:
+    raw = {
+        "type": "roboflow_core/image_stack@v1",
+        "name": "stack1",
+        "image": "$inputs.image",
+        "stack_size": MAX_STACK_SIZE + 1,
+    }
+    with pytest.raises(ValidationError):
+        BlockManifest.model_validate(raw)
+
+
+def test_manifest_rejects_stack_size_zero() -> None:
+    raw = {
+        "type": "roboflow_core/image_stack@v1",
+        "name": "stack1",
+        "image": "$inputs.image",
+        "stack_size": 0,
+    }
+    with pytest.raises(ValidationError):
+        BlockManifest.model_validate(raw)
+
+
+def test_manifest_rejects_resolution_too_large() -> None:
+    raw = {
+        "type": "roboflow_core/image_stack@v1",
+        "name": "stack1",
+        "image": "$inputs.image",
+        "resolution_width": MAX_RESOLUTION_WIDTH + 1,
+    }
+    with pytest.raises(ValidationError):
+        BlockManifest.model_validate(raw)
+
+
+def test_manifest_accepts_selectors_for_int_fields() -> None:
+    raw = {
+        "type": "roboflow_core/image_stack@v1",
+        "name": "stack1",
+        "image": "$inputs.image",
+        "stack_size": "$inputs.stack_size",
+        "resolution_width": "$inputs.width",
+        "resolution_height": "$inputs.height",
+    }
+    result = BlockManifest.model_validate(raw)
+    assert result.stack_size == "$inputs.stack_size"
+    assert result.resolution_width == "$inputs.width"
+    assert result.resolution_height == "$inputs.height"
+
+
+# ── _compress_frame helper ───────────────────────────────────────────
+
+
+def test_compress_frame_returns_jpeg_bytes() -> None:
+    img = np.zeros((100, 200, 3), dtype=np.uint8)
+    result = _compress_frame(img, max_width=1920, max_height=1080)
+    assert isinstance(result, bytes)
+    # JPEG magic bytes
+    assert result[:2] == b"\xff\xd8"
+
+
+def test_compress_frame_downsamples_wide_image() -> None:
+    img = np.zeros((1080, 3840, 3), dtype=np.uint8)
+    result = _compress_frame(img, max_width=1920, max_height=1080)
+    # decode and check dimensions
+    decoded = cv2.imdecode(
+        np.frombuffer(result, dtype=np.uint8), cv2.IMREAD_COLOR
+    )
+    assert decoded.shape[1] <= 1920
+    assert decoded.shape[0] <= 1080
+
+
+def test_compress_frame_downsamples_tall_image() -> None:
+    img = np.zeros((2160, 1000, 3), dtype=np.uint8)
+    result = _compress_frame(img, max_width=1920, max_height=1080)
+    decoded = cv2.imdecode(
+        np.frombuffer(result, dtype=np.uint8), cv2.IMREAD_COLOR
+    )
+    assert decoded.shape[0] <= 1080
+    assert decoded.shape[1] <= 1920
+
+
+def test_compress_frame_preserves_small_image_dimensions() -> None:
+    img = np.zeros((100, 200, 3), dtype=np.uint8)
+    result = _compress_frame(img, max_width=1920, max_height=1080)
+    decoded = cv2.imdecode(
+        np.frombuffer(result, dtype=np.uint8), cv2.IMREAD_COLOR
+    )
+    assert decoded.shape[:2] == (100, 200)
+
+
+def test_compress_frame_handles_grayscale() -> None:
+    img = np.zeros((100, 200), dtype=np.uint8)
+    result = _compress_frame(img, max_width=1920, max_height=1080)
+    assert isinstance(result, bytes)
+    assert result[:2] == b"\xff\xd8"
+
+
+def test_compress_frame_handles_rgba() -> None:
+    img = np.zeros((100, 200, 4), dtype=np.uint8)
+    result = _compress_frame(img, max_width=1920, max_height=1080)
+    assert isinstance(result, bytes)
+    assert result[:2] == b"\xff\xd8"
+
+
+# ── Block accumulation ───────────────────────────────────────────────
+
+
+def test_single_frame_added() -> None:
+    block = ImageStackBlockV1()
+    result = block.run(
+        image=_make_image(),
+        stack_size=3,
+        resolution_width=1920,
+        resolution_height=1080,
+        clear=False,
+    )
+    assert result["frames_count"] == 1
+    assert len(result["frames"]) == 1
+    assert isinstance(result["frames"][0], bytes)
+
+
+def test_frames_accumulate_up_to_stack_size() -> None:
+    block = ImageStackBlockV1()
+    for i in range(5):
+        result = block.run(
+            image=_make_image(frame_number=i),
+            stack_size=3,
+            resolution_width=1920,
+            resolution_height=1080,
+            clear=False,
+        )
+    assert result["frames_count"] == 3
+    assert len(result["frames"]) == 3
+
+
+def test_newest_frame_is_first() -> None:
+    block = ImageStackBlockV1()
+    # Add two distinct frames
+    img1 = _make_image(width=100, height=100, frame_number=0)
+    img2 = _make_image(width=100, height=100, frame_number=1)
+
+    block.run(
+        image=img1,
+        stack_size=5,
+        resolution_width=1920,
+        resolution_height=1080,
+        clear=False,
+    )
+    result = block.run(
+        image=img2,
+        stack_size=5,
+        resolution_width=1920,
+        resolution_height=1080,
+        clear=False,
+    )
+    # newest (img2) at index 0, oldest (img1) at index 1
+    assert len(result["frames"]) == 2
+    assert result["frames"][0] != result["frames"][1]
+
+
+def test_oldest_frame_evicted_on_overflow() -> None:
+    block = ImageStackBlockV1()
+    frames_added = []
+    for i in range(4):
+        result = block.run(
+            image=_make_image(frame_number=i),
+            stack_size=2,
+            resolution_width=1920,
+            resolution_height=1080,
+            clear=False,
+        )
+        frames_added.append(result["frames"][0])  # newest each time
+
+    # only last 2 frames remain
+    assert result["frames_count"] == 2
+    assert result["frames"][0] == frames_added[3]
+    assert result["frames"][1] == frames_added[2]
+
+
+# ── Clear ────────────────────────────────────────────────────────────
+
+
+def test_clear_flushes_buffer_then_adds_current() -> None:
+    block = ImageStackBlockV1()
+    # fill buffer
+    for i in range(3):
+        block.run(
+            image=_make_image(frame_number=i),
+            stack_size=5,
+            resolution_width=1920,
+            resolution_height=1080,
+            clear=False,
+        )
+
+    # clear and add one frame
+    result = block.run(
+        image=_make_image(frame_number=99),
+        stack_size=5,
+        resolution_width=1920,
+        resolution_height=1080,
+        clear=True,
+    )
+    assert result["frames_count"] == 1
+
+
+def test_clear_false_preserves_buffer() -> None:
+    block = ImageStackBlockV1()
+    block.run(
+        image=_make_image(frame_number=0),
+        stack_size=5,
+        resolution_width=1920,
+        resolution_height=1080,
+        clear=False,
+    )
+    result = block.run(
+        image=_make_image(frame_number=1),
+        stack_size=5,
+        resolution_width=1920,
+        resolution_height=1080,
+        clear=False,
+    )
+    assert result["frames_count"] == 2
+
+
+# ── Per-camera isolation ─────────────────────────────────────────────
+
+
+def test_buffers_isolated_per_camera() -> None:
+    block = ImageStackBlockV1()
+
+    # feed 3 frames to cam-1
+    for i in range(3):
+        block.run(
+            image=_make_image(video_id="cam-1", frame_number=i),
+            stack_size=5,
+            resolution_width=1920,
+            resolution_height=1080,
+            clear=False,
+        )
+
+    # feed 1 frame to cam-2
+    result_cam2 = block.run(
+        image=_make_image(video_id="cam-2", frame_number=0),
+        stack_size=5,
+        resolution_width=1920,
+        resolution_height=1080,
+        clear=False,
+    )
+    assert result_cam2["frames_count"] == 1
+
+    # cam-1 still has its own count
+    result_cam1 = block.run(
+        image=_make_image(video_id="cam-1", frame_number=3),
+        stack_size=5,
+        resolution_width=1920,
+        resolution_height=1080,
+        clear=False,
+    )
+    assert result_cam1["frames_count"] == 4
+
+
+def test_clear_only_affects_targeted_camera() -> None:
+    block = ImageStackBlockV1()
+
+    # fill both cameras
+    for i in range(3):
+        block.run(
+            image=_make_image(video_id="cam-1", frame_number=i),
+            stack_size=5,
+            resolution_width=1920,
+            resolution_height=1080,
+            clear=False,
+        )
+        block.run(
+            image=_make_image(video_id="cam-2", frame_number=i),
+            stack_size=5,
+            resolution_width=1920,
+            resolution_height=1080,
+            clear=False,
+        )
+
+    # clear cam-1 only
+    result_cam1 = block.run(
+        image=_make_image(video_id="cam-1", frame_number=99),
+        stack_size=5,
+        resolution_width=1920,
+        resolution_height=1080,
+        clear=True,
+    )
+    assert result_cam1["frames_count"] == 1
+
+    # cam-2 unaffected
+    result_cam2 = block.run(
+        image=_make_image(video_id="cam-2", frame_number=3),
+        stack_size=5,
+        resolution_width=1920,
+        resolution_height=1080,
+        clear=False,
+    )
+    assert result_cam2["frames_count"] == 4
+
+
+# ── Stack size change mid-stream ─────────────────────────────────────
+
+
+def test_stack_size_shrink_preserves_newest_frames() -> None:
+    block = ImageStackBlockV1()
+
+    # fill with stack_size=3
+    for i in range(3):
+        block.run(
+            image=_make_image(frame_number=i),
+            stack_size=3,
+            resolution_width=1920,
+            resolution_height=1080,
+            clear=False,
+        )
+
+    # shrink stack_size to 2 — preserves 2 newest + adds current frame
+    result = block.run(
+        image=_make_image(frame_number=10),
+        stack_size=2,
+        resolution_width=1920,
+        resolution_height=1080,
+        clear=False,
+    )
+    # deque(old_3_items, maxlen=2) keeps 2 newest, then appendleft adds 1 more
+    # but maxlen=2 evicts oldest → 2 frames
+    assert result["frames_count"] == 2
+
+
+def test_stack_size_grow_preserves_all_frames() -> None:
+    block = ImageStackBlockV1()
+
+    # fill with stack_size=2
+    for i in range(2):
+        block.run(
+            image=_make_image(frame_number=i),
+            stack_size=2,
+            resolution_width=1920,
+            resolution_height=1080,
+            clear=False,
+        )
+
+    # grow stack_size to 5 — all 2 existing frames preserved + new one
+    result = block.run(
+        image=_make_image(frame_number=10),
+        stack_size=5,
+        resolution_width=1920,
+        resolution_height=1080,
+        clear=False,
+    )
+    assert result["frames_count"] == 3
+
+
+# ── Resolution enforcement ───────────────────────────────────────────
+
+
+def test_custom_resolution_limits_applied() -> None:
+    block = ImageStackBlockV1()
+    # 800x600 image with 400x300 cap
+    result = block.run(
+        image=_make_image(width=800, height=600),
+        stack_size=3,
+        resolution_width=400,
+        resolution_height=300,
+        clear=False,
+    )
+    jpeg_bytes = result["frames"][0]
+    decoded = cv2.imdecode(
+        np.frombuffer(jpeg_bytes, dtype=np.uint8), cv2.IMREAD_COLOR
+    )
+    assert decoded.shape[1] <= 400
+    assert decoded.shape[0] <= 300


### PR DESCRIPTION
## What does this PR do?

New fusion block that accumulates compressed video frames into a
per-camera FIFO buffer, outputting JPEG blobs and frame count.
Designed for shared-hosting safety (always compresses, caps resolution)
and useful for feeding frame sequences to VLMs for action recognition.

## Type of Change

- New feature (non-breaking change that adds functionality)

## Testing

New tests added

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)

## Additional Context

N/A