### PR TITLE
Migrate FastAPI on_event handlers to lifespan

### DIFF
--- a/inference/core/interfaces/http/http_api.py
+++ b/inference/core/interfaces/http/http_api.py
@@ -4,6 +4,7 @@ import logging
 import os
 import re
 from concurrent.futures import CancelledError, Future, ThreadPoolExecutor
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from functools import partial
 from threading import Lock, Thread
@@ -517,6 +518,9 @@ class HttpInterface(BaseInterface):
         model_manager (ModelManager): The manager for handling different models.
     """
 
+    async def startup_hook(self) -> None:
+        """Subclass extension point: extra async work to run on app startup."""
+
     def __init__(
         self,
         model_manager: ModelManager,
@@ -535,6 +539,25 @@ class HttpInterface(BaseInterface):
 
         description = "Roboflow inference server"
 
+        @asynccontextmanager
+        async def lifespan(_app: FastAPI):
+            # startup
+            if should_preload:
+                startup_thread = Thread(
+                    target=initialize_models,
+                    args=(model_init_state,),
+                    daemon=True,
+                )
+                startup_thread.start()
+                logger.info("Model initialization started in the background.")
+            await self.startup_hook()
+            yield
+            # shutdown
+            logger.info("Shutting down %s", description)
+            await usage_collector.async_push_usage_payloads()
+            if OTEL_TRACING_ENABLED:
+                shutdown_telemetry()
+
         app = FastAPI(
             title="Roboflow Inference Server",
             description=description,
@@ -549,6 +572,7 @@ class HttpInterface(BaseInterface):
                 "name": "Apache 2.0",
                 "url": "https://www.apache.org/licenses/LICENSE-2.0.html",
             },
+            lifespan=lifespan,
             root_path=root_path,
         )
         # Ensure in-memory logging is initialized as early as possible for all runtimes
@@ -582,13 +606,6 @@ class HttpInterface(BaseInterface):
                 return await call_next(request)
             finally:
                 current_request_path.reset(token)
-
-        @app.on_event("shutdown")
-        async def on_shutdown():
-            logger.info("Shutting down %s", description)
-            await usage_collector.async_push_usage_payloads()
-            if OTEL_TRACING_ENABLED:
-                shutdown_telemetry()
 
         self._instrumentator = InferenceInstrumentator(
             app, model_manager=model_manager, endpoint="/metrics"
@@ -2483,15 +2500,6 @@ class HttpInterface(BaseInterface):
                 # Update the readiness state in a thread-safe manner
                 with state.lock:
                     state.is_ready = True
-
-            @app.on_event("startup")
-            def startup_model_init():
-                """Initialize the models on startup."""
-                startup_thread = Thread(
-                    target=initialize_models, args=(model_init_state,), daemon=True
-                )
-                startup_thread.start()
-                logger.info("Model initialization started in the background.")
 
         # Attach health/readiness endpoints
         @app.get("/readiness", status_code=200)

--- a/inference/enterprise/parallel/parallel_http_api.py
+++ b/inference/enterprise/parallel/parallel_http_api.py
@@ -13,18 +13,14 @@ from inference.models.utils import ROBOFLOW_MODEL_TYPES
 
 
 class ParallelHttpInterface(HttpInterface):
-    def __init__(self, model_manager: DispatchModelManager, root_path: str = None):
-        super().__init__(model_manager, root_path)
-
-        @self.app.on_event("startup")
-        async def app_startup():
-            model_registry = RoboflowModelRegistry(ROBOFLOW_MODEL_TYPES)
-            checker = ResultsChecker(Redis(host=REDIS_HOST, port=REDIS_PORT))
-            self.model_manager = DispatchModelManager(model_registry, checker)
-            self.model_manager.init_pingback()
-            checker_loop_thread = Thread(
-                target=self.model_manager.checker.loop, args=(), daemon=True
-            )
-            checker_loop_thread.start()
-            # keep checker loop reference so it doesn't get gc'd
-            self.checker_loop = checker_loop_thread
+    async def startup_hook(self) -> None:
+        model_registry = RoboflowModelRegistry(ROBOFLOW_MODEL_TYPES)
+        checker = ResultsChecker(Redis(host=REDIS_HOST, port=REDIS_PORT))
+        self.model_manager = DispatchModelManager(model_registry, checker)
+        self.model_manager.init_pingback()
+        checker_loop_thread = Thread(
+            target=self.model_manager.checker.loop, args=(), daemon=True
+        )
+        checker_loop_thread.start()
+        # keep checker loop reference so it doesn't get gc'd
+        self.checker_loop = checker_loop_thread

--- a/requirements/_requirements.txt
+++ b/requirements/_requirements.txt
@@ -5,7 +5,7 @@ asyncua~=1.1.5
 cachetools<6.0.0
 cython~=3.0.0
 python-dotenv~=1.2.2
-fastapi>=0.100,<0.116  # be careful with upper pin - fastapi might remove support for on_event
+fastapi>=0.100
 numpy>=2.0.0,<2.4.0
 opencv-python>=4.8.1.78,<=4.10.0.84
 opencv-contrib-python>=4.8.1.78,<=4.10.0.84  # Note: opencv-python considers this as a bad practice, but since our dependencies rely on both we pin both here


### PR DESCRIPTION
FastAPI deprecated `on_event` in 0.109; the upper pin `<0.116` was added defensively in case it was removed. It hasn't been removed through 0.128+, but the pin still blocks users who need a newer FastAPI. This PR migrates off `on_event` and drops the pin.

Closes #1960

## What does this PR do?

Replaces the three `on_event` handlers in `http_api.py` and `parallel_http_api.py` with a single `asynccontextmanager`-based `lifespan` function. Adds an `async startup_hook()` extension point on `HttpInterface` that `ParallelHttpInterface` overrides for its Redis-dispatch setup. Drops the `fastapi<0.116` upper bound from `requirements/_requirements.txt`.

All existing behavior is preserved: shutdown telemetry flush, preload model thread launch (still gated on `PRELOAD_MODELS`/`PINNED_MODELS`), and parallel Redis checker thread setup all work identically — just triggered by `lifespan` instead of `on_event`.

**Related Issue(s):** Fixes #1960

## Type of Change

- Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] I have tested this change locally
- [ ] I have added/updated tests for this change

**Test details:**

- `python -m py_compile` passes on both modified Python files (syntax and closure validity confirmed)
- `make check_code_quality` passes clean — black, isort, flake8 all green
- CI will run the full unit test suite

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [ ] I have updated the documentation accordingly (if applicable)

## Additional Context

The `lifespan` function is defined inside `HttpInterface.__init__` so it can close over local variables (`description`, `should_preload`, `model_init_state`, `initialize_models`) that are needed at startup/shutdown time. Python resolves these at call time, not definition time, so there is no `NameError` risk even though some variables are defined later in `__init__`.