### PR TITLE
Support scheme-qualified SECURE_GATEWAY URLs

### DIFF
--- a/inference/core/env.py
+++ b/inference/core/env.py
@@ -406,6 +406,8 @@ LEGACY_ROUTE_ENABLED = str2bool(os.getenv("LEGACY_ROUTE_ENABLED", True))
 
 # Secure gateway address for air-gapped deployments.
 # Accepts SECURE_GATEWAY (preferred) or LICENSE_SERVER (legacy).
+# May be a bare host[:port] (proxied over http, legacy behaviour) or
+# scheme-qualified, e.g. https://gateway.local, for TLS gateways.
 _legacy_license_server = os.getenv("LICENSE_SERVER")
 SECURE_GATEWAY = os.getenv("SECURE_GATEWAY") or _legacy_license_server or None
 if _legacy_license_server and not os.getenv("SECURE_GATEWAY"):

--- a/inference/core/utils/url_utils.py
+++ b/inference/core/utils/url_utils.py
@@ -6,6 +6,11 @@ from inference.core.env import SECURE_GATEWAY
 def wrap_url(url: str) -> str:
     if not SECURE_GATEWAY:
         return url
-    return f"http://{SECURE_GATEWAY}/proxy?url=" + urllib.parse.quote(
-        url, safe="~()*!'"
-    )
+    # The secure gateway serves TLS on 443 by default, so SECURE_GATEWAY may
+    # be scheme-qualified (https://gateway.local). Bare host[:port] values
+    # keep the historical http:// behaviour for legacy license servers.
+    if "://" in SECURE_GATEWAY:
+        gateway_base = SECURE_GATEWAY.rstrip("/")
+    else:
+        gateway_base = f"http://{SECURE_GATEWAY}"
+    return f"{gateway_base}/proxy?url=" + urllib.parse.quote(url, safe="~()*!'")

--- a/tests/inference/unit_tests/core/utils/test_url_utils.py
+++ b/tests/inference/unit_tests/core/utils/test_url_utils.py
@@ -31,3 +31,34 @@ def test_wrap_url_when_secure_gateway_is_not_provided() -> None:
 
     # then
     assert result == original_url
+
+
+@mock.patch.object(url_utils, "SECURE_GATEWAY", "https://gateway.local")
+def test_wrap_url_when_secure_gateway_is_scheme_qualified() -> None:
+    # given
+    original_url = "https://detection.roboflow.com/eye-detection/1?api_key=X"
+
+    # when
+    result = wrap_url(url=original_url)
+
+    # then
+    assert (
+        result
+        == "https://gateway.local/proxy?url=https%3A%2F%2Fdetection.roboflow.com%2Feye-detection%2F1%3Fapi_key%3DX"
+    )
+    assert parse_qs(urlparse(result).query)["url"][0] == original_url
+
+
+@mock.patch.object(url_utils, "SECURE_GATEWAY", "https://gateway.local/")
+def test_wrap_url_when_scheme_qualified_secure_gateway_has_trailing_slash() -> None:
+    # given
+    original_url = "https://detection.roboflow.com/eye-detection/1?api_key=X"
+
+    # when
+    result = wrap_url(url=original_url)
+
+    # then
+    assert (
+        result
+        == "https://gateway.local/proxy?url=https%3A%2F%2Fdetection.roboflow.com%2Feye-detection%2F1%3Fapi_key%3DX"
+    )


### PR DESCRIPTION
## Description

`wrap_url()` unconditionally prefixes `SECURE_GATEWAY` with `http://`, so a gateway that terminates TLS is unusable — every proxied request dials plaintext at a TLS listener.

`SECURE_GATEWAY` now accepts a scheme-qualified URL (e.g. `SECURE_GATEWAY=https://gateway.local`), used as-is with any trailing slash trimmed. Bare `host[:port]` values keep the `http://` prefix, so existing deployments (including legacy `LICENSE_SERVER`) are unchanged.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested

- `tests/inference/unit_tests/core/utils/test_url_utils.py`: added scheme-qualified and trailing-slash cases; all pass.

## Any specific deployment considerations

None — behaviour changes only when `SECURE_GATEWAY` carries a scheme.