### PR TITLE
feat(yolo26-sem): support fine-tuned models + binary head

### DIFF
--- a/inference/models/utils.py
+++ b/inference/models/utils.py
@@ -991,13 +991,8 @@ if USE_INFERENCE_MODELS:
             )
 
     # YOLO26 semantic segmentation is inference_models-only (no legacy implementation),
-    # so we add entries directly rather than swapping existing ones. Register the
-    # architecture family ("yolo26", reported by pretrained/public models via
-    # modelArchitecture) plus every trained variant ("yolo26n-sem" ... reported by
-    # fine-tuned versioned models via their ORT modelType). There's no
-    # variant->family normalization in get_model_type, so both must be present
-    # (mirrors the YOLOLite registration below).
-    for _yolo26_sem_variant in [
+    # so we add entries directly rather than swapping existing ones.
+    for variant in [
         "yolo26",
         "yolo26n-sem",
         "yolo26s-sem",
@@ -1005,7 +1000,7 @@ if USE_INFERENCE_MODELS:
         "yolo26l-sem",
         "yolo26x-sem",
     ]:
-        ROBOFLOW_MODEL_TYPES[("semantic-segmentation", _yolo26_sem_variant)] = (
+        ROBOFLOW_MODEL_TYPES[("semantic-segmentation", variant)] = (
             InferenceModelsSemanticSegmentationAdapter
         )
 

--- a/inference/models/utils.py
+++ b/inference/models/utils.py
@@ -991,10 +991,23 @@ if USE_INFERENCE_MODELS:
             )
 
     # YOLO26 semantic segmentation is inference_models-only (no legacy implementation),
-    # so we add entries directly rather than swapping existing ones.
-    ROBOFLOW_MODEL_TYPES[("semantic-segmentation", "yolo26")] = (
-        InferenceModelsSemanticSegmentationAdapter
-    )
+    # so we add entries directly rather than swapping existing ones. Register the
+    # architecture family ("yolo26", reported by pretrained/public models via
+    # modelArchitecture) plus every trained variant ("yolo26n-sem" ... reported by
+    # fine-tuned versioned models via their ORT modelType). There's no
+    # variant->family normalization in get_model_type, so both must be present
+    # (mirrors the YOLOLite registration below).
+    for _yolo26_sem_variant in [
+        "yolo26",
+        "yolo26n-sem",
+        "yolo26s-sem",
+        "yolo26m-sem",
+        "yolo26l-sem",
+        "yolo26x-sem",
+    ]:
+        ROBOFLOW_MODEL_TYPES[("semantic-segmentation", _yolo26_sem_variant)] = (
+            InferenceModelsSemanticSegmentationAdapter
+        )
 
     # RFDETR keypoint detection is inference_models-only (no legacy implementation),
     # so we add entries directly rather than swapping existing ones.

--- a/inference_models/docs/changelog.md
+++ b/inference_models/docs/changelog.md
@@ -3,6 +3,7 @@
 ## `0.29.0`
 
 - Added RF-DETR preview keypoint support (ONNX backend).
+- Added support for fine-tuned YOLO26 semantic segmentation models.
 
 ## `0.28.7`
 

--- a/inference_models/inference_models/models/common/roboflow/model_packages.py
+++ b/inference_models/inference_models/models/common/roboflow/model_packages.py
@@ -28,31 +28,29 @@ def parse_class_names_file(class_names_path: str) -> List[str]:
         ) from error
 
 
-def resolve_background_class_id(class_names: List[str]) -> int:
-    """Return the index of the `background` class for a semantic-segmentation
-    package.
+def validate_class_names(class_names: List[str]) -> None:
+    """Validate the class names of a semantic-segmentation model package.
 
-    Roboflow semantic segmentation maps every pixel to a class id, with one
-    class reserved for background (sub-threshold / unlabeled pixels). A valid,
-    in-range background id is required - a negative sentinel would alias a real
-    class via negative indexing in downstream consumers (`class_names[-1]`,
-    palette LUTs, the 0=background platform convention), silently corrupting
-    the segmentation map. Packages must therefore declare a `background` class.
+    A valid package declares a `background` class plus at least one foreground
+    class, so `class_names` has >= 2 entries. `background` is required so that
+    sub-threshold / unlabeled pixels map to a valid class id (a negative
+    sentinel would alias a real class via negative indexing in downstream
+    consumers — `class_names[-1]`, palette LUTs, the 0=background platform
+    convention). At least one foreground class is required so consumers (e.g.
+    the binary `nc==1` post-process) can assume a foreground class id exists.
 
