### PR TITLE
[codex] Experimental Qwen vLLM backend materializer

### DIFF
--- a/inference/core/env.py
+++ b/inference/core/env.py
@@ -214,6 +214,20 @@ CORE_MODEL_GROUNDINGDINO_ENABLED = str2bool(
 
 LMM_ENABLED = str2bool(os.getenv("LMM_ENABLED", False))
 
+VLLM_MODE = os.getenv("VLLM_MODE", "disabled").lower()
+
+VLLM_BASE_URL = os.getenv("VLLM_BASE_URL", "http://localhost:8000/v1")
+
+VLLM_API_KEY = os.getenv("VLLM_API_KEY")
+
+VLLM_REQUEST_TIMEOUT = float(os.getenv("VLLM_REQUEST_TIMEOUT", "120"))
+
+VLLM_NATIVE_FALLBACK_ENABLED = str2bool(
+    os.getenv("VLLM_NATIVE_FALLBACK_ENABLED", False)
+)
+
+LMM_QWEN_BACKEND = os.getenv("LMM_QWEN_BACKEND", "native").lower()
+
 QWEN_2_5_ENABLED = str2bool(os.getenv("QWEN_2_5_ENABLED", True))
 
 QWEN_3_ENABLED = str2bool(os.getenv("QWEN_3_ENABLED", True))

--- a/inference/models/qwen3_5vl/qwen3_5vl_inference_models.py
+++ b/inference/models/qwen3_5vl/qwen3_5vl_inference_models.py
@@ -1,7 +1,9 @@
-from typing import Any, List
+from time import perf_counter
+from typing import TYPE_CHECKING, Any, List
 
 import torch
 
+from inference.core import logger
 from inference.core.entities.responses import (
     InferenceResponseImage,
     LMMInferenceResponse,
@@ -10,13 +12,28 @@ from inference.core.env import (
     ALLOW_INFERENCE_MODELS_DIRECTLY_ACCESS_LOCAL_PACKAGES,
     ALLOW_INFERENCE_MODELS_UNTRUSTED_PACKAGES,
     API_KEY,
+    LMM_QWEN_BACKEND,
+    VLLM_API_KEY,
+    VLLM_BASE_URL,
+    VLLM_MODE,
+    VLLM_NATIVE_FALLBACK_ENABLED,
+    VLLM_REQUEST_TIMEOUT,
 )
 from inference.core.models.base import Model
 from inference.core.models.types import PreprocessReturnMetadata
 from inference.core.roboflow_api import get_extra_weights_provider_headers
 from inference.core.utils.image_utils import load_image_bgr
 from inference_models import AutoModel
-from inference_models.models.qwen3_5.qwen3_5_hf import Qwen35HF
+
+from inference.models.qwen3_5vl.vllm import QwenVLLMClient
+
+if TYPE_CHECKING:
+    from inference_models.models.qwen3_5.qwen3_5_hf import Qwen35HF
+
+QWEN_BACKEND_NATIVE = "native"
+QWEN_BACKEND_VLLM = "vllm"
+QWEN_BACKEND_AUTO = "auto"
+VLLM_ENABLED_MODES = {"sidecar", "remote"}
 
 
 class InferenceModelsQwen35VLAdapter(Model):
@@ -26,22 +43,91 @@ class InferenceModelsQwen35VLAdapter(Model):
         self.metrics = {"num_inferences": 0, "avg_inference_time": 0.0}
 
         self.api_key = api_key if api_key else API_KEY
+        self.model_id = model_id
+        self._native_init_kwargs = dict(kwargs)
+        self._model = None
+        self._backend = resolve_qwen_backend(
+            qwen_backend=LMM_QWEN_BACKEND,
+            vllm_mode=VLLM_MODE,
+        )
 
         self.task_type = "lmm"
 
+        if self._backend == QWEN_BACKEND_VLLM:
+            self._vllm_client = QwenVLLMClient(
+                base_url=VLLM_BASE_URL,
+                api_key=VLLM_API_KEY,
+                request_timeout=VLLM_REQUEST_TIMEOUT,
+            )
+            return
+
+        self._vllm_client = None
+        self._ensure_native_model()
+
+    def _ensure_native_model(self) -> None:
+        if self._model is not None:
+            return
         extra_weights_provider_headers = get_extra_weights_provider_headers(
-            countinference=kwargs.get("countinference"),
-            service_secret=kwargs.get("service_secret"),
+            countinference=self._native_init_kwargs.get("countinference"),
+            service_secret=self._native_init_kwargs.get("service_secret"),
         )
 
-        self._model: Qwen35HF = AutoModel.from_pretrained(
-            model_id_or_path=model_id,
+        self._model: "Qwen35HF" = AutoModel.from_pretrained(
+            model_id_or_path=self.model_id,
             api_key=self.api_key,
             allow_untrusted_packages=ALLOW_INFERENCE_MODELS_UNTRUSTED_PACKAGES,
             allow_direct_local_storage_loading=ALLOW_INFERENCE_MODELS_DIRECTLY_ACCESS_LOCAL_PACKAGES,
             weights_provider_extra_headers=extra_weights_provider_headers,
-            **kwargs,
+            **self._native_init_kwargs,
         )
+
+    def infer_from_request(
+        self,
+        request,
+    ):
+        if self._backend != QWEN_BACKEND_VLLM:
+            return super().infer_from_request(request=request)
+        try:
+            return self._infer_from_request_vllm(request=request)
+        except Exception as error:
+            if not VLLM_NATIVE_FALLBACK_ENABLED:
+                raise
+            logger.warning(
+                "Qwen vLLM inference failed for model %s; falling back to native backend: %s",
+                self.model_id,
+                error,
+            )
+            self._ensure_native_model()
+            return super().infer_from_request(request=request)
+
+    def _infer_from_request_vllm(self, request) -> LMMInferenceResponse:
+        if isinstance(request.image, list):
+            raise ValueError("This model does not support batched-inference.")
+        if self._vllm_client is None:
+            raise RuntimeError("vLLM client is not configured for Qwen backend.")
+        t1 = perf_counter()
+        np_image = load_image_bgr(
+            request.image,
+            disable_preproc_auto_orient=request.disable_preproc_auto_orient,
+        )
+        raw_response = self._vllm_client.generate(
+            model_id=self.model_id,
+            image_bgr=np_image,
+            prompt=request.prompt,
+            enable_thinking=request.enable_thinking,
+            max_tokens=request.max_new_tokens,
+        )
+        response = LMMInferenceResponse(
+            response=raw_response,
+            image=InferenceResponseImage(
+                width=np_image.shape[1],
+                height=np_image.shape[0],
+            ),
+        )
+        response.time = perf_counter() - t1
+        if request.id:
+            response.inference_id = request.id
+        return response
 
     def map_inference_kwargs(self, kwargs: dict) -> dict:
         return kwargs
@@ -87,3 +173,23 @@ class InferenceModelsQwen35VLAdapter(Model):
 
     def clear_cache(self, delete_from_disk: bool = True) -> None:
         pass
+
+
+def resolve_qwen_backend(qwen_backend: str, vllm_mode: str) -> str:
+    if qwen_backend == QWEN_BACKEND_NATIVE:
+        return QWEN_BACKEND_NATIVE
+    if qwen_backend == QWEN_BACKEND_AUTO:
+        if vllm_mode in VLLM_ENABLED_MODES:
+            return QWEN_BACKEND_VLLM
+        return QWEN_BACKEND_NATIVE
+    if qwen_backend == QWEN_BACKEND_VLLM:
+        if vllm_mode not in VLLM_ENABLED_MODES:
+            raise ValueError(
+                "LMM_QWEN_BACKEND=vllm requires VLLM_MODE to be one of: "
+                f"{sorted(VLLM_ENABLED_MODES)}"
+            )
+        return QWEN_BACKEND_VLLM
+    raise ValueError(
+        f"Unknown LMM_QWEN_BACKEND={qwen_backend!r}. "
+        f"Expected one of: {QWEN_BACKEND_NATIVE}, {QWEN_BACKEND_VLLM}, {QWEN_BACKEND_AUTO}."
+    )

--- a/inference/models/qwen3_5vl/vllm.py
+++ b/inference/models/qwen3_5vl/vllm.py
@@ -1,0 +1,158 @@
+import base64
+import re
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Union
+
+import numpy as np
+import requests
+
+from inference.core.utils.image_utils import encode_image_to_jpeg_bytes
+
+DEFAULT_QWEN_SYSTEM_PROMPT = "You are a helpful assistant."
+
+
+class QwenVLLMInferenceError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class QwenPromptParts:
+    prompt: str
+    system_prompt: str
+
+
+class QwenVLLMClient:
+    def __init__(
+        self,
+        base_url: str,
+        api_key: Optional[str] = None,
+        request_timeout: float = 120.0,
+    ):
+        self._base_url = base_url.rstrip("/")
+        self._api_key = api_key
+        self._request_timeout = request_timeout
+
+    def generate(
+        self,
+        model_id: str,
+        image_bgr: np.ndarray,
+        prompt: Optional[str],
+        max_tokens: Optional[int] = None,
+        enable_thinking: bool = False,
+    ) -> Union[str, Dict[str, str]]:
+        prompt_parts = split_qwen_prompt(prompt=prompt)
+        payload: Dict[str, Any] = {
+            "model": model_id,
+            "messages": [
+                {
+                    "role": "system",
+                    "content": prompt_parts.system_prompt,
+                },
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "image_url",
+                            "image_url": {
+                                "url": image_bgr_to_data_url(image_bgr=image_bgr)
+                            },
+                        },
+                        {"type": "text", "text": prompt_parts.prompt},
+                    ],
+                },
+            ],
+            "temperature": 0,
+            "chat_template_kwargs": {"enable_thinking": enable_thinking},
+        }
+        if max_tokens is not None:
+            payload["max_tokens"] = max_tokens
+        headers = {}
+        if self._api_key:
+            headers["Authorization"] = f"Bearer {self._api_key}"
+        try:
+            response = requests.post(
+                f"{self._base_url}/chat/completions",
+                json=payload,
+                headers=headers,
+                timeout=self._request_timeout,
+            )
+            response.raise_for_status()
+            response_payload = response.json()
+        except Exception as error:
+            raise QwenVLLMInferenceError(
+                f"vLLM chat completion request failed for model {model_id}: {error}"
+            ) from error
+        return parse_chat_completion_output(
+            response_payload=response_payload,
+            enable_thinking=enable_thinking,
+        )
+
+
+def split_qwen_prompt(prompt: Optional[str]) -> QwenPromptParts:
+    if prompt is None:
+        return QwenPromptParts(
+            prompt="Describe what's in this image.",
+            system_prompt=DEFAULT_QWEN_SYSTEM_PROMPT,
+        )
+    split_prompt = prompt.split("<system_prompt>")
+    if len(split_prompt) == 1:
+        return QwenPromptParts(
+            prompt=split_prompt[0] or "Describe what's in this image.",
+            system_prompt=DEFAULT_QWEN_SYSTEM_PROMPT,
+        )
+    return QwenPromptParts(
+        prompt=split_prompt[0] or "Describe what's in this image.",
+        system_prompt=split_prompt[1] or DEFAULT_QWEN_SYSTEM_PROMPT,
+    )
+
+
+def image_bgr_to_data_url(image_bgr: np.ndarray) -> str:
+    jpeg_bytes = encode_image_to_jpeg_bytes(image=image_bgr)
+    base64_image = base64.b64encode(jpeg_bytes).decode("ascii")
+    return f"data:image/jpeg;base64,{base64_image}"
+
+
+def parse_chat_completion_output(
+    response_payload: dict,
+    enable_thinking: bool,
+) -> Union[str, Dict[str, str]]:
+    try:
+        message = response_payload["choices"][0]["message"]
+    except (KeyError, IndexError, TypeError) as error:
+        raise QwenVLLMInferenceError(
+            "vLLM chat completion response did not include choices[0].message"
+        ) from error
+    answer = message.get("content") or ""
+    reasoning = (
+        message.get("reasoning_content")
+        or message.get("reasoning")
+        or message.get("reasoning_text")
+    )
+    if enable_thinking:
+        if reasoning is not None:
+            return {"thinking": str(reasoning).strip(), "answer": answer.strip()}
+        return split_thinking_from_answer(text=answer)
+    return strip_thinking(text=answer)
+
+
+def split_thinking_from_answer(text: str) -> Dict[str, str]:
+    text = ensure_open_think_tag(text=text)
+    think_match = re.search(r"<think>(.*?)</think>", text, flags=re.DOTALL)
+    if think_match:
+        thinking = think_match.group(1).strip()
+        answer = re.sub(r"<think>.*?</think>\s*", "", text, flags=re.DOTALL).strip()
+        return {"thinking": thinking, "answer": answer}
+    return {"thinking": text.replace("<think>", "").strip(), "answer": ""}
+
+
+def strip_thinking(text: str) -> str:
+    text = re.sub(r"<think>.*?</think>\s*", "", text, flags=re.DOTALL)
+    return text.strip()
+
+
+def ensure_open_think_tag(text: str) -> str:
+    if text.lstrip().startswith("<think>"):
+        return text
+    if "</think>" in text:
+        return "<think>" + text
+    return text

