### PR TITLE
Fix owlv2 / rf-instant forward for best/default confidence modes

### DIFF
--- a/inference_models/docs/changelog.md
+++ b/inference_models/docs/changelog.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - RFDetr pre- and post-processing aligned with training transforms. Pre-processing replaced with a dedicated `PIL → F.resize → F.to_tensor → F.normalize` chain matching the training pipeline. For model packages with non-stretch `dataset_version_resize_dimensions`, the dataset-version resize (cv2 letterbox / center-crop) runs first, then the PIL stretch to `training_input_size`. Post-processing uses topk-flat across (queries × classes) via shared `select_topk_predictions`. Fixes a cross-backend divergence at low confidence thresholds.
+- Fixed a bug where 'best' and 'default' confidence modes were not correctly handled by `RoboflowInstantHF` models.
 
 ## `0.27.2`
 

--- a/inference_models/inference_models/models/roboflow_instant/roboflow_instant_hf.py
+++ b/inference_models/inference_models/models/roboflow_instant/roboflow_instant_hf.py
@@ -118,15 +118,34 @@ class RoboflowInstantHF(ObjectDetectionModel):
     def forward(
         self,
         pre_processed_images: List[ImageEmbeddings],
-        confidence: float = INFERENCE_MODELS_ROBOFLOW_INSTANT_DEFAULT_CONFIDENCE,
+        confidence: Confidence = INFERENCE_MODELS_ROBOFLOW_INSTANT_DEFAULT_CONFIDENCE,
         iou_threshold: float = INFERENCE_MODELS_ROBOFLOW_INSTANT_DEFAULT_IOU_THRESHOLD,
         **kwargs,
     ) -> List[Tuple[torch.Tensor, torch.Tensor, torch.Tensor]]:
+        forward_confidence = self._resolve_forward_confidence(confidence)
         return self._feature_extractor.forward_pass_with_precomputed_embeddings(
             images_embeddings=pre_processed_images,
             class_embeddings=self._reference_examples_embeddings.class_embeddings,
-            confidence=confidence,
+            confidence=forward_confidence,
             iou_threshold=iou_threshold,
+        )
+
+    def _resolve_forward_confidence(self, confidence: Confidence) -> float:
+        if not isinstance(confidence, str):
+            return confidence
+        per_class_confidence = self._build_confidence_filter(confidence).get_threshold(
+            self.class_names
+        )
+        if isinstance(per_class_confidence, torch.Tensor):
+            return float(per_class_confidence.min().item())
+        else:
+            return per_class_confidence
+
+    def _build_confidence_filter(self, confidence: Confidence) -> ConfidenceFilter:
+        return ConfidenceFilter(
+            confidence=confidence,
+            recommended_parameters=self.recommended_parameters,
+            default_confidence=INFERENCE_MODELS_ROBOFLOW_INSTANT_DEFAULT_CONFIDENCE,
         )
 
     def post_process(
@@ -138,11 +157,7 @@ class RoboflowInstantHF(ObjectDetectionModel):
         iou_threshold: float = INFERENCE_MODELS_ROBOFLOW_INSTANT_DEFAULT_IOU_THRESHOLD,
         **kwargs,
     ) -> List[Detections]:
-        confidence_filter = ConfidenceFilter(
-            confidence=confidence,
-            recommended_parameters=self.recommended_parameters,
-            default_confidence=INFERENCE_MODELS_ROBOFLOW_INSTANT_DEFAULT_CONFIDENCE,
-        )
+        confidence_filter = self._build_confidence_filter(confidence)
         results = (
             self._feature_extractor.post_process_predictions_for_precomputed_embeddings(
                 predictions=model_results,

--- a/inference_models/pyproject.toml
+++ b/inference_models/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inference-models"
-version = "0.27.3rc1"
+version = "0.27.3rc4"
 description = "The new inference engine for Computer Vision models"
 readme = "README.md"
 requires-python = ">=3.10,<3.13"

--- a/inference_models/tests/integration_tests/models/test_owlv2_predictions.py
+++ b/inference_models/tests/integration_tests/models/test_owlv2_predictions.py
@@ -58,9 +58,11 @@ def test_owlv2_predictions_for_open_vocabulary(
 
 @pytest.mark.slow
 @pytest.mark.hf_vlm_models
+@pytest.mark.parametrize("confidence", [0.99, "best", "default"])
 def test_owlv2_predictions_for_reference_dataset(
     owlv2_model: OWLv2HF,
     dog_image_numpy: np.ndarray,
+    confidence,
 ) -> None:
     # when
     predictions = owlv2_model.infer_with_reference_examples(
@@ -74,7 +76,7 @@ def test_owlv2_predictions_for_reference_dataset(
                 ],
             )
         ],
-        confidence=0.99,
+        confidence=confidence,
         iou_threshold=0.3,
         max_detections=300,
     )
@@ -85,15 +87,17 @@ def test_owlv2_predictions_for_reference_dataset(
 
 @pytest.mark.slow
 @pytest.mark.hf_vlm_models
+@pytest.mark.parametrize("confidence", [0.99, "best", "default"])
 def test_instant_model_predictions(
     instant_model: RoboflowInstantHF,
     coins_counting_image_torch: torch.Tensor,
     coins_counting_image_numpy: np.ndarray,
+    confidence,
 ) -> None:
     # when
     predictions = instant_model(
         coins_counting_image_torch,
-        confidence=0.99,
+        confidence=confidence,
         iou_threshold=0.3,
         class_agnostic_nms=False,
         max_detections=300,

--- a/inference_models/uv.lock
+++ b/inference_models/uv.lock
@@ -922,7 +922,7 @@ wheels = [
 
 [[package]]
 name = "inference-models"
-version = "0.27.3rc1"
+version = "0.27.3rc4"
 source = { virtual = "." }
 dependencies = [
     { name = "accelerate" },


### PR DESCRIPTION
## What does this PR do?

<!-- Provide a clear and concise description of the changes -->

Bugfix for rf-instant/owlv2: `confidence` is used in `forward()` not just in `post_process()`, so we need to resolve `"best"/"default"` to a number for the forward pass. Fix is to select the minimum per-class confidence or the global fallback confidence.

Reported here: https://roboflow.slack.com/archives/C0ADCC1QMA8/p1778342973735529

Updated `inference_models` version to `0.27.3rc4`.

## Type of Change

<!-- Please select one and delete the others, or describe if Other -->

- Bug fix (non-breaking change that fixes an issue)

## Testing

<!-- Describe how you tested your changes -->

- [x] I have tested this change locally
- [x] I have added/updated tests for this change

**Test details:**
<!-- Describe what tests were added/updated and what they cover -->

- [x] `test_owlv2_predictions` parameterized to explicitly test `"best"/"default"` confidence
- [x] Verified object detection v3 workflow block works with rf_instant model from report thread (local server build)
 
<img width="1449" height="1165" alt="image" src="https://github.com/user-attachments/assets/e309aa91-906f-484e-bfd5-b2ad1256fabe" />


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)

## Additional Context

<!-- Add any other context, screenshots, or notes about the PR here -->
