### PR TITLE
fix(workflows): translate oriented bounding box corners in `dynamic_crop`

### DIFF
--- a/inference/core/workflows/core_steps/transformations/dynamic_crop/v1.py
+++ b/inference/core/workflows/core_steps/transformations/dynamic_crop/v1.py
@@ -5,6 +5,7 @@ import cv2
 import numpy as np
 import supervision as sv
 from pydantic import AliasChoices, ConfigDict, Field
+from supervision.config import ORIENTED_BOX_COORDINATES
 
 from inference.core.workflows.execution_engine.constants import (
     DETECTION_ID_KEY,
@@ -255,6 +256,14 @@ def crop_image(
         if POLYGON_KEY_IN_SV_DETECTIONS in detections.data:
             translated_detection[POLYGON_KEY_IN_SV_DETECTIONS] = selected_detection[
                 POLYGON_KEY_IN_SV_DETECTIONS
+            ] - np.array([x_min, y_min])
+        if ORIENTED_BOX_COORDINATES in detections.data:
+            # OBB corners (shape (1, 4, 2) on a single-detection slice) get the
+            # same crop-local offset applied to xyxy / keypoints / polygon. Without
+            # this, OBB-aware downstream blocks see corners in the original image
+            # frame next to a crop-local xyxy.
+            translated_detection[ORIENTED_BOX_COORDINATES] = selected_detection[
+                ORIENTED_BOX_COORDINATES
             ] - np.array([x_min, y_min])
 
         crops.append(

--- a/tests/workflows/unit_tests/core_steps/transformations/test_crop.py
+++ b/tests/workflows/unit_tests/core_steps/transformations/test_crop.py
@@ -5,6 +5,7 @@ import numpy as np
 import pytest
 import supervision as sv
 from pydantic import ValidationError
+from supervision.config import ORIENTED_BOX_COORDINATES
 
 from inference.core.workflows.core_steps.transformations.dynamic_crop.v1 import (
     BlockManifest,
@@ -450,3 +451,68 @@ def test_crop_image_when_background_removal_requested_and_mask_found() -> None:
     assert (
         result[2]["crops"].numpy_image == expected_third_crop
     ).all(), "Image must have expected size and color"
+
+
+@pytest.mark.parametrize(
+    "crop_offset",
+    [
+        pytest.param((250, 300), id="interior-crop"),
+        pytest.param((0, 0), id="top-left-crop"),
+        pytest.param((100, 0), id="x-only-crop"),
+    ],
+)
+def test_crop_image_translates_oriented_bounding_box_corners(
+    crop_offset: Tuple[int, int],
+) -> None:
+    """OBB corners stored in `data['xyxyxyxy']` must follow the same `-(x_min, y_min)`
+    translation already applied to `xyxy`, `mask`, `keypoints`, and `polygon`.
+    Without this, downstream OBB-aware blocks would see corners in the original
+    image frame next to a crop-local `xyxy`."""
+    # given
+    x_min, y_min = crop_offset
+    side = 40
+    np_image = np.zeros((1000, 1000, 3), dtype=np.uint8)
+    image = WorkflowImageData(
+        parent_metadata=ImageParentMetadata(parent_id="origin_image"),
+        numpy_image=np_image,
+    )
+    # OBB centered inside the crop region, rotated 45-deg (diamond corners).
+    image_corners = np.array(
+        [
+            [
+                [x_min + side / 2, y_min],
+                [x_min + side, y_min + side / 2],
+                [x_min + side / 2, y_min + side],
+                [x_min, y_min + side / 2],
+            ]
+        ],
+        dtype=np.float32,
+    )
+    detections = sv.Detections(
+        xyxy=np.array([[x_min, y_min, x_min + side, y_min + side]], dtype=np.float64),
+        class_id=np.array([0]),
+        confidence=np.array([0.9], dtype=np.float64),
+        data={
+            "detection_id": np.array(["one"]),
+            "class_name": np.array(["thing"]),
+            ORIENTED_BOX_COORDINATES: image_corners,
+        },
+    )
+
+    # when
+    result = crop_image(
+        image=image,
+        detections=detections,
+        mask_opacity=0.0,
+        background_color=(0, 0, 0),
+    )
+
+    # then
+    assert len(result) == 1
+    translated = result[0]["predictions"]
+    expected_corners = image_corners - np.array([x_min, y_min], dtype=np.float32)
+    assert np.allclose(translated.data[ORIENTED_BOX_COORDINATES], expected_corners)
+    # Cross-check: AABB of the translated corners sits inside [0, side]^2.
+    translated_corners = translated.data[ORIENTED_BOX_COORDINATES][0]
+    assert translated_corners.min() >= 0.0
+    assert translated_corners.max() <= side


### PR DESCRIPTION
## What does this PR do?

`crop_image` in `dynamic_crop` translates every other detection geometry to the crop-local frame - `xyxy` via `move_boxes`, `mask` via slicing, `keypoints` and `polygon` via explicit `- (x_min, y_min)` - but skips `data["xyxyxyxy"]`. OBB workflows that fed the block ended up with each crop's `xyxy` correctly in crop-local coordinates while the oriented corners still pointed into the original image frame.

The fix mirrors the translation already applied to `keypoints` and `polygon` a few lines above - subtract `(x_min, y_min)` from each OBB corner - gated on `ORIENTED_BOX_COORDINATES` being present. Same class of bug as #2427 in `detections_stitch`.

## Type of Change

- Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] I have tested this change locally
- [x] I have added/updated tests for this change

**Test details:**

One parametric test in `tests/workflows/unit_tests/core_steps/transformations/test_crop.py`:

- `test_crop_image_translates_oriented_bounding_box_corners` - three crop offsets (interior, top-left, x-only) - asserts the translated corners equal `image_corners - (x_min, y_min)` and land inside the crop bounds.

Fails on `main`. Existing `test_crop` cases are unchanged.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [ ] I have updated the documentation accordingly (if applicable)
