### PR TITLE
feat(workflows): add OpenAI-compatible LLM block for custom endpoints

### DIFF
--- a/inference/core/workflows/core_steps/loader.py
+++ b/inference/core/workflows/core_steps/loader.py
@@ -275,6 +275,9 @@ from inference.core.workflows.core_steps.models.foundation.openai.v3 import (
 from inference.core.workflows.core_steps.models.foundation.openai.v4 import (
     OpenAIBlockV4,
 )
+from inference.core.workflows.core_steps.models.foundation.openai_compatible.v1 import (
+    OpenAICompatibleBlockV1,
+)
 from inference.core.workflows.core_steps.models.foundation.perception_encoder.v1 import (
     PerceptionEncoderModelBlockV1,
 )
@@ -931,6 +934,7 @@ def load_blocks() -> List[Type[WorkflowBlock]]:
         Qwen35VLBlockV1,
         Qwen35OpenRouterBlockV1,
         Qwen36OpenRouterBlockV1,
+        OpenAICompatibleBlockV1,
         KimiOpenRouterBlockV1,
         SmolVLM2BlockV1,
         Moondream2BlockV1,

--- a/inference/core/workflows/core_steps/models/foundation/openai_compatible/v1.py
+++ b/inference/core/workflows/core_steps/models/foundation/openai_compatible/v1.py
@@ -7,7 +7,6 @@ from openai import OpenAI
 from pydantic import ConfigDict, Field
 
 from inference.core.logger import logger
-
 from inference.core.utils.image_utils import encode_image_to_jpeg_bytes
 from inference.core.workflows.core_steps.common.query_language.entities.operations import (
     AllOperationsType,

--- a/inference/core/workflows/core_steps/models/foundation/openai_compatible/v1.py
+++ b/inference/core/workflows/core_steps/models/foundation/openai_compatible/v1.py
@@ -1,0 +1,399 @@
+import base64
+import re
+from collections import defaultdict
+from typing import Any, Dict, List, Literal, Optional, Type, Union
+
+from openai import OpenAI
+from pydantic import ConfigDict, Field
+
+from inference.core.utils.image_utils import encode_image_to_jpeg_bytes
+from inference.core.workflows.core_steps.common.query_language.entities.operations import (
+    AllOperationsType,
+)
+from inference.core.workflows.core_steps.common.query_language.operations.core import (
+    build_operations_chain,
+)
+from inference.core.workflows.execution_engine.entities.base import (
+    OutputDefinition,
+    WorkflowImageData,
+)
+from inference.core.workflows.execution_engine.entities.types import (
+    FLOAT_KIND,
+    LANGUAGE_MODEL_OUTPUT_KIND,
+    SECRET_KIND,
+    STRING_KIND,
+    Selector,
+)
+from inference.core.workflows.prototypes.block import (
+    AirGappedAvailability,
+    BlockResult,
+    WorkflowBlock,
+    WorkflowBlockManifest,
+)
+
+PARAMETER_REGEX = re.compile(r"({{\s*\$parameters\.(\w+)\s*}})")
+
+LONG_DESCRIPTION = """
+Send a prompt to any OpenAI-compatible API endpoint (e.g. local Qwen, vLLM, Ollama,
+LM Studio, or any service that implements the OpenAI chat completions API).
+
+## How This Block Works
+
+1. You provide a **base URL** (e.g. `http://localhost:8000/v1`) and a **model name**
+2. Write a **prompt template** using `{{ $parameters.param_name }}` placeholders
+3. Supply **prompt_parameters** mapping parameter names to workflow data selectors
+4. Parameters that resolve to images — either `WorkflowImageData` objects or raw JPEG
+   `bytes` (e.g. from the Image Stack block) — are automatically base64-encoded and
+   sent as `image_url` content parts in the OpenAI message
+5. Lists of images are supported: each image in the list becomes a separate content part
+6. Non-image parameters are converted to strings and substituted into the prompt text
+7. Optionally apply **UQL operations** to transform parameter values before insertion
+
+## Image Handling
+
+The block detects image values automatically:
+
+- **`WorkflowImageData`** — the numpy image is JPEG-encoded then base64-encoded
+- **`bytes`** — assumed to be JPEG blobs already (e.g. from the Image Stack block),
+  base64-encoded directly
+- **`list`** of either type — each element becomes a separate `image_url` content part
+
+Image parameters referenced in the prompt template have their placeholders removed from
+the text (the images are sent as vision content parts, not inline text).
+
+## Example
+
+```
+prompt: "Describe the activity across these frames: {{ $parameters.context }}"
+prompt_parameters:
+  context: "$steps.some_step.output"
+  frames: "$steps.image_stack.frames"
+```
+
+`frames` (list of JPEG bytes) becomes multiple vision content parts.
+`context` (string) gets substituted into the prompt text.
+"""
+
+
+class BlockManifest(WorkflowBlockManifest):
+    model_config = ConfigDict(
+        json_schema_extra={
+            "name": "OpenAI-Compatible LLM",
+            "version": "v1",
+            "short_description": "Send prompts to any OpenAI-compatible API endpoint.",
+            "long_description": LONG_DESCRIPTION,
+            "license": "Apache-2.0",
+            "block_type": "model",
+            "search_keywords": [
+                "LLM",
+                "VLM",
+                "OpenAI",
+                "vLLM",
+                "Ollama",
+                "Qwen",
+                "compatible",
+            ],
+            "ui_manifest": {
+                "section": "model",
+                "icon": "fal fa-atom",
+            },
+        },
+        protected_namespaces=(),
+    )
+    type: Literal["roboflow_core/openai_compatible@v1"]
+    base_url: Union[Selector(kind=[STRING_KIND]), str] = Field(
+        description="Base URL of the OpenAI-compatible API (e.g. http://localhost:8000/v1).",
+        examples=["http://localhost:8000/v1", "$inputs.base_url"],
+    )
+    model_name: Union[Selector(kind=[STRING_KIND]), str] = Field(
+        description="Model name to pass in the API request.",
+        examples=["Qwen/Qwen2.5-VL-7B-Instruct", "$inputs.model_name"],
+    )
+    api_key: Optional[Union[Selector(kind=[STRING_KIND, SECRET_KIND]), str]] = Field(
+        default=None,
+        description="API key for the endpoint (if required).",
+        examples=["xxx-xxx", "$inputs.api_key"],
+        private=True,
+    )
+    system_prompt: Optional[Union[Selector(kind=[STRING_KIND]), str]] = Field(
+        default=None,
+        description="Optional system prompt to set model behavior.",
+        examples=["You are a helpful assistant.", "$inputs.system_prompt"],
+        json_schema_extra={
+            "multiline": True,
+        },
+    )
+    prompt: Union[Selector(kind=[STRING_KIND]), str] = Field(
+        description="Prompt template with optional {{ $parameters.param_name }} placeholders. "
+        "Non-image parameters are substituted as text. Image parameters are sent as "
+        "vision content parts.",
+        examples=[
+            "Describe what you see in the image.",
+            "Count the {{ $parameters.object_type }} in the image.",
+        ],
+        json_schema_extra={
+            "multiline": True,
+            "always_visible": True,
+        },
+    )
+    prompt_parameters: Dict[
+        str,
+        Union[Selector(), Selector(), str, int, float, bool],
+    ] = Field(
+        description="Dictionary mapping parameter names to workflow data sources. "
+        "Keys are referenced in prompt as {{ $parameters.key }}. "
+        "Values that resolve to images (WorkflowImageData or JPEG bytes) are sent as "
+        "vision content parts. Lists of images are supported. "
+        "All other values are converted to strings and substituted into the prompt text.",
+        examples=[
+            {
+                "detections": "$steps.model.predictions",
+                "frames": "$steps.image_stack.frames",
+            }
+        ],
+        default_factory=dict,
+        json_schema_extra={
+            "always_visible": True,
+        },
+    )
+    prompt_parameters_operations: Dict[str, List[AllOperationsType]] = Field(
+        description="Optional UQL operation chains to transform parameter values before "
+        "insertion. Keys must match parameter names in prompt_parameters.",
+        examples=[
+            {
+                "detections": [
+                    {
+                        "type": "DetectionsPropertyExtract",
+                        "property_name": "class_name",
+                    }
+                ]
+            }
+        ],
+        default_factory=dict,
+    )
+    max_tokens: int = Field(
+        default=500,
+        description="Maximum number of tokens the model can generate.",
+        gt=1,
+    )
+    temperature: Optional[Union[float, Selector(kind=[FLOAT_KIND])]] = Field(
+        default=None,
+        description="Sampling temperature (0.0-2.0). Higher = more random.",
+        ge=0.0,
+        le=2.0,
+    )
+
+    @classmethod
+    def get_air_gapped_availability(cls) -> AirGappedAvailability:
+        return AirGappedAvailability(available=False, reason="requires_internet")
+
+    @classmethod
+    def describe_outputs(cls) -> List[OutputDefinition]:
+        return [
+            OutputDefinition(
+                name="output", kind=[STRING_KIND, LANGUAGE_MODEL_OUTPUT_KIND]
+            ),
+            OutputDefinition(name="error_status", kind=[STRING_KIND]),
+        ]
+
+    @classmethod
+    def get_execution_engine_compatibility(cls) -> Optional[str]:
+        return ">=1.4.0,<2.0.0"
+
+
+class OpenAICompatibleBlockV1(WorkflowBlock):
+
+    @classmethod
+    def get_init_parameters(cls) -> List[str]:
+        return []
+
+    @classmethod
+    def get_manifest(cls) -> Type[WorkflowBlockManifest]:
+        return BlockManifest
+
+    @classmethod
+    def get_execution_engine_compatibility(cls) -> Optional[str]:
+        return ">=1.4.0,<2.0.0"
+
+    def run(
+        self,
+        base_url: str,
+        model_name: str,
+        api_key: Optional[str],
+        system_prompt: Optional[str],
+        prompt: str,
+        prompt_parameters: Dict[str, Any],
+        prompt_parameters_operations: Dict[str, List[AllOperationsType]],
+        max_tokens: int,
+        temperature: Optional[float],
+    ) -> BlockResult:
+        resolved_params = _resolve_parameters(
+            prompt_parameters=prompt_parameters,
+            prompt_parameters_operations=prompt_parameters_operations,
+        )
+        text_prompt, image_parts = _build_prompt_content(
+            prompt=prompt,
+            resolved_params=resolved_params,
+        )
+        messages = _build_messages(
+            system_prompt=system_prompt,
+            text_prompt=text_prompt,
+            image_parts=image_parts,
+        )
+        try:
+            output = _execute_request(
+                base_url=base_url,
+                api_key=api_key or "no-key",
+                model_name=model_name,
+                messages=messages,
+                max_tokens=max_tokens,
+                temperature=temperature,
+            )
+            return {"output": output, "error_status": ""}
+        except Exception as e:
+            return {"output": "", "error_status": str(e)}
+
+
+def _resolve_parameters(
+    prompt_parameters: Dict[str, Any],
+    prompt_parameters_operations: Dict[str, List[AllOperationsType]],
+) -> Dict[str, Any]:
+    resolved = {}
+    for name, value in prompt_parameters.items():
+        operations = prompt_parameters_operations.get(name)
+        if operations:
+            chain = build_operations_chain(operations=operations)
+            value = chain(value, global_parameters={})
+        resolved[name] = value
+    return resolved
+
+
+def _is_image_value(value: Any) -> bool:
+    if isinstance(value, (WorkflowImageData, bytes)):
+        return True
+    return False
+
+
+def _is_image_list(value: Any) -> bool:
+    if not isinstance(value, list) or not value:
+        return False
+    return _is_image_value(value[0])
+
+
+def _encode_single_image(value: Any) -> str:
+    if isinstance(value, WorkflowImageData):
+        jpeg_bytes = encode_image_to_jpeg_bytes(value.numpy_image)
+        b64 = base64.b64encode(jpeg_bytes).decode("ascii")
+    elif isinstance(value, bytes):
+        b64 = base64.b64encode(value).decode("ascii")
+    else:
+        raise ValueError(f"Cannot encode value of type {type(value)} as image")
+    return f"data:image/jpeg;base64,{b64}"
+
+
+def _collect_image_data_urls(value: Any) -> List[str]:
+    if _is_image_value(value):
+        return [_encode_single_image(value)]
+    if _is_image_list(value):
+        return [_encode_single_image(item) for item in value if _is_image_value(item)]
+    return []
+
+
+def _build_prompt_content(
+    prompt: str,
+    resolved_params: Dict[str, Any],
+) -> tuple:
+    """Build text prompt and image content parts from template + params.
+
+    Returns (text_prompt, image_parts) where image_parts is a list of
+    base64 data URLs for any image parameters found.
+    """
+    image_parts: List[str] = []
+    image_param_names: set = set()
+
+    matching_parameters = PARAMETER_REGEX.findall(prompt)
+    parameters_to_substitute = {
+        p[1] for p in matching_parameters if p[1] in resolved_params
+    }
+
+    # Collect images from params referenced in the template
+    for name in parameters_to_substitute:
+        value = resolved_params[name]
+        urls = _collect_image_data_urls(value)
+        if urls:
+            image_parts.extend(urls)
+            image_param_names.add(name)
+
+    # Collect images from params NOT referenced in the template
+    for name, value in resolved_params.items():
+        if name in image_param_names or name in parameters_to_substitute:
+            continue
+        urls = _collect_image_data_urls(value)
+        if urls:
+            image_parts.extend(urls)
+            image_param_names.add(name)
+
+    # Substitute non-image params into the prompt text
+    parameter_to_placeholders: Dict[str, List[str]] = defaultdict(list)
+    for placeholder, param_name in matching_parameters:
+        if param_name not in parameters_to_substitute:
+            continue
+        parameter_to_placeholders[param_name].append(placeholder)
+
+    for param_name, placeholders in parameter_to_placeholders.items():
+        for placeholder in placeholders:
+            if param_name in image_param_names:
+                prompt = prompt.replace(placeholder, "")
+            else:
+                prompt = prompt.replace(placeholder, str(resolved_params[param_name]))
+
+    return prompt.strip(), image_parts
+
+
+def _build_messages(
+    system_prompt: Optional[str],
+    text_prompt: str,
+    image_parts: List[str],
+) -> List[dict]:
+    messages = []
+    if system_prompt:
+        messages.append({"role": "system", "content": system_prompt})
+
+    content: List[dict] = []
+    if text_prompt:
+        content.append({"type": "text", "text": text_prompt})
+    for image_url in image_parts:
+        content.append(
+            {
+                "type": "image_url",
+                "image_url": {"url": image_url},
+            }
+        )
+
+    messages.append({"role": "user", "content": content})
+    return messages
+
+
+def _execute_request(
+    base_url: str,
+    api_key: str,
+    model_name: str,
+    messages: List[dict],
+    max_tokens: int,
+    temperature: Optional[float],
+) -> str:
+    client = OpenAI(base_url=base_url, api_key=api_key)
+    kwargs: Dict[str, Any] = {
+        "model": model_name,
+        "messages": messages,
+        "max_tokens": max_tokens,
+    }
+    if temperature is not None:
+        kwargs["temperature"] = temperature
+    response = client.chat.completions.create(**kwargs)
+    if response.choices is None or len(response.choices) == 0:
+        error_detail = getattr(response, "error", {})
+        if isinstance(error_detail, dict):
+            error_detail = error_detail.get("message", "No response choices returned")
+        raise RuntimeError(f"API returned no choices. Details: {error_detail}")
+    return response.choices[0].message.content

--- a/inference/core/workflows/core_steps/models/foundation/openai_compatible/v1.py
+++ b/inference/core/workflows/core_steps/models/foundation/openai_compatible/v1.py
@@ -1,10 +1,12 @@
 import base64
 import re
 from collections import defaultdict
-from typing import Any, Dict, List, Literal, Optional, Type, Union
+from typing import Any, Dict, List, Literal, Optional, Set, Tuple, Type, Union
 
 from openai import OpenAI
 from pydantic import ConfigDict, Field
+
+from inference.core.logger import logger
 
 from inference.core.utils.image_utils import encode_image_to_jpeg_bytes
 from inference.core.workflows.core_steps.common.query_language.entities.operations import (
@@ -203,6 +205,9 @@ class BlockManifest(WorkflowBlockManifest):
 
 class OpenAICompatibleBlockV1(WorkflowBlock):
 
+    def __init__(self):
+        self._client_cache: Dict[Tuple[str, str], OpenAI] = {}
+
     @classmethod
     def get_init_parameters(cls) -> List[str]:
         return []
@@ -214,6 +219,14 @@ class OpenAICompatibleBlockV1(WorkflowBlock):
     @classmethod
     def get_execution_engine_compatibility(cls) -> Optional[str]:
         return ">=1.4.0,<2.0.0"
+
+    def _get_client(self, base_url: str, api_key: str) -> OpenAI:
+        cache_key = (base_url, api_key)
+        client = self._client_cache.get(cache_key)
+        if client is None:
+            client = OpenAI(base_url=base_url, api_key=api_key, timeout=120.0)
+            self._client_cache[cache_key] = client
+        return client
 
     def run(
         self,
@@ -242,8 +255,7 @@ class OpenAICompatibleBlockV1(WorkflowBlock):
         )
         try:
             output = _execute_request(
-                base_url=base_url,
-                api_key=api_key or "no-key",
+                client=self._get_client(base_url, api_key or "no-key"),
                 model_name=model_name,
                 messages=messages,
                 max_tokens=max_tokens,
@@ -251,6 +263,10 @@ class OpenAICompatibleBlockV1(WorkflowBlock):
             )
             return {"output": output, "error_status": ""}
         except Exception as e:
+            logger.warning(
+                f"OpenAI-compatible request to {base_url} failed: {e}",
+                exc_info=True,
+            )
             return {"output": "", "error_status": str(e)}
 
 
@@ -277,7 +293,7 @@ def _is_image_value(value: Any) -> bool:
 def _is_image_list(value: Any) -> bool:
     if not isinstance(value, list) or not value:
         return False
-    return _is_image_value(value[0])
+    return any(_is_image_value(item) for item in value)
 
 
 def _encode_single_image(value: Any) -> str:
@@ -302,14 +318,14 @@ def _collect_image_data_urls(value: Any) -> List[str]:
 def _build_prompt_content(
     prompt: str,
     resolved_params: Dict[str, Any],
-) -> tuple:
+) -> Tuple[str, List[str]]:
     """Build text prompt and image content parts from template + params.
 
     Returns (text_prompt, image_parts) where image_parts is a list of
     base64 data URLs for any image parameters found.
     """
     image_parts: List[str] = []
-    image_param_names: set = set()
+    image_param_names: Set[str] = set()
 
     matching_parameters = PARAMETER_REGEX.findall(prompt)
     parameters_to_substitute = {
@@ -375,14 +391,12 @@ def _build_messages(
 
 
 def _execute_request(
-    base_url: str,
-    api_key: str,
+    client: OpenAI,
     model_name: str,
     messages: List[dict],
     max_tokens: int,
     temperature: Optional[float],
 ) -> str:
-    client = OpenAI(base_url=base_url, api_key=api_key)
     kwargs: Dict[str, Any] = {
         "model": model_name,
         "messages": messages,

--- a/tests/workflows/unit_tests/core_steps/models/foundation/test_openai_compatible_v1.py
+++ b/tests/workflows/unit_tests/core_steps/models/foundation/test_openai_compatible_v1.py
@@ -1,0 +1,242 @@
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+from pydantic import ValidationError
+
+from inference.core.workflows.core_steps.models.foundation.openai_compatible.v1 import (
+    BlockManifest,
+    OpenAICompatibleBlockV1,
+    _build_messages,
+    _build_prompt_content,
+    _collect_image_data_urls,
+    _encode_single_image,
+    _is_image_list,
+    _is_image_value,
+    _resolve_parameters,
+)
+from inference.core.workflows.execution_engine.entities.base import WorkflowImageData
+
+
+def test_manifest_validation_valid_input() -> None:
+    specification = {
+        "type": "roboflow_core/openai_compatible@v1",
+        "name": "step_1",
+        "base_url": "http://localhost:8000/v1",
+        "model_name": "Qwen/Qwen2.5-VL-7B-Instruct",
+        "prompt": "Describe what you see.",
+    }
+    result = BlockManifest.model_validate(specification)
+    assert result.type == "roboflow_core/openai_compatible@v1"
+    assert result.base_url == "http://localhost:8000/v1"
+    assert result.model_name == "Qwen/Qwen2.5-VL-7B-Instruct"
+
+
+def test_manifest_validation_with_selectors() -> None:
+    specification = {
+        "type": "roboflow_core/openai_compatible@v1",
+        "name": "step_1",
+        "base_url": "$inputs.base_url",
+        "model_name": "$inputs.model_name",
+        "prompt": "$inputs.prompt",
+        "api_key": "$inputs.api_key",
+    }
+    result = BlockManifest.model_validate(specification)
+    assert result.base_url == "$inputs.base_url"
+
+
+def test_manifest_validation_missing_prompt() -> None:
+    specification = {
+        "type": "roboflow_core/openai_compatible@v1",
+        "name": "step_1",
+        "base_url": "http://localhost:8000/v1",
+        "model_name": "test-model",
+    }
+    with pytest.raises(ValidationError):
+        BlockManifest.model_validate(specification)
+
+
+def test_manifest_validation_with_parameters() -> None:
+    specification = {
+        "type": "roboflow_core/openai_compatible@v1",
+        "name": "step_1",
+        "base_url": "http://localhost:8000/v1",
+        "model_name": "test-model",
+        "prompt": "Count {{ $parameters.obj_type }} objects",
+        "prompt_parameters": {
+            "obj_type": "$steps.classifier.class_name",
+        },
+    }
+    result = BlockManifest.model_validate(specification)
+    assert "obj_type" in result.prompt_parameters
+
+
+def test_is_image_value_with_bytes() -> None:
+    assert _is_image_value(b"\xff\xd8\xff") is True
+
+
+def test_is_image_value_with_workflow_image() -> None:
+    image = MagicMock(spec=WorkflowImageData)
+    assert _is_image_value(image) is True
+
+
+def test_is_image_value_with_string() -> None:
+    assert _is_image_value("hello") is False
+
+
+def test_is_image_list_with_bytes_list() -> None:
+    assert _is_image_list([b"\xff\xd8\xff", b"\xff\xd8\xff"]) is True
+
+
+def test_is_image_list_with_empty_list() -> None:
+    assert _is_image_list([]) is False
+
+
+def test_is_image_list_with_string_list() -> None:
+    assert _is_image_list(["a", "b"]) is False
+
+
+def test_encode_single_image_bytes() -> None:
+    jpeg_bytes = b"\xff\xd8\xff\xe0"
+    result = _encode_single_image(jpeg_bytes)
+    assert result.startswith("data:image/jpeg;base64,")
+
+
+def test_collect_image_data_urls_single_bytes() -> None:
+    result = _collect_image_data_urls(b"\xff\xd8\xff")
+    assert len(result) == 1
+    assert result[0].startswith("data:image/jpeg;base64,")
+
+
+def test_collect_image_data_urls_list_of_bytes() -> None:
+    result = _collect_image_data_urls([b"\xff\xd8", b"\xff\xd9"])
+    assert len(result) == 2
+
+
+def test_collect_image_data_urls_non_image() -> None:
+    result = _collect_image_data_urls("hello")
+    assert result == []
+
+
+def test_build_prompt_content_text_only() -> None:
+    text, images = _build_prompt_content(
+        prompt="Count {{ $parameters.obj_type }} in the scene",
+        resolved_params={"obj_type": "cars"},
+    )
+    assert text == "Count cars in the scene"
+    assert images == []
+
+
+def test_build_prompt_content_image_param_removed_from_text() -> None:
+    text, images = _build_prompt_content(
+        prompt="Describe {{ $parameters.frame }}",
+        resolved_params={"frame": b"\xff\xd8\xff"},
+    )
+    assert "frame" not in text
+    assert len(images) == 1
+
+
+def test_build_prompt_content_image_list() -> None:
+    text, images = _build_prompt_content(
+        prompt="What happens across these frames?",
+        resolved_params={"frames": [b"\xff\xd8", b"\xff\xd9", b"\xff\xda"]},
+    )
+    assert len(images) == 3
+
+
+def test_build_prompt_content_mixed_params() -> None:
+    text, images = _build_prompt_content(
+        prompt="Find {{ $parameters.object_type }} in the video",
+        resolved_params={
+            "object_type": "person",
+            "frames": [b"\xff\xd8", b"\xff\xd9"],
+        },
+    )
+    assert text == "Find person in the video"
+    assert len(images) == 2
+
+
+def test_build_messages_text_only() -> None:
+    messages = _build_messages(
+        system_prompt=None,
+        text_prompt="Hello",
+        image_parts=[],
+    )
+    assert len(messages) == 1
+    assert messages[0]["role"] == "user"
+    assert messages[0]["content"] == [{"type": "text", "text": "Hello"}]
+
+
+def test_build_messages_with_system_prompt() -> None:
+    messages = _build_messages(
+        system_prompt="You are helpful.",
+        text_prompt="Hello",
+        image_parts=[],
+    )
+    assert len(messages) == 2
+    assert messages[0]["role"] == "system"
+    assert messages[0]["content"] == "You are helpful."
+
+
+def test_build_messages_with_images() -> None:
+    messages = _build_messages(
+        system_prompt=None,
+        text_prompt="Describe",
+        image_parts=["data:image/jpeg;base64,abc", "data:image/jpeg;base64,def"],
+    )
+    content = messages[0]["content"]
+    assert len(content) == 3
+    assert content[0]["type"] == "text"
+    assert content[1]["type"] == "image_url"
+    assert content[2]["type"] == "image_url"
+
+
+def test_resolve_parameters_no_ops() -> None:
+    result = _resolve_parameters(
+        prompt_parameters={"a": "hello", "b": 42},
+        prompt_parameters_operations={},
+    )
+    assert result == {"a": "hello", "b": 42}
+
+
+@patch(
+    "inference.core.workflows.core_steps.models.foundation.openai_compatible.v1._execute_request"
+)
+def test_block_run_success(mock_execute: MagicMock) -> None:
+    mock_execute.return_value = "The model response"
+    block = OpenAICompatibleBlockV1()
+    result = block.run(
+        base_url="http://localhost:8000/v1",
+        model_name="test-model",
+        api_key="test-key",
+        system_prompt=None,
+        prompt="Hello",
+        prompt_parameters={},
+        prompt_parameters_operations={},
+        max_tokens=100,
+        temperature=None,
+    )
+    assert result["output"] == "The model response"
+    assert result["error_status"] == ""
+
+
+@patch(
+    "inference.core.workflows.core_steps.models.foundation.openai_compatible.v1._execute_request"
+)
+def test_block_run_error(mock_execute: MagicMock) -> None:
+    mock_execute.side_effect = RuntimeError("Connection refused")
+    block = OpenAICompatibleBlockV1()
+    result = block.run(
+        base_url="http://localhost:8000/v1",
+        model_name="test-model",
+        api_key=None,
+        system_prompt=None,
+        prompt="Hello",
+        prompt_parameters={},
+        prompt_parameters_operations={},
+        max_tokens=100,
+        temperature=None,
+    )
+    assert result["output"] == ""
+    assert "Connection refused" in result["error_status"]


### PR DESCRIPTION
## What does this PR do?

Block that sends chat completion requests to any OpenAI-compatible API (vLLM, Ollama, local Qwen, etc). User provides base URL + model name. Prompt uses email-block-style {{ $parameters.xxx }} template params. Image params (JPEG bytes from Image Stack or WorkflowImageData) auto-base64-encoded and sent as vision content parts.

## Type of Change

- New feature (non-breaking change that adds functionality)

## Testing

Tests added

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)

## Additional Context

N/A