### PR TITLE
fix(workflows): shift oriented bounding box corners in `detections_stitch`

### DIFF
--- a/inference/core/workflows/core_steps/fusion/detections_stitch/v1.py
+++ b/inference/core/workflows/core_steps/fusion/detections_stitch/v1.py
@@ -5,6 +5,7 @@ import numpy as np
 import supervision as sv
 from pydantic import ConfigDict, Field
 from supervision import OverlapFilter, move_boxes, move_masks
+from supervision.config import ORIENTED_BOX_COORDINATES
 
 from inference.core.workflows.core_steps.common.utils import (
     attach_parents_coordinates_to_sv_detections,
@@ -261,15 +262,25 @@ def move_detections(
     resolution_wh: Optional[Tuple[int, int]],
 ) -> sv.Detections:
     """
-    Copied from: https://github.com/roboflow/supervision/blob/5123085037ec594524fc8f9d9b71b1cd9f487e8d/supervision/detection/tools/inference_slicer.py#L17-L16
-    to avoid fragile contract with supervision, as this function is not element of public
-    API.
+    Shift detections by ``offset``, keeping every geometry field consistent:
+    axis-aligned boxes, segmentation masks, and oriented-box corners.
+
+    Mirrors ``supervision.detection.tools.inference_slicer.move_detections``;
+    kept local since that helper is not part of supervision's public API.
     """
     if len(detections) == 0:
         return detections
     if offset is None:
         raise ValueError("To move non-empty detections offset is needed, but not given")
     detections.xyxy = move_boxes(xyxy=detections.xyxy, offset=offset)
+    if ORIENTED_BOX_COORDINATES in detections.data:
+        # OBB corners live in `data["xyxyxyxy"]` with shape (N, 4, 2); broadcast
+        # `offset` (shape (2,)) over the trailing axis to translate each (x, y).
+        # Without this, downstream OBB-aware NMS/NMM compares corners in
+        # tile-local coords against `xyxy` already moved to image coords.
+        detections.data[ORIENTED_BOX_COORDINATES] = (
+            detections.data[ORIENTED_BOX_COORDINATES] + offset
+        )
     if detections.mask is not None:
         if resolution_wh is None:
             raise ValueError(

--- a/tests/workflows/unit_tests/core_steps/fusion/test_detections_stitch.py
+++ b/tests/workflows/unit_tests/core_steps/fusion/test_detections_stitch.py
@@ -3,6 +3,7 @@ from typing import Union
 import numpy as np
 import pytest
 import supervision as sv
+from supervision.config import ORIENTED_BOX_COORDINATES
 
 from inference.core.workflows.core_steps.fusion.detections_stitch.v1 import (
     BlockManifest,
@@ -477,3 +478,49 @@ def test_detections_stitch_missing_parent_coordinates_error() -> None:
 
     # then
     assert "parent_coordinates" in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    "parent_offset",
+    [
+        pytest.param((250, 300), id="positive-offset"),
+        pytest.param((0, 0), id="zero-offset"),
+        pytest.param((100, 0), id="x-only-offset"),
+    ],
+)
+def test_detections_stitch_shifts_oriented_bounding_box_corners(
+    parent_offset: tuple,
+) -> None:
+    """OBB corners stored in `data['xyxyxyxy']` must follow the same offset
+    applied to `xyxy`; without that, stitched OBB detections carry an AABB
+    in image coords next to corners still in tile-local coords, which breaks
+    downstream OBB-aware NMS / NMM."""
+    # given
+    block = DetectionsStitchBlockV1()
+    reference_image = make_test_image(width=1000, height=1000)
+    tile_corners = np.array(
+        [[[25.0, 50.0], [50.0, 25.0], [75.0, 50.0], [50.0, 75.0]]],
+        dtype=np.float32,
+    )
+    detections = make_test_detections(
+        boxes=np.array([[25.0, 25.0, 75.0, 75.0]], dtype=np.float32),
+        parent_offset=parent_offset,
+        parent_dims=(1000, 1000),
+    )
+    detections.data[ORIENTED_BOX_COORDINATES] = tile_corners
+
+    # when
+    result = block.run(
+        reference_image=reference_image,
+        predictions=[detections],
+        overlap_filtering_strategy="none",
+        iou_threshold=0.3,
+    )
+
+    # then
+    merged = result["predictions"]
+    dx, dy = parent_offset
+    expected_xyxy = np.array([[25 + dx, 25 + dy, 75 + dx, 75 + dy]], dtype=np.float32)
+    expected_corners = tile_corners + np.array([dx, dy], dtype=np.float32)
+    assert np.allclose(merged.xyxy, expected_xyxy)
+    assert np.allclose(merged.data[ORIENTED_BOX_COORDINATES], expected_corners)


### PR DESCRIPTION
## What does this PR do?

The block's local copy of `move_detections` shifts `xyxy` and `mask` by the per-tile offset but leaves `data["xyxyxyxy"]` (the four OBB corners) in tile-local coordinates. SAHI workflows that produce oriented bounding boxes end up with detections whose AABB sits in image coordinates while the corners are still indexed to the tile they were detected in, so downstream OBB-aware filters (`with_nms` / `with_nmm` via `OverlapFilter`) compare corners across unrelated coordinate systems - either letting through duplicates or suppressing valid detections.

The fix is a single broadcasted addition inside `move_detections`. `supervision.detection.tools.inference_slicer.move_detections` already does the equivalent; the local copy just had not kept up since it was forked.

## Type of Change

- Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] I have tested this change locally
- [x] I have added/updated tests for this change

**Test details:**

One parametric test in `tests/workflows/unit_tests/core_steps/fusion/test_detections_stitch.py`:

- `test_detections_stitch_shifts_oriented_bounding_box_corners` - three offsets (positive, zero, x-only) - asserts that both `xyxy` and `data["xyxyxyxy"]` end up shifted by the same amount.

Fails on `main`. Existing stitch tests are unchanged.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [ ] I have updated the documentation accordingly (if applicable)