### PR TITLE
docs(sam3): document exemplar and PVS prompting

### DIFF
--- a/docs/foundation/sam3.md
+++ b/docs/foundation/sam3.md
@@ -3,8 +3,9 @@
 [Segment Anything 3 (SAM 3)](https://ai.meta.com/sam3) is a unified foundation model for promptable segmentation in images and videos. It builds upon SAM 2 by introducing the ability to exhaustively segment all instances of an open-vocabulary concept specified by a short text phrase or exemplars.
 
 SAM 3 can detect, segment, and track objects using:
-- **Text prompts** (e.g., "a person", "red car")
-- **Visual prompts** (boxes, points)
+- **Text prompts** (e.g., "a person", "red car") — segment every instance of a concept
+- **Exemplar box prompts** — box one example object and segment every similar instance, optionally combined with text and with negative exemplars to exclude lookalikes
+- **Interactive visual prompts** (points, boxes) — segment one specific object, SAM 2 style
 
 ## How to Use SAM 3 with Inference
 
@@ -43,10 +44,29 @@ model = SegmentAnything3(model_id="sam3/sam3_final")
 image_path = "path/to/your/image.jpg"
 
 # Define prompts
-# SAM 3 supports both text and visual prompts
+# SAM 3 supports text prompts, exemplar box prompts, and combinations of both
 prompts = [
+    # Text prompt: segment every instance of a concept
     Sam3Prompt(type="text", text="person"),
-    Sam3Prompt(type="text", text="car")
+    # Exemplar prompt: box one example object (absolute pixels, top-left
+    # anchored XYWH) and segment every similar instance in the image.
+    # box_labels is required: 1 = positive exemplar, 0 = negative exemplar.
+    Sam3Prompt(
+        type="visual",
+        boxes=[Sam3Prompt.Box(x=1409, y=705, width=112, height=183)],
+        box_labels=[1],
+    ),
+    # Combined prompt: text narrowed by exemplars. Here the negative
+    # exemplar suppresses instances similar to the second box.
+    Sam3Prompt(
+        type="visual",
+        text="car",
+        boxes=[
+            Sam3Prompt.BoxXYXY(x0=100, y0=200, x1=300, y1=400),
+            Sam3Prompt.BoxXYXY(x0=500, y0=200, x1=700, y1=400),
+        ],
+        box_labels=[1, 0],
+    ),
 ]
 
 # Run inference
@@ -106,9 +126,9 @@ SAM 3 exposes two main modes via API:
 docker run -it --rm -p 9001:9001 --gpus=all roboflow/inference-server:latest
 ```
 
-#### 2. Concept Segmentation (Text Prompts)
+#### 2. Concept Segmentation (Text and Exemplar Prompts)
 
-This is the most common usage for SAM 3, allowing you to segment objects by text description.
+This is the most common usage for SAM 3, allowing you to segment all instances of a concept. Concepts can be described by text:
 
 ```bash
 curl -X POST 'http://localhost:9001/sam3/concept_segment?api_key=<YOUR_API_KEY>' \
@@ -121,6 +141,30 @@ curl -X POST 'http://localhost:9001/sam3/concept_segment?api_key=<YOUR_API_KEY>'
     "prompts": [
         { "type": "text", "text": "cat" },
         { "type": "text", "text": "dog" }
+    ]
+  }'
+```
+
+Concepts can also be described by exemplar boxes — box one example object and SAM 3 segments every similar instance. Boxes use absolute pixel coordinates, either top-left anchored XYWH (`{"x", "y", "width", "height"}`) or corner form (`{"x0", "y0", "x1", "y1"}`). `box_labels` is required alongside `boxes`: `1` marks a positive exemplar, `0` a negative exemplar to exclude lookalikes. Text and exemplars can be combined in one prompt:
+
+```bash
+curl -X POST 'http://localhost:9001/sam3/concept_segment?api_key=<YOUR_API_KEY>' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "image": {
+      "type": "url",
+      "value": "https://media.roboflow.com/inference/sample.jpg"
+    },
+    "prompts": [
+        {
+          "type": "visual",
+          "text": "dog",
+          "boxes": [
+            { "x": 100, "y": 200, "width": 150, "height": 120 },
+            { "x0": 400, "y0": 200, "x1": 550, "y1": 320 }
+          ],
+          "box_labels": [1, 0]
+        }
     ]
   }'
 ```
@@ -143,7 +187,7 @@ curl -X POST 'http://localhost:9001/sam3/embed_image?api_key=<YOUR_API_KEY>' \
 # Returns an "image_id"
 ```
 
-**Step 2: Segment with Points**
+**Step 2: Segment with Points and/or a Box**
 
 ```bash
 curl -X POST 'http://localhost:9001/sam3/visual_segment?api_key=<YOUR_API_KEY>' \
@@ -151,10 +195,18 @@ curl -X POST 'http://localhost:9001/sam3/visual_segment?api_key=<YOUR_API_KEY>' 
   -d '{
     "image_id": "<IMAGE_ID_FROM_STEP_1>",
     "prompts": [
-      { "points": [ { "x": 100, "y": 100, "positive": true } ] }
-    ]
+      {
+        "points": [ { "x": 100, "y": 100, "positive": true } ],
+        "box": { "x": 100, "y": 100, "width": 200, "height": 150 }
+      }
+    ],
+    "multimask_output": false
   }'
 ```
