### PR TITLE
Nk/add volume support

### DIFF
--- a/docs/inference_helpers/cli_commands/server.md
+++ b/docs/inference_helpers/cli_commands/server.md
@@ -37,6 +37,22 @@ in case that values of internal parameters needs to be adjusted. Any value passe
 is considered as more important and will shadow the value defined in `.env` file under the same target variable name.
 
 
+### Volume Mounts
+
+Use the `--volume` (or `-v`) flag to mount a host directory into the container. This is useful for persisting files written by workflows (e.g. via the `local_file_sink` block) to your local machine.
+
+```bash
+inference server start --volume /host/path:/container/path
+```
+
+You can mount multiple volumes by repeating the flag:
+
+```bash
+inference server start --volume /host/data:/data --volume /host/models:/models:ro
+```
+
+The optional `:ro` suffix mounts the volume as read-only. If omitted, the volume is mounted read-write.
+
 ### Development Mode
 
 Use the `--dev` flag to start the Inference Server in development mode. Development mode enables the Inference Server's built in notebook environment for easy testing and development.

--- a/inference_cli/lib/container_adapter.py
+++ b/inference_cli/lib/container_adapter.py
@@ -212,6 +212,7 @@ def start_inference_container(
     env_file_path: Optional[str] = None,
     development: bool = False,
     use_local_images: bool = False,
+    volumes: Optional[Dict[str, dict]] = None,
 ) -> None:
     containers = find_running_inference_containers()
     if len(containers) > 0:
@@ -279,7 +280,7 @@ def start_inference_container(
             else None
         ),
         read_only=not is_jetson,
-        volumes={"/tmp": {"bind": "/tmp", "mode": "rw"}},
+        volumes={"/tmp": {"bind": "/tmp", "mode": "rw"}, **(volumes or {})},
         network_mode="bridge",
         ipc_mode="private" if not is_jetson else None,
         **docker_run_kwargs,

--- a/inference_cli/server.py
+++ b/inference_cli/server.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import List, Optional
 
 import typer
 from typing_extensions import Annotated
@@ -87,6 +87,14 @@ def start(
             help="Flag controlling if metrics are enabled (default is True)",
         ),
     ] = True,
+    volumes: Annotated[
+        Optional[List[str]],
+        typer.Option(
+            "--volume",
+            "-v",
+            help="Volume mount in the format /host/path:/container/path[:ro]. Can be specified multiple times.",
+        ),
+    ] = None,
 ) -> None:
 
     try:
