### PR TITLE
Add change to enforce dense representation of instance segmentation mask when used in inference models, enabled by default for old versions of IS block

### DIFF
--- a/inference/core/entities/requests/inference.py
+++ b/inference/core/entities/requests/inference.py
@@ -246,6 +246,13 @@ class InstanceSegmentationInferenceRequest(ObjectDetectionInferenceRequest):
         "require special decoding on the caller side - currently supported in `opt-in` mode when server is "
         "running with `USE_INFERENCE_MODELS=True` - otherwise it's ignored.",
     )
+    enforce_dense_masks_in_inference_models: Optional[bool] = Field(
+        default=False,
+        examples=[False],
+        description="Flag to enforce dense masks in inference models. Such masks are faster than "
+        "RLE but consume more memory which may be unstable in some cases. This flag cannot be tweaked "
+        "when used on Roboflow serverless platform.",
+    )
 
 
 class SemanticSegmentationInferenceRequest(CVInferenceRequest):

--- a/inference/core/models/inference_models_adapters.py
+++ b/inference/core/models/inference_models_adapters.py
@@ -35,6 +35,7 @@ from inference.core.env import (
     ALLOW_INFERENCE_MODELS_UNTRUSTED_PACKAGES,
     API_KEY,
     DISABLED_INFERENCE_MODELS_BACKENDS,
+    GCP_SERVERLESS,
     RFDETR_ONNX_MAX_RESOLUTION,
     VALID_INFERENCE_MODELS_BACKENDS,
 )
@@ -279,8 +280,18 @@ class InferenceModelsInstanceSegmentationAdapter(Model):
             disable_grayscale=kwargs.get("disable_preproc_grayscale", False),
             disable_static_crop=kwargs.get("disable_preproc_static_crop", False),
         )
+        if GCP_SERVERLESS:
+            enforce_dense_masks_in_inference_models = False
+        else:
+            enforce_dense_masks_in_inference_models = kwargs.get(
+                "enforce_dense_masks_in_inference_models",
+                False,
+            )
         kwargs["pre_processing_overrides"] = pre_processing_overrides
-        if "rle" in self._model.supported_mask_formats:
+        if (
+            "rle" in self._model.supported_mask_formats
+            and not enforce_dense_masks_in_inference_models
+        ):
             kwargs["mask_format"] = "rle"
         return kwargs
 

--- a/inference/core/version.py
+++ b/inference/core/version.py
@@ -1,4 +1,4 @@
-__version__ = "1.2.11"
+__version__ = "1.2.12"
 
 
 if __name__ == "__main__":

--- a/inference/core/workflows/core_steps/models/roboflow/instance_segmentation/v1.py
+++ b/inference/core/workflows/core_steps/models/roboflow/instance_segmentation/v1.py
@@ -153,6 +153,15 @@ class BlockManifest(WorkflowBlockManifest):
         description="Target dataset for active learning, if enabled.",
         examples=["my_project", "$inputs.al_target_project"],
     )
+    enforce_dense_masks_in_inference_models: Union[
+        bool, Selector(kind=[BOOLEAN_KIND])
+    ] = Field(
+        default=True,
+        description="Boolean flag to enforce dense masks when inference models backend is in use "
+        "(irrelevant in other cases). Dense masks are faster to process, but require more memory. "
+        "Users can't tweak this flag when running on Roboflow serverless platform.",
+        examples=[True, "$inputs.enforce_dense_masks_in_inference_models"],
+    )
 
     @classmethod
     def get_compatible_task_types(cls) -> Optional[List[str]]:
@@ -211,6 +220,7 @@ class RoboflowInstanceSegmentationModelBlockV1(WorkflowBlock):
         tradeoff_factor: Optional[float],
         disable_active_learning: Optional[bool],
         active_learning_target_dataset: Optional[str],
