### PR TITLE
Bump the Execution Engine to v1.10.1

### DIFF
--- a/.cursor/rules/execution-engine-version-changelog.mdc
+++ b/.cursor/rules/execution-engine-version-changelog.mdc
@@ -1,0 +1,62 @@
+---
+description: Bump Execution Engine version and changelog when workflow compile/run logic changes
+globs: inference/core/workflows/execution_engine/**/*.py
+alwaysApply: false
+---
+
+# Execution Engine version and changelog
+
+When you change **behavior** of workflow **compilation** or **execution** under
+`inference/core/workflows/execution_engine/`, update the Execution Engine release
+metadata in the **same PR** (unless the user explicitly says to skip versioning).
+
+## When this applies
+
+- Compiler pipeline, parsing, graph construction, inlining, dynamic blocks assembly
+- Runtime execution, input assembly/validation, step scheduling, error handling
+- Execution Engine v1 APIs that affect compile or run outcomes
+
+## When this does NOT apply
+
+- Comments, types-only refactors, or formatting with **no** behavior change
+- Workflow **block** implementations in `core_steps/` (unless they require an EE change)
+- Documentation or tests that only mirror existing behavior
+
+## Required updates
+
+1. **Version constant** — bump `EXECUTION_ENGINE_V1_VERSION` in
+   `inference/core/workflows/execution_engine/v1/core.py`.
+
+2. **Changelog** — add a new section at the top of
+   `docs/workflows/execution_engine_changelog.md`:
+   - Heading: `## Execution Engine \`vX.Y.Z\` | inference \`vA.B.C\``
+   - Use current `inference/core/version.py` → `__version__` for the inference version
+   - Short **What changed** bullets (user-facing behavior, not file lists)
+
+3. **Version tests** — update any hardcoded EE version assertions, especially:
+   - `tests/inference/integration_tests/test_workflow_endpoints.py`
+     (`test_get_versions_of_execution_engine`)
+   - `tests/inference/hosted_platform_tests/test_workflows.py`
+
+   Search: `execution_engine/versions`, `EXECUTION_ENGINE_V1_VERSION`, and
+   `["1.` in workflow tests.
+
+## Patch vs minor
+
+| Change | Bump |
+|--------|------|
+| Bug fix, non-breaking compile/run correction | **Patch** (e.g. `1.10.0` → `1.10.1`) |
+| New compile/run capability or intentional behavior change | **Minor** (e.g. `1.10.0` → `1.11.0`) |
+| Breaking workflow contract | **Major** (rare; coordinate with maintainers) |
+
+When unsure, prefer **patch** for fixes and **minor** for new capabilities.
+
+## Example changelog entry
+
+```markdown
+## Execution Engine `v1.10.1` | inference `v1.2.12`
+
+**What changed**
+
+* **Short title** — One or two sentences on compile/run impact for workflow authors.
+```

--- a/docs/workflows/execution_engine_changelog.md
+++ b/docs/workflows/execution_engine_changelog.md
@@ -18,7 +18,7 @@ Below you can find the changelog for Execution Engine.
 
 **What changed**
 
-* Added capability to recognize dictionaries wiath values being mix of static values and selectors - in previous 
+* Added capability to recognize dictionaries with values being mix of static values and selectors - in previous 
 versions, only dicts mapping keys to selectors were recognized, making some blocks not correctly wired to 
 referred values in runtime. Change is non-breaking, but fixes certain blocks which was broken in the past.
 

--- a/docs/workflows/execution_engine_changelog.md
+++ b/docs/workflows/execution_engine_changelog.md
@@ -2,11 +2,23 @@
 
 Below you can find the changelog for Execution Engine.
 
+## Execution Engine `v1.10.1` | inference `v1.2.12`
+
+**What changed**
+
+* **Dynamic blocks in nested inner workflows** — The compiler now collects
+  `dynamic_blocks_definitions` from the root workflow and every nested
+  `inner_workflow` child (depth-first), deduplicates by `manifest.block_type`
+  (first occurrence wins; a warning is logged when a duplicate is skipped), and
+  hoists the merged list onto the root definition before `compile_dynamic_blocks`
+  and inlining. Child steps that use custom Python block types defined only on
+  the nested workflow spec compile and run correctly after inlining.
+
 ## Execution Engine `v1.10.0` | inference `v1.2.10`
 
 **What changed**
 
-* Added capability to recognize dictionaries with values being mix of static values and selectors - in previous 
+* Added capability to recognize dictionaries wiath values being mix of static values and selectors - in previous 
 versions, only dicts mapping keys to selectors were recognized, making some blocks not correctly wired to 
 referred values in runtime. Change is non-breaking, but fixes certain blocks which was broken in the past.
 

--- a/inference/core/workflows/execution_engine/v1/core.py
+++ b/inference/core/workflows/execution_engine/v1/core.py
@@ -29,7 +29,7 @@ from inference.core.workflows.execution_engine.v1.step_error_handlers import (
     legacy_step_error_handler,
 )
 
-EXECUTION_ENGINE_V1_VERSION = Version("1.10.0")
+EXECUTION_ENGINE_V1_VERSION = Version("1.10.1")
 
 DEFAULT_WORKFLOWS_STEP_ERROR_HANDLER = os.getenv(
     "DEFAULT_WORKFLOWS_STEP_ERROR_HANDLER", "extended_roboflow_errors"

--- a/tests/inference/hosted_platform_tests/test_workflows.py
+++ b/tests/inference/hosted_platform_tests/test_workflows.py
@@ -129,7 +129,7 @@ def test_get_versions_of_execution_engine(object_detection_service_url: str) -> 
     # then
     response.raise_for_status()
     response_data = response.json()
-    assert response_data["versions"] == ["1.10.0"]
+    assert response_data["versions"] == ["1.10.1"]
 
 
 FUNCTION = """

--- a/tests/inference/integration_tests/test_workflow_endpoints.py
+++ b/tests/inference/integration_tests/test_workflow_endpoints.py
@@ -691,7 +691,7 @@ def test_get_versions_of_execution_engine(server_url: str) -> None:
     # then
     response.raise_for_status()
     response_data = response.json()
-    assert response_data["versions"] == ["1.10.0"]
+    assert response_data["versions"] == ["1.10.1"]
 
 
 def test_getting_block_schema_using_get_endpoint(server_url) -> None:


### PR DESCRIPTION
## What does this PR do?

This PR bumps the registered Execution Engine to **`v1.10.1`** (patch) and adds a matching entry at the top of `docs/workflows/execution_engine_changelog.md`. The `/workflows/execution_engine/versions` endpoint and related tests now report `1.10.1`.

A Cursor rule (`.cursor/rules/execution-engine-version-changelog.mdc`) reminds contributors to bump the EE version and changelog whenever compile- or run-time logic under `inference/core/workflows/execution_engine/` changes.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other:

## Testing

- Update version assertions only; re-run when validating this PR:

```bash
uv run pytest tests/inference/integration_tests/test_workflow_endpoints.py::test_get_versions_of_execution_engine
```

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where necessary, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have updated the documentation accordingly (if applicable)

## Additional Context

- Relates to #2380 (`Fix inner workflow dynamic block setup`), which merged the compiler changes without an EE version bump.
- Changelog pairs EE `v1.10.1` with inference `v1.2.12` per `inference/core/version.py` at release time; adjust the changelog header if inference version differs on your branch.
