### PR TITLE
fix(aliases): resolve public yolo26-sem model aliases

### DIFF
--- a/inference/models/aliases.py
+++ b/inference/models/aliases.py
@@ -88,6 +88,19 @@ YOLO26_POSE_ALIASES = {
     "yolo26x-pose-640": "coco-pose-detection/16",
 }
 
+YOLO26_SEM_ALIASES = {
+    "yolov26n-sem-1024": "yolo26-pretrains/yolo26n-sem",
+    "yolov26s-sem-1024": "yolo26-pretrains/yolo26s-sem",
+    "yolov26m-sem-1024": "yolo26-pretrains/yolo26m-sem",
+    "yolov26l-sem-1024": "yolo26-pretrains/yolo26l-sem",
+    "yolov26x-sem-1024": "yolo26-pretrains/yolo26x-sem",
+    "yolo26n-sem-1024": "yolo26-pretrains/yolo26n-sem",
+    "yolo26s-sem-1024": "yolo26-pretrains/yolo26s-sem",
+    "yolo26m-sem-1024": "yolo26-pretrains/yolo26m-sem",
+    "yolo26l-sem-1024": "yolo26-pretrains/yolo26l-sem",
+    "yolo26x-sem-1024": "yolo26-pretrains/yolo26x-sem",
+}
+
 YOLOV11_ALIASES = {
     **YOLOV11_ALIASES,
     **{k.replace("yolov11", "yolo11"): v for k, v in YOLOV11_ALIASES.items()},
@@ -172,6 +185,7 @@ REGISTERED_ALIASES = {
     **YOLO26_ALIASES,
     **YOLO26_SEG_ALIASES,
     **YOLO26_POSE_ALIASES,
+    **YOLO26_SEM_ALIASES,
 }
 
 

--- a/inference_sdk/http/utils/aliases.py
+++ b/inference_sdk/http/utils/aliases.py
@@ -60,6 +60,19 @@ YOLO26_POSE_ALIASES = {
     "yolo26x-pose-640": "coco-pose-detection/16",
 }
 
+YOLO26_SEM_ALIASES = {
+    "yolov26n-sem-1024": "yolo26-pretrains/yolo26n-sem",
+    "yolov26s-sem-1024": "yolo26-pretrains/yolo26s-sem",
+    "yolov26m-sem-1024": "yolo26-pretrains/yolo26m-sem",
+    "yolov26l-sem-1024": "yolo26-pretrains/yolo26l-sem",
+    "yolov26x-sem-1024": "yolo26-pretrains/yolo26x-sem",
+    "yolo26n-sem-1024": "yolo26-pretrains/yolo26n-sem",
+    "yolo26s-sem-1024": "yolo26-pretrains/yolo26s-sem",
+    "yolo26m-sem-1024": "yolo26-pretrains/yolo26m-sem",
+    "yolo26l-sem-1024": "yolo26-pretrains/yolo26l-sem",
+    "yolo26x-sem-1024": "yolo26-pretrains/yolo26x-sem",
+}
+
 RFDETR_ALIASES = {
     "rfdetr-base": "coco/36",
     # "rfdetr-large": "coco/37", deprecated
@@ -155,6 +168,7 @@ REGISTERED_ALIASES = {
     **YOLO26_ALIASES,
     **YOLO26_SEG_ALIASES,
     **YOLO26_POSE_ALIASES,
+    **YOLO26_SEM_ALIASES,
 }
 
 OCR_ENDPOINTS = {

--- a/tests/inference/unit_tests/models/test_aliases.py
+++ b/tests/inference/unit_tests/models/test_aliases.py
@@ -15,3 +15,12 @@ def test_resolve_roboflow_model_alias_when_registry_hit_should_not_happen() -> N
 
     # then
     assert result == "my_project/3"
+
+
+def test_resolve_roboflow_model_alias_for_yolo26_sem_public_models() -> None:
+    for size in ["n", "s", "m", "l", "x"]:
+        # when
+        result = resolve_roboflow_model_alias(model_id=f"yolo26{size}-sem-1024")
+
+        # then
+        assert result == f"yolo26-pretrains/yolo26{size}-sem"

--- a/tests/inference_sdk/unit_tests/http/utils/test_aliases.py
+++ b/tests/inference_sdk/unit_tests/http/utils/test_aliases.py
@@ -15,3 +15,12 @@ def test_resolve_roboflow_model_alias_when_registry_hit_should_not_happen() -> N
 
     # then
     assert result == "my_project/3"
+
+
+def test_resolve_roboflow_model_alias_for_yolo26_sem_public_models() -> None:
+    for size in ["n", "s", "m", "l", "x"]:
+        # when
+        result = resolve_roboflow_model_alias(model_id=f"yolo26{size}-sem-1024")
+
+        # then
+        assert result == f"yolo26-pretrains/yolo26{size}-sem"


### PR DESCRIPTION
## Summary

The public YOLO26 semantic-segmentation catalog models (`yolo26{n,s,m,l,x}-sem-1024`) fail to resolve in Workflows (and any v0-path consumer) with:

```
InvalidModelIdentifier: Invalid model id: yolo26n-sem-1024. Expected format: project_id/model_version_id.
```

These models are registered in the model registry as `yolo26-pretrains/yolo26{size}-sem` with the `yolo26{size}-sem-1024` alias, but those aliases were missing from the static alias maps (`inference_sdk/http/utils/aliases.py` and the duplicate `inference/models/aliases.py`). After #2393 routed the semantic-segmentation workflow block to the **v0** API, the v0 client resolves aliases then requires a `project/version` id — so the unresolved single-token alias raised `InvalidModelIdentifier`.

This adds `yolo26{n,s,m,l,x}-sem-1024` (and the `yolov26…` form) → `yolo26-pretrains/yolo26{size}-sem` to both maps, matching the existing seg/pose/detect public-model alias pattern.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested?

- `resolve_roboflow_model_alias` (server) and `REGISTERED_ALIASES` (SDK) both map all five `yolo26{size}-sem-1024` aliases to `yolo26-pretrains/yolo26{size}-sem`; existing aliases unaffected.
- Verified the target is servable over the v0 legacy route: `POST https://serverless.roboflow.one/yolo26-pretrains/yolo26n-sem?api_key=…&image=…` → **HTTP 200** with `predictions.segmentation_mask`.

## Docs

- [ ] Docs updated — _n/a_, data-only alias addition.