+        enforce_dense_masks_in_inference_models: bool,
     ) -> BlockResult:
         if self._step_execution_mode is StepExecutionMode.LOCAL:
             return self.run_locally(
@@ -226,6 +236,7 @@ class RoboflowInstanceSegmentationModelBlockV1(WorkflowBlock):
                 tradeoff_factor=tradeoff_factor,
                 disable_active_learning=disable_active_learning,
                 active_learning_target_dataset=active_learning_target_dataset,
+                enforce_dense_masks_in_inference_models=enforce_dense_masks_in_inference_models,
             )
         elif self._step_execution_mode is StepExecutionMode.REMOTE:
             return self.run_remotely(
@@ -261,6 +272,7 @@ class RoboflowInstanceSegmentationModelBlockV1(WorkflowBlock):
         tradeoff_factor: Optional[float],
         disable_active_learning: Optional[bool],
         active_learning_target_dataset: Optional[str],
+        enforce_dense_masks_in_inference_models: bool,
     ) -> BlockResult:
         inference_images = [i.to_inference_format(numpy_preferred=True) for i in images]
         request = InstanceSegmentationInferenceRequest(
@@ -278,6 +290,7 @@ class RoboflowInstanceSegmentationModelBlockV1(WorkflowBlock):
             mask_decode_mode=mask_decode_mode,
             tradeoff_factor=tradeoff_factor,
             source="workflow-execution",
+            enforce_dense_masks_in_inference_models=enforce_dense_masks_in_inference_models,
         )
         self._model_manager.add_model(
             model_id=model_id,

--- a/inference/core/workflows/core_steps/models/roboflow/instance_segmentation/v2.py
+++ b/inference/core/workflows/core_steps/models/roboflow/instance_segmentation/v2.py
@@ -150,6 +150,15 @@ class BlockManifest(WorkflowBlockManifest):
         description="Target dataset for active learning, if enabled.",
         examples=["my_project", "$inputs.al_target_project"],
     )
+    enforce_dense_masks_in_inference_models: Union[
+        bool, Selector(kind=[BOOLEAN_KIND])
+    ] = Field(
+        default=True,
+        description="Boolean flag to enforce dense masks when inference models backend is in use "
+        "(irrelevant in other cases). Dense masks are faster to process, but require more memory. "
+        "Users can't tweak this flag when running on Roboflow serverless platform.",
+        examples=[True, "$inputs.enforce_dense_masks_in_inference_models"],
+    )
 
     @classmethod
     def get_compatible_task_types(cls) -> Optional[List[str]]:
@@ -209,6 +218,7 @@ class RoboflowInstanceSegmentationModelBlockV2(WorkflowBlock):
         tradeoff_factor: Optional[float],
         disable_active_learning: Optional[bool],
         active_learning_target_dataset: Optional[str],
+        enforce_dense_masks_in_inference_models: bool,
     ) -> BlockResult:
         if self._step_execution_mode is StepExecutionMode.LOCAL:
             return self.run_locally(
@@ -224,6 +234,7 @@ class RoboflowInstanceSegmentationModelBlockV2(WorkflowBlock):
                 tradeoff_factor=tradeoff_factor,
                 disable_active_learning=disable_active_learning,
                 active_learning_target_dataset=active_learning_target_dataset,
+                enforce_dense_masks_in_inference_models=enforce_dense_masks_in_inference_models,
             )
         elif self._step_execution_mode is StepExecutionMode.REMOTE:
             return self.run_remotely(
@@ -259,6 +270,7 @@ class RoboflowInstanceSegmentationModelBlockV2(WorkflowBlock):
         tradeoff_factor: Optional[float],
         disable_active_learning: Optional[bool],
         active_learning_target_dataset: Optional[str],
+        enforce_dense_masks_in_inference_models: bool,
     ) -> BlockResult:
         inference_images = [i.to_inference_format(numpy_preferred=True) for i in images]
         request = InstanceSegmentationInferenceRequest(
@@ -276,6 +288,7 @@ class RoboflowInstanceSegmentationModelBlockV2(WorkflowBlock):
             mask_decode_mode=mask_decode_mode,
             tradeoff_factor=tradeoff_factor,
             source="workflow-execution",
+            enforce_dense_masks_in_inference_models=enforce_dense_masks_in_inference_models,
         )
         self._model_manager.add_model(
             model_id=model_id,

--- a/inference/core/workflows/core_steps/models/roboflow/instance_segmentation/v3.py
+++ b/inference/core/workflows/core_steps/models/roboflow/instance_segmentation/v3.py
@@ -179,6 +179,15 @@ class BlockManifest(WorkflowBlockManifest):
         description="Target dataset for active learning, if enabled.",
         examples=["my_project", "$inputs.al_target_project"],
     )
