### PR TITLE
Prefer NVENC for WebRTC H264 encoding

### DIFF
--- a/inference/core/interfaces/stream_manager/manager_app/webrtc.py
+++ b/inference/core/interfaces/stream_manager/manager_app/webrtc.py
@@ -37,10 +37,7 @@ from inference.core.interfaces.stream_manager.manager_app.entities import (
     WebRTCOffer,
     WebRTCTURNConfig,
 )
-from inference.core.interfaces.webrtc_worker.h264_nvenc import (
-    log_answer_video_codecs,
-    prefer_h264_nvenc_encoder,
-)
+from inference.core.interfaces.webrtc_worker.h264_nvenc import prefer_h264_nvenc_encoder
 from inference.core.utils.async_utils import Queue as SyncAsyncQueue
 from inference.core.utils.function import experimental
 from inference.core.workflows.execution_engine.entities.base import WorkflowImageData
@@ -481,7 +478,6 @@ async def init_rtc_peer_connection(
     )
     answer = await peer_connection.createAnswer()
     await peer_connection.setLocalDescription(answer)
-    log_answer_video_codecs(peer_connection.localDescription.sdp)
     logger.debug(f"WebRTC connection status: {peer_connection.connectionState}")
 
     return peer_connection

--- a/inference/core/interfaces/stream_manager/manager_app/webrtc.py
+++ b/inference/core/interfaces/stream_manager/manager_app/webrtc.py
@@ -37,10 +37,14 @@ from inference.core.interfaces.stream_manager.manager_app.entities import (
     WebRTCOffer,
     WebRTCTURNConfig,
 )
+from inference.core.interfaces.webrtc_worker.h264_nvenc import (
+    prefer_h264_nvenc_encoder,
+)
 from inference.core.utils.async_utils import Queue as SyncAsyncQueue
 from inference.core.utils.function import experimental
 from inference.core.workflows.execution_engine.entities.base import WorkflowImageData
 
+prefer_h264_nvenc_encoder()
 logging.getLogger("aiortc").setLevel(logging.WARNING)
 
 

--- a/inference/core/interfaces/stream_manager/manager_app/webrtc.py
+++ b/inference/core/interfaces/stream_manager/manager_app/webrtc.py
@@ -37,9 +37,7 @@ from inference.core.interfaces.stream_manager.manager_app.entities import (
     WebRTCOffer,
     WebRTCTURNConfig,
 )
-from inference.core.interfaces.webrtc_worker.h264_nvenc import (
-    prefer_h264_nvenc_encoder,
-)
+from inference.core.interfaces.webrtc_worker.h264_nvenc import prefer_h264_nvenc_encoder
 from inference.core.utils.async_utils import Queue as SyncAsyncQueue
 from inference.core.utils.function import experimental
 from inference.core.workflows.execution_engine.entities.base import WorkflowImageData

--- a/inference/core/interfaces/stream_manager/manager_app/webrtc.py
+++ b/inference/core/interfaces/stream_manager/manager_app/webrtc.py
@@ -37,7 +37,10 @@ from inference.core.interfaces.stream_manager.manager_app.entities import (
     WebRTCOffer,
     WebRTCTURNConfig,
 )
-from inference.core.interfaces.webrtc_worker.h264_nvenc import prefer_h264_nvenc_encoder
+from inference.core.interfaces.webrtc_worker.h264_nvenc import (
+    log_answer_video_codecs,
+    prefer_h264_nvenc_encoder,
+)
 from inference.core.utils.async_utils import Queue as SyncAsyncQueue
 from inference.core.utils.function import experimental
 from inference.core.workflows.execution_engine.entities.base import WorkflowImageData
@@ -478,6 +481,7 @@ async def init_rtc_peer_connection(
     )
     answer = await peer_connection.createAnswer()
     await peer_connection.setLocalDescription(answer)
+    log_answer_video_codecs(peer_connection.localDescription.sdp)
     logger.debug(f"WebRTC connection status: {peer_connection.connectionState}")
 
     return peer_connection

--- a/inference/core/interfaces/webrtc_worker/h264_nvenc.py
+++ b/inference/core/interfaces/webrtc_worker/h264_nvenc.py
@@ -1,11 +1,10 @@
 import fractions
 import time
-from typing import Any, Dict, Iterator, List, Optional, Tuple
+from typing import Any, Dict, Iterator, Optional, Tuple
 
 from inference.core import logger
 
 H264_NVENC_ENCODER = "h264_nvenc"
