### PR TITLE
Only push usage payloads when WebRTC connection was established

### DIFF
--- a/inference/core/interfaces/webrtc_worker/modal.py
+++ b/inference/core/interfaces/webrtc_worker/modal.py
@@ -458,11 +458,12 @@ if modal is not None:
                     else 0
                 ),
             )
-            usage_collector.push_usage_payloads()
+
             logger.info("Function completed")
 
             if no_frames_processed:
                 if watchdog.connection_established:
+                    usage_collector.push_usage_payloads()
                     raise Exception(
                         "WebRTC connection was established but no frames were processed. "
                         "This typically indicates an invalid RTSP stream URL or corrupted video file."
@@ -472,6 +473,7 @@ if modal is not None:
                         "WebRTC connection could not be established. "
                         "No frames were processed."
                     )
+            usage_collector.push_usage_payloads()
 
         @modal.exit()
         def stop(self):


### PR DESCRIPTION

## What does this PR do?
Previously usage payloads were always flushed when the modal function completed, including the case where no WebRTC connection could be established at all. Move the push so it only fires on the success path and on the "connection established but no frames" error path, and skip it entirely when the connection was never established.


## Type of Change
- Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] I have tested this change locally

**Test details:**
Running locally

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [ ] I have updated the documentation accordingly (if applicable)

## Additional Context

N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts usage-flush behavior in the WebRTC Modal worker, which can affect billing/telemetry accuracy. Change is small and localized but touches usage reporting on error paths.
> 
> **Overview**
> Usage tracking in `webrtc_worker/modal.py` is adjusted so `usage_collector.push_usage_payloads()` is **not** called when a WebRTC connection was never established.
> 
> Payloads are now flushed only on the normal success path and on the "connection established but no frames processed" failure path, avoiding sending usage for sessions that never connected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a22cb06119ff7200e93c9e1d5e40c0dc0f9c654. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->