### PR TITLE
Fix RLE mask parsing for instance segmentation remote execution

### DIFF
--- a/inference/core/workflows/core_steps/common/utils.py
+++ b/inference/core/workflows/core_steps/common/utils.py
@@ -33,6 +33,8 @@ from inference.core.workflows.execution_engine.constants import (
     PARENT_ID_KEY,
     POLYGON_KEY_IN_SV_DETECTIONS,
     PREDICTION_TYPE_KEY,
+    RLE_MASK_KEY_IN_INFERENCE_RESPONSE,
+    RLE_MASK_KEY_IN_SV_DETECTIONS,
     ROOT_PARENT_COORDINATES_KEY,
     ROOT_PARENT_DIMENSIONS_KEY,
     ROOT_PARENT_ID_KEY,
@@ -124,6 +126,14 @@ def convert_inference_detections_batch_to_sv_detections(
         if INFERENCE_ID_KEY in p:
             detections[INFERENCE_ID_KEY] = np.array(
                 [p[INFERENCE_ID_KEY]] * len(detections)
+            )
+        rle_masks = [
+            d.get(RLE_MASK_KEY_IN_INFERENCE_RESPONSE) or d.get("rle")
+            for d in raw_predictions
+        ]
+        if any(m is not None for m in rle_masks):
+            detections.data[RLE_MASK_KEY_IN_SV_DETECTIONS] = np.array(
+                rle_masks, dtype=object
             )
         batch_of_detections.append(detections)
     return batch_of_detections

--- a/inference/core/workflows/core_steps/loader.py
+++ b/inference/core/workflows/core_steps/loader.py
@@ -332,6 +332,9 @@ from inference.core.workflows.core_steps.models.foundation.segment_anything3.v2 
 from inference.core.workflows.core_steps.models.foundation.segment_anything3.v3 import (
     SegmentAnything3BlockV3,
 )
+from inference.core.workflows.core_steps.models.roboflow.instance_segmentation.v4 import (
+    RoboflowInstanceSegmentationModelBlockV4,
+)
 
 if SAM3_3D_OBJECTS_ENABLED:
     from inference.core.workflows.core_steps.models.foundation.segment_anything3_3d.v1 import (
@@ -929,6 +932,7 @@ def load_blocks() -> List[Type[WorkflowBlock]]:
         VelocityBlockV1,
         RoboflowInstanceSegmentationModelBlockV2,
         RoboflowInstanceSegmentationModelBlockV3,
+        RoboflowInstanceSegmentationModelBlockV4,
         RoboflowSemanticSegmentationModelBlockV1,
         RoboflowSemanticSegmentationModelBlockV2,
         RoboflowKeypointDetectionModelBlockV2,

--- a/inference/core/workflows/core_steps/models/roboflow/instance_segmentation/v3.py
+++ b/inference/core/workflows/core_steps/models/roboflow/instance_segmentation/v3.py
@@ -374,6 +374,7 @@ class RoboflowInstanceSegmentationModelBlockV3(WorkflowBlock):
             max_candidates=max_candidates,
             mask_decode_mode=mask_decode_mode,
             tradeoff_factor=tradeoff_factor,
+            response_mask_format="rle",
             max_batch_size=WORKFLOWS_REMOTE_EXECUTION_MAX_STEP_BATCH_SIZE,
             max_concurrent_requests=WORKFLOWS_REMOTE_EXECUTION_MAX_STEP_CONCURRENT_REQUESTS,
             source="workflow-execution",

--- a/inference/core/workflows/core_steps/models/roboflow/instance_segmentation/v4.py
+++ b/inference/core/workflows/core_steps/models/roboflow/instance_segmentation/v4.py
@@ -58,6 +58,10 @@ on [Roboflow Universe](https://universe.roboflow.com).
 You will need to set your Roboflow API key in your Inference environment to use this
 block. To learn more about setting your Roboflow API key, [refer to the Inference
 documentation](https://inference.roboflow.com/quickstart/configure_api_key/).
+
+This version of block introduces breaking change in behaviour of mask construction - it uses 
+`rle` format instead `polygon` making it possible to retrieve 
+shapes of any kind from remote server.
 """
 
 
@@ -81,7 +85,7 @@ class BlockManifest(WorkflowBlockManifest):
         },
         protected_namespaces=(),
     )
-    type: Literal["roboflow_core/roboflow_instance_segmentation_model@v3"]
+    type: Literal["roboflow_core/roboflow_instance_segmentation_model@v4"]
     images: Selector(kind=[IMAGE_KIND]) = ImageInputField
     model_id: Union[Selector(kind=[ROBOFLOW_MODEL_ID_KIND]), str] = RoboflowModelField
     confidence_mode: Union[
@@ -212,7 +216,7 @@ class BlockManifest(WorkflowBlockManifest):
         return ">=1.3.0,<2.0.0"
 
 
-class RoboflowInstanceSegmentationModelBlockV3(WorkflowBlock):
+class RoboflowInstanceSegmentationModelBlockV4(WorkflowBlock):
 
     def __init__(
         self,
@@ -317,6 +321,7 @@ class RoboflowInstanceSegmentationModelBlockV3(WorkflowBlock):
             mask_decode_mode=mask_decode_mode,
             tradeoff_factor=tradeoff_factor,
             source="workflow-execution",
+            response_mask_format="rle",
         )
         self._model_manager.add_model(
             model_id=model_id,
@@ -374,6 +379,7 @@ class RoboflowInstanceSegmentationModelBlockV3(WorkflowBlock):
             max_candidates=max_candidates,
             mask_decode_mode=mask_decode_mode,
             tradeoff_factor=tradeoff_factor,
+            response_mask_format="rle",
             max_batch_size=WORKFLOWS_REMOTE_EXECUTION_MAX_STEP_BATCH_SIZE,
             max_concurrent_requests=WORKFLOWS_REMOTE_EXECUTION_MAX_STEP_CONCURRENT_REQUESTS,
             source="workflow-execution",


### PR DESCRIPTION
Request `response_mask_format="rle"` when the instance segmentation v3 block runs remotely, and propagate raw RLE dicts from the API response into `detections.data["rle_mask"]` so downstream workflow blocks can decode them correctly.