### PR TITLE
[codex] Add vLLM backend for Qwen LMM adapter

### DIFF
--- a/inference/core/env.py
+++ b/inference/core/env.py
@@ -221,6 +221,13 @@ QWEN_3_ENABLED = str2bool(os.getenv("QWEN_3_ENABLED", True))
 
 QWEN_3_5_ENABLED = str2bool(os.getenv("QWEN_3_5_ENABLED", True))
 
+VLLM_LMM_ENABLED = str2bool(os.getenv("VLLM_LMM_ENABLED", False))
+VLLM_LMM_BASE_URL = os.getenv("VLLM_LMM_BASE_URL", "")
+VLLM_LMM_MODEL_NAME = os.getenv("VLLM_LMM_MODEL_NAME", "vlm-ocr-14")
+VLLM_LMM_API_KEY = os.getenv("VLLM_LMM_API_KEY", "EMPTY")
+VLLM_LMM_TIMEOUT_SECONDS = float(os.getenv("VLLM_LMM_TIMEOUT_SECONDS", "120"))
+VLLM_LMM_TEMPERATURE = float(os.getenv("VLLM_LMM_TEMPERATURE", "0"))
+
 DEPTH_ESTIMATION_ENABLED = str2bool(os.getenv("DEPTH_ESTIMATION_ENABLED", True))
 
 SMOLVLM2_ENABLED = str2bool(os.getenv("SMOLVLM2_ENABLED", True))

--- a/inference/models/qwen3_5vl/qwen3_5vl_inference_models.py
+++ b/inference/models/qwen3_5vl/qwen3_5vl_inference_models.py
@@ -1,6 +1,7 @@
-from typing import Any, List
+import base64
+from typing import Any, Dict, List, Optional, Tuple
 
