### PR TITLE
fix: emit RLE masks from instance segmentation v4 block

### DIFF
--- a/inference/core/workflows/core_steps/models/roboflow/instance_segmentation/v4.py
+++ b/inference/core/workflows/core_steps/models/roboflow/instance_segmentation/v4.py
@@ -34,6 +34,7 @@ from inference.core.workflows.execution_engine.entities.types import (
     INSTANCE_SEGMENTATION_PREDICTION_KIND,
     INTEGER_KIND,
     LIST_OF_VALUES_KIND,
+    RLE_INSTANCE_SEGMENTATION_PREDICTION_KIND,
     ROBOFLOW_MODEL_ID_KIND,
     ROBOFLOW_PROJECT_KIND,
     STRING_KIND,
@@ -69,7 +70,7 @@ class BlockManifest(WorkflowBlockManifest):
     model_config = ConfigDict(
         json_schema_extra={
             "name": "Instance Segmentation Model",
-            "version": "v3",
+            "version": "v4",
             "short_description": "Predict the shape, size, and location of objects.",
             "long_description": LONG_DESCRIPTION,
             "license": "Apache-2.0",
@@ -206,7 +207,10 @@ class BlockManifest(WorkflowBlockManifest):
             OutputDefinition(name=INFERENCE_ID_KEY, kind=[INFERENCE_ID_KIND]),
             OutputDefinition(
                 name="predictions",
-                kind=[INSTANCE_SEGMENTATION_PREDICTION_KIND],
+                kind=[
+                    RLE_INSTANCE_SEGMENTATION_PREDICTION_KIND,
+                    INSTANCE_SEGMENTATION_PREDICTION_KIND,
+                ],
             ),
             OutputDefinition(name="model_id", kind=[ROBOFLOW_MODEL_ID_KIND]),
         ]

--- a/tests/workflows/unit_tests/core_steps/models/roboflow/instance_segmentation/test_v4.py
+++ b/tests/workflows/unit_tests/core_steps/models/roboflow/instance_segmentation/test_v4.py
@@ -1,0 +1,69 @@
+import pytest
+from pydantic import ValidationError
+
+from inference.core.workflows.core_steps.models.roboflow.instance_segmentation.v4 import (
+    BlockManifest,
+)
+from inference.core.workflows.execution_engine.entities.types import (
+    INSTANCE_SEGMENTATION_PREDICTION_KIND,
+    RLE_INSTANCE_SEGMENTATION_PREDICTION_KIND,
+)
+
+
+@pytest.mark.parametrize("images_field_alias", ["images", "image"])
+def test_instance_segmentation_model_v4_validation_when_minimalistic_config_is_provided(
+    images_field_alias: str,
+) -> None:
+    data = {
+        "type": "roboflow_core/roboflow_instance_segmentation_model@v4",
+        "name": "some",
+        images_field_alias: "$inputs.image",
+        "model_id": "some/1",
+    }
+
+    result = BlockManifest.model_validate(data)
+
+    assert result == BlockManifest(
+        type="roboflow_core/roboflow_instance_segmentation_model@v4",
+        name="some",
+        images="$inputs.image",
+        model_id="some/1",
+    )
+
+
+@pytest.mark.parametrize("field", ["type", "name", "images", "model_id"])
+def test_instance_segmentation_model_v4_validation_when_required_field_is_not_given(
+    field: str,
+) -> None:
+    data = {
+        "type": "roboflow_core/roboflow_instance_segmentation_model@v4",
+        "name": "some",
+        "images": "$inputs.image",
+        "model_id": "some/1",
+    }
+    del data[field]
+
+    with pytest.raises(ValidationError):
+        _ = BlockManifest.model_validate(data)
+
+
+def test_instance_segmentation_model_v4_predictions_output_advertises_rle_kind_first() -> None:
+    outputs = {o.name: o for o in BlockManifest.describe_outputs()}
+
+    predictions_kinds = outputs["predictions"].kind
+
+    assert predictions_kinds[0] is RLE_INSTANCE_SEGMENTATION_PREDICTION_KIND, (
+        "RLE kind must be listed first so the RLE serializer is attempted before "
+        "the polygon fallback — otherwise the block silently emits polygon points "
+        "even though it requested RLE from the model."
+    )
+    assert INSTANCE_SEGMENTATION_PREDICTION_KIND in predictions_kinds, (
+        "Polygon kind must remain as a fallback for code paths where the model "
+        "did not produce RLE (e.g. USE_INFERENCE_MODELS=False)."
+    )
+
+
+def test_instance_segmentation_model_v4_ui_version_label_matches_type() -> None:
+    schema_extra = BlockManifest.model_config["json_schema_extra"]
+
+    assert schema_extra["version"] == "v4"


### PR DESCRIPTION
## What does this PR do?

Fixes the v4 instance segmentation block so it actually emits RLE masks instead of polygon points. The block requests `response_mask_format="rle"` from the model, but its output kind was wired to a polygon-only serializer that ignored the attached RLE and re-derived polygons from the bitmap. Declares `RLE_INSTANCE_SEGMENTATION_PREDICTION_KIND` first on the output (engine tries serializers in order; RLE serializer raises and falls back to polygon when `rle_mask` isn't attached, e.g. `USE_INFERENCE_MODELS=False`). Also fixes the UI version label (`v3` → `v4`).

**Related Issue(s):** _n/a_

## Type of Change

- Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] I have tested this change locally
- [x] I have added/updated tests for this change

**Test details:**
- [x] New `test_v4.py` pins the output kind order and the version label. Full suite: `pytest tests/workflows/unit_tests/core_steps/models/roboflow/instance_segmentation/` — 79 passed.

- [x] E2E workflow test in staging - RLE output as expected
<img width="1964" height="1364" alt="image" src="https://github.com/user-attachments/assets/cb1c206c-0a18-4f4d-b75a-300b51f708ee" />
<img width="640" height="640" alt="image" src="https://github.com/user-attachments/assets/66ef4cda-5dc4-4cf2-837a-9d946a7739da" />

- [x] E2E workflow test in staging with `USE_INFERENCE_MODELS=false` (windows default) - fallback to polygon
<img width="1964" height="1364" alt="image" src="https://github.com/user-attachments/assets/fb73d305-af00-4cab-a5c0-ee061f2dbe6a" />
<img width="640" height="640" alt="image" src="https://github.com/user-attachments/assets/319bddaf-d974-440f-b8ee-cc607e24d03d" />

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [ ] I have updated the documentation accordingly (if applicable)

## Additional Context

🤖 Generated with [Claude Code](https://claude.com/claude-code)