### PR TITLE
fix(core-models): forward countinference/service_secret when downloading weights

### DIFF
--- a/inference/core/models/roboflow.py
+++ b/inference/core/models/roboflow.py
@@ -134,9 +134,6 @@ class RoboflowInferenceModel(Model):
         self.load_weights = load_weights
         self.metrics = {"num_inferences": 0, "avg_inference_time": 0.0}
         self.api_key = api_key if api_key else API_KEY
-        # Retained so subclasses' download_weights/download_model_from_roboflow_api
-        # can forward them to the Roboflow API and skip credit verification for
-        # internal service calls.
         self.countinference: Optional[bool] = kwargs.get("countinference")
         self.service_secret: Optional[str] = kwargs.get("service_secret")
         model_id = resolve_roboflow_model_alias(model_id=model_id)

--- a/inference/core/models/roboflow.py
+++ b/inference/core/models/roboflow.py
@@ -134,6 +134,11 @@ class RoboflowInferenceModel(Model):
         self.load_weights = load_weights
         self.metrics = {"num_inferences": 0, "avg_inference_time": 0.0}
         self.api_key = api_key if api_key else API_KEY
+        # Retained so subclasses' download_weights/download_model_from_roboflow_api
+        # can forward them to the Roboflow API and skip credit verification for
+        # internal service calls.
+        self.countinference: Optional[bool] = kwargs.get("countinference")
+        self.service_secret: Optional[str] = kwargs.get("service_secret")
         model_id = resolve_roboflow_model_alias(model_id=model_id)
         self.dataset_id, self.version_id = get_model_id_chunks(model_id=model_id)
         self.endpoint = model_id
@@ -671,6 +676,8 @@ class RoboflowCoreModel(RoboflowInferenceModel):
                 api_key=self.api_key,
                 model_id=self.endpoint,
                 endpoint_type=ModelEndpointType.CORE_MODEL,
+                countinference=self.countinference,
+                service_secret=self.service_secret,
             ):
                 raise RoboflowAPINotAuthorizedError(
                     f"API key {self.api_key} does not have access to model {self.endpoint}"
@@ -698,6 +705,8 @@ class RoboflowCoreModel(RoboflowInferenceModel):
                     model_id=self.endpoint,
                     endpoint_type=ModelEndpointType.CORE_MODEL,
                     device_id=self.device_id,
+                    countinference=self.countinference,
+                    service_secret=self.service_secret,
                 )
                 if "weights" not in api_data:
                     raise ModelArtefactError(

--- a/inference/models/sam3/segment_anything3.py
+++ b/inference/models/sam3/segment_anything3.py
@@ -438,6 +438,8 @@ class SegmentAnything3(RoboflowCoreModel):
                 api_key=self.api_key,
                 model_id=self.endpoint,
                 endpoint_type=endpoint_type,
+                countinference=self.countinference,
+                service_secret=self.service_secret,
             ):
                 raise RoboflowAPINotAuthorizedError(
                     f"API key {self.api_key} does not have access to model {self.endpoint}"
@@ -463,6 +465,8 @@ class SegmentAnything3(RoboflowCoreModel):
             model_id=self.endpoint,
             endpoint_type=ModelEndpointType.ORT,
             device_id=self.device_id,
+            countinference=self.countinference,
+            service_secret=self.service_secret,
         )
 
         ort = api_data.get("ort") if isinstance(api_data, dict) else None

--- a/inference/models/sam3/visual_segmentation.py
+++ b/inference/models/sam3/visual_segmentation.py
@@ -375,6 +375,8 @@ class Sam3ForInteractiveImageSegmentation(RoboflowCoreModel):
                 api_key=self.api_key,
                 model_id=self.endpoint,
                 endpoint_type=endpoint_type,
+                countinference=self.countinference,
+                service_secret=self.service_secret,
             ):
                 raise RoboflowAPINotAuthorizedError(
                     f"API key {self.api_key} does not have access to model {self.endpoint}"
@@ -397,6 +399,8 @@ class Sam3ForInteractiveImageSegmentation(RoboflowCoreModel):
             model_id=self.endpoint,
             endpoint_type=ModelEndpointType.ORT,
             device_id=self.device_id,
+            countinference=self.countinference,
+            service_secret=self.service_secret,
         )
 
         ort = api_data.get("ort") if isinstance(api_data, dict) else None

--- a/inference/models/sam3_3d/segment_anything_3d.py
+++ b/inference/models/sam3_3d/segment_anything_3d.py
@@ -341,6 +341,8 @@ class SegmentAnything3_3D_Objects(RoboflowCoreModel):
                 model_id="sam3-3d-weights-vc6vz/1",
                 endpoint_type=ModelEndpointType.ORT,
                 device_id=self.device_id,
+                countinference=self.countinference,
+                service_secret=self.service_secret,
             )["ort"]
             if "weights" not in api_data:
                 raise ModelArtefactError(


### PR DESCRIPTION
## Summary

- Requests from internal services (e.g. autodistill) with `countinference=false&service_secret=<ROBOFLOW_SERVICE_SECRET>` were returning **HTTP 402** for workspaces without credits, even though the serverless auth middleware correctly classified them as non-billable.
- Root cause: `RoboflowCoreModel.download_weights` (and the SAM3 / SAM3-3D overrides) call `_check_if_api_key_has_access_to_model` and `get_roboflow_model_data` **without** forwarding `countinference`/`service_secret`, so the internal Roboflow API calls for weights metadata do not opt out of credit verification and return 402. `_check_if_api_key_has_access_to_model` only catches `RoboflowAPINotAuthorizedError`, so `PaymentRequiredError` propagates to the handler and the user sees 402.
- Fix: capture `countinference`/`service_secret` from `kwargs` on `RoboflowInferenceModel.__init__` and forward them in every CORE_MODEL / SAM3 download path.

## Affected paths

- `RoboflowCoreModel.download_weights` + `download_model_from_roboflow_api`
- `SegmentAnything3.download_weights` + fine-tuned ORT fetch
- `Sam3ForInteractiveImageSegmentation.download_weights` + fine-tuned ORT fetch
- `SegmentAnything3_3D_Objects.download_model_from_roboflow_api`

## Verified in GCP logs

Example failing request observed in `autodistill` namespace (workspace `steam-ay8s2`, `WlcCzusKQ3cxH8z79NI4`):

```
POST /sam3/concept_segment?api_key=…&countinference=false&service_secret=… → 402
error_handlers.py:275  "PaymentRequiredError: Not enough credits to perform this request."
```

The middleware (`http_api.py:506` "Request received") let it through; the 402 came from the internal Roboflow API call inside `add_model` for the `sam3/sam3_final` weights metadata.

## Test plan

- [ ] Build the GPU inference image with this branch
- [ ] Replay an `autodistill` SAM3 request against a workspace without credits using `countinference=false&service_secret=$ROBOFLOW_SERVICE_SECRET` and confirm 200
- [ ] Confirm a request without `service_secret` (or with a wrong one) against the same workspace still returns 402
- [ ] Confirm `/sam3/visual_segment` and `/sam3_3d/infer` also work for the non-billable internal path

🤖 Generated with [Claude Code](https://claude.com/claude-code)