-H264_NVENC_TIMING_SAMPLE_INTERVAL = 120
 H264_NVENC_OPTION_SETS = (
     {
         "preset": "p1",
@@ -87,12 +86,10 @@ def prefer_h264_nvenc_encoder() -> None:
                 options,
             )
 
-        should_log_timing = _should_log_timing(self)
-        encode_started = time.perf_counter() if should_log_timing else None
         try:
             data_to_send = _encode_to_bytes(self.codec, frame)
         except Exception as error:
-            logger.info(
+            logger.warning(
                 "[WEBRTC_NVENC] encoder=%s failed; falling_back=libx264 "
                 "resolution=%sx%s target_bps=%s error=%r",
                 H264_NVENC_ENCODER,
@@ -104,19 +101,6 @@ def prefer_h264_nvenc_encoder() -> None:
             _reset_encoder(self)
             yield from original_encode_frame(self, frame, force_keyframe)
             return
-
-        if should_log_timing and encode_started is not None:
-            logger.info(
-                "[WEBRTC_NVENC] encode_sample frame=%s encode_ms=%.2f "
-                "payload_bytes=%s resolution=%sx%s target_bps=%s codec_bps=%s",
-                self._roboflow_h264_nvenc_frame_count,
-                (time.perf_counter() - encode_started) * 1000,
-                len(data_to_send),
-                frame.width,
-                frame.height,
-                self.target_bitrate,
-                getattr(self.codec, "bit_rate", None),
-            )
 
         if data_to_send:
             yield from self._split_bitstream(data_to_send)
@@ -153,7 +137,7 @@ def _create_nvenc_context(
         except Exception as error:
             last_error = error
 
-    logger.info(
+    logger.warning(
         "[WEBRTC_NVENC] encoder=%s unavailable; falling_back=libx264 "
         "resolution=%sx%s target_bps=%s error=%r",
         H264_NVENC_ENCODER,
@@ -163,18 +147,6 @@ def _create_nvenc_context(
         last_error,
     )
     return None, {}, 0.0
-
-
-def log_answer_video_codecs(sdp: str) -> None:
-    video_payloads, rtpmap = _parse_video_codecs(sdp)
-    ordered_codecs = [
-        f"{payload}:{rtpmap.get(payload, 'unknown')}" for payload in video_payloads
-    ]
-    logger.info(
-        "[WEBRTC_NVENC] answer_video_codecs preferred=%s codecs=%s",
-        ordered_codecs[0] if ordered_codecs else None,
-        ",".join(ordered_codecs[:16]),
-    )
 
 
 def _try_set_baseline_profile(codec: Any) -> None:
@@ -204,11 +176,10 @@ def _bitrate_change_ratio(encoder: Any) -> float:
 
 def _update_nvenc_bitrate(encoder: Any) -> None:
     previous_bitrate = getattr(encoder.codec, "bit_rate", None)
-    started_at = time.perf_counter()
     try:
         encoder.codec.bit_rate = encoder.target_bitrate
     except Exception as error:
-        logger.info(
+        logger.warning(
             "[WEBRTC_NVENC] bitrate_update_failed previous_bps=%s "
             "target_bps=%s error=%r",
             previous_bitrate,
@@ -217,21 +188,6 @@ def _update_nvenc_bitrate(encoder: Any) -> None:
         )
         _reset_encoder(encoder)
         return
-
-    logger.info(
-        "[WEBRTC_NVENC] bitrate_updated update_ms=%.2f previous_bps=%s "
-        "target_bps=%s codec_bps=%s",
-        (time.perf_counter() - started_at) * 1000,
-        previous_bitrate,
-        encoder.target_bitrate,
-        getattr(encoder.codec, "bit_rate", None),
-    )
-
-
-def _should_log_timing(encoder: Any) -> bool:
-    frame_count = getattr(encoder, "_roboflow_h264_nvenc_frame_count", 0) + 1
-    encoder._roboflow_h264_nvenc_frame_count = frame_count
-    return frame_count == 1 or frame_count % H264_NVENC_TIMING_SAMPLE_INTERVAL == 0
 
 
 def _encode_to_bytes(codec: Any, frame: Any) -> bytes:
@@ -246,30 +202,3 @@ def _reset_encoder(encoder: Any) -> None:
     encoder.buffer_pts = None
     encoder.codec = None
     encoder._roboflow_h264_nvenc_active = False
-
-
-def _parse_video_codecs(sdp: str) -> Tuple[List[str], Dict[str, str]]:
-    video_payloads: List[str] = []
-    rtpmap: Dict[str, str] = {}
-    in_video_section = False
-
-    for raw_line in sdp.splitlines():
-        line = raw_line.strip()
-        if line.startswith("m="):
-            if in_video_section:
-                break
-            if line.startswith("m=video "):
-                parts = line.split()
-                video_payloads = parts[3:]
-                in_video_section = True
-            continue
-
-        if not in_video_section or not line.startswith("a=rtpmap:"):
-            continue
-
-        payload_and_codec = line[len("a=rtpmap:") :]
-        payload, separator, codec = payload_and_codec.partition(" ")
-        if separator:
-            rtpmap[payload] = codec.split("/", 1)[0]
-
-    return video_payloads, rtpmap

--- a/inference/core/interfaces/webrtc_worker/h264_nvenc.py
+++ b/inference/core/interfaces/webrtc_worker/h264_nvenc.py
@@ -51,7 +51,13 @@ def prefer_h264_nvenc_encoder() -> None:
             if _frame_size_changed(self, frame):
                 _reset_encoder(self)
             elif _bitrate_change_ratio(self) > 0.1:
-                _update_nvenc_bitrate(self)
+                logger.info(
+                    "[WEBRTC_NVENC] bitrate_changed recreating_encoder "
+                    "previous_bps=%s target_bps=%s",
+                    getattr(self.codec, "bit_rate", None),
+                    self.target_bitrate,
+                )
+                _reset_encoder(self)
 
         _set_picture_type(h264, frame, force_keyframe)
 
@@ -176,36 +182,6 @@ def _bitrate_change_ratio(encoder: Any) -> float:
     if not codec_bitrate:
         return 0.0
     return abs(encoder.target_bitrate - codec_bitrate) / codec_bitrate
-
-
-def _update_nvenc_bitrate(encoder: Any) -> None:
-    previous_bitrate = getattr(encoder.codec, "bit_rate", None)
-    try:
-        encoder.codec.bit_rate = encoder.target_bitrate
-    except Exception as error:
-        logger.info(
-            "[WEBRTC_NVENC] bitrate_update_failed requested_bps=%s "
-            "previous_bps=%s error=%r",
-            encoder.target_bitrate,
-            previous_bitrate,
-            error,
-        )
-        _reset_encoder(encoder)
-        return
-
-    if getattr(encoder, "_roboflow_h264_nvenc_logged_bitrate", None) != (
-        previous_bitrate,
-        encoder.target_bitrate,
-    ):
-        logger.info(
-            "[WEBRTC_NVENC] bitrate_updated previous_bps=%s target_bps=%s",
-            previous_bitrate,
-            encoder.target_bitrate,
-        )
-        encoder._roboflow_h264_nvenc_logged_bitrate = (
-            previous_bitrate,
-            encoder.target_bitrate,
-        )
 
 
 def _should_log_timing(encoder: Any) -> bool:

--- a/inference/core/interfaces/webrtc_worker/h264_nvenc.py
+++ b/inference/core/interfaces/webrtc_worker/h264_nvenc.py
@@ -1,0 +1,213 @@
+import fractions
+import time
+from typing import Any, Dict, Iterator, Optional, Tuple
+
+from inference.core import logger
+
+
+H264_NVENC_ENCODER = "h264_nvenc"
+H264_NVENC_TIMING_SAMPLE_INTERVAL = 120
+H264_NVENC_OPTION_SETS = (
+    {
+        "preset": "p2",
+        "tune": "ll",
+        "rc": "cbr",
+        "profile": "baseline",
+        "bf": "0",
+    },
+    {},
+)
+
+
+def prefer_h264_nvenc_encoder() -> None:
+    """Prefer NVIDIA H.264 hardware encoding when aiortc sends H.264 video."""
+    import aiortc.codecs.h264 as h264
+
+    encoder_cls = h264.H264Encoder
+    if getattr(encoder_cls, "_roboflow_h264_nvenc_patched", False):
+        return
+
+    original_encode_frame = encoder_cls._encode_frame
+
+    def _encode_frame(self: Any, frame: Any, force_keyframe: bool) -> Iterator[bytes]:
+        if self.codec is not None and not getattr(
+            self, "_roboflow_h264_nvenc_active", False
+        ):
+            yield from original_encode_frame(self, frame, force_keyframe)
+            return
+
+        if self.codec is not None:
+            if _frame_size_changed(self, frame):
+                _reset_encoder(self)
+            elif _bitrate_change_ratio(self) > 0.1:
+                _update_nvenc_bitrate(self)
+
+        _set_picture_type(h264, frame, force_keyframe)
+
+        if self.codec is None:
+            codec, options = _create_nvenc_context(
+                h264_module=h264,
+                frame=frame,
+                target_bitrate=self.target_bitrate,
+            )
+            if codec is None:
+                yield from original_encode_frame(self, frame, force_keyframe)
+                return
+
+            self.codec = codec
+            self._roboflow_h264_nvenc_active = True
+            logger.info(
+                "[WEBRTC_NVENC] using encoder=%s resolution=%sx%s target_bps=%s "
+                "options=%s",
+                H264_NVENC_ENCODER,
+                frame.width,
+                frame.height,
+                self.target_bitrate,
+                options,
+            )
+
+        should_log_timing = _should_log_timing(self)
+        encode_started = time.perf_counter() if should_log_timing else None
+        try:
+            data_to_send = _encode_to_bytes(self.codec, frame)
+        except Exception as error:
+            logger.info(
+                "[WEBRTC_NVENC] encoder=%s failed; falling_back=libx264 "
+                "resolution=%sx%s target_bps=%s error=%r",
+                H264_NVENC_ENCODER,
+                frame.width,
+                frame.height,
+                self.target_bitrate,
+                error,
+            )
+            _reset_encoder(self)
+            yield from original_encode_frame(self, frame, force_keyframe)
+            return
+
+        if should_log_timing and encode_started is not None:
+            logger.info(
+                "[WEBRTC_NVENC] encode_sample frame=%s encode_ms=%.2f "
+                "payload_bytes=%s resolution=%sx%s target_bps=%s",
+                self._roboflow_h264_nvenc_frame_count,
+                (time.perf_counter() - encode_started) * 1000,
+                len(data_to_send),
+                frame.width,
+                frame.height,
+                self.target_bitrate,
+            )
+
+        if data_to_send:
+            yield from self._split_bitstream(data_to_send)
+
+    encoder_cls._encode_frame = _encode_frame
+    encoder_cls._roboflow_h264_nvenc_patched = True
+    logger.info(
+        "[WEBRTC_NVENC] patched aiortc H264Encoder to prefer encoder=%s",
+        H264_NVENC_ENCODER,
+    )
+
+
+def _create_nvenc_context(
+    h264_module: Any,
+    frame: Any,
+    target_bitrate: int,
+) -> Tuple[Optional[Any], Dict[str, str]]:
+    last_error: Optional[Exception] = None
+
+    for options in H264_NVENC_OPTION_SETS:
+        try:
+            codec = h264_module.av.CodecContext.create(H264_NVENC_ENCODER, "w")
+            codec.width = frame.width
+            codec.height = frame.height
+            codec.bit_rate = target_bitrate
+            codec.pix_fmt = "yuv420p"
+            codec.framerate = fractions.Fraction(h264_module.MAX_FRAME_RATE, 1)
+            codec.time_base = fractions.Fraction(1, h264_module.MAX_FRAME_RATE)
+            codec.options = options
+            codec.open()
+            return codec, options
+        except Exception as error:
+            last_error = error
+
+    logger.info(
+        "[WEBRTC_NVENC] encoder=%s unavailable; falling_back=libx264 "
+        "resolution=%sx%s target_bps=%s error=%r",
+        H264_NVENC_ENCODER,
+        frame.width,
+        frame.height,
+        target_bitrate,
+        last_error,
+    )
+    return None, {}
+
+
+def _set_picture_type(h264_module: Any, frame: Any, force_keyframe: bool) -> None:
+    if force_keyframe:
+        frame.pict_type = h264_module.av.video.frame.PictureType.I
+    else:
+        frame.pict_type = h264_module.av.video.frame.PictureType.NONE
+
+
+def _frame_size_changed(encoder: Any, frame: Any) -> bool:
+    return frame.width != encoder.codec.width or frame.height != encoder.codec.height
+
+
+def _bitrate_change_ratio(encoder: Any) -> float:
+    codec_bitrate = getattr(encoder.codec, "bit_rate", None)
+    if not codec_bitrate:
+        return 0.0
+    return abs(encoder.target_bitrate - codec_bitrate) / codec_bitrate
+
+
+def _update_nvenc_bitrate(encoder: Any) -> None:
+    previous_bitrate = getattr(encoder.codec, "bit_rate", None)
+    try:
+        encoder.codec.bit_rate = encoder.target_bitrate
+    except Exception as error:
+        logger.info(
+            "[WEBRTC_NVENC] bitrate_update_failed requested_bps=%s "
+            "previous_bps=%s error=%r",
+            encoder.target_bitrate,
+            previous_bitrate,
+            error,
+        )
+        _reset_encoder(encoder)
+        return
+
+    if getattr(encoder, "_roboflow_h264_nvenc_logged_bitrate", None) != (
+        previous_bitrate,
+        encoder.target_bitrate,
+    ):
+        logger.info(
+            "[WEBRTC_NVENC] bitrate_updated previous_bps=%s target_bps=%s",
+            previous_bitrate,
+            encoder.target_bitrate,
+        )
+        encoder._roboflow_h264_nvenc_logged_bitrate = (
+            previous_bitrate,
+            encoder.target_bitrate,
+        )
+
+
+def _should_log_timing(encoder: Any) -> bool:
+    frame_count = getattr(encoder, "_roboflow_h264_nvenc_frame_count", 0) + 1
+    encoder._roboflow_h264_nvenc_frame_count = frame_count
+    return (
+        frame_count == 1
+        or frame_count % H264_NVENC_TIMING_SAMPLE_INTERVAL == 0
+    )
+
+
+def _encode_to_bytes(codec: Any, frame: Any) -> bytes:
+    data_to_send = b""
+    for package in codec.encode(frame):
+        data_to_send += bytes(package)
+    return data_to_send
+
+
+def _reset_encoder(encoder: Any) -> None:
+    encoder.buffer_data = b""
+    encoder.buffer_pts = None
+    encoder.codec = None
+    encoder._roboflow_h264_nvenc_active = False
+

--- a/inference/core/interfaces/webrtc_worker/h264_nvenc.py
+++ b/inference/core/interfaces/webrtc_worker/h264_nvenc.py
@@ -8,13 +8,25 @@ H264_NVENC_ENCODER = "h264_nvenc"
 H264_NVENC_TIMING_SAMPLE_INTERVAL = 120
 H264_NVENC_OPTION_SETS = (
     {
-        "preset": "p2",
-        "tune": "ll",
+        "preset": "p1",
+        "tune": "ull",
         "rc": "cbr",
-        "profile": "baseline",
+        "zerolatency": "1",
+        "delay": "0",
         "bf": "0",
     },
-    {},
+    {
+        "preset": "llhp",
+        "rc": "cbr",
+        "zerolatency": "1",
+        "delay": "0",
+        "bf": "0",
+    },
+    {
+        "preset": "fast",
+        "rc": "cbr",
+        "bf": "0",
+    },
 )
 
 
@@ -123,6 +135,7 @@ def _create_nvenc_context(
             codec.framerate = fractions.Fraction(h264_module.MAX_FRAME_RATE, 1)
             codec.time_base = fractions.Fraction(1, h264_module.MAX_FRAME_RATE)
             codec.options = options
+            _try_set_baseline_profile(codec)
             codec.open()
             return codec, options
         except Exception as error:
@@ -138,6 +151,13 @@ def _create_nvenc_context(
         last_error,
     )
     return None, {}
+
+
+def _try_set_baseline_profile(codec: Any) -> None:
+    try:
+        codec.profile = "Baseline"
+    except Exception:
+        pass
 
 
 def _set_picture_type(h264_module: Any, frame: Any, force_keyframe: bool) -> None:

--- a/inference/core/interfaces/webrtc_worker/h264_nvenc.py
+++ b/inference/core/interfaces/webrtc_worker/h264_nvenc.py
@@ -1,6 +1,6 @@
 import fractions
 import time
-from typing import Any, Dict, Iterator, Optional, Tuple
+from typing import Any, Dict, Iterator, List, Optional, Tuple
 
 from inference.core import logger
 
@@ -49,20 +49,23 @@ def prefer_h264_nvenc_encoder() -> None:
 
         if self.codec is not None:
             if _frame_size_changed(self, frame):
-                _reset_encoder(self)
-            elif _bitrate_change_ratio(self) > 0.1:
                 logger.info(
-                    "[WEBRTC_NVENC] bitrate_changed recreating_encoder "
-                    "previous_bps=%s target_bps=%s",
-                    getattr(self.codec, "bit_rate", None),
+                    "[WEBRTC_NVENC] resolution_changed recreating_encoder "
+                    "previous=%sx%s next=%sx%s target_bps=%s",
+                    self.codec.width,
+                    self.codec.height,
+                    frame.width,
+                    frame.height,
                     self.target_bitrate,
                 )
                 _reset_encoder(self)
+            elif _bitrate_change_ratio(self) > 0.1:
+                _update_nvenc_bitrate(self)
 
         _set_picture_type(h264, frame, force_keyframe)
 
         if self.codec is None:
-            codec, options = _create_nvenc_context(
+            codec, options, open_ms = _create_nvenc_context(
                 h264_module=h264,
                 frame=frame,
                 target_bitrate=self.target_bitrate,
@@ -74,9 +77,10 @@ def prefer_h264_nvenc_encoder() -> None:
             self.codec = codec
             self._roboflow_h264_nvenc_active = True
             logger.info(
-                "[WEBRTC_NVENC] using encoder=%s resolution=%sx%s target_bps=%s "
-                "options=%s",
+                "[WEBRTC_NVENC] open_context encoder=%s open_ms=%.2f "
+                "resolution=%sx%s target_bps=%s options=%s",
                 H264_NVENC_ENCODER,
+                open_ms,
                 frame.width,
                 frame.height,
                 self.target_bitrate,
@@ -104,13 +108,14 @@ def prefer_h264_nvenc_encoder() -> None:
         if should_log_timing and encode_started is not None:
             logger.info(
                 "[WEBRTC_NVENC] encode_sample frame=%s encode_ms=%.2f "
-                "payload_bytes=%s resolution=%sx%s target_bps=%s",
+                "payload_bytes=%s resolution=%sx%s target_bps=%s codec_bps=%s",
                 self._roboflow_h264_nvenc_frame_count,
                 (time.perf_counter() - encode_started) * 1000,
                 len(data_to_send),
                 frame.width,
                 frame.height,
                 self.target_bitrate,
+                getattr(self.codec, "bit_rate", None),
             )
 
         if data_to_send:
@@ -128,11 +133,12 @@ def _create_nvenc_context(
     h264_module: Any,
     frame: Any,
     target_bitrate: int,
-) -> Tuple[Optional[Any], Dict[str, str]]:
+) -> Tuple[Optional[Any], Dict[str, str], float]:
     last_error: Optional[Exception] = None
 
     for options in H264_NVENC_OPTION_SETS:
         try:
+            started_at = time.perf_counter()
             codec = h264_module.av.CodecContext.create(H264_NVENC_ENCODER, "w")
             codec.width = frame.width
             codec.height = frame.height
@@ -143,7 +149,7 @@ def _create_nvenc_context(
             codec.options = options
             _try_set_baseline_profile(codec)
             codec.open()
-            return codec, options
+            return codec, options, (time.perf_counter() - started_at) * 1000
         except Exception as error:
             last_error = error
 
@@ -156,7 +162,19 @@ def _create_nvenc_context(
         target_bitrate,
         last_error,
     )
-    return None, {}
+    return None, {}, 0.0
+
+
+def log_answer_video_codecs(sdp: str) -> None:
+    video_payloads, rtpmap = _parse_video_codecs(sdp)
+    ordered_codecs = [
+        f"{payload}:{rtpmap.get(payload, 'unknown')}" for payload in video_payloads
+    ]
+    logger.info(
+        "[WEBRTC_NVENC] answer_video_codecs preferred=%s codecs=%s",
+        ordered_codecs[0] if ordered_codecs else None,
+        ",".join(ordered_codecs[:16]),
+    )
 
 
 def _try_set_baseline_profile(codec: Any) -> None:
@@ -184,6 +202,32 @@ def _bitrate_change_ratio(encoder: Any) -> float:
     return abs(encoder.target_bitrate - codec_bitrate) / codec_bitrate
 
 
+def _update_nvenc_bitrate(encoder: Any) -> None:
+    previous_bitrate = getattr(encoder.codec, "bit_rate", None)
+    started_at = time.perf_counter()
+    try:
+        encoder.codec.bit_rate = encoder.target_bitrate
+    except Exception as error:
+        logger.info(
+            "[WEBRTC_NVENC] bitrate_update_failed previous_bps=%s "
+            "target_bps=%s error=%r",
+            previous_bitrate,
+            encoder.target_bitrate,
+            error,
+        )
+        _reset_encoder(encoder)
+        return
+
+    logger.info(
+        "[WEBRTC_NVENC] bitrate_updated update_ms=%.2f previous_bps=%s "
+        "target_bps=%s codec_bps=%s",
+        (time.perf_counter() - started_at) * 1000,
+        previous_bitrate,
+        encoder.target_bitrate,
+        getattr(encoder.codec, "bit_rate", None),
+    )
+
+
 def _should_log_timing(encoder: Any) -> bool:
     frame_count = getattr(encoder, "_roboflow_h264_nvenc_frame_count", 0) + 1
     encoder._roboflow_h264_nvenc_frame_count = frame_count
@@ -202,3 +246,30 @@ def _reset_encoder(encoder: Any) -> None:
     encoder.buffer_pts = None
     encoder.codec = None
     encoder._roboflow_h264_nvenc_active = False
+
+
+def _parse_video_codecs(sdp: str) -> Tuple[List[str], Dict[str, str]]:
+    video_payloads: List[str] = []
+    rtpmap: Dict[str, str] = {}
+    in_video_section = False
+
+    for raw_line in sdp.splitlines():
+        line = raw_line.strip()
+        if line.startswith("m="):
+            if in_video_section:
+                break
+            if line.startswith("m=video "):
+                parts = line.split()
+                video_payloads = parts[3:]
+                in_video_section = True
+            continue
+
+        if not in_video_section or not line.startswith("a=rtpmap:"):
+            continue
+
+        payload_and_codec = line[len("a=rtpmap:") :]
+        payload, separator, codec = payload_and_codec.partition(" ")
+        if separator:
+            rtpmap[payload] = codec.split("/", 1)[0]
+
+    return video_payloads, rtpmap

--- a/inference/core/interfaces/webrtc_worker/h264_nvenc.py
+++ b/inference/core/interfaces/webrtc_worker/h264_nvenc.py
@@ -4,7 +4,6 @@ from typing import Any, Dict, Iterator, Optional, Tuple
 
 from inference.core import logger
 
-
 H264_NVENC_ENCODER = "h264_nvenc"
 H264_NVENC_TIMING_SAMPLE_INTERVAL = 120
 H264_NVENC_OPTION_SETS = (
@@ -192,10 +191,7 @@ def _update_nvenc_bitrate(encoder: Any) -> None:
 def _should_log_timing(encoder: Any) -> bool:
     frame_count = getattr(encoder, "_roboflow_h264_nvenc_frame_count", 0) + 1
     encoder._roboflow_h264_nvenc_frame_count = frame_count
-    return (
-        frame_count == 1
-        or frame_count % H264_NVENC_TIMING_SAMPLE_INTERVAL == 0
-    )
+    return frame_count == 1 or frame_count % H264_NVENC_TIMING_SAMPLE_INTERVAL == 0
 
 
 def _encode_to_bytes(codec: Any, frame: Any) -> bytes:
@@ -210,4 +206,3 @@ def _reset_encoder(encoder: Any) -> None:
     encoder.buffer_pts = None
     encoder.codec = None
     encoder._roboflow_h264_nvenc_active = False
-

--- a/inference/core/interfaces/webrtc_worker/webrtc.py
+++ b/inference/core/interfaces/webrtc_worker/webrtc.py
@@ -57,9 +57,7 @@ from inference.core.interfaces.webrtc_worker.entities import (
     WebRTCWorkerRequest,
     WebRTCWorkerResult,
 )
-from inference.core.interfaces.webrtc_worker.h264_nvenc import (
-    prefer_h264_nvenc_encoder,
-)
+from inference.core.interfaces.webrtc_worker.h264_nvenc import prefer_h264_nvenc_encoder
 from inference.core.interfaces.webrtc_worker.serializers import serialize_for_webrtc
 from inference.core.interfaces.webrtc_worker.sources.file import (
     ThreadedVideoFileTrack,

--- a/inference/core/interfaces/webrtc_worker/webrtc.py
+++ b/inference/core/interfaces/webrtc_worker/webrtc.py
@@ -57,7 +57,10 @@ from inference.core.interfaces.webrtc_worker.entities import (
     WebRTCWorkerRequest,
     WebRTCWorkerResult,
 )
-from inference.core.interfaces.webrtc_worker.h264_nvenc import prefer_h264_nvenc_encoder
+from inference.core.interfaces.webrtc_worker.h264_nvenc import (
+    log_answer_video_codecs,
+    prefer_h264_nvenc_encoder,
+)
 from inference.core.interfaces.webrtc_worker.serializers import serialize_for_webrtc
 from inference.core.interfaces.webrtc_worker.sources.file import (
     ThreadedVideoFileTrack,
@@ -1303,6 +1306,7 @@ async def init_rtc_peer_connection_with_loop(
     )
     answer = await peer_connection.createAnswer()
     await peer_connection.setLocalDescription(answer)
+    log_answer_video_codecs(peer_connection.localDescription.sdp)
 
     await _wait_ice_complete(peer_connection, timeout=2.0)
 

--- a/inference/core/interfaces/webrtc_worker/webrtc.py
+++ b/inference/core/interfaces/webrtc_worker/webrtc.py
@@ -57,10 +57,7 @@ from inference.core.interfaces.webrtc_worker.entities import (
     WebRTCWorkerRequest,
     WebRTCWorkerResult,
 )
-from inference.core.interfaces.webrtc_worker.h264_nvenc import (
-    log_answer_video_codecs,
-    prefer_h264_nvenc_encoder,
-)
+from inference.core.interfaces.webrtc_worker.h264_nvenc import prefer_h264_nvenc_encoder
 from inference.core.interfaces.webrtc_worker.serializers import serialize_for_webrtc
 from inference.core.interfaces.webrtc_worker.sources.file import (
     ThreadedVideoFileTrack,
@@ -1306,7 +1303,6 @@ async def init_rtc_peer_connection_with_loop(
     )
     answer = await peer_connection.createAnswer()
     await peer_connection.setLocalDescription(answer)
-    log_answer_video_codecs(peer_connection.localDescription.sdp)
 
     await _wait_ice_complete(peer_connection, timeout=2.0)
 

--- a/inference/core/interfaces/webrtc_worker/webrtc.py
+++ b/inference/core/interfaces/webrtc_worker/webrtc.py
@@ -57,6 +57,9 @@ from inference.core.interfaces.webrtc_worker.entities import (
     WebRTCWorkerRequest,
     WebRTCWorkerResult,
 )
+from inference.core.interfaces.webrtc_worker.h264_nvenc import (
+    prefer_h264_nvenc_encoder,
+)
 from inference.core.interfaces.webrtc_worker.serializers import serialize_for_webrtc
 from inference.core.interfaces.webrtc_worker.sources.file import (
     ThreadedVideoFileTrack,
@@ -77,6 +80,7 @@ from inference.core.workflows.errors import WorkflowError, WorkflowSyntaxError
 from inference.core.workflows.execution_engine.entities.base import WorkflowImageData
 from inference.usage_tracking.collector import usage_collector
 
+prefer_h264_nvenc_encoder()
 logging.getLogger("aiortc").setLevel(logging.WARNING)
 
 # WebRTC data channel chunking configuration


### PR DESCRIPTION
## Summary

- Prefer NVIDIA `h264_nvenc` for aiortc H.264 WebRTC encoding when available.
- Fall back to the existing `libx264` encoder when NVENC is unavailable or fails.
- Add scoped `[WEBRTC_NVENC]` logs for patch activation, encoder selection, fallback, and resolution-triggered encoder recreation.

## Why

Modal GPU workers run on NVIDIA GPUs, so H.264 hardware encoding can reduce server-side encode latency without changing the negotiated browser codec. H.264 stays the WebRTC-compatible path; this does not introduce H.265/HEVC or bitrate/congestion-control changes.

## Testing

- `python3 -m py_compile inference/core/interfaces/webrtc_worker/h264_nvenc.py inference/core/interfaces/webrtc_worker/webrtc.py inference/core/interfaces/stream_manager/manager_app/webrtc.py`
- Local smoke test with repo `venv` and `aiortc 1.14.0`: confirmed `h264_nvenc` fallback to `libx264` on a non-NVIDIA Mac still produces H.264 packets.
- `git diff --check`

## Staging benchmark

| Encoder | Hardware | 1080p encode time | Relative speed | Notes |
|---|---:|---:|---:|---|
| `libx264` | CPU | ~14-17 ms/frame steady-state | baseline | Works everywhere, but uses CPU and can become expensive at higher resolution/bitrate. |
| `h264_nvenc` | NVIDIA GPU | avg ~2.6 ms/frame, min ~2.1 ms, max ~3.1 ms | ~5-6x faster | Uses the dedicated NVIDIA video encoder on T4/L4/L40S. Frees CPU and gives much more headroom for 1080p WebRTC output. |

In staging, software `libx264` encoding took roughly 14-17 ms per 1080p frame. With `h264_nvenc`, sampled encode time dropped to about 2.6 ms per frame, roughly a 5-6x improvement. This does not by itself solve all WebRTC congestion/ramp-up behavior, but it removes server-side H.264 encoding as a major bottleneck on NVIDIA GPU Modal workers.

For comparison, I also tested VP8: backend VP8 encode sampled around 10-17 ms/frame, while browser-side encode/decode stayed in the same low-ms range as H.264, so VP8 did not look like the better backend output codec.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Monkey-patches `aiortc`'s `H264Encoder` to prefer GPU NVENC, which can affect WebRTC video stability/compatibility and may surface runtime/driver-specific failures despite the fallback path.
> 
> **Overview**
> **Prefers NVIDIA NVENC for WebRTC H.264 video encoding when available.**
> 
> Adds `h264_nvenc` support via a runtime patch (`prefer_h264_nvenc_encoder`) that overrides `aiortc.codecs.h264.H264Encoder._encode_frame` to try opening an NVENC `av.CodecContext`, update bitrate, recreate the encoder on resolution change, and **fall back to the original `libx264` path** on unavailability or encode errors (with `[WEBRTC_NVENC]` scoped logs).
> 
> Enables this behavior by invoking `prefer_h264_nvenc_encoder()` at import time in both the stream manager WebRTC app and the WebRTC worker entrypoints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 880594031b4292052b8dd6ddac0c4d39cc79cb0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->