+
+A prompt can contain `points`, a `box`, or both. Positive points include the clicked region; negative points (`"positive": false`) exclude it — add points to iteratively refine the mask. Note that the PVS `box` is **center-anchored** XYWH (`x`, `y` is the box center), unlike concept segmentation boxes which are top-left anchored.
+
+The response contains the single highest-confidence mask for the prompt: `multimask_output` controls how many internal mask proposals the model generates (three when `true`), but the best proposal is always selected for the response. Send one prompt per request — multiple prompts in one request currently return only one prediction.
 
 ## Workflow Integration
 
@@ -253,7 +305,41 @@ cv.waitKey(0)
 cv.destroyAllWindows()
 ```
 
-### 2. SAM3 raw API
+### 2. SAM3 via the Inference SDK
+
+The `inference-sdk` client wraps both SAM3 endpoints. Prompt dicts take the same shape as the HTTP payloads, so text, exemplar, and combined prompts all work:
+
+```python
+from inference_sdk import InferenceHTTPClient
+
+client = InferenceHTTPClient(
+    api_url="https://serverless.roboflow.com",
+    api_key="<YOUR_ROBOFLOW_API_KEY>",
+)
+
+# Concept segmentation: text, exemplar boxes, or both per prompt
+result = client.sam3_concept_segment(
+    inference_input="https://media.roboflow.com/inference/people-walking.jpg",
+    prompts=[
+        {"type": "text", "text": "person"},
+        {
+            "type": "visual",
+            "boxes": [{"x": 1409, "y": 705, "width": 112, "height": 183}],
+            "box_labels": [1],
+        },
+    ],
+    output_prob_thresh=0.5,
+)
+
+# Interactive visual segmentation: points and/or a center-anchored box
+result = client.sam3_visual_segment(
+    inference_input="https://media.roboflow.com/inference/people-walking.jpg",
+    prompts=[{"points": [{"x": 1465, "y": 796, "positive": True}]}],
+    multimask_output=False,
+)
+```
+
+### 3. SAM3 raw API
 
 For direct API access to SAM3 without workflows, you can use Roboflow's serverless endpoint.
 This approach gives you raw segmentation results that you can process however you need.

--- a/inference/core/entities/requests/sam3.py
+++ b/inference/core/entities/requests/sam3.py
@@ -16,9 +16,14 @@ class Sam3Prompt(BaseModel):
     """
 
     type: Optional[str] = Field(
-        default=None, description="Optional hint: 'text' or 'visual'"
+        default=None,
+        description="Optional hint: 'text' or 'visual'. 'visual' requires at least one box.",
     )
-    text: Optional[str] = Field(default=None)
+    text: Optional[str] = Field(
+        default=None,
+        description="Concept to segment as a short noun phrase (e.g. 'person'). "
+        "All matching instances are returned. Can be combined with exemplar boxes in the same prompt.",
+    )
 
     output_prob_thresh: Optional[float] = Field(
         default=None,
@@ -43,10 +48,18 @@ class Sam3Prompt(BaseModel):
     # Single unified boxes field; each entry can be XYWH or XYXY
     boxes: Optional[List[Union[Box, BoxXYXY]]] = Field(
         default=None,
-        description="Absolute pixel boxes as either XYWH or XYXY entries",
+        description="Exemplar boxes in absolute pixels, as XYWH entries "
+        "({x, y, width, height}, top-left anchored) or XYXY entries ({x0, y0, x1, y1}). "
+        "Each box marks an example object; the model segments every instance matching "
+        "the exemplars (and text, if provided), not just the boxed objects. "
+        "Requires box_labels.",
     )
     box_labels: Optional[List[Union[int, bool]]] = Field(
-        default=None, description="List of 0/1 or booleans for boxes"
+        default=None,
+        description="Per-box exemplar labels, one per entry in boxes: "
+        "1/true marks a positive exemplar (segment objects like this), "
+        "0/false marks a negative exemplar (exclude objects like this). "
+        "Required when boxes is set.",
     )
 
     @validator("boxes", always=True)


### PR DESCRIPTION
## What does this PR do?

Documents SAM3 prompting types that already work but were undocumented, in response to the common complaint that our SAM3 endpoints are text-only (Slack: https://roboflow.slack.com/archives/C08QA59S0F5/p1781049083091209):

- `docs/foundation/sam3.md`: exemplar box prompts and combined text+exemplar examples for the SDK, HTTP API, and `inference_sdk` client; fleshed-out PVS section (points + center-anchored box, best-mask-only response, one-prompt-per-request caveat).
- `inference/core/entities/requests/sam3.py`: richer `Field(description=...)` strings on `Sam3Prompt.type/text/boxes/box_labels`. Description-only change; these feed the OpenAPI schema that docs.roboflow.com embeds.

**Related Issue(s):** n/a (Slack thread above)

## Type of Change

- Documentation update

## Testing

- [x] I have tested this change locally
- [ ] I have added/updated tests for this change

**Test details:**
- Every documented payload was run live against `serverless.roboflow.com` (exemplar generalization, negative exemplars, XYXY/XYWH equivalence, PVS point and point+box, 16-prompt batch limit).
- `pytest tests/inference/unit_tests/models/test_sam3.py` → 20 passed (entity description edits are behavior-neutral).

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)

## Additional Context

Found during verification (filed separately, not addressed here): /sam3/visual_segment with multiple prompts returns only one prediction; visual prompts with `boxes` but no `box_labels` return HTTP 500. Companion product-docs PR updates docs.roboflow.com.

🤖 Generated with [Claude Code](https://claude.com/claude-code)