@@ -94,6 +102,16 @@ def start(
     except Exception as docker_error:
         typer.echo(docker_error)
         raise typer.Exit(code=1) from docker_error
+
+    parsed_volumes = {}
+    for v in volumes or []:
+        parts = v.split(":")
+        if len(parts) < 2:
+            typer.echo(f"Invalid volume format: {v}. Expected /host/path:/container/path[:ro]")
+            raise typer.Exit(code=1)
+        host_path, container_path = parts[0], parts[1]
+        mode = parts[2] if len(parts) == 3 else "rw"
+        parsed_volumes[host_path] = {"bind": container_path, "mode": mode}
 
     try:
         start_inference_container(
@@ -105,6 +123,7 @@ def start(
             api_key=api_key,
             use_local_images=use_local_images,
             metrics_enabled=metrics_enabled,
+            volumes=parsed_volumes or None,
         )
     except Exception as container_error:
         typer.echo(container_error)

--- a/inference_cli/server.py
+++ b/inference_cli/server.py
@@ -107,7 +107,9 @@ def start(
     for v in volumes or []:
         parts = v.split(":")
         if len(parts) < 2:
-            typer.echo(f"Invalid volume format: {v}. Expected /host/path:/container/path[:ro]")
+            typer.echo(
+                f"Invalid volume format: {v}. Expected /host/path:/container/path[:ro]"
+            )
             raise typer.Exit(code=1)
         host_path, container_path = parts[0], parts[1]
         mode = parts[2] if len(parts) == 3 else "rw"

--- a/tests/inference_cli/unit_tests/test_container_adapter.py
+++ b/tests/inference_cli/unit_tests/test_container_adapter.py
@@ -1,8 +1,11 @@
 from unittest import mock
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 
 from inference_cli.lib import container_adapter
-from inference_cli.lib.container_adapter import prepare_container_environment
+from inference_cli.lib.container_adapter import (
+    prepare_container_environment,
+    start_inference_container,
+)
 
 
 @mock.patch.object(container_adapter, "read_env_file")
@@ -41,6 +44,47 @@ def test_prepare_container_environment_when_env_file_defined(
         ]
     )
     read_env_file_mock.assert_called_once_with(path="my_env_file")
+
+
+@mock.patch.object(container_adapter, "pull_image")
+@mock.patch.object(container_adapter, "find_running_inference_containers", return_value=[])
+@mock.patch.object(container_adapter, "docker")
+def test_start_inference_container_default_tmp_volume_always_present(
+    docker_mock: MagicMock,
+    _find_containers_mock: MagicMock,
+    _pull_image_mock: MagicMock,
+) -> None:
+    # when
+    start_inference_container(image="roboflow/roboflow-inference-server-cpu:latest")
+
+    # then
+    _, kwargs = docker_mock.from_env.return_value.containers.run.call_args
+    assert "/tmp" in kwargs["volumes"]
+    assert kwargs["volumes"]["/tmp"] == {"bind": "/tmp", "mode": "rw"}
+
+
+@mock.patch.object(container_adapter, "pull_image")
+@mock.patch.object(container_adapter, "find_running_inference_containers", return_value=[])
+@mock.patch.object(container_adapter, "docker")
+def test_start_inference_container_user_volumes_merged_with_tmp(
+    docker_mock: MagicMock,
+    _find_containers_mock: MagicMock,
+    _pull_image_mock: MagicMock,
+) -> None:
+    # given
+    user_volumes = {"/home/user/data": {"bind": "/data", "mode": "rw"}}
+
+    # when
+    start_inference_container(
+        image="roboflow/roboflow-inference-server-cpu:latest",
+        volumes=user_volumes,
+    )
+
+    # then
+    _, kwargs = docker_mock.from_env.return_value.containers.run.call_args
+    assert "/tmp" in kwargs["volumes"]
+    assert "/home/user/data" in kwargs["volumes"]
+    assert kwargs["volumes"]["/home/user/data"] == {"bind": "/data", "mode": "rw"}
 
 
 def test_prepare_container_environment_when_env_file_not_defined() -> None:

--- a/tests/inference_cli/unit_tests/test_container_adapter.py
+++ b/tests/inference_cli/unit_tests/test_container_adapter.py
@@ -47,7 +47,9 @@ def test_prepare_container_environment_when_env_file_defined(
 
 
 @mock.patch.object(container_adapter, "pull_image")
-@mock.patch.object(container_adapter, "find_running_inference_containers", return_value=[])
+@mock.patch.object(
+    container_adapter, "find_running_inference_containers", return_value=[]
+)
 @mock.patch.object(container_adapter, "docker")
 def test_start_inference_container_default_tmp_volume_always_present(
     docker_mock: MagicMock,
@@ -64,7 +66,9 @@ def test_start_inference_container_default_tmp_volume_always_present(
 
 
 @mock.patch.object(container_adapter, "pull_image")
-@mock.patch.object(container_adapter, "find_running_inference_containers", return_value=[])
+@mock.patch.object(
+    container_adapter, "find_running_inference_containers", return_value=[]
+)
 @mock.patch.object(container_adapter, "docker")
 def test_start_inference_container_user_volumes_merged_with_tmp(
     docker_mock: MagicMock,

--- a/tests/inference_cli/unit_tests/test_container_adapter.py
+++ b/tests/inference_cli/unit_tests/test_container_adapter.py
@@ -1,5 +1,5 @@
 from unittest import mock
-from unittest.mock import MagicMock, call
+from unittest.mock import MagicMock
 
 from inference_cli.lib import container_adapter
 from inference_cli.lib.container_adapter import (


### PR DESCRIPTION
## What does this PR do?
Adding an option to bind mount a local volume to the inference server. This was only possible through running the docker run command manually prior to this. The option exists now for creating the inference server throug both the CLI and Python.  

<!-- Provide a clear and concise description of the changes -->

**Related Issue(s):** <!-- Link to related issues, e.g., Fixes #123 or Related to #456 -->
Stems from a feature I wanted when building my demo project
## Type of Change

<!-- Please select one and delete the others, or describe if Other -->

- New feature (non-breaking change that adds functionality)

## Testing

<!-- Describe how you tested your changes -->

- [✅ ] I have tested this change locally
- [✅ ] I have added/updated tests for this change

**Test details:**
<!-- Describe what tests were added/updated and what they cover -->
The tests verify that the hardcoded /tmp volume is always present in the container regardless of what the user passes, and that any user-supplied volumes are merged in alongside it correctly. 

## Checklist

- [ ✅] My code follows the style guidelines of this project
- [✅ ] I have performed a self-review of my own code
- [ ✅] I have commented my code where necessary, particularly in hard-to-understand areas
- [ ✅] My changes generate no new warnings or errors
- [ ✅] I have updated the documentation accordingly (if applicable)