-    A valid semantic-segmentation package also has at least one foreground class
-    (so `class_names` has >= 2 entries: background plus the segmented class(es)).
-    This is validated here so downstream consumers can assume the precondition.
+    Raises `CorruptedModelPackageError` if either condition is unmet. Call this
+    once at model load; downstream helpers (`resolve_background_class_id`, the
+    post-process) then assume the precondition holds.
     """
-    try:
-        background_class_id = [c.lower() for c in class_names].index("background")
-    except ValueError as error:
+    if "background" not in [c.lower() for c in class_names]:
         raise CorruptedModelPackageError(
             message="Semantic segmentation model package does not define a `background` class in "
             "`class_names.txt`. A background class is required so that sub-threshold pixels map to a "
             "valid class id. If you created the model package manually, prepend `background` to the class "
             "names. If the weights are hosted on the Roboflow platform - contact support.",
             help_url="https://inference-models.roboflow.com/errors/model-loading/#corruptedmodelpackageerror",
-        ) from error
+        )
     if len(class_names) < 2:
         raise CorruptedModelPackageError(
             message="Semantic segmentation model package must define `background` plus at least one "
@@ -61,7 +59,15 @@ def resolve_background_class_id(class_names: List[str]) -> int:
             "If the weights are hosted on the Roboflow platform - contact support.",
             help_url="https://inference-models.roboflow.com/errors/model-loading/#corruptedmodelpackageerror",
         )
-    return background_class_id
+
+
+def resolve_background_class_id(class_names: List[str]) -> int:
+    """Return the index of the `background` class.
+
+    Assumes the package has already been validated via `validate_class_names`
+    (so `background` is present); call that at model load time.
+    """
+    return [c.lower() for c in class_names].index("background")
 
 
 PADDING_VALUES_MAPPING = {

--- a/inference_models/inference_models/models/common/roboflow/model_packages.py
+++ b/inference_models/inference_models/models/common/roboflow/model_packages.py
@@ -28,48 +28,6 @@ def parse_class_names_file(class_names_path: str) -> List[str]:
         ) from error
 
 
-def validate_class_names(class_names: List[str]) -> None:
-    """Validate the class names of a semantic-segmentation model package.
-
-    A valid package declares a `background` class plus at least one foreground
-    class, so `class_names` has >= 2 entries. `background` is required so that
-    sub-threshold / unlabeled pixels map to a valid class id (a negative
-    sentinel would alias a real class via negative indexing in downstream
-    consumers — `class_names[-1]`, palette LUTs, the 0=background platform
-    convention). At least one foreground class is required so consumers (e.g.
-    the binary `nc==1` post-process) can assume a foreground class id exists.
-
-    Raises `CorruptedModelPackageError` if either condition is unmet. Call this
-    once at model load; downstream helpers (`resolve_background_class_id`, the
-    post-process) then assume the precondition holds.
-    """
-    if "background" not in [c.lower() for c in class_names]:
-        raise CorruptedModelPackageError(
-            message="Semantic segmentation model package does not define a `background` class in "
-            "`class_names.txt`. A background class is required so that sub-threshold pixels map to a "
-            "valid class id. If you created the model package manually, prepend `background` to the class "
-            "names. If the weights are hosted on the Roboflow platform - contact support.",
-            help_url="https://inference-models.roboflow.com/errors/model-loading/#corruptedmodelpackageerror",
-        )
-    if len(class_names) < 2:
-        raise CorruptedModelPackageError(
-            message="Semantic segmentation model package must define `background` plus at least one "
-            f"foreground class, but `class_names.txt` only contains {class_names}. If you created the "
-            "model package manually, ensure it lists `background` followed by the foreground class(es). "
-            "If the weights are hosted on the Roboflow platform - contact support.",
-            help_url="https://inference-models.roboflow.com/errors/model-loading/#corruptedmodelpackageerror",
-        )
-
-
-def resolve_background_class_id(class_names: List[str]) -> int:
-    """Return the index of the `background` class.
-
-    Assumes the package has already been validated via `validate_class_names`
-    (so `background` is present); call that at model load time.
-    """
-    return [c.lower() for c in class_names].index("background")
-
-
 PADDING_VALUES_MAPPING = {
     "black edges": 0,
     "grey edges": 127,

--- a/inference_models/inference_models/models/common/roboflow/model_packages.py
+++ b/inference_models/inference_models/models/common/roboflow/model_packages.py
@@ -38,9 +38,13 @@ def resolve_background_class_id(class_names: List[str]) -> int:
     class via negative indexing in downstream consumers (`class_names[-1]`,
     palette LUTs, the 0=background platform convention), silently corrupting
     the segmentation map. Packages must therefore declare a `background` class.
+
+    A valid semantic-segmentation package also has at least one foreground class
+    (so `class_names` has >= 2 entries: background plus the segmented class(es)).
+    This is validated here so downstream consumers can assume the precondition.
     """
     try:
-        return [c.lower() for c in class_names].index("background")
+        background_class_id = [c.lower() for c in class_names].index("background")
     except ValueError as error:
         raise CorruptedModelPackageError(
             message="Semantic segmentation model package does not define a `background` class in "
@@ -49,6 +53,15 @@ def resolve_background_class_id(class_names: List[str]) -> int:
             "names. If the weights are hosted on the Roboflow platform - contact support.",
             help_url="https://inference-models.roboflow.com/errors/model-loading/#corruptedmodelpackageerror",
         ) from error
