### PR TITLE
fix(workflows): correct values_difference aggregation in Data Aggregator

### DIFF
--- a/inference/core/workflows/core_steps/analytics/data_aggregator/v1.py
+++ b/inference/core/workflows/core_steps/analytics/data_aggregator/v1.py
@@ -451,15 +451,13 @@ class ValuesDifferenceState(AggregationState):
     def on_data(self, value: Any) -> None:
         if self._min_value is None:
             self._min_value = value
-            return None
-        if self._max_value is None:
             self._max_value = value
             return None
         self._min_value = min(self._min_value, value)
         self._max_value = max(self._max_value, value)
 
     def get_result(self) -> Any:
-        if self._min_value is None or self._max_value is None:
+        if self._min_value is None:
             return None
         return self._max_value - self._min_value
 

--- a/tests/workflows/unit_tests/core_steps/analytics/test_data_aggregator_v1.py
+++ b/tests/workflows/unit_tests/core_steps/analytics/test_data_aggregator_v1.py
@@ -1,0 +1,156 @@
+import pytest
+
+from inference.core.workflows.core_steps.analytics.data_aggregator.v1 import (
+    DataAggregatorBlockV1,
+    ValuesDifferenceState,
+)
+
+
+def _feed(state: ValuesDifferenceState, values):
+    for value in values:
+        state.on_data(value=value)
+    return state.get_result()
+
+
+def test_values_difference_with_decreasing_then_min_pair():
+    # Arrange
+    state = ValuesDifferenceState()
+
+    # Act
+    result = _feed(state, [10, 1])
+
+    # Assert
+    assert result == 9
+
+
+def test_values_difference_with_max_first_then_smaller_values():
+    # Arrange
+    state = ValuesDifferenceState()
+
+    # Act
+    result = _feed(state, [10, 1, 5])
+
+    # Assert
+    assert result == 9
+
+
+def test_values_difference_with_monotonically_decreasing_values():
+    # Arrange
+    state = ValuesDifferenceState()
+
+    # Act
+    result = _feed(state, [5, 4, 3, 2, 1])
+
+    # Assert
+    assert result == 4
+
+
+def test_values_difference_with_monotonically_increasing_values():
+    # Arrange
+    state = ValuesDifferenceState()
+
+    # Act
+    result = _feed(state, [1, 2, 3, 4, 5])
+
+    # Assert
+    assert result == 4
+
+
+def test_values_difference_with_single_value_returns_zero():
+    # Arrange
+    state = ValuesDifferenceState()
+
+    # Act
+    result = _feed(state, [7])
+
+    # Assert
+    assert result == 0
+
+
+def test_values_difference_with_no_values_returns_none():
+    # Arrange
+    state = ValuesDifferenceState()
+
+    # Act
+    result = state.get_result()
+
+    # Assert
+    assert result is None
+
+
+def test_values_difference_with_all_equal_values_returns_zero():
+    # Arrange
+    state = ValuesDifferenceState()
+
+    # Act
+    result = _feed(state, [5, 5, 5])
+
+    # Assert
+    assert result == 0
+
+
+def test_values_difference_with_negative_values():
+    # Arrange
+    state = ValuesDifferenceState()
+
+    # Act
+    result = _feed(state, [-10, -3, -7])
+
+    # Assert
+    assert result == 7
+
+
+def test_values_difference_with_float_values():
+    # Arrange
+    state = ValuesDifferenceState()
+
+    # Act
+    result = _feed(state, [1.5, 3.7, 2.0])
+
+    # Assert
+    assert result == pytest.approx(2.2)
+
+
+def test_values_difference_is_never_negative():
+    # Regression test: previously the first observed value was locked into the
+    # min slot and the second into the max slot without cross-comparison, so a
+    # descending stream like [10, 1] produced -9 instead of 9.
+    # Arrange
+    state = ValuesDifferenceState()
+
+    # Act
+    result = _feed(state, [10, 1])
+
+    # Assert
+    assert result == 9
+    assert result >= 0
+
+
+def test_values_difference_matches_max_minus_min_end_to_end():
+    # Regression test at the block level: the documented behaviour is
+    # values_difference == max - min. Before the fix the block could return
+    # values_difference=0 while reporting max=10 and min=1.
+    # Arrange
+    block = DataAggregatorBlockV1()
+    aggregation_mode = {"speed": ["values_difference", "max", "min"]}
+    observations = [10, 1, 5, 5]
+
+    # Act
+    result = None
+    for value in observations:
+        result = block.run(
+            data={"speed": value},
+            data_operations={},
+            aggregation_mode=aggregation_mode,
+            interval_unit="runs",
+            interval=4,
+        )
+
+    # Assert
+    assert result is not None
+    assert result["speed_max"] == 10
+    assert result["speed_min"] == 1
+    assert (
+        result["speed_values_difference"] == result["speed_max"] - result["speed_min"]
+    )
+    assert result["speed_values_difference"] == 9


