### PR TITLE
feat(batch-processing-cli): add --max-image-failure-rate flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -215,3 +215,6 @@ inference_testing
 
 # rerun.io recordings
 *.rrd
+
+openspec*/
+opsx/

--- a/inference_cli/lib/roboflow_cloud/batch_processing/api_operations.py
+++ b/inference_cli/lib/roboflow_cloud/batch_processing/api_operations.py
@@ -401,6 +401,7 @@ def trigger_job_with_workflows_images_processing(
     api_key: str,
     inference_backend: Optional[InferenceBackend] = None,
     job_name: Optional[str] = None,
+    max_image_failure_rate: Optional[float] = None,
 ) -> str:
     workspace = get_workspace(api_key=api_key)
     compute_configuration = ComputeConfigurationV2(
@@ -431,6 +432,7 @@ def trigger_job_with_workflows_images_processing(
         compute_configuration=compute_configuration,
         processing_timeout_seconds=max_runtime_seconds,
         max_parallel_tasks=max_parallel_tasks,
+        max_image_failure_rate=max_image_failure_rate,
         processing_specification=processing_specification,
         notifications_url=notifications_url,
         inference_backend=inference_backend,
@@ -755,6 +757,7 @@ def restart_batch_job(
     workers_per_machine: Optional[int] = None,
     max_runtime_seconds: Optional[float] = None,
     max_parallel_tasks: Optional[int] = None,
+    max_image_failure_rate: Optional[float] = None,
 ) -> None:
     workspace = get_workspace(api_key=api_key)
     response = send_restart_job_request(
@@ -765,6 +768,7 @@ def restart_batch_job(
         workers_per_machine=workers_per_machine,
         max_runtime_seconds=max_runtime_seconds,
         max_parallel_tasks=max_parallel_tasks,
+        max_image_failure_rate=max_image_failure_rate,
     )
     console = Console()
     console.print(JSON.from_data(response, indent=2))
@@ -784,6 +788,7 @@ def send_restart_job_request(
     workers_per_machine: Optional[int] = None,
     max_runtime_seconds: Optional[float] = None,
     max_parallel_tasks: Optional[int] = None,
+    max_image_failure_rate: Optional[float] = None,
 ) -> dict:
     payload = {
         "type": "parameters-override-v1",
@@ -799,6 +804,8 @@ def send_restart_job_request(
         payload["maxParallelTasks"] = max_parallel_tasks
     if max_runtime_seconds is not None:
         payload["processingTimeoutSeconds"] = max_runtime_seconds
+    if max_image_failure_rate is not None:
+        payload["maxImageFailureRate"] = max_image_failure_rate
     params = {"api_key": api_key}
     try:
         response = requests.post(

--- a/inference_cli/lib/roboflow_cloud/batch_processing/core.py
+++ b/inference_cli/lib/roboflow_cloud/batch_processing/core.py
@@ -189,6 +189,19 @@ def process_images_with_workflow(
             "--max-parallel-tasks", help="Max number of concurrent processing tasks"
         ),
     ] = None,
+    max_image_failure_rate: Annotated[
+        Optional[float],
+        typer.Option(
+            "--max-image-failure-rate",
+            help=(
+                "Maximum fraction of images per shard that may fail before the shard "
+                "is aborted (0.0-1.0). Default: 10 absolute failures per shard "
+                "(~3.9% on a full 256-image shard, higher effective tolerance on "
+                "partial last shards). No client-side validation is performed; "
+                "out-of-range values are rejected by the server with HTTP 400."
+            ),
+        ),
+    ] = None,
     aggregation_format: Annotated[
         Optional[AggregationFormat],
         typer.Option("--aggregation-format", help="Format of results aggregation"),
@@ -261,6 +274,7 @@ def process_images_with_workflow(
             api_key=api_key,
             inference_backend=inference_backend,
             job_name=job_name,
+            max_image_failure_rate=max_image_failure_rate,
         )
         print(f"Triggered job with ID: {job_id}")
     except KeyboardInterrupt:
@@ -591,6 +605,19 @@ def restart_job(
             "--max-parallel-tasks", help="Max number of concurrent processing tasks"
         ),
     ] = None,
+    max_image_failure_rate: Annotated[
+        Optional[float],
+        typer.Option(
+            "--max-image-failure-rate",
+            help=(
+                "Maximum fraction of images per shard that may fail before the shard "
+                "is aborted (0.0-1.0). Default: 10 absolute failures per shard "
+                "(~3.9% on a full 256-image shard, higher effective tolerance on "
+                "partial last shards). No client-side validation is performed; "
+                "out-of-range values are rejected by the server with HTTP 400."
+            ),
+        ),
+    ] = None,
     debug_mode: Annotated[
         bool,
         typer.Option(
@@ -610,6 +637,7 @@ def restart_job(
             workers_per_machine=workers_per_machine,
             max_runtime_seconds=max_runtime_seconds,
             max_parallel_tasks=max_parallel_tasks,
+            max_image_failure_rate=max_image_failure_rate,
         )
     except KeyboardInterrupt:
         print("Command interrupted.")

--- a/inference_cli/lib/roboflow_cloud/batch_processing/entities.py
+++ b/inference_cli/lib/roboflow_cloud/batch_processing/entities.py
@@ -144,6 +144,9 @@ class WorkflowProcessingJobV1(BaseModel):
     max_parallel_tasks: Optional[int] = Field(
         serialization_alias="maxParallelTasks", default=None
     )
+    max_image_failure_rate: Optional[float] = Field(
+        serialization_alias="maxImageFailureRate", default=None
+    )
     processing_specification: WorkflowsProcessingSpecificationV1 = Field(
         serialization_alias="processingSpecification"
     )


### PR DESCRIPTION
## Summary

- Adds a new `--max-image-failure-rate` flag to `inference rf-cloud batch-processing process-images-with-workflow` and `restart-job`. Value is a `float` in `[0.0, 1.0]`; semantic is "fraction of images per shard that may fail before the worker aborts that shard."