### PR TITLE
Fix inner workflow dynamic block setup

### DIFF
--- a/inference/core/workflows/execution_engine/v1/compiler/core.py
+++ b/inference/core/workflows/execution_engine/v1/compiler/core.py
@@ -49,6 +49,10 @@ from inference.core.workflows.execution_engine.v1.dynamic_blocks.block_assembler
 from inference.core.workflows.execution_engine.v1.inner_workflow.compiler_bridge import (
     validate_inner_workflow_composition_from_raw_workflow_definition,
 )
+from inference.core.workflows.execution_engine.v1.inner_workflow.dynamic_blocks_collection import (
+    apply_collected_dynamic_blocks_definitions_to_workflow_root,
+    collect_dynamic_blocks_definitions_from_workflow_definition,
+)
 from inference.core.workflows.execution_engine.v1.inner_workflow.inline import (
     inline_inner_workflow_steps,
 )
@@ -121,8 +125,10 @@ def compile_workflow_graph(
     )
     cached_value = COMPILATION_CACHE.get(key=key)
     if cached_value is not None:
-        dynamic_blocks_definitions = workflow_definition.get(
-            "dynamic_blocks_definitions", []
+        dynamic_blocks_definitions = (
+            collect_dynamic_blocks_definitions_from_workflow_definition(
+                workflow_definition=workflow_definition,
+            )
         )
         ensure_dynamic_blocks_allowed(
             dynamic_blocks_definitions=dynamic_blocks_definitions
@@ -134,6 +140,11 @@ def compile_workflow_graph(
             init_parameters=init_parameters,
         )
     )
+    dynamic_blocks_definitions = (
+        apply_collected_dynamic_blocks_definitions_to_workflow_root(
+            workflow_definition=raw_workflow_definition,
+        )
+    )
     statically_defined_blocks = load_workflow_blocks(
         execution_engine_version=execution_engine_version,
         profiler=profiler,
@@ -142,9 +153,7 @@ def compile_workflow_graph(
     kinds_serializers = load_kinds_serializers(profiler=profiler)
     kinds_deserializers = load_kinds_deserializers(profiler=profiler)
     dynamic_blocks = compile_dynamic_blocks(
-        dynamic_blocks_definitions=raw_workflow_definition.get(
-            "dynamic_blocks_definitions", []
-        ),
+        dynamic_blocks_definitions=dynamic_blocks_definitions,
         profiler=profiler,
         api_key=init_parameters.get("workflows_core.api_key", None),
     )

--- a/inference/core/workflows/execution_engine/v1/compiler/core.py
+++ b/inference/core/workflows/execution_engine/v1/compiler/core.py
@@ -134,6 +134,7 @@ def compile_workflow_graph(
             dynamic_blocks_definitions=dynamic_blocks_definitions
         )
         return cached_value
+
     raw_workflow_definition: Dict[str, Any] = (
         normalize_inner_workflow_references_in_definition(
             workflow_definition=workflow_definition,

--- a/inference/core/workflows/execution_engine/v1/inner_workflow/dynamic_blocks_collection.py
+++ b/inference/core/workflows/execution_engine/v1/inner_workflow/dynamic_blocks_collection.py
@@ -7,11 +7,14 @@ compiler must discover all of them before ``compile_dynamic_blocks`` and inlinin
 
 from __future__ import annotations
 
+import logging
 from typing import Any, Dict, List, Optional, Set
 
 from inference.core.workflows.execution_engine.v1.inner_workflow.constants import (
     USE_INNER_WORKFLOW_BLOCK_TYPE,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def _dynamic_block_type(definition: Dict[str, Any]) -> Optional[str]:
@@ -29,7 +32,7 @@ def _dynamic_block_type(definition: Dict[str, Any]) -> Optional[str]:
 
 def collect_dynamic_blocks_definitions_from_workflow_definition(
     workflow_definition: Dict[str, Any],
-) -> List[dict]:
+) -> List[Any]:
     """Collect dynamic block definitions from a workflow and nested inner workflows.
 
     Walks ``workflow_definition`` depth-first. For each level, appends entries from
@@ -37,8 +40,12 @@ def collect_dynamic_blocks_definitions_from_workflow_definition(
     ``workflow_definition``.
 
     When the same ``manifest.block_type`` appears more than once, the first occurrence
-    is kept (parent definitions win over nested children). Definitions without a
-    ``block_type`` are still included and are not deduplicated.
+    is kept (parent definitions win over nested children) and a warning is logged for
+    each skipped duplicate. Definitions without a ``block_type`` are still included and
+    are not deduplicated.
+
+    Malformed entries (non-list ``dynamic_blocks_definitions``, non-dict list items)
+    are passed through as-is so :func:`compile_dynamic_blocks` can validate them.
 
     Args:
         workflow_definition: Raw workflow JSON (``steps``, optional nested definitions).
@@ -46,28 +53,37 @@ def collect_dynamic_blocks_definitions_from_workflow_definition(
     Returns:
         Merged list of dynamic block definition dicts in discovery order.
     """
-    collected: List[dict] = []
+    collected: List[Any] = []
     seen_block_types: Set[str] = set()
+
+    def append_definition(definition: Any) -> None:
+        block_type = None
+        if isinstance(definition, dict):
+            block_type = _dynamic_block_type(definition)
+
+        if block_type is not None:
+            if block_type in seen_block_types:
+                logger.warning(
+                    "Skipping duplicate dynamic block definition for block_type=%r; "
+                    "using the first definition collected while compiling the workflow.",
+                    block_type,
+                )
+                return
+
+            seen_block_types.add(block_type)
+
+        collected.append(definition)
 
     def append_level(definitions: Any) -> None:
         if not definitions:
             return
 
         if not isinstance(definitions, list):
+            append_definition(definitions)
             return
 
         for definition in definitions:
-            if not isinstance(definition, dict):
-                continue
-
-            block_type = _dynamic_block_type(definition)
-            if block_type is not None:
-                if block_type in seen_block_types:
-                    continue
-
-                seen_block_types.add(block_type)
-
-            collected.append(definition)
+            append_definition(definition)
 
     def visit(workflow: Dict[str, Any]) -> None:
         append_level(workflow.get("dynamic_blocks_definitions"))
@@ -90,7 +106,7 @@ def collect_dynamic_blocks_definitions_from_workflow_definition(
 
 def apply_collected_dynamic_blocks_definitions_to_workflow_root(
     workflow_definition: Dict[str, Any],
-) -> List[dict]:
+) -> List[Any]:
     """Hoist collected dynamic block definitions onto the root workflow dict.
 
     Calls :func:`collect_dynamic_blocks_definitions_from_workflow_definition` and, when

--- a/inference/core/workflows/execution_engine/v1/inner_workflow/dynamic_blocks_collection.py
+++ b/inference/core/workflows/execution_engine/v1/inner_workflow/dynamic_blocks_collection.py
@@ -1,0 +1,113 @@
+"""
+Collect ``dynamic_blocks_definitions`` from a workflow and nested inner workflows.
+
+Inner workflows may declare custom Python blocks on their own definition object. The
+compiler must discover all of them before ``compile_dynamic_blocks`` and inlining.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Set
+
+from inference.core.workflows.execution_engine.v1.inner_workflow.constants import (
+    USE_INNER_WORKFLOW_BLOCK_TYPE,
+)
+
+
+def _dynamic_block_type(definition: Dict[str, Any]) -> Optional[str]:
+    """Return ``manifest.block_type`` when present, else ``None``."""
+    manifest = definition.get("manifest")
+    if not isinstance(manifest, dict):
+        return None
+
+    block_type = manifest.get("block_type")
+    if isinstance(block_type, str) and block_type:
+        return block_type
+
+    return None
+
+
+def collect_dynamic_blocks_definitions_from_workflow_definition(
+    workflow_definition: Dict[str, Any],
+) -> List[dict]:
+    """Collect dynamic block definitions from a workflow and nested inner workflows.
+
+    Walks ``workflow_definition`` depth-first. For each level, appends entries from
+    ``dynamic_blocks_definitions``; then recurses into ``inner_workflow`` steps via
+    ``workflow_definition``.
+
+    When the same ``manifest.block_type`` appears more than once, the first occurrence
+    is kept (parent definitions win over nested children). Definitions without a
+    ``block_type`` are still included and are not deduplicated.
+
+    Args:
+        workflow_definition: Raw workflow JSON (``steps``, optional nested definitions).
+
+    Returns:
+        Merged list of dynamic block definition dicts in discovery order.
+    """
+    collected: List[dict] = []
+    seen_block_types: Set[str] = set()
+
+    def append_level(definitions: Any) -> None:
+        if not definitions:
+            return
+
+        if not isinstance(definitions, list):
+            return
+
+        for definition in definitions:
+            if not isinstance(definition, dict):
+                continue
+
+            block_type = _dynamic_block_type(definition)
+            if block_type is not None:
+                if block_type in seen_block_types:
+                    continue
+
+                seen_block_types.add(block_type)
+
+            collected.append(definition)
+
+    def visit(workflow: Dict[str, Any]) -> None:
+        append_level(workflow.get("dynamic_blocks_definitions"))
+
+        for step in workflow.get("steps") or []:
+            if not isinstance(step, dict):
+                continue
+
+            if step.get("type") != USE_INNER_WORKFLOW_BLOCK_TYPE:
+                continue
+
+            child = step.get("workflow_definition")
+            if isinstance(child, dict):
+                visit(child)
+
+    visit(workflow_definition)
+
+    return collected
+
+
+def apply_collected_dynamic_blocks_definitions_to_workflow_root(
+    workflow_definition: Dict[str, Any],
+) -> List[dict]:
+    """Hoist collected dynamic block definitions onto the root workflow dict.
+
+    Calls :func:`collect_dynamic_blocks_definitions_from_workflow_definition` and, when
+    the result is non-empty, sets ``workflow_definition["dynamic_blocks_definitions"]``
+    to that merged list (mutates ``workflow_definition`` in place).
+
+    Args:
+        workflow_definition: Raw workflow JSON to update and scan for definitions.
+
+    Returns:
+        The merged dynamic block definition list (possibly empty).
+    """
+    merged = collect_dynamic_blocks_definitions_from_workflow_definition(
+        workflow_definition=workflow_definition,
+    )
+
+    if merged:
+        workflow_definition["dynamic_blocks_definitions"] = merged
+
+    return merged

--- a/tests/workflows/integration_tests/execution/inner_workflow_inlining/test_inner_workflow_child_dynamic_blocks_definitions.py
+++ b/tests/workflows/integration_tests/execution/inner_workflow_inlining/test_inner_workflow_child_dynamic_blocks_definitions.py
@@ -1,0 +1,146 @@
+"""
+Equivalence for a child workflow whose ``dynamic_blocks_definitions`` live only on the
+nested definition: parent ``inner_workflow`` vs a flat workflow with hoisted definitions
+and an inlined step name.
+"""
+
+from typing import Any, Dict
+from unittest import mock
+
+from inference.core.managers.base import ModelManager
+from inference.core.workflows.execution_engine.v1.dynamic_blocks import block_assembler
+from tests.workflows.integration_tests.execution.inner_workflow_inlining._common import (
+    execution_engine,
+)
+
+_SCALAR_ECHO_DYNAMIC_RUN_CODE = """
+def run(self, value: str) -> BlockResult:
+    return {"output": value}
+"""
+
+_DYNAMIC_BLOCK_TYPE = "InnerScalarEcho"
+
+
+def _dynamic_block_definition() -> Dict[str, Any]:
+    return {
+        "type": "DynamicBlockDefinition",
+        "manifest": {
+            "type": "ManifestDescription",
+            "block_type": _DYNAMIC_BLOCK_TYPE,
+            "inputs": {
+                "value": {
+                    "type": "DynamicInputDefinition",
+                    "selector_types": ["input_parameter"],
+                },
+            },
+            "outputs": {
+                "output": {"type": "DynamicOutputDefinition", "kind": []},
+            },
+        },
+        "code": {
+            "type": "PythonCode",
+            "run_function_code": _SCALAR_ECHO_DYNAMIC_RUN_CODE,
+        },
+    }
+
+
+def _child_workflow_with_dynamic_block() -> Dict[str, Any]:
+    return {
+        "version": "1.0",
+        "dynamic_blocks_definitions": [_dynamic_block_definition()],
+        "inputs": [
+            {
+                "type": "WorkflowParameter",
+                "name": "child_msg",
+                "default_value": "default-child",
+            },
+        ],
+        "steps": [
+            {
+                "type": _DYNAMIC_BLOCK_TYPE,
+                "name": "pick",
+                "value": "$inputs.child_msg",
+            },
+        ],
+        "outputs": [
+            {
+                "type": "JsonField",
+                "name": "echo",
+                "selector": "$steps.pick.output",
+            },
+        ],
+    }
+
+
+def _nested_parent_workflow() -> Dict[str, Any]:
+    return {
+        "version": "1.0",
+        "inputs": [
+            {
+                "type": "WorkflowParameter",
+                "name": "root_msg",
+                "default_value": "unused-root",
+            },
+        ],
+        "steps": [
+            {
+                "type": "roboflow_core/inner_workflow@v1",
+                "name": "nested",
+                "workflow_definition": _child_workflow_with_dynamic_block(),
+                "parameter_bindings": {
+                    "child_msg": "$inputs.root_msg",
+                },
+            },
+        ],
+        "outputs": [
+            {
+                "type": "JsonField",
+                "name": "final",
+                "selector": "$steps.nested.echo",
+            },
+        ],
+    }
+
+
+def _flat_inlined_equivalent() -> Dict[str, Any]:
+    return {
+        "version": "1.0",
+        "dynamic_blocks_definitions": [_dynamic_block_definition()],
+        "inputs": [
+            {
+                "type": "WorkflowParameter",
+                "name": "root_msg",
+                "default_value": "unused-root",
+            },
+        ],
+        "steps": [
+            {
+                "type": _DYNAMIC_BLOCK_TYPE,
+                "name": "nested__pick",
+                "value": "$inputs.root_msg",
+            },
+        ],
+        "outputs": [
+            {
+                "type": "JsonField",
+                "name": "final",
+                "selector": "$steps.nested__pick.output",
+            },
+        ],
+    }
+
+
+@mock.patch.object(block_assembler, "ALLOW_CUSTOM_PYTHON_EXECUTION_IN_WORKFLOWS", True)
+def test_inlined_dynamic_block_matches_inner_workflow_child_definitions(
+    model_manager: ModelManager,
+) -> None:
+    nested_engine = execution_engine(model_manager, _nested_parent_workflow())
+    flat_engine = execution_engine(model_manager, _flat_inlined_equivalent())
+
+    runtime_parameters = {"root_msg": "dynamic-inner-value"}
+    nested_result = nested_engine.run(runtime_parameters=runtime_parameters)
+    flat_result = flat_engine.run(runtime_parameters=runtime_parameters)
+
+    assert nested_result == flat_result
+    assert len(nested_result) == 1
+    assert nested_result[0] == {"final": "dynamic-inner-value"}

--- a/tests/workflows/unit_tests/execution_engine/compiler/test_core_dynamic_blocks_in_inner_workflow.py
+++ b/tests/workflows/unit_tests/execution_engine/compiler/test_core_dynamic_blocks_in_inner_workflow.py
@@ -1,0 +1,93 @@
+"""Compiler collects dynamic block definitions from nested inner workflows."""
+
+from unittest import mock
+
+from inference.core.workflows.execution_engine.v1.compiler import core as compiler_core
+from inference.core.workflows.execution_engine.v1.inner_workflow.constants import (
+    USE_INNER_WORKFLOW_BLOCK_TYPE,
+)
+
+
+def _dynamic_block_definition(block_type: str) -> dict:
+    return {
+        "type": "DynamicBlockDefinition",
+        "manifest": {
+            "type": "ManifestDescription",
+            "block_type": block_type,
+            "inputs": {},
+            "outputs": {},
+        },
+        "code": {
+            "type": "PythonCode",
+            "run_function_code": "def run(self): return {}",
+        },
+    }
+
+
+@mock.patch.object(compiler_core, "compile_dynamic_blocks")
+@mock.patch.object(compiler_core, "inline_inner_workflow_steps")
+@mock.patch.object(
+    compiler_core,
+    "validate_inner_workflow_composition_from_raw_workflow_definition",
+)
+@mock.patch.object(compiler_core, "parse_workflow_definition")
+@mock.patch.object(compiler_core, "prepare_execution_graph")
+@mock.patch.object(compiler_core, "validate_workflow_specification")
+@mock.patch.object(compiler_core, "load_kinds_deserializers")
+@mock.patch.object(compiler_core, "load_kinds_serializers")
+@mock.patch.object(compiler_core, "load_initializers")
+@mock.patch.object(compiler_core, "load_workflow_blocks", return_value=[])
+def test_compile_workflow_graph_passes_inner_dynamic_blocks_to_compiler(
+    _load_blocks,
+    _load_initializers,
+    _load_serializers,
+    _load_deserializers,
+    _validate_spec,
+    _prepare_graph,
+    parse_workflow_definition,
+    _validate_composition,
+    inline_inner_workflow_steps,
+    compile_dynamic_blocks,
+) -> None:
+    child_block = _dynamic_block_definition("InnerOnlyBlock")
+    child_workflow = {
+        "version": "1.0",
+        "dynamic_blocks_definitions": [child_block],
+        "inputs": [],
+        "steps": [],
+        "outputs": [],
+    }
+    workflow_definition = {
+        "version": "1.0",
+        "inputs": [],
+        "steps": [
+            {
+                "type": USE_INNER_WORKFLOW_BLOCK_TYPE,
+                "name": "nested",
+                "workflow_definition": child_workflow,
+                "parameter_bindings": {},
+            },
+        ],
+        "outputs": [],
+    }
+
+    compile_dynamic_blocks.return_value = []
+    parse_workflow_definition.return_value = mock.Mock(
+        steps=[],
+        inputs=[],
+        outputs=[],
+    )
+    inline_inner_workflow_steps.side_effect = lambda definition, **_: definition
+
+    compiler_core.compile_workflow_graph(
+        workflow_definition=workflow_definition,
+        init_parameters={},
+    )
+
+    compile_dynamic_blocks.assert_called_once()
+    passed_definitions = compile_dynamic_blocks.call_args.kwargs[
+        "dynamic_blocks_definitions"
+    ]
+
+    assert passed_definitions == [child_block]
+    assert workflow_definition["dynamic_blocks_definitions"] == [child_block]

--- a/tests/workflows/unit_tests/execution_engine/inner_workflow/test_dynamic_blocks_collection.py
+++ b/tests/workflows/unit_tests/execution_engine/inner_workflow/test_dynamic_blocks_collection.py
@@ -1,9 +1,13 @@
 """Tests for collecting dynamic block definitions from nested inner workflows."""
 
 from typing import Any, Dict
+from unittest import mock
 
 from inference.core.workflows.execution_engine.v1.inner_workflow.constants import (
     USE_INNER_WORKFLOW_BLOCK_TYPE,
+)
+from inference.core.workflows.execution_engine.v1.inner_workflow import (
+    dynamic_blocks_collection,
 )
 from inference.core.workflows.execution_engine.v1.inner_workflow.dynamic_blocks_collection import (
     apply_collected_dynamic_blocks_definitions_to_workflow_root,
@@ -185,3 +189,72 @@ def test_collect_deduplicates_same_block_type_from_repeated_inner_child() -> Non
     )
 
     assert collected == [child_block]
+
+
+@mock.patch.object(dynamic_blocks_collection.logger, "warning")
+def test_collect_logs_warning_for_duplicate_block_type(mock_warning: mock.Mock) -> None:
+    parent_block = _dynamic_block_definition("SharedType")
+    child_block = _dynamic_block_definition("SharedType")
+    child_workflow = {
+        "version": "1.0",
+        "dynamic_blocks_definitions": [child_block],
+        "inputs": [],
+        "steps": [],
+        "outputs": [],
+    }
+    workflow = {
+        "version": "1.0",
+        "dynamic_blocks_definitions": [parent_block],
+        "inputs": [],
+        "steps": [
+            {
+                "type": USE_INNER_WORKFLOW_BLOCK_TYPE,
+                "name": "nested",
+                "workflow_definition": child_workflow,
+                "parameter_bindings": {},
+            },
+        ],
+        "outputs": [],
+    }
+
+    collected = collect_dynamic_blocks_definitions_from_workflow_definition(
+        workflow_definition=workflow,
+    )
+
+    assert collected == [parent_block]
+    mock_warning.assert_called_once()
+    assert mock_warning.call_args.args[1] == "SharedType"
+
+
+def test_collect_passes_through_non_dict_entries_for_downstream_validation() -> None:
+    invalid_entry = "not-a-dynamic-block-definition"
+    workflow = {
+        "version": "1.0",
+        "dynamic_blocks_definitions": [invalid_entry],
+        "inputs": [],
+        "steps": [],
+        "outputs": [],
+    }
+
+    collected = collect_dynamic_blocks_definitions_from_workflow_definition(
+        workflow_definition=workflow,
+    )
+
+    assert collected == [invalid_entry]
+
+
+def test_collect_passes_through_non_list_dynamic_blocks_definitions() -> None:
+    invalid_definitions = {"type": "DynamicBlockDefinition"}
+    workflow = {
+        "version": "1.0",
+        "dynamic_blocks_definitions": invalid_definitions,
+        "inputs": [],
+        "steps": [],
+        "outputs": [],
+    }
+
+    collected = collect_dynamic_blocks_definitions_from_workflow_definition(
+        workflow_definition=workflow,
+    )
+
+    assert collected == [invalid_definitions]

--- a/tests/workflows/unit_tests/execution_engine/inner_workflow/test_dynamic_blocks_collection.py
+++ b/tests/workflows/unit_tests/execution_engine/inner_workflow/test_dynamic_blocks_collection.py
@@ -1,0 +1,187 @@
+"""Tests for collecting dynamic block definitions from nested inner workflows."""
+
+from typing import Any, Dict
+
+from inference.core.workflows.execution_engine.v1.inner_workflow.constants import (
+    USE_INNER_WORKFLOW_BLOCK_TYPE,
+)
+from inference.core.workflows.execution_engine.v1.inner_workflow.dynamic_blocks_collection import (
+    apply_collected_dynamic_blocks_definitions_to_workflow_root,
+    collect_dynamic_blocks_definitions_from_workflow_definition,
+)
+
+
+def _dynamic_block_definition(block_type: str) -> Dict[str, Any]:
+    return {
+        "type": "DynamicBlockDefinition",
+        "manifest": {
+            "type": "ManifestDescription",
+            "block_type": block_type,
+            "inputs": {},
+            "outputs": {},
+        },
+        "code": {
+            "type": "PythonCode",
+            "run_function_code": "def run(self): return {}",
+        },
+    }
+
+
+def test_collect_returns_empty_when_no_dynamic_blocks() -> None:
+    workflow = {
+        "version": "1.0",
+        "inputs": [],
+        "steps": [],
+        "outputs": [],
+    }
+
+    collected = collect_dynamic_blocks_definitions_from_workflow_definition(
+        workflow_definition=workflow,
+    )
+
+    assert collected == []
+
+
+def test_collect_from_root_only() -> None:
+    parent_block = _dynamic_block_definition("ParentBlock")
+    workflow = {
+        "version": "1.0",
+        "dynamic_blocks_definitions": [parent_block],
+        "inputs": [],
+        "steps": [],
+        "outputs": [],
+    }
+
+    collected = collect_dynamic_blocks_definitions_from_workflow_definition(
+        workflow_definition=workflow,
+    )
+
+    assert collected == [parent_block]
+
+
+def test_collect_from_nested_inner_workflow() -> None:
+    child_block = _dynamic_block_definition("ChildBlock")
+    child_workflow = {
+        "version": "1.0",
+        "dynamic_blocks_definitions": [child_block],
+        "inputs": [],
+        "steps": [
+            {
+                "type": "ChildBlock",
+                "name": "use_child",
+            },
+        ],
+        "outputs": [],
+    }
+    workflow = {
+        "version": "1.0",
+        "inputs": [],
+        "steps": [
+            {
+                "type": USE_INNER_WORKFLOW_BLOCK_TYPE,
+                "name": "nested",
+                "workflow_definition": child_workflow,
+                "parameter_bindings": {},
+            },
+        ],
+        "outputs": [],
+    }
+
+    collected = collect_dynamic_blocks_definitions_from_workflow_definition(
+        workflow_definition=workflow,
+    )
+
+    assert collected == [child_block]
+
+
+def test_collect_merges_parent_and_child_with_parent_first() -> None:
+    parent_block = _dynamic_block_definition("SharedType")
+    child_block = _dynamic_block_definition("SharedType")
+    child_only = _dynamic_block_definition("ChildOnly")
+    child_workflow = {
+        "version": "1.0",
+        "dynamic_blocks_definitions": [child_block, child_only],
+        "inputs": [],
+        "steps": [],
+        "outputs": [],
+    }
+    workflow = {
+        "version": "1.0",
+        "dynamic_blocks_definitions": [parent_block],
+        "inputs": [],
+        "steps": [
+            {
+                "type": USE_INNER_WORKFLOW_BLOCK_TYPE,
+                "name": "nested",
+                "workflow_definition": child_workflow,
+                "parameter_bindings": {},
+            },
+        ],
+        "outputs": [],
+    }
+
+    collected = collect_dynamic_blocks_definitions_from_workflow_definition(
+        workflow_definition=workflow,
+    )
+
+    assert collected == [parent_block, child_only]
+
+
+def test_apply_hoists_collected_definitions_to_workflow_root() -> None:
+    child_block = _dynamic_block_definition("ChildBlock")
+    child_workflow = {
+        "version": "1.0",
+        "dynamic_blocks_definitions": [child_block],
+        "inputs": [],
+        "steps": [],
+        "outputs": [],
+    }
+    workflow = {
+        "version": "1.0",
+        "inputs": [],
+        "steps": [
+            {
+                "type": USE_INNER_WORKFLOW_BLOCK_TYPE,
+                "name": "nested",
+                "workflow_definition": child_workflow,
+                "parameter_bindings": {},
+            },
+        ],
+        "outputs": [],
+    }
+
+    merged = apply_collected_dynamic_blocks_definitions_to_workflow_root(
+        workflow_definition=workflow,
+    )
+
+    assert merged == [child_block]
+    assert workflow["dynamic_blocks_definitions"] == [child_block]
+
+
+def test_collect_deduplicates_same_block_type_from_repeated_inner_child() -> None:
+    child_block = _dynamic_block_definition("ChildBlock")
+    child_workflow = {
+        "version": "1.0",
+        "dynamic_blocks_definitions": [child_block],
+        "inputs": [],
+        "steps": [],
+        "outputs": [],
+    }
+    inner_step = {
+        "type": USE_INNER_WORKFLOW_BLOCK_TYPE,
+        "name": "nested",
+        "workflow_definition": child_workflow,
+        "parameter_bindings": {},
+    }
+    workflow = {
+        "version": "1.0",
+        "inputs": [],
+        "steps": [inner_step, {**inner_step, "name": "nested_copy"}],
+        "outputs": [],
+    }
+
+    collected = collect_dynamic_blocks_definitions_from_workflow_definition(
+        workflow_definition=workflow,
+    )
+
+    assert collected == [child_block]


### PR DESCRIPTION
## What does this PR do?

No linked Linear issue.

Workflows that embed an `inner_workflow` could declare custom Python blocks only on the nested child definition. The compiler previously read `dynamic_blocks_definitions` from the root workflow only, so `compile_dynamic_blocks` never saw blocks defined inside inner workflows. Child steps still referenced those block types after inlining, which led to compilation failures or missing block types.

This change collects `dynamic_blocks_definitions` from the root workflow and every nested `inner_workflow` child (depth-first), deduplicates by `manifest.block_type` (parent wins over children), and hoists the merged list onto the root definition before dynamic block compilation and inlining. The cache-hit path uses the same collection logic for `ensure_dynamic_blocks_allowed`, so permission checks cover blocks defined only in nested workflows. Inlining continues to rename step `name` values and rewrite selectors; step `type` / `block_type` strings are unchanged.

**Main elements:**
- `inference/core/workflows/execution_engine/v1/inner_workflow/dynamic_blocks_collection.py` — collect and hoist helpers
- `inference/core/workflows/execution_engine/v1/compiler/core.py` — wire collection into `compile_workflow_graph`
- Unit tests for collection, compiler wiring, and inner-workflow integration equivalence

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other:

## Testing

### Unit tests

- `tests/workflows/unit_tests/execution_engine/inner_workflow/test_dynamic_blocks_collection.py` — empty workflow, root-only defs, nested inner workflow, parent/child merge order, hoist to root, dedupe by `block_type` across repeated inner steps
- `tests/workflows/unit_tests/execution_engine/compiler/test_core_dynamic_blocks_in_inner_workflow.py` — `compile_workflow_graph` passes child-only `dynamic_blocks_definitions` to `compile_dynamic_blocks` and hoists onto the workflow root

### Integration tests

- `tests/workflows/integration_tests/execution/inner_workflow_inlining/test_inner_workflow_child_dynamic_blocks_definitions.py` — parent with `inner_workflow` whose child defines a dynamic block only on the nested spec; runtime output matches a flat workflow with hoisted definitions and inlined step name `nested__pick`

### Other

```bash
uv run pytest tests/workflows/unit_tests/execution_engine/inner_workflow/test_dynamic_blocks_collection.py
uv run pytest tests/workflows/unit_tests/execution_engine/compiler/test_core_dynamic_blocks_in_inner_workflow.py
uv run pytest tests/workflows/integration_tests/execution/inner_workflow_inlining/test_inner_workflow_child_dynamic_blocks_definitions.py
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [ ] I have updated the documentation accordingly (if applicable)

## Additional Context

- Deduplication assumes the same `block_type` represents the same block across parent and child; conflicting definitions with the same `block_type` but different code are not detected (parent definition is kept).
- Docs (`docs/workflows/inner_workflow_design.md`) were not updated in this PR; consider a follow-up note that nested workflows may carry `dynamic_blocks_definitions` that are hoisted at compile time.
