### PR TITLE
fix(dynamic_crop): missing output 

### DIFF
--- a/inference/core/workflows/core_steps/transformations/dynamic_crop/v1.py
+++ b/inference/core/workflows/core_steps/transformations/dynamic_crop/v1.py
@@ -214,7 +214,7 @@ def crop_image(
     ):
         cropped_image = image.numpy_image[y_min:y_max, x_min:x_max]
         if not cropped_image.size:
-            crops.append({"crops": None})
+            crops.append({"crops": None, "predictions": None})
             continue
         if mask_opacity > 0 and detections.mask is not None:
             detection_mask = detections.mask[idx]

--- a/tests/workflows/unit_tests/core_steps/transformations/test_crop.py
+++ b/tests/workflows/unit_tests/core_steps/transformations/test_crop.py
@@ -219,11 +219,63 @@ def test_crop_image_on_zero_size_detections() -> None:
 
     # then
     assert len(result) == 3, "Expected 3 outputs"
-    assert result[0] == {"crops": None}, "Expected first element empty"
+    assert result[0] == {
+        "crops": None,
+        "predictions": None,
+    }, "Both manifest-declared keys must be present, even on zero-area"
+    assert set(result[1].keys()) == {
+        "crops",
+        "predictions",
+    }, "Happy path must produce both manifest-declared keys"
     assert (
         result[1]["crops"].parent_metadata.parent_id == "two"
     ), "Appropriate parent id (from detection id) must be attached"
-    assert result[2] == {"crops": None}, "Expected last element empty"
+    assert result[2] == {
+        "crops": None,
+        "predictions": None,
+    }, "Both manifest-declared keys must be present, even on zero-area"
+
+
+def test_crop_image_output_keys_match_manifest_on_mixed_detections() -> None:
+    # given a mix of zero-area and valid detections
+    np_image = np.zeros((1000, 1000, 3), dtype=np.uint8)
+    image = WorkflowImageData(
+        parent_metadata=ImageParentMetadata(parent_id="origin_image"),
+        numpy_image=np_image,
+    )
+    detections = sv.Detections(
+        xyxy=np.array(
+            [[0, 0, 0, 0], [80, 80, 120, 120]], dtype=np.float64
+        ),
+        class_id=np.array([1, 1]),
+        confidence=np.array([0.5, 0.5], dtype=np.float64),
+        data={
+            "detection_id": np.array(["zero", "valid"]),
+            "class_name": np.array(["cat", "cat"]),
+        },
+    )
+
+    # when
+    result = crop_image(
+        image=image,
+        detections=detections,
+        mask_opacity=0.0,
+        background_color=(0, 0, 0),
+    )
+
+    # then — every emitted dict must carry exactly the manifest output keys
+    expected_keys = {
+        output.name for output in BlockManifest.describe_outputs()
+    }
+    assert expected_keys == {"crops", "predictions"}, (
+        "Sanity: manifest declares the two outputs this test locks against. "
+        "If this changes, update the assertion below accordingly."
+    )
+    for i, element in enumerate(result):
+        assert set(element.keys()) == expected_keys, (
+            f"Element {i} keys {set(element.keys())} != manifest keys "
+            f"{expected_keys}"
+        )
 
 
 def test_crop_image_when_detections_without_ids_provided() -> None:


### PR DESCRIPTION
## What does this PR do?

<!-- Provide a clear and concise description of the changes -->


The zero-area branch in crop_image() appended {"crops": None} while the manifest declares two outputs (crops, predictions). The execution engine's strict set-equality check on element keys then failed the step with `Expected: {'predictions', 'crops'}. Got: {'crops'}` whenever a detection's bbox rounded to zero width/height. Drift dates to commit b4e3ab96b which added the predictions output to the manifest and happy path but missed this error path.

Test updates pin the two-key contract and add a regression that locks crop_image() output keys against BlockManifest.describe_outputs().
## Type of Change

<!-- Please select one and delete the others, or describe if Other -->

- Bug fix (non-breaking change that fixes an issue)


## Testing

<!-- Describe how you tested your changes -->

- [x] I have tested this change locally
- [x] I have added/updated tests for this change

**Test details:**
<!-- Describe what tests were added/updated and what they cover -->

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)

## Additional Context

<!-- Add any other context, screenshots, or notes about the PR here -->