-import torch
+from openai import OpenAI
 
 from inference.core.entities.responses import (
     InferenceResponseImage,
@@ -10,13 +11,59 @@ from inference.core.env import (
     ALLOW_INFERENCE_MODELS_DIRECTLY_ACCESS_LOCAL_PACKAGES,
     ALLOW_INFERENCE_MODELS_UNTRUSTED_PACKAGES,
     API_KEY,
+    VLLM_LMM_API_KEY,
+    VLLM_LMM_BASE_URL,
+    VLLM_LMM_ENABLED,
+    VLLM_LMM_MODEL_NAME,
+    VLLM_LMM_TEMPERATURE,
+    VLLM_LMM_TIMEOUT_SECONDS,
 )
 from inference.core.models.base import Model
 from inference.core.models.types import PreprocessReturnMetadata
 from inference.core.roboflow_api import get_extra_weights_provider_headers
-from inference.core.utils.image_utils import load_image_bgr
+from inference.core.utils.image_utils import encode_image_to_jpeg_bytes, load_image_bgr
 from inference_models import AutoModel
 from inference_models.models.qwen3_5.qwen3_5_hf import Qwen35HF
+
+NATIVE_SYSTEM_PROMPT_SEPARATOR = "<system_prompt>"
+
+
+def _normalize_vllm_base_url(base_url: str) -> str:
+    normalized_base_url = base_url.rstrip("/")
+    if normalized_base_url.endswith("/v1"):
+        return normalized_base_url
+    return f"{normalized_base_url}/v1"
+
+
+def _split_native_prompt(prompt: Optional[str]) -> Tuple[str, Optional[str]]:
+    if not prompt:
+        return "", None
+    user_prompt, separator, system_prompt = prompt.partition(
+        NATIVE_SYSTEM_PROMPT_SEPARATOR
+    )
+    if not separator:
+        return prompt, None
+    return user_prompt, system_prompt or None
+
+
+def _encode_image_data_url(image: Any) -> str:
+    jpeg_bytes = encode_image_to_jpeg_bytes(image)
+    b64 = base64.b64encode(jpeg_bytes).decode("ascii")
+    return f"data:image/jpeg;base64,{b64}"
+
+
+def _build_vllm_messages(prompt: Optional[str], image_data_url: str) -> List[Dict]:
+    user_prompt, system_prompt = _split_native_prompt(prompt)
+    messages: List[Dict] = []
+    if system_prompt:
+        messages.append({"role": "system", "content": system_prompt})
+
+    user_content = []
+    if user_prompt:
+        user_content.append({"type": "text", "text": user_prompt})
+    user_content.append({"type": "image_url", "image_url": {"url": image_data_url}})
+    messages.append({"role": "user", "content": user_content})
+    return messages
 
 
 class InferenceModelsQwen35VLAdapter(Model):
@@ -28,13 +75,29 @@ class InferenceModelsQwen35VLAdapter(Model):
         self.api_key = api_key if api_key else API_KEY
 
         self.task_type = "lmm"
+        self._model: Optional[Qwen35HF] = None
+        self._vllm_client: Optional[OpenAI] = None
+        self._vllm_model_name = VLLM_LMM_MODEL_NAME
+        self._vllm_temperature = VLLM_LMM_TEMPERATURE
+
+        if VLLM_LMM_ENABLED:
+            if not VLLM_LMM_BASE_URL:
+                raise ValueError(
+                    "VLLM_LMM_BASE_URL must be set when VLLM_LMM_ENABLED=True"
+                )
+            self._vllm_client = OpenAI(
+                base_url=_normalize_vllm_base_url(VLLM_LMM_BASE_URL),
+                api_key=VLLM_LMM_API_KEY,
+                timeout=VLLM_LMM_TIMEOUT_SECONDS,
+            )
+            return
 
         extra_weights_provider_headers = get_extra_weights_provider_headers(
             countinference=kwargs.get("countinference"),
             service_secret=kwargs.get("service_secret"),
         )
 
-        self._model: Qwen35HF = AutoModel.from_pretrained(
+        self._model = AutoModel.from_pretrained(
             model_id_or_path=model_id,
             api_key=self.api_key,
             allow_untrusted_packages=ALLOW_INFERENCE_MODELS_UNTRUSTED_PACKAGES,
@@ -58,23 +121,38 @@ class InferenceModelsQwen35VLAdapter(Model):
         )
         input_shape = PreprocessReturnMetadata({"image_dims": np_image.shape[:2][::-1]})
         mapped_kwargs = self.map_inference_kwargs(kwargs)
+        if self._vllm_client is not None:
+            return (
+                {
+                    "image_data_url": _encode_image_data_url(np_image),
+                    "prompt": prompt,
+                },
+                input_shape,
+            )
         return (
             self._model.pre_process_generation(np_image, prompt, **mapped_kwargs),
             input_shape,
         )
 
-    def predict(self, inputs, **kwargs) -> torch.Tensor:
+    def predict(self, inputs, **kwargs) -> Any:
         mapped_kwargs = self.map_inference_kwargs(kwargs)
+        if self._vllm_client is not None:
+            return self._generate_with_vllm(inputs, **mapped_kwargs)
         return self._model.generate(inputs, **mapped_kwargs)
 
     def postprocess(
         self,
-        predictions: torch.Tensor,
+        predictions: Any,
         preprocess_return_metadata: PreprocessReturnMetadata,
         **kwargs,
     ) -> List[LMMInferenceResponse]:
         mapped_kwargs = self.map_inference_kwargs(kwargs)
-        result = self._model.post_process_generation(predictions, **mapped_kwargs)[0]
+        if self._vllm_client is not None:
+            result = predictions
+        else:
+            result = self._model.post_process_generation(predictions, **mapped_kwargs)[
+                0
+            ]
         return [
             LMMInferenceResponse(
                 response=result,
@@ -87,3 +165,39 @@ class InferenceModelsQwen35VLAdapter(Model):
 
     def clear_cache(self, delete_from_disk: bool = True) -> None:
         pass
+
+    def _generate_with_vllm(self, inputs: Dict[str, Any], **kwargs) -> str:
+        messages = _build_vllm_messages(
+            prompt=inputs["prompt"],
+            image_data_url=inputs["image_data_url"],
+        )
+        request_kwargs: Dict[str, Any] = {
+            "model": self._vllm_model_name,
+            "messages": messages,
+            "temperature": self._vllm_temperature,
+        }
+        max_tokens = kwargs.get("max_new_tokens") or kwargs.get("max_tokens")
+        if max_tokens is not None:
+            request_kwargs["max_tokens"] = max_tokens
+        extra_body = _build_vllm_extra_body(kwargs)
+        if extra_body:
+            request_kwargs["extra_body"] = extra_body
+
+        response = self._vllm_client.chat.completions.create(**request_kwargs)
+        content = response.choices[0].message.content
+        if content is None:
+            finish_reason = getattr(response.choices[0], "finish_reason", "unknown")
+            raise RuntimeError(
+                f"vLLM returned empty message content, finish_reason={finish_reason}"
+            )
+        return content
+
+
+def _build_vllm_extra_body(kwargs: Dict[str, Any]) -> Dict[str, Any]:
+    if "enable_thinking" not in kwargs:
+        return {}
+    return {
+        "chat_template_kwargs": {
+            "enable_thinking": bool(kwargs["enable_thinking"]),
+        }
+    }

--- a/inference/models/qwen3_5vl/qwen3_5vl_inference_models.py
+++ b/inference/models/qwen3_5vl/qwen3_5vl_inference_models.py
@@ -1,8 +1,10 @@
 import base64
+import binascii
 from typing import Any, Dict, List, Optional, Tuple
 
 from openai import OpenAI
 
+from inference.core.entities.requests.inference import InferenceRequestImage
 from inference.core.entities.responses import (
     InferenceResponseImage,
     LMMInferenceResponse,
@@ -28,6 +30,51 @@ from inference_models.models.qwen3_5.qwen3_5_hf import Qwen35HF
 NATIVE_SYSTEM_PROMPT_SEPARATOR = "<system_prompt>"
 
 
+def _extract_base64_image_payload(image: Any) -> Optional[str]:
+    image_type = None
+    image_value = None
+    if isinstance(image, InferenceRequestImage):
+        image_type = image.type
+        image_value = image.value
+    elif isinstance(image, dict):
+        image_type = image.get("type")
+        image_value = image.get("value")
+
+    if image_type is None or image_type.lower() != "base64":
+        return None
+    if isinstance(image_value, bytes):
+        image_value = image_value.decode("ascii")
+    if not isinstance(image_value, str):
+        return None
+    return image_value
+
+
+def _base64_payload_to_data_url(base64_payload: str) -> str:
+    if base64_payload.startswith("data:image/"):
+        return base64_payload
+    media_type = _guess_base64_image_media_type(base64_payload)
+    return f"data:{media_type};base64,{base64_payload}"
+
+
+def _guess_base64_image_media_type(base64_payload: str) -> str:
+    sample = base64_payload[:64]
+    try:
+        header = base64.b64decode(sample, validate=False)
+    except (binascii.Error, ValueError):
+        return "image/jpeg"
+    if header.startswith(b"\xff\xd8\xff"):
+        return "image/jpeg"
+    if header.startswith(b"\x89PNG\r\n\x1a\n"):
+        return "image/png"
+    if header.startswith(b"GIF87a") or header.startswith(b"GIF89a"):
+        return "image/gif"
+    if header.startswith(b"RIFF") and header[8:12] == b"WEBP":
+        return "image/webp"
+    if header.startswith(b"BM"):
+        return "image/bmp"
+    return "image/jpeg"
+
+
 def _normalize_vllm_base_url(base_url: str) -> str:
     normalized_base_url = base_url.rstrip("/")
     if normalized_base_url.endswith("/v1"):
@@ -50,6 +97,13 @@ def _encode_image_data_url(image: Any) -> str:
     jpeg_bytes = encode_image_to_jpeg_bytes(image)
     b64 = base64.b64encode(jpeg_bytes).decode("ascii")
     return f"data:image/jpeg;base64,{b64}"
+
+
+def _image_data_url_from_input(image: Any, loaded_image: Any) -> str:
+    base64_payload = _extract_base64_image_payload(image)
+    if base64_payload is not None:
+        return _base64_payload_to_data_url(base64_payload)
+    return _encode_image_data_url(loaded_image)
 
 
 def _build_vllm_messages(prompt: Optional[str], image_data_url: str) -> List[Dict]:
@@ -124,7 +178,7 @@ class InferenceModelsQwen35VLAdapter(Model):
         if self._vllm_client is not None:
             return (
                 {
-                    "image_data_url": _encode_image_data_url(np_image),
+                    "image_data_url": _image_data_url_from_input(image, np_image),
                     "prompt": prompt,
                 },
                 input_shape,

--- a/tests/inference/unit_tests/models/test_qwen3_5vl_vllm_adapter.py
+++ b/tests/inference/unit_tests/models/test_qwen3_5vl_vllm_adapter.py
@@ -1,0 +1,88 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import numpy as np
+
+from inference.models.qwen3_5vl import qwen3_5vl_inference_models as qwen35_module
+
+
+def test_normalize_vllm_base_url_adds_openai_path() -> None:
+    result = qwen35_module._normalize_vllm_base_url("http://vllm:8000")
+
+    assert result == "http://vllm:8000/v1"
+
+
+def test_normalize_vllm_base_url_keeps_existing_openai_path() -> None:
+    result = qwen35_module._normalize_vllm_base_url("http://vllm:8000/v1/")
+
+    assert result == "http://vllm:8000/v1"
+
+
+def test_split_native_prompt_extracts_system_prompt() -> None:
+    user_prompt, system_prompt = qwen35_module._split_native_prompt(
+        "OCR<system_prompt>You are helpful."
+    )
+
+    assert user_prompt == "OCR"
+    assert system_prompt == "You are helpful."
+
+
+def test_qwen35_adapter_delegates_to_vllm(monkeypatch) -> None:
+    fake_client = MagicMock()
+    fake_client.chat.completions.create.return_value = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(content="HOME 42"),
+                finish_reason="stop",
+            )
+        ]
+    )
+    openai_factory = MagicMock(return_value=fake_client)
+    from_pretrained = MagicMock()
+
+    monkeypatch.setattr(qwen35_module, "VLLM_LMM_ENABLED", True)
+    monkeypatch.setattr(qwen35_module, "VLLM_LMM_BASE_URL", "http://vllm:8000")
+    monkeypatch.setattr(qwen35_module, "VLLM_LMM_MODEL_NAME", "vlm-ocr-14")
+    monkeypatch.setattr(qwen35_module, "VLLM_LMM_API_KEY", "EMPTY")
+    monkeypatch.setattr(qwen35_module, "VLLM_LMM_TIMEOUT_SECONDS", 12.0)
+    monkeypatch.setattr(qwen35_module, "VLLM_LMM_TEMPERATURE", 0.0)
+    monkeypatch.setattr(qwen35_module, "OpenAI", openai_factory)
+    monkeypatch.setattr(qwen35_module.AutoModel, "from_pretrained", from_pretrained)
+
+    adapter = qwen35_module.InferenceModelsQwen35VLAdapter(
+        model_id="vlm-ocr/14",
+        api_key="rf-api-key",
+    )
+    responses = adapter.infer(
+        image=np.zeros((2, 3, 3), dtype=np.uint8),
+        prompt="OCR<system_prompt>You are Qwen.",
+        max_new_tokens=16,
+        enable_thinking=False,
+    )
+
+    assert responses[0].response == "HOME 42"
+    assert responses[0].image.width == 3
+    assert responses[0].image.height == 2
+    openai_factory.assert_called_once_with(
+        base_url="http://vllm:8000/v1",
+        api_key="EMPTY",
+        timeout=12.0,
+    )
+    from_pretrained.assert_not_called()
+
+    create_kwargs = fake_client.chat.completions.create.call_args.kwargs
+    assert create_kwargs["model"] == "vlm-ocr-14"
+    assert create_kwargs["max_tokens"] == 16
+    assert create_kwargs["temperature"] == 0.0
+    assert create_kwargs["extra_body"] == {
+        "chat_template_kwargs": {"enable_thinking": False}
+    }
+
+    messages = create_kwargs["messages"]
+    assert messages[0] == {"role": "system", "content": "You are Qwen."}
+    assert messages[1]["role"] == "user"
+    assert messages[1]["content"][0] == {"type": "text", "text": "OCR"}
+    assert messages[1]["content"][1]["type"] == "image_url"
+    assert messages[1]["content"][1]["image_url"]["url"].startswith(
+        "data:image/jpeg;base64,"
+    )

--- a/tests/inference/unit_tests/models/test_qwen3_5vl_vllm_adapter.py
+++ b/tests/inference/unit_tests/models/test_qwen3_5vl_vllm_adapter.py
@@ -1,3 +1,4 @@
+import base64
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -85,4 +86,45 @@ def test_qwen35_adapter_delegates_to_vllm(monkeypatch) -> None:
     assert messages[1]["content"][1]["type"] == "image_url"
     assert messages[1]["content"][1]["image_url"]["url"].startswith(
         "data:image/jpeg;base64,"
+    )
+
+
+def test_qwen35_adapter_preserves_base64_request_image_for_vllm(monkeypatch) -> None:
+    fake_client = MagicMock()
+    fake_client.chat.completions.create.return_value = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(content="HOME 42"),
+                finish_reason="stop",
+            )
+        ]
+    )
+    image = np.zeros((2, 3, 3), dtype=np.uint8)
+    image_base64 = base64.b64encode(
+        qwen35_module.encode_image_to_jpeg_bytes(image)
+    ).decode("ascii")
+
+    monkeypatch.setattr(qwen35_module, "VLLM_LMM_ENABLED", True)
+    monkeypatch.setattr(qwen35_module, "VLLM_LMM_BASE_URL", "http://vllm:8000")
+    monkeypatch.setattr(qwen35_module, "VLLM_LMM_MODEL_NAME", "vlm-ocr-14")
+    monkeypatch.setattr(qwen35_module, "VLLM_LMM_API_KEY", "EMPTY")
+    monkeypatch.setattr(qwen35_module, "VLLM_LMM_TIMEOUT_SECONDS", 12.0)
+    monkeypatch.setattr(qwen35_module, "VLLM_LMM_TEMPERATURE", 0.0)
+    monkeypatch.setattr(qwen35_module, "OpenAI", MagicMock(return_value=fake_client))
+    monkeypatch.setattr(qwen35_module.AutoModel, "from_pretrained", MagicMock())
+
+    adapter = qwen35_module.InferenceModelsQwen35VLAdapter(
+        model_id="vlm-ocr/14",
+        api_key="rf-api-key",
+    )
+    responses = adapter.infer(
+        image={"type": "base64", "value": image_base64},
+        prompt="OCR<system_prompt>You are Qwen.",
+    )
+
+    assert responses[0].image.width == 3
+    assert responses[0].image.height == 2
+    messages = fake_client.chat.completions.create.call_args.kwargs["messages"]
+    assert messages[1]["content"][1]["image_url"]["url"] == (
+        f"data:image/jpeg;base64,{image_base64}"
     )


