### PR TITLE
fix(workflows): select v0 API for hosted semantic-segmentation remote execution

### DIFF
--- a/inference/core/workflows/core_steps/models/roboflow/semantic_segmentation/v1.py
+++ b/inference/core/workflows/core_steps/models/roboflow/semantic_segmentation/v1.py
@@ -182,6 +182,8 @@ class RoboflowSemanticSegmentationModelBlockV1(WorkflowBlock):
             api_url=api_url,
             api_key=self._api_key,
         )
+        if WORKFLOWS_REMOTE_API_TARGET == "hosted":
+            client.select_api_v0()
         client_config = InferenceConfiguration(
             max_batch_size=WORKFLOWS_REMOTE_EXECUTION_MAX_STEP_BATCH_SIZE,
             max_concurrent_requests=WORKFLOWS_REMOTE_EXECUTION_MAX_STEP_CONCURRENT_REQUESTS,

--- a/inference/core/workflows/core_steps/models/roboflow/semantic_segmentation/v2.py
+++ b/inference/core/workflows/core_steps/models/roboflow/semantic_segmentation/v2.py
@@ -239,6 +239,8 @@ class RoboflowSemanticSegmentationModelBlockV2(WorkflowBlock):
             api_url=api_url,
             api_key=self._api_key,
         )