### PR DESCRIPTION
## What's broken

The **Data Aggregator** block's `values_difference` aggregation is documented as *"Calculate difference between max and min value observed"* (`data_aggregator/v1.py`), but it returns wrong — sometimes **negative** — values.

`ValuesDifferenceState.on_data` locked the **first** observed value into the `min` slot and the **second** into the `max` slot, and never cross-compared them:

```python
def on_data(self, value):
    if self._min_value is None:
        self._min_value = value      # 1st value -> min slot only
        return None
    if self._max_value is None:
        self._max_value = value      # 2nd value -> max slot only, no comparison
        return None
    self._min_value = min(self._min_value, value)
    self._max_value = max(self._max_value, value)
```

So:

| Observed values | `values_difference` | Correct (max − min) |
|---|---|---|
| `[10, 1]` | **−9** | 9 |
| `[10, 1, 5]` | **0** | 9 |
| `[5, 4, 3, 2, 1]` | **3** | 4 |

A max−min difference can never be negative, yet this produced `−9`.

The clearest demonstration is **internal self-contradiction**: feeding `10, 1, 5, 5` with `aggregation_mode={"speed": ["values_difference", "max", "min"]}`, the block returns

```
{'speed_values_difference': 0, 'speed_max': 10, 'speed_min': 1}
```

— it reports `max=10` and `min=1` but `values_difference=0`, in a single result.

## Root cause

The two-slot bootstrap assigned values to `min`/`max` by **arrival order** instead of by comparison, so the first value was never eligible to become the max and the second was never eligible to become the min.

## The fix

Seed **both** `min` and `max` from the first observation, then update both on every subsequent value:

```python
def on_data(self, value):
    if self._min_value is None:
        self._min_value = value
        self._max_value = value
        return None
    self._min_value = min(self._min_value, value)
    self._max_value = max(self._max_value, value)
```

This matches the idiom already used by the sibling `MaxState` / `MinState` classes in the same file. No other aggregation mode is affected.

## Behavior change to note

A window with a **single** observed value now returns `0` (was `None`). `0` is the correct max−min for one point and is consistent with `max`/`min`/`avg`, which already return a value for a single observation; the old `None` was an artifact of the broken two-slot seeding, not an intentional "insufficient data" signal. `None` is still returned when **no** values were observed.

## Tests

Added `tests/workflows/unit_tests/core_steps/analytics/test_data_aggregator_v1.py` (11 tests): the regression cases above, all-equal / negative / float ranges, single-value (`0`) and empty (`None`), and an **end-to-end test through `DataAggregatorBlockV1.run()`** asserting `values_difference == max − min` for `[10, 1, 5, 5]`.

```
pytest tests/workflows/unit_tests/core_steps/analytics/test_data_aggregator_v1.py -v
# 11 passed
```

The block-level test exercises the full aggregation path. Happy to add a full workflow integration test under `tests/workflows/integration_tests/execution/` (extending `test_workflow_with_data_aggregation.py` with a `values_difference` assertion) if you'd prefer that coverage as well.