--- a/inference_models/inference_models/developer_tools.py
+++ b/inference_models/inference_models/developer_tools.py
@@ -15,6 +15,10 @@ along with library. Utilities depending on optional dependencies are exposed as 
 
 from typing import Any, Dict, Union
 
+from inference_models.models.auto_loaders.core import (
+    MaterializedModelPackage,
+    materialize_model_package,
+)
 from inference_models.models.common.model_packages import get_model_package_contents
 from inference_models.runtime_introspection.core import (
     RuntimeXRayResult,
@@ -92,6 +96,8 @@ OPTIONAL_IMPORTS: Dict[str, Union[LazyFunction, LazyClass]] = {
 
 __all__ = [
     "get_model_package_contents",
+    "MaterializedModelPackage",
+    "materialize_model_package",
     "x_ray_runtime_environment",
     "RuntimeXRayResult",
     "download_files_to_directory",

--- a/inference_models/inference_models/models/auto_loaders/core.py
+++ b/inference_models/inference_models/models/auto_loaders/core.py
@@ -3,6 +3,7 @@ import importlib
 import importlib.util
 import os.path
 import re
+from dataclasses import dataclass
 from datetime import datetime
 from functools import partial
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
@@ -107,6 +108,23 @@ DEFAULT_KWARGS_PARAMS_TO_BE_FORWARDED_TO_DEPENDENT_MODELS = [
     "owlv2_class_embeddings_cache",
     "owlv2_images_embeddings_cache",
 ]
+
+
+@dataclass(frozen=True)
+class MaterializedModelPackage:
+    model_id: str
+    model_architecture: ModelArchitecture
+    task_type: Optional[TaskType]
+    model_package_id: str
+    backend: BackendType
+    package_dir: str
+    resolved_files: Set[str]
+    model_package: ModelPackageMetadata
+    requested_model_id: Optional[str] = None
+    model_variant: Optional[str] = None
+    model_dependencies: Optional[List[ModelDependency]] = None
+    model_features: Optional[dict] = None
+    recommended_parameters: Optional[RecommendedParameters] = None
 
 
 class AutoModel:
@@ -1108,6 +1126,97 @@ def all_files_exist(files: List[str]) -> bool:
     return all(os.path.exists(f) for f in files)
 
 
+def materialize_model_package(
+    model_id: str,
+    weights_provider: str = "roboflow",
+    api_key: Optional[str] = None,
+    model_package_id: Optional[str] = None,
+    backend: Optional[Union[str, BackendType, List[Union[str, BackendType]]]] = None,
+    batch_size: Optional[Union[int, Tuple[int, int]]] = None,
+    quantization: Optional[
+        Union[str, Quantization, List[Union[str, Quantization]]]
+    ] = None,
+    onnx_execution_providers: Optional[List[Union[str, tuple]]] = None,
+    device: Union[torch.device, str] = DEFAULT_DEVICE,
+    verbose: bool = False,
+    model_download_file_lock_acquire_timeout: int = FILE_LOCK_ACQUIRE_TIMEOUT,
+    allow_untrusted_packages: bool = False,
+    trt_engine_host_code_allowed: bool = True,
+    verify_hash_while_download: bool = True,
+    download_files_without_hash: bool = False,
+    nms_fusion_preferences: Optional[Union[bool, dict]] = None,
+    model_dependencies_directories: Optional[Dict[str, str]] = None,
+    weights_provider_extra_query_params: Optional[List[Tuple[str, str]]] = None,
+    weights_provider_extra_headers: Optional[Dict[str, str]] = None,
+    on_file_created: Optional[Callable[[str], None]] = None,
+    on_file_renamed: Optional[Callable[[str, str], None]] = None,
+    on_symlink_created: Optional[Callable[[str, str], None]] = None,
+    on_symlink_deleted: Optional[Callable[[str], None]] = None,
+) -> MaterializedModelPackage:
+    """Download a selected model package into the inference-models cache.
+
+    This is the package-materialization portion of AutoModel loading, exposed for
+    runtimes such as vLLM that need the local Hugging Face-style files but should
+    not instantiate the native inference-models adapter.
+    """
+    if isinstance(device, str):
+        try:
+            device = torch.device(device)
+        except RuntimeError as error:
+            raise InvalidParameterError(
+                message="Could not parse `device` parameter value - make sure that it is a valid string "
+                f"representation of torch device. Valid values: 'cpu', 'cuda' or 'cuda:0'. If you see this error "
+                "while using Roboflow infrastructure - contact us to get help. Otherwise - verify your setup.",
+                help_url="https://inference-models.roboflow.com/errors/input-validation/#invalidparametererror",
+            ) from error
+    model_metadata = get_model_from_provider(
+        provider=weights_provider,
+        model_id=model_id,
+        api_key=api_key,
+        weights_provider_extra_query_params=weights_provider_extra_query_params,
+        weights_provider_extra_headers=weights_provider_extra_headers,
+    )
+    matching_model_packages = negotiate_model_packages(
+        model_architecture=model_metadata.model_architecture,
+        task_type=model_metadata.task_type,
+        model_packages=model_metadata.model_packages,
+        requested_model_package_id=model_package_id,
+        requested_backends=backend,
+        requested_batch_size=batch_size,
+        requested_quantization=quantization,
+        device=device,
+        onnx_execution_providers=onnx_execution_providers,
+        allow_untrusted_packages=allow_untrusted_packages,
+        trt_engine_host_code_allowed=trt_engine_host_code_allowed,
+        nms_fusion_preferences=nms_fusion_preferences,
+        verbose=verbose,
+    )
+    if not matching_model_packages:
+        raise NoModelPackagesAvailableError(
+            message=f"Cannot materialize model {model_id} - no matching model package candidates for given model "
+            f"running in this environment.",
+            help_url="https://inference-models.roboflow.com/errors/package-negotiation/#nomodelpackagesavailableerror",
+        )
+    return materialize_selected_model_package(
+        model_id=model_metadata.model_id,
+        requested_model_id=model_id,
+        model_architecture=model_metadata.model_architecture,
+        model_variant=model_metadata.model_variant,
+        task_type=model_metadata.task_type,
+        model_package=matching_model_packages[0],
+        model_dependencies=model_metadata.model_dependencies,
+        model_dependencies_directories=model_dependencies_directories,
+        recommended_parameters=model_metadata.recommended_parameters,
+        model_download_file_lock_acquire_timeout=model_download_file_lock_acquire_timeout,
+        verify_hash_while_download=verify_hash_while_download,
+        download_files_without_hash=download_files_without_hash,
+        on_file_created=on_file_created,
+        on_file_renamed=on_file_renamed,
+        on_symlink_created=on_symlink_created,
+        on_symlink_deleted=on_symlink_deleted,
+    )
+
+
 def attempt_loading_matching_model_packages(
     model_id: str,
     model_architecture: ModelArchitecture,
@@ -1232,17 +1341,15 @@ def attempt_loading_matching_model_packages(
     )
 
 
-def initialize_model(
+def materialize_selected_model_package(
     model_id: str,
     model_architecture: ModelArchitecture,
     task_type: Optional[TaskType],
     model_package: ModelPackageMetadata,
-    model_init_kwargs: dict,
-    auto_resolution_cache: AutoResolutionCache,
-    auto_negotiation_hash: str,
-    model_dependencies: Optional[List[ModelDependency]],
-    model_dependencies_instances: Dict[str, AnyModel],
-    model_dependencies_directories: Dict[str, str],
+    requested_model_id: Optional[str] = None,
+    model_variant: Optional[str] = None,
+    model_dependencies: Optional[List[ModelDependency]] = None,
+    model_dependencies_directories: Optional[Dict[str, str]] = None,
     recommended_parameters: Optional[RecommendedParameters] = None,
     model_download_file_lock_acquire_timeout: int = FILE_LOCK_ACQUIRE_TIMEOUT,
     verify_hash_while_download: bool = True,
@@ -1251,17 +1358,7 @@ def initialize_model(
     on_file_renamed: Optional[Callable[[str, str], None]] = None,
     on_symlink_created: Optional[Callable[[str, str], None]] = None,
     on_symlink_deleted: Optional[Callable[[str], None]] = None,
-    use_auto_resolution_cache: bool = True,
-) -> Tuple[AnyModel, str]:
-    model_features = None
-    if model_package.model_features:
-        model_features = set(model_package.model_features.keys())
-    model_class = resolve_model_class(
-        model_architecture=model_architecture,
-        task_type=task_type,
-        backend=model_package.backend,
-        model_features=model_features,
-    )
+) -> MaterializedModelPackage:
     for artefact in model_package.package_artefacts:
         if artefact.file_handle == MODEL_CONFIG_FILE_NAME:
             raise CorruptedModelPackageError(
@@ -1324,6 +1421,7 @@ def initialize_model(
     resolved_files.update(model_specific_files_mapping.values())
     resolved_files.update(symlinks_mapping.values())
     resolved_files.add(config_path)
+    model_dependencies_directories = model_dependencies_directories or {}
     dependencies_resolved_files = handle_dependencies_directories_creation(
         model_package_cache_dir=model_package_cache_dir,
         model_dependencies_directories=model_dependencies_directories,
@@ -1332,14 +1430,80 @@ def initialize_model(
         on_symlink_deleted=on_symlink_deleted,
     )
     resolved_files.update(dependencies_resolved_files)
-    model_init_kwargs[MODEL_DEPENDENCIES_KEY] = model_dependencies_instances
     resolved_recommended_parameters = resolve_recommended_parameters(
         package_level=model_package.recommended_parameters,
         model_level=recommended_parameters,
     )
+    return MaterializedModelPackage(
+        model_id=model_id,
+        requested_model_id=requested_model_id,
+        model_architecture=model_architecture,
+        model_variant=model_variant,
+        task_type=task_type,
+        model_package_id=model_package.package_id,
+        backend=model_package.backend,
+        package_dir=model_package_cache_dir,
+        resolved_files=resolved_files,
+        model_package=model_package,
+        model_dependencies=model_dependencies,
+        model_features=model_package.model_features,
+        recommended_parameters=resolved_recommended_parameters,
+    )
+
+
+def initialize_model(
+    model_id: str,
+    model_architecture: ModelArchitecture,
+    task_type: Optional[TaskType],
+    model_package: ModelPackageMetadata,
+    model_init_kwargs: dict,
+    auto_resolution_cache: AutoResolutionCache,
+    auto_negotiation_hash: str,
+    model_dependencies: Optional[List[ModelDependency]],
+    model_dependencies_instances: Dict[str, AnyModel],
+    model_dependencies_directories: Dict[str, str],
+    recommended_parameters: Optional[RecommendedParameters] = None,
+    model_download_file_lock_acquire_timeout: int = FILE_LOCK_ACQUIRE_TIMEOUT,
+    verify_hash_while_download: bool = True,
+    download_files_without_hash: bool = False,
+    on_file_created: Optional[Callable[[str], None]] = None,
+    on_file_renamed: Optional[Callable[[str, str], None]] = None,
+    on_symlink_created: Optional[Callable[[str, str], None]] = None,
+    on_symlink_deleted: Optional[Callable[[str], None]] = None,
+    use_auto_resolution_cache: bool = True,
+) -> Tuple[AnyModel, str]:
+    model_features = None
+    if model_package.model_features:
+        model_features = set(model_package.model_features.keys())
+    model_class = resolve_model_class(
+        model_architecture=model_architecture,
+        task_type=task_type,
+        backend=model_package.backend,
+        model_features=model_features,
+    )
+    materialized_package = materialize_selected_model_package(
+        model_id=model_id,
+        model_architecture=model_architecture,
+        task_type=task_type,
+        model_package=model_package,
+        model_dependencies=model_dependencies,
+        model_dependencies_directories=model_dependencies_directories,
+        recommended_parameters=recommended_parameters,
+        model_download_file_lock_acquire_timeout=model_download_file_lock_acquire_timeout,
+        verify_hash_while_download=verify_hash_while_download,
+        download_files_without_hash=download_files_without_hash,
+        on_file_created=on_file_created,
+        on_file_renamed=on_file_renamed,
+        on_symlink_created=on_symlink_created,
+        on_symlink_deleted=on_symlink_deleted,
+    )
+    model_init_kwargs[MODEL_DEPENDENCIES_KEY] = model_dependencies_instances
+    resolved_recommended_parameters = materialized_package.recommended_parameters
     if resolved_recommended_parameters is not None:
         model_init_kwargs["recommended_parameters"] = resolved_recommended_parameters
-    model = model_class.from_pretrained(model_package_cache_dir, **model_init_kwargs)
+    model = model_class.from_pretrained(
+        materialized_package.package_dir, **model_init_kwargs
+    )
     dump_auto_resolution_cache(
         use_auto_resolution_cache=use_auto_resolution_cache,
         auto_resolution_cache=auto_resolution_cache,
@@ -1349,12 +1513,12 @@ def initialize_model(
         model_architecture=model_architecture,
         task_type=task_type,
         backend_type=model_package.backend,
-        resolved_files=resolved_files,
+        resolved_files=materialized_package.resolved_files,
         model_dependencies=model_dependencies,
         model_features=model_package.model_features,
         recommended_parameters=resolved_recommended_parameters,
     )
-    return model, model_package_cache_dir
+    return model, materialized_package.package_dir
 
 
 def create_symlinks_to_shared_blobs(

--- a/inference_models/tests/unit_tests/models/auto_loaders/test_core.py
+++ b/inference_models/tests/unit_tests/models/auto_loaders/test_core.py
@@ -24,6 +24,8 @@ from inference_models.models.auto_loaders.core import (
     dump_model_config_for_offline_use,
     generate_model_package_cache_path,
     load_class_from_path,
+    materialize_model_package,
+    materialize_selected_model_package,
     parse_model_config,
     resolve_recommended_parameters,
 )
@@ -31,7 +33,13 @@ from inference_models.models.auto_loaders.entities import (
     BackendType,
     InferenceModelConfig,
 )
-from inference_models.weights_providers.entities import RecommendedParameters
+from inference_models.weights_providers.entities import (
+    FileDownloadSpecs,
+    ModelMetadata,
+    ModelPackageMetadata,
+    Quantization,
+    RecommendedParameters,
+)
 
 
 def test_load_class_from_path_when_valid_python_module_provided(
@@ -197,6 +205,172 @@ def test_generate_model_package_cache_path_when_package_id_is_not_sanitized() ->
         _ = generate_model_package_cache_path(
             model_id="my-model", package_id="/my-package"
         )
+
+
+def test_materialize_selected_model_package_downloads_files_without_instantiating(
+    empty_local_dir: str,
+) -> None:
+    # given
+    package_params = RecommendedParameters(confidence=0.8)
+    model_params = RecommendedParameters(confidence=0.4)
+    model_package = ModelPackageMetadata(
+        package_id="pkgHF",
+        backend=BackendType.HF,
+        quantization=Quantization.UNKNOWN,
+        package_artefacts=[
+            FileDownloadSpecs(
+                download_url="https://example.com/base-config",
+                file_handle="base/config.json",
+                md5_hash="hashbaseconfig",
+            ),
+            FileDownloadSpecs(
+                download_url="https://example.com/adapter-config",
+                file_handle="adapter_config.json",
+                md5_hash="hashadapterconfig",
+            ),
+            FileDownloadSpecs(
+                download_url="https://example.com/tokenizer",
+                file_handle="tokenizer_config.json",
+            ),
+        ],
+        trusted_source=True,
+        recommended_parameters=package_params,
+    )
+    on_file_created = MagicMock()
+    on_file_renamed = MagicMock()
+    on_symlink_created = MagicMock()
+    on_symlink_deleted = MagicMock()
+
+    # when
+    with mock.patch.object(core, "INFERENCE_HOME", empty_local_dir), mock.patch.object(
+        core,
+        "download_files_to_directory",
+        side_effect=_fake_download_files_to_directory,
+    ), mock.patch.object(core, "resolve_model_class") as resolve_model_class_mock:
+        result = materialize_selected_model_package(
+            model_id="vlm-ocr/11",
+            model_architecture="qwen3_5",
+            model_variant="2b-peft",
+            task_type="vlm",
+            model_package=model_package,
+            model_dependencies=None,
+            model_dependencies_directories={},
+            recommended_parameters=model_params,
+            model_download_file_lock_acquire_timeout=10,
+            on_file_created=on_file_created,
+            on_file_renamed=on_file_renamed,
+            on_symlink_created=on_symlink_created,
+            on_symlink_deleted=on_symlink_deleted,
+        )
+
+    # then
+    expected_package_dir = result.package_dir
+    expected_config_path = os.path.join(expected_package_dir, "model_config.json")
+    expected_base_link = os.path.join(expected_package_dir, "base", "config.json")
+    expected_adapter_link = os.path.join(expected_package_dir, "adapter_config.json")
+    expected_tokenizer_path = os.path.join(
+        expected_package_dir, "tokenizer_config.json"
+    )
+    expected_shared_base_path = os.path.join(
+        empty_local_dir, "shared-blobs", "hashbaseconfig"
+    )
+    expected_shared_adapter_path = os.path.join(
+        empty_local_dir, "shared-blobs", "hashadapterconfig"
+    )
+
+    assert result.model_id == "vlm-ocr/11"
+    assert result.model_architecture == "qwen3_5"
+    assert result.model_variant == "2b-peft"
+    assert result.task_type == "vlm"
+    assert result.model_package_id == "pkgHF"
+    assert result.backend == BackendType.HF
+    assert result.package_dir == expected_package_dir
+    assert result.model_package is model_package
+    assert result.recommended_parameters is package_params
+    assert expected_base_link in result.resolved_files
+    assert expected_adapter_link in result.resolved_files
+    assert expected_tokenizer_path in result.resolved_files
+    assert expected_shared_base_path in result.resolved_files
+    assert expected_shared_adapter_path in result.resolved_files
+    assert expected_config_path in result.resolved_files
+    assert os.path.islink(expected_base_link)
+    assert os.path.islink(expected_adapter_link)
+    assert not os.path.islink(expected_tokenizer_path)
+    assert _read_file(expected_base_link) == "base/config.json"
+    assert _read_file(expected_adapter_link) == "adapter_config.json"
+    assert _read_file(expected_tokenizer_path) == "tokenizer_config.json"
+    resolve_model_class_mock.assert_not_called()
+
+
+def test_materialize_model_package_resolves_metadata_and_selects_package(
+    empty_local_dir: str,
+) -> None:
+    # given
+    qwen_package = ModelPackageMetadata(
+        package_id="qwenHF",
+        backend=BackendType.HF,
+        quantization=Quantization.UNKNOWN,
+        package_artefacts=[
+            FileDownloadSpecs(
+                download_url="https://example.com/adapter",
+                file_handle="adapter_config.json",
+                md5_hash="hashadapterconfig",
+            )
+        ],
+        trusted_source=True,
+    )
+    metadata = ModelMetadata(
+        model_id="vlm-ocr/11",
+        model_architecture="qwen3_5",
+        model_variant="2b-peft",
+        task_type="vlm",
+        model_packages=[qwen_package],
+    )
+
+    # when
+    with mock.patch.object(core, "INFERENCE_HOME", empty_local_dir), mock.patch.object(
+        core,
+        "get_model_from_provider",
+        return_value=metadata,
+    ) as get_model_from_provider_mock, mock.patch.object(
+        core,
+        "negotiate_model_packages",
+        return_value=[qwen_package],
+    ) as negotiate_model_packages_mock, mock.patch.object(
+        core,
+        "download_files_to_directory",
+        side_effect=_fake_download_files_to_directory,
+    ):
+        result = materialize_model_package(
+            model_id="vlm-ocr/11",
+            weights_provider="test-provider",
+            api_key="test-key",
+            backend=BackendType.HF,
+            quantization=Quantization.UNKNOWN,
+            device="cpu",
+            verify_hash_while_download=True,
+        )
+
+    # then
+    assert result.model_id == "vlm-ocr/11"
+    assert result.requested_model_id == "vlm-ocr/11"
+    assert result.model_architecture == "qwen3_5"
+    assert result.model_variant == "2b-peft"
+    assert result.backend == BackendType.HF
+    get_model_from_provider_mock.assert_called_once_with(
+        provider="test-provider",
+        model_id="vlm-ocr/11",
+        api_key="test-key",
+        weights_provider_extra_query_params=None,
+        weights_provider_extra_headers=None,
+    )
+    negotiate_model_packages_mock.assert_called_once()
+    _, negotiate_kwargs = negotiate_model_packages_mock.call_args
+    assert negotiate_kwargs["model_architecture"] == "qwen3_5"
+    assert negotiate_kwargs["task_type"] == "vlm"
+    assert negotiate_kwargs["model_packages"] == [qwen_package]
+    assert negotiate_kwargs["requested_backends"] == BackendType.HF
+    assert negotiate_kwargs["requested_quantization"] == Quantization.UNKNOWN
 
 
 def test_dump_auto_resolution_cache_when_cache_disabled() -> None:
@@ -523,6 +697,21 @@ def test_create_symlinks_to_shared_blobs_when_hooks_not_provided(
     assert _read_file(result["my_file_b.txt"]) == "b"
     assert _read_file(result["existing.txt"]) == "existing"
     assert _read_file(result["initially_broken.txt"]) == "b"
+
+
+def _fake_download_files_to_directory(
+    target_dir: str,
+    files_specs: list,
+    name_after: str = None,
+    **kwargs,
+) -> dict:
+    result = {}
+    for file_handle, _download_url, md5_hash in files_specs:
+        filename = md5_hash if name_after == "md5_hash" else file_handle
+        file_path = os.path.join(target_dir, filename)
+        _create_file(path=file_path, content=file_handle)
+        result[file_handle] = file_path
+    return result
 
 
 def _create_file(path: str, content: str) -> None:

--- a/tests/inference/unit_tests/models/test_qwen3_5vl_vllm.py
+++ b/tests/inference/unit_tests/models/test_qwen3_5vl_vllm.py
@@ -1,0 +1,129 @@
+from unittest import mock
+
+import numpy as np
+import pytest
+
+from inference.core.entities.requests.inference import LMMInferenceRequest
+from inference.models.qwen3_5vl import qwen3_5vl_inference_models as qwen_module
+from inference.models.qwen3_5vl import vllm as qwen_vllm
+
+
+class FakeResponse:
+    def __init__(self, payload: dict):
+        self._payload = payload
+
+    def raise_for_status(self) -> None:
+        pass
+
+    def json(self) -> dict:
+        return self._payload
+
+
+def test_qwen35_vllm_backend_sends_openai_compatible_request() -> None:
+    image = np.zeros((2, 3, 3), dtype=np.uint8)
+    response_payload = {
+        "choices": [
+            {
+                "message": {
+                    "content": "The answer",
+                    "reasoning_content": "The reasoning",
+                }
+            }
+        ]
+    }
+
+    with mock.patch.object(qwen_module, "LMM_QWEN_BACKEND", "vllm"), mock.patch.object(
+        qwen_module, "VLLM_MODE", "sidecar"
+    ), mock.patch.object(
+        qwen_module, "VLLM_BASE_URL", "http://vllm:8000/v1"
+    ), mock.patch.object(
+        qwen_module, "VLLM_API_KEY", "vllm-key"
+    ), mock.patch.object(
+        qwen_module, "VLLM_REQUEST_TIMEOUT", 42.0
+    ), mock.patch.object(
+        qwen_module.AutoModel, "from_pretrained"
+    ) as from_pretrained_mock, mock.patch.object(
+        qwen_module, "load_image_bgr", return_value=image
+    ) as load_image_bgr_mock, mock.patch.object(
+        qwen_vllm.requests,
+        "post",
+        return_value=FakeResponse(response_payload),
+    ) as post_mock:
+        adapter = qwen_module.InferenceModelsQwen35VLAdapter(
+            model_id="vlm-ocr/11",
+            api_key="rf-key",
+        )
+        response = adapter.infer_from_request(
+            LMMInferenceRequest(
+                model_id="vlm-ocr/11",
+                image={"type": "base64", "value": "ignored"},
+                prompt="What is in this image?<system_prompt>You are terse.",
+                enable_thinking=True,
+                max_new_tokens=25,
+                id="request-id",
+            )
+        )
+
+    from_pretrained_mock.assert_not_called()
+    load_image_bgr_mock.assert_called_once()
+    post_mock.assert_called_once()
+    (endpoint,) = post_mock.call_args.args
+    payload = post_mock.call_args.kwargs["json"]
+    assert endpoint == "http://vllm:8000/v1/chat/completions"
+    assert post_mock.call_args.kwargs["headers"] == {"Authorization": "Bearer vllm-key"}
+    assert post_mock.call_args.kwargs["timeout"] == 42.0
+    assert payload["model"] == "vlm-ocr/11"
+    assert payload["max_tokens"] == 25
+    assert payload["temperature"] == 0
+    assert payload["chat_template_kwargs"] == {"enable_thinking": True}
+    assert payload["messages"][0] == {
+        "role": "system",
+        "content": "You are terse.",
+    }
+    user_content = payload["messages"][1]["content"]
+    assert user_content[0]["type"] == "image_url"
+    assert user_content[0]["image_url"]["url"].startswith("data:image/jpeg;base64,")
+    assert user_content[1] == {"type": "text", "text": "What is in this image?"}
+    assert response.response == {
+        "answer": "The answer",
+        "thinking": "The reasoning",
+    }
+    assert response.image.width == 3
+    assert response.image.height == 2
+    assert response.inference_id == "request-id"
+
+
+def test_resolve_qwen_backend() -> None:
+    assert (
+        qwen_module.resolve_qwen_backend(qwen_backend="native", vllm_mode="disabled")
+        == "native"
+    )
+    assert (
+        qwen_module.resolve_qwen_backend(qwen_backend="auto", vllm_mode="disabled")
+        == "native"
+    )
+    assert (
+        qwen_module.resolve_qwen_backend(qwen_backend="auto", vllm_mode="remote")
+        == "vllm"
+    )
+    assert (
+        qwen_module.resolve_qwen_backend(qwen_backend="vllm", vllm_mode="sidecar")
+        == "vllm"
+    )
+    with pytest.raises(ValueError):
+        qwen_module.resolve_qwen_backend(qwen_backend="vllm", vllm_mode="disabled")
+    with pytest.raises(ValueError):
+        qwen_module.resolve_qwen_backend(qwen_backend="unknown", vllm_mode="remote")
+
+
+def test_parse_vllm_thinking_tags_when_reasoning_content_is_absent() -> None:
+    result = qwen_vllm.parse_chat_completion_output(
+        response_payload={
+            "choices": [
+                {"message": {"content": "I thought about it.</think>Final answer"}}
+            ]
+        },
+        enable_thinking=True,
+    )
+
+    assert result == {"thinking": "I thought about it.", "answer": "Final answer"}


### PR DESCRIPTION
## Experimental

This is experimental groundwork for serving Qwen 3.5 LMM requests through an internal vLLM backend. It is not a production rollout by itself.

## What changed

- Add `materialize_model_package(...)` and `MaterializedModelPackage` to `inference-models` so callers can resolve provider metadata, negotiate a package, download files into the existing cache/shared-blob layout, and stop before native model instantiation.
- Refactor the native auto-loader path to reuse that materialization logic while preserving existing `AutoModel.from_pretrained(...)` behavior.
- Add a Qwen 3.5 vLLM backend bridge in Inference behind `LMM_QWEN_BACKEND=native|vllm|auto` plus generic vLLM transport settings.
- Add an internal OpenAI-compatible `/chat/completions` client for Qwen requests, forwarding image input as a JPEG data URL and Qwen thinking mode through `chat_template_kwargs.enable_thinking`.
- Avoid importing the native Qwen HF class at module import time when vLLM mode is selected.

## Why

This keeps Inference as the auth/request-contract boundary while allowing deployments to delegate selected Qwen requests to an internal vLLM service. It also gives the future vLLM service/reloader a supported way to materialize Roboflow model packages without relying on `AutoModel.from_pretrained(...)` returning anything other than a model instance.

## Validation

- `MPLCONFIGDIR=/private/tmp/codex-mpl PYTHONPATH=/private/tmp/codex-inference-qwen-vllm/inference_models /Users/hansent/code/inference/inference_models/.venv/bin/python -m pytest inference_models/tests/unit_tests/models/auto_loaders -q`
- `MPLCONFIGDIR=/private/tmp/codex-mpl PYTHONPATH=/private/tmp/codex-inference-qwen-vllm:/private/tmp/codex-inference-qwen-vllm/inference_models /Users/hansent/venvs/inference-exp-workflows/bin/python -m pytest tests/inference/unit_tests/models/test_qwen3_5vl_vllm.py -q`

## Notes

Companion async-serverless routing prep: https://github.com/roboflow/async-serverless/pull/294

Remaining work before hosted rollout: the internal vLLM service still needs to resolve the Roboflow model ID sent by Inference into base weights plus the correct LoRA adapter and manage adapter locality/preload policy.