### PR TITLE
fix: handle empty SDK request headers

### DIFF
--- a/inference_sdk/http/utils/request_building.py
+++ b/inference_sdk/http/utils/request_building.py
@@ -120,14 +120,14 @@ def assembly_request_data(
     elif image_placement is ImagePlacement.DATA:
         data = batch_inference_inputs[0][0]
     else:
-        raise NotImplemented(
+        raise NotImplementedError(
             f"Not implemented request building method for {image_placement}"
         )
     scaling_factors = [e[1] for e in batch_inference_inputs]
 
     execution_id_value = execution_id.get()
     if execution_id_value:
-        headers = headers.copy()
+        headers = headers.copy() if headers is not None else {}
         headers[EXECUTION_ID_HEADER] = execution_id_value
         if ENABLE_INTERNAL_REMOTE_EXEC_HEADER:
             _internal_secret = os.getenv("ROBOFLOW_INTERNAL_SERVICE_SECRET")

--- a/tests/inference_sdk/unit_tests/http/utils/test_request_building.py
+++ b/tests/inference_sdk/unit_tests/http/utils/test_request_building.py
@@ -2,7 +2,11 @@ from unittest.mock import patch
 
 import pytest
 
-from inference_sdk.config import INTERNAL_REMOTE_EXEC_REQ_HEADER, execution_id
+from inference_sdk.config import (
+    EXECUTION_ID_HEADER,
+    INTERNAL_REMOTE_EXEC_REQ_HEADER,
+    execution_id,
+)
 from inference_sdk.http.utils.request_building import (
     ImagePlacement,
     RequestData,
@@ -154,6 +158,43 @@ def test_prepare_requests_data() -> None:
         },
         image_scaling_factors=[0.75],
     )
+
+
+def test_assembly_request_data_when_execution_id_is_set_and_headers_are_empty() -> None:
+    # given
+    token = execution_id.set("test-exec-id")
+
+    try:
+        # when
+        result = assembly_request_data(
+            url="https://some.com",
+            batch_inference_inputs=[("image_1", None)],
+            headers=None,
+            parameters=None,
+            payload=None,
+            image_placement=ImagePlacement.DATA,
+        )
+
+        # then
+        assert result.headers == {EXECUTION_ID_HEADER: "test-exec-id"}
+    finally:
+        execution_id.reset(token)
+
+
+def test_assembly_request_data_when_image_placement_is_not_supported() -> None:
+    # when / then
+    with pytest.raises(
+        NotImplementedError,
+        match="Not implemented request building method",
+    ):
+        assembly_request_data(
+            url="https://some.com",
+            batch_inference_inputs=[("image_1", None)],
+            headers=None,
+            parameters=None,
+            payload=None,
+            image_placement=object(),
+        )
 
 
 class TestInternalRemoteExecHeader:


### PR DESCRIPTION
## What changed
- handles `headers=None` when SDK request building injects `execution_id`
- raises `NotImplementedError` for unsupported image placement, not `NotImplemented`
- adds tight regression tests so this does not sneak back in

## Repro
```py
from inference_sdk.config import execution_id
from inference_sdk.http.utils.request_building import ImagePlacement, assembly_request_data

token = execution_id.set("test-exec-id")
try:
    assembly_request_data(
        url="https://some.com",
        batch_inference_inputs=[("image_1", None)],
        headers=None,
        parameters=None,
        payload=None,
        image_placement=ImagePlacement.DATA,
    )
finally:
    execution_id.reset(token)
```

Before: blows up with `AttributeError: NoneType object has no attribute copy`. Not great.
After: builds headers with `execution_id`, we chill.

## Test
`uv run --python 3.10 --with-requirements requirements/requirements.sdk.http.txt --with-requirements requirements/requirements.test.unit.txt pytest tests/inference_sdk/unit_tests/http/utils/test_request_building.py`

11 passed.
