### PR TITLE
Drop default/best confidence parametrization from OWLv2HF test

### DIFF
--- a/inference_models/tests/integration_tests/models/test_owlv2_predictions.py
+++ b/inference_models/tests/integration_tests/models/test_owlv2_predictions.py
@@ -58,11 +58,9 @@ def test_owlv2_predictions_for_open_vocabulary(
 
 @pytest.mark.slow
 @pytest.mark.hf_vlm_models
-@pytest.mark.parametrize("confidence", [0.99, "best", "default"])
 def test_owlv2_predictions_for_reference_dataset(
     owlv2_model: OWLv2HF,
     dog_image_numpy: np.ndarray,
-    confidence,
 ) -> None:
     # when
     predictions = owlv2_model.infer_with_reference_examples(
@@ -76,7 +74,7 @@ def test_owlv2_predictions_for_reference_dataset(
                 ],
             )
         ],
-        confidence=confidence,
+        confidence=0.99,
         iou_threshold=0.3,
         max_detections=300,
     )


### PR DESCRIPTION
## What does this PR do?

<!-- Provide a clear and concise description of the changes -->

Drop confidence parameterization for base OWLv2HF model - only RoboflowInstanceHF should have it (mistake in #2324).

## Type of Change

<!-- Please select one and delete the others, or describe if Other -->

- Bug fix (non-breaking change that fixes an issue)

## Testing

<!-- Describe how you tested your changes -->

- [ ] I have tested this change locally
- [x] I have added/updated tests for this change - fix to the test

**Test details:**
<!-- Describe what tests were added/updated and what they cover -->

Manual trigger of INTEGRATION TESTS - inference-models (GPU) https://github.com/roboflow/inference/actions/runs/25757812924

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)

## Additional Context

<!-- Add any other context, screenshots, or notes about the PR here -->