+    enforce_dense_masks_in_inference_models: Union[
+        bool, Selector(kind=[BOOLEAN_KIND])
+    ] = Field(
+        default=True,
+        description="Boolean flag to enforce dense masks when inference models backend is in use "
+        "(irrelevant in other cases). Dense masks are faster to process, but require more memory. "
+        "Users can't tweak this flag when running on Roboflow serverless platform.",
+        examples=[True, "$inputs.enforce_dense_masks_in_inference_models"],
+    )
 
     @model_validator(mode="after")
     def validate(self) -> "BlockManifest":
@@ -247,6 +256,7 @@ class RoboflowInstanceSegmentationModelBlockV3(WorkflowBlock):
         tradeoff_factor: Optional[float],
         disable_active_learning: Optional[bool],
         active_learning_target_dataset: Optional[str],
+        enforce_dense_masks_in_inference_models: bool,
     ) -> BlockResult:
         confidence = (
             custom_confidence if confidence_mode == "custom" else confidence_mode
@@ -265,6 +275,7 @@ class RoboflowInstanceSegmentationModelBlockV3(WorkflowBlock):
                 tradeoff_factor=tradeoff_factor,
                 disable_active_learning=disable_active_learning,
                 active_learning_target_dataset=active_learning_target_dataset,
+                enforce_dense_masks_in_inference_models=enforce_dense_masks_in_inference_models,
             )
         elif self._step_execution_mode is StepExecutionMode.REMOTE:
             return self.run_remotely(
@@ -300,6 +311,7 @@ class RoboflowInstanceSegmentationModelBlockV3(WorkflowBlock):
         tradeoff_factor: Optional[float],
         disable_active_learning: Optional[bool],
         active_learning_target_dataset: Optional[str],
+        enforce_dense_masks_in_inference_models: bool,
     ) -> BlockResult:
         inference_images = [i.to_inference_format(numpy_preferred=True) for i in images]
         request = InstanceSegmentationInferenceRequest(
@@ -317,6 +329,7 @@ class RoboflowInstanceSegmentationModelBlockV3(WorkflowBlock):
             mask_decode_mode=mask_decode_mode,
             tradeoff_factor=tradeoff_factor,
             source="workflow-execution",
+            enforce_dense_masks_in_inference_models=enforce_dense_masks_in_inference_models,
         )
         self._model_manager.add_model(
             model_id=model_id,


### PR DESCRIPTION
## What does this PR do?

<!-- Provide a clear and concise description of the changes -->

This PR tries to address problem with speed of decoding regarding instance segmentation workflows blocks with `inference-models`.

Change from release 1.2.4 introduced RLE which enforced laborious conversion of masks to RLE to polygions to full masks in standard chain of execution for Workflow block - decreasing the throughput of workflows running in the field. Addressing that we introduce a knob to enforce dense representation in old blocks - with flag to control that behaviour if memory usage is to high.

## Type of Change

<!-- Please select one and delete the others, or describe if Other -->

- Bug fix (non-breaking change that fixes an issue)

## Testing

<!-- Describe how you tested your changes -->
- ci tests
- [x] I have tested this change locally
- [ ] I have added/updated tests for this change

**Test details:**
<!-- Describe what tests were added/updated and what they cover -->

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)

## Additional Context

<!-- Add any other context, screenshots, or notes about the PR here -->
