### PR TITLE
fix: serialize TorchScript load/script behind a global lock

### DIFF
--- a/inference/core/managers/base.py
+++ b/inference/core/managers/base.py
@@ -1,7 +1,8 @@
+import inspect
 import time
 from contextlib import contextmanager
 from threading import Lock
-from typing import Dict, Generator, List, Optional, Tuple, Union
+from typing import Callable, Dict, Generator, List, Optional, Tuple, Union
 
 import numpy as np
 from fastapi.encoders import jsonable_encoder
@@ -48,6 +49,22 @@ from inference.core.telemetry import (
     set_span_attribute,
     start_span,
 )
+
+
+# torch.jit.load/script mutate a process-global, non-thread-safe TorchScript registry.
+# Every model load acquires this so concurrent loads (preload / parallel requests) cannot
+# corrupt it. Passed only to loaders that accept `torchscript_state_global_lock`.
+_TORCHSCRIPT_STATE_GLOBAL_LOCK = Lock()
+
+
+def _accepts_kwarg(fn: Callable, name: str) -> bool:
+    try:
+        params = inspect.signature(fn).parameters
+    except (TypeError, ValueError):
+        return False
+    if name in params:
+        return True
+    return any(p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values())
 
 
 class ModelManager:
@@ -134,11 +151,19 @@ class ModelManager:
                         service_secret=service_secret,
                     )
 
+                    extra_init_kwargs = {}
+                    if _accepts_kwarg(
+                        model_class.__init__, "torchscript_state_global_lock"
+                    ):
+                        extra_init_kwargs["torchscript_state_global_lock"] = (
+                            _TORCHSCRIPT_STATE_GLOBAL_LOCK
+                        )
                     model = model_class(
                         model_id=model_id,
                         api_key=api_key,
                         countinference=countinference,
                         service_secret=service_secret,
+                        **extra_init_kwargs,
                     )
                     vram_after = _get_cuda_memory_allocated()
                     if vram_before is not None and vram_after is not None:

--- a/inference/core/managers/base.py
+++ b/inference/core/managers/base.py
@@ -1,8 +1,7 @@
-import inspect
 import time
 from contextlib import contextmanager
 from threading import Lock
-from typing import Callable, Dict, Generator, List, Optional, Tuple, Union
+from typing import Dict, Generator, List, Optional, Tuple, Union
 
 import numpy as np
 from fastapi.encoders import jsonable_encoder
@@ -51,22 +50,6 @@ from inference.core.telemetry import (
 )
 
 
-# torch.jit.load/script mutate a process-global, non-thread-safe TorchScript registry.
-# Every model load acquires this so concurrent loads (preload / parallel requests) cannot
-# corrupt it. Passed only to loaders that accept `torchscript_state_global_lock`.
-_TORCHSCRIPT_STATE_GLOBAL_LOCK = Lock()
-
-
-def _accepts_kwarg(fn: Callable, name: str) -> bool:
-    try:
-        params = inspect.signature(fn).parameters
-    except (TypeError, ValueError):
-        return False
-    if name in params:
-        return True
-    return any(p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values())
-
-
 class ModelManager:
     """Model managers keep track of a dictionary of Model objects and is responsible for passing requests to the right model using the infer method."""
 
@@ -78,6 +61,9 @@ class ModelManager:
         self.pingback = None
         self._state_lock = Lock()
         self._models_state_locks: Dict[str, Lock] = {}
+        # torch.jit.load/script mutate a process-global, non-thread-safe TorchScript
+        # registry; loaders acquire this so concurrent loads cannot corrupt it.
+        self.torchscript_state_global_lock = Lock()
 
     def init_pingback(self):
         """Initializes pingback mechanism."""
@@ -152,11 +138,9 @@ class ModelManager:
                     )
 
                     extra_init_kwargs = {}
-                    if _accepts_kwarg(
-                        model_class.__init__, "torchscript_state_global_lock"
-                    ):
+                    if USE_INFERENCE_MODELS:
                         extra_init_kwargs["torchscript_state_global_lock"] = (
-                            _TORCHSCRIPT_STATE_GLOBAL_LOCK
+                            self.torchscript_state_global_lock
                         )
                     model = model_class(
                         model_id=model_id,

--- a/inference_models/docs/changelog.md
+++ b/inference_models/docs/changelog.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## `0.28.6`
+
+- torch.jit.load/script share a process-global which is not thread-safe, introduced lock to prevent race conditions when loading SAM3 and other torchscript models
+- `0.28.5` yanked
+
+## `0.28.4`
+
+- Ported SAM3 to inference_models
+- There were issues with dependencies while introducing SAM3 hence versions `0.28.2` and `0.28.3`
+
 ## `0.28.1`
 
 ### Fixed

--- a/inference_models/inference_models/models/clip/clip_pytorch.py
+++ b/inference_models/inference_models/models/clip/clip_pytorch.py
@@ -1,3 +1,4 @@
+from threading import Lock
 from typing import Callable, List, Optional, Union
 
 import clip
@@ -11,6 +12,7 @@ from inference_models.errors import CorruptedModelPackageError
 from inference_models.models.base.embeddings import TextImageEmbeddingModel
 from inference_models.models.clip.preprocessing import create_clip_preprocessor
 from inference_models.models.common.model_packages import get_model_package_contents
+from inference_models.models.common.torch import torchscript_global_lock
 
 
 class ClipTorch(TextImageEmbeddingModel):
@@ -21,6 +23,7 @@ class ClipTorch(TextImageEmbeddingModel):
         model_name_or_path: str,
         device: torch.device = DEFAULT_DEVICE,
         max_batch_size: int = 32,
+        torchscript_state_global_lock: Optional[Lock] = None,
         **kwargs,
     ) -> "ClipTorch":
         model_package_content = get_model_package_contents(
@@ -28,7 +31,11 @@ class ClipTorch(TextImageEmbeddingModel):
             elements=["model.pt"],
         )
         model_weights_file = model_package_content["model.pt"]
