### PR TITLE
Constraint transformers on Jetson with JP5

### DIFF
--- a/docker/dockerfiles/Dockerfile.onnx.jetson.5.1.1
+++ b/docker/dockerfiles/Dockerfile.onnx.jetson.5.1.1
@@ -25,7 +25,8 @@ RUN python -m pip install \
     -r requirements.gpu.txt \
     "pycuda>=2025.0.0,<2026.0.0" \
     "torch==2.4.1" \
-    "torchvision==0.19.1"
+    "torchvision==0.19.1" \
+    "transformers<=5.7.0"
 
 
 WORKDIR /app/


### PR DESCRIPTION
## What does this PR do?

<!-- Provide a clear and concise description of the changes -->

Detected runtime error in JP5 build - `peft` seems to be broken with transformers beyond 5.7.0

Confirmation of RC with deep research from Claude

```
  (B) transformers/integrations/moe.py:250 registers a torch.library.custom_op at import time, with PEP-563
  string annotations. moe.py carries from __future__ import annotations at line 14, so _grouped_mm_fallback's
  annotations are the strings 'torch.Tensor', not the class. The custom_op call (v5.8.0 and earlier) passes no
  explicit schema=, so infer_schema runs and compares 'torch.Tensor' (string) against the supported-types dict
  whose keys are <class 'torch.Tensor'> (class) → fails. This codepath ships in transformers ≥ 5.5.0 (PR
  huggingface/transformers#44043, commit 39ddb88af0, merged 2026-02-18). The fix is on transformers main — PR
  #45804 adds schema="(Tensor input, Tensor weight, Tensor offs) -> Tensor" to the custom_op call — but is not
  in any released tag through v5.8.1 (tagged 2026-05-13). Canonical upstream issue: transformers#45800.

  (C) The Jetson container has torch < 2.5. Verified per dockerfile:
  - docker/dockerfiles/Dockerfile.onnx.jetson.5.1.1:27 hard-pins torch==2.4.1. This matches the user's JP5
  prompt (jetson-orin-nx-jp5).
  - JP6.0 / JP6.2 build torch==2.6.0 from source.
  - JP7.1 builds torch==2.10.0 from source.

  torch._library.infer_schema gained string-annotation resolution in torch 2.5.0 (convert_type_string) and was
  hardened to unstringify_type(..., pf_globals) in torch 2.7.0. Torch 2.4.x raises the exact ValueError:
  Parameter input has unsupported type torch.Tensor. The valid types are: dict_keys([<class 'torch.Tensor'>,
  ...]) seen in the user's trace. NVIDIA does not ship an official torch ≥ 2.5 wheel for JP5 / L4T r35 — JP5
  cannot satisfy the requirement without a custom build.

  Why it crashes now and not before: inference_models/pyproject.toml:15 pins transformers~=5.5 (≥5.5, <6.0).
  The recent commit 30b099679 ("[INC-302] Add Gemma 4 to inference") bumped this. Fresh Jetson container builds
   now pull transformers ≥ 5.5 → the custom_op registration → fails on torch 2.4.1. The JP6/JP7.1 builds escape
   because they ship torch 2.6 / 2.10.
```

## Type of Change

<!-- Please select one and delete the others, or describe if Other -->

- Bug fix (non-breaking change that fixes an issue)


## Testing

<!-- Describe how you tested your changes -->

- mnaual test
- [ ] I have tested this change locally
- [ ] I have added/updated tests for this change

**Test details:**
<!-- Describe what tests were added/updated and what they cover -->

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)

## Additional Context

<!-- Add any other context, screenshots, or notes about the PR here -->
