### PR TITLE
Fix wrong step name rewrite when inner and outer workflow have the same step name, and outer step provided in bindings

### DIFF
--- a/inference/core/workflows/execution_engine/v1/inner_workflow/inline.py
+++ b/inference/core/workflows/execution_engine/v1/inner_workflow/inline.py
@@ -256,11 +256,13 @@ def _rewrite_inner_scalar(
 
     Non-strings are returned unchanged. For strings, replacements run in order:
 
-    1. ``_replace_inputs_in_string`` — workflow inputs and defaults.
-    2. If that step produced a non-string (whole ``$inputs.*`` reference), it is returned as-is;
-       dotted step references are not applied to non-strings.
-    3. ``_replace_step_prefixes_in_string`` — ``$steps.<child>.`` → ``$steps.<new>.``.
-    4. ``_replace_bare_child_step_refs_in_string`` — bare ``$steps.<child>`` tokens.
+    1. ``_replace_step_prefixes_in_string`` — ``$steps.<child>.`` → ``$steps.<new>.``.
+    2. ``_replace_bare_child_step_refs_in_string`` — bare ``$steps.<child>`` tokens.
+    3. ``_replace_inputs_in_string`` — workflow inputs and defaults (parent selectors).
+
+    Child step renames run before parameter bindings so a binding such as
+    ``$steps.dynamic_crop.crops`` that refers to a parent step is not rewritten when the
+    child workflow also defines a step named ``dynamic_crop``.
 
     ``step_pairs`` maps each original child step name to its unique name after inlining
     (typically ``f"{inner_name}__{child_step}"``).
@@ -293,26 +295,21 @@ def _rewrite_inner_scalar(
     if not isinstance(value, str):
         return value
 
-    after_inputs = _replace_inputs_in_string(
-        value,
-        bindings=bindings,
-        input_defaults=input_defaults,
-    )
-
-    if not isinstance(after_inputs, str):
-        return after_inputs
-
     dotted = _replace_step_prefixes_in_string(
-        after_inputs,
+        value,
         old_to_new=step_pairs,
     )
 
-    out = _replace_bare_child_step_refs_in_string(
+    after_bare = _replace_bare_child_step_refs_in_string(
         dotted,
         step_pairs=step_pairs,
     )
 
-    return out
+    return _replace_inputs_in_string(
+        after_bare,
+        bindings=bindings,
+        input_defaults=input_defaults,
+    )
 
 
 def _deep_map_leaves(obj: Any, fn: Callable[[Any], Any]) -> Any:

--- a/tests/workflows/unit_tests/execution_engine/inner_workflow/test_inline.py
+++ b/tests/workflows/unit_tests/execution_engine/inner_workflow/test_inline.py
@@ -221,7 +221,7 @@ def test_rewrite_inner_scalar_non_string_unchanged() -> None:
     ) == {"nested": True}
 
 
-def test_rewrite_inner_scalar_pipeline_inputs_then_dotted_then_bare() -> None:
+def test_rewrite_inner_scalar_pipeline_dotted_then_bare_then_inputs() -> None:
     out = _rewrite_inner_scalar(
         "$inputs.msg and $steps.echo.out and $steps.echo",
         step_pairs=[("echo", "inner__echo")],
@@ -229,6 +229,17 @@ def test_rewrite_inner_scalar_pipeline_inputs_then_dotted_then_bare() -> None:
         input_defaults={},
     )
     assert out == "hello and $steps.inner__echo.out and $steps.inner__echo"
+
+
+def test_rewrite_inner_scalar_preserves_parent_step_in_parameter_binding() -> None:
+    """Parent ``$steps.<name>`` in bindings must not be renamed to the inlined child step."""
+    out = _rewrite_inner_scalar(
+        "$inputs.vehicle_image",
+        step_pairs=[("dynamic_crop", "inner__dynamic_crop")],
+        bindings={"vehicle_image": "$steps.dynamic_crop.crops"},
+        input_defaults={},
+    )
+    assert out == "$steps.dynamic_crop.crops"
 
 
 def test_rewrite_inner_scalar_whole_input_non_string_skips_step_rewrite() -> None:


### PR DESCRIPTION
## What does this PR do?

Fixes a false `ExecutionGraphStructureError` (detected cycle) when compiling workflows that use `roboflow_core/inner_workflow@v1` and pass a **parent** step reference through `parameter_bindings` while the **child** workflow defines a step with the same name.

During inlining, `_rewrite_inner_scalar` previously applied parameter bindings before renaming child steps. A binding such as `$steps.dynamic_crop.crops` (parent) was then incorrectly rewritten to `$steps.{inner}__dynamic_crop.crops` when the child also had a step named `dynamic_crop`, creating a self-edge on the inlined `dynamic_crop` step and a compile-time cycle.

This PR reorders scalar rewriting so child step renames run **before** input/binding substitution, preserving parent selectors in bindings.

**Related Issue(s):** N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other:

## Testing

- [x] I have tested this change locally
- [x] I have added/updated tests for this change

**Test details:**

- Updated `test_rewrite_inner_scalar_pipeline_*` to reflect the new replacement order (child step renames → bare step refs → parameter bindings).
- Added `test_rewrite_inner_scalar_preserves_parent_step_in_parameter_binding` to assert that `$inputs.vehicle_image` bound to `$steps.dynamic_crop.crops` stays a parent reference when the child also has a `dynamic_crop` step.
- Verified manually with a nested workflow (parent `dynamic_crop` → `inner_workflow` with child `dynamic_crop` + `parameter_bindings.vehicle_image: $steps.dynamic_crop.crops`): compilation succeeds and the inlined child `dynamic_crop` uses `$steps.dynamic_crop.crops` instead of a self-reference.

**Commands run:**

```bash
uv run pytest tests/workflows/unit_tests/execution_engine/inner_workflow/test_inline.py -q
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [ ] I have updated the documentation accordingly (if applicable)

## Additional Context

**Root cause example**

Parent workflow binds inner input to parent crops:

```json
"parameter_bindings": {
  "vehicle_image": "$steps.dynamic_crop.crops"
}
```

Child workflow (before inlining) uses `$inputs.vehicle_image` on its own `dynamic_crop` step. After the buggy order, `images` became `$steps.license_plate_number_extractor__dynamic_crop.crops` (self-loop). After this fix, it correctly remains `$steps.dynamic_crop.crops`.

**Files changed**

- `inference/core/workflows/execution_engine/v1/inner_workflow/inline.py` — reorder steps in `_rewrite_inner_scalar`
- `tests/workflows/unit_tests/execution_engine/inner_workflow/test_inline.py` — unit test coverage