### PR DESCRIPTION
## Summary

Adds an env-gated vLLM backend path for the Qwen 3.5 VLM adapter so native Qwen workflow blocks can keep using the existing Inference/LMM request surface while delegating generation to an OpenAI-compatible vLLM server.

## Changes

- Adds `VLLM_LMM_*` environment variables for enabling delegation, configuring the backend URL, served model name, API key, timeout, and temperature.
- Updates `InferenceModelsQwen35VLAdapter` to skip local `AutoModel.from_pretrained(...)` when `VLLM_LMM_ENABLED=true` and call `chat.completions.create(...)` on the configured vLLM backend instead.
- Converts the native Qwen prompt convention (`prompt<system_prompt>system`) into OpenAI-compatible chat messages.
- Preserves already-base64 LMM request images by wrapping the existing payload as a data URL, avoiding an extra JPEG recompress before sending to vLLM. Non-base64 image inputs still use the existing image loading fallback.
- Adds unit tests covering URL normalization, prompt splitting, skipped local model loading, vLLM payload construction, and base64 image preservation.

## Deploy Notes

For the PlayOn custom image/deployment, the intended env shape is:

```text
VLLM_LMM_ENABLED=true
VLLM_LMM_BASE_URL=http://playon-vllm.playon-vllm.svc.cluster.local:8000
VLLM_LMM_MODEL_NAME=vlm-ocr-14
VLLM_LMM_TEMPERATURE=0
VLLM_LMM_TIMEOUT_SECONDS=120
```

`VLLM_LMM_BASE_URL` may omit `/v1`; the adapter appends it before constructing the OpenAI client.

## Validation

```text
uv run --no-project --python /Users/hansent/code/inference/.venv/bin/python pytest \
  tests/inference/unit_tests/models/test_qwen3_5vl_vllm_adapter.py \
  tests/workflows/unit_tests/core_steps/models/foundation/test_qwen_vlm.py \
  tests/workflows/unit_tests/core_steps/models/foundation/test_vlm_remote_execution.py
```

Result: `36 passed`.