### PR TITLE
refactor(gemini): remove deprecated model versions and update default to 2.5-flash

### DIFF
--- a/inference/core/workflows/core_steps/models/foundation/google_gemini/v1.py
+++ b/inference/core/workflows/core_steps/models/foundation/google_gemini/v1.py
@@ -43,7 +43,6 @@ GEMINI_MODEL_ALIASES = {
     "gemini-2.5-pro-preview-06-05": "gemini-2.5-pro",
     "gemini-2.5-pro-preview-05-06": "gemini-2.5-pro",
     "gemini-2.5-pro-preview-03-25": "gemini-2.5-pro",
-    "gemini-2.0-flash-exp": "gemini-2.0-flash",
 }
 
 SUPPORTED_TASK_TYPES_LIST = [
@@ -186,13 +185,9 @@ class BlockManifest(WorkflowBlockManifest):
             "gemini-2.5-pro",
             "gemini-2.5-flash",
             "gemini-2.5-flash-lite",
-            "gemini-2.0-flash",
-            "gemini-2.0-flash-lite",
-            "gemini-1.5-pro",
-            "gemini-1.5-flash",
         ],
     ] = Field(
-        default="gemini-2.0-flash",
+        default="gemini-2.5-flash",
         description="Model to be used",
         examples=["gemini-2.5-pro", "$inputs.gemini_model"],
     )

--- a/inference/core/workflows/core_steps/models/foundation/google_gemini/v2.py
+++ b/inference/core/workflows/core_steps/models/foundation/google_gemini/v2.py
@@ -43,7 +43,6 @@ MODEL_ALIASES = {
     "gemini-2.5-pro-preview-06-05": "gemini-2.5-pro",
     "gemini-2.5-pro-preview-05-06": "gemini-2.5-pro",
     "gemini-2.5-pro-preview-03-25": "gemini-2.5-pro",
-    "gemini-2.0-flash-exp": "gemini-2.0-flash",
 }
 
 GEMINI_MODELS = [
@@ -70,16 +69,6 @@ GEMINI_MODELS = [
     {
         "id": "gemini-2.5-flash-lite",
         "name": "Gemini 2.5 Flash-Lite",
-        "supports_thinking_level": False,
-    },
-    {
-        "id": "gemini-2.0-flash",
-        "name": "Gemini 2.0 Flash",
-        "supports_thinking_level": False,
-    },
-    {
-        "id": "gemini-2.0-flash-lite",
-        "name": "Gemini 2.0 Flash-Lite",
         "supports_thinking_level": False,
     },
 ]

--- a/inference/core/workflows/core_steps/models/foundation/google_gemini/v3.py
+++ b/inference/core/workflows/core_steps/models/foundation/google_gemini/v3.py
@@ -46,7 +46,6 @@ MODEL_ALIASES = {
     "gemini-2.5-pro-preview-06-05": "gemini-2.5-pro",
     "gemini-2.5-pro-preview-05-06": "gemini-2.5-pro",
     "gemini-2.5-pro-preview-03-25": "gemini-2.5-pro",
-    "gemini-2.0-flash-exp": "gemini-2.0-flash",
 }
 
 GEMINI_MODELS = [
@@ -95,18 +94,6 @@ GEMINI_MODELS = [
     {
         "id": "gemini-2.5-flash-lite",
         "name": "Gemini 2.5 Flash-Lite",
-        "supports_thinking_level": False,
-        "supports_native_code_execution": False,
-    },
-    {
-        "id": "gemini-2.0-flash",
-        "name": "Gemini 2.0 Flash",
-        "supports_thinking_level": False,
-        "supports_native_code_execution": False,
-    },
-    {
-        "id": "gemini-2.0-flash-lite",
-        "name": "Gemini 2.0 Flash-Lite",
         "supports_thinking_level": False,
         "supports_native_code_execution": False,
     },

--- a/tests/workflows/integration_tests/execution/test_workflow_with_gemini_models.py
+++ b/tests/workflows/integration_tests/execution/test_workflow_with_gemini_models.py
@@ -953,12 +953,11 @@ def test_workflow_with_different_gemini_versions(
 ) -> None:
     # Test all available model versions
     model_versions = [
-        "gemini-1.5-flash",
-        "gemini-1.5-pro",
-        "gemini-2.0-flash",
-        "gemini-2.0-flash-exp",
+        "gemini-3.1-pro-preview",
+        "gemini-2.5-pro",
+        "gemini-2.5-flash",
+        "gemini-2.5-flash-lite",
         "gemini-2.5-pro-preview-05-06",
-        "gemini-2.0-flash-lite",
     ]
 
     # given

--- a/tests/workflows/unit_tests/core_steps/models/foundation/test_google_gemini.py
+++ b/tests/workflows/unit_tests/core_steps/models/foundation/test_google_gemini.py
@@ -71,7 +71,7 @@ def test_gemini_step_validation_when_prompt_is_given_directly() -> None:
 
 @pytest.mark.parametrize(
     "model_version",
-    ["gemini-3-pro-preview", "gemini-2.5-pro", "gemini-2.0-flash", "$inputs.model"],
+    ["gemini-3-pro-preview", "gemini-2.5-pro", "gemini-2.5-flash", "$inputs.model"],
 )
 def test_gemini_step_validation_when_model_version_valid(model_version: str) -> None:
     # given
@@ -99,7 +99,7 @@ def test_gemini_step_validation_with_model_alias() -> None:
         "images": "$inputs.image",
         "task_type": "caption",
         "api_key": "$inputs.google_api_key",
-        "model_version": "gemini-2.0-flash-exp",  # This is an alias
+        "model_version": "gemini-2.5-pro-preview-05-06",  # This is an alias
     }
 
     # when
@@ -107,7 +107,7 @@ def test_gemini_step_validation_with_model_alias() -> None:
 
     # then
     # Should be converted to the canonical name
-    assert result.model_version == "gemini-2.0-flash"
+    assert result.model_version == "gemini-2.5-pro"
 
 
 @pytest.mark.parametrize("thinking_level", ["low", "high", "$inputs.thinking"])


### PR DESCRIPTION
## What does this PR do?

This PR cleans up the Gemini model definitions by removing references to outdated models (gemini-2.0-flash and gemini-1.5 series) across v1, v2, and v3 files. The default model version has been updated to "gemini-2.5-flash" in the relevant classes and tests to reflect the current standard. Additionally, integration tests have been adjusted to include the latest model versions, ensuring compatibility with the updated model list.

## Type of Change

- Bug fix (non-breaking change that fixes an issue)

## Testing

<!-- Describe how you tested your changes -->

- [x] I have tested this change locally
- [x] I have added/updated tests for this change

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where necessary, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have updated the documentation accordingly (if applicable)

## Additional Context

<!-- Add any other context, screenshots, or notes about the PR here -->