+        if WORKFLOWS_REMOTE_API_TARGET == "hosted":
+            client.select_api_v0()
         client_config = InferenceConfiguration(
             confidence_threshold=confidence,
             max_batch_size=WORKFLOWS_REMOTE_EXECUTION_MAX_STEP_BATCH_SIZE,

--- a/tests/workflows/unit_tests/core_steps/models/roboflow/_hosted_api_resolution.py
+++ b/tests/workflows/unit_tests/core_steps/models/roboflow/_hosted_api_resolution.py
@@ -1,0 +1,84 @@
+"""Shared harness for hosted-vs-non-hosted API path-resolution tests.
+
+Not a test module (underscore prefix keeps it out of collection). Each Roboflow
+model block's ``run_remotely`` must, against the hosted target, talk to its
+dedicated hosted URL over the v0 API (``select_api_v0``); against any other
+target it must use ``LOCAL_INFERENCE_API_URL`` and not force v0. This regression
+guard exists because the hosted v1 endpoints were retired in favour of the
+serverless backend, which only serves the v0 / path-parameter API.
+
+Block families and versions are enumerated explicitly in each per-family test
+file (``BLOCK_CLASSES``).
+"""
+
+import importlib
+import inspect
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from inference.core.workflows.core_steps.common.entities import StepExecutionMode
+
+_MODULE_PREFIX = "inference.core.workflows.core_steps.models.roboflow"
+
+
+class _StopAfterClientSetup(Exception):
+    """Raised by the mocked ``client.infer`` to halt ``run_remotely`` once the
+    API selection has happened, before any prediction post-processing runs."""
+
+
+def _load_block(family: str, version: str, class_name: str):
+    module = importlib.import_module(f"{_MODULE_PREFIX}.{family}.{version}")
+    return module, getattr(module, class_name)
+
+
+def _make_block(block_cls):
+    return block_cls(
+        model_manager=MagicMock(),
+        api_key="test-key",
+        step_execution_mode=StepExecutionMode.REMOTE,
+    )
+
+
+def _run_remotely_kwargs(method) -> dict:
+    # run_remotely signatures vary per family/version; fill model-tuning params
+    # with None (InferenceConfiguration is mocked, so values don't affect path
+    # resolution, which depends only on WORKFLOWS_REMOTE_API_TARGET).
+    kwargs = {}
+    for name in inspect.signature(method).parameters:
+        if name == "images":
+            kwargs[name] = [MagicMock()]
+        elif name == "model_id":
+            kwargs[name] = "workspace/model/1"
+        else:
+            kwargs[name] = None
+    return kwargs
+
+
+def _invoke_run_remotely(module, block_cls, remote_target: str):
+    block = _make_block(block_cls)
+    kwargs = _run_remotely_kwargs(block.run_remotely)
+    with patch.object(module, "InferenceHTTPClient") as client_cls, patch.object(
+        module, "InferenceConfiguration"
+    ), patch.object(module, "WORKFLOWS_REMOTE_API_TARGET", remote_target):
+        client = client_cls.return_value
+        client.infer.side_effect = _StopAfterClientSetup
+        with pytest.raises(_StopAfterClientSetup):
+            block.run_remotely(**kwargs)
+    return client_cls, client
+
+
+def assert_hosted_selects_v0(family: str, version: str, class_name: str, hosted_url_attr: str):
+    module, block_cls = _load_block(family, version, class_name)
+    client_cls, client = _invoke_run_remotely(module, block_cls, "hosted")
+    assert client_cls.call_args.kwargs["api_url"] == getattr(module, hosted_url_attr)
+    client.select_api_v0.assert_called_once()
+
+
+def assert_non_hosted_uses_local(family: str, version: str, class_name: str):
+    module, block_cls = _load_block(family, version, class_name)
+    client_cls, client = _invoke_run_remotely(module, block_cls, "self-hosted")
+    assert client_cls.call_args.kwargs["api_url"] == getattr(
+        module, "LOCAL_INFERENCE_API_URL"
+    )
+    client.select_api_v0.assert_not_called()

--- a/tests/workflows/unit_tests/core_steps/models/roboflow/instance_segmentation/test_hosted_api_resolution.py
+++ b/tests/workflows/unit_tests/core_steps/models/roboflow/instance_segmentation/test_hosted_api_resolution.py
@@ -1,0 +1,25 @@
+import pytest
+
+from tests.workflows.unit_tests.core_steps.models.roboflow._hosted_api_resolution import (
+    assert_hosted_selects_v0,
+    assert_non_hosted_uses_local,
+)
+
+FAMILY = "instance_segmentation"
+HOSTED_URL_ATTR = "HOSTED_INSTANCE_SEGMENTATION_URL"
+BLOCK_CLASSES = {
+    "v1": "RoboflowInstanceSegmentationModelBlockV1",
+    "v2": "RoboflowInstanceSegmentationModelBlockV2",
+    "v3": "RoboflowInstanceSegmentationModelBlockV3",
+    "v4": "RoboflowInstanceSegmentationModelBlockV4",
+}
+
+
+@pytest.mark.parametrize("version", list(BLOCK_CLASSES))
+def test_hosted_remote_execution_selects_v0_and_hosted_url(version):
+    assert_hosted_selects_v0(FAMILY, version, BLOCK_CLASSES[version], HOSTED_URL_ATTR)
+
+
+@pytest.mark.parametrize("version", list(BLOCK_CLASSES))
+def test_non_hosted_remote_execution_uses_local_url_and_no_v0(version):
+    assert_non_hosted_uses_local(FAMILY, version, BLOCK_CLASSES[version])

--- a/tests/workflows/unit_tests/core_steps/models/roboflow/keypoint_detection/test_hosted_api_resolution.py
+++ b/tests/workflows/unit_tests/core_steps/models/roboflow/keypoint_detection/test_hosted_api_resolution.py
@@ -1,0 +1,24 @@
+import pytest
+
+from tests.workflows.unit_tests.core_steps.models.roboflow._hosted_api_resolution import (
+    assert_hosted_selects_v0,
+    assert_non_hosted_uses_local,
+)
+
+FAMILY = "keypoint_detection"
+HOSTED_URL_ATTR = "HOSTED_DETECT_URL"
+BLOCK_CLASSES = {
+    "v1": "RoboflowKeypointDetectionModelBlockV1",
+    "v2": "RoboflowKeypointDetectionModelBlockV2",
+    "v3": "RoboflowKeypointDetectionModelBlockV3",
+}
+
+
+@pytest.mark.parametrize("version", list(BLOCK_CLASSES))
+def test_hosted_remote_execution_selects_v0_and_hosted_url(version):
+    assert_hosted_selects_v0(FAMILY, version, BLOCK_CLASSES[version], HOSTED_URL_ATTR)
+
+
+@pytest.mark.parametrize("version", list(BLOCK_CLASSES))
+def test_non_hosted_remote_execution_uses_local_url_and_no_v0(version):
+    assert_non_hosted_uses_local(FAMILY, version, BLOCK_CLASSES[version])

--- a/tests/workflows/unit_tests/core_steps/models/roboflow/multi_class_classification/test_hosted_api_resolution.py
+++ b/tests/workflows/unit_tests/core_steps/models/roboflow/multi_class_classification/test_hosted_api_resolution.py
@@ -1,0 +1,24 @@
+import pytest
+
+from tests.workflows.unit_tests.core_steps.models.roboflow._hosted_api_resolution import (
+    assert_hosted_selects_v0,
+    assert_non_hosted_uses_local,
+)
+
+FAMILY = "multi_class_classification"
+HOSTED_URL_ATTR = "HOSTED_CLASSIFICATION_URL"
+BLOCK_CLASSES = {
+    "v1": "RoboflowClassificationModelBlockV1",
+    "v2": "RoboflowClassificationModelBlockV2",
+    "v3": "RoboflowClassificationModelBlockV3",
+}
+
+
+@pytest.mark.parametrize("version", list(BLOCK_CLASSES))
+def test_hosted_remote_execution_selects_v0_and_hosted_url(version):
+    assert_hosted_selects_v0(FAMILY, version, BLOCK_CLASSES[version], HOSTED_URL_ATTR)
+
+
+@pytest.mark.parametrize("version", list(BLOCK_CLASSES))
+def test_non_hosted_remote_execution_uses_local_url_and_no_v0(version):
+    assert_non_hosted_uses_local(FAMILY, version, BLOCK_CLASSES[version])

--- a/tests/workflows/unit_tests/core_steps/models/roboflow/multi_label_classification/test_hosted_api_resolution.py
+++ b/tests/workflows/unit_tests/core_steps/models/roboflow/multi_label_classification/test_hosted_api_resolution.py
@@ -1,0 +1,24 @@
+import pytest
+
+from tests.workflows.unit_tests.core_steps.models.roboflow._hosted_api_resolution import (
+    assert_hosted_selects_v0,
+    assert_non_hosted_uses_local,
+)
+
+FAMILY = "multi_label_classification"
+HOSTED_URL_ATTR = "HOSTED_CLASSIFICATION_URL"
+BLOCK_CLASSES = {
+    "v1": "RoboflowMultiLabelClassificationModelBlockV1",
+    "v2": "RoboflowMultiLabelClassificationModelBlockV2",
+    "v3": "RoboflowMultiLabelClassificationModelBlockV3",
+}
+
+
+@pytest.mark.parametrize("version", list(BLOCK_CLASSES))
+def test_hosted_remote_execution_selects_v0_and_hosted_url(version):
+    assert_hosted_selects_v0(FAMILY, version, BLOCK_CLASSES[version], HOSTED_URL_ATTR)
+
+
+@pytest.mark.parametrize("version", list(BLOCK_CLASSES))
+def test_non_hosted_remote_execution_uses_local_url_and_no_v0(version):
+    assert_non_hosted_uses_local(FAMILY, version, BLOCK_CLASSES[version])

--- a/tests/workflows/unit_tests/core_steps/models/roboflow/object_detection/test_hosted_api_resolution.py
+++ b/tests/workflows/unit_tests/core_steps/models/roboflow/object_detection/test_hosted_api_resolution.py
@@ -1,0 +1,24 @@
+import pytest
+
+from tests.workflows.unit_tests.core_steps.models.roboflow._hosted_api_resolution import (
+    assert_hosted_selects_v0,
+    assert_non_hosted_uses_local,
+)
+
+FAMILY = "object_detection"
+HOSTED_URL_ATTR = "HOSTED_DETECT_URL"
+BLOCK_CLASSES = {
+    "v1": "RoboflowObjectDetectionModelBlockV1",
+    "v2": "RoboflowObjectDetectionModelBlockV2",
+    "v3": "RoboflowObjectDetectionModelBlockV3",
+}
+
+
+@pytest.mark.parametrize("version", list(BLOCK_CLASSES))
+def test_hosted_remote_execution_selects_v0_and_hosted_url(version):
+    assert_hosted_selects_v0(FAMILY, version, BLOCK_CLASSES[version], HOSTED_URL_ATTR)
+
+
+@pytest.mark.parametrize("version", list(BLOCK_CLASSES))
+def test_non_hosted_remote_execution_uses_local_url_and_no_v0(version):
+    assert_non_hosted_uses_local(FAMILY, version, BLOCK_CLASSES[version])

--- a/tests/workflows/unit_tests/core_steps/models/roboflow/semantic_segmentation/test_hosted_api_resolution.py
+++ b/tests/workflows/unit_tests/core_steps/models/roboflow/semantic_segmentation/test_hosted_api_resolution.py
@@ -1,0 +1,23 @@
+import pytest
+
+from tests.workflows.unit_tests.core_steps.models.roboflow._hosted_api_resolution import (
+    assert_hosted_selects_v0,
+    assert_non_hosted_uses_local,
+)
+
+FAMILY = "semantic_segmentation"
+HOSTED_URL_ATTR = "HOSTED_SEMANTIC_SEGMENTATION_URL"
+BLOCK_CLASSES = {
+    "v1": "RoboflowSemanticSegmentationModelBlockV1",
+    "v2": "RoboflowSemanticSegmentationModelBlockV2",
+}
+
+
+@pytest.mark.parametrize("version", list(BLOCK_CLASSES))
+def test_hosted_remote_execution_selects_v0_and_hosted_url(version):
+    assert_hosted_selects_v0(FAMILY, version, BLOCK_CLASSES[version], HOSTED_URL_ATTR)
+
+
+@pytest.mark.parametrize("version", list(BLOCK_CLASSES))
+def test_non_hosted_remote_execution_uses_local_url_and_no_v0(version):
+    assert_non_hosted_uses_local(FAMILY, version, BLOCK_CLASSES[version])


### PR DESCRIPTION
## Summary

The `semantic_segmentation` workflow block (v1 and v2) is missing the `client.select_api_v0()` call that every other hosted model block makes in `run_remotely`. Without it, `InferenceHTTPClient` talks to the hosted semantic-seg endpoint (`segment.roboflow.com`) over the **v1** API.

Now that the dedicated v1 hosted inference endpoints have been sunset and `segment.roboflow.com` is served by the **serverless** backend (which only supports the v0 / path-parameter API), the v1 path fails: the model load hits `POST /model/add`, the model id never reaches the path-based serverless authorizer, and the request 403s — surfaced as a spurious "API key" error. This breaks **all** hosted semantic-seg models in workflows (DeepLabV3+ and yolo26-sem), staging and prod. The sibling blocks (object/instance/keypoint detection, classification) already force v0, so they were unaffected by the migration.

Fix: force v0 in `run_remotely` for hosted execution, matching the sibling blocks.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested?

- Diagnosed from staging + prod logs: executor → `segment.roboflow.com/model/add` 403; platform-side `GET /models/v1/external/weights?modelId=model/add` 403.
- Change mirrors the existing v0-forcing blocks verbatim; the real path is hosted serverless, verifiable post-deploy by running a semantic-seg workflow (DeepLabV3+ and `yolo26n-sem-1024`) and confirming a mask is returned.

## Docs

- [ ] Docs updated — _n/a_, internal routing fix.