### PR TITLE
[codex] Enable SAM3 3D and embed_image routes on serverless

### DIFF
--- a/inference/core/interfaces/http/http_api.py
+++ b/inference/core/interfaces/http/http_api.py
@@ -190,6 +190,7 @@ from inference.core.env import (
     ROBOFLOW_INTERNAL_SERVICE_NAME,
     ROBOFLOW_INTERNAL_SERVICE_SECRET,
     ROBOFLOW_SERVICE_SECRET,
+    SAM3_3D_OBJECTS_ENABLED,
     SAM3_EXEC_MODE,
     SAM3_FINE_TUNED_MODELS_ENABLED,
     STRUCTURED_API_LOGGING,
@@ -3240,7 +3241,7 @@ class HttpInterface(BaseInterface):
                         )
                     return model_response
 
-            if CORE_MODEL_SAM3_ENABLED and not GCP_SERVERLESS:
+            if CORE_MODEL_SAM3_ENABLED:
 
                 @app.post(
                     "/sam3/embed_image",
@@ -3511,7 +3512,7 @@ class HttpInterface(BaseInterface):
                     )
                     return model_response
 
-            if CORE_MODEL_SAM3_ENABLED and not GCP_SERVERLESS:
+            if SAM3_3D_OBJECTS_ENABLED:
 
                 @app.post(
                     "/sam3_3d/infer",

--- a/tests/inference/unit_tests/core/interfaces/http/test_http_api.py
+++ b/tests/inference/unit_tests/core/interfaces/http/test_http_api.py
@@ -40,6 +40,10 @@ def _make_inference_request() -> dict:
     }
 
 
+def _route_paths(interface):
+    return {route.path for route in interface.app.routes}
+
+
 def _build_serverless_interface(
     monkeypatch,
     usage_check_result,
@@ -121,6 +125,69 @@ def _build_dedicated_deployment_interface(
     model_manager.infer_from_request_sync.return_value = _DummyResponse()
     interface = http_api.HttpInterface(model_manager=model_manager)
     return interface, model_manager, workspace_lookup_mock
+
+
+def test_serverless_registers_sam3_routes_when_model_flags_are_enabled(
+    monkeypatch,
+) -> None:
+    import inference.core.interfaces.http.http_api as http_api
+
+    monkeypatch.setattr(http_api, "CORE_MODEL_SAM3_ENABLED", True)
+    monkeypatch.setattr(http_api, "SAM3_3D_OBJECTS_ENABLED", True)
+    interface, _, _, _ = _build_serverless_interface(
+        monkeypatch=monkeypatch,
+        usage_check_result=ServerlessUsageCheckResponse(
+            status_code=200,
+            workspace_id="rf-inference-benchmark",
+            under_cap=True,
+        ),
+    )
+
+    paths = _route_paths(interface)
+    assert "/sam3/embed_image" in paths
+    assert "/sam3_3d/infer" in paths
+
+
+def test_serverless_sam3_3d_route_only_depends_on_sam3_3d_flag(
+    monkeypatch,
+) -> None:
+    import inference.core.interfaces.http.http_api as http_api
+
+    monkeypatch.setattr(http_api, "CORE_MODEL_SAM3_ENABLED", False)
+    monkeypatch.setattr(http_api, "SAM3_3D_OBJECTS_ENABLED", True)
+    interface, _, _, _ = _build_serverless_interface(
+        monkeypatch=monkeypatch,
+        usage_check_result=ServerlessUsageCheckResponse(
+            status_code=200,
+            workspace_id="rf-inference-benchmark",
+            under_cap=True,
+        ),
+    )
+
+    paths = _route_paths(interface)
+    assert "/sam3/embed_image" not in paths
+    assert "/sam3_3d/infer" in paths
+
+
+def test_serverless_does_not_register_sam3_3d_route_when_sam3_3d_flag_is_disabled(
+    monkeypatch,
+) -> None:
+    import inference.core.interfaces.http.http_api as http_api
+
+    monkeypatch.setattr(http_api, "CORE_MODEL_SAM3_ENABLED", True)
+    monkeypatch.setattr(http_api, "SAM3_3D_OBJECTS_ENABLED", False)
+    interface, _, _, _ = _build_serverless_interface(
+        monkeypatch=monkeypatch,
+        usage_check_result=ServerlessUsageCheckResponse(
+            status_code=200,
+            workspace_id="rf-inference-benchmark",
+            under_cap=True,
+        ),
+    )
+
+    paths = _route_paths(interface)
+    assert "/sam3/embed_image" in paths
+    assert "/sam3_3d/infer" not in paths
 
 
 def test_infer_lmm_with_model_id_uses_alias_registry_key(monkeypatch) -> None:


### PR DESCRIPTION
## What changed

- Allow `POST /sam3/embed_image` to register whenever `CORE_MODEL_SAM3_ENABLED=True`, including GCP serverless deployments.
- Allow `POST /sam3_3d/infer` to register based solely on `SAM3_3D_OBJECTS_ENABLED=True` instead of the base SAM3 flag or `GCP_SERVERLESS`.
- Add route-registration regression tests for the serverless SAM3 and SAM3 3D gates.

## Why

SAM3 Embed and SAM3 3D Objects already have model-specific env flags, but the HTTP routes were still blocked on GCP serverless. This prevented testing those endpoints on serverless even when the deployment explicitly enabled the model flag.

## Validation

- `python -m py_compile inference/core/interfaces/http/http_api.py tests/inference/unit_tests/core/interfaces/http/test_http_api.py`
- `git diff --check`

Could not run targeted pytest locally because the active Python environment does not have `pytest` installed: `No module named pytest`.