### PR TITLE
Add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,3 +87,31 @@ The repository follows PEP 8 and uses Black (88 characters), isort and flake8.
 - PR descriptions should explain what changed and why, list test commands run,
   and follow the templates in `.github`.
 - Update documentation when applicable.
+
+## Cursor Cloud specific instructions
+
+### Running the inference server locally (without Docker)
+
+Use the `debugrun.py` script at the repo root. It creates the model registry, manager, and HTTP interface directly:
+
+```bash
+cd /agent/repos/inference
+PORT=9001 CORE_MODEL_SAM_ENABLED=False CORE_MODEL_SAM3_ENABLED=False python3 debugrun.py
+```
+
+The server will be available at `http://localhost:9001`. Verify with `curl http://localhost:9001/info`.
+
+Disable SAM/SAM3 models via env vars to avoid missing-dependency warnings unless you specifically need them.
+
+### Testing
+
+- Unit tests: `pytest tests/inference/unit_tests/` (1400+ tests, ~2 min)
+- SDK tests: `pytest tests/inference_sdk/unit_tests/`
+- CLI tests: `pytest tests/inference_cli/unit_tests/`
+- Workflow tests: `pytest tests/workflows/unit_tests/`
+- Lint: `make check_code_quality` (Black + isort + flake8). Note: there are pre-existing flake8 F824 warnings in the repo.
+
+### Gotchas
+
+- The `inference_cli server start` command is designed to manage Docker containers, not for local dev. Use `debugrun.py` instead.
+- The `app` attribute does not exist as a module-level variable in `http_api.py` (it is created inside the `HttpInterface` class). Do not try to start with `uvicorn inference.core.interfaces.http.http_api:app`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a `## Cursor Cloud specific instructions` section to AGENTS.md with guidance for Cloud Agents:

- How to run the inference server locally without Docker using `debugrun.py`
- Testing commands and expected run times
- Gotchas: `inference_cli server start` is Docker-only; `http_api.py` app attribute is class-level not module-level

Verified by running unit tests (1405 passed) and starting the server via `debugrun.py`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ac617329-a9ad-4983-9965-75eb99c0961c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ac617329-a9ad-4983-9965-75eb99c0961c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