+    if len(class_names) < 2:
+        raise CorruptedModelPackageError(
+            message="Semantic segmentation model package must define `background` plus at least one "
+            f"foreground class, but `class_names.txt` only contains {class_names}. If you created the "
+            "model package manually, ensure it lists `background` followed by the foreground class(es). "
+            "If the weights are hosted on the Roboflow platform - contact support.",
+            help_url="https://inference-models.roboflow.com/errors/model-loading/#corruptedmodelpackageerror",
+        )
+    return background_class_id
 
 
 PADDING_VALUES_MAPPING = {

--- a/inference_models/inference_models/models/common/roboflow/post_processing.py
+++ b/inference_models/inference_models/models/common/roboflow/post_processing.py
@@ -826,7 +826,6 @@ def post_process_semantic_segmentation_logits(
             image_results = torch.nn.functional.softmax(image_results, dim=0)
             image_confidence, image_class_ids = torch.max(image_results, dim=0)
             if len(class_names) == image_results.shape[0] + 1:
-                # +1 would only be correct when background is class 0
                 foreground_ids = torch.tensor(
                     [i for i in range(len(class_names)) if i != background_class_id],
                     device=image_class_ids.device,

--- a/inference_models/inference_models/models/common/roboflow/post_processing.py
+++ b/inference_models/inference_models/models/common/roboflow/post_processing.py
@@ -745,6 +745,11 @@ def post_process_semantic_segmentation_logits(
     softmax over classes → argmax → place into original-image canvas if
     static_crop was applied → apply per-class confidence threshold
     (sub-threshold pixels collapse to background_class_id).
+
+    Single-channel (K==1) outputs are the Ultralytics binary (``nc==1``) head:
+    instead of softmax+argmax, the sigmoid foreground probability is used and the
+    lone foreground class is read from ``class_names`` (``[background, <fg>]``).
+    Sub-threshold pixels collapse to background via the same threshold step.
     """
     confidence_filter = ConfidenceFilter(
         confidence=confidence,
@@ -809,10 +814,25 @@ def post_process_semantic_segmentation_logits(
                 ],
                 interpolation=functional.InterpolationMode.BILINEAR,
             )
-        image_results = torch.nn.functional.softmax(image_results, dim=0)
-        image_confidence, image_class_ids = torch.max(image_results, dim=0)
-        if len(class_names) == image_results.shape[0] + 1:
-            image_class_ids = image_class_ids + 1
+        if image_results.shape[0] == 1:
+            # Binary (Ultralytics nc==1) head emits a single foreground logit;
+            # softmax over one channel is degenerate (≡1.0), so use the sigmoid
+            # foreground probability. class_names is [background, <foreground>];
+            # every pixel is provisionally that foreground class and sub-threshold
+            # pixels collapse to background below.
+            image_confidence = image_results[0].sigmoid()
+            foreground_id = next(
+                (i for i in range(len(class_names)) if i != background_class_id),
+                background_class_id,
+            )
+            image_class_ids = torch.full_like(
+                image_confidence, foreground_id, dtype=torch.long
+            )
+        else:
+            image_results = torch.nn.functional.softmax(image_results, dim=0)
+            image_confidence, image_class_ids = torch.max(image_results, dim=0)
+            if len(class_names) == image_results.shape[0] + 1:
+                image_class_ids = image_class_ids + 1
         if (
             image_metadata.static_crop_offset.offset_x > 0
             or image_metadata.static_crop_offset.offset_y > 0

--- a/inference_models/inference_models/models/common/roboflow/post_processing.py
+++ b/inference_models/inference_models/models/common/roboflow/post_processing.py
@@ -815,11 +815,6 @@ def post_process_semantic_segmentation_logits(
                 interpolation=functional.InterpolationMode.BILINEAR,
             )
         if image_results.shape[0] == 1:
-            # Binary (Ultralytics nc==1) head: a single foreground logit; softmax
-            # over one channel is degenerate (≡1.0), so use the sigmoid foreground
-            # probability. The package is validated at load time
-            # (resolve_background_class_id) to have >= 1 foreground class, so the
-            # lone non-background id always exists.
             image_confidence = image_results[0].sigmoid()
             foreground_id = next(
                 i for i in range(len(class_names)) if i != background_class_id

--- a/inference_models/inference_models/models/common/roboflow/post_processing.py
+++ b/inference_models/inference_models/models/common/roboflow/post_processing.py
@@ -826,7 +826,16 @@ def post_process_semantic_segmentation_logits(
             image_results = torch.nn.functional.softmax(image_results, dim=0)
             image_confidence, image_class_ids = torch.max(image_results, dim=0)
             if len(class_names) == image_results.shape[0] + 1:
-                image_class_ids = image_class_ids + 1
+                # Model emits K foreground channels; class_names has K+1 entries
+                # (background + foreground). Map channel j -> the j-th
+                # non-background class id. (A blanket +1 only holds when
+                # background is at index 0; background_class_id is data-driven.)
+                foreground_ids = torch.tensor(
+                    [i for i in range(len(class_names)) if i != background_class_id],
+                    device=image_class_ids.device,
+                    dtype=image_class_ids.dtype,
+                )
+                image_class_ids = foreground_ids[image_class_ids]
         if (
             image_metadata.static_crop_offset.offset_x > 0
             or image_metadata.static_crop_offset.offset_y > 0

--- a/inference_models/inference_models/models/common/roboflow/post_processing.py
+++ b/inference_models/inference_models/models/common/roboflow/post_processing.py
@@ -15,6 +15,9 @@ from inference_models.models.common.roboflow.model_packages import (
     PreProcessingMetadata,
     StaticCropOffset,
 )
+from inference_models.models.common.roboflow.semantic_segmentation import (
+    insert_background_class,
+)
 from inference_models.weights_providers.entities import RecommendedParameters
 
 
@@ -816,22 +819,20 @@ def post_process_semantic_segmentation_logits(
             )
         if image_results.shape[0] == 1:
             image_confidence = image_results[0].sigmoid()
-            foreground_id = next(
-                i for i in range(len(class_names)) if i != background_class_id
-            )
-            image_class_ids = torch.full_like(
-                image_confidence, foreground_id, dtype=torch.long
+            image_class_ids = insert_background_class(
+                torch.zeros_like(image_confidence, dtype=torch.long),
+                background_class_id=background_class_id,
+                num_classes=len(class_names),
             )
         else:
             image_results = torch.nn.functional.softmax(image_results, dim=0)
             image_confidence, image_class_ids = torch.max(image_results, dim=0)
             if len(class_names) == image_results.shape[0] + 1:
-                foreground_ids = torch.tensor(
-                    [i for i in range(len(class_names)) if i != background_class_id],
-                    device=image_class_ids.device,
-                    dtype=image_class_ids.dtype,
+                image_class_ids = insert_background_class(
+                    image_class_ids,
+                    background_class_id=background_class_id,
+                    num_classes=len(class_names),
                 )
-                image_class_ids = foreground_ids[image_class_ids]
         if (
             image_metadata.static_crop_offset.offset_x > 0
             or image_metadata.static_crop_offset.offset_y > 0

--- a/inference_models/inference_models/models/common/roboflow/post_processing.py
+++ b/inference_models/inference_models/models/common/roboflow/post_processing.py
@@ -815,15 +815,14 @@ def post_process_semantic_segmentation_logits(
                 interpolation=functional.InterpolationMode.BILINEAR,
             )
         if image_results.shape[0] == 1:
-            # Binary (Ultralytics nc==1) head emits a single foreground logit;
-            # softmax over one channel is degenerate (≡1.0), so use the sigmoid
-            # foreground probability. class_names is [background, <foreground>];
-            # every pixel is provisionally that foreground class and sub-threshold
-            # pixels collapse to background below.
+            # Binary (Ultralytics nc==1) head: a single foreground logit; softmax
+            # over one channel is degenerate (≡1.0), so use the sigmoid foreground
+            # probability. The package is validated at load time
+            # (resolve_background_class_id) to have >= 1 foreground class, so the
+            # lone non-background id always exists.
             image_confidence = image_results[0].sigmoid()
             foreground_id = next(
-                (i for i in range(len(class_names)) if i != background_class_id),
-                background_class_id,
+                i for i in range(len(class_names)) if i != background_class_id
             )
             image_class_ids = torch.full_like(
                 image_confidence, foreground_id, dtype=torch.long

--- a/inference_models/inference_models/models/common/roboflow/post_processing.py
+++ b/inference_models/inference_models/models/common/roboflow/post_processing.py
@@ -826,10 +826,7 @@ def post_process_semantic_segmentation_logits(
             image_results = torch.nn.functional.softmax(image_results, dim=0)
             image_confidence, image_class_ids = torch.max(image_results, dim=0)
             if len(class_names) == image_results.shape[0] + 1:
-                # Model emits K foreground channels; class_names has K+1 entries
-                # (background + foreground). Map channel j -> the j-th
-                # non-background class id. (A blanket +1 only holds when
-                # background is at index 0; background_class_id is data-driven.)
+                # +1 would only be correct when background is class 0
                 foreground_ids = torch.tensor(
                     [i for i in range(len(class_names)) if i != background_class_id],
                     device=image_class_ids.device,

--- a/inference_models/inference_models/models/common/roboflow/semantic_segmentation.py
+++ b/inference_models/inference_models/models/common/roboflow/semantic_segmentation.py
@@ -3,6 +3,8 @@ YOLO26-sem backends (kept out of the generic `model_packages` module)."""
 
 from typing import List
 
+import torch
+
 from inference_models.errors import CorruptedModelPackageError
 
 
@@ -32,3 +34,16 @@ def validate_class_names(class_names: List[str]) -> None:
 def resolve_background_class_id(class_names: List[str]) -> int:
     """Index of the `background` class; assumes a `validate_class_names`-checked package."""
     return [c.lower() for c in class_names].index("background")
+
+
+def insert_background_class(
+    class_ids: torch.Tensor, *, background_class_id: int, num_classes: int
+) -> torch.Tensor:
+    """Map foreground-channel indices (``0..K-1``) to full class ids, skipping the
+    background slot. ``num_classes`` is the full class count (``K + 1``)."""
+    foreground_ids = torch.tensor(
+        [i for i in range(num_classes) if i != background_class_id],
+        device=class_ids.device,
+        dtype=class_ids.dtype,
+    )
+    return foreground_ids[class_ids]

--- a/inference_models/inference_models/models/common/roboflow/semantic_segmentation.py
+++ b/inference_models/inference_models/models/common/roboflow/semantic_segmentation.py
@@ -1,10 +1,5 @@
-"""Semantic-segmentation helpers for Roboflow model packages.
-
-These live apart from the generic `model_packages` parsing/config helpers
-because they encode the semantic-segmentation *class-name contract* — a
-`background` class plus at least one foreground class — shared by the
-DeepLabV3+ and YOLO26-sem backends.
-"""
+"""Semantic-segmentation class-name helpers shared by the DeepLabV3+ and
+YOLO26-sem backends (kept out of the generic `model_packages` module)."""
 
 from typing import List
 
@@ -12,19 +7,9 @@ from inference_models.errors import CorruptedModelPackageError
 
 
 def validate_class_names(class_names: List[str]) -> None:
-    """Validate the class names of a semantic-segmentation model package.
+    """Require a `background` class plus >= 1 foreground class, raising otherwise.
 
-    A valid package declares a `background` class plus at least one foreground
-    class, so `class_names` has >= 2 entries. `background` is required so that
-    sub-threshold / unlabeled pixels map to a valid class id (a negative
-    sentinel would alias a real class via negative indexing in downstream
-    consumers — `class_names[-1]`, palette LUTs, the 0=background platform
-    convention). At least one foreground class is required so consumers (e.g.
-    the binary `nc==1` post-process) can assume a foreground class id exists.
-
-    Raises `CorruptedModelPackageError` if either condition is unmet. Call this
-    once at model load; downstream helpers (`resolve_background_class_id`, the
-    post-process) then assume the precondition holds.
+    Call once at model load so downstream helpers can assume the precondition.
     """
     if "background" not in [c.lower() for c in class_names]:
         raise CorruptedModelPackageError(
@@ -45,9 +30,5 @@ def validate_class_names(class_names: List[str]) -> None:
 
 
 def resolve_background_class_id(class_names: List[str]) -> int:
-    """Return the index of the `background` class.
-
-    Assumes the package has already been validated via `validate_class_names`
-    (so `background` is present); call that at model load time.
-    """
+    """Index of the `background` class; assumes a `validate_class_names`-checked package."""
     return [c.lower() for c in class_names].index("background")

--- a/inference_models/inference_models/models/common/roboflow/semantic_segmentation.py
+++ b/inference_models/inference_models/models/common/roboflow/semantic_segmentation.py
@@ -1,0 +1,53 @@
+"""Semantic-segmentation helpers for Roboflow model packages.
+
+These live apart from the generic `model_packages` parsing/config helpers
+because they encode the semantic-segmentation *class-name contract* — a
+`background` class plus at least one foreground class — shared by the
+DeepLabV3+ and YOLO26-sem backends.
+"""
+
+from typing import List
+
+from inference_models.errors import CorruptedModelPackageError
+
+
+def validate_class_names(class_names: List[str]) -> None:
+    """Validate the class names of a semantic-segmentation model package.
+
+    A valid package declares a `background` class plus at least one foreground
+    class, so `class_names` has >= 2 entries. `background` is required so that
+    sub-threshold / unlabeled pixels map to a valid class id (a negative
+    sentinel would alias a real class via negative indexing in downstream
+    consumers — `class_names[-1]`, palette LUTs, the 0=background platform
+    convention). At least one foreground class is required so consumers (e.g.
+    the binary `nc==1` post-process) can assume a foreground class id exists.
+
+    Raises `CorruptedModelPackageError` if either condition is unmet. Call this
+    once at model load; downstream helpers (`resolve_background_class_id`, the
+    post-process) then assume the precondition holds.
+    """
+    if "background" not in [c.lower() for c in class_names]:
+        raise CorruptedModelPackageError(
+            message="Semantic segmentation model package does not define a `background` class in "
+            "`class_names.txt`. A background class is required so that sub-threshold pixels map to a "
+            "valid class id. If you created the model package manually, prepend `background` to the class "
+            "names. If the weights are hosted on the Roboflow platform - contact support.",
+            help_url="https://inference-models.roboflow.com/errors/model-loading/#corruptedmodelpackageerror",
+        )
+    if len(class_names) < 2:
+        raise CorruptedModelPackageError(
+            message="Semantic segmentation model package must define `background` plus at least one "
+            f"foreground class, but `class_names.txt` only contains {class_names}. If you created the "
+            "model package manually, ensure it lists `background` followed by the foreground class(es). "
+            "If the weights are hosted on the Roboflow platform - contact support.",
+            help_url="https://inference-models.roboflow.com/errors/model-loading/#corruptedmodelpackageerror",
+        )
+
+
+def resolve_background_class_id(class_names: List[str]) -> int:
+    """Return the index of the `background` class.
+
+    Assumes the package has already been validated via `validate_class_names`
+    (so `background` is present); call that at model load time.
+    """
+    return [c.lower() for c in class_names].index("background")

--- a/inference_models/inference_models/models/deep_lab_v3_plus/deep_lab_v3_plus_segmentation_onnx.py
+++ b/inference_models/inference_models/models/deep_lab_v3_plus/deep_lab_v3_plus_segmentation_onnx.py
@@ -33,6 +33,7 @@ from inference_models.models.common.roboflow.model_packages import (
 )
 from inference_models.models.common.roboflow.semantic_segmentation import (
     resolve_background_class_id,
+    validate_class_names,
 )
 from inference_models.models.common.roboflow.post_processing import (
     post_process_semantic_segmentation_logits,
@@ -96,6 +97,7 @@ class DeepLabV3PlusForSemanticSegmentationOnnx(
         class_names = parse_class_names_file(
             class_names_path=model_package_content["class_names.txt"]
         )
+        validate_class_names(class_names)
         background_class_id = resolve_background_class_id(class_names)
         inference_config = parse_inference_config(
             config_path=model_package_content["inference_config.json"],

--- a/inference_models/inference_models/models/deep_lab_v3_plus/deep_lab_v3_plus_segmentation_onnx.py
+++ b/inference_models/inference_models/models/deep_lab_v3_plus/deep_lab_v3_plus_segmentation_onnx.py
@@ -30,6 +30,8 @@ from inference_models.models.common.roboflow.model_packages import (
     ResizeMode,
     parse_class_names_file,
     parse_inference_config,
+)
+from inference_models.models.common.roboflow.semantic_segmentation import (
     resolve_background_class_id,
 )
 from inference_models.models.common.roboflow.post_processing import (

--- a/inference_models/inference_models/models/deep_lab_v3_plus/deep_lab_v3_plus_segmentation_torch.py
+++ b/inference_models/inference_models/models/deep_lab_v3_plus/deep_lab_v3_plus_segmentation_torch.py
@@ -23,6 +23,8 @@ from inference_models.models.common.roboflow.model_packages import (
     ResizeMode,
     parse_class_names_file,
     parse_inference_config,
+)
+from inference_models.models.common.roboflow.semantic_segmentation import (
     resolve_background_class_id,
 )
 from inference_models.models.common.roboflow.post_processing import (

--- a/inference_models/inference_models/models/deep_lab_v3_plus/deep_lab_v3_plus_segmentation_torch.py
+++ b/inference_models/inference_models/models/deep_lab_v3_plus/deep_lab_v3_plus_segmentation_torch.py
@@ -26,6 +26,7 @@ from inference_models.models.common.roboflow.model_packages import (
 )
 from inference_models.models.common.roboflow.semantic_segmentation import (
     resolve_background_class_id,
+    validate_class_names,
 )
 from inference_models.models.common.roboflow.post_processing import (
     post_process_semantic_segmentation_logits,
@@ -59,6 +60,7 @@ class DeepLabV3PlusForSemanticSegmentationTorch(
         class_names = parse_class_names_file(
             class_names_path=model_package_content["class_names.txt"]
         )
+        validate_class_names(class_names)
         background_class_id = resolve_background_class_id(class_names)
         inference_config = parse_inference_config(
             config_path=model_package_content["inference_config.json"],

--- a/inference_models/inference_models/models/deep_lab_v3_plus/deep_lab_v3_plus_segmentation_trt.py
+++ b/inference_models/inference_models/models/deep_lab_v3_plus/deep_lab_v3_plus_segmentation_trt.py
@@ -36,6 +36,7 @@ from inference_models.models.common.roboflow.model_packages import (
 )
 from inference_models.models.common.roboflow.semantic_segmentation import (
     resolve_background_class_id,
+    validate_class_names,
 )
 from inference_models.models.common.roboflow.post_processing import (
     post_process_semantic_segmentation_logits,
@@ -112,6 +113,7 @@ class DeepLabV3PlusForSemanticSegmentationTRT(
         class_names = parse_class_names_file(
             class_names_path=model_package_content["class_names.txt"]
         )
+        validate_class_names(class_names)
         background_class_id = resolve_background_class_id(class_names)
         inference_config = parse_inference_config(
             config_path=model_package_content["inference_config.json"],

--- a/inference_models/inference_models/models/deep_lab_v3_plus/deep_lab_v3_plus_segmentation_trt.py
+++ b/inference_models/inference_models/models/deep_lab_v3_plus/deep_lab_v3_plus_segmentation_trt.py
@@ -32,8 +32,10 @@ from inference_models.models.common.roboflow.model_packages import (
     TRTConfig,
     parse_class_names_file,
     parse_inference_config,
-    resolve_background_class_id,
     parse_trt_config,
+)
+from inference_models.models.common.roboflow.semantic_segmentation import (
+    resolve_background_class_id,
 )
 from inference_models.models.common.roboflow.post_processing import (
     post_process_semantic_segmentation_logits,

--- a/inference_models/inference_models/models/yolo26/yolo26_semantic_segmentation_onnx.py
+++ b/inference_models/inference_models/models/yolo26/yolo26_semantic_segmentation_onnx.py
@@ -28,8 +28,10 @@ from inference_models.models.common.roboflow.model_packages import (
     PreProcessingMetadata,
     ResizeMode,
     parse_class_names_file,
-    resolve_background_class_id,
     parse_inference_config,
+)
+from inference_models.models.common.roboflow.semantic_segmentation import (
+    resolve_background_class_id,
     validate_class_names,
 )
 from inference_models.models.common.roboflow.post_processing import (

--- a/inference_models/inference_models/models/yolo26/yolo26_semantic_segmentation_onnx.py
+++ b/inference_models/inference_models/models/yolo26/yolo26_semantic_segmentation_onnx.py
@@ -30,6 +30,7 @@ from inference_models.models.common.roboflow.model_packages import (
     parse_class_names_file,
     resolve_background_class_id,
     parse_inference_config,
+    validate_class_names,
 )
 from inference_models.models.common.roboflow.post_processing import (
     post_process_semantic_segmentation_logits,
@@ -99,6 +100,7 @@ class YOLO26ForSemanticSegmentationOnnx(
         class_names = parse_class_names_file(
             class_names_path=model_package_content["class_names.txt"]
         )
+        validate_class_names(class_names)
         background_class_id = resolve_background_class_id(class_names)
         inference_config = parse_inference_config(
             config_path=model_package_content["inference_config.json"],

--- a/inference_models/inference_models/models/yolo26/yolo26_semantic_segmentation_torch_script.py
+++ b/inference_models/inference_models/models/yolo26/yolo26_semantic_segmentation_torch_script.py
@@ -22,6 +22,8 @@ from inference_models.models.common.roboflow.model_packages import (
     ResizeMode,
     parse_class_names_file,
     parse_inference_config,
+)
+from inference_models.models.common.roboflow.semantic_segmentation import (
     resolve_background_class_id,
     validate_class_names,
 )

--- a/inference_models/inference_models/models/yolo26/yolo26_semantic_segmentation_torch_script.py
+++ b/inference_models/inference_models/models/yolo26/yolo26_semantic_segmentation_torch_script.py
@@ -23,6 +23,7 @@ from inference_models.models.common.roboflow.model_packages import (
     parse_class_names_file,
     parse_inference_config,
     resolve_background_class_id,
+    validate_class_names,
 )
 from inference_models.models.common.roboflow.post_processing import (
     post_process_semantic_segmentation_logits,
@@ -61,6 +62,7 @@ class YOLO26ForSemanticSegmentationTorchScript(
         class_names = parse_class_names_file(
             class_names_path=model_package_content["class_names.txt"]
         )
+        validate_class_names(class_names)
         background_class_id = resolve_background_class_id(class_names)
         inference_config = parse_inference_config(
             config_path=model_package_content["inference_config.json"],

--- a/inference_models/inference_models/models/yolo26/yolo26_semantic_segmentation_trt.py
+++ b/inference_models/inference_models/models/yolo26/yolo26_semantic_segmentation_trt.py
@@ -34,6 +34,7 @@ from inference_models.models.common.roboflow.model_packages import (
     parse_inference_config,
     resolve_background_class_id,
     parse_trt_config,
+    validate_class_names,
 )
 from inference_models.models.common.roboflow.post_processing import (
     post_process_semantic_segmentation_logits,
@@ -110,6 +111,7 @@ class YOLO26ForSemanticSegmentationTRT(
         class_names = parse_class_names_file(
             class_names_path=model_package_content["class_names.txt"]
         )
+        validate_class_names(class_names)
         background_class_id = resolve_background_class_id(class_names)
         inference_config = parse_inference_config(
             config_path=model_package_content["inference_config.json"],

--- a/inference_models/inference_models/models/yolo26/yolo26_semantic_segmentation_trt.py
+++ b/inference_models/inference_models/models/yolo26/yolo26_semantic_segmentation_trt.py
@@ -32,8 +32,10 @@ from inference_models.models.common.roboflow.model_packages import (
     TRTConfig,
     parse_class_names_file,
     parse_inference_config,
-    resolve_background_class_id,
     parse_trt_config,
+)
+from inference_models.models.common.roboflow.semantic_segmentation import (
+    resolve_background_class_id,
     validate_class_names,
 )
 from inference_models.models.common.roboflow.post_processing import (

--- a/inference_models/pyproject.toml
+++ b/inference_models/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inference-models"
-version = "0.29.0-rc3"
+version = "0.29.0-rc4"
 description = "The new inference engine for Computer Vision models"
 readme = "README.md"
 requires-python = ">=3.10,<3.13"

--- a/inference_models/pyproject.toml
+++ b/inference_models/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inference-models"
-version = "0.29.0-rc4"
+version = "0.29.0"
 description = "The new inference engine for Computer Vision models"
 readme = "README.md"
 requires-python = ">=3.10,<3.13"

--- a/inference_models/tests/unit_tests/models/common/roboflow/test_model_packages.py
+++ b/inference_models/tests/unit_tests/models/common/roboflow/test_model_packages.py
@@ -20,8 +20,6 @@ from inference_models.models.common.roboflow.model_packages import (
     parse_inference_config,
     parse_key_points_metadata,
     parse_trt_config,
-    resolve_background_class_id,
-    validate_class_names,
 )
 
 
@@ -270,42 +268,6 @@ def test_parse_class_names_file_when_valid_config_provided(
 
     # then
     assert result == ["some", "other", "yet-another"]
-
-
-def test_resolve_background_class_id_when_background_present() -> None:
-    # when
-    result = resolve_background_class_id(["background", "road", "sidewalk"])
-
-    # then
-    assert result == 0
-
-
-def test_resolve_background_class_id_is_case_insensitive() -> None:
-    # when
-    result = resolve_background_class_id(["road", "Background", "sidewalk"])
-
-    # then
-    assert result == 1
-
-
-def test_validate_class_names_with_minimal_binary_class_list() -> None:
-    # background + a single foreground class is the minimal valid package
-    validate_class_names(["background", "object"])  # does not raise
-
-
-def test_validate_class_names_with_multiclass() -> None:
-    validate_class_names(["background", "road", "sidewalk"])  # does not raise
-
-
-def test_validate_class_names_when_background_absent() -> None:
-    with pytest.raises(CorruptedModelPackageError):
-        validate_class_names(["road", "sidewalk", "building"])
-
-
-def test_validate_class_names_when_no_foreground_class() -> None:
-    # background present but no foreground class -> invalid semantic-seg package
-    with pytest.raises(CorruptedModelPackageError):
-        validate_class_names(["background"])
 
 
 def test_parse_inference_config_when_path_does_not_exists() -> None:

--- a/inference_models/tests/unit_tests/models/common/roboflow/test_model_packages.py
+++ b/inference_models/tests/unit_tests/models/common/roboflow/test_model_packages.py
@@ -293,6 +293,17 @@ def test_resolve_background_class_id_when_background_absent() -> None:
         _ = resolve_background_class_id(["road", "sidewalk", "building"])
 
 
+def test_resolve_background_class_id_with_minimal_binary_class_list() -> None:
+    # background + a single foreground class is the minimal valid package
+    assert resolve_background_class_id(["background", "object"]) == 0
+
+
+def test_resolve_background_class_id_when_no_foreground_class() -> None:
+    # background present but no foreground class -> invalid semantic-seg package
+    with pytest.raises(CorruptedModelPackageError):
+        _ = resolve_background_class_id(["background"])
+
+
 def test_parse_inference_config_when_path_does_not_exists() -> None:
     # when
     with pytest.raises(CorruptedModelPackageError):

--- a/inference_models/tests/unit_tests/models/common/roboflow/test_model_packages.py
+++ b/inference_models/tests/unit_tests/models/common/roboflow/test_model_packages.py
@@ -21,6 +21,7 @@ from inference_models.models.common.roboflow.model_packages import (
     parse_key_points_metadata,
     parse_trt_config,
     resolve_background_class_id,
+    validate_class_names,
 )
 
 
@@ -287,21 +288,24 @@ def test_resolve_background_class_id_is_case_insensitive() -> None:
     assert result == 1
 
 
-def test_resolve_background_class_id_when_background_absent() -> None:
-    # when
-    with pytest.raises(CorruptedModelPackageError):
-        _ = resolve_background_class_id(["road", "sidewalk", "building"])
-
-
-def test_resolve_background_class_id_with_minimal_binary_class_list() -> None:
+def test_validate_class_names_with_minimal_binary_class_list() -> None:
     # background + a single foreground class is the minimal valid package
-    assert resolve_background_class_id(["background", "object"]) == 0
+    validate_class_names(["background", "object"])  # does not raise
 
 
-def test_resolve_background_class_id_when_no_foreground_class() -> None:
+def test_validate_class_names_with_multiclass() -> None:
+    validate_class_names(["background", "road", "sidewalk"])  # does not raise
+
+
+def test_validate_class_names_when_background_absent() -> None:
+    with pytest.raises(CorruptedModelPackageError):
+        validate_class_names(["road", "sidewalk", "building"])
+
+
+def test_validate_class_names_when_no_foreground_class() -> None:
     # background present but no foreground class -> invalid semantic-seg package
     with pytest.raises(CorruptedModelPackageError):
-        _ = resolve_background_class_id(["background"])
+        validate_class_names(["background"])
 
 
 def test_parse_inference_config_when_path_does_not_exists() -> None:

--- a/inference_models/tests/unit_tests/models/common/roboflow/test_semantic_segmentation.py
+++ b/inference_models/tests/unit_tests/models/common/roboflow/test_semantic_segmentation.py
@@ -16,7 +16,6 @@ def test_resolve_background_class_id_is_case_insensitive() -> None:
 
 
 def test_validate_class_names_with_minimal_binary_class_list() -> None:
-    # background + a single foreground class is the minimal valid package
     validate_class_names(["background", "object"])  # does not raise
 
 
@@ -30,6 +29,5 @@ def test_validate_class_names_when_background_absent() -> None:
 
 
 def test_validate_class_names_when_no_foreground_class() -> None:
-    # background present but no foreground class -> invalid semantic-seg package
     with pytest.raises(CorruptedModelPackageError):
         validate_class_names(["background"])

--- a/inference_models/tests/unit_tests/models/common/roboflow/test_semantic_segmentation.py
+++ b/inference_models/tests/unit_tests/models/common/roboflow/test_semantic_segmentation.py
@@ -1,7 +1,9 @@
 import pytest
+import torch
 
 from inference_models.errors import CorruptedModelPackageError
 from inference_models.models.common.roboflow.semantic_segmentation import (
+    insert_background_class,
     resolve_background_class_id,
     validate_class_names,
 )
@@ -31,3 +33,24 @@ def test_validate_class_names_when_background_absent() -> None:
 def test_validate_class_names_when_no_foreground_class() -> None:
     with pytest.raises(CorruptedModelPackageError):
         validate_class_names(["background"])
+
+
+def test_insert_background_class_when_background_first() -> None:
+    out = insert_background_class(
+        torch.tensor([0, 1, 2]), background_class_id=0, num_classes=4
+    )
+    assert out.tolist() == [1, 2, 3]
+
+
+def test_insert_background_class_when_background_not_first() -> None:
+    out = insert_background_class(
+        torch.tensor([0, 1, 2]), background_class_id=1, num_classes=4
+    )
+    assert out.tolist() == [0, 2, 3]
+
+
+def test_insert_background_class_binary_single_foreground() -> None:
+    out = insert_background_class(
+        torch.zeros(3, dtype=torch.long), background_class_id=0, num_classes=2
+    )
+    assert out.tolist() == [1, 1, 1]

--- a/inference_models/tests/unit_tests/models/common/roboflow/test_semantic_segmentation.py
+++ b/inference_models/tests/unit_tests/models/common/roboflow/test_semantic_segmentation.py
@@ -1,0 +1,35 @@
+import pytest
+
+from inference_models.errors import CorruptedModelPackageError
+from inference_models.models.common.roboflow.semantic_segmentation import (
+    resolve_background_class_id,
+    validate_class_names,
+)
+
+
+def test_resolve_background_class_id_when_background_present() -> None:
+    assert resolve_background_class_id(["background", "road", "sidewalk"]) == 0
+
+
+def test_resolve_background_class_id_is_case_insensitive() -> None:
+    assert resolve_background_class_id(["road", "Background", "sidewalk"]) == 1
+
+
+def test_validate_class_names_with_minimal_binary_class_list() -> None:
+    # background + a single foreground class is the minimal valid package
+    validate_class_names(["background", "object"])  # does not raise
+
+
+def test_validate_class_names_with_multiclass() -> None:
+    validate_class_names(["background", "road", "sidewalk"])  # does not raise
+
+
+def test_validate_class_names_when_background_absent() -> None:
+    with pytest.raises(CorruptedModelPackageError):
+        validate_class_names(["road", "sidewalk", "building"])
+
+
+def test_validate_class_names_when_no_foreground_class() -> None:
+    # background present but no foreground class -> invalid semantic-seg package
+    with pytest.raises(CorruptedModelPackageError):
+        validate_class_names(["background"])

--- a/inference_models/tests/unit_tests/models/test_yolo26_semantic_segmentation.py
+++ b/inference_models/tests/unit_tests/models/test_yolo26_semantic_segmentation.py
@@ -114,6 +114,72 @@ def test_post_process_semantic_segmentation_logits_shifts_when_class_names_prepe
     assert torch.all(results[0].segmentation_map == 3)
 
 
+def _binary_meta(h, w):
+    return [
+        MagicMock(
+            inference_size=MagicMock(height=h, width=w),
+            pad_top=0,
+            pad_bottom=0,
+            pad_left=0,
+            pad_right=0,
+            size_after_pre_processing=MagicMock(height=h, width=w),
+            original_size=MagicMock(height=h, width=w),
+            static_crop_offset=MagicMock(offset_x=0, offset_y=0),
+        )
+    ]
+
+
+def test_post_process_semantic_segmentation_logits_binary_single_channel_foreground():
+    """A single-channel (Ultralytics nc==1) output uses the sigmoid foreground
+    probability — high-positive logits map to the lone foreground class, not the
+    degenerate softmax-over-one-channel."""
+    from inference_models.models.common.roboflow.post_processing import (
+        post_process_semantic_segmentation_logits,
+    )
+
+    h, w = 6, 6
+    logits = torch.full((1, 1, h, w), 5.0)  # sigmoid ~ 0.993 -> foreground
+
+    results = post_process_semantic_segmentation_logits(
+        model_results=logits,
+        pre_processing_meta=_binary_meta(h, w),
+        class_names=["background", "object"],
+        background_class_id=0,
+        device=torch.device("cpu"),
+        confidence=0.5,
+        recommended_parameters=None,
+        default_confidence=0.5,
+    )
+
+    assert results[0].segmentation_map.shape == (h, w)
+    assert torch.all(results[0].segmentation_map == 1)  # lone foreground class id
+    assert torch.all(results[0].confidence > 0.99)
+
+
+def test_post_process_semantic_segmentation_logits_binary_sub_threshold_to_background():
+    """Single-channel logits with low sigmoid confidence collapse to background."""
+    from inference_models.models.common.roboflow.post_processing import (
+        post_process_semantic_segmentation_logits,
+    )
+
+    h, w = 4, 4
+    logits = torch.full((1, 1, h, w), -5.0)  # sigmoid ~ 0.0067 -> below threshold
+
+    results = post_process_semantic_segmentation_logits(
+        model_results=logits,
+        pre_processing_meta=_binary_meta(h, w),
+        class_names=["background", "object"],
+        background_class_id=0,
+        device=torch.device("cpu"),
+        confidence=0.5,
+        recommended_parameters=None,
+        default_confidence=0.5,
+    )
+
+    assert torch.all(results[0].segmentation_map == 0)  # background
+    assert torch.all(results[0].confidence == 0.0)
+
+
 def test_yolo26_semantic_segmentation_registered():
     from inference_models.models.auto_loaders.entities import BackendType
     from inference_models.models.auto_loaders.models_registry import (

--- a/inference_models/tests/unit_tests/models/test_yolo26_semantic_segmentation.py
+++ b/inference_models/tests/unit_tests/models/test_yolo26_semantic_segmentation.py
@@ -187,10 +187,9 @@ def test_post_process_semantic_segmentation_logits_maps_channels_when_background
         post_process_semantic_segmentation_logits,
     )
 
-    # class_names: a=0, background=1, b=2, c=3 -> foreground ids [0, 2, 3]
     h, w, num_channels = 6, 6, 3
     logits = torch.zeros(1, num_channels, h, w)
-    logits[0, 0] = 5.0  # channel 0 dominant -> first foreground class -> "a" (id 0)
+    logits[0, 0] = 5.0  # channel 0 dominant
 
     results = post_process_semantic_segmentation_logits(
         model_results=logits,
@@ -203,7 +202,6 @@ def test_post_process_semantic_segmentation_logits_maps_channels_when_background
         default_confidence=0.0,
     )
 
-    # channel 0 -> class id 0 ("a"); a blanket +1 would wrongly yield 1 (background)
     assert torch.all(results[0].segmentation_map == 0)
 
 

--- a/inference_models/tests/unit_tests/models/test_yolo26_semantic_segmentation.py
+++ b/inference_models/tests/unit_tests/models/test_yolo26_semantic_segmentation.py
@@ -180,6 +180,33 @@ def test_post_process_semantic_segmentation_logits_binary_sub_threshold_to_backg
     assert torch.all(results[0].confidence == 0.0)
 
 
+def test_post_process_semantic_segmentation_logits_maps_channels_when_background_not_first():
+    """K foreground channels with background NOT at index 0: channel j maps to
+    the j-th non-background class id, not a blanket +1."""
+    from inference_models.models.common.roboflow.post_processing import (
+        post_process_semantic_segmentation_logits,
+    )
+
+    # class_names: a=0, background=1, b=2, c=3 -> foreground ids [0, 2, 3]
+    h, w, num_channels = 6, 6, 3
+    logits = torch.zeros(1, num_channels, h, w)
+    logits[0, 0] = 5.0  # channel 0 dominant -> first foreground class -> "a" (id 0)
+
+    results = post_process_semantic_segmentation_logits(
+        model_results=logits,
+        pre_processing_meta=_binary_meta(h, w),
+        class_names=["a", "background", "b", "c"],
+        background_class_id=1,
+        device=torch.device("cpu"),
+        confidence=0.0,
+        recommended_parameters=None,
+        default_confidence=0.0,
+    )
+
+    # channel 0 -> class id 0 ("a"); a blanket +1 would wrongly yield 1 (background)
+    assert torch.all(results[0].segmentation_map == 0)
+
+
 def test_yolo26_semantic_segmentation_registered():
     from inference_models.models.auto_loaders.entities import BackendType
     from inference_models.models.auto_loaders.models_registry import (

--- a/requirements/requirements.cpu.txt
+++ b/requirements/requirements.cpu.txt
@@ -1,3 +1,3 @@
 onnxruntime>=1.15.1,<1.22.0
 nvidia-ml-py<13.0.0
-inference-models[torch-cpu,onnx-cpu]~=0.29.0rc3  # keep in sync between requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt
+inference-models[torch-cpu,onnx-cpu]~=0.29.0  # keep in sync between requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt

--- a/requirements/requirements.gpu.txt
+++ b/requirements/requirements.gpu.txt
@@ -1,2 +1,2 @@
 onnxruntime-gpu>=1.15.1,<1.22.0
-inference-models[torch-cu124,onnx-cu12]~=0.29.0rc3 # keep in sync between requirements.jetson requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt
+inference-models[torch-cu124,onnx-cu12]~=0.29.0 # keep in sync between requirements.jetson requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt

--- a/requirements/requirements.jetson.txt
+++ b/requirements/requirements.jetson.txt
@@ -1,4 +1,4 @@
 pypdfium2>=4.11.0,<5.0.0
 jupyterlab>=4.3.0,<5.0.0
 PyYAML~=6.0.0
-inference-models~=0.29.0rc3  # keep in sync between requirements.jetson requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt
+inference-models~=0.29.0  # keep in sync between requirements.jetson requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt

--- a/requirements/requirements.vino.txt
+++ b/requirements/requirements.vino.txt
@@ -1,2 +1,2 @@
 onnxruntime-openvino>=1.15.0,<1.22.0
-inference-models[torch-cpu]~=0.29.0rc3  # keep in sync between requirements.jetson requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt
+inference-models[torch-cpu]~=0.29.0  # keep in sync between requirements.jetson requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt


### PR DESCRIPTION
## What does this PR do?

Makes fine-tuned YOLO26 semantic-segmentation models work end-to-end on the inference server, and handle the special binary head for yolo26-sem models trained with only 1 foreground class.

1. **Core registry** (`inference/models/utils.py`): `ROBOFLOW_MODEL_TYPES` registered only the family key `("semantic-segmentation", "yolo26")`, which pretrained/public models match — but fine-tuned versioned models report their ORT `modelType` (`"yolo26n-sem"`, …) with no variant→family normalization, raising `ModelNotRecognisedError`. Now registers the family alias **plus every trained variant** (mirrors the YOLOLite registration).

2. **Binary (`nc==1`) post-process**: a single-foreground-class model trains as Ultralytics' native binary head → one output channel, where `softmax` is degenerate (≡1.0). The single-channel case now uses the **sigmoid foreground probability**; sub-threshold pixels collapse to background. Shared by ONNX/TorchScript/TRT; the multi-channel path (DeepLab + multiclass) only triggers on `shape[0] == 1`, so it's untouched.

3. **Class-name handling** moved into `common/roboflow/semantic_segmentation.py` (shared by the DeepLabV3+ and YOLO26-sem backends):
   - `validate_class_names` — load-time precondition that a semantic-seg package declares `background` + ≥1 foreground class (≥2 names), raising `CorruptedModelPackageError` instead of failing silently.
   - `resolve_background_class_id` — pure lookup on a validated package.
   - `insert_background_class` — maps foreground channel indices back into the full class-index space, correct for a **non-zero** `background` id (replaces an incorrect `+1` shift).

## Type of Change

- Bug fix (non-breaking change that fixes an issue)
- New feature (non-breaking change that adds functionality)
- Refactoring (no functional changes)

## Testing

- [x] I have tested this change locally
- [x] I have added/updated tests for this change

- [x] Local inference workflow in staging with fine-tuned binary and multi-class yolo26-sem models (trained via https://github.com/roboflow/roboflow-train/pull/807)

<img width="1419" height="1220" alt="image" src="https://github.com/user-attachments/assets/d72fa148-0381-4905-82e3-3e419a72e97d" />
<img width="1419" height="1220" alt="image" src="https://github.com/user-attachments/assets/8f1d6d24-e440-4bdb-adbd-fca0d5563675" />

- [x] Deeplab semantic seg inference still works

<img width="1419" height="1220" alt="image" src="https://github.com/user-attachments/assets/709c47a7-98d5-4748-a66f-5f572847eefd" />



## Additional Context

Builds on #2372 (YOLO26-sem ONNX/TorchScript/TRT backends, now on `main`). `post_process_semantic_segmentation_logits` stays in `post_processing.py` (it's a post-processor); only the class-name validation/resolution helpers moved out of the generic `model_packages.py`.
