### PR TITLE
feat(workflows): enable "best" confidence for semantic segmentation

### DIFF
--- a/inference/core/entities/requests/inference.py
+++ b/inference/core/entities/requests/inference.py
@@ -264,25 +264,12 @@ class SemanticSegmentationInferenceRequest(CVInferenceRequest):
 
     confidence: Confidence = Field(
         default=0.4,
-        examples=[0.5, "default"],
+        examples=[0.5, "best", "default"],
         description=(
-            '"default" uses the model built-in threshold, or pass a float. '
-            '"best" (model-eval threshold) is not supported for semantic '
-            "segmentation yet."
+            'Confidence threshold. "best" uses model-eval thresholds, '
+            '"default" uses the model built-in, or pass a float.'
         ),
     )
-
-    # TODO: drop this validator once model eval supports semantic segmentation.
-    @field_validator("confidence", mode="before")
-    @classmethod
-    def _reject_best_confidence(cls, value: Any) -> Any:
-        if value == "best":
-            raise ValueError(
-                'confidence="best" is not supported for semantic segmentation '
-                "— model eval does not yet produce per-class thresholds for "
-                'this task. Use a float or "default".'
-            )
-        return value
 
 
 class ClassificationInferenceRequest(CVInferenceRequest):

--- a/inference/core/workflows/core_steps/models/roboflow/semantic_segmentation/v2.py
+++ b/inference/core/workflows/core_steps/models/roboflow/semantic_segmentation/v2.py
@@ -86,16 +86,19 @@ class BlockManifest(WorkflowBlockManifest):
     type: Literal["roboflow_core/roboflow_semantic_segmentation_model@v2"]
     images: Selector(kind=[IMAGE_KIND]) = ImageInputField
     model_id: Union[Selector(kind=[ROBOFLOW_MODEL_ID_KIND]), str] = RoboflowModelField
