### PR TITLE
feat(yolo26-sem): YOLO26 semantic segmentation via inference_models (ONNX + TorchScript + TRT)

### DIFF
--- a/inference/models/utils.py
+++ b/inference/models/utils.py
@@ -990,6 +990,12 @@ if USE_INFERENCE_MODELS:
                 category=InferenceModelsStackMissing,
             )
 
+    # YOLO26 semantic segmentation is inference_models-only (no legacy implementation),
+    # so we add entries directly rather than swapping existing ones.
+    ROBOFLOW_MODEL_TYPES[("semantic-segmentation", "yolo26")] = (
+        InferenceModelsSemanticSegmentationAdapter
+    )
+
     # YOLOLite is inference_models-only (no legacy implementation),
     # so we add entries directly rather than swapping existing ones.
     for variant in [

--- a/inference_models/docs/changelog.md
+++ b/inference_models/docs/changelog.md
@@ -2,7 +2,7 @@
 
 ## `0.28.7`
 
-- Added YOLO26 semantic segmentation support (ONNX and TorchScript backends).
+- Added YOLO26 semantic segmentation support (ONNX, TorchScript, and TensorRT backends).
 
 ## `0.28.6`
 

--- a/inference_models/docs/changelog.md
+++ b/inference_models/docs/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## `0.28.7`
+
+- Added YOLO26 semantic segmentation support (ONNX and TorchScript backends).
+
 ## `0.28.6`
 
 - torch.jit.load/script share a process-global which is not thread-safe, introduced lock to prevent race conditions when loading SAM3 and other torchscript models

--- a/inference_models/inference_models/models/auto_loaders/models_registry.py
+++ b/inference_models/inference_models/models/auto_loaders/models_registry.py
@@ -263,6 +263,10 @@ REGISTERED_MODELS: Dict[
         module_name="inference_models.models.yolo26.yolo26_semantic_segmentation_torch_script",
         class_name="YOLO26ForSemanticSegmentationTorchScript",
     ),
+    ("yolo26", SEMANTIC_SEGMENTATION_TASK, BackendType.TRT): LazyClass(
+        module_name="inference_models.models.yolo26.yolo26_semantic_segmentation_trt",
+        class_name="YOLO26ForSemanticSegmentationTRT",
+    ),
     ("yololite", OBJECT_DETECTION_TASK, BackendType.ONNX): RegistryEntry(
         model_class=LazyClass(
             module_name="inference_models.models.yololite.yololite_object_detection_onnx",

--- a/inference_models/inference_models/models/auto_loaders/models_registry.py
+++ b/inference_models/inference_models/models/auto_loaders/models_registry.py
@@ -255,6 +255,14 @@ REGISTERED_MODELS: Dict[
         module_name="inference_models.models.yolo26.yolo26_instance_segmentation_trt",
         class_name="YOLO26ForInstanceSegmentationTRT",
     ),
+    ("yolo26", SEMANTIC_SEGMENTATION_TASK, BackendType.ONNX): LazyClass(
+        module_name="inference_models.models.yolo26.yolo26_semantic_segmentation_onnx",
+        class_name="YOLO26ForSemanticSegmentationOnnx",
+    ),
+    ("yolo26", SEMANTIC_SEGMENTATION_TASK, BackendType.TORCH_SCRIPT): LazyClass(
+        module_name="inference_models.models.yolo26.yolo26_semantic_segmentation_torch_script",
+        class_name="YOLO26ForSemanticSegmentationTorchScript",
+    ),
     ("yololite", OBJECT_DETECTION_TASK, BackendType.ONNX): RegistryEntry(
         model_class=LazyClass(
             module_name="inference_models.models.yololite.yololite_object_detection_onnx",

--- a/inference_models/inference_models/models/common/roboflow/model_packages.py
+++ b/inference_models/inference_models/models/common/roboflow/model_packages.py
@@ -28,6 +28,29 @@ def parse_class_names_file(class_names_path: str) -> List[str]:
         ) from error
 
 
+def resolve_background_class_id(class_names: List[str]) -> int:
+    """Return the index of the `background` class for a semantic-segmentation
+    package.
+
+    Roboflow semantic segmentation maps every pixel to a class id, with one
+    class reserved for background (sub-threshold / unlabeled pixels). A valid,
+    in-range background id is required - a negative sentinel would alias a real
+    class via negative indexing in downstream consumers (`class_names[-1]`,
+    palette LUTs, the 0=background platform convention), silently corrupting
+    the segmentation map. Packages must therefore declare a `background` class.
+    """
+    try:
+        return [c.lower() for c in class_names].index("background")
+    except ValueError as error:
+        raise CorruptedModelPackageError(
+            message="Semantic segmentation model package does not define a `background` class in "
+            "`class_names.txt`. A background class is required so that sub-threshold pixels map to a "
+            "valid class id. If you created the model package manually, prepend `background` to the class "
+            "names. If the weights are hosted on the Roboflow platform - contact support.",
+            help_url="https://inference-models.roboflow.com/errors/model-loading/#corruptedmodelpackageerror",
+        ) from error
+
+
 PADDING_VALUES_MAPPING = {
     "black edges": 0,
     "grey edges": 127,

--- a/inference_models/inference_models/models/common/roboflow/post_processing.py
+++ b/inference_models/inference_models/models/common/roboflow/post_processing.py
@@ -7,6 +7,9 @@ from torchvision.transforms import functional
 from inference_models.configuration import INFERENCE_MODELS_DEFAULT_CONFIDENCE
 from inference_models.entities import Confidence, ImageDimensions
 from inference_models.logger import LOGGER
+from inference_models.models.base.semantic_segmentation import (
+    SemanticSegmentationResult,
+)
 from inference_models.models.common.rle_utils import torch_mask_to_coco_rle
 from inference_models.models.common.roboflow.model_packages import (
     PreProcessingMetadata,
@@ -723,3 +726,148 @@ class ConfidenceFilter:
         ):
             return recommended_parameters.confidence
         return default_confidence
+
+
+def post_process_semantic_segmentation_logits(
+    model_results: torch.Tensor,
+    pre_processing_meta: List[PreProcessingMetadata],
+    class_names: List[str],
+    background_class_id: int,
+    device: torch.device,
+    confidence: Confidence,
+    recommended_parameters: Optional[RecommendedParameters],
+    default_confidence: float,
+) -> List[SemanticSegmentationResult]:
+    """Shared post-processing for semantic-segmentation models that emit
+    (B, K, H, W) float logits. Used by DeepLabV3+ and YOLO26-sem.
+
+    Steps: crop out letterbox padding → resize back to pre-letterbox size →
+    softmax over classes → argmax → place into original-image canvas if
+    static_crop was applied → apply per-class confidence threshold
+    (sub-threshold pixels collapse to background_class_id).
+    """
+    confidence_filter = ConfidenceFilter(
+        confidence=confidence,
+        recommended_parameters=recommended_parameters,
+        default_confidence=default_confidence,
+    )
+    results: List[SemanticSegmentationResult] = []
+    for image_results, image_metadata in zip(model_results, pre_processing_meta):
+        inference_size = image_metadata.inference_size
+        mask_h_scale = model_results.shape[2] / inference_size.height
+        mask_w_scale = model_results.shape[3] / inference_size.width
+        mask_pad_top, mask_pad_bottom, mask_pad_left, mask_pad_right = (
+            round(mask_h_scale * image_metadata.pad_top),
+            round(mask_h_scale * image_metadata.pad_bottom),
+            round(mask_w_scale * image_metadata.pad_left),
+            round(mask_w_scale * image_metadata.pad_right),
+        )
+        _, mh, mw = image_results.shape
+        if (
+            mask_pad_top < 0
+            or mask_pad_bottom < 0
+            or mask_pad_left < 0
+            or mask_pad_right < 0
+        ):
+            image_results = torch.nn.functional.pad(
+                image_results,
+                (
+                    abs(min(mask_pad_left, 0)),
+                    abs(min(mask_pad_right, 0)),
+                    abs(min(mask_pad_top, 0)),
+                    abs(min(mask_pad_bottom, 0)),
+                ),
+                "constant",
+                background_class_id,
+            )
+            padded_mask_offset_top = max(mask_pad_top, 0)
+            padded_mask_offset_bottom = max(mask_pad_bottom, 0)
+            padded_mask_offset_left = max(mask_pad_left, 0)
+            padded_mask_offset_right = max(mask_pad_right, 0)
+            image_results = image_results[
+                :,
+                padded_mask_offset_top : image_results.shape[1]
+                - padded_mask_offset_bottom,
+                padded_mask_offset_left : image_results.shape[2]
+                - padded_mask_offset_right,
+            ]
+        else:
+            image_results = image_results[
+                :,
+                mask_pad_top : mh - mask_pad_bottom,
+                mask_pad_left : mw - mask_pad_right,
+            ]
+        if (
+            image_results.shape[1] != image_metadata.size_after_pre_processing.height
+            or image_results.shape[2] != image_metadata.size_after_pre_processing.width
+        ):
+            image_results = functional.resize(
+                image_results,
+                [
+                    image_metadata.size_after_pre_processing.height,
+                    image_metadata.size_after_pre_processing.width,
+                ],
+                interpolation=functional.InterpolationMode.BILINEAR,
+            )
+        image_results = torch.nn.functional.softmax(image_results, dim=0)
+        image_confidence, image_class_ids = torch.max(image_results, dim=0)
+        if len(class_names) == image_results.shape[0] + 1:
+            image_class_ids = image_class_ids + 1
+        if (
+            image_metadata.static_crop_offset.offset_x > 0
+            or image_metadata.static_crop_offset.offset_y > 0
+        ):
+            original_size_confidence_canvas = torch.zeros(
+                (
+                    image_metadata.original_size.height,
+                    image_metadata.original_size.width,
+                ),
+                device=device,
+                dtype=image_confidence.dtype,
+            )
+            original_size_confidence_canvas[
+                image_metadata.static_crop_offset.offset_y : image_metadata.static_crop_offset.offset_y
+                + image_confidence.shape[0],
+                image_metadata.static_crop_offset.offset_x : image_metadata.static_crop_offset.offset_x
+                + image_confidence.shape[1],
+            ] = image_confidence
+            original_size_confidence_class_id_canvas = (
+                torch.ones(
+                    (
+                        image_metadata.original_size.height,
+                        image_metadata.original_size.width,
+                    ),
+                    device=device,
+                    dtype=image_class_ids.dtype,
+                )
+                * background_class_id
+            )
+            original_size_confidence_class_id_canvas[
+                image_metadata.static_crop_offset.offset_y : image_metadata.static_crop_offset.offset_y
+                + image_class_ids.shape[0],
+                image_metadata.static_crop_offset.offset_x : image_metadata.static_crop_offset.offset_x
+                + image_class_ids.shape[1],
+            ] = image_class_ids
+            image_class_ids = original_size_confidence_class_id_canvas
+            image_confidence = original_size_confidence_canvas
+        threshold = confidence_filter.get_threshold(class_names)
+        if isinstance(threshold, torch.Tensor):
+            threshold = threshold.to(
+                dtype=image_confidence.dtype, device=image_confidence.device
+            )
+        below = image_confidence < (
+            threshold[image_class_ids.long()]
+            if isinstance(threshold, torch.Tensor)
+            else threshold
+        )
+        image_class_ids = image_class_ids.clone()
+        image_confidence = image_confidence.clone()
+        image_class_ids[below] = background_class_id
+        image_confidence[below] = 0.0
+        results.append(
+            SemanticSegmentationResult(
+                segmentation_map=image_class_ids,
+                confidence=image_confidence,
+            )
+        )
+    return results

--- a/inference_models/inference_models/models/deep_lab_v3_plus/deep_lab_v3_plus_segmentation_onnx.py
+++ b/inference_models/inference_models/models/deep_lab_v3_plus/deep_lab_v3_plus_segmentation_onnx.py
@@ -2,7 +2,6 @@ from threading import Lock
 from typing import List, Optional, Tuple, Union
 
 import torch
-from torchvision.transforms import functional
 
 from inference_models import ColorFormat, SemanticSegmentationModel
 from inference_models.configuration import (
@@ -32,7 +31,9 @@ from inference_models.models.common.roboflow.model_packages import (
     parse_class_names_file,
     parse_inference_config,
 )
-from inference_models.models.common.roboflow.post_processing import ConfidenceFilter
+from inference_models.models.common.roboflow.post_processing import (
+    post_process_semantic_segmentation_logits,
+)
 from inference_models.models.common.roboflow.pre_processing import (
     pre_process_network_input,
 )
@@ -194,128 +195,13 @@ class DeepLabV3PlusForSemanticSegmentationOnnx(
         confidence: Confidence = "default",
         **kwargs,
     ) -> List[SemanticSegmentationResult]:
-        confidence_filter = ConfidenceFilter(
+        return post_process_semantic_segmentation_logits(
+            model_results=model_results,
+            pre_processing_meta=pre_processing_meta,
+            class_names=self._class_names,
+            background_class_id=self._background_class_id,
+            device=self._device,
             confidence=confidence,
             recommended_parameters=self.recommended_parameters,
             default_confidence=INFERENCE_MODELS_DEEP_LAB_V3_PLUS_DEFAULT_CONFIDENCE,
         )
-        results = []
-        for image_results, image_metadata in zip(model_results, pre_processing_meta):
-            inference_size = image_metadata.inference_size
-            mask_h_scale = model_results.shape[2] / inference_size.height
-            mask_w_scale = model_results.shape[3] / inference_size.width
-            mask_pad_top, mask_pad_bottom, mask_pad_left, mask_pad_right = (
-                round(mask_h_scale * image_metadata.pad_top),
-                round(mask_h_scale * image_metadata.pad_bottom),
-                round(mask_w_scale * image_metadata.pad_left),
-                round(mask_w_scale * image_metadata.pad_right),
-            )
-            _, mh, mw = image_results.shape
-            if (
-                mask_pad_top < 0
-                or mask_pad_bottom < 0
-                or mask_pad_left < 0
-                or mask_pad_right < 0
-            ):
-                image_results = torch.nn.functional.pad(
-                    image_results,
-                    (
-                        abs(min(mask_pad_left, 0)),
-                        abs(min(mask_pad_right, 0)),
-                        abs(min(mask_pad_top, 0)),
-                        abs(min(mask_pad_bottom, 0)),
-                    ),
-                    "constant",
-                    self._background_class_id,
-                )
-                padded_mask_offset_top = max(mask_pad_top, 0)
-                padded_mask_offset_bottom = max(mask_pad_bottom, 0)
-                padded_mask_offset_left = max(mask_pad_left, 0)
-                padded_mask_offset_right = max(mask_pad_right, 0)
-                image_results = image_results[
-                    :,
-                    padded_mask_offset_top : image_results.shape[1]
-                    - padded_mask_offset_bottom,
-                    padded_mask_offset_left : image_results.shape[2]
-                    - padded_mask_offset_right,
-                ]
-            else:
-                image_results = image_results[
-                    :,
-                    mask_pad_top : mh - mask_pad_bottom,
-                    mask_pad_left : mw - mask_pad_right,
-                ]
-            if (
-                image_results.shape[1]
-                != image_metadata.size_after_pre_processing.height
-                or image_results.shape[2]
-                != image_metadata.size_after_pre_processing.width
-            ):
-                image_results = functional.resize(
-                    image_results,
-                    [
-                        image_metadata.size_after_pre_processing.height,
-                        image_metadata.size_after_pre_processing.width,
-                    ],
-                    interpolation=functional.InterpolationMode.BILINEAR,
-                )
-            image_results = torch.nn.functional.softmax(image_results, dim=0)
-            image_confidence, image_class_ids = torch.max(image_results, dim=0)
-            if (
-                image_metadata.static_crop_offset.offset_x > 0
-                or image_metadata.static_crop_offset.offset_y > 0
-            ):
-                original_size_confidence_canvas = torch.zeros(
-                    (
-                        image_metadata.original_size.height,
-                        image_metadata.original_size.width,
-                    ),
-                    device=self._device,
-                    dtype=image_confidence.dtype,
-                )
-                original_size_confidence_canvas[
-                    image_metadata.static_crop_offset.offset_y : image_metadata.static_crop_offset.offset_y
-                    + image_confidence.shape[0],
-                    image_metadata.static_crop_offset.offset_x : image_metadata.static_crop_offset.offset_x
-                    + image_confidence.shape[1],
-                ] = image_confidence
-                original_size_confidence_class_id_canvas = (
-                    torch.ones(
-                        (
-                            image_metadata.original_size.height,
-                            image_metadata.original_size.width,
-                        ),
-                        device=self._device,
-                        dtype=image_class_ids.dtype,
-                    )
-                    * self._background_class_id
-                )
-                original_size_confidence_class_id_canvas[
-                    image_metadata.static_crop_offset.offset_y : image_metadata.static_crop_offset.offset_y
-                    + image_class_ids.shape[0],
-                    image_metadata.static_crop_offset.offset_x : image_metadata.static_crop_offset.offset_x
-                    + image_class_ids.shape[1],
-                ] = image_class_ids
-                image_class_ids = original_size_confidence_class_id_canvas
-                image_confidence = original_size_confidence_canvas
-            threshold = confidence_filter.get_threshold(self.class_names)
-            if isinstance(threshold, torch.Tensor):
-                threshold = threshold.to(
-                    dtype=image_confidence.dtype, device=image_confidence.device
-                )
-            below = image_confidence < (
-                threshold[image_class_ids.long()]
-                if isinstance(threshold, torch.Tensor)
-                else threshold
-            )
-            image_class_ids = image_class_ids.clone()
-            image_confidence = image_confidence.clone()
-            image_class_ids[below] = self._background_class_id
-            image_confidence[below] = 0.0
-            results.append(
-                SemanticSegmentationResult(
-                    segmentation_map=image_class_ids,
-                    confidence=image_confidence,
-                )
-            )
-        return results

--- a/inference_models/inference_models/models/deep_lab_v3_plus/deep_lab_v3_plus_segmentation_onnx.py
+++ b/inference_models/inference_models/models/deep_lab_v3_plus/deep_lab_v3_plus_segmentation_onnx.py
@@ -30,6 +30,7 @@ from inference_models.models.common.roboflow.model_packages import (
     ResizeMode,
     parse_class_names_file,
     parse_inference_config,
+    resolve_background_class_id,
 )
 from inference_models.models.common.roboflow.post_processing import (
     post_process_semantic_segmentation_logits,
@@ -93,10 +94,7 @@ class DeepLabV3PlusForSemanticSegmentationOnnx(
         class_names = parse_class_names_file(
             class_names_path=model_package_content["class_names.txt"]
         )
-        try:
-            background_class_id = [c.lower() for c in class_names].index("background")
-        except ValueError:
-            background_class_id = -1
+        background_class_id = resolve_background_class_id(class_names)
         inference_config = parse_inference_config(
             config_path=model_package_content["inference_config.json"],
             allowed_resize_modes={

--- a/inference_models/inference_models/models/deep_lab_v3_plus/deep_lab_v3_plus_segmentation_torch.py
+++ b/inference_models/inference_models/models/deep_lab_v3_plus/deep_lab_v3_plus_segmentation_torch.py
@@ -23,6 +23,7 @@ from inference_models.models.common.roboflow.model_packages import (
     ResizeMode,
     parse_class_names_file,
     parse_inference_config,
+    resolve_background_class_id,
 )
 from inference_models.models.common.roboflow.post_processing import (
     post_process_semantic_segmentation_logits,
@@ -56,10 +57,7 @@ class DeepLabV3PlusForSemanticSegmentationTorch(
         class_names = parse_class_names_file(
             class_names_path=model_package_content["class_names.txt"]
         )
-        try:
-            background_class_id = [c.lower() for c in class_names].index("background")
-        except ValueError:
-            background_class_id = -1
+        background_class_id = resolve_background_class_id(class_names)
         inference_config = parse_inference_config(
             config_path=model_package_content["inference_config.json"],
             allowed_resize_modes={

--- a/inference_models/inference_models/models/deep_lab_v3_plus/deep_lab_v3_plus_segmentation_torch.py
+++ b/inference_models/inference_models/models/deep_lab_v3_plus/deep_lab_v3_plus_segmentation_torch.py
@@ -3,7 +3,6 @@ from typing import List, Optional, Tuple, Union
 
 import segmentation_models_pytorch as smp
 import torch
-from torchvision.transforms import functional
 
 from inference_models import ColorFormat, SemanticSegmentationModel
 from inference_models.configuration import (
@@ -25,7 +24,9 @@ from inference_models.models.common.roboflow.model_packages import (
     parse_class_names_file,
     parse_inference_config,
 )
-from inference_models.models.common.roboflow.post_processing import ConfidenceFilter
+from inference_models.models.common.roboflow.post_processing import (
+    post_process_semantic_segmentation_logits,
+)
 from inference_models.models.common.roboflow.pre_processing import (
     pre_process_network_input,
 )
@@ -169,128 +170,13 @@ class DeepLabV3PlusForSemanticSegmentationTorch(
         confidence: Confidence = "default",
         **kwargs,
     ) -> List[SemanticSegmentationResult]:
-        confidence_filter = ConfidenceFilter(
+        return post_process_semantic_segmentation_logits(
+            model_results=model_results,
+            pre_processing_meta=pre_processing_meta,
+            class_names=self._class_names,
+            background_class_id=self._background_class_id,
+            device=self._device,
             confidence=confidence,
             recommended_parameters=self.recommended_parameters,
             default_confidence=INFERENCE_MODELS_DEEP_LAB_V3_PLUS_DEFAULT_CONFIDENCE,
         )
-        results = []
-        for image_results, image_metadata in zip(model_results, pre_processing_meta):
-            inference_size = image_metadata.inference_size
-            mask_h_scale = model_results.shape[2] / inference_size.height
-            mask_w_scale = model_results.shape[3] / inference_size.width
-            mask_pad_top, mask_pad_bottom, mask_pad_left, mask_pad_right = (
-                round(mask_h_scale * image_metadata.pad_top),
-                round(mask_h_scale * image_metadata.pad_bottom),
-                round(mask_w_scale * image_metadata.pad_left),
-                round(mask_w_scale * image_metadata.pad_right),
-            )
-            _, mh, mw = image_results.shape
-            if (
-                mask_pad_top < 0
-                or mask_pad_bottom < 0
-                or mask_pad_left < 0
-                or mask_pad_right < 0
-            ):
-                image_results = torch.nn.functional.pad(
-                    image_results,
-                    (
-                        abs(min(mask_pad_left, 0)),
-                        abs(min(mask_pad_right, 0)),
-                        abs(min(mask_pad_top, 0)),
-                        abs(min(mask_pad_bottom, 0)),
-                    ),
-                    "constant",
-                    self._background_class_id,
-                )
-                padded_mask_offset_top = max(mask_pad_top, 0)
-                padded_mask_offset_bottom = max(mask_pad_bottom, 0)
-                padded_mask_offset_left = max(mask_pad_left, 0)
-                padded_mask_offset_right = max(mask_pad_right, 0)
-                image_results = image_results[
-                    :,
-                    padded_mask_offset_top : image_results.shape[1]
-                    - padded_mask_offset_bottom,
-                    padded_mask_offset_left : image_results.shape[2]
-                    - padded_mask_offset_right,
-                ]
-            else:
-                image_results = image_results[
-                    :,
-                    mask_pad_top : mh - mask_pad_bottom,
-                    mask_pad_left : mw - mask_pad_right,
-                ]
-            if (
-                image_results.shape[1]
-                != image_metadata.size_after_pre_processing.height
-                or image_results.shape[2]
-                != image_metadata.size_after_pre_processing.width
-            ):
-                image_results = functional.resize(
-                    image_results,
-                    [
-                        image_metadata.size_after_pre_processing.height,
-                        image_metadata.size_after_pre_processing.width,
-                    ],
-                    interpolation=functional.InterpolationMode.BILINEAR,
-                )
-            image_results = torch.nn.functional.softmax(image_results, dim=0)
-            image_confidence, image_class_ids = torch.max(image_results, dim=0)
-            if (
-                image_metadata.static_crop_offset.offset_x > 0
-                or image_metadata.static_crop_offset.offset_y > 0
-            ):
-                original_size_confidence_canvas = torch.zeros(
-                    (
-                        image_metadata.original_size.height,
-                        image_metadata.original_size.width,
-                    ),
-                    device=self._device,
-                    dtype=image_confidence.dtype,
-                )
-                original_size_confidence_canvas[
-                    image_metadata.static_crop_offset.offset_y : image_metadata.static_crop_offset.offset_y
-                    + image_confidence.shape[0],
-                    image_metadata.static_crop_offset.offset_x : image_metadata.static_crop_offset.offset_x
-                    + image_confidence.shape[1],
-                ] = image_confidence
-                original_size_confidence_class_id_canvas = (
-                    torch.ones(
-                        (
-                            image_metadata.original_size.height,
-                            image_metadata.original_size.width,
-                        ),
-                        device=self._device,
-                        dtype=image_class_ids.dtype,
-                    )
-                    * self._background_class_id
-                )
-                original_size_confidence_class_id_canvas[
-                    image_metadata.static_crop_offset.offset_y : image_metadata.static_crop_offset.offset_y
-                    + image_class_ids.shape[0],
-                    image_metadata.static_crop_offset.offset_x : image_metadata.static_crop_offset.offset_x
-                    + image_class_ids.shape[1],
-                ] = image_class_ids
-                image_class_ids = original_size_confidence_class_id_canvas
-                image_confidence = original_size_confidence_canvas
-            threshold = confidence_filter.get_threshold(self.class_names)
-            if isinstance(threshold, torch.Tensor):
-                threshold = threshold.to(
-                    dtype=image_confidence.dtype, device=image_confidence.device
-                )
-            below = image_confidence < (
-                threshold[image_class_ids.long()]
-                if isinstance(threshold, torch.Tensor)
-                else threshold
-            )
-            image_class_ids = image_class_ids.clone()
-            image_confidence = image_confidence.clone()
-            image_class_ids[below] = self._background_class_id
-            image_confidence[below] = 0.0
-            results.append(
-                SemanticSegmentationResult(
-                    segmentation_map=image_class_ids,
-                    confidence=image_confidence,
-                )
-            )
-        return results

--- a/inference_models/inference_models/models/deep_lab_v3_plus/deep_lab_v3_plus_segmentation_trt.py
+++ b/inference_models/inference_models/models/deep_lab_v3_plus/deep_lab_v3_plus_segmentation_trt.py
@@ -32,6 +32,7 @@ from inference_models.models.common.roboflow.model_packages import (
     TRTConfig,
     parse_class_names_file,
     parse_inference_config,
+    resolve_background_class_id,
     parse_trt_config,
 )
 from inference_models.models.common.roboflow.post_processing import (
@@ -109,10 +110,7 @@ class DeepLabV3PlusForSemanticSegmentationTRT(
         class_names = parse_class_names_file(
             class_names_path=model_package_content["class_names.txt"]
         )
-        try:
-            background_class_id = [c.lower() for c in class_names].index("background")
-        except ValueError:
-            background_class_id = -1
+        background_class_id = resolve_background_class_id(class_names)
         inference_config = parse_inference_config(
             config_path=model_package_content["inference_config.json"],
             allowed_resize_modes={

--- a/inference_models/inference_models/models/deep_lab_v3_plus/deep_lab_v3_plus_segmentation_trt.py
+++ b/inference_models/inference_models/models/deep_lab_v3_plus/deep_lab_v3_plus_segmentation_trt.py
@@ -3,7 +3,6 @@ from threading import Lock
 from typing import List, Optional, Tuple, Union
 
 import torch
-from torchvision.transforms import functional
 
 from inference_models import ColorFormat, SemanticSegmentationModel
 from inference_models.configuration import (
@@ -35,7 +34,9 @@ from inference_models.models.common.roboflow.model_packages import (
     parse_inference_config,
     parse_trt_config,
 )
-from inference_models.models.common.roboflow.post_processing import ConfidenceFilter
+from inference_models.models.common.roboflow.post_processing import (
+    post_process_semantic_segmentation_logits,
+)
 from inference_models.models.common.roboflow.pre_processing import (
     pre_process_network_input,
 )
@@ -255,134 +256,18 @@ class DeepLabV3PlusForSemanticSegmentationTRT(
         confidence: Confidence = "default",
         **kwargs,
     ) -> List[SemanticSegmentationResult]:
-        confidence_filter = ConfidenceFilter(
-            confidence=confidence,
-            recommended_parameters=self.recommended_parameters,
-            default_confidence=INFERENCE_MODELS_DEEP_LAB_V3_PLUS_DEFAULT_CONFIDENCE,
-        )
         with torch.cuda.stream(self._post_process_stream):
             model_results.record_stream(self._post_process_stream)
-            results = []
-            for image_results, image_metadata in zip(
-                model_results, pre_processing_meta
-            ):
-                inference_size = image_metadata.inference_size
-                mask_h_scale = model_results.shape[2] / inference_size.height
-                mask_w_scale = model_results.shape[3] / inference_size.width
-                mask_pad_top, mask_pad_bottom, mask_pad_left, mask_pad_right = (
-                    round(mask_h_scale * image_metadata.pad_top),
-                    round(mask_h_scale * image_metadata.pad_bottom),
-                    round(mask_w_scale * image_metadata.pad_left),
-                    round(mask_w_scale * image_metadata.pad_right),
-                )
-                _, mh, mw = image_results.shape
-                if (
-                    mask_pad_top < 0
-                    or mask_pad_bottom < 0
-                    or mask_pad_left < 0
-                    or mask_pad_right < 0
-                ):
-                    image_results = torch.nn.functional.pad(
-                        image_results,
-                        (
-                            abs(min(mask_pad_left, 0)),
-                            abs(min(mask_pad_right, 0)),
-                            abs(min(mask_pad_top, 0)),
-                            abs(min(mask_pad_bottom, 0)),
-                        ),
-                        "constant",
-                        self._background_class_id,
-                    )
-                    padded_mask_offset_top = max(mask_pad_top, 0)
-                    padded_mask_offset_bottom = max(mask_pad_bottom, 0)
-                    padded_mask_offset_left = max(mask_pad_left, 0)
-                    padded_mask_offset_right = max(mask_pad_right, 0)
-                    image_results = image_results[
-                        :,
-                        padded_mask_offset_top : image_results.shape[1]
-                        - padded_mask_offset_bottom,
-                        padded_mask_offset_left : image_results.shape[2]
-                        - padded_mask_offset_right,
-                    ]
-                else:
-                    image_results = image_results[
-                        :,
-                        mask_pad_top : mh - mask_pad_bottom,
-                        mask_pad_left : mw - mask_pad_right,
-                    ]
-                if (
-                    image_results.shape[1]
-                    != image_metadata.size_after_pre_processing.height
-                    or image_results.shape[2]
-                    != image_metadata.size_after_pre_processing.width
-                ):
-                    image_results = functional.resize(
-                        image_results,
-                        [
-                            image_metadata.size_after_pre_processing.height,
-                            image_metadata.size_after_pre_processing.width,
-                        ],
-                        interpolation=functional.InterpolationMode.BILINEAR,
-                    )
-                image_results = torch.nn.functional.softmax(image_results, dim=0)
-                image_confidence, image_class_ids = torch.max(image_results, dim=0)
-                if (
-                    image_metadata.static_crop_offset.offset_x > 0
-                    or image_metadata.static_crop_offset.offset_y > 0
-                ):
-                    original_size_confidence_canvas = torch.zeros(
-                        (
-                            image_metadata.original_size.height,
-                            image_metadata.original_size.width,
-                        ),
-                        device=self._device,
-                        dtype=image_confidence.dtype,
-                    )
-                    original_size_confidence_canvas[
-                        image_metadata.static_crop_offset.offset_y : image_metadata.static_crop_offset.offset_y
-                        + image_confidence.shape[0],
-                        image_metadata.static_crop_offset.offset_x : image_metadata.static_crop_offset.offset_x
-                        + image_confidence.shape[1],
-                    ] = image_confidence
-                    original_size_confidence_class_id_canvas = (
-                        torch.ones(
-                            (
-                                image_metadata.original_size.height,
-                                image_metadata.original_size.width,
-                            ),
-                            device=self._device,
-                            dtype=image_class_ids.dtype,
-                        )
-                        * self._background_class_id
-                    )
-                    original_size_confidence_class_id_canvas[
-                        image_metadata.static_crop_offset.offset_y : image_metadata.static_crop_offset.offset_y
-                        + image_class_ids.shape[0],
-                        image_metadata.static_crop_offset.offset_x : image_metadata.static_crop_offset.offset_x
-                        + image_class_ids.shape[1],
-                    ] = image_class_ids
-                    image_class_ids = original_size_confidence_class_id_canvas
-                    image_confidence = original_size_confidence_canvas
-                threshold = confidence_filter.get_threshold(self.class_names)
-                if isinstance(threshold, torch.Tensor):
-                    threshold = threshold.to(
-                        dtype=image_confidence.dtype, device=image_confidence.device
-                    )
-                below = image_confidence < (
-                    threshold[image_class_ids.long()]
-                    if isinstance(threshold, torch.Tensor)
-                    else threshold
-                )
-                image_class_ids = image_class_ids.clone()
-                image_confidence = image_confidence.clone()
-                image_class_ids[below] = self._background_class_id
-                image_confidence[below] = 0.0
-                results.append(
-                    SemanticSegmentationResult(
-                        segmentation_map=image_class_ids,
-                        confidence=image_confidence,
-                    )
-                )
+            results = post_process_semantic_segmentation_logits(
+                model_results=model_results,
+                pre_processing_meta=pre_processing_meta,
+                class_names=self._class_names,
+                background_class_id=self._background_class_id,
+                device=self._device,
+                confidence=confidence,
+                recommended_parameters=self.recommended_parameters,
+                default_confidence=INFERENCE_MODELS_DEEP_LAB_V3_PLUS_DEFAULT_CONFIDENCE,
+            )
         self._post_process_stream.synchronize()
         return results
 

--- a/inference_models/inference_models/models/yolo26/yolo26_semantic_segmentation_onnx.py
+++ b/inference_models/inference_models/models/yolo26/yolo26_semantic_segmentation_onnx.py
@@ -1,0 +1,214 @@
+from threading import Lock
+from typing import List, Optional, Tuple, Union
+
+import numpy as np
+import torch
+
+from inference_models import ColorFormat, SemanticSegmentationModel
+from inference_models.configuration import (
+    DEFAULT_DEVICE,
+    INFERENCE_MODELS_YOLO26_DEFAULT_CONFIDENCE,
+)
+from inference_models.entities import Confidence
+from inference_models.errors import (
+    EnvironmentConfigurationError,
+    MissingDependencyError,
+)
+from inference_models.models.auto_loaders.entities import PreProcessingOverrides
+from inference_models.models.base.semantic_segmentation import (
+    SemanticSegmentationResult,
+)
+from inference_models.models.common.model_packages import get_model_package_contents
+from inference_models.models.common.onnx import (
+    run_onnx_session_with_batch_size_limit,
+    set_onnx_execution_provider_defaults,
+)
+from inference_models.models.common.roboflow.model_packages import (
+    InferenceConfig,
+    PreProcessingMetadata,
+    ResizeMode,
+    parse_class_names_file,
+    parse_inference_config,
+)
+from inference_models.models.common.roboflow.post_processing import (
+    post_process_semantic_segmentation_logits,
+)
+from inference_models.models.common.roboflow.pre_processing import (
+    pre_process_network_input,
+)
+from inference_models.utils.onnx_introspection import (
+    get_selected_onnx_execution_providers,
+)
+from inference_models.weights_providers.entities import RecommendedParameters
+
+try:
+    import onnxruntime
+except ImportError as import_error:
+    raise MissingDependencyError(
+        message="Running YOLO26 Semantic Segmentation model with ONNX backend requires `onnxruntime` installation, which is brought with "
+        "`onnx-*` extras of `inference-models` library. If you see this error running locally, "
+        "please follow our installation guide: https://inference-models.roboflow.com/getting-started/installation/"
+        " If you see this error using Roboflow infrastructure, make sure the service you use does support the "
+        f"model, You can also contact Roboflow to get support."
+        "Additionally - if AutoModel.from_pretrained(...) "
+        f"automatically selects model package which does not match your environment - that's a serious problem and "
+        f"we will really appreciate letting us know - https://github.com/roboflow/inference/issues",
+        help_url="https://inference-models.roboflow.com/errors/runtime-environment/#missingdependencyerror",
+    ) from import_error
+
+
+class YOLO26ForSemanticSegmentationOnnx(
+    SemanticSegmentationModel[torch.Tensor, PreProcessingMetadata, torch.Tensor]
+):
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        model_name_or_path: str,
+        onnx_execution_providers: Optional[List[Union[str, tuple]]] = None,
+        default_onnx_trt_options: bool = True,
+        device: torch.device = DEFAULT_DEVICE,
+        recommended_parameters: Optional[RecommendedParameters] = None,
+        **kwargs,
+    ) -> "YOLO26ForSemanticSegmentationOnnx":
+        if onnx_execution_providers is None:
+            onnx_execution_providers = get_selected_onnx_execution_providers()
+        if not onnx_execution_providers:
+            raise EnvironmentConfigurationError(
+                message=f"Could not initialize model - selected backend is ONNX which requires execution provider to "
+                f"be specified - explicitly in `from_pretrained(...)` method or via env variable "
+                f"`ONNXRUNTIME_EXECUTION_PROVIDERS`. If you run model locally - adjust your setup, otherwise "
+                f"contact the platform support.",
+                help_url="https://inference-models.roboflow.com/errors/runtime-environment/#environmentconfigurationerror",
+            )
+        onnx_execution_providers = set_onnx_execution_provider_defaults(
+            providers=onnx_execution_providers,
+            model_package_path=model_name_or_path,
+            device=device,
+            default_onnx_trt_options=default_onnx_trt_options,
+        )
+        model_package_content = get_model_package_contents(
+            model_package_dir=model_name_or_path,
+            elements=[
+                "class_names.txt",
+                "inference_config.json",
+                "weights.onnx",
+            ],
+        )
+        class_names = parse_class_names_file(
+            class_names_path=model_package_content["class_names.txt"]
+        )
+        try:
+            background_class_id = [c.lower() for c in class_names].index("background")
+        except ValueError:
+            background_class_id = -1
+        inference_config = parse_inference_config(
+            config_path=model_package_content["inference_config.json"],
+            allowed_resize_modes={
+                ResizeMode.STRETCH_TO,
+                ResizeMode.LETTERBOX,
+                ResizeMode.CENTER_CROP,
+                ResizeMode.LETTERBOX_REFLECT_EDGES,
+            },
+            implicit_resize_mode_substitutions={
+                ResizeMode.FIT_LONGER_EDGE: (
+                    ResizeMode.LETTERBOX,
+                    127,
+                    "YOLO26 Semantic Segmentation model running with ONNX backend was trained with "
+                    "`fit-longer-edge` input resize mode. This transform cannot be applied properly for "
+                    "models with input dimensions fixed during weights export. To ensure interoperability, `letterbox` "
+                    "resize mode with gray edges will be used instead. If model was trained on Roboflow platform, "
+                    "we recommend using preprocessing method different that `fit-longer-edge`.",
+                )
+            },
+        )
+        session = onnxruntime.InferenceSession(
+            path_or_bytes=model_package_content["weights.onnx"],
+            providers=onnx_execution_providers,
+        )
+        input_batch_size = session.get_inputs()[0].shape[0]
+        if isinstance(input_batch_size, str):
+            input_batch_size = None
+        input_name = session.get_inputs()[0].name
+        return cls(
+            session=session,
+            input_name=input_name,
+            class_names=class_names,
+            background_class_id=background_class_id,
+            inference_config=inference_config,
+            device=device,
+            input_batch_size=input_batch_size,
+            recommended_parameters=recommended_parameters,
+        )
+
+    def __init__(
+        self,
+        session: onnxruntime.InferenceSession,
+        input_name: str,
+        inference_config: InferenceConfig,
+        class_names: List[str],
+        background_class_id: int,
+        device: torch.device,
+        input_batch_size: Optional[int],
+        recommended_parameters: Optional[RecommendedParameters] = None,
+    ):
+        self._session = session
+        self._input_name = input_name
+        self._inference_config = inference_config
+        self._class_names = class_names
+        self._background_class_id = background_class_id
+        self._device = device
+        self._input_batch_size = input_batch_size
+        self._session_thread_lock = Lock()
+        self.recommended_parameters = recommended_parameters
+
+    @property
+    def class_names(self) -> List[str]:
+        return self._class_names
+
+    def pre_process(
+        self,
+        images: Union[torch.Tensor, List[torch.Tensor], np.ndarray, List[np.ndarray]],
+        input_color_format: Optional[ColorFormat] = None,
+        image_size: Optional[Tuple[int, int]] = None,
+        pre_processing_overrides: Optional[PreProcessingOverrides] = None,
+        **kwargs,
+    ) -> Tuple[torch.Tensor, List[PreProcessingMetadata]]:
+        return pre_process_network_input(
+            images=images,
+            image_pre_processing=self._inference_config.image_pre_processing,
+            network_input=self._inference_config.network_input,
+            target_device=self._device,
+            input_color_format=input_color_format,
+            image_size_wh=image_size,
+            pre_processing_overrides=pre_processing_overrides,
+        )
+
+    def forward(
+        self, pre_processed_images: torch.Tensor, **kwargs
+    ) -> torch.Tensor:
+        with self._session_thread_lock:
+            return run_onnx_session_with_batch_size_limit(
+                session=self._session,
+                inputs={self._input_name: pre_processed_images},
+                min_batch_size=self._input_batch_size,
+                max_batch_size=self._input_batch_size,
+            )[0]
+
+    def post_process(
+        self,
+        model_results: torch.Tensor,
+        pre_processing_meta: List[PreProcessingMetadata],
+        confidence: Confidence = "default",
+        **kwargs,
+    ) -> List[SemanticSegmentationResult]:
+        return post_process_semantic_segmentation_logits(
+            model_results=model_results,
+            pre_processing_meta=pre_processing_meta,
+            class_names=self._class_names,
+            background_class_id=self._background_class_id,
+            device=self._device,
+            confidence=confidence,
+            recommended_parameters=self.recommended_parameters,
+            default_confidence=INFERENCE_MODELS_YOLO26_DEFAULT_CONFIDENCE,
+        )

--- a/inference_models/inference_models/models/yolo26/yolo26_semantic_segmentation_onnx.py
+++ b/inference_models/inference_models/models/yolo26/yolo26_semantic_segmentation_onnx.py
@@ -28,6 +28,7 @@ from inference_models.models.common.roboflow.model_packages import (
     PreProcessingMetadata,
     ResizeMode,
     parse_class_names_file,
+    resolve_background_class_id,
     parse_inference_config,
 )
 from inference_models.models.common.roboflow.post_processing import (
@@ -98,10 +99,7 @@ class YOLO26ForSemanticSegmentationOnnx(
         class_names = parse_class_names_file(
             class_names_path=model_package_content["class_names.txt"]
         )
-        try:
-            background_class_id = [c.lower() for c in class_names].index("background")
-        except ValueError:
-            background_class_id = -1
+        background_class_id = resolve_background_class_id(class_names)
         inference_config = parse_inference_config(
             config_path=model_package_content["inference_config.json"],
             allowed_resize_modes={

--- a/inference_models/inference_models/models/yolo26/yolo26_semantic_segmentation_torch_script.py
+++ b/inference_models/inference_models/models/yolo26/yolo26_semantic_segmentation_torch_script.py
@@ -1,0 +1,174 @@
+from threading import Lock
+from typing import List, Optional, Tuple, Union
+
+import numpy as np
+import torch
+
+from inference_models import ColorFormat, SemanticSegmentationModel
+from inference_models.configuration import (
+    DEFAULT_DEVICE,
+    INFERENCE_MODELS_YOLO26_DEFAULT_CONFIDENCE,
+)
+from inference_models.entities import Confidence
+from inference_models.errors import CorruptedModelPackageError
+from inference_models.models.auto_loaders.entities import PreProcessingOverrides
+from inference_models.models.base.semantic_segmentation import (
+    SemanticSegmentationResult,
+)
+from inference_models.models.common.model_packages import get_model_package_contents
+from inference_models.models.common.roboflow.model_packages import (
+    InferenceConfig,
+    PreProcessingMetadata,
+    ResizeMode,
+    parse_class_names_file,
+    parse_inference_config,
+)
+from inference_models.models.common.roboflow.post_processing import (
+    post_process_semantic_segmentation_logits,
+)
+from inference_models.models.common.roboflow.pre_processing import (
+    pre_process_network_input,
+)
+from inference_models.models.common.torch import generate_batch_chunks
+from inference_models.weights_providers.entities import RecommendedParameters
+
+
+class YOLO26ForSemanticSegmentationTorchScript(
+    SemanticSegmentationModel[torch.Tensor, PreProcessingMetadata, torch.Tensor]
+):
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        model_name_or_path: str,
+        device: torch.device = DEFAULT_DEVICE,
+        recommended_parameters: Optional[RecommendedParameters] = None,
+        **kwargs,
+    ) -> "YOLO26ForSemanticSegmentationTorchScript":
+        model_package_content = get_model_package_contents(
+            model_package_dir=model_name_or_path,
+            elements=[
+                "class_names.txt",
+                "inference_config.json",
+                "weights.torchscript",
+            ],
+        )
+        class_names = parse_class_names_file(
+            class_names_path=model_package_content["class_names.txt"]
+        )
+        try:
+            background_class_id = [c.lower() for c in class_names].index("background")
+        except ValueError:
+            background_class_id = -1
+        inference_config = parse_inference_config(
+            config_path=model_package_content["inference_config.json"],
+            allowed_resize_modes={
+                ResizeMode.STRETCH_TO,
+                ResizeMode.LETTERBOX,
+                ResizeMode.CENTER_CROP,
+                ResizeMode.LETTERBOX_REFLECT_EDGES,
+            },
+            implicit_resize_mode_substitutions={
+                ResizeMode.FIT_LONGER_EDGE: (
+                    ResizeMode.LETTERBOX,
+                    127,
+                    "YOLO26 Semantic Segmentation model running with TorchScript backend was trained with "
+                    "`fit-longer-edge` input resize mode. This transform cannot be applied properly for "
+                    "models with input dimensions fixed during weights export. To ensure interoperability, `letterbox` "
+                    "resize mode with gray edges will be used instead. If model was trained on Roboflow platform, "
+                    "we recommend using preprocessing method different that `fit-longer-edge`.",
+                )
+            },
+        )
+        if inference_config.forward_pass.static_batch_size is None:
+            raise CorruptedModelPackageError(
+                message="Expected static batch size to be registered in the inference configuration.",
+                help_url="https://inference-models.roboflow.com/errors/model-loading/#corruptedmodelpackageerror",
+            )
+        model = torch.jit.load(
+            model_package_content["weights.torchscript"], map_location=device
+        ).train(False)
+        return cls(
+            model=model,
+            class_names=class_names,
+            background_class_id=background_class_id,
+            inference_config=inference_config,
+            device=device,
+            recommended_parameters=recommended_parameters,
+        )
+
+    def __init__(
+        self,
+        model: torch.nn.Module,
+        inference_config: InferenceConfig,
+        class_names: List[str],
+        background_class_id: int,
+        device: torch.device,
+        recommended_parameters: Optional[RecommendedParameters] = None,
+    ):
+        self._model = model
+        self._inference_config = inference_config
+        self._class_names = class_names
+        self._background_class_id = background_class_id
+        self._device = device
+        self._lock = Lock()
+        self.recommended_parameters = recommended_parameters
+
+    @property
+    def class_names(self) -> List[str]:
+        return self._class_names
+
+    def pre_process(
+        self,
+        images: Union[torch.Tensor, List[torch.Tensor], np.ndarray, List[np.ndarray]],
+        input_color_format: Optional[ColorFormat] = None,
+        pre_processing_overrides: Optional[PreProcessingOverrides] = None,
+        **kwargs,
+    ) -> Tuple[torch.Tensor, List[PreProcessingMetadata]]:
+        return pre_process_network_input(
+            images=images,
+            image_pre_processing=self._inference_config.image_pre_processing,
+            network_input=self._inference_config.network_input,
+            target_device=self._device,
+            input_color_format=input_color_format,
+            pre_processing_overrides=pre_processing_overrides,
+        )
+
+    def forward(
+        self, pre_processed_images: torch.Tensor, **kwargs
+    ) -> torch.Tensor:
+        with self._lock, torch.inference_mode():
+            if (
+                pre_processed_images.shape[0]
+                == self._inference_config.forward_pass.static_batch_size
+            ):
+                output = self._model(pre_processed_images)
+                return output.to(self._device)
+            chunks = []
+            for input_tensor, padding_size in generate_batch_chunks(
+                input_batch=pre_processed_images,
+                chunk_size=self._inference_config.forward_pass.static_batch_size,
+            ):
+                output_for_chunk = self._model(input_tensor)
+                if padding_size > 0:
+                    output_for_chunk = output_for_chunk[:-padding_size]
+                chunks.append(output_for_chunk)
+            return torch.cat(chunks, dim=0).to(self._device)
+
+    def post_process(
+        self,
+        model_results: torch.Tensor,
+        pre_processing_meta: List[PreProcessingMetadata],
+        confidence: Confidence = "default",
+        **kwargs,
+    ) -> List[SemanticSegmentationResult]:
+        return post_process_semantic_segmentation_logits(
+            model_results=model_results,
+            pre_processing_meta=pre_processing_meta,
+            class_names=self._class_names,
+            background_class_id=self._background_class_id,
+            device=self._device,
+            confidence=confidence,
+            recommended_parameters=self.recommended_parameters,
+            default_confidence=INFERENCE_MODELS_YOLO26_DEFAULT_CONFIDENCE,
+        )

--- a/inference_models/inference_models/models/yolo26/yolo26_semantic_segmentation_torch_script.py
+++ b/inference_models/inference_models/models/yolo26/yolo26_semantic_segmentation_torch_script.py
@@ -22,6 +22,7 @@ from inference_models.models.common.roboflow.model_packages import (
     ResizeMode,
     parse_class_names_file,
     parse_inference_config,
+    resolve_background_class_id,
 )
 from inference_models.models.common.roboflow.post_processing import (
     post_process_semantic_segmentation_logits,
@@ -56,10 +57,7 @@ class YOLO26ForSemanticSegmentationTorchScript(
         class_names = parse_class_names_file(
             class_names_path=model_package_content["class_names.txt"]
         )
-        try:
-            background_class_id = [c.lower() for c in class_names].index("background")
-        except ValueError:
-            background_class_id = -1
+        background_class_id = resolve_background_class_id(class_names)
         inference_config = parse_inference_config(
             config_path=model_package_content["inference_config.json"],
             allowed_resize_modes={

--- a/inference_models/inference_models/models/yolo26/yolo26_semantic_segmentation_torch_script.py
+++ b/inference_models/inference_models/models/yolo26/yolo26_semantic_segmentation_torch_script.py
@@ -30,7 +30,10 @@ from inference_models.models.common.roboflow.post_processing import (
 from inference_models.models.common.roboflow.pre_processing import (
     pre_process_network_input,
 )
-from inference_models.models.common.torch import generate_batch_chunks
+from inference_models.models.common.torch import (
+    generate_batch_chunks,
+    torchscript_global_lock,
+)
 from inference_models.weights_providers.entities import RecommendedParameters
 
 
@@ -44,6 +47,7 @@ class YOLO26ForSemanticSegmentationTorchScript(
         model_name_or_path: str,
         device: torch.device = DEFAULT_DEVICE,
         recommended_parameters: Optional[RecommendedParameters] = None,
+        torchscript_state_global_lock: Optional[Lock] = None,
         **kwargs,
     ) -> "YOLO26ForSemanticSegmentationTorchScript":
         model_package_content = get_model_package_contents(
@@ -83,9 +87,10 @@ class YOLO26ForSemanticSegmentationTorchScript(
                 message="Expected static batch size to be registered in the inference configuration.",
                 help_url="https://inference-models.roboflow.com/errors/model-loading/#corruptedmodelpackageerror",
             )
-        model = torch.jit.load(
-            model_package_content["weights.torchscript"], map_location=device
-        ).train(False)
+        with torchscript_global_lock(torchscript_state_global_lock):
+            model = torch.jit.load(
+                model_package_content["weights.torchscript"], map_location=device
+            ).train(False)
         return cls(
             model=model,
             class_names=class_names,

--- a/inference_models/inference_models/models/yolo26/yolo26_semantic_segmentation_trt.py
+++ b/inference_models/inference_models/models/yolo26/yolo26_semantic_segmentation_trt.py
@@ -1,0 +1,286 @@
+import threading
+from threading import Lock
+from typing import List, Optional, Tuple, Union
+
+import numpy as np
+import torch
+
+from inference_models import ColorFormat, SemanticSegmentationModel
+from inference_models.configuration import (
+    DEFAULT_DEVICE,
+    INFERENCE_MODELS_YOLO26_DEFAULT_CONFIDENCE,
+)
+from inference_models.entities import Confidence
+from inference_models.errors import (
+    CorruptedModelPackageError,
+    MissingDependencyError,
+    ModelRuntimeError,
+)
+from inference_models.models.auto_loaders.entities import PreProcessingOverrides
+from inference_models.models.base.semantic_segmentation import (
+    SemanticSegmentationResult,
+)
+from inference_models.models.common.cuda import (
+    use_cuda_context,
+    use_primary_cuda_context,
+)
+from inference_models.models.common.model_packages import get_model_package_contents
+from inference_models.models.common.roboflow.model_packages import (
+    InferenceConfig,
+    PreProcessingMetadata,
+    ResizeMode,
+    TRTConfig,
+    parse_class_names_file,
+    parse_inference_config,
+    resolve_background_class_id,
+    parse_trt_config,
+)
+from inference_models.models.common.roboflow.post_processing import (
+    post_process_semantic_segmentation_logits,
+)
+from inference_models.models.common.roboflow.pre_processing import (
+    pre_process_network_input,
+)
+from inference_models.models.common.trt import (
+    TRTCudaGraphCache,
+    establish_trt_cuda_graph_cache,
+    get_trt_engine_inputs_and_outputs,
+    infer_from_trt_engine,
+    load_trt_model,
+)
+from inference_models.weights_providers.entities import RecommendedParameters
+
+try:
+    import tensorrt as trt
+except ImportError as import_error:
+    raise MissingDependencyError(
+        message="Running YOLO26 model with TRT backend on GPU requires pycuda installation, which is brought with "
+        "`trt-*` extras of `inference-models` library. If you see this error running locally, "
+        "please follow our installation guide: https://inference-models.roboflow.com/getting-started/installation/"
+        " If you see this error using Roboflow infrastructure, make sure the service you use does support the "
+        f"model, You can also contact Roboflow to get support."
+        "Additionally - if AutoModel.from_pretrained(...) "
+        f"automatically selects model package which does not match your environment - that's a serious problem and "
+        f"we will really appreciate letting us know - https://github.com/roboflow/inference/issues",
+        help_url="https://inference-models.roboflow.com/errors/runtime-environment/#missingdependencyerror",
+    ) from import_error
+
+try:
+    import pycuda.driver as cuda
+except ImportError as import_error:
+    raise MissingDependencyError(
+        message="Running YOLO26 model with TRT backend on GPU requires pycuda installation, which is brought with "
+        "`trt-*` extras of `inference-models` library. If you see this error running locally, "
+        "please follow our installation guide: https://inference-models.roboflow.com/getting-started/installation/"
+        " If you see this error using Roboflow infrastructure, make sure the service you use does support the "
+        f"model, You can also contact Roboflow to get support.",
+        help_url="https://inference-models.roboflow.com/errors/runtime-environment/#missingdependencyerror",
+    ) from import_error
+
+
+class YOLO26ForSemanticSegmentationTRT(
+    SemanticSegmentationModel[torch.Tensor, PreProcessingMetadata, torch.Tensor]
+):
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        model_name_or_path: str,
+        device: torch.device = DEFAULT_DEVICE,
+        engine_host_code_allowed: bool = False,
+        trt_cuda_graph_cache: Optional[TRTCudaGraphCache] = None,
+        default_trt_cuda_graph_cache_size: int = 8,
+        recommended_parameters: Optional[RecommendedParameters] = None,
+        **kwargs,
+    ) -> "YOLO26ForSemanticSegmentationTRT":
+        if device.type != "cuda":
+            raise ModelRuntimeError(
+                message=f"TRT engine only runs on CUDA device - {device} device detected.",
+                help_url="https://inference-models.roboflow.com/errors/models-runtime/#modelruntimeerror",
+            )
+        model_package_content = get_model_package_contents(
+            model_package_dir=model_name_or_path,
+            elements=[
+                "class_names.txt",
+                "inference_config.json",
+                "trt_config.json",
+                "engine.plan",
+            ],
+        )
+        class_names = parse_class_names_file(
+            class_names_path=model_package_content["class_names.txt"]
+        )
+        background_class_id = resolve_background_class_id(class_names)
+        inference_config = parse_inference_config(
+            config_path=model_package_content["inference_config.json"],
+            allowed_resize_modes={
+                ResizeMode.STRETCH_TO,
+                ResizeMode.LETTERBOX,
+                ResizeMode.CENTER_CROP,
+                ResizeMode.LETTERBOX_REFLECT_EDGES,
+            },
+            implicit_resize_mode_substitutions={
+                ResizeMode.FIT_LONGER_EDGE: (
+                    ResizeMode.LETTERBOX,
+                    127,
+                    "YOLO26 Semantic Segmentation model running with TRT backend was trained with "
+                    "`fit-longer-edge` input resize mode. This transform cannot be applied properly for "
+                    "models with input dimensions fixed during weights export. To ensure interoperability, `letterbox` "
+                    "resize mode with gray edges will be used instead. If model was trained on Roboflow platform, "
+                    "we recommend using preprocessing method different that `fit-longer-edge`.",
+                )
+            },
+        )
+        trt_config = parse_trt_config(
+            config_path=model_package_content["trt_config.json"]
+        )
+        cuda.init()
+        cuda_device = cuda.Device(device.index or 0)
+        with use_primary_cuda_context(cuda_device=cuda_device) as cuda_context:
+            engine = load_trt_model(
+                model_path=model_package_content["engine.plan"],
+                engine_host_code_allowed=engine_host_code_allowed,
+            )
+            execution_context = engine.create_execution_context()
+        inputs, outputs = get_trt_engine_inputs_and_outputs(engine=engine)
+        if len(inputs) != 1:
+            raise CorruptedModelPackageError(
+                message=f"Implementation assume single model input, found: {len(inputs)}.",
+                help_url="https://inference-models.roboflow.com/errors/model-loading/#corruptedmodelpackageerror",
+            )
+        if len(outputs) != 1:
+            raise CorruptedModelPackageError(
+                message=f"Implementation assume single model output, found: {len(outputs)}.",
+                help_url="https://inference-models.roboflow.com/errors/model-loading/#corruptedmodelpackageerror",
+            )
+        trt_cuda_graph_cache = establish_trt_cuda_graph_cache(
+            default_cuda_graph_cache_size=default_trt_cuda_graph_cache_size,
+            cuda_graph_cache=trt_cuda_graph_cache,
+        )
+        return cls(
+            engine=engine,
+            input_name=inputs[0],
+            output_name=outputs[0],
+            class_names=class_names,
+            background_class_id=background_class_id,
+            inference_config=inference_config,
+            trt_config=trt_config,
+            device=device,
+            cuda_context=cuda_context,
+            execution_context=execution_context,
+            trt_cuda_graph_cache=trt_cuda_graph_cache,
+            recommended_parameters=recommended_parameters,
+        )
+
+    def __init__(
+        self,
+        engine: trt.ICudaEngine,
+        input_name: str,
+        output_name: str,
+        class_names: List[str],
+        background_class_id: int,
+        inference_config: InferenceConfig,
+        trt_config: TRTConfig,
+        device: torch.device,
+        cuda_context: cuda.Context,
+        execution_context: trt.IExecutionContext,
+        trt_cuda_graph_cache: Optional[TRTCudaGraphCache],
+        recommended_parameters: Optional[RecommendedParameters] = None,
+    ):
+        self._engine = engine
+        self._input_name = input_name
+        self._output_names = [output_name]
+        self._class_names = class_names
+        self._background_class_id = background_class_id
+        self._inference_config = inference_config
+        self._trt_config = trt_config
+        self._device = device
+        self._cuda_context = cuda_context
+        self._execution_context = execution_context
+        self._trt_cuda_graph_cache = trt_cuda_graph_cache
+        self._lock = Lock()
+        self._inference_stream = torch.cuda.Stream(device=self._device)
+        self._thread_local_storage = threading.local()
+        self.recommended_parameters = recommended_parameters
+
+    @property
+    def class_names(self) -> List[str]:
+        return self._class_names
+
+    def pre_process(
+        self,
+        images: Union[torch.Tensor, List[torch.Tensor], np.ndarray, List[np.ndarray]],
+        input_color_format: Optional[ColorFormat] = None,
+        pre_processing_overrides: Optional[PreProcessingOverrides] = None,
+        **kwargs,
+    ) -> Tuple[torch.Tensor, List[PreProcessingMetadata]]:
+        with torch.cuda.stream(self._pre_process_stream):
+            pre_processed_images, pre_processing_meta = pre_process_network_input(
+                images=images,
+                image_pre_processing=self._inference_config.image_pre_processing,
+                network_input=self._inference_config.network_input,
+                target_device=self._device,
+                input_color_format=input_color_format,
+                pre_processing_overrides=pre_processing_overrides,
+            )
+        self._pre_process_stream.synchronize()
+        return pre_processed_images, pre_processing_meta
+
+    def forward(
+        self,
+        pre_processed_images: torch.Tensor,
+        disable_cuda_graphs: bool = False,
+        **kwargs,
+    ) -> torch.Tensor:
+        cache = self._trt_cuda_graph_cache if not disable_cuda_graphs else None
+        with self._lock:
+            with use_cuda_context(context=self._cuda_context):
+                return infer_from_trt_engine(
+                    pre_processed_images=pre_processed_images,
+                    trt_config=self._trt_config,
+                    engine=self._engine,
+                    context=self._execution_context,
+                    device=self._device,
+                    input_name=self._input_name,
+                    outputs=self._output_names,
+                    stream=self._inference_stream,
+                    trt_cuda_graph_cache=cache,
+                )[0]
+
+    def post_process(
+        self,
+        model_results: torch.Tensor,
+        pre_processing_meta: List[PreProcessingMetadata],
+        confidence: Confidence = "default",
+        **kwargs,
+    ) -> List[SemanticSegmentationResult]:
+        with torch.cuda.stream(self._post_process_stream):
+            model_results.record_stream(self._post_process_stream)
+            results = post_process_semantic_segmentation_logits(
+                model_results=model_results,
+                pre_processing_meta=pre_processing_meta,
+                class_names=self._class_names,
+                background_class_id=self._background_class_id,
+                device=self._device,
+                confidence=confidence,
+                recommended_parameters=self.recommended_parameters,
+                default_confidence=INFERENCE_MODELS_YOLO26_DEFAULT_CONFIDENCE,
+            )
+        self._post_process_stream.synchronize()
+        return results
+
+    @property
+    def _pre_process_stream(self) -> torch.cuda.Stream:
+        if not hasattr(self._thread_local_storage, "pre_process_stream"):
+            self._thread_local_storage.pre_process_stream = torch.cuda.Stream(
+                device=self._device
+            )
+        return self._thread_local_storage.pre_process_stream
+
+    @property
+    def _post_process_stream(self) -> torch.cuda.Stream:
+        if not hasattr(self._thread_local_storage, "post_process_stream"):
+            self._thread_local_storage.post_process_stream = torch.cuda.Stream(
+                device=self._device
+            )
+        return self._thread_local_storage.post_process_stream

--- a/inference_models/pyproject.toml
+++ b/inference_models/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inference-models"
-version = "0.28.6"
+version = "0.28.7"
 description = "The new inference engine for Computer Vision models"
 readme = "README.md"
 requires-python = ">=3.10,<3.13"

--- a/inference_models/tests/integration_tests/conftest.py
+++ b/inference_models/tests/integration_tests/conftest.py
@@ -33,6 +33,8 @@ BALLOONS_IMAGE_URL = (
     "https://media.roboflow.com/inference/example-input-images/balloons.jpg"
 )
 BALLOONS_IMAGE_PATH = os.path.join(ASSETS_DIR, "balloons.jpg")
+BUS_IMAGE_URL = "https://storage.googleapis.com/roboflow-tests-assets/test-images/bus.jpg"
+BUS_IMAGE_PATH = os.path.join(ASSETS_DIR, "bus.jpg")
 FLOWERS_IMAGE_URL = (
     "https://media.roboflow.com/inference/example-input-images/flowers.jpg"
 )
@@ -126,6 +128,20 @@ def balloons_image_numpy() -> np.ndarray:
 def balloons_image_torch() -> torch.Tensor:
     _download_if_not_exists(file_path=BALLOONS_IMAGE_PATH, url=BALLOONS_IMAGE_URL)
     return torchvision.io.read_image(BALLOONS_IMAGE_PATH)
+
+
+@pytest.fixture(scope="function")
+def bus_image_numpy() -> np.ndarray:
+    _download_if_not_exists(file_path=BUS_IMAGE_PATH, url=BUS_IMAGE_URL)
+    image = cv2.imread(BUS_IMAGE_PATH)
+    assert image is not None, "Could not load test image"
+    return image
+
+
+@pytest.fixture(scope="function")
+def bus_image_torch() -> torch.Tensor:
+    _download_if_not_exists(file_path=BUS_IMAGE_PATH, url=BUS_IMAGE_URL)
+    return torchvision.io.read_image(BUS_IMAGE_PATH)
 
 
 @pytest.fixture(scope="function")

--- a/inference_models/tests/integration_tests/models/conftest.py
+++ b/inference_models/tests/integration_tests/models/conftest.py
@@ -166,6 +166,9 @@ YOLO26N_SEG_SNAKES_STRETCH_TORCH_SCRIPT_URL = "https://storage.googleapis.com/ro
 YOLO26N_SEG_SNAKES_LETTERBOX_ONNX_STATIC_URL = "https://storage.googleapis.com/roboflow-tests-assets/yolo26n-packages/yolo26n-seg-snakes-letterbox-onnx-static.zip"
 YOLO26N_SEG_SNAKES_LETTERBOX_ONNX_DYNAMIC_URL = "https://storage.googleapis.com/roboflow-tests-assets/yolo26n-packages/yolo26n-seg-snakes-letterbox-onnx-dynamic.zip"
 YOLO26N_SEG_SNAKES_LETTERBOX_TORCH_SCRIPT_URL = "https://storage.googleapis.com/roboflow-tests-assets/yolo26n-packages/yolo26n-seg-snakes-letterbox-torch-script.zip"
+YOLO26N_SEM_ONNX_STATIC_URL = "https://storage.googleapis.com/roboflow-tests-assets/yolo26n-packages/yolo26n-sem-onnx-static.zip"
+YOLO26N_SEM_ONNX_DYNAMIC_URL = "https://storage.googleapis.com/roboflow-tests-assets/yolo26n-packages/yolo26n-sem-onnx-dynamic.zip"
+YOLO26N_SEM_TORCH_SCRIPT_URL = "https://storage.googleapis.com/roboflow-tests-assets/yolo26n-packages/yolo26n-sem-torch-script.zip"
 YOLO26N_POSE_BASKETBALL_LETTERBOX_ONNX_STATIC_URL = "https://storage.googleapis.com/roboflow-tests-assets/yolo26n-packages/yolo26n-pose-basketball-letterbox-onnx-static.zip"
 YOLO26N_POSE_BASKETBALL_LETTERBOX_ONNX_DYNAMIC_URL = "https://storage.googleapis.com/roboflow-tests-assets/yolo26n-packages/yolo26n-pose-basketball-letterbox-onnx-dynamic.zip"
 YOLO26N_POSE_BASKETBALL_LETTERBOX_TORCH_SCRIPT_URL = "https://storage.googleapis.com/roboflow-tests-assets/yolo26n-packages/yolo26n-pose-basketball-letterbox-torch-script.zip"
@@ -1503,6 +1506,30 @@ def yolo26n_seg_snakes_letterbox_torch_script_package() -> str:
     return download_model_package(
         model_package_zip_url=YOLO26N_SEG_SNAKES_LETTERBOX_TORCH_SCRIPT_URL,
         package_name="yolo26n-seg-snakes-letterbox-torch-script",
+    )
+
+
+@pytest.fixture(scope="module")
+def yolo26n_sem_onnx_static_package() -> str:
+    return download_model_package(
+        model_package_zip_url=YOLO26N_SEM_ONNX_STATIC_URL,
+        package_name="yolo26n-sem-onnx-static",
+    )
+
+
+@pytest.fixture(scope="module")
+def yolo26n_sem_onnx_dynamic_package() -> str:
+    return download_model_package(
+        model_package_zip_url=YOLO26N_SEM_ONNX_DYNAMIC_URL,
+        package_name="yolo26n-sem-onnx-dynamic",
+    )
+
+
+@pytest.fixture(scope="module")
+def yolo26n_sem_torch_script_package() -> str:
+    return download_model_package(
+        model_package_zip_url=YOLO26N_SEM_TORCH_SCRIPT_URL,
+        package_name="yolo26n-sem-torch-script",
     )
 
 

--- a/inference_models/tests/integration_tests/models/test_yolo26_semantic_segmentation_predictions_onnx.py
+++ b/inference_models/tests/integration_tests/models/test_yolo26_semantic_segmentation_predictions_onnx.py
@@ -1,0 +1,234 @@
+"""
+Integration tests for the public yolo26{n}-sem-1024 pretrained packages,
+exercising the YOLO26ForSemanticSegmentationOnnx class end-to-end with the
+Cityscapes-class bus.jpg test image.
+
+Class IDs follow the Roboflow convention with class 0 = background; the
+underlying Cityscapes 19 classes are shifted to indices 1..19.
+
+Numpy vs torch input pathways disagree by ~870 pixels on the dominant
+class. cv2.imread (BGR via libjpeg) and torchvision.io.read_image (RGB via
+libjpeg-turbo) decode the same JPEG to slightly different uint8 values;
+for a 19-class semantic head with many near-tie argmax decisions the drift
+amplifies. The model + post-processing are deterministic — only the
+decoded input bytes differ.
+
+On top of that, the torch pathway also diverges between CPU and CUDA
+execution providers by another ~1500 pixels; the numpy pathway happens to
+be stable across hardware. Per-path bounds keep regressions catchable
+without forcing a single loose union range; the torch bounds are
+deliberately wider to cover both hardware backends.
+"""
+
+from typing import List, Tuple
+
+import numpy as np
+import pytest
+import torch
+
+
+EXPECTED_CLASSES_PRESENT: List[int] = [0, 1, 2, 3, 5, 6, 8, 9, 12, 14, 15, 17]
+
+# cv2.imread (BGR) input pathway.
+NUMPY_MEAN_CONFIDENCE = 0.9355
+NUMPY_TRAIN_PIXEL_RANGE = (256150, 256250)  # class 17 dominates bus body
+NUMPY_ROAD_PIXEL_RANGE = (221140, 221240)  # class 1 ground plane
+
+# torchvision.io.read_image (RGB) input pathway. Bounds are wider than the
+# numpy path because CPU and CUDA execution providers disagree by ~1500
+# pixels here (CPU local: train=257073, road=221256; GPU CI: train=255529).
+# Same model graph, same input bytes — the drift comes from execution-provider
+# precision differences amplified by 19-class near-tie argmax decisions.
+TORCH_MEAN_CONFIDENCE = 0.9358
+TORCH_TRAIN_PIXEL_RANGE = (255500, 257150)
+TORCH_ROAD_PIXEL_RANGE = (221050, 221350)
+
+
+def _assert_bus_predictions(
+    prediction,
+    mean_confidence: float,
+    train_pixel_range: Tuple[int, int],
+    road_pixel_range: Tuple[int, int],
+) -> None:
+    seg = prediction.segmentation_map
+    conf = prediction.confidence
+    assert seg.shape == (1080, 810)
+    assert conf.shape == (1080, 810)
+    assert sorted(torch.unique(seg).cpu().tolist()) == EXPECTED_CLASSES_PRESENT
+    assert torch.allclose(
+        torch.mean(conf).cpu(),
+        torch.tensor(mean_confidence).cpu(),
+        atol=0.005,
+    )
+    train_lo, train_hi = train_pixel_range
+    train_px = int(torch.sum(seg.cpu() == 17).item())
+    assert train_lo <= train_px <= train_hi, train_px
+    road_lo, road_hi = road_pixel_range
+    road_px = int(torch.sum(seg.cpu() == 1).item())
+    assert road_lo <= road_px <= road_hi, road_px
+
+
+def _assert_bus_predictions_numpy(prediction) -> None:
+    _assert_bus_predictions(
+        prediction,
+        mean_confidence=NUMPY_MEAN_CONFIDENCE,
+        train_pixel_range=NUMPY_TRAIN_PIXEL_RANGE,
+        road_pixel_range=NUMPY_ROAD_PIXEL_RANGE,
+    )
+
+
+def _assert_bus_predictions_torch(prediction) -> None:
+    _assert_bus_predictions(
+        prediction,
+        mean_confidence=TORCH_MEAN_CONFIDENCE,
+        train_pixel_range=TORCH_TRAIN_PIXEL_RANGE,
+        road_pixel_range=TORCH_ROAD_PIXEL_RANGE,
+    )
+
+
+@pytest.mark.slow
+@pytest.mark.onnx_extras
+def test_onnx_static_package_numpy(
+    yolo26n_sem_onnx_static_package: str,
+    bus_image_numpy: np.ndarray,
+) -> None:
+    # given
+    from inference_models.models.yolo26.yolo26_semantic_segmentation_onnx import (
+        YOLO26ForSemanticSegmentationOnnx,
+    )
+
+    model = YOLO26ForSemanticSegmentationOnnx.from_pretrained(
+        model_name_or_path=yolo26n_sem_onnx_static_package,
+        onnx_execution_providers=["CUDAExecutionProvider", "CPUExecutionProvider"],
+    )
+
+    # when
+    predictions = model(bus_image_numpy, confidence=0.5)
+
+    # then
+    assert len(predictions) == 1
+    _assert_bus_predictions_numpy(predictions[0])
+
+
+@pytest.mark.slow
+@pytest.mark.onnx_extras
+def test_onnx_static_package_batch_numpy(
+    yolo26n_sem_onnx_static_package: str,
+    bus_image_numpy: np.ndarray,
+) -> None:
+    # given
+    from inference_models.models.yolo26.yolo26_semantic_segmentation_onnx import (
+        YOLO26ForSemanticSegmentationOnnx,
+    )
+
+    model = YOLO26ForSemanticSegmentationOnnx.from_pretrained(
+        model_name_or_path=yolo26n_sem_onnx_static_package,
+        onnx_execution_providers=["CUDAExecutionProvider", "CPUExecutionProvider"],
+    )
+
+    # when
+    predictions = model([bus_image_numpy, bus_image_numpy], confidence=0.5)
+
+    # then
+    assert len(predictions) == 2
+    _assert_bus_predictions_numpy(predictions[0])
+    _assert_bus_predictions_numpy(predictions[1])
+
+
+@pytest.mark.slow
+@pytest.mark.onnx_extras
+def test_onnx_static_package_torch(
+    yolo26n_sem_onnx_static_package: str,
+    bus_image_torch: torch.Tensor,
+) -> None:
+    # given
+    from inference_models.models.yolo26.yolo26_semantic_segmentation_onnx import (
+        YOLO26ForSemanticSegmentationOnnx,
+    )
+
+    model = YOLO26ForSemanticSegmentationOnnx.from_pretrained(
+        model_name_or_path=yolo26n_sem_onnx_static_package,
+        onnx_execution_providers=["CUDAExecutionProvider", "CPUExecutionProvider"],
+    )
+
+    # when
+    predictions = model(bus_image_torch, confidence=0.5)
+
+    # then
+    assert len(predictions) == 1
+    _assert_bus_predictions_torch(predictions[0])
+
+
+@pytest.mark.slow
+@pytest.mark.onnx_extras
+def test_onnx_dynamic_package_numpy(
+    yolo26n_sem_onnx_dynamic_package: str,
+    bus_image_numpy: np.ndarray,
+) -> None:
+    # given
+    from inference_models.models.yolo26.yolo26_semantic_segmentation_onnx import (
+        YOLO26ForSemanticSegmentationOnnx,
+    )
+
+    model = YOLO26ForSemanticSegmentationOnnx.from_pretrained(
+        model_name_or_path=yolo26n_sem_onnx_dynamic_package,
+        onnx_execution_providers=["CUDAExecutionProvider", "CPUExecutionProvider"],
+    )
+
+    # when
+    predictions = model(bus_image_numpy, confidence=0.5)
+
+    # then
+    assert len(predictions) == 1
+    _assert_bus_predictions_numpy(predictions[0])
+
+
+@pytest.mark.slow
+@pytest.mark.onnx_extras
+def test_onnx_dynamic_package_batch_numpy(
+    yolo26n_sem_onnx_dynamic_package: str,
+    bus_image_numpy: np.ndarray,
+) -> None:
+    # given
+    from inference_models.models.yolo26.yolo26_semantic_segmentation_onnx import (
+        YOLO26ForSemanticSegmentationOnnx,
+    )
+
+    model = YOLO26ForSemanticSegmentationOnnx.from_pretrained(
+        model_name_or_path=yolo26n_sem_onnx_dynamic_package,
+        onnx_execution_providers=["CUDAExecutionProvider", "CPUExecutionProvider"],
+    )
+
+    # when
+    predictions = model(
+        [bus_image_numpy, bus_image_numpy, bus_image_numpy], confidence=0.5
+    )
+
+    # then
+    assert len(predictions) == 3
+    for prediction in predictions:
+        _assert_bus_predictions_numpy(prediction)
+
+
+@pytest.mark.slow
+@pytest.mark.onnx_extras
+def test_onnx_static_package_below_confidence_collapses_to_background(
+    yolo26n_sem_onnx_static_package: str,
+    bus_image_numpy: np.ndarray,
+) -> None:
+    """At confidence=1.0 every pixel falls back to the background_class_id."""
+    # given
+    from inference_models.models.yolo26.yolo26_semantic_segmentation_onnx import (
+        YOLO26ForSemanticSegmentationOnnx,
+    )
+
+    model = YOLO26ForSemanticSegmentationOnnx.from_pretrained(
+        model_name_or_path=yolo26n_sem_onnx_static_package,
+        onnx_execution_providers=["CUDAExecutionProvider", "CPUExecutionProvider"],
+    )
+
+    # when
+    predictions = model(bus_image_numpy, confidence=1.0)
+
+    seg = predictions[0].segmentation_map
+    assert torch.all(seg == 0)

--- a/inference_models/tests/integration_tests/models/test_yolo26_semantic_segmentation_predictions_torch_script.py
+++ b/inference_models/tests/integration_tests/models/test_yolo26_semantic_segmentation_predictions_torch_script.py
@@ -1,0 +1,149 @@
+"""
+Integration tests for the public yolo26{n}-sem-1024 pretrained TorchScript
+package, exercising the YOLO26ForSemanticSegmentationTorchScript class
+end-to-end with the Cityscapes-class bus.jpg test image.
+
+Numpy vs torch input pathways disagree by ~870 pixels on the dominant
+class. cv2.imread (BGR via libjpeg) and torchvision.io.read_image (RGB via
+libjpeg-turbo) decode the same JPEG to slightly different uint8 values;
+for a 19-class semantic head with many near-tie argmax decisions the drift
+amplifies. The model + post-processing are deterministic — only the
+decoded input bytes differ.
+
+On top of that, the torch pathway also diverges between CPU and CUDA
+execution by another ~1500 pixels; the numpy pathway is stable across
+hardware. Per-path bounds keep regressions catchable without forcing a
+single loose union range; the torch bounds are deliberately wider to
+cover both hardware backends.
+"""
+
+from typing import List, Tuple
+
+import numpy as np
+import pytest
+import torch
+
+
+EXPECTED_CLASSES_PRESENT: List[int] = [0, 1, 2, 3, 5, 6, 8, 9, 12, 14, 15, 17]
+
+# cv2.imread (BGR) input pathway.
+NUMPY_MEAN_CONFIDENCE = 0.9355
+NUMPY_TRAIN_PIXEL_RANGE = (256150, 256250)
+NUMPY_ROAD_PIXEL_RANGE = (221140, 221240)
+
+# torchvision.io.read_image (RGB) input pathway. Bounds are wider than the
+# numpy path because CPU and CUDA execution providers disagree by ~1500
+# pixels here. The TorchScript backend goes through the same torch tensor
+# pre-processing path as ONNX, so the same drift applies.
+TORCH_MEAN_CONFIDENCE = 0.9358
+TORCH_TRAIN_PIXEL_RANGE = (255500, 257150)
+TORCH_ROAD_PIXEL_RANGE = (221050, 221350)
+
+
+def _assert_bus_predictions(
+    prediction,
+    mean_confidence: float,
+    train_pixel_range: Tuple[int, int],
+    road_pixel_range: Tuple[int, int],
+) -> None:
+    seg = prediction.segmentation_map
+    conf = prediction.confidence
+    assert seg.shape == (1080, 810)
+    assert conf.shape == (1080, 810)
+    assert sorted(torch.unique(seg).cpu().tolist()) == EXPECTED_CLASSES_PRESENT
+    assert torch.allclose(
+        torch.mean(conf).cpu(),
+        torch.tensor(mean_confidence).cpu(),
+        atol=0.005,
+    )
+    train_lo, train_hi = train_pixel_range
+    train_px = int(torch.sum(seg.cpu() == 17).item())
+    assert train_lo <= train_px <= train_hi, train_px
+    road_lo, road_hi = road_pixel_range
+    road_px = int(torch.sum(seg.cpu() == 1).item())
+    assert road_lo <= road_px <= road_hi, road_px
+
+
+def _assert_bus_predictions_numpy(prediction) -> None:
+    _assert_bus_predictions(
+        prediction,
+        mean_confidence=NUMPY_MEAN_CONFIDENCE,
+        train_pixel_range=NUMPY_TRAIN_PIXEL_RANGE,
+        road_pixel_range=NUMPY_ROAD_PIXEL_RANGE,
+    )
+
+
+def _assert_bus_predictions_torch(prediction) -> None:
+    _assert_bus_predictions(
+        prediction,
+        mean_confidence=TORCH_MEAN_CONFIDENCE,
+        train_pixel_range=TORCH_TRAIN_PIXEL_RANGE,
+        road_pixel_range=TORCH_ROAD_PIXEL_RANGE,
+    )
+
+
+@pytest.mark.slow
+def test_torch_script_package_numpy(
+    yolo26n_sem_torch_script_package: str,
+    bus_image_numpy: np.ndarray,
+) -> None:
+    # given
+    from inference_models.models.yolo26.yolo26_semantic_segmentation_torch_script import (
+        YOLO26ForSemanticSegmentationTorchScript,
+    )
+
+    model = YOLO26ForSemanticSegmentationTorchScript.from_pretrained(
+        model_name_or_path=yolo26n_sem_torch_script_package,
+    )
+
+    # when
+    predictions = model(bus_image_numpy, confidence=0.5)
+
+    # then
+    assert len(predictions) == 1
+    _assert_bus_predictions_numpy(predictions[0])
+
+
+@pytest.mark.slow
+def test_torch_script_package_batch_numpy(
+    yolo26n_sem_torch_script_package: str,
+    bus_image_numpy: np.ndarray,
+) -> None:
+    # given
+    from inference_models.models.yolo26.yolo26_semantic_segmentation_torch_script import (
+        YOLO26ForSemanticSegmentationTorchScript,
+    )
+
+    model = YOLO26ForSemanticSegmentationTorchScript.from_pretrained(
+        model_name_or_path=yolo26n_sem_torch_script_package,
+    )
+
+    # when
+    predictions = model([bus_image_numpy, bus_image_numpy], confidence=0.5)
+
+    # then
+    assert len(predictions) == 2
+    _assert_bus_predictions_numpy(predictions[0])
+    _assert_bus_predictions_numpy(predictions[1])
+
+
+@pytest.mark.slow
+def test_torch_script_package_torch(
+    yolo26n_sem_torch_script_package: str,
+    bus_image_torch: torch.Tensor,
+) -> None:
+    # given
+    from inference_models.models.yolo26.yolo26_semantic_segmentation_torch_script import (
+        YOLO26ForSemanticSegmentationTorchScript,
+    )
+
+    model = YOLO26ForSemanticSegmentationTorchScript.from_pretrained(
+        model_name_or_path=yolo26n_sem_torch_script_package,
+    )
+
+    # when
+    predictions = model(bus_image_torch, confidence=0.5)
+
+    # then
+    assert len(predictions) == 1
+    _assert_bus_predictions_torch(predictions[0])

--- a/inference_models/tests/unit_tests/models/common/roboflow/test_model_packages.py
+++ b/inference_models/tests/unit_tests/models/common/roboflow/test_model_packages.py
@@ -20,6 +20,7 @@ from inference_models.models.common.roboflow.model_packages import (
     parse_inference_config,
     parse_key_points_metadata,
     parse_trt_config,
+    resolve_background_class_id,
 )
 
 
@@ -268,6 +269,28 @@ def test_parse_class_names_file_when_valid_config_provided(
 
     # then
     assert result == ["some", "other", "yet-another"]
+
+
+def test_resolve_background_class_id_when_background_present() -> None:
+    # when
+    result = resolve_background_class_id(["background", "road", "sidewalk"])
+
+    # then
+    assert result == 0
+
+
+def test_resolve_background_class_id_is_case_insensitive() -> None:
+    # when
+    result = resolve_background_class_id(["road", "Background", "sidewalk"])
+
+    # then
+    assert result == 1
+
+
+def test_resolve_background_class_id_when_background_absent() -> None:
+    # when
+    with pytest.raises(CorruptedModelPackageError):
+        _ = resolve_background_class_id(["road", "sidewalk", "building"])
 
 
 def test_parse_inference_config_when_path_does_not_exists() -> None:

--- a/inference_models/tests/unit_tests/models/test_yolo26_semantic_segmentation.py
+++ b/inference_models/tests/unit_tests/models/test_yolo26_semantic_segmentation.py
@@ -1,0 +1,145 @@
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+
+def test_post_process_semantic_segmentation_logits_argmax_collapses_to_winning_class():
+    """Logits (B, K, H, W) with class 2 dominant collapse to a (H, W) seg_map
+    of class 2 across the board after softmax + argmax."""
+    from inference_models.models.common.roboflow.post_processing import (
+        post_process_semantic_segmentation_logits,
+    )
+
+    h, w, num_classes = 8, 8, 3
+    logits = torch.zeros(1, num_classes, h, w)
+    logits[0, 2] = 5.0  # class 2 dominates everywhere
+
+    meta = [
+        MagicMock(
+            inference_size=MagicMock(height=h, width=w),
+            pad_top=0, pad_bottom=0, pad_left=0, pad_right=0,
+            size_after_pre_processing=MagicMock(height=h, width=w),
+            original_size=MagicMock(height=h, width=w),
+            static_crop_offset=MagicMock(offset_x=0, offset_y=0),
+        )
+    ]
+
+    results = post_process_semantic_segmentation_logits(
+        model_results=logits,
+        pre_processing_meta=meta,
+        class_names=["a", "b", "c"],
+        background_class_id=-1,
+        device=torch.device("cpu"),
+        confidence=0.0,
+        recommended_parameters=None,
+        default_confidence=0.0,
+    )
+
+    assert len(results) == 1
+    assert results[0].segmentation_map.shape == (h, w)
+    assert torch.all(results[0].segmentation_map == 2)
+    assert results[0].confidence.shape == (h, w)
+    # softmax of [0, 0, 5] for class 2 dominant = e^5 / (2 + e^5) ~= 0.987
+    assert torch.all(results[0].confidence > 0.98)
+
+
+def test_post_process_semantic_segmentation_logits_sub_threshold_collapses_to_background():
+    """Pixels whose softmax confidence is below the threshold collapse to background_class_id."""
+    from inference_models.models.common.roboflow.post_processing import (
+        post_process_semantic_segmentation_logits,
+    )
+
+    h, w, num_classes = 4, 4, 3
+    # Uniform logits → softmax = 1/3 everywhere; with threshold 0.5 all pixels go below
+    logits = torch.zeros(1, num_classes, h, w)
+
+    meta = [
+        MagicMock(
+            inference_size=MagicMock(height=h, width=w),
+            pad_top=0, pad_bottom=0, pad_left=0, pad_right=0,
+            size_after_pre_processing=MagicMock(height=h, width=w),
+            original_size=MagicMock(height=h, width=w),
+            static_crop_offset=MagicMock(offset_x=0, offset_y=0),
+        )
+    ]
+
+    results = post_process_semantic_segmentation_logits(
+        model_results=logits,
+        pre_processing_meta=meta,
+        class_names=["a", "b", "c"],
+        background_class_id=-1,
+        device=torch.device("cpu"),
+        confidence=0.5,
+        recommended_parameters=None,
+        default_confidence=0.5,
+    )
+
+    assert torch.all(results[0].segmentation_map == -1)
+    assert torch.all(results[0].confidence == 0.0)
+
+
+def test_post_process_semantic_segmentation_logits_shifts_when_class_names_prepends_background():
+    """When class_names has one extra entry (background at index 0) compared to
+    the number of logit channels, argmax outputs are shifted by +1 so class 0
+    stays reserved for sub-threshold pixels."""
+    from inference_models.models.common.roboflow.post_processing import (
+        post_process_semantic_segmentation_logits,
+    )
+
+    h, w, num_channels = 8, 8, 3
+    logits = torch.zeros(1, num_channels, h, w)
+    logits[0, 2] = 5.0  # channel 2 dominates → expect class_id 3 after shift
+
+    meta = [
+        MagicMock(
+            inference_size=MagicMock(height=h, width=w),
+            pad_top=0, pad_bottom=0, pad_left=0, pad_right=0,
+            size_after_pre_processing=MagicMock(height=h, width=w),
+            original_size=MagicMock(height=h, width=w),
+            static_crop_offset=MagicMock(offset_x=0, offset_y=0),
+        )
+    ]
+
+    results = post_process_semantic_segmentation_logits(
+        model_results=logits,
+        pre_processing_meta=meta,
+        class_names=["background", "a", "b", "c"],
+        background_class_id=0,
+        device=torch.device("cpu"),
+        confidence=0.0,
+        recommended_parameters=None,
+        default_confidence=0.0,
+    )
+
+    assert torch.all(results[0].segmentation_map == 3)
+
+
+def test_yolo26_semantic_segmentation_onnx_import():
+    try:
+        from inference_models.models.yolo26.yolo26_semantic_segmentation_onnx import (
+            YOLO26ForSemanticSegmentationOnnx,
+        )
+    except Exception as exc:
+        pytest.skip(f"ONNX extras unavailable: {exc}")
+    assert YOLO26ForSemanticSegmentationOnnx is not None
+
+
+def test_yolo26_semantic_segmentation_torch_script_import():
+    from inference_models.models.yolo26.yolo26_semantic_segmentation_torch_script import (
+        YOLO26ForSemanticSegmentationTorchScript,
+    )
+    assert YOLO26ForSemanticSegmentationTorchScript is not None
+
+
+def test_yolo26_semantic_segmentation_registered():
+    from inference_models.models.auto_loaders.entities import BackendType
+    from inference_models.models.auto_loaders.models_registry import (
+        REGISTERED_MODELS,
+        SEMANTIC_SEGMENTATION_TASK,
+    )
+
+    for backend in (BackendType.ONNX, BackendType.TORCH_SCRIPT):
+        assert ("yolo26", SEMANTIC_SEGMENTATION_TASK, backend) in REGISTERED_MODELS, (
+            f"Missing yolo26 semantic seg entry for backend {backend}"
+        )

--- a/inference_models/tests/unit_tests/models/test_yolo26_semantic_segmentation.py
+++ b/inference_models/tests/unit_tests/models/test_yolo26_semantic_segmentation.py
@@ -1,6 +1,5 @@
 from unittest.mock import MagicMock
 
-import pytest
 import torch
 
 
@@ -115,23 +114,6 @@ def test_post_process_semantic_segmentation_logits_shifts_when_class_names_prepe
     assert torch.all(results[0].segmentation_map == 3)
 
 
-def test_yolo26_semantic_segmentation_onnx_import():
-    try:
-        from inference_models.models.yolo26.yolo26_semantic_segmentation_onnx import (
-            YOLO26ForSemanticSegmentationOnnx,
-        )
-    except Exception as exc:
-        pytest.skip(f"ONNX extras unavailable: {exc}")
-    assert YOLO26ForSemanticSegmentationOnnx is not None
-
-
-def test_yolo26_semantic_segmentation_torch_script_import():
-    from inference_models.models.yolo26.yolo26_semantic_segmentation_torch_script import (
-        YOLO26ForSemanticSegmentationTorchScript,
-    )
-    assert YOLO26ForSemanticSegmentationTorchScript is not None
-
-
 def test_yolo26_semantic_segmentation_registered():
     from inference_models.models.auto_loaders.entities import BackendType
     from inference_models.models.auto_loaders.models_registry import (
@@ -139,7 +121,7 @@ def test_yolo26_semantic_segmentation_registered():
         SEMANTIC_SEGMENTATION_TASK,
     )
 
-    for backend in (BackendType.ONNX, BackendType.TORCH_SCRIPT):
+    for backend in (BackendType.ONNX, BackendType.TORCH_SCRIPT, BackendType.TRT):
         assert ("yolo26", SEMANTIC_SEGMENTATION_TASK, backend) in REGISTERED_MODELS, (
             f"Missing yolo26 semantic seg entry for backend {backend}"
         )

--- a/requirements/requirements.cpu.txt
+++ b/requirements/requirements.cpu.txt
@@ -1,3 +1,3 @@
 onnxruntime>=1.15.1,<1.22.0
 nvidia-ml-py<13.0.0
-inference-models[torch-cpu,onnx-cpu]~=0.28.6  # keep in sync between requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt
+inference-models[torch-cpu,onnx-cpu]~=0.28.7  # keep in sync between requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt

--- a/requirements/requirements.gpu.txt
+++ b/requirements/requirements.gpu.txt
@@ -1,2 +1,2 @@
 onnxruntime-gpu>=1.15.1,<1.22.0
-inference-models[torch-cu124,onnx-cu12]~=0.28.6  # keep in sync between requirements.jetson requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt
+inference-models[torch-cu124,onnx-cu12]~=0.28.7  # keep in sync between requirements.jetson requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt

--- a/requirements/requirements.jetson.txt
+++ b/requirements/requirements.jetson.txt
@@ -1,4 +1,4 @@
 pypdfium2>=4.11.0,<5.0.0
 jupyterlab>=4.3.0,<5.0.0
 PyYAML~=6.0.0
-inference-models~=0.28.6  # keep in sync between requirements.jetson requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt
+inference-models~=0.28.7  # keep in sync between requirements.jetson requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt

--- a/requirements/requirements.vino.txt
+++ b/requirements/requirements.vino.txt
@@ -1,2 +1,2 @@
 onnxruntime-openvino>=1.15.0,<1.22.0
-inference-models[torch-cpu]~=0.28.6  # keep in sync between requirements.jetson requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt
+inference-models[torch-cpu]~=0.28.7  # keep in sync between requirements.jetson requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt


### PR DESCRIPTION
## What does this PR do?

Adds YOLO26 semantic segmentation support to `inference_models` for the ONNX and TorchScript backends. Unblocks the `yolo26{n,s,m,l,x}-sem-1024` pretrained models. TRT backend follows in #2379 once compiled engines exist to test against.

- New `YOLO26ForSemanticSegmentation{Onnx,TorchScript}` classes, two `(yolo26, semantic-segmentation, …)` registry tuples, one `/infer` dispatch entry.
- Extracts semantic-seg post-processing into a shared helper (`post_process_semantic_segmentation_logits`); refactors the three DeepLabV3+ backends onto it. Helper shifts argmax `+1` when `len(class_names) == n_logit_channels + 1` so the 0=background convention holds for models trained without an explicit background channel.

**Related Issue(s):** _n/a_

## Type of Change

- New feature (non-breaking change that adds functionality)

## Testing

- [x] I have tested this change locally
- [x] I have added/updated tests for this change

**Test details:**

- **Unit**: helper coverage (winning-class collapse, sub-threshold background fallback, +1 shift), import smoke, registry lookup.
- **Integration ONNX (CPU + GPU CI)**: 6 tests against the \`yolo26n-sem\` static + dynamic packages on \`bus.jpg\`, asserting class set, mean confidence, and per-class pixel counts. Separate bounds for the cv2/BGR vs torchvision/RGB input pathways (with wider torch bounds covering CPU↔CUDA drift).
- **Integration TorchScript (CPU CI)**: 3 mirroring tests.
- **Manual**: all five sizes registered on staging, validated end-to-end via \`AutoModel.from_pretrained\` + \`/infer/semantic_segmentation\` against \`bus.jpg\`. Also exercised via Semantic Seg workflow block.

<img width="1818" height="1456" alt="image" src="https://github.com/user-attachments/assets/caaf4a6f-6ec8-4911-8efc-984815a686cf" />


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)

## Additional Context

Pairs with [roboflow/roboflow-model-conversion#92](https://github.com/roboflow/roboflow-model-conversion/pull/92) (converter \`-sem\` task + background prepend) and [roboflow/roboflow#11989](https://github.com/roboflow/roboflow/pull/11989) (platform catalog).