### PR TITLE
Add Claude Fable 5 workflow model

### DIFF
--- a/inference/core/workflows/core_steps/models/foundation/anthropic_claude/v1.py
+++ b/inference/core/workflows/core_steps/models/foundation/anthropic_claude/v1.py
@@ -165,6 +165,7 @@ class BlockManifest(WorkflowBlockManifest):
     model_version: Union[
         Selector(kind=[STRING_KIND]),
         Literal[
+            "claude-fable-5",
             "claude-opus-4-7",
             "claude-opus-4-6",
             "claude-sonnet-4-6",
@@ -376,6 +377,7 @@ def execute_claude_requests(
 
 
 EXACT_MODELS_VERSIONS_MAPPING = {
+    "claude-fable-5": "claude-fable-5",
     "claude-opus-4-7": "claude-opus-4-7",
     "claude-opus-4-6": "claude-opus-4-6",
     "claude-sonnet-4-6": "claude-sonnet-4-6",

--- a/inference/core/workflows/core_steps/models/foundation/anthropic_claude/v2.py
+++ b/inference/core/workflows/core_steps/models/foundation/anthropic_claude/v2.py
@@ -38,6 +38,12 @@ from inference.core.workflows.prototypes.block import (
 
 CLAUDE_MODELS = [
     {
+        "id": "claude-fable-5",
+        "name": "Claude Fable 5",
+        "exact_version": "claude-fable-5",
+        "max_output_tokens": 128000,
+    },
+    {
         "id": "claude-opus-4-7",
         "name": "Claude Opus 4.7",
         "exact_version": "claude-opus-4-7",

--- a/inference/core/workflows/core_steps/models/foundation/anthropic_claude/v3.py
+++ b/inference/core/workflows/core_steps/models/foundation/anthropic_claude/v3.py
@@ -41,6 +41,12 @@ from inference.core.workflows.prototypes.block import (
 
 CLAUDE_MODELS = [
     {
+        "id": "claude-fable-5",
+        "name": "Claude Fable 5",
+        "exact_version": "claude-fable-5",
+        "max_output_tokens": 128000,
+    },
+    {
         "id": "claude-opus-4-7",
         "name": "Claude Opus 4.7",
         "exact_version": "claude-opus-4-7",

--- a/tests/workflows/unit_tests/core_steps/models/foundation/test_anthropic_claude.py
+++ b/tests/workflows/unit_tests/core_steps/models/foundation/test_anthropic_claude.py
@@ -11,6 +11,10 @@ from inference.core.workflows.core_steps.models.foundation.anthropic_claude.v2 i
     BlockManifest,
     execute_claude_request,
 )
+from inference.core.workflows.core_steps.models.foundation.anthropic_claude.v3 import (
+    EXACT_MODEL_VERSIONS as EXACT_MODEL_VERSIONS_V3,
+    MAX_OUTPUT_TOKENS as MAX_OUTPUT_TOKENS_V3,
+)
 
 
 def test_claude_step_validation_when_input_is_valid() -> None:
@@ -74,6 +78,7 @@ def test_claude_step_validation_when_prompt_is_given_directly() -> None:
 @pytest.mark.parametrize(
     "model_version",
     [
+        "claude-fable-5",
         "claude-opus-4-7",
         "claude-sonnet-4-5",
         "claude-haiku-4-5",
@@ -337,6 +342,7 @@ def test_claude_step_validation_with_structured_answering() -> None:
 
 def test_max_output_tokens_mapping() -> None:
     # then - verify all models have max_output_tokens defined
+    assert MAX_OUTPUT_TOKENS["claude-fable-5"] == 128000
     assert MAX_OUTPUT_TOKENS["claude-opus-4-7"] == 128000
     assert MAX_OUTPUT_TOKENS["claude-sonnet-4-5"] == 64000
     assert MAX_OUTPUT_TOKENS["claude-haiku-4-5"] == 64000
@@ -349,6 +355,7 @@ def test_max_output_tokens_mapping() -> None:
 
 def test_exact_model_versions_mapping() -> None:
     # then - verify all models have exact versions defined
+    assert EXACT_MODEL_VERSIONS["claude-fable-5"] == "claude-fable-5"
     assert EXACT_MODEL_VERSIONS["claude-opus-4-7"] == "claude-opus-4-7"
     assert EXACT_MODEL_VERSIONS["claude-sonnet-4-5"] == "claude-sonnet-4-5-20250929"
     assert EXACT_MODEL_VERSIONS["claude-haiku-4-5"] == "claude-haiku-4-5-20251001"
@@ -356,6 +363,12 @@ def test_exact_model_versions_mapping() -> None:
     assert EXACT_MODEL_VERSIONS["claude-sonnet-4"] == "claude-sonnet-4-20250514"
     assert EXACT_MODEL_VERSIONS["claude-opus-4-1"] == "claude-opus-4-1-20250805"
     assert EXACT_MODEL_VERSIONS["claude-opus-4"] == "claude-opus-4-20250514"
+
+
+def test_v3_claude_fable_model_metadata() -> None:
+    # then
+    assert MAX_OUTPUT_TOKENS_V3["claude-fable-5"] == 128000
+    assert EXACT_MODEL_VERSIONS_V3["claude-fable-5"] == "claude-fable-5"
 
 
 @patch(


### PR DESCRIPTION
## Summary
- add Claude Fable 5 to the Anthropic Claude workflow block model lists
- map Claude Fable 5 to its exact Anthropic model ID
- add unit metadata coverage for the new model

## Verification
- python3 -m py_compile inference/core/workflows/core_steps/models/foundation/anthropic_claude/v1.py inference/core/workflows/core_steps/models/foundation/anthropic_claude/v2.py inference/core/workflows/core_steps/models/foundation/anthropic_claude/v3.py tests/workflows/unit_tests/core_steps/models/foundation/test_anthropic_claude.py
- Targeted pytest not run locally: pytest is not installed in python3, .venv, venv, or uv run