-    # TODO: add "best" option once model eval supports semantic segmentation.
     confidence_mode: Union[
-        Literal["default", "custom"],
+        Literal["best", "default", "custom"],
         Selector(kind=[STRING_KIND]),
     ] = Field(
-        default="default",
+        default="best",
         description="How confidence thresholds are determined.",
         json_schema_extra={
             "always_visible": True,
             "values_metadata": {
+                "best": {
+                    "name": "Best (Recommended)",
+                    "description": "Use F1-optimal thresholds from model evaluation.",
+                },
                 "default": {
                     "name": "Default",
                     "description": "Use the model's built-in default threshold.",
@@ -200,7 +203,7 @@ class RoboflowSemanticSegmentationModelBlockV2(WorkflowBlock):
         self,
         images: Batch[WorkflowImageData],
         model_id: str,
-        confidence: Union[None, float, Literal["default"]],
+        confidence: Union[None, float, Literal["best", "default"]],
     ) -> BlockResult:
         inference_images = [i.to_inference_format(numpy_preferred=True) for i in images]
         request = SemanticSegmentationInferenceRequest(
@@ -228,7 +231,7 @@ class RoboflowSemanticSegmentationModelBlockV2(WorkflowBlock):
         self,
         images: Batch[WorkflowImageData],
         model_id: str,
-        confidence: Union[None, float, Literal["default"]],
+        confidence: Union[None, float, Literal["best", "default"]],
     ) -> BlockResult:
         api_url = (
             LOCAL_INFERENCE_API_URL

--- a/tests/inference/unit_tests/core/interfaces/http/test_legacy_http_route_accepts_confidence_modes.py
+++ b/tests/inference/unit_tests/core/interfaces/http/test_legacy_http_route_accepts_confidence_modes.py
@@ -53,15 +53,14 @@ def _build_interface(monkeypatch, task_type: str):
 
 # task_type -> set of confidence values the corresponding request entity is
 # expected to accept. "best"/"default" are the two non-float modes v3 blocks
-# can serialize; semseg and keypoint-detection reject "best" via field
-# validators because model eval doesn't yet produce thresholds for those
-# tasks.
+# can serialize; keypoint-detection rejects "best" via a field validator
+# because model eval doesn't yet produce thresholds for that task.
 _ACCEPTED_CONFIDENCE_MODES = {
     "object-detection": ["best", "default", 0.5],
     "instance-segmentation": ["best", "default", 0.5],
     "keypoint-detection": ["default", 0.5],
     "classification": ["best", "default", 0.5],
-    "semantic-segmentation": ["default", 0.5],
+    "semantic-segmentation": ["best", "default", 0.5],
 }
 
 
@@ -99,7 +98,7 @@ def test_legacy_route_accepts_confidence_mode(
 
 @pytest.mark.parametrize(
     "task_type",
-    ["semantic-segmentation", "keypoint-detection"],
+    ["keypoint-detection"],
 )
 def test_legacy_route_rejects_best_confidence_for_unsupported_tasks(
     monkeypatch,

--- a/tests/workflows/unit_tests/core_steps/models/roboflow/semantic_segmentation/test_v2.py
+++ b/tests/workflows/unit_tests/core_steps/models/roboflow/semantic_segmentation/test_v2.py
@@ -120,22 +120,6 @@ def test_semantic_segmentation_model_validation_when_custom_mode_missing_custom_
         _ = BlockManifest.model_validate(data)
 
 
-def test_semantic_segmentation_model_defaults_to_best_confidence_mode() -> None:
-    # given
-    data = {
-        "type": "roboflow_core/roboflow_semantic_segmentation_model@v2",
-        "name": "some",
-        "images": "$inputs.image",
-        "model_id": "some/1",
-    }
-
-    # when
-    result = BlockManifest.model_validate(data)
-
-    # then
-    assert result.confidence_mode == "best"
-
-
 def test_semantic_segmentation_model_validation_accepts_best_confidence_mode() -> None:
     # model eval now produces thresholds for semantic segmentation, so "best"
     # is an accepted confidence mode (matching object detection / instance seg).

--- a/tests/workflows/unit_tests/core_steps/models/roboflow/semantic_segmentation/test_v2.py
+++ b/tests/workflows/unit_tests/core_steps/models/roboflow/semantic_segmentation/test_v2.py
@@ -120,9 +120,25 @@ def test_semantic_segmentation_model_validation_when_custom_mode_missing_custom_
         _ = BlockManifest.model_validate(data)
 
 
-def test_semantic_segmentation_model_validation_rejects_best_confidence_mode() -> None:
-    # "best" is not offered for semantic segmentation since model eval does
-    # not yet produce thresholds for this task.
+def test_semantic_segmentation_model_defaults_to_best_confidence_mode() -> None:
+    # given
+    data = {
+        "type": "roboflow_core/roboflow_semantic_segmentation_model@v2",
+        "name": "some",
+        "images": "$inputs.image",
+        "model_id": "some/1",
+    }
+
+    # when
+    result = BlockManifest.model_validate(data)
+
+    # then
+    assert result.confidence_mode == "best"
+
+
+def test_semantic_segmentation_model_validation_accepts_best_confidence_mode() -> None:
+    # model eval now produces thresholds for semantic segmentation, so "best"
+    # is an accepted confidence mode (matching object detection / instance seg).
     data = {
         "type": "roboflow_core/roboflow_semantic_segmentation_model@v2",
         "name": "some",
@@ -131,8 +147,11 @@ def test_semantic_segmentation_model_validation_rejects_best_confidence_mode() -
         "confidence_mode": "best",
     }
 
-    with pytest.raises(ValidationError):
-        _ = BlockManifest.model_validate(data)
+    # when
+    result = BlockManifest.model_validate(data)
+
+    # then
+    assert result.confidence_mode == "best"
 
 
 # --- _convert_to_sv_detections tests ---


### PR DESCRIPTION
## What does this PR do?

Allow "best" confidence for semantic segmentation inference now that model-eval supports it (https://github.com/roboflow/model_eval/pull/161), and make it the new default for the semantic seg model workflow block, matching other supported model blocks.

**Related Issue(s):** _n/a_

## Type of Change

- New feature (non-breaking change that adds functionality)

## Testing

- [x] I have tested this change locally
- [x] I have added/updated tests for this change

**Test details:**

- [x] Updated unit tests
- [x] Tested workflow in staging with local inference server
<img width="1904" height="1245" alt="image" src="https://github.com/user-attachments/assets/ec448ca3-552e-4d4e-af84-68bb25461478" />
<img width="1904" height="1245" alt="image" src="https://github.com/user-attachments/assets/09150eeb-5b05-4f51-b89e-f160c2376ca5" />


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [ ] I have updated the documentation accordingly (if applicable)

## Additional Context
