### PR TITLE
Support dynamic blocks inside inner workflows

### DIFF
--- a/inference/core/workflows/execution_engine/v1/compiler/core.py
+++ b/inference/core/workflows/execution_engine/v1/compiler/core.py
@@ -47,6 +47,7 @@ from inference.core.workflows.execution_engine.v1.dynamic_blocks.block_assembler
     ensure_dynamic_blocks_allowed,
 )
 from inference.core.workflows.execution_engine.v1.inner_workflow.compiler_bridge import (
+    collect_dynamic_blocks_definitions_from_raw_workflow_definition,
     validate_inner_workflow_composition_from_raw_workflow_definition,
 )
 from inference.core.workflows.execution_engine.v1.inner_workflow.inline import (
@@ -121,8 +122,10 @@ def compile_workflow_graph(
     )
     cached_value = COMPILATION_CACHE.get(key=key)
     if cached_value is not None:
-        dynamic_blocks_definitions = workflow_definition.get(
-            "dynamic_blocks_definitions", []
+        dynamic_blocks_definitions = (
+            collect_dynamic_blocks_definitions_from_raw_workflow_definition(
+                workflow_definition
+            )
         )
         ensure_dynamic_blocks_allowed(
             dynamic_blocks_definitions=dynamic_blocks_definitions
@@ -134,6 +137,9 @@ def compile_workflow_graph(
             init_parameters=init_parameters,
         )
     )
+    validate_inner_workflow_composition_from_raw_workflow_definition(
+        raw_workflow_definition
+    )
     statically_defined_blocks = load_workflow_blocks(
         execution_engine_version=execution_engine_version,
         profiler=profiler,
@@ -141,17 +147,17 @@ def compile_workflow_graph(
     initializers = load_initializers(profiler=profiler)
     kinds_serializers = load_kinds_serializers(profiler=profiler)
     kinds_deserializers = load_kinds_deserializers(profiler=profiler)
+    dynamic_blocks_definitions = (
+        collect_dynamic_blocks_definitions_from_raw_workflow_definition(
+            raw_workflow_definition
+        )
+    )
     dynamic_blocks = compile_dynamic_blocks(
-        dynamic_blocks_definitions=raw_workflow_definition.get(
-            "dynamic_blocks_definitions", []
-        ),
+        dynamic_blocks_definitions=dynamic_blocks_definitions,
         profiler=profiler,
         api_key=init_parameters.get("workflows_core.api_key", None),
     )
     available_blocks = statically_defined_blocks + dynamic_blocks
-    validate_inner_workflow_composition_from_raw_workflow_definition(
-        raw_workflow_definition
-    )
     inlined_raw_workflow_definition: Dict[str, Any] = inline_inner_workflow_steps(
         raw_workflow_definition,
         available_blocks=available_blocks,

--- a/inference/core/workflows/execution_engine/v1/inner_workflow/compiler_bridge.py
+++ b/inference/core/workflows/execution_engine/v1/inner_workflow/compiler_bridge.py
@@ -34,6 +34,46 @@ from inference.core.workflows.execution_engine.v1.inner_workflow.errors import (
 )
 
 
+def collect_dynamic_blocks_definitions_from_raw_workflow_definition(
+    raw_workflow_definition: Dict[str, Any],
+) -> List[Dict[str, Any]]:
+    definitions: List[Dict[str, Any]] = []
+    seen: Set[str] = set()
+    visiting: Set[int] = set()
+
+    def visit(workflow_definition: Dict[str, Any]) -> None:
+        workflow_object_id = id(workflow_definition)
+        if workflow_object_id in visiting:
+            raise InnerWorkflowInvalidStepEntryError(
+                "Circular inner_workflow definition detected while collecting dynamic block definitions."
+            )
+        visiting.add(workflow_object_id)
+
+        for dynamic_block_definition in (
+            workflow_definition.get("dynamic_blocks_definitions") or []
+        ):
+            definition_key = json.dumps(
+                dynamic_block_definition, sort_keys=True, separators=(",", ":")
+            )
+            if definition_key in seen:
+                continue
+            seen.add(definition_key)
+            definitions.append(dynamic_block_definition)
+
+        for step in workflow_definition.get("steps") or []:
+            if (
+                isinstance(step, dict)
+                and step.get("type") == USE_INNER_WORKFLOW_BLOCK_TYPE
+                and isinstance(step.get("workflow_definition"), dict)
+            ):
+                visit(step["workflow_definition"])
+
+        visiting.remove(workflow_object_id)
+
+    visit(raw_workflow_definition)
+    return definitions
+
+
 def validate_inner_workflow_composition_from_raw_workflow_definition(
     raw_workflow_definition: Dict[str, Any],
 ) -> None:

--- a/tests/workflows/unit_tests/execution_engine/inner_workflow/test_dynamic_blocks_collection.py
+++ b/tests/workflows/unit_tests/execution_engine/inner_workflow/test_dynamic_blocks_collection.py
@@ -1,0 +1,129 @@
+import pytest
+
+from inference.core.workflows.execution_engine.v1.inner_workflow.compiler_bridge import (
+    collect_dynamic_blocks_definitions_from_raw_workflow_definition,
+)
+from inference.core.workflows.execution_engine.v1.inner_workflow.constants import (
+    USE_INNER_WORKFLOW_BLOCK_TYPE,
+)
+from inference.core.workflows.execution_engine.v1.inner_workflow.errors import (
+    InnerWorkflowInvalidStepEntryError,
+)
+
+
+def _dynamic_block_definition(block_type: str) -> dict:
+    return {
+        "type": "DynamicBlockDefinition",
+        "manifest": {
+            "type": "ManifestDescription",
+            "block_type": block_type,
+            "inputs": {
+                "value": {
+                    "type": "DynamicInputDefinition",
+                    "value_types": ["float"],
+                },
+            },
+            "outputs": {"output": {"type": "DynamicOutputDefinition", "kind": []}},
+        },
+        "code": {
+            "type": "PythonCode",
+            "run_function_code": "def run(self, value):\n    return {'output': value}\n",
+        },
+    }
+
+
+def test_collects_dynamic_blocks_from_inner_workflow_definitions() -> None:
+    root_block = _dynamic_block_definition("RootDynamicBlock")
+    child_block = _dynamic_block_definition("ConfidenceTransformer")
+    grandchild_block = _dynamic_block_definition("GrandchildDynamicBlock")
+    workflow_definition = {
+        "version": "1.0",
+        "inputs": [],
+        "dynamic_blocks_definitions": [root_block],
+        "steps": [
+            {
+                "type": USE_INNER_WORKFLOW_BLOCK_TYPE,
+                "name": "inner",
+                "workflow_definition": {
+                    "version": "1.0",
+                    "inputs": [],
+                    "dynamic_blocks_definitions": [child_block],
+                    "steps": [
+                        {
+                            "type": USE_INNER_WORKFLOW_BLOCK_TYPE,
+                            "name": "grandchild",
+                            "workflow_definition": {
+                                "version": "1.0",
+                                "inputs": [],
+                                "dynamic_blocks_definitions": [grandchild_block],
+                                "steps": [],
+                                "outputs": [],
+                            },
+                            "parameter_bindings": {},
+                        }
+                    ],
+                    "outputs": [],
+                },
+                "parameter_bindings": {},
+            }
+        ],
+        "outputs": [],
+    }
+
+    result = collect_dynamic_blocks_definitions_from_raw_workflow_definition(
+        workflow_definition
+    )
+
+    assert result == [root_block, child_block, grandchild_block]
+
+
+def test_collecting_dynamic_blocks_deduplicates_exact_repeated_definitions() -> None:
+    shared_block = _dynamic_block_definition("SharedDynamicBlock")
+    workflow_definition = {
+        "version": "1.0",
+        "inputs": [],
+        "dynamic_blocks_definitions": [shared_block],
+        "steps": [
+            {
+                "type": USE_INNER_WORKFLOW_BLOCK_TYPE,
+                "name": "inner",
+                "workflow_definition": {
+                    "version": "1.0",
+                    "inputs": [],
+                    "dynamic_blocks_definitions": [shared_block],
+                    "steps": [],
+                    "outputs": [],
+                },
+                "parameter_bindings": {},
+            }
+        ],
+        "outputs": [],
+    }
+
+    result = collect_dynamic_blocks_definitions_from_raw_workflow_definition(
+        workflow_definition
+    )
+
+    assert result == [shared_block]
+
+
+def test_collecting_dynamic_blocks_rejects_circular_python_workflow_objects() -> None:
+    workflow_definition = {
+        "version": "1.0",
+        "inputs": [],
+        "steps": [],
+        "outputs": [],
+    }
+    workflow_definition["steps"].append(
+        {
+            "type": USE_INNER_WORKFLOW_BLOCK_TYPE,
+            "name": "inner",
+            "workflow_definition": workflow_definition,
+            "parameter_bindings": {},
+        }
+    )
+
+    with pytest.raises(InnerWorkflowInvalidStepEntryError, match="Circular"):
+        collect_dynamic_blocks_definitions_from_raw_workflow_definition(
+            workflow_definition
+        )

--- a/tests/workflows/unit_tests/execution_engine/inner_workflow/test_nested_dynamic_blocks.py
+++ b/tests/workflows/unit_tests/execution_engine/inner_workflow/test_nested_dynamic_blocks.py
@@ -1,0 +1,107 @@
+from inference.core.workflows.execution_engine.v1.compiler.core import (
+    compile_workflow_graph,
+)
+from inference.core.workflows.execution_engine.v1.inner_workflow.constants import (
+    USE_INNER_WORKFLOW_BLOCK_TYPE,
+)
+
+
+def _confidence_transformer_dynamic_block() -> dict:
+    return {
+        "type": "DynamicBlockDefinition",
+        "manifest": {
+            "type": "ManifestDescription",
+            "block_type": "ConfidenceTransformer",
+            "inputs": {
+                "confidence": {
+                    "type": "DynamicInputDefinition",
+                    "selector_types": ["input_parameter"],
+                    "selector_data_kind": {"input_parameter": ["*"]},
+                    "value_types": ["float"],
+                    "has_default_value": True,
+                    "default_value": 0.5,
+                },
+            },
+            "outputs": {
+                "transformed_confidence": {
+                    "type": "DynamicOutputDefinition",
+                    "kind": [],
+                },
+            },
+        },
+        "code": {
+            "type": "PythonCode",
+            "run_function_code": """
+import math
+
+def run(self, confidence=0.5):
+    try:
+        value = float(confidence)
+    except (TypeError, ValueError):
+        value = 0.5
+
+    if not math.isfinite(value):
+        value = 0.5
+
+    transformed = 0.75 + value * 0.25
+    transformed = max(0.0, min(1.0, transformed))
+    return {"transformed_confidence": round(transformed, 4)}
+""",
+        },
+    }
+
+
+def _workflow_with_nested_dynamic_block_definition() -> dict:
+    child_workflow = {
+        "version": "1.0",
+        "inputs": [
+            {"type": "WorkflowParameter", "name": "confidence"},
+        ],
+        "dynamic_blocks_definitions": [_confidence_transformer_dynamic_block()],
+        "steps": [
+            {
+                "type": "ConfidenceTransformer",
+                "name": "transform_confidence",
+                "confidence": "$inputs.confidence",
+            },
+        ],
+        "outputs": [
+            {
+                "type": "JsonField",
+                "name": "transformed_confidence",
+                "selector": "$steps.transform_confidence.transformed_confidence",
+            },
+        ],
+    }
+    return {
+        "version": "1.0",
+        "inputs": [
+            {"type": "WorkflowParameter", "name": "confidence"},
+        ],
+        "steps": [
+            {
+                "type": USE_INNER_WORKFLOW_BLOCK_TYPE,
+                "name": "inner",
+                "workflow_definition": child_workflow,
+                "parameter_bindings": {"confidence": "$inputs.confidence"},
+            },
+        ],
+        "outputs": [
+            {
+                "type": "JsonField",
+                "name": "transformed_confidence",
+                "selector": "$steps.inner.transformed_confidence",
+            },
+        ],
+    }
+
+
+def test_compiles_dynamic_block_definition_declared_inside_inner_workflow() -> None:
+    result = compile_workflow_graph(
+        workflow_definition=_workflow_with_nested_dynamic_block_definition(),
+        init_parameters={},
+    )
+
+    assert [
+        (step.name, step.type) for step in result.parsed_workflow_definition.steps
+    ] == [("inner__transform_confidence", "ConfidenceTransformer")]


### PR DESCRIPTION
# Description

Collect dynamic block definitions recursively from inline inner workflow definitions before compiling workflow block manifests.

Previously, `compile_workflow_graph()` only compiled `dynamic_blocks_definitions` from the root workflow. During inner workflow inlining, child workflow steps were parsed against that root-only block registry, so a custom Python block declared inside the child workflow, such as `ConfidenceTransformer`, failed validation with an unknown discriminator tag.

This change collects dynamic block definitions from the root workflow and nested `roboflow_core/inner_workflow@v1` definitions before building `available_blocks`. Exact repeated definitions are deduplicated to avoid registering the same nested block more than once.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

- Added unit coverage for recursively collecting dynamic block definitions from nested inner workflows.
- Added regression coverage for compiling an inner workflow whose child definition declares and uses `ConfidenceTransformer`.
- Ran `pytest tests/workflows/unit_tests/execution_engine/inner_workflow/test_dynamic_blocks_collection.py -q`.
- Ran `python -m py_compile` on touched compiler/test files.
- Could not run the end-to-end compiler regression locally because this checkout's Python env fails importing workflow dependencies before test execution.

## Will the change affect Universe? If so was this change tested in universe?

No

## Any specific deployment considerations

- light-v2-query

### Infrastructure impact

- [ ] This change affects infrastructure needs (GPUs, Cloud Function sizing, storage etc.)
