### PR TITLE
Fix workflow block display names for acronym segments

### DIFF
--- a/inference/core/workflows/execution_engine/introspection/utils.py
+++ b/inference/core/workflows/execution_engine/introspection/utils.py
@@ -1,4 +1,7 @@
 import re
+from typing import List
+
+CLASS_NAME_WORD_PATTERN = re.compile(r"[A-Z](?:[a-z1-9]+|[A-Z]*(?=[A-Z]|$))")
 
 
 def get_full_type_name(selected_type: type) -> str:
@@ -18,7 +21,19 @@ def build_human_friendly_block_name(
             return manual_title
 
     class_name = fully_qualified_name.split(".")[-1]
-    words = re.findall(r"[A-Z](?:[a-z1-9]+|[A-Z]*(?=[A-Z]|$))", class_name)
+    words = _words_from_class_name(class_name=class_name)
     if words[-1] == "Block":
         words.pop()
     return " ".join(words)
+
+
+def _words_from_class_name(class_name: str) -> List[str]:
+    words = []
+    for segment in class_name.split("_"):
+        if segment:
+            words.extend(_words_from_class_segment(class_segment=segment))
+    return words
+
+
+def _words_from_class_segment(class_segment: str) -> List[str]:
+    return CLASS_NAME_WORD_PATTERN.findall(class_segment)

--- a/tests/workflows/unit_tests/execution_engine/introspection/test_utils.py
+++ b/tests/workflows/unit_tests/execution_engine/introspection/test_utils.py
@@ -39,6 +39,36 @@ def test_build_human_friendly_block_name_when_block_suffix_present() -> None:
     assert result == "My Crop"
 
 
+def test_build_human_friendly_block_name_when_acronym_and_block_suffix_present() -> None:
+    # when
+    result = build_human_friendly_block_name(
+        fully_qualified_name="inference.core.workflows.core_steps.example.OCRResultsParserBlock"
+    )
+
+    # then
+    assert result == "OCR Results Parser"
+
+
+def test_build_human_friendly_block_name_when_underscores_separate_segments() -> None:
+    # when
+    result = build_human_friendly_block_name(
+        fully_qualified_name="inference.core.workflows.core_steps.example.OCR_Results_Parser"
+    )
+
+    # then
+    assert result == "OCR Results Parser"
+
+
+def test_build_human_friendly_block_name_when_underscores_and_block_suffix_present() -> None:
+    # when
+    result = build_human_friendly_block_name(
+        fully_qualified_name="inference.core.workflows.core_steps.example.OCR_Results_Parser_Block"
+    )
+
+    # then
+    assert result == "OCR Results Parser"
+
+
 def test_build_human_friendly_block_name_when_block_suffix_not_present() -> None:
     # when
     result = build_human_friendly_block_name(


### PR DESCRIPTION
## Summary
- Split underscore-separated block class name segments before applying PascalCase tokenization.
- Preserve acronym boundaries for titles like `OCR_Results_Parser` while keeping existing `OCRResultsParserBlock` behavior.
- Add regression coverage for acronym parsing, underscore-separated segments, and trailing `Block` stripping.

Bug: 
- OCR_Results_Parser -> "OC Results Parser"


Fixed: 
- OCR_Results_Parser -> "OCR Results Parser"

## Test plan
- [x] `ReadLints` on `inference/core/workflows/execution_engine/introspection/utils.py` and `tests/workflows/unit_tests/execution_engine/introspection/test_utils.py`
- [x] Direct smoke check of `build_human_friendly_block_name` via module path import
- [ ] `pytest tests/workflows/unit_tests/execution_engine/introspection/test_utils.py` (blocked locally during collection by NumPy 2.0 / matplotlib binary compatibility import error in workflow test conftest)

Made with [Cursor](https://cursor.com)