### PR TITLE
feat(yolo26-sem): TRT backend follow-up to #2372

### DIFF
--- a/inference_models/docs/changelog.md
+++ b/inference_models/docs/changelog.md
@@ -2,7 +2,7 @@
 
 ## `0.28.7`
 
-- Added YOLO26 semantic segmentation support (ONNX and TorchScript backends).
+- Added YOLO26 semantic segmentation support (ONNX, TorchScript, and TensorRT backends).
 
 ## `0.28.6`
 

--- a/inference_models/inference_models/models/auto_loaders/models_registry.py
+++ b/inference_models/inference_models/models/auto_loaders/models_registry.py
@@ -263,6 +263,10 @@ REGISTERED_MODELS: Dict[
         module_name="inference_models.models.yolo26.yolo26_semantic_segmentation_torch_script",
         class_name="YOLO26ForSemanticSegmentationTorchScript",
     ),
+    ("yolo26", SEMANTIC_SEGMENTATION_TASK, BackendType.TRT): LazyClass(
+        module_name="inference_models.models.yolo26.yolo26_semantic_segmentation_trt",
+        class_name="YOLO26ForSemanticSegmentationTRT",
+    ),
     ("yololite", OBJECT_DETECTION_TASK, BackendType.ONNX): RegistryEntry(
         model_class=LazyClass(
             module_name="inference_models.models.yololite.yololite_object_detection_onnx",

--- a/inference_models/inference_models/models/yolo26/yolo26_semantic_segmentation_trt.py
+++ b/inference_models/inference_models/models/yolo26/yolo26_semantic_segmentation_trt.py
@@ -1,0 +1,286 @@
+import threading
+from threading import Lock
+from typing import List, Optional, Tuple, Union
+
+import numpy as np
+import torch
+
+from inference_models import ColorFormat, SemanticSegmentationModel
+from inference_models.configuration import (
+    DEFAULT_DEVICE,
+    INFERENCE_MODELS_YOLO26_DEFAULT_CONFIDENCE,
+)
+from inference_models.entities import Confidence
+from inference_models.errors import (
+    CorruptedModelPackageError,
+    MissingDependencyError,
+    ModelRuntimeError,
+)
+from inference_models.models.auto_loaders.entities import PreProcessingOverrides
+from inference_models.models.base.semantic_segmentation import (
+    SemanticSegmentationResult,
+)
+from inference_models.models.common.cuda import (
+    use_cuda_context,
+    use_primary_cuda_context,
+)
+from inference_models.models.common.model_packages import get_model_package_contents
+from inference_models.models.common.roboflow.model_packages import (
+    InferenceConfig,
+    PreProcessingMetadata,
+    ResizeMode,
+    TRTConfig,
+    parse_class_names_file,
+    parse_inference_config,
+    resolve_background_class_id,
+    parse_trt_config,
+)
+from inference_models.models.common.roboflow.post_processing import (
+    post_process_semantic_segmentation_logits,
+)
+from inference_models.models.common.roboflow.pre_processing import (
+    pre_process_network_input,
+)
+from inference_models.models.common.trt import (
+    TRTCudaGraphCache,
+    establish_trt_cuda_graph_cache,
+    get_trt_engine_inputs_and_outputs,
+    infer_from_trt_engine,
+    load_trt_model,
+)
+from inference_models.weights_providers.entities import RecommendedParameters
+
+try:
+    import tensorrt as trt
+except ImportError as import_error:
+    raise MissingDependencyError(
+        message="Running YOLO26 model with TRT backend on GPU requires pycuda installation, which is brought with "
+        "`trt-*` extras of `inference-models` library. If you see this error running locally, "
+        "please follow our installation guide: https://inference-models.roboflow.com/getting-started/installation/"
+        " If you see this error using Roboflow infrastructure, make sure the service you use does support the "
+        f"model, You can also contact Roboflow to get support."
+        "Additionally - if AutoModel.from_pretrained(...) "
+        f"automatically selects model package which does not match your environment - that's a serious problem and "
+        f"we will really appreciate letting us know - https://github.com/roboflow/inference/issues",
+        help_url="https://inference-models.roboflow.com/errors/runtime-environment/#missingdependencyerror",
+    ) from import_error
+
+try:
+    import pycuda.driver as cuda
+except ImportError as import_error:
+    raise MissingDependencyError(
+        message="Running YOLO26 model with TRT backend on GPU requires pycuda installation, which is brought with "
+        "`trt-*` extras of `inference-models` library. If you see this error running locally, "
+        "please follow our installation guide: https://inference-models.roboflow.com/getting-started/installation/"
+        " If you see this error using Roboflow infrastructure, make sure the service you use does support the "
+        f"model, You can also contact Roboflow to get support.",
+        help_url="https://inference-models.roboflow.com/errors/runtime-environment/#missingdependencyerror",
+    ) from import_error
+
+
+class YOLO26ForSemanticSegmentationTRT(
+    SemanticSegmentationModel[torch.Tensor, PreProcessingMetadata, torch.Tensor]
+):
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        model_name_or_path: str,
+        device: torch.device = DEFAULT_DEVICE,
+        engine_host_code_allowed: bool = False,
+        trt_cuda_graph_cache: Optional[TRTCudaGraphCache] = None,
+        default_trt_cuda_graph_cache_size: int = 8,
+        recommended_parameters: Optional[RecommendedParameters] = None,
+        **kwargs,
+    ) -> "YOLO26ForSemanticSegmentationTRT":
+        if device.type != "cuda":
+            raise ModelRuntimeError(
+                message=f"TRT engine only runs on CUDA device - {device} device detected.",
+                help_url="https://inference-models.roboflow.com/errors/models-runtime/#modelruntimeerror",
+            )
+        model_package_content = get_model_package_contents(
+            model_package_dir=model_name_or_path,
+            elements=[
+                "class_names.txt",
+                "inference_config.json",
+                "trt_config.json",
+                "engine.plan",
+            ],
+        )
+        class_names = parse_class_names_file(
+            class_names_path=model_package_content["class_names.txt"]
+        )
+        background_class_id = resolve_background_class_id(class_names)
+        inference_config = parse_inference_config(
+            config_path=model_package_content["inference_config.json"],
+            allowed_resize_modes={
+                ResizeMode.STRETCH_TO,
+                ResizeMode.LETTERBOX,
+                ResizeMode.CENTER_CROP,
+                ResizeMode.LETTERBOX_REFLECT_EDGES,
+            },
+            implicit_resize_mode_substitutions={
+                ResizeMode.FIT_LONGER_EDGE: (
+                    ResizeMode.LETTERBOX,
+                    127,
+                    "YOLO26 Semantic Segmentation model running with TRT backend was trained with "
+                    "`fit-longer-edge` input resize mode. This transform cannot be applied properly for "
+                    "models with input dimensions fixed during weights export. To ensure interoperability, `letterbox` "
+                    "resize mode with gray edges will be used instead. If model was trained on Roboflow platform, "
+                    "we recommend using preprocessing method different that `fit-longer-edge`.",
+                )
+            },
+        )
+        trt_config = parse_trt_config(
+            config_path=model_package_content["trt_config.json"]
+        )
+        cuda.init()
+        cuda_device = cuda.Device(device.index or 0)
+        with use_primary_cuda_context(cuda_device=cuda_device) as cuda_context:
+            engine = load_trt_model(
+                model_path=model_package_content["engine.plan"],
+                engine_host_code_allowed=engine_host_code_allowed,
+            )
+            execution_context = engine.create_execution_context()
+        inputs, outputs = get_trt_engine_inputs_and_outputs(engine=engine)
+        if len(inputs) != 1:
+            raise CorruptedModelPackageError(
+                message=f"Implementation assume single model input, found: {len(inputs)}.",
+                help_url="https://inference-models.roboflow.com/errors/model-loading/#corruptedmodelpackageerror",
+            )
+        if len(outputs) != 1:
+            raise CorruptedModelPackageError(
+                message=f"Implementation assume single model output, found: {len(outputs)}.",
+                help_url="https://inference-models.roboflow.com/errors/model-loading/#corruptedmodelpackageerror",
+            )
+        trt_cuda_graph_cache = establish_trt_cuda_graph_cache(
+            default_cuda_graph_cache_size=default_trt_cuda_graph_cache_size,
+            cuda_graph_cache=trt_cuda_graph_cache,
+        )
+        return cls(
+            engine=engine,
+            input_name=inputs[0],
+            output_name=outputs[0],
+            class_names=class_names,
+            background_class_id=background_class_id,
+            inference_config=inference_config,
+            trt_config=trt_config,
+            device=device,
+            cuda_context=cuda_context,
+            execution_context=execution_context,
+            trt_cuda_graph_cache=trt_cuda_graph_cache,
+            recommended_parameters=recommended_parameters,
+        )
+
+    def __init__(
+        self,
+        engine: trt.ICudaEngine,
+        input_name: str,
+        output_name: str,
+        class_names: List[str],
+        background_class_id: int,
+        inference_config: InferenceConfig,
+        trt_config: TRTConfig,
+        device: torch.device,
+        cuda_context: cuda.Context,
+        execution_context: trt.IExecutionContext,
+        trt_cuda_graph_cache: Optional[TRTCudaGraphCache],
+        recommended_parameters: Optional[RecommendedParameters] = None,
+    ):
+        self._engine = engine
+        self._input_name = input_name
+        self._output_names = [output_name]
+        self._class_names = class_names
+        self._background_class_id = background_class_id
+        self._inference_config = inference_config
+        self._trt_config = trt_config
+        self._device = device
+        self._cuda_context = cuda_context
+        self._execution_context = execution_context
+        self._trt_cuda_graph_cache = trt_cuda_graph_cache
+        self._lock = Lock()
+        self._inference_stream = torch.cuda.Stream(device=self._device)
+        self._thread_local_storage = threading.local()
+        self.recommended_parameters = recommended_parameters
+
+    @property
+    def class_names(self) -> List[str]:
+        return self._class_names
+
+    def pre_process(
+        self,
+        images: Union[torch.Tensor, List[torch.Tensor], np.ndarray, List[np.ndarray]],
+        input_color_format: Optional[ColorFormat] = None,
+        pre_processing_overrides: Optional[PreProcessingOverrides] = None,
+        **kwargs,
+    ) -> Tuple[torch.Tensor, List[PreProcessingMetadata]]:
+        with torch.cuda.stream(self._pre_process_stream):
+            pre_processed_images, pre_processing_meta = pre_process_network_input(
+                images=images,
+                image_pre_processing=self._inference_config.image_pre_processing,
+                network_input=self._inference_config.network_input,
+                target_device=self._device,
+                input_color_format=input_color_format,
+                pre_processing_overrides=pre_processing_overrides,
+            )
+        self._pre_process_stream.synchronize()
+        return pre_processed_images, pre_processing_meta
+
+    def forward(
+        self,
+        pre_processed_images: torch.Tensor,
+        disable_cuda_graphs: bool = False,
+        **kwargs,
+    ) -> torch.Tensor:
+        cache = self._trt_cuda_graph_cache if not disable_cuda_graphs else None
+        with self._lock:
+            with use_cuda_context(context=self._cuda_context):
+                return infer_from_trt_engine(
+                    pre_processed_images=pre_processed_images,
+                    trt_config=self._trt_config,
+                    engine=self._engine,
+                    context=self._execution_context,
+                    device=self._device,
+                    input_name=self._input_name,
+                    outputs=self._output_names,
+                    stream=self._inference_stream,
+                    trt_cuda_graph_cache=cache,
+                )[0]
+
+    def post_process(
+        self,
+        model_results: torch.Tensor,
+        pre_processing_meta: List[PreProcessingMetadata],
+        confidence: Confidence = "default",
+        **kwargs,
+    ) -> List[SemanticSegmentationResult]:
+        with torch.cuda.stream(self._post_process_stream):
+            model_results.record_stream(self._post_process_stream)
+            results = post_process_semantic_segmentation_logits(
+                model_results=model_results,
+                pre_processing_meta=pre_processing_meta,
+                class_names=self._class_names,
+                background_class_id=self._background_class_id,
+                device=self._device,
+                confidence=confidence,
+                recommended_parameters=self.recommended_parameters,
+                default_confidence=INFERENCE_MODELS_YOLO26_DEFAULT_CONFIDENCE,
+            )
+        self._post_process_stream.synchronize()
+        return results
+
+    @property
+    def _pre_process_stream(self) -> torch.cuda.Stream:
+        if not hasattr(self._thread_local_storage, "pre_process_stream"):
+            self._thread_local_storage.pre_process_stream = torch.cuda.Stream(
+                device=self._device
+            )
+        return self._thread_local_storage.pre_process_stream
+
+    @property
+    def _post_process_stream(self) -> torch.cuda.Stream:
+        if not hasattr(self._thread_local_storage, "post_process_stream"):
+            self._thread_local_storage.post_process_stream = torch.cuda.Stream(
+                device=self._device
+            )
+        return self._thread_local_storage.post_process_stream

--- a/inference_models/tests/unit_tests/models/test_yolo26_semantic_segmentation.py
+++ b/inference_models/tests/unit_tests/models/test_yolo26_semantic_segmentation.py
@@ -1,6 +1,5 @@
 from unittest.mock import MagicMock
 
-import pytest
 import torch
 
 
@@ -115,23 +114,6 @@ def test_post_process_semantic_segmentation_logits_shifts_when_class_names_prepe
     assert torch.all(results[0].segmentation_map == 3)
 
 
-def test_yolo26_semantic_segmentation_onnx_import():
-    try:
-        from inference_models.models.yolo26.yolo26_semantic_segmentation_onnx import (
-            YOLO26ForSemanticSegmentationOnnx,
-        )
-    except Exception as exc:
-        pytest.skip(f"ONNX extras unavailable: {exc}")
-    assert YOLO26ForSemanticSegmentationOnnx is not None
-
-
-def test_yolo26_semantic_segmentation_torch_script_import():
-    from inference_models.models.yolo26.yolo26_semantic_segmentation_torch_script import (
-        YOLO26ForSemanticSegmentationTorchScript,
-    )
-    assert YOLO26ForSemanticSegmentationTorchScript is not None
-
-
 def test_yolo26_semantic_segmentation_registered():
     from inference_models.models.auto_loaders.entities import BackendType
     from inference_models.models.auto_loaders.models_registry import (
@@ -139,7 +121,7 @@ def test_yolo26_semantic_segmentation_registered():
         SEMANTIC_SEGMENTATION_TASK,
     )
 
-    for backend in (BackendType.ONNX, BackendType.TORCH_SCRIPT):
+    for backend in (BackendType.ONNX, BackendType.TORCH_SCRIPT, BackendType.TRT):
         assert ("yolo26", SEMANTIC_SEGMENTATION_TASK, backend) in REGISTERED_MODELS, (
             f"Missing yolo26 semantic seg entry for backend {backend}"
         )


### PR DESCRIPTION
## What does this PR do?

Follow-up to #2372. Adds the TRT backend for YOLO26 semantic segmentation: \`YOLO26ForSemanticSegmentationTRT\` class, \`(yolo26, semantic-segmentation, TRT)\` registry tuple, TRT entries in the unit tests. Reuses the shared post-processing helper introduced in #2372.

**Related Issue(s):** _n/a_

## Type of Change

- New feature (non-breaking change that adds functionality)

## Testing

- [x] I have tested this change locally
- [ ] I have added/updated tests for this change

**Test details:**

- **Unit**: TRT import-or-skip + registry lookup.
- **Integration TRT**: pending — needs the trt-compiler image rebuilt against #2372 so it recognises the yolo26-sem registration, then engines compiled for T4/L4/L40S and added to the staging registrations. Integration test mirroring the ONNX path will land on this branch before ready-for-review.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)

## Additional Context

Depends on:
- Merging #2372.
- Rebuild + redeploy the \`trt-compiler\` Cloud Run image (Spacelift \`gcp_trt_precompilation\` stack) against the new \`inference_models\` release.
- Triggering TRT compilation for \`yolo26-pretrains/yolo26{n,s,m,l,x}-sem\` and confirming \`trt-model-package-v1\` entries appear in the model registry.