### PR TITLE
eject leaked bf16 autocast from Sam3TrackerPredictor

### DIFF
--- a/inference_models/inference_models/models/sam3/sam3_torch.py
+++ b/inference_models/inference_models/models/sam3/sam3_torch.py
@@ -50,6 +50,20 @@ SUPPORTED_VERSIONS = {
 }
 
 
+def _eject_sam3_leaked_bf16_autocast(sam3_model) -> None:
+    inst_predictor = getattr(sam3_model, "inst_interactive_predictor", None)
+    if inst_predictor is None:
+        return
+    tracker = getattr(inst_predictor, "model", None)
+    ctx = getattr(tracker, "bf16_context", None)
+    if ctx is None:
+        return
+    try:
+        ctx.__exit__(None, None, None)
+    finally:
+        tracker.bf16_context = None
+
+
 class SAM3Torch:
     @classmethod
     def from_pretrained(
@@ -106,6 +120,12 @@ class SAM3Torch:
             compile=compile_model,
             enable_inst_interactivity=enable_inst_interactivity,
         )
+        # sam3==0.1.3 Sam3TrackerPredictor.__init__ enters a CUDA bf16
+        # torch.autocast context and never exits it, leaking bf16 globally
+        # for the rest of the process and breaking unrelated models in the
+        # same pytest session. Eject it; SAM3 inference paths in this file
+        # re-enter autocast in scoped `with` blocks where actually needed.
+        _eject_sam3_leaked_bf16_autocast(sam3_model)
 
         transform = ComposeAPI(
             transforms=[


### PR DESCRIPTION
## What does this PR do?

sam3==0.1.3 enters CUDA bf16 torch.autocast in __init__ and never exits, poisoning every other torch model in the same process.

## Type of Change

- Bug fix (non-breaking change that fixes an issue)

## Testing

tested below on main and on this branch:

pytest -x -p no:randomly tests/integration_tests/models/test_sam3_predictions.py::test_sam3_segment_images_with_point_prompting tests/integration_tests/models/test_sam_predictions.py::test_sam_predictions_without_prompting_numpy tests/integration_tests/models/test_vit_classifier_predictions_torch.py::test_multi_label_hf_package_numpy

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)

## Additional Context

N/A