-        model = build_clip_model(model_weights_file=model_weights_file, device=device)
+        model = build_clip_model(
+            model_weights_file=model_weights_file,
+            device=device,
+            torchscript_state_global_lock=torchscript_state_global_lock,
+        )
         model.eval()
         return cls(
             model=model,
@@ -88,11 +95,16 @@ class ClipTorch(TextImageEmbeddingModel):
         return torch.cat(results, dim=0)
 
 
-def build_clip_model(model_weights_file: str, device: torch.device) -> CLIP:
+def build_clip_model(
+    model_weights_file: str,
+    device: torch.device,
+    torchscript_state_global_lock: Optional[Lock] = None,
+) -> CLIP:
     try:
         # The model file is a JIT archive, so we load it as such
         # and then build a new model from its state dict.
-        jit_model = torch.jit.load(model_weights_file, map_location="cpu").eval()
+        with torchscript_global_lock(torchscript_state_global_lock):
+            jit_model = torch.jit.load(model_weights_file, map_location="cpu").eval()
         state_dict = jit_model.state_dict()
         model = build_model(state_dict).to(device)
         if device.type == "cpu":

--- a/inference_models/inference_models/models/common/torch.py
+++ b/inference_models/inference_models/models/common/torch.py
@@ -1,6 +1,29 @@
+import threading
+from contextlib import contextmanager
 from typing import Generator, Tuple
 
 import torch
+
+# TorchScript deserialization/compilation mutates a process-global type registry and
+# compilation unit that is NOT thread-safe. Loading two TorchScript-backed models
+# concurrently (e.g. preloading several PINNED_MODELS on a ThreadPoolExecutor) can
+# corrupt it, surfacing non-deterministically as `KeyError: '__torch__...'` or
+# `Enum<...___torch_mangle_N.InterpolationMode>` type mismatches. Serialize every
+# TorchScript load behind this single process-wide lock.
+_TORCHSCRIPT_LOAD_LOCK = threading.Lock()
+
+
+@contextmanager
+def torchscript_load_lock() -> Generator[None, None, None]:
+    """Serialize TorchScript model loading across threads.
+
+    Wrap any call that triggers TorchScript deserialization/compilation
+    (`torch.jit.load`, or model builders that script submodules) so concurrent loads
+    cannot corrupt TorchScript's global type registry. Guards one-time model
+    construction only; it does not affect inference concurrency.
+    """
+    with _TORCHSCRIPT_LOAD_LOCK:
+        yield
 
 
 def generate_batch_chunks(

--- a/inference_models/inference_models/models/common/torch.py
+++ b/inference_models/inference_models/models/common/torch.py
@@ -1,29 +1,18 @@
-import threading
-from contextlib import contextmanager
-from typing import Generator, Tuple
+from contextlib import nullcontext
+from threading import Lock
+from typing import ContextManager, Generator, Optional, Tuple
 
 import torch
 
-# TorchScript deserialization/compilation mutates a process-global type registry and
-# compilation unit that is NOT thread-safe. Loading two TorchScript-backed models
-# concurrently (e.g. preloading several PINNED_MODELS on a ThreadPoolExecutor) can
-# corrupt it, surfacing non-deterministically as `KeyError: '__torch__...'` or
-# `Enum<...___torch_mangle_N.InterpolationMode>` type mismatches. Serialize every
-# TorchScript load behind this single process-wide lock.
-_TORCHSCRIPT_LOAD_LOCK = threading.Lock()
 
+def torchscript_global_lock(lock: Optional[Lock]) -> ContextManager[None]:
+    """Serialize TorchScript load/script against a caller-provided lock.
 
-@contextmanager
-def torchscript_load_lock() -> Generator[None, None, None]:
-    """Serialize TorchScript model loading across threads.
-
-    Wrap any call that triggers TorchScript deserialization/compilation
-    (`torch.jit.load`, or model builders that script submodules) so concurrent loads
-    cannot corrupt TorchScript's global type registry. Guards one-time model
-    construction only; it does not affect inference concurrency.
+    `torch.jit.load`/`torch.jit.script` mutate a process-global, non-thread-safe
+    TorchScript registry; wrap them with this so concurrent model construction cannot
+    corrupt it. With `lock=None` it is a no-op (direct single-threaded library use).
     """
-    with _TORCHSCRIPT_LOAD_LOCK:
-        yield
+    return lock if lock is not None else nullcontext()
 
 
 def generate_batch_chunks(

--- a/inference_models/inference_models/models/sam3/sam3_torch.py
+++ b/inference_models/inference_models/models/sam3/sam3_torch.py
@@ -1,7 +1,7 @@
 import hashlib
 import json
 from copy import copy, deepcopy
-from threading import RLock
+from threading import Lock, RLock
 from typing import Dict, Generator, List, Optional, Tuple, TypeVar, Union
 
 import numpy as np
@@ -26,6 +26,7 @@ from sam3.train.transforms.basic_for_api import (
 from inference_models.configuration import DEFAULT_DEVICE, SAM3_IMAGE_SIZE
 from inference_models.errors import CorruptedModelPackageError, ModelInputError
 from inference_models.models.common.model_packages import get_model_package_contents
+from inference_models.models.common.torch import torchscript_global_lock
 from inference_models.models.sam3.cache import (
     Sam3ImageEmbeddingsCache,
     Sam3ImageEmbeddingsCacheNullObject,
@@ -77,6 +78,7 @@ class SAM3Torch:
         compile_model: bool = False,
         enable_inst_interactivity: bool = True,
         sam3_allow_client_generated_hash_ids: bool = False,
+        torchscript_state_global_lock: Optional[Lock] = None,
         **kwargs,
     ) -> "SAM3Torch":
         if sam3_image_embeddings_cache is None:
@@ -112,14 +114,18 @@ class SAM3Torch:
             pass
 
         device_str = "cuda" if device.type == "cuda" else "cpu"
-        sam3_model = build_sam3_image_model(
-            bpe_path=model_package_content["bpe_simple_vocab_16e6.txt.gz"],
-            checkpoint_path=model_package_content["weights.pt"],
-            device=device_str,
-            load_from_HF=False,
-            compile=compile_model,
-            enable_inst_interactivity=enable_inst_interactivity,
-        )
+        # build_sam3_image_model runs torch.jit.script on torchvision transforms
+        # (SAM2Transforms: Resize + Normalize), mutating the process-global TorchScript
+        # registry; serialize against concurrent loads/scripts.
+        with torchscript_global_lock(torchscript_state_global_lock):
+            sam3_model = build_sam3_image_model(
+                bpe_path=model_package_content["bpe_simple_vocab_16e6.txt.gz"],
+                checkpoint_path=model_package_content["weights.pt"],
+                device=device_str,
+                load_from_HF=False,
+                compile=compile_model,
+                enable_inst_interactivity=enable_inst_interactivity,
+            )
         # sam3==0.1.3 Sam3TrackerPredictor.__init__ enters a CUDA bf16
         # torch.autocast context and never exits it, leaking bf16 globally
         # for the rest of the process and breaking unrelated models in the

--- a/inference_models/inference_models/models/yolo26/yolo26_instance_segmentation_torch_script.py
+++ b/inference_models/inference_models/models/yolo26/yolo26_instance_segmentation_torch_script.py
@@ -17,6 +17,7 @@ from inference_models.configuration import (
 from inference_models.entities import ColorFormat, Confidence
 from inference_models.errors import CorruptedModelPackageError, ModelInputError
 from inference_models.models.common.model_packages import get_model_package_contents
+from inference_models.models.common.torch import torchscript_global_lock
 from inference_models.models.common.roboflow.model_packages import (
     InferenceConfig,
     PreProcessingMetadata,
@@ -48,6 +49,7 @@ class YOLO26ForInstanceSegmentationTorchScript(
         model_name_or_path: str,
         device: torch.device = DEFAULT_DEVICE,
         recommended_parameters: Optional[RecommendedParameters] = None,
+        torchscript_state_global_lock: Optional[Lock] = None,
         **kwargs,
     ) -> "YOLO26ForInstanceSegmentationTorchScript":
         model_package_content = get_model_package_contents(
@@ -86,9 +88,10 @@ class YOLO26ForInstanceSegmentationTorchScript(
                 message="Expected static batch size to be registered in the inference configuration.",
                 help_url="https://inference-models.roboflow.com/errors/model-loading/#corruptedmodelpackageerror",
             )
-        model = torch.jit.load(
-            model_package_content["weights.torchscript"], map_location=device
-        ).eval()
+        with torchscript_global_lock(torchscript_state_global_lock):
+            model = torch.jit.load(
+                model_package_content["weights.torchscript"], map_location=device
+            ).eval()
         return cls(
             model=model,
             class_names=class_names,

--- a/inference_models/inference_models/models/yolo26/yolo26_key_points_detection_torch_script.py
+++ b/inference_models/inference_models/models/yolo26/yolo26_key_points_detection_torch_script.py
@@ -18,6 +18,7 @@ from inference_models.configuration import (
 from inference_models.entities import ColorFormat, Confidence
 from inference_models.errors import CorruptedModelPackageError
 from inference_models.models.common.model_packages import get_model_package_contents
+from inference_models.models.common.torch import torchscript_global_lock
 from inference_models.models.common.roboflow.model_packages import (
     InferenceConfig,
     PreProcessingMetadata,
@@ -48,6 +49,7 @@ class YOLO26ForKeyPointsDetectionTorchScript(
         model_name_or_path: str,
         device: torch.device = DEFAULT_DEVICE,
         recommended_parameters: Optional[RecommendedParameters] = None,
+        torchscript_state_global_lock: Optional[Lock] = None,
         **kwargs,
     ) -> "YOLO26ForKeyPointsDetectionTorchScript":
         model_package_content = get_model_package_contents(
@@ -90,9 +92,10 @@ class YOLO26ForKeyPointsDetectionTorchScript(
         parsed_key_points_metadata, skeletons = parse_key_points_metadata(
             key_points_metadata_path=model_package_content["keypoints_metadata.json"]
         )
-        model = torch.jit.load(
-            model_package_content["weights.torchscript"], map_location=device
-        ).eval()
+        with torchscript_global_lock(torchscript_state_global_lock):
+            model = torch.jit.load(
+                model_package_content["weights.torchscript"], map_location=device
+            ).eval()
         return cls(
             model=model,
             class_names=class_names,

--- a/inference_models/inference_models/models/yolo26/yolo26_object_detection_torch_script.py
+++ b/inference_models/inference_models/models/yolo26/yolo26_object_detection_torch_script.py
@@ -12,6 +12,7 @@ from inference_models.configuration import (
 from inference_models.entities import ColorFormat, Confidence
 from inference_models.errors import CorruptedModelPackageError
 from inference_models.models.common.model_packages import get_model_package_contents
+from inference_models.models.common.torch import torchscript_global_lock
 from inference_models.models.common.roboflow.model_packages import (
     InferenceConfig,
     PreProcessingMetadata,
@@ -41,6 +42,7 @@ class YOLO26ForObjectDetectionTorchScript(
         model_name_or_path: str,
         device: torch.device = DEFAULT_DEVICE,
         recommended_parameters: Optional[RecommendedParameters] = None,
+        torchscript_state_global_lock: Optional[Lock] = None,
         **kwargs,
     ) -> "YOLO26ForObjectDetectionTorchScript":
         model_package_content = get_model_package_contents(
@@ -79,9 +81,10 @@ class YOLO26ForObjectDetectionTorchScript(
                 message="Expected static batch size to be registered in the inference configuration.",
                 help_url="https://inference-models.roboflow.com/errors/model-loading/#corruptedmodelpackageerror",
             )
-        model = torch.jit.load(
-            model_package_content["weights.torchscript"], map_location=device
-        ).eval()
+        with torchscript_global_lock(torchscript_state_global_lock):
+            model = torch.jit.load(
+                model_package_content["weights.torchscript"], map_location=device
+            ).eval()
         return cls(
             model=model,
             class_names=class_names,

--- a/inference_models/inference_models/models/yolov8/yolov8_instance_segmentation_torch_script.py
+++ b/inference_models/inference_models/models/yolov8/yolov8_instance_segmentation_torch_script.py
@@ -23,6 +23,7 @@ from inference_models.configuration import (
 from inference_models.entities import ColorFormat, Confidence
 from inference_models.errors import CorruptedModelPackageError, ModelInputError
 from inference_models.models.common.model_packages import get_model_package_contents
+from inference_models.models.common.torch import torchscript_global_lock
 from inference_models.models.common.roboflow.model_packages import (
     InferenceConfig,
     PreProcessingMetadata,
@@ -55,6 +56,7 @@ class YOLOv8ForInstanceSegmentationTorchScript(
         model_name_or_path: str,
         device: torch.device = DEFAULT_DEVICE,
         recommended_parameters: Optional[RecommendedParameters] = None,
+        torchscript_state_global_lock: Optional[Lock] = None,
         **kwargs,
     ) -> "YOLOv8ForInstanceSegmentationTorchScript":
         model_package_content = get_model_package_contents(
@@ -98,9 +100,10 @@ class YOLOv8ForInstanceSegmentationTorchScript(
                 message="Expected static batch size to be registered in the inference configuration.",
                 help_url="https://inference-models.roboflow.com/errors/model-loading/#corruptedmodelpackageerror",
             )
-        model = torch.jit.load(
-            model_package_content["weights.torchscript"], map_location=device
-        ).eval()
+        with torchscript_global_lock(torchscript_state_global_lock):
+            model = torch.jit.load(
+                model_package_content["weights.torchscript"], map_location=device
+            ).eval()
         return cls(
             model=model,
             class_names=class_names,

--- a/inference_models/inference_models/models/yolov8/yolov8_key_points_detection_torch_script.py
+++ b/inference_models/inference_models/models/yolov8/yolov8_key_points_detection_torch_script.py
@@ -22,6 +22,7 @@ from inference_models.configuration import (
 from inference_models.entities import ColorFormat, Confidence
 from inference_models.errors import CorruptedModelPackageError
 from inference_models.models.common.model_packages import get_model_package_contents
+from inference_models.models.common.torch import torchscript_global_lock
 from inference_models.models.common.roboflow.model_packages import (
     InferenceConfig,
     PreProcessingMetadata,
@@ -53,6 +54,7 @@ class YOLOv8ForKeyPointsDetectionTorchScript(
         model_name_or_path: str,
         device: torch.device = DEFAULT_DEVICE,
         recommended_parameters: Optional[RecommendedParameters] = None,
+        torchscript_state_global_lock: Optional[Lock] = None,
         **kwargs,
     ) -> "YOLOv8ForKeyPointsDetectionTorchScript":
         model_package_content = get_model_package_contents(
@@ -100,9 +102,10 @@ class YOLOv8ForKeyPointsDetectionTorchScript(
         parsed_key_points_metadata, skeletons = parse_key_points_metadata(
             key_points_metadata_path=model_package_content["keypoints_metadata.json"]
         )
-        model = torch.jit.load(
-            model_package_content["weights.torchscript"], map_location=device
-        ).eval()
+        with torchscript_global_lock(torchscript_state_global_lock):
+            model = torch.jit.load(
+                model_package_content["weights.torchscript"], map_location=device
+            ).eval()
         return cls(
             model=model,
             class_names=class_names,

--- a/inference_models/inference_models/models/yolov8/yolov8_object_detection_torch_script.py
+++ b/inference_models/inference_models/models/yolov8/yolov8_object_detection_torch_script.py
@@ -16,6 +16,7 @@ from inference_models.configuration import (
 from inference_models.entities import ColorFormat, Confidence
 from inference_models.errors import CorruptedModelPackageError
 from inference_models.models.common.model_packages import get_model_package_contents
+from inference_models.models.common.torch import torchscript_global_lock
 from inference_models.models.common.roboflow.model_packages import (
     InferenceConfig,
     PreProcessingMetadata,
@@ -46,6 +47,7 @@ class YOLOv8ForObjectDetectionTorchScript(
         model_name_or_path: str,
         device: torch.device = DEFAULT_DEVICE,
         recommended_parameters: Optional[RecommendedParameters] = None,
+        torchscript_state_global_lock: Optional[Lock] = None,
         **kwargs,
     ) -> "YOLOv8ForObjectDetectionTorchScript":
         model_package_content = get_model_package_contents(
@@ -89,9 +91,10 @@ class YOLOv8ForObjectDetectionTorchScript(
                 message="Expected static batch size to be registered in the inference configuration.",
                 help_url="https://inference-models.roboflow.com/errors/model-loading/#corruptedmodelpackageerror",
             )
-        model = torch.jit.load(
-            model_package_content["weights.torchscript"], map_location=device
-        ).eval()
+        with torchscript_global_lock(torchscript_state_global_lock):
+            model = torch.jit.load(
+                model_package_content["weights.torchscript"], map_location=device
+            ).eval()
         return cls(
             model=model,
             class_names=class_names,

--- a/inference_models/pyproject.toml
+++ b/inference_models/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inference-models"
-version = "0.28.4"
+version = "0.28.5"
 description = "The new inference engine for Computer Vision models"
 readme = "README.md"
 requires-python = ">=3.10,<3.13"

--- a/inference_models/pyproject.toml
+++ b/inference_models/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inference-models"
-version = "0.28.5"
+version = "0.28.6"
 description = "The new inference engine for Computer Vision models"
 readme = "README.md"
 requires-python = ">=3.10,<3.13"

--- a/inference_models/tests/integration_tests/models/test_torchscript_concurrent_loading.py
+++ b/inference_models/tests/integration_tests/models/test_torchscript_concurrent_loading.py
@@ -1,0 +1,79 @@
+"""Regression test for concurrent TorchScript model loading.
+
+TorchScript deserialization mutates a process-global type registry that is not
+thread-safe. Loading TorchScript-backed models concurrently (as the HTTP server does
+when preloading several PINNED_MODELS on a ThreadPoolExecutor) could corrupt it,
+surfacing non-deterministically as:
+
+    KeyError: '__torch__.torch.nn.functional.interpolate'
+    RuntimeError: ... Enum<...___torch_mangle_0.InterpolationMode> ...
+
+The loaders now serialize TorchScript loads behind a shared lock
+(`inference_models.models.common.torch.torchscript_load_lock`). This test loads several
+different TorchScript packages (object detection + instance segmentation + key points)
+at once, releasing every thread into `torch.jit.load` simultaneously via a barrier, and
+asserts every load succeeds.
+"""
+
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from inference_models.configuration import DEFAULT_DEVICE
+from inference_models.models.yolov8.yolov8_instance_segmentation_torch_script import (
+    YOLOv8ForInstanceSegmentationTorchScript,
+)
+from inference_models.models.yolov8.yolov8_key_points_detection_torch_script import (
+    YOLOv8ForKeyPointsDetectionTorchScript,
+)
+from inference_models.models.yolov8.yolov8_object_detection_torch_script import (
+    YOLOv8ForObjectDetectionTorchScript,
+)
+
+
+@pytest.mark.slow
+@pytest.mark.torch_models
+def test_concurrent_torchscript_loading_does_not_corrupt_global_registry(
+    coin_counting_yolov8n_torch_script_static_bs_letterbox_package: str,
+    asl_yolov8n_torchscript_seg_static_bs_stretch: str,
+    yolov8n_pose_torchscript_static_static_crop_letterbox_package: str,
+) -> None:
+    # given
+    load_specs = [
+        (
+            YOLOv8ForObjectDetectionTorchScript,
+            coin_counting_yolov8n_torch_script_static_bs_letterbox_package,
+        ),
+        (
+            YOLOv8ForInstanceSegmentationTorchScript,
+            asl_yolov8n_torchscript_seg_static_bs_stretch,
+        ),
+        (
+            YOLOv8ForKeyPointsDetectionTorchScript,
+            yolov8n_pose_torchscript_static_static_crop_letterbox_package,
+        ),
+    ] * 2
+    barrier = threading.Barrier(len(load_specs))
+
+    def _load(loader_cls, package_path):
+        barrier.wait(timeout=60)
+        return loader_cls.from_pretrained(
+            model_name_or_path=package_path,
+            device=DEFAULT_DEVICE,
+        )
+
+    # when
+    with ThreadPoolExecutor(max_workers=len(load_specs)) as executor:
+        futures = [
+            executor.submit(_load, loader_cls, package_path)
+            for loader_cls, package_path in load_specs
+        ]
+        models = [future.result(timeout=300) for future in futures]
+
+    # then
+    assert len(models) == len(load_specs)
+    assert all(
+        isinstance(model, expected_cls)
+        for model, (expected_cls, _) in zip(models, load_specs)
+    )

--- a/inference_models/tests/integration_tests/models/test_torchscript_concurrent_loading.py
+++ b/inference_models/tests/integration_tests/models/test_torchscript_concurrent_loading.py
@@ -1,4 +1,4 @@
-"""Regression test for concurrent TorchScript work corrupting the global registry.
+"""Reproduction test: concurrent TorchScript work corrupts the global registry.
 
 `torch.jit.script` (run by SAM3 at build time on torchvision transforms) and
 `torch.jit.load` (run by the YOLO/CLIP TorchScript loaders) mutate the SAME process-global,
@@ -10,11 +10,10 @@ non-deterministically as:
     RuntimeError: ... Enum<...___torch_mangle_0.InterpolationMode> ...
     RuntimeError: Can't redefine method: forward on class: ...Resize...
 
-Every TorchScript-touching path now serializes on a single process-wide lock
-(`inference_models.models.common.torch.torchscript_load_lock`). This test reproduces the
-mixed scenario: threads loading a TorchScript model via the real loader (which takes the
-lock) run alongside threads scripting `nn.Sequential(Resize, Normalize)` under the same
-lock (mirroring SAM3's build), released together through a barrier on every round.
+This test reproduces it: threads loading a TorchScript model via the real loader run
+alongside threads scripting `nn.Sequential(Resize, Normalize)` (mirroring SAM3's build),
+released together through a barrier on every round. Without serializing TorchScript work
+behind a shared lock the test FAILS with one of the errors above.
 """
 
 import threading
@@ -26,7 +25,6 @@ from torch import nn
 from torchvision.transforms import Normalize, Resize
 
 from inference_models.configuration import DEFAULT_DEVICE
-from inference_models.models.common.torch import torchscript_load_lock
 from inference_models.models.yolov8.yolov8_object_detection_torch_script import (
     YOLOv8ForObjectDetectionTorchScript,
 )
@@ -48,7 +46,7 @@ def test_concurrent_torchscript_work_does_not_corrupt_global_registry(
 
     def _load_worker() -> None:
         for _ in range(ROUNDS):
-            barrier.wait(timeout=300)
+            barrier.wait(timeout=120)
             try:
                 YOLOv8ForObjectDetectionTorchScript.from_pretrained(
                     model_name_or_path=coin_counting_yolov8n_torch_script_static_bs_letterbox_package,
@@ -60,15 +58,14 @@ def test_concurrent_torchscript_work_does_not_corrupt_global_registry(
 
     def _script_worker() -> None:
         for _ in range(ROUNDS):
-            barrier.wait(timeout=300)
+            barrier.wait(timeout=120)
             try:
-                with torchscript_load_lock():
-                    torch.jit.script(
-                        nn.Sequential(
-                            Resize((RESOLUTION, RESOLUTION)),
-                            Normalize([0.5, 0.5, 0.5], [0.5, 0.5, 0.5]),
-                        )
+                torch.jit.script(
+                    nn.Sequential(
+                        Resize((RESOLUTION, RESOLUTION)),
+                        Normalize([0.5, 0.5, 0.5], [0.5, 0.5, 0.5]),
                     )
+                )
             except Exception as error:
                 errors.append(("script", repr(error)))
                 raise
@@ -78,7 +75,7 @@ def test_concurrent_torchscript_work_does_not_corrupt_global_registry(
         futures = [executor.submit(_load_worker) for _ in range(LOAD_WORKERS)]
         futures += [executor.submit(_script_worker) for _ in range(SCRIPT_WORKERS)]
         for future in futures:
-            future.result(timeout=1200)
+            future.result(timeout=60)
 
     # then
     assert not errors

--- a/inference_models/tests/integration_tests/models/test_torchscript_concurrent_loading.py
+++ b/inference_models/tests/integration_tests/models/test_torchscript_concurrent_loading.py
@@ -25,6 +25,7 @@ from torch import nn
 from torchvision.transforms import Normalize, Resize
 
 from inference_models.configuration import DEFAULT_DEVICE
+from inference_models.models.common.torch import torchscript_load_lock
 from inference_models.models.yolov8.yolov8_object_detection_torch_script import (
     YOLOv8ForObjectDetectionTorchScript,
 )
@@ -60,12 +61,13 @@ def test_concurrent_torchscript_work_does_not_corrupt_global_registry(
         for _ in range(ROUNDS):
             barrier.wait(timeout=120)
             try:
-                torch.jit.script(
-                    nn.Sequential(
-                        Resize((RESOLUTION, RESOLUTION)),
-                        Normalize([0.5, 0.5, 0.5], [0.5, 0.5, 0.5]),
+                with torchscript_load_lock():
+                    torch.jit.script(
+                        nn.Sequential(
+                            Resize((RESOLUTION, RESOLUTION)),
+                            Normalize([0.5, 0.5, 0.5], [0.5, 0.5, 0.5]),
+                        )
                     )
-                )
             except Exception as error:
                 errors.append(("script", repr(error)))
                 raise

--- a/inference_models/tests/integration_tests/models/test_torchscript_concurrent_loading.py
+++ b/inference_models/tests/integration_tests/models/test_torchscript_concurrent_loading.py
@@ -1,68 +1,84 @@
-"""Regression test for concurrent TorchScript model loading.
+"""Regression test for concurrent TorchScript work corrupting the global registry.
 
-TorchScript deserialization mutates a process-global type registry that is not
-thread-safe. Loading TorchScript-backed models concurrently (as the HTTP server does
-when preloading several PINNED_MODELS on a ThreadPoolExecutor) could corrupt it,
-surfacing non-deterministically as:
+`torch.jit.script` (run by SAM3 at build time on torchvision transforms) and
+`torch.jit.load` (run by the YOLO/CLIP TorchScript loaders) mutate the SAME process-global,
+non-thread-safe TorchScript type registry. Running them concurrently (as the HTTP server
+does when preloading several PINNED_MODELS on a ThreadPoolExecutor) corrupts it, surfacing
+non-deterministically as:
 
     KeyError: '__torch__.torch.nn.functional.interpolate'
     RuntimeError: ... Enum<...___torch_mangle_0.InterpolationMode> ...
+    RuntimeError: Can't redefine method: forward on class: ...Resize...
 
-This test hammers `torch.jit.load` directly from several threads, releasing them through
-a barrier immediately before the load on every round so the unsafe deserialization
-windows overlap, repeated over many rounds to make the race fire deterministically.
+Every TorchScript-touching path now serializes on a single process-wide lock
+(`inference_models.models.common.torch.torchscript_load_lock`). This test reproduces the
+mixed scenario: threads loading a TorchScript model via the real loader (which takes the
+lock) run alongside threads scripting `nn.Sequential(Resize, Normalize)` under the same
+lock (mirroring SAM3's build), released together through a barrier on every round.
 """
 
-import os
 import threading
 from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 import torch
+from torch import nn
+from torchvision.transforms import Normalize, Resize
 
 from inference_models.configuration import DEFAULT_DEVICE
+from inference_models.models.common.torch import torchscript_load_lock
+from inference_models.models.yolov8.yolov8_object_detection_torch_script import (
+    YOLOv8ForObjectDetectionTorchScript,
+)
 
-ROUNDS = 50
-WORKERS = 8
+ROUNDS = 5
+LOAD_WORKERS = 2
+SCRIPT_WORKERS = 3
+RESOLUTION = 1024
 
 
 @pytest.mark.slow
 @pytest.mark.torch_models
-def test_concurrent_torchscript_loading_does_not_corrupt_global_registry(
+def test_concurrent_torchscript_work_does_not_corrupt_global_registry(
     coin_counting_yolov8n_torch_script_static_bs_letterbox_package: str,
-    asl_yolov8n_torchscript_seg_static_bs_stretch: str,
-    yolov8n_pose_torchscript_static_static_crop_letterbox_package: str,
 ) -> None:
     # given
-    weights_paths = [
-        os.path.join(pkg, "weights.torchscript")
-        for pkg in (
-            coin_counting_yolov8n_torch_script_static_bs_letterbox_package,
-            asl_yolov8n_torchscript_seg_static_bs_stretch,
-            yolov8n_pose_torchscript_static_static_crop_letterbox_package,
-        )
-    ]
-    for path in weights_paths:
-        assert os.path.exists(path), path
-
-    barrier = threading.Barrier(WORKERS)
+    barrier = threading.Barrier(LOAD_WORKERS + SCRIPT_WORKERS)
     errors = []
 
-    def _load(worker_idx: int) -> None:
-        path = weights_paths[worker_idx % len(weights_paths)]
+    def _load_worker() -> None:
         for _ in range(ROUNDS):
-            barrier.wait(timeout=120)
+            barrier.wait(timeout=300)
             try:
-                torch.jit.load(path, map_location=DEFAULT_DEVICE).eval()
+                YOLOv8ForObjectDetectionTorchScript.from_pretrained(
+                    model_name_or_path=coin_counting_yolov8n_torch_script_static_bs_letterbox_package,
+                    device=DEFAULT_DEVICE,
+                )
             except Exception as error:
-                errors.append(error)
+                errors.append(("load", repr(error)))
+                raise
+
+    def _script_worker() -> None:
+        for _ in range(ROUNDS):
+            barrier.wait(timeout=300)
+            try:
+                with torchscript_load_lock():
+                    torch.jit.script(
+                        nn.Sequential(
+                            Resize((RESOLUTION, RESOLUTION)),
+                            Normalize([0.5, 0.5, 0.5], [0.5, 0.5, 0.5]),
+                        )
+                    )
+            except Exception as error:
+                errors.append(("script", repr(error)))
                 raise
 
     # when
-    with ThreadPoolExecutor(max_workers=WORKERS) as executor:
-        futures = [executor.submit(_load, i) for i in range(WORKERS)]
+    with ThreadPoolExecutor(max_workers=LOAD_WORKERS + SCRIPT_WORKERS) as executor:
+        futures = [executor.submit(_load_worker) for _ in range(LOAD_WORKERS)]
+        futures += [executor.submit(_script_worker) for _ in range(SCRIPT_WORKERS)]
         for future in futures:
-            future.result(timeout=600)
+            future.result(timeout=1200)
 
     # then
     assert not errors

--- a/inference_models/tests/integration_tests/models/test_torchscript_concurrent_loading.py
+++ b/inference_models/tests/integration_tests/models/test_torchscript_concurrent_loading.py
@@ -8,28 +8,22 @@ surfacing non-deterministically as:
     KeyError: '__torch__.torch.nn.functional.interpolate'
     RuntimeError: ... Enum<...___torch_mangle_0.InterpolationMode> ...
 
-The loaders now serialize TorchScript loads behind a shared lock
-(`inference_models.models.common.torch.torchscript_load_lock`). This test loads several
-different TorchScript packages (object detection + instance segmentation + key points)
-at once, releasing every thread into `torch.jit.load` simultaneously via a barrier, and
-asserts every load succeeds.
+This test hammers `torch.jit.load` directly from several threads, releasing them through
+a barrier immediately before the load on every round so the unsafe deserialization
+windows overlap, repeated over many rounds to make the race fire deterministically.
 """
 
+import os
 import threading
 from concurrent.futures import ThreadPoolExecutor
 
 import pytest
+import torch
 
 from inference_models.configuration import DEFAULT_DEVICE
-from inference_models.models.yolov8.yolov8_instance_segmentation_torch_script import (
-    YOLOv8ForInstanceSegmentationTorchScript,
-)
-from inference_models.models.yolov8.yolov8_key_points_detection_torch_script import (
-    YOLOv8ForKeyPointsDetectionTorchScript,
-)
-from inference_models.models.yolov8.yolov8_object_detection_torch_script import (
-    YOLOv8ForObjectDetectionTorchScript,
-)
+
+ROUNDS = 50
+WORKERS = 8
 
 
 @pytest.mark.slow
@@ -40,40 +34,35 @@ def test_concurrent_torchscript_loading_does_not_corrupt_global_registry(
     yolov8n_pose_torchscript_static_static_crop_letterbox_package: str,
 ) -> None:
     # given
-    load_specs = [
-        (
-            YOLOv8ForObjectDetectionTorchScript,
+    weights_paths = [
+        os.path.join(pkg, "weights.torchscript")
+        for pkg in (
             coin_counting_yolov8n_torch_script_static_bs_letterbox_package,
-        ),
-        (
-            YOLOv8ForInstanceSegmentationTorchScript,
             asl_yolov8n_torchscript_seg_static_bs_stretch,
-        ),
-        (
-            YOLOv8ForKeyPointsDetectionTorchScript,
             yolov8n_pose_torchscript_static_static_crop_letterbox_package,
-        ),
-    ] * 2
-    barrier = threading.Barrier(len(load_specs))
-
-    def _load(loader_cls, package_path):
-        barrier.wait(timeout=60)
-        return loader_cls.from_pretrained(
-            model_name_or_path=package_path,
-            device=DEFAULT_DEVICE,
         )
+    ]
+    for path in weights_paths:
+        assert os.path.exists(path), path
+
+    barrier = threading.Barrier(WORKERS)
+    errors = []
+
+    def _load(worker_idx: int) -> None:
+        path = weights_paths[worker_idx % len(weights_paths)]
+        for _ in range(ROUNDS):
+            barrier.wait(timeout=120)
+            try:
+                torch.jit.load(path, map_location=DEFAULT_DEVICE).eval()
+            except Exception as error:
+                errors.append(error)
+                raise
 
     # when
-    with ThreadPoolExecutor(max_workers=len(load_specs)) as executor:
-        futures = [
-            executor.submit(_load, loader_cls, package_path)
-            for loader_cls, package_path in load_specs
-        ]
-        models = [future.result(timeout=300) for future in futures]
+    with ThreadPoolExecutor(max_workers=WORKERS) as executor:
+        futures = [executor.submit(_load, i) for i in range(WORKERS)]
+        for future in futures:
+            future.result(timeout=600)
 
     # then
-    assert len(models) == len(load_specs)
-    assert all(
-        isinstance(model, expected_cls)
-        for model, (expected_cls, _) in zip(models, load_specs)
-    )
+    assert not errors

--- a/inference_models/tests/integration_tests/models/test_torchscript_concurrent_loading.py
+++ b/inference_models/tests/integration_tests/models/test_torchscript_concurrent_loading.py
@@ -29,7 +29,7 @@ from inference_models.models.yolov8.yolov8_object_detection_torch_script import 
     YOLOv8ForObjectDetectionTorchScript,
 )
 
-ROUNDS = 5
+ROUNDS = 1
 LOAD_WORKERS = 2
 SCRIPT_WORKERS = 3
 RESOLUTION = 1024

--- a/inference_models/tests/integration_tests/models/test_torchscript_concurrent_loading.py
+++ b/inference_models/tests/integration_tests/models/test_torchscript_concurrent_loading.py
@@ -1,4 +1,4 @@
-"""Reproduction test: concurrent TorchScript work corrupts the global registry.
+"""Regression test: concurrent TorchScript work corrupts the global registry.
 
 `torch.jit.script` (run by SAM3 at build time on torchvision transforms) and
 `torch.jit.load` (run by the YOLO/CLIP TorchScript loaders) mutate the SAME process-global,
@@ -10,10 +10,10 @@ non-deterministically as:
     RuntimeError: ... Enum<...___torch_mangle_0.InterpolationMode> ...
     RuntimeError: Can't redefine method: forward on class: ...Resize...
 
-This test reproduces it: threads loading a TorchScript model via the real loader run
-alongside threads scripting `nn.Sequential(Resize, Normalize)` (mirroring SAM3's build),
-released together through a barrier on every round. Without serializing TorchScript work
-behind a shared lock the test FAILS with one of the errors above.
+Threads loading a TorchScript model via the real loader run alongside threads scripting
+`nn.Sequential(Resize, Normalize)` (mirroring SAM3's build), released together through a
+barrier on every round. Both serialize on one shared `torchscript_state_global_lock`, so
+the test passes; with `lock=None` it reproduces the corruption above.
 """
 
 import threading
@@ -25,7 +25,7 @@ from torch import nn
 from torchvision.transforms import Normalize, Resize
 
 from inference_models.configuration import DEFAULT_DEVICE
-from inference_models.models.common.torch import torchscript_load_lock
+from inference_models.models.common.torch import torchscript_global_lock
 from inference_models.models.yolov8.yolov8_object_detection_torch_script import (
     YOLOv8ForObjectDetectionTorchScript,
 )
@@ -42,6 +42,7 @@ def test_concurrent_torchscript_work_does_not_corrupt_global_registry(
     coin_counting_yolov8n_torch_script_static_bs_letterbox_package: str,
 ) -> None:
     # given
+    lock = threading.Lock()
     barrier = threading.Barrier(LOAD_WORKERS + SCRIPT_WORKERS)
     errors = []
 
@@ -52,6 +53,7 @@ def test_concurrent_torchscript_work_does_not_corrupt_global_registry(
                 YOLOv8ForObjectDetectionTorchScript.from_pretrained(
                     model_name_or_path=coin_counting_yolov8n_torch_script_static_bs_letterbox_package,
                     device=DEFAULT_DEVICE,
+                    torchscript_state_global_lock=lock,
                 )
             except Exception as error:
                 errors.append(("load", repr(error)))
@@ -61,7 +63,7 @@ def test_concurrent_torchscript_work_does_not_corrupt_global_registry(
         for _ in range(ROUNDS):
             barrier.wait(timeout=120)
             try:
-                with torchscript_load_lock():
+                with torchscript_global_lock(lock):
                     torch.jit.script(
                         nn.Sequential(
                             Resize((RESOLUTION, RESOLUTION)),
@@ -77,7 +79,7 @@ def test_concurrent_torchscript_work_does_not_corrupt_global_registry(
         futures = [executor.submit(_load_worker) for _ in range(LOAD_WORKERS)]
         futures += [executor.submit(_script_worker) for _ in range(SCRIPT_WORKERS)]
         for future in futures:
-            future.result(timeout=60)
+            future.result(timeout=30)
 
     # then
     assert not errors

--- a/requirements/requirements.cpu.txt
+++ b/requirements/requirements.cpu.txt
@@ -1,3 +1,3 @@
 onnxruntime>=1.15.1,<1.22.0
 nvidia-ml-py<13.0.0
-inference-models[torch-cpu,onnx-cpu]~=0.28.5  # keep in sync between requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt
+inference-models[torch-cpu,onnx-cpu]~=0.28.6  # keep in sync between requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt

--- a/requirements/requirements.cpu.txt
+++ b/requirements/requirements.cpu.txt
@@ -1,3 +1,3 @@
 onnxruntime>=1.15.1,<1.22.0
 nvidia-ml-py<13.0.0
-inference-models[torch-cpu,onnx-cpu]~=0.28.4  # keep in sync between requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt
+inference-models[torch-cpu,onnx-cpu]~=0.28.5  # keep in sync between requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt

--- a/requirements/requirements.gpu.txt
+++ b/requirements/requirements.gpu.txt
@@ -1,2 +1,2 @@
 onnxruntime-gpu>=1.15.1,<1.22.0
-inference-models[torch-cu124,onnx-cu12]~=0.28.4  # keep in sync between requirements.jetson requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt
+inference-models[torch-cu124,onnx-cu12]~=0.28.5  # keep in sync between requirements.jetson requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt

--- a/requirements/requirements.gpu.txt
+++ b/requirements/requirements.gpu.txt
@@ -1,2 +1,2 @@
 onnxruntime-gpu>=1.15.1,<1.22.0
-inference-models[torch-cu124,onnx-cu12]~=0.28.5  # keep in sync between requirements.jetson requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt
+inference-models[torch-cu124,onnx-cu12]~=0.28.6  # keep in sync between requirements.jetson requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt

--- a/requirements/requirements.jetson.txt
+++ b/requirements/requirements.jetson.txt
@@ -1,4 +1,4 @@
 pypdfium2>=4.11.0,<5.0.0
 jupyterlab>=4.3.0,<5.0.0
 PyYAML~=6.0.0
-inference-models~=0.28.5  # keep in sync between requirements.jetson requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt
+inference-models~=0.28.6  # keep in sync between requirements.jetson requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt

--- a/requirements/requirements.jetson.txt
+++ b/requirements/requirements.jetson.txt
@@ -1,4 +1,4 @@
 pypdfium2>=4.11.0,<5.0.0
 jupyterlab>=4.3.0,<5.0.0
 PyYAML~=6.0.0
-inference-models~=0.28.4  # keep in sync between requirements.jetson requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt
+inference-models~=0.28.5  # keep in sync between requirements.jetson requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt

--- a/requirements/requirements.vino.txt
+++ b/requirements/requirements.vino.txt
@@ -1,2 +1,2 @@
 onnxruntime-openvino>=1.15.0,<1.22.0
-inference-models[torch-cpu]~=0.28.5  # keep in sync between requirements.jetson requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt
+inference-models[torch-cpu]~=0.28.6  # keep in sync between requirements.jetson requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt

--- a/requirements/requirements.vino.txt
+++ b/requirements/requirements.vino.txt
@@ -1,2 +1,2 @@
 onnxruntime-openvino>=1.15.0,<1.22.0
-inference-models[torch-cpu]~=0.28.4  # keep in sync between requirements.jetson requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt
+inference-models[torch-cpu]~=0.28.5  # keep in sync between requirements.jetson requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt


### PR DESCRIPTION
## What does this PR do?

torch.jit.load/script share a process-global, non-thread-safe registry; concurrent model loads (PINNED_MODELS preload) corrupt it. Thread an optional torchscript_state_global_lock through the SAM3/CLIP/YOLO loaders, always supplied by ModelManager, plus a regression test.

## Type of Change

- Bug fix (non-breaking change that fixes an issue)

## Testing

test added

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)

## Additional Context

N/A