### PR TITLE
feat: dynamic micro-batching for VLM generate paths (off by default) + GPU image inference_models fix

### DIFF
--- a/docker/dockerfiles/Dockerfile.onnx.gpu
+++ b/docker/dockerfiles/Dockerfile.onnx.gpu
@@ -108,6 +108,11 @@ COPY examples/notebooks .
 
 WORKDIR /app/
 COPY inference inference
+# Overwrite the PyPI-installed inference_models content with the repo source.
+# The builder stage installs inference_models DEPENDENCIES from the repo's
+# uv.lock, but the package content itself resolved from the registry — repo
+# changes to inference_models/ never shipped without this line.
+COPY inference_models/inference_models /usr/local/lib/python3.10/dist-packages/inference_models
 COPY docker/config/gpu_http.py gpu_http.py
 COPY docker/entrypoint/run_uvicorn.sh /usr/local/bin/run_uvicorn.sh
 RUN chmod +x /usr/local/bin/run_uvicorn.sh

--- a/inference/core/env.py
+++ b/inference/core/env.py
@@ -1008,6 +1008,14 @@ HTTP_API_SHARED_WORKFLOWS_THREAD_POOL_WORKERS = int(
     os.getenv("HTTP_API_SHARED_WORKFLOWS_THREAD_POOL_WORKERS", "16")
 )
 
+# Size of the anyio thread pool serving synchronous HTTP handlers.
+# Default is None, which leaves the anyio default (40 threads) untouched.
+HTTP_API_THREADPOOL_WORKERS = os.getenv("HTTP_API_THREADPOOL_WORKERS")
+if HTTP_API_THREADPOOL_WORKERS:
+    HTTP_API_THREADPOOL_WORKERS = int(HTTP_API_THREADPOOL_WORKERS)
+else:
+    HTTP_API_THREADPOOL_WORKERS = None
+
 # Workflow block filtering configuration
 # Comma-separated list of block type categories to disable (e.g., "sink,model")
 WORKFLOW_DISABLED_BLOCK_TYPES = os.getenv("WORKFLOW_DISABLED_BLOCK_TYPES", "")

--- a/inference/core/interfaces/http/http_api.py
+++ b/inference/core/interfaces/http/http_api.py
@@ -172,6 +172,7 @@ from inference.core.env import (
     GET_MODEL_REGISTRY_ENABLED,
     HTTP_API_SHARED_WORKFLOWS_THREAD_POOL_ENABLED,
     HTTP_API_SHARED_WORKFLOWS_THREAD_POOL_WORKERS,
+    HTTP_API_THREADPOOL_WORKERS,
     INFERENCE_MODELS_CACHE_WATCHDOG_INTERVAL_MINUTES,
     LAMBDA,
     LEGACY_ROUTE_ENABLED,
@@ -2529,6 +2530,20 @@ class HttpInterface(BaseInterface):
                 )
                 startup_thread.start()
                 logger.info("Model initialization started in the background.")
+
+        if HTTP_API_THREADPOOL_WORKERS:
+
+            @app.on_event("startup")
+            async def adjust_http_threadpool_size():
+                """Resize the anyio thread pool serving sync HTTP handlers."""
+                import anyio.to_thread
+
+                limiter = anyio.to_thread.current_default_thread_limiter()
+                limiter.total_tokens = HTTP_API_THREADPOOL_WORKERS
+                logger.info(
+                    "HTTP API thread pool resized to %s threads",
+                    HTTP_API_THREADPOOL_WORKERS,
+                )
 
         # Attach health/readiness endpoints
         @app.get("/readiness", status_code=200)

--- a/inference_models/inference_models/configuration.py
+++ b/inference_models/inference_models/configuration.py
@@ -146,6 +146,24 @@ INFERENCE_MODELS_DEFAULT_SKIP_SPECIAL_TOKENS = get_boolean_from_env(
     default=False,
 )
 
+# Dynamic micro-batching of concurrent generation requests for HF VLM models
+INFERENCE_MODELS_DYNAMIC_BATCHING_ENABLED = get_boolean_from_env(
+    variable_name="INFERENCE_MODELS_DYNAMIC_BATCHING_ENABLED",
+    default=False,
+)
+INFERENCE_MODELS_DYNAMIC_BATCH_MAX_SIZE = get_integer_from_env(
+    variable_name="INFERENCE_MODELS_DYNAMIC_BATCH_MAX_SIZE",
+    default=8,
+)
+INFERENCE_MODELS_DYNAMIC_BATCH_MAX_WAIT_MS = get_integer_from_env(
+    variable_name="INFERENCE_MODELS_DYNAMIC_BATCH_MAX_WAIT_MS",
+    default=30,
+)
+INFERENCE_MODELS_DYNAMIC_BATCH_RESULT_TIMEOUT_S = get_integer_from_env(
+    variable_name="INFERENCE_MODELS_DYNAMIC_BATCH_RESULT_TIMEOUT_S",
+    default=120,
+)
+
 
 # Model-specific parameters defaults
 INFERENCE_MODELS_DEEP_LAB_V3_PLUS_DEFAULT_CONFIDENCE = get_float_from_env(

--- a/inference_models/inference_models/models/common/dynamic_batching.py
+++ b/inference_models/inference_models/models/common/dynamic_batching.py
@@ -1,0 +1,544 @@
+"""
+Dynamic micro-batching for HF VLM wrappers.
+
+Each VLM HF wrapper serializes inference with a `threading.Lock` around
+`self._model.generate(...)`. Under concurrent HTTP traffic all requests for
+the same model queue on that lock and run one-by-one. The `DynamicBatcher`
+defined here lets concurrent requests for the same model instance run as a
+single batched `generate()` call, while keeping the per-request surface
+(inputs in, trimmed new-token tensor out) unchanged.
+
+The feature is opt-in via `INFERENCE_MODELS_DYNAMIC_BATCHING_ENABLED` - when
+the flag is off, wrappers keep the existing lock-serialized path and no
+batcher thread is ever created.
+"""
+
+import inspect
+import queue
+import time
+import weakref
+from concurrent.futures import Future
+from dataclasses import dataclass, field
+from threading import Lock, Thread
+from typing import Callable, Dict, List, Optional, Sequence, Tuple
+
+import torch
+
+from inference_models import configuration
+from inference_models.logger import LOGGER
+
+
+class InputsCollationError(Exception):
+    pass
+
+
+@dataclass
+class _PendingRequest:
+    inputs: dict
+    gen_kwargs: dict
+    future: Future
+    enqueued_at: float = field(default_factory=time.monotonic)
+
+    @property
+    def rows(self) -> int:
+        return self.inputs["input_ids"].shape[0]
+
+
+class DynamicBatcher:
+    """
+    Per-model-instance dynamic micro-batcher.
+
+    Requests are enqueued by `submit(...)` and consumed by a single daemon
+    thread. The thread blocks for the first request, then keeps collecting
+    requests until `max_batch_size` is reached or `max_wait_ms` elapsed.
+    Collected requests are grouped by generation-parameter signature
+    (everything except `max_new_tokens`) - requests with different sampling
+    parameters never share a batch. Each group is collated into one batched
+    `generate()` call running at `max(max_new_tokens)`; per-request outputs
+    are then split back, trimmed to the request's own `max_new_tokens` and
+    stripped of trailing padding so the output contract matches the
+    single-request path exactly.
+
+    `runner` and `collate_inputs` are injected callables, which keeps the
+    batching loop unit-testable without real torch models:
+    * `runner(inputs, gen_kwargs)` must return the trimmed new-token tensor
+      (the `generation[:, input_len:]` equivalent) - with left-padding the
+      padded input length is uniform across the batch, so the existing slice
+      semantics of the wrappers carry over.
+    * `collate_inputs(inputs_list)` must combine per-request inputs into one
+      batch (see `collate_left_padded_inputs`).
+
+    Failure isolation: if collation or the batched generation fails, every
+    member of the group is re-run serially, so only genuinely-bad requests
+    receive the exception.
+
+    Bound-method callables are held through weak references, so the batcher
+    thread never keeps an evicted model wrapper (and its weights) alive - it
+    exits once the owning wrapper is garbage-collected.
+    """
+
+    # How often the idle batcher thread checks whether its owner still exists.
+    _IDLE_LIVENESS_INTERVAL_S = 10.0
+
+    def __init__(
+        self,
+        runner: Callable[[dict, dict], torch.Tensor],
+        collate_inputs: Callable[[List[dict]], dict],
+        max_batch_size: int,
+        max_wait_ms: float,
+        result_timeout_s: float,
+        pad_token_id: Optional[int] = None,
+        eos_token_id: Optional[int] = None,
+        name: str = "model",
+    ):
+        self._runner_ref = _make_callable_ref(runner)
+        self._collate_inputs_ref = _make_callable_ref(collate_inputs)
+        self._max_batch_size = max(int(max_batch_size), 1)
+        self._max_wait_s = max(float(max_wait_ms), 0.0) / 1000
+        self._result_timeout_s = result_timeout_s
+        self._pad_token_id = pad_token_id
+        self._eos_token_id = eos_token_id
+        self._name = name
+        self._queue: "queue.SimpleQueue[_PendingRequest]" = queue.SimpleQueue()
+        self.stats: Dict[str, int] = {
+            "batches": 0,
+            "requests": 0,
+            "batched_requests": 0,
+            "serial_fallbacks": 0,
+            "max_batch_size_seen": 0,
+        }
+        self._thread = Thread(
+            target=self._batching_loop,
+            name=f"{name}-dynamic-batcher",
+            daemon=True,
+        )
+        self._thread.start()
+
+    def submit(self, inputs: dict, gen_kwargs: dict) -> torch.Tensor:
+        future: Future = Future()
+        self._queue.put(
+            _PendingRequest(inputs=inputs, gen_kwargs=gen_kwargs, future=future)
+        )
+        return future.result(timeout=self._result_timeout_s)
+
+    def _batching_loop(self) -> None:
+        while True:
+            try:
+                try:
+                    first_request = self._queue.get(
+                        timeout=self._IDLE_LIVENESS_INTERVAL_S
+                    )
+                except queue.Empty:
+                    # As long as anyone waits in `submit(...)`, the owning
+                    # wrapper is referenced through the submitter's stack -
+                    # an empty queue with a dead owner means the model got
+                    # evicted and this thread can exit.
+                    if self._runner_ref() is None:
+                        LOGGER.debug(
+                            "Dynamic batcher (%s): owning model released - "
+                            "exiting batching loop",
+                            self._name,
+                        )
+                        return None
+                    continue
+                self._process_batch(first_request=first_request)
+            except Exception:
+                # The batcher thread must never die while its model lives -
+                # any error which is not handled by group execution is logged
+                # and the loop continues with the next batch.
+                LOGGER.exception(
+                    "Dynamic batcher (%s): unexpected error in batching loop",
+                    self._name,
+                )
+
+    def _process_batch(self, first_request: _PendingRequest) -> None:
+        requests = [first_request]
+        deadline = time.monotonic() + self._max_wait_s
+        while len(requests) < self._max_batch_size:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            try:
+                requests.append(self._queue.get(timeout=remaining))
+            except queue.Empty:
+                break
+        now = time.monotonic()
+        max_queue_wait_ms = max(
+            (now - request.enqueued_at) * 1000 for request in requests
+        )
+        groups = self._group_by_generation_signature(requests=requests)
+        self.stats["requests"] += len(requests)
+        self.stats["max_batch_size_seen"] = max(
+            self.stats["max_batch_size_seen"], len(requests)
+        )
+        LOGGER.debug(
+            "Dynamic batcher (%s): collected %d request(s) in %d signature "
+            "group(s); max queue wait: %.1fms",
+            self._name,
+            len(requests),
+            len(groups),
+            max_queue_wait_ms,
+        )
+        for group in groups:
+            self._execute_group_safely(group=group)
+
+    @staticmethod
+    def _group_by_generation_signature(
+        requests: List[_PendingRequest],
+    ) -> List[List[_PendingRequest]]:
+        groups: Dict[tuple, List[_PendingRequest]] = {}
+        for request in requests:
+            signature = _generation_signature(gen_kwargs=request.gen_kwargs)
+            groups.setdefault(signature, []).append(request)
+        return list(groups.values())
+
+    def _execute_group_safely(self, group: List[_PendingRequest]) -> None:
+        try:
+            if len(group) == 1:
+                self._execute_single(request=group[0])
+            else:
+                self._execute_batched(group=group)
+        except Exception as error:
+            # Last-resort safety net - no waiter may ever be left hanging.
+            for request in group:
+                if not request.future.done():
+                    request.future.set_exception(error)
+
+    def _execute_single(self, request: _PendingRequest) -> None:
+        self.stats["batches"] += 1
+        try:
+            result = self._resolve_callable(reference=self._runner_ref)(
+                request.inputs, request.gen_kwargs
+            )
+        except Exception as error:
+            _handle_potential_cuda_oom(error=error)
+            request.future.set_exception(error)
+        else:
+            request.future.set_result(result)
+
+    def _execute_batched(self, group: List[_PendingRequest]) -> None:
+        self.stats["batches"] += 1
+        try:
+            collated_inputs = self._resolve_callable(
+                reference=self._collate_inputs_ref
+            )([request.inputs for request in group])
+            merged_gen_kwargs = _merge_gen_kwargs(group=group)
+            output = self._resolve_callable(reference=self._runner_ref)(
+                collated_inputs, merged_gen_kwargs
+            )
+            self.stats["batched_requests"] += len(group)
+            self._dispatch_batched_output(group=group, output=output)
+        except Exception as error:
+            _handle_potential_cuda_oom(error=error)
+            LOGGER.warning(
+                "Dynamic batcher (%s): batched generation of %d request(s) "
+                "failed (%s) - retrying each request serially",
+                self._name,
+                len(group),
+                error,
+            )
+            self.stats["serial_fallbacks"] += 1
+            self._run_serially(group=group)
+
+    def _dispatch_batched_output(
+        self, group: List[_PendingRequest], output: torch.Tensor
+    ) -> None:
+        expected_rows = sum(request.rows for request in group)
+        if output.shape[0] != expected_rows:
+            raise InputsCollationError(
+                f"Batched generation returned {output.shape[0]} row(s), but "
+                f"{expected_rows} row(s) were expected"
+            )
+        start = 0
+        for request in group:
+            request_output = output[start : start + request.rows]
+            start += request.rows
+            max_new_tokens = request.gen_kwargs.get("max_new_tokens")
+            if isinstance(max_new_tokens, int):
+                request_output = request_output[:, :max_new_tokens]
+            request_output = strip_trailing_padding(
+                generated_ids=request_output,
+                pad_token_id=self._pad_token_id,
+                eos_token_id=self._eos_token_id,
+            )
+            request.future.set_result(request_output)
+
+    def _run_serially(self, group: List[_PendingRequest]) -> None:
+        for request in group:
+            if request.future.done():
+                continue
+            self._execute_single(request=request)
+
+    @staticmethod
+    def _resolve_callable(reference: Callable[[], Optional[Callable]]) -> Callable:
+        resolved = reference()
+        if resolved is None:
+            raise RuntimeError(
+                "Model wrapper owning the dynamic batcher was released"
+            )
+        return resolved
+
+
+def _make_callable_ref(target: Callable) -> Callable[[], Optional[Callable]]:
+    # Bound methods are held weakly, so the batcher thread does not keep an
+    # evicted model wrapper alive. Plain callables (functions, lambdas, test
+    # doubles) are held strongly - a weak reference to them would die at once.
+    if inspect.ismethod(target):
+        return weakref.WeakMethod(target)
+    return lambda: target
+
+
+def _generation_signature(gen_kwargs: dict) -> tuple:
+    # `max_new_tokens` is excluded from the signature - requests with
+    # different limits can share a batch (the batch runs at the max limit and
+    # each output is trimmed back). Everything else (do_sample, num_beams,
+    # temperature, ...) changes generation semantics and must not be mixed.
+    # A `None` limit cannot be merged with `max(...)`, so it stays part of
+    # the signature and only batches with identical requests.
+    return tuple(
+        sorted(
+            (key, repr(value))
+            for key, value in gen_kwargs.items()
+            if key != "max_new_tokens" or value is None
+        )
+    )
+
+
+def _merge_gen_kwargs(group: List[_PendingRequest]) -> dict:
+    merged = dict(group[0].gen_kwargs)
+    limits = [request.gen_kwargs.get("max_new_tokens") for request in group]
+    if all(isinstance(limit, int) for limit in limits):
+        merged["max_new_tokens"] = max(limits)
+    return merged
+
+
+def _handle_potential_cuda_oom(error: Exception) -> None:
+    if not isinstance(error, torch.cuda.OutOfMemoryError):
+        return None
+    try:
+        torch.cuda.empty_cache()
+    except Exception:
+        pass
+
+
+def strip_trailing_padding(
+    generated_ids: torch.Tensor,
+    pad_token_id: Optional[int],
+    eos_token_id: Optional[int] = None,
+) -> torch.Tensor:
+    """
+    Removes trailing all-padding columns from a single request's output.
+
+    In a batched `generate()`, sequences which finish early get padded up to
+    the longest sequence of the batch. A non-batched call only pads up to the
+    longest sequence of the request, so trailing padding shared by all rows
+    of the request is stripped to match the single-request output exactly.
+    """
+    if pad_token_id is None or generated_ids.numel() == 0:
+        return generated_ids
+    total_columns = generated_ids.shape[1]
+    non_pad = generated_ids != pad_token_id
+    column_numbers = torch.arange(
+        1, total_columns + 1, device=generated_ids.device
+    )
+    keep_length = int((non_pad.long() * column_numbers).max().item())
+    if (
+        eos_token_id is not None
+        and eos_token_id == pad_token_id
+        and keep_length < total_columns
+    ):
+        # When PAD and EOS share the same token id, a finished sequence ends
+        # with one terminating EOS - keep it, as non-batched generation would.
+        keep_length += 1
+    keep_length = max(keep_length, 1)
+    return generated_ids[:, :keep_length]
+
+
+def collate_left_padded_inputs(
+    inputs_list: List[dict],
+    pad_token_id: Optional[int],
+    cat_keys: Sequence[str] = (),
+    frame_pad_keys: Sequence[str] = (),
+) -> dict:
+    """
+    Default collate for decoder-only VLMs: left-pads `input_ids` with
+    `pad_token_id` (extending `attention_mask` with zeros accordingly) and
+    concatenates per-request image tensors on dim 0.
+
+    * `cat_keys` - tensors concatenated on dim 0 as-is (e.g. qwen-family
+      `pixel_values` rows are flattened patches and `image_grid_thw` is
+      `[num_images, 3]` - both batch by plain concatenation).
+    * `frame_pad_keys` - `[batch, frames, ...]` tensors (e.g. smolvlm
+      `pixel_values` / `pixel_attention_mask`) zero-padded on the frames
+      dimension to the longest request before concatenation on dim 0.
+
+    Raises `InputsCollationError` on any unsupported/inconsistent input - the
+    batcher treats that as a failed batch and re-runs requests serially.
+    """
+    if not inputs_list:
+        raise InputsCollationError("Cannot collate an empty list of inputs")
+    key_set = set(inputs_list[0].keys())
+    for inputs in inputs_list[1:]:
+        if set(inputs.keys()) != key_set:
+            raise InputsCollationError(
+                "Cannot collate inputs with inconsistent keys: "
+                f"{sorted(key_set)} vs {sorted(inputs.keys())}"
+            )
+    if "input_ids" not in key_set:
+        raise InputsCollationError("Cannot collate inputs without `input_ids`")
+    handled_keys = (
+        {"input_ids", "attention_mask"} | set(cat_keys) | set(frame_pad_keys)
+    )
+    unsupported_keys = key_set - handled_keys
+    if unsupported_keys:
+        raise InputsCollationError(
+            f"Cannot collate inputs with unsupported keys: {sorted(unsupported_keys)}"
+        )
+    max_length = max(inputs["input_ids"].shape[-1] for inputs in inputs_list)
+    requires_padding = any(
+        inputs["input_ids"].shape[-1] != max_length for inputs in inputs_list
+    )
+    if requires_padding and pad_token_id is None:
+        raise InputsCollationError(
+            "Cannot left-pad inputs without a pad token id"
+        )
+    if requires_padding and "attention_mask" not in key_set:
+        raise InputsCollationError(
+            "Cannot left-pad inputs without `attention_mask`"
+        )
+    input_ids_rows, attention_mask_rows = [], []
+    for inputs in inputs_list:
+        input_ids = inputs["input_ids"]
+        attention_mask = inputs.get("attention_mask")
+        missing_columns = max_length - input_ids.shape[-1]
+        if missing_columns > 0:
+            pad_block = torch.full(
+                (input_ids.shape[0], missing_columns),
+                pad_token_id,
+                dtype=input_ids.dtype,
+                device=input_ids.device,
+            )
+            input_ids = torch.cat([pad_block, input_ids], dim=1)
+            attention_mask = torch.cat(
+                [
+                    torch.zeros(
+                        (attention_mask.shape[0], missing_columns),
+                        dtype=attention_mask.dtype,
+                        device=attention_mask.device,
+                    ),
+                    attention_mask,
+                ],
+                dim=1,
+            )
+        input_ids_rows.append(input_ids)
+        if attention_mask is not None:
+            attention_mask_rows.append(attention_mask)
+    collated = {"input_ids": torch.cat(input_ids_rows, dim=0)}
+    if "attention_mask" in key_set:
+        collated["attention_mask"] = torch.cat(attention_mask_rows, dim=0)
+    for key in cat_keys:
+        if key in key_set:
+            collated[key] = torch.cat([inputs[key] for inputs in inputs_list], dim=0)
+    for key in frame_pad_keys:
+        if key in key_set:
+            collated[key] = _cat_with_frame_padding(
+                tensors=[inputs[key] for inputs in inputs_list], key=key
+            )
+    return collated
+
+
+def _cat_with_frame_padding(tensors: List[torch.Tensor], key: str) -> torch.Tensor:
+    trailing_shapes = {tuple(tensor.shape[2:]) for tensor in tensors}
+    if len(trailing_shapes) > 1:
+        raise InputsCollationError(
+            f"Cannot collate `{key}` - incompatible shapes: {sorted(trailing_shapes)}"
+        )
+    max_frames = max(tensor.shape[1] for tensor in tensors)
+    padded_tensors = []
+    for tensor in tensors:
+        missing_frames = max_frames - tensor.shape[1]
+        if missing_frames > 0:
+            pad_block = tensor.new_zeros(
+                (tensor.shape[0], missing_frames) + tuple(tensor.shape[2:])
+            )
+            tensor = torch.cat([tensor, pad_block], dim=1)
+        padded_tensors.append(tensor)
+    return torch.cat(padded_tensors, dim=0)
+
+
+_BATCHER_CREATION_LOCK = Lock()
+
+DEFAULT_BATCH_CAT_KEYS = ("pixel_values", "image_grid_thw", "pixel_attention_mask")
+
+
+class DynamicBatchingMixin:
+    """
+    Mixin wiring an HF VLM wrapper into a `DynamicBatcher`.
+
+    The hosting wrapper must define `_run_locked_generation(inputs, gen_kwargs)`
+    (the existing lock-protected `generate()` body, returning the trimmed
+    new-token tensor) and expose `self._processor` with a `tokenizer`.
+
+    One `DynamicBatcher` is created lazily per model instance, only when
+    dynamic batching is enabled and the first request arrives. The runner
+    acquires the wrapper's existing `self._lock` - uncontended when batching
+    is on (all requests funnel through one batcher thread), but still correct
+    if anything else calls the locked generation directly.
+
+    Image tensor collation is overridable per model family with the
+    `BATCH_CAT_KEYS` / `BATCH_FRAME_PAD_KEYS` class attributes or a custom
+    `_collate_inputs` method.
+    """
+
+    BATCH_CAT_KEYS: Tuple[str, ...] = DEFAULT_BATCH_CAT_KEYS
+    BATCH_FRAME_PAD_KEYS: Tuple[str, ...] = ()
+
+    def _dynamic_batching_enabled(self) -> bool:
+        return configuration.INFERENCE_MODELS_DYNAMIC_BATCHING_ENABLED
+
+    def _submit_to_dynamic_batcher(
+        self, inputs: dict, gen_kwargs: dict
+    ) -> torch.Tensor:
+        return self._get_dynamic_batcher().submit(
+            inputs=inputs, gen_kwargs=gen_kwargs
+        )
+
+    def _get_dynamic_batcher(self) -> DynamicBatcher:
+        batcher = getattr(self, "_dynamic_batcher", None)
+        if batcher is not None:
+            return batcher
+        with _BATCHER_CREATION_LOCK:
+            batcher = getattr(self, "_dynamic_batcher", None)
+            if batcher is None:
+                batcher = DynamicBatcher(
+                    runner=self._run_locked_generation,
+                    collate_inputs=self._collate_inputs,
+                    max_batch_size=configuration.INFERENCE_MODELS_DYNAMIC_BATCH_MAX_SIZE,
+                    max_wait_ms=configuration.INFERENCE_MODELS_DYNAMIC_BATCH_MAX_WAIT_MS,
+                    result_timeout_s=configuration.INFERENCE_MODELS_DYNAMIC_BATCH_RESULT_TIMEOUT_S,
+                    pad_token_id=self._generation_pad_token_id(),
+                    eos_token_id=self._generation_eos_token_id(),
+                    name=type(self).__name__,
+                )
+                self._dynamic_batcher = batcher
+        return batcher
+
+    def _run_locked_generation(self, inputs: dict, gen_kwargs: dict) -> torch.Tensor:
+        raise NotImplementedError(
+            f"{type(self).__name__} must implement `_run_locked_generation(...)` "
+            "to use dynamic batching"
+        )
+
+    def _collate_inputs(self, inputs_list: List[dict]) -> dict:
+        return collate_left_padded_inputs(
+            inputs_list=inputs_list,
+            pad_token_id=self._generation_pad_token_id(),
+            cat_keys=self.BATCH_CAT_KEYS,
+            frame_pad_keys=self.BATCH_FRAME_PAD_KEYS,
+        )
+
+    def _generation_pad_token_id(self) -> Optional[int]:
+        return self._processor.tokenizer.pad_token_id
+
+    def _generation_eos_token_id(self) -> Optional[int]:
+        return self._processor.tokenizer.eos_token_id

--- a/inference_models/inference_models/models/glm_ocr/glm_ocr_hf.py
+++ b/inference_models/inference_models/models/glm_ocr/glm_ocr_hf.py
@@ -17,6 +17,7 @@ from inference_models.configuration import (
     RUNNING_ON_JETSON,
 )
 from inference_models.entities import ColorFormat
+from inference_models.models.common.dynamic_batching import DynamicBatchingMixin
 
 TEXT_RECOGNITION_PROMPT = "Text Recognition:"
 FORMULA_RECOGNITION_PROMPT = "Formula Recognition:"
@@ -49,7 +50,7 @@ def _is_ampere_plus(device: torch.device) -> bool:
     return major >= 8
 
 
-class GlmOcrHF:
+class GlmOcrHF(DynamicBatchingMixin):
     default_dtype = torch.bfloat16
 
     @classmethod
@@ -224,13 +225,18 @@ class GlmOcrHF:
     ) -> torch.Tensor:
         if max_new_tokens is None:
             max_new_tokens = INFERENCE_MODELS_GLM_OCR_DEFAULT_MAX_NEW_TOKENS
+        gen_kwargs = {"max_new_tokens": max_new_tokens, "do_sample": do_sample}
+        if self._dynamic_batching_enabled():
+            return self._submit_to_dynamic_batcher(inputs=inputs, gen_kwargs=gen_kwargs)
+        return self._run_locked_generation(inputs=inputs, gen_kwargs=gen_kwargs)
+
+    def _run_locked_generation(self, inputs: dict, gen_kwargs: dict) -> torch.Tensor:
         input_len = inputs["input_ids"].shape[-1]
 
         with self._lock, torch.inference_mode():
             generation = self._model.generate(
                 **inputs,
-                max_new_tokens=max_new_tokens,
-                do_sample=do_sample,
+                **gen_kwargs,
             )
 
         return generation[:, input_len:]

--- a/inference_models/inference_models/models/glm_ocr/glm_ocr_hf.py
+++ b/inference_models/inference_models/models/glm_ocr/glm_ocr_hf.py
@@ -208,10 +208,15 @@ class GlmOcrHF(DynamicBatchingMixin):
             return_tensors="pt",
         )
 
+        # The GLM checkpoint ships a bare `PreTrainedTokenizerFast`, whose
+        # default `model_input_names` makes `apply_chat_template` emit
+        # `token_type_ids`. The model does not consume it and the dynamic
+        # batcher cannot collate it - keeping it would force every concurrent
+        # batch into the serial fallback, so it is dropped here.
         inputs = {
             k: v.to(self._device)
             for k, v in inputs.items()
-            if isinstance(v, torch.Tensor)
+            if isinstance(v, torch.Tensor) and k != "token_type_ids"
         }
 
         return inputs

--- a/inference_models/inference_models/models/paligemma/paligemma_hf.py
+++ b/inference_models/inference_models/models/paligemma/paligemma_hf.py
@@ -47,6 +47,7 @@ from inference_models.configuration import (
     INFERENCE_MODELS_PALIGEMMA_DEFAULT_SKIP_SPECIAL_TOKENS,
 )
 from inference_models.entities import ColorFormat
+from inference_models.models.common.dynamic_batching import DynamicBatchingMixin
 from inference_models.models.common.roboflow.model_packages import (
     InferenceConfig,
     ResizeMode,
@@ -57,7 +58,11 @@ from inference_models.models.common.roboflow.pre_processing import (
 )
 
 
-class PaliGemmaHF:
+class PaliGemmaHF(DynamicBatchingMixin):
+
+    # PaliGemma `pixel_values` is `[batch, 3, H, W]` with a fixed, processor-enforced
+    # resolution - rows batch by plain concatenation on dim 0.
+    BATCH_CAT_KEYS = ("pixel_values",)
 
     @classmethod
     def from_pretrained(
@@ -237,10 +242,14 @@ class PaliGemmaHF:
         do_sample: bool = INFERENCE_MODELS_PALIGEMMA_DEFAULT_DO_SAMPLE,
         **kwargs,
     ) -> torch.Tensor:
+        gen_kwargs = {"max_new_tokens": max_new_tokens, "do_sample": do_sample}
+        if self._dynamic_batching_enabled():
+            return self._submit_to_dynamic_batcher(inputs=inputs, gen_kwargs=gen_kwargs)
+        return self._run_locked_generation(inputs=inputs, gen_kwargs=gen_kwargs)
+
+    def _run_locked_generation(self, inputs: dict, gen_kwargs: dict) -> torch.Tensor:
         with self._lock, torch.inference_mode():
-            generation = self._model.generate(
-                **inputs, max_new_tokens=max_new_tokens, do_sample=do_sample
-            )
+            generation = self._model.generate(**inputs, **gen_kwargs)
             input_len = inputs["input_ids"].shape[-1]
             return generation[:, input_len:]
 

--- a/inference_models/inference_models/models/qwen25vl/qwen25vl_hf.py
+++ b/inference_models/inference_models/models/qwen25vl/qwen25vl_hf.py
@@ -21,6 +21,7 @@ from inference_models.configuration import (
     INFERENCE_MODELS_QWEN25_VL_DEFAULT_SKIP_SPECIAL_TOKENS,
 )
 from inference_models.entities import ColorFormat
+from inference_models.models.common.dynamic_batching import DynamicBatchingMixin
 from inference_models.models.common.roboflow.model_packages import (
     InferenceConfig,
     ResizeMode,
@@ -56,7 +57,7 @@ def _is_model_running_against_ampere_plus_aarch(device: torch.device) -> bool:
     return major >= 8
 
 
-class Qwen25VLHF:
+class Qwen25VLHF(DynamicBatchingMixin):
     @classmethod
     def from_pretrained(
         cls,
@@ -282,13 +283,18 @@ class Qwen25VLHF:
         do_sample: bool = INFERENCE_MODELS_QWEN25_VL_DEFAULT_DO_SAMPLE,
         **kwargs,
     ) -> torch.Tensor:
+        gen_kwargs = {"max_new_tokens": max_new_tokens, "do_sample": do_sample}
+        if self._dynamic_batching_enabled():
+            return self._submit_to_dynamic_batcher(inputs=inputs, gen_kwargs=gen_kwargs)
+        return self._run_locked_generation(inputs=inputs, gen_kwargs=gen_kwargs)
+
+    def _run_locked_generation(self, inputs: dict, gen_kwargs: dict) -> torch.Tensor:
         input_len = inputs["input_ids"].shape[-1]
 
         with self._lock, torch.inference_mode():
             generation = self._model.generate(
                 **inputs,
-                max_new_tokens=max_new_tokens,
-                do_sample=do_sample,
+                **gen_kwargs,
                 pad_token_id=self._processor.tokenizer.pad_token_id,
                 eos_token_id=self._processor.tokenizer.eos_token_id,
                 bos_token_id=self._processor.tokenizer.bos_token_id,

--- a/inference_models/inference_models/models/qwen3_5/qwen3_5_hf.py
+++ b/inference_models/inference_models/models/qwen3_5/qwen3_5_hf.py
@@ -18,6 +18,7 @@ from inference_models.configuration import (
     INFERENCE_MODELS_QWEN3_5_DEFAULT_MAX_NEW_TOKENS,
 )
 from inference_models.entities import ColorFormat
+from inference_models.models.common.dynamic_batching import DynamicBatchingMixin
 from inference_models.models.common.roboflow.model_packages import (
     InferenceConfig,
     ResizeMode,
@@ -26,7 +27,7 @@ from inference_models.models.common.roboflow.model_packages import (
 from inference_models.models.qwen3vl.qwen3vl_hf import _get_qwen3vl_attn_implementation
 
 
-class Qwen35HF:
+class Qwen35HF(DynamicBatchingMixin):
     default_dtype = torch.bfloat16
 
     @classmethod
@@ -248,13 +249,18 @@ class Qwen35HF:
     ) -> torch.Tensor:
         if max_new_tokens is None:
             max_new_tokens = INFERENCE_MODELS_QWEN3_5_DEFAULT_MAX_NEW_TOKENS
+        gen_kwargs = {"max_new_tokens": max_new_tokens, "do_sample": do_sample}
+        if self._dynamic_batching_enabled():
+            return self._submit_to_dynamic_batcher(inputs=inputs, gen_kwargs=gen_kwargs)
+        return self._run_locked_generation(inputs=inputs, gen_kwargs=gen_kwargs)
+
+    def _run_locked_generation(self, inputs: dict, gen_kwargs: dict) -> torch.Tensor:
         input_len = inputs["input_ids"].shape[-1]
 
         with self._lock, torch.inference_mode():
             generation = self._model.generate(
                 **inputs,
-                max_new_tokens=max_new_tokens,
-                do_sample=do_sample,
+                **gen_kwargs,
                 pad_token_id=self._processor.tokenizer.pad_token_id,
                 eos_token_id=self._processor.tokenizer.eos_token_id,
                 bos_token_id=self._processor.tokenizer.bos_token_id,

--- a/inference_models/inference_models/models/qwen3vl/qwen3vl_hf.py
+++ b/inference_models/inference_models/models/qwen3vl/qwen3vl_hf.py
@@ -19,6 +19,7 @@ from inference_models.configuration import (
     INFERENCE_MODELS_QWEN3_VL_DEFAULT_MAX_NEW_TOKENS,
 )
 from inference_models.entities import ColorFormat
+from inference_models.models.common.dynamic_batching import DynamicBatchingMixin
 from inference_models.models.common.roboflow.model_packages import (
     InferenceConfig,
     ResizeMode,
@@ -51,7 +52,7 @@ def _is_model_running_against_ampere_plus_aarch(device: torch.device) -> bool:
     return major >= 8
 
 
-class Qwen3VLHF:
+class Qwen3VLHF(DynamicBatchingMixin):
     default_dtype = torch.bfloat16
 
     @classmethod
@@ -264,13 +265,18 @@ class Qwen3VLHF:
         do_sample: bool = INFERENCE_MODELS_QWEN3_VL_DEFAULT_DO_SAMPLE,
         **kwargs,
     ) -> torch.Tensor:
+        gen_kwargs = {"max_new_tokens": max_new_tokens, "do_sample": do_sample}
+        if self._dynamic_batching_enabled():
+            return self._submit_to_dynamic_batcher(inputs=inputs, gen_kwargs=gen_kwargs)
+        return self._run_locked_generation(inputs=inputs, gen_kwargs=gen_kwargs)
+
+    def _run_locked_generation(self, inputs: dict, gen_kwargs: dict) -> torch.Tensor:
         input_len = inputs["input_ids"].shape[-1]
 
         with self._lock, torch.inference_mode():
             generation = self._model.generate(
                 **inputs,
-                max_new_tokens=max_new_tokens,
-                do_sample=do_sample,
+                **gen_kwargs,
                 pad_token_id=self._processor.tokenizer.pad_token_id,
                 eos_token_id=self._processor.tokenizer.eos_token_id,
                 bos_token_id=self._processor.tokenizer.bos_token_id,

--- a/inference_models/inference_models/models/smolvlm/smolvlm_hf.py
+++ b/inference_models/inference_models/models/smolvlm/smolvlm_hf.py
@@ -16,6 +16,7 @@ from inference_models.configuration import (
     INFERENCE_MODELS_SMOL_VLM_DEFAULT_SKIP_SPECIAL_TOKENS,
 )
 from inference_models.entities import ColorFormat
+from inference_models.models.common.dynamic_batching import DynamicBatchingMixin
 from inference_models.models.common.roboflow.model_packages import (
     InferenceConfig,
     ResizeMode,
@@ -51,7 +52,15 @@ def _is_model_running_against_ampere_plus_aarch(device: torch.device) -> bool:
     return major >= 8
 
 
-class SmolVLMHF:
+class SmolVLMHF(DynamicBatchingMixin):
+
+    # SmolVLM (Idefics3) `pixel_values` is `[batch, num_images, 3, H, W]` with
+    # `pixel_attention_mask` of `[batch, num_images, H, W]` - the number of image
+    # splits varies per request, so the images dimension is zero-padded to the
+    # longest request before concatenation (all-zero images are dropped by the
+    # model, mirroring how the processor pads multi-sample batches).
+    BATCH_CAT_KEYS = ()
+    BATCH_FRAME_PAD_KEYS = ("pixel_values", "pixel_attention_mask")
 
     @classmethod
     def from_pretrained(
@@ -271,11 +280,16 @@ class SmolVLMHF:
         do_sample: bool = INFERENCE_MODELS_SMOL_VLM_DEFAULT_DO_SAMPLE,
         **kwargs,
     ) -> torch.Tensor:
+        gen_kwargs = {"max_new_tokens": max_new_tokens, "do_sample": do_sample}
+        if self._dynamic_batching_enabled():
+            return self._submit_to_dynamic_batcher(inputs=inputs, gen_kwargs=gen_kwargs)
+        return self._run_locked_generation(inputs=inputs, gen_kwargs=gen_kwargs)
+
+    def _run_locked_generation(self, inputs: dict, gen_kwargs: dict) -> torch.Tensor:
         with self._lock:
             generation = self._model.generate(
                 **inputs,
-                do_sample=do_sample,
-                max_new_tokens=max_new_tokens,
+                **gen_kwargs,
                 pad_token_id=self._processor.tokenizer.pad_token_id,
                 eos_token_id=self._processor.tokenizer.eos_token_id,
             )

--- a/inference_models/tests/unit_tests/models/common/test_dynamic_batching.py
+++ b/inference_models/tests/unit_tests/models/common/test_dynamic_batching.py
@@ -6,6 +6,7 @@ from threading import Event, Lock
 from typing import Optional
 from unittest.mock import MagicMock
 
+import numpy as np
 import pytest
 import torch
 
@@ -728,3 +729,76 @@ def test_glm_ocr_generate_routes_through_batcher_when_enabled(monkeypatch) -> No
     assert getattr(glm_ocr, "_dynamic_batcher", None) is not None
     assert result.tolist() == [[21, 22]]
     assert model.generate.call_args.kwargs["max_new_tokens"] == 4
+
+
+def test_glm_ocr_concurrent_requests_batch_despite_tokenizer_token_type_ids(
+    monkeypatch,
+) -> None:
+    # given - regression test: GLM's bare `PreTrainedTokenizerFast` emits
+    # `token_type_ids` from `apply_chat_template`; if `pre_process_generation`
+    # let it through, every concurrent batch would fail collation and fall
+    # back to serial execution
+    from inference_models.models.glm_ocr.glm_ocr_hf import GlmOcrHF
+
+    monkeypatch.setattr(
+        configuration, "INFERENCE_MODELS_DYNAMIC_BATCHING_ENABLED", True
+    )
+    gate = Event()
+    generate_batch_sizes = []
+    calls_lock = Lock()
+
+    class _GatedModel:
+        def generate(self, **kwargs):
+            input_ids = kwargs["input_ids"]
+            with calls_lock:
+                generate_batch_sizes.append(input_ids.shape[0])
+                is_first_call = len(generate_batch_sizes) == 1
+            if is_first_call:
+                assert gate.wait(timeout=10.0), "Model gate never released"
+            new_tokens = torch.full((input_ids.shape[0], 2), 7, dtype=torch.long)
+            return torch.cat([input_ids, new_tokens], dim=1)
+
+    def _chat_template_inputs(*args, **kwargs):
+        input_ids = torch.tensor([[11, 12]], dtype=torch.long)
+        return {
+            "input_ids": input_ids,
+            "attention_mask": torch.ones_like(input_ids),
+            "token_type_ids": torch.zeros_like(input_ids),
+            "pixel_values": torch.randn(4, 8),
+            "image_grid_thw": torch.tensor([[1, 2, 2]]),
+        }
+
+    processor = MagicMock()
+    processor.apply_chat_template.side_effect = _chat_template_inputs
+    processor.tokenizer.pad_token_id = PAD_TOKEN_ID
+    processor.tokenizer.eos_token_id = 2
+    glm_ocr = GlmOcrHF(
+        model=_GatedModel(), processor=processor, device=torch.device("cpu")
+    )
+    image = np.zeros((2, 2, 3), dtype=np.uint8)
+
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        # when - first request occupies the batcher thread inside the model
+        first = executor.submit(
+            glm_ocr.generate, glm_ocr.pre_process_generation(images=image), 4
+        )
+        wait_for(lambda: len(generate_batch_sizes) == 1)
+        batcher = glm_ocr._get_dynamic_batcher()
+        # two more requests queue up behind the in-flight one
+        second = executor.submit(
+            glm_ocr.generate, glm_ocr.pre_process_generation(images=image), 4
+        )
+        third = executor.submit(
+            glm_ocr.generate, glm_ocr.pre_process_generation(images=image), 4
+        )
+        wait_for(lambda: batcher._queue.qsize() == 2)
+        gate.set()
+
+        # then - all requests produce the single-request output contract
+        for future in (first, second, third):
+            assert future.result(timeout=5).tolist() == [[7, 7]]
+
+    # then - queued requests ran as one batched call, with no serial fallback
+    assert generate_batch_sizes == [1, 2]
+    assert batcher.stats["batched_requests"] == 2
+    assert batcher.stats["serial_fallbacks"] == 0

--- a/inference_models/tests/unit_tests/models/common/test_dynamic_batching.py
+++ b/inference_models/tests/unit_tests/models/common/test_dynamic_batching.py
@@ -1,0 +1,730 @@
+import gc
+import time
+from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import TimeoutError as FuturesTimeoutError
+from threading import Event, Lock
+from typing import Optional
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+from inference_models import configuration
+from inference_models.models.common.dynamic_batching import (
+    DynamicBatcher,
+    DynamicBatchingMixin,
+    InputsCollationError,
+    collate_left_padded_inputs,
+    strip_trailing_padding,
+)
+
+PAD_TOKEN_ID = 0
+
+
+def wait_for(condition, timeout: float = 5.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if condition():
+            return None
+        time.sleep(0.005)
+    raise AssertionError("Condition not met before timeout")
+
+
+def request_inputs(*token_values: int) -> dict:
+    input_ids = torch.tensor([list(token_values)], dtype=torch.long)
+    return {"input_ids": input_ids, "attention_mask": torch.ones_like(input_ids)}
+
+
+def expected_result(last_token_value: int, max_new_tokens: int) -> list:
+    # mirrors ControllableRunner output for a single-row request
+    return [
+        [last_token_value * 10 + step for step in range(1, max_new_tokens + 1)]
+    ]
+
+
+class ControllableRunner:
+    """
+    Fake runner standing in for the wrappers' locked `generate()` body.
+
+    For each input row it emits `max_new_tokens` values derived from the
+    row's last (non-padded) token, so per-request results are identical
+    whether the request ran alone or inside a batch.
+    """
+
+    def __init__(
+        self,
+        gate_for_first_call: Optional[Event] = None,
+        poison_value: Optional[int] = None,
+        batched_calls_raise: Optional[Exception] = None,
+    ):
+        self.calls = []
+        self._calls_lock = Lock()
+        self._gate = gate_for_first_call
+        self._poison_value = poison_value
+        self._batched_calls_raise = batched_calls_raise
+
+    def __call__(self, inputs: dict, gen_kwargs: dict) -> torch.Tensor:
+        with self._calls_lock:
+            self.calls.append((inputs, dict(gen_kwargs)))
+            gate, self._gate = self._gate, None
+        if gate is not None:
+            assert gate.wait(timeout=10.0), "Runner gate never released"
+        input_ids = inputs["input_ids"]
+        if self._batched_calls_raise is not None and input_ids.shape[0] > 1:
+            raise self._batched_calls_raise
+        if self._poison_value is not None and bool(
+            (input_ids == self._poison_value).any()
+        ):
+            raise ValueError("poisoned request")
+        max_new_tokens = gen_kwargs["max_new_tokens"]
+        rows = [
+            [int(row[-1]) * 10 + step for step in range(1, max_new_tokens + 1)]
+            for row in input_ids
+        ]
+        return torch.tensor(rows, dtype=torch.long)
+
+
+def make_batcher(
+    runner,
+    max_batch_size: int = 8,
+    max_wait_ms: float = 30,
+    result_timeout_s: float = 10.0,
+    pad_token_id: Optional[int] = PAD_TOKEN_ID,
+    eos_token_id: Optional[int] = None,
+) -> DynamicBatcher:
+    return DynamicBatcher(
+        runner=runner,
+        collate_inputs=lambda inputs_list: collate_left_padded_inputs(
+            inputs_list=inputs_list,
+            pad_token_id=pad_token_id,
+        ),
+        max_batch_size=max_batch_size,
+        max_wait_ms=max_wait_ms,
+        result_timeout_s=result_timeout_s,
+        pad_token_id=pad_token_id,
+        eos_token_id=eos_token_id,
+        name="test-model",
+    )
+
+
+def test_single_request_passes_through_unbatched() -> None:
+    # given
+    runner = ControllableRunner()
+    batcher = make_batcher(runner=runner)
+
+    # when
+    result = batcher.submit(
+        inputs=request_inputs(1, 2, 3),
+        gen_kwargs={"max_new_tokens": 4, "do_sample": False},
+    )
+
+    # then
+    assert result.tolist() == expected_result(3, 4)
+    assert len(runner.calls) == 1
+    assert runner.calls[0][0]["input_ids"].tolist() == [[1, 2, 3]]
+    assert runner.calls[0][1] == {"max_new_tokens": 4, "do_sample": False}
+
+
+def test_concurrent_requests_are_collected_into_one_batched_call() -> None:
+    # given
+    gate = Event()
+    runner = ControllableRunner(gate_for_first_call=gate)
+    batcher = make_batcher(runner=runner)
+
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        # when - first request occupies the batcher thread inside the runner
+        first = executor.submit(
+            batcher.submit, request_inputs(1, 2, 3), {"max_new_tokens": 3, "do_sample": False}
+        )
+        wait_for(lambda: len(runner.calls) == 1)
+        # two more requests queue up behind the in-flight one
+        second = executor.submit(
+            batcher.submit, request_inputs(5), {"max_new_tokens": 2, "do_sample": False}
+        )
+        third = executor.submit(
+            batcher.submit, request_inputs(6, 7), {"max_new_tokens": 4, "do_sample": False}
+        )
+        wait_for(lambda: batcher._queue.qsize() == 2)
+        gate.set()
+
+        # then - each result matches the single-request contract
+        assert first.result(timeout=5).tolist() == expected_result(3, 3)
+        assert second.result(timeout=5).tolist() == expected_result(5, 2)
+        assert third.result(timeout=5).tolist() == expected_result(7, 4)
+
+    # then - queued requests ran as one batched call at max(max_new_tokens),
+    # with the shorter request left-padded
+    assert len(runner.calls) == 2
+    batched_inputs, batched_gen_kwargs = runner.calls[1]
+    assert batched_inputs["input_ids"].tolist() == [[PAD_TOKEN_ID, 5], [6, 7]]
+    assert batched_inputs["attention_mask"].tolist() == [[0, 1], [1, 1]]
+    assert batched_gen_kwargs == {"max_new_tokens": 4, "do_sample": False}
+    assert batcher.stats["batched_requests"] == 2
+
+
+def test_requests_with_different_sampling_params_do_not_share_a_batch() -> None:
+    # given
+    gate = Event()
+    runner = ControllableRunner(gate_for_first_call=gate)
+    batcher = make_batcher(runner=runner)
+
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        # when
+        first = executor.submit(
+            batcher.submit, request_inputs(1), {"max_new_tokens": 2, "do_sample": False}
+        )
+        wait_for(lambda: len(runner.calls) == 1)
+        second = executor.submit(
+            batcher.submit, request_inputs(5), {"max_new_tokens": 2, "do_sample": False}
+        )
+        third = executor.submit(
+            batcher.submit, request_inputs(6), {"max_new_tokens": 2, "do_sample": True}
+        )
+        wait_for(lambda: batcher._queue.qsize() == 2)
+        gate.set()
+
+        # then
+        assert first.result(timeout=5).tolist() == expected_result(1, 2)
+        assert second.result(timeout=5).tolist() == expected_result(5, 2)
+        assert third.result(timeout=5).tolist() == expected_result(6, 2)
+
+    # then - do_sample=True must not batch with do_sample=False
+    assert len(runner.calls) == 3
+    assert all(call[0]["input_ids"].shape[0] == 1 for call in runner.calls)
+
+
+def test_poisoned_request_only_fails_its_own_submitter() -> None:
+    # given
+    gate = Event()
+    runner = ControllableRunner(gate_for_first_call=gate, poison_value=666)
+    batcher = make_batcher(runner=runner)
+
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        # when
+        first = executor.submit(
+            batcher.submit, request_inputs(1), {"max_new_tokens": 2, "do_sample": False}
+        )
+        wait_for(lambda: len(runner.calls) == 1)
+        good = executor.submit(
+            batcher.submit, request_inputs(5), {"max_new_tokens": 2, "do_sample": False}
+        )
+        poisoned = executor.submit(
+            batcher.submit, request_inputs(666), {"max_new_tokens": 2, "do_sample": False}
+        )
+        another_good = executor.submit(
+            batcher.submit, request_inputs(7), {"max_new_tokens": 2, "do_sample": False}
+        )
+        wait_for(lambda: batcher._queue.qsize() == 3)
+        gate.set()
+
+        # then - the batched call fails, members re-run serially and only the
+        # poisoned request observes the exception
+        assert first.result(timeout=5).tolist() == expected_result(1, 2)
+        assert good.result(timeout=5).tolist() == expected_result(5, 2)
+        assert another_good.result(timeout=5).tolist() == expected_result(7, 2)
+        with pytest.raises(ValueError):
+            poisoned.result(timeout=5)
+
+    # then - 1 single + 1 failed batched + 3 serial re-runs
+    assert len(runner.calls) == 5
+    assert batcher.stats["serial_fallbacks"] == 1
+
+
+def test_cuda_oom_on_batched_call_triggers_cache_cleanup_and_serial_retry(
+    monkeypatch,
+) -> None:
+    # given
+    empty_cache_calls = []
+    monkeypatch.setattr(
+        torch.cuda, "empty_cache", lambda: empty_cache_calls.append(1)
+    )
+    gate = Event()
+    runner = ControllableRunner(
+        gate_for_first_call=gate,
+        batched_calls_raise=torch.cuda.OutOfMemoryError("CUDA out of memory"),
+    )
+    batcher = make_batcher(runner=runner)
+
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        # when
+        first = executor.submit(
+            batcher.submit, request_inputs(1), {"max_new_tokens": 2, "do_sample": False}
+        )
+        wait_for(lambda: len(runner.calls) == 1)
+        second = executor.submit(
+            batcher.submit, request_inputs(5), {"max_new_tokens": 2, "do_sample": False}
+        )
+        third = executor.submit(
+            batcher.submit, request_inputs(6), {"max_new_tokens": 2, "do_sample": False}
+        )
+        wait_for(lambda: batcher._queue.qsize() == 2)
+        gate.set()
+
+        # then - both requests recover through the serial path
+        assert first.result(timeout=5).tolist() == expected_result(1, 2)
+        assert second.result(timeout=5).tolist() == expected_result(5, 2)
+        assert third.result(timeout=5).tolist() == expected_result(6, 2)
+
+    assert len(empty_cache_calls) == 1
+    assert batcher.stats["serial_fallbacks"] == 1
+
+
+def test_submit_times_out_when_runner_never_returns() -> None:
+    # given
+    gate = Event()
+    runner = ControllableRunner(gate_for_first_call=gate)
+    batcher = make_batcher(runner=runner, result_timeout_s=0.2)
+
+    # when / then
+    try:
+        with pytest.raises(FuturesTimeoutError):
+            batcher.submit(
+                inputs=request_inputs(1),
+                gen_kwargs={"max_new_tokens": 2, "do_sample": False},
+            )
+    finally:
+        gate.set()
+
+
+def test_concurrent_submit_stress() -> None:
+    # given
+    runner = ControllableRunner()
+    batcher = make_batcher(runner=runner, max_batch_size=8, max_wait_ms=5)
+
+    # when
+    with ThreadPoolExecutor(max_workers=64) as executor:
+        futures = {
+            executor.submit(
+                batcher.submit,
+                request_inputs(value),
+                {"max_new_tokens": 3, "do_sample": False},
+            ): value
+            for value in range(1, 65)
+        }
+        # then - every submitter gets its own result back
+        for future, value in futures.items():
+            assert future.result(timeout=30).tolist() == expected_result(value, 3)
+
+    # then - no request was lost or duplicated
+    total_rows = sum(call[0]["input_ids"].shape[0] for call in runner.calls)
+    assert total_rows == 64
+    assert batcher.stats["requests"] == 64
+    assert batcher.stats["max_batch_size_seen"] <= 8
+
+
+def test_batcher_thread_survives_collate_errors() -> None:
+    # given - a collate raising on every batched attempt
+    gate = Event()
+    runner = ControllableRunner(gate_for_first_call=gate)
+
+    def broken_collate(inputs_list):
+        raise RuntimeError("collate exploded")
+
+    batcher = DynamicBatcher(
+        runner=runner,
+        collate_inputs=broken_collate,
+        max_batch_size=8,
+        max_wait_ms=30,
+        result_timeout_s=10.0,
+        pad_token_id=PAD_TOKEN_ID,
+        name="test-model",
+    )
+
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        # when
+        first = executor.submit(
+            batcher.submit, request_inputs(1), {"max_new_tokens": 2, "do_sample": False}
+        )
+        wait_for(lambda: len(runner.calls) == 1)
+        second = executor.submit(
+            batcher.submit, request_inputs(5), {"max_new_tokens": 2, "do_sample": False}
+        )
+        third = executor.submit(
+            batcher.submit, request_inputs(6), {"max_new_tokens": 2, "do_sample": False}
+        )
+        wait_for(lambda: batcher._queue.qsize() == 2)
+        gate.set()
+
+        # then - collate failure falls back to serial execution
+        assert first.result(timeout=5).tolist() == expected_result(1, 2)
+        assert second.result(timeout=5).tolist() == expected_result(5, 2)
+        assert third.result(timeout=5).tolist() == expected_result(6, 2)
+
+    # then - the batcher thread is still alive and serving requests
+    assert batcher._thread.is_alive()
+    result = batcher.submit(
+        inputs=request_inputs(9), gen_kwargs={"max_new_tokens": 2, "do_sample": False}
+    )
+    assert result.tolist() == expected_result(9, 2)
+
+
+def test_strip_trailing_padding_removes_shared_trailing_padding() -> None:
+    # given
+    generated_ids = torch.tensor(
+        [
+            [11, 12, PAD_TOKEN_ID, PAD_TOKEN_ID],
+            [21, 22, 23, PAD_TOKEN_ID],
+        ]
+    )
+
+    # when
+    result = strip_trailing_padding(
+        generated_ids=generated_ids, pad_token_id=PAD_TOKEN_ID, eos_token_id=2
+    )
+
+    # then - padding making rows of the same request even is preserved,
+    # only the columns padded by other batch members are dropped
+    assert result.tolist() == [[11, 12, PAD_TOKEN_ID], [21, 22, 23]]
+
+
+def test_strip_trailing_padding_keeps_single_eos_when_pad_equals_eos() -> None:
+    # given
+    generated_ids = torch.tensor([[11, 12, 2, 2, 2]])
+
+    # when
+    result = strip_trailing_padding(
+        generated_ids=generated_ids, pad_token_id=2, eos_token_id=2
+    )
+
+    # then - a finished sequence keeps exactly one terminating EOS
+    assert result.tolist() == [[11, 12, 2]]
+
+
+def test_strip_trailing_padding_without_pad_token_returns_input() -> None:
+    # given
+    generated_ids = torch.tensor([[11, 12, 0, 0]])
+
+    # when
+    result = strip_trailing_padding(
+        generated_ids=generated_ids, pad_token_id=None, eos_token_id=None
+    )
+
+    # then
+    assert result.tolist() == [[11, 12, 0, 0]]
+
+
+def test_strip_trailing_padding_keeps_at_least_one_column() -> None:
+    # given
+    generated_ids = torch.tensor([[PAD_TOKEN_ID, PAD_TOKEN_ID]])
+
+    # when
+    result = strip_trailing_padding(
+        generated_ids=generated_ids, pad_token_id=PAD_TOKEN_ID, eos_token_id=2
+    )
+
+    # then
+    assert result.tolist() == [[PAD_TOKEN_ID]]
+
+
+def test_collate_qwen_family_shapes() -> None:
+    # given - qwen-family: `pixel_values` rows are flattened patches,
+    # `image_grid_thw` is [num_images, 3]
+    first = {
+        "input_ids": torch.tensor([[1, 2, 3, 4, 5]]),
+        "attention_mask": torch.ones(1, 5, dtype=torch.long),
+        "pixel_values": torch.randn(12, 7),
+        "image_grid_thw": torch.tensor([[1, 3, 4]]),
+    }
+    second = {
+        "input_ids": torch.tensor([[6, 7, 8]]),
+        "attention_mask": torch.ones(1, 3, dtype=torch.long),
+        "pixel_values": torch.randn(8, 7),
+        "image_grid_thw": torch.tensor([[1, 2, 4]]),
+    }
+
+    # when
+    collated = collate_left_padded_inputs(
+        inputs_list=[first, second],
+        pad_token_id=PAD_TOKEN_ID,
+        cat_keys=("pixel_values", "image_grid_thw"),
+    )
+
+    # then
+    assert collated["input_ids"].tolist() == [
+        [1, 2, 3, 4, 5],
+        [PAD_TOKEN_ID, PAD_TOKEN_ID, 6, 7, 8],
+    ]
+    assert collated["attention_mask"].tolist() == [
+        [1, 1, 1, 1, 1],
+        [0, 0, 1, 1, 1],
+    ]
+    assert collated["pixel_values"].shape == (20, 7)
+    assert torch.equal(collated["pixel_values"][:12], first["pixel_values"])
+    assert torch.equal(collated["pixel_values"][12:], second["pixel_values"])
+    assert collated["image_grid_thw"].tolist() == [[1, 3, 4], [1, 2, 4]]
+
+
+def test_collate_smolvlm_family_shapes() -> None:
+    # given - smolvlm: `pixel_values` is [1, num_images, 3, H, W] with
+    # `pixel_attention_mask` [1, num_images, H, W]; num_images varies
+    first = {
+        "input_ids": torch.tensor([[1, 2, 3]]),
+        "attention_mask": torch.ones(1, 3, dtype=torch.long),
+        "pixel_values": torch.randn(1, 2, 3, 8, 8),
+        "pixel_attention_mask": torch.ones(1, 2, 8, 8, dtype=torch.long),
+    }
+    second = {
+        "input_ids": torch.tensor([[4, 5, 6]]),
+        "attention_mask": torch.ones(1, 3, dtype=torch.long),
+        "pixel_values": torch.randn(1, 4, 3, 8, 8),
+        "pixel_attention_mask": torch.ones(1, 4, 8, 8, dtype=torch.long),
+    }
+
+    # when
+    collated = collate_left_padded_inputs(
+        inputs_list=[first, second],
+        pad_token_id=PAD_TOKEN_ID,
+        frame_pad_keys=("pixel_values", "pixel_attention_mask"),
+    )
+
+    # then - the shorter request gets all-zero image padding (which the
+    # Idefics3-style model drops), masks padded with zeros
+    assert collated["pixel_values"].shape == (2, 4, 3, 8, 8)
+    assert torch.equal(collated["pixel_values"][0, :2], first["pixel_values"][0])
+    assert torch.all(collated["pixel_values"][0, 2:] == 0)
+    assert torch.equal(collated["pixel_values"][1], second["pixel_values"][0])
+    assert collated["pixel_attention_mask"].shape == (2, 4, 8, 8)
+    assert torch.all(collated["pixel_attention_mask"][0, 2:] == 0)
+    assert torch.all(collated["pixel_attention_mask"][0, :2] == 1)
+
+
+def test_collate_paligemma_family_shapes() -> None:
+    # given - paligemma: fixed-resolution `pixel_values` [batch, 3, H, W],
+    # requests may carry multiple rows (one per image)
+    first = {
+        "input_ids": torch.tensor([[1, 2, 3]]),
+        "attention_mask": torch.ones(1, 3, dtype=torch.long),
+        "pixel_values": torch.randn(1, 3, 8, 8),
+    }
+    second = {
+        "input_ids": torch.tensor([[4, 5], [6, 7]]),
+        "attention_mask": torch.ones(2, 2, dtype=torch.long),
+        "pixel_values": torch.randn(2, 3, 8, 8),
+    }
+
+    # when
+    collated = collate_left_padded_inputs(
+        inputs_list=[first, second],
+        pad_token_id=PAD_TOKEN_ID,
+        cat_keys=("pixel_values",),
+    )
+
+    # then
+    assert collated["input_ids"].tolist() == [
+        [1, 2, 3],
+        [PAD_TOKEN_ID, 4, 5],
+        [PAD_TOKEN_ID, 6, 7],
+    ]
+    assert collated["attention_mask"].tolist() == [[1, 1, 1], [0, 1, 1], [0, 1, 1]]
+    assert collated["pixel_values"].shape == (3, 3, 8, 8)
+
+
+def test_collate_rejects_inconsistent_keys() -> None:
+    # given
+    first = request_inputs(1, 2)
+    second = {"input_ids": torch.tensor([[3, 4]])}
+
+    # when / then
+    with pytest.raises(InputsCollationError):
+        collate_left_padded_inputs(
+            inputs_list=[first, second], pad_token_id=PAD_TOKEN_ID
+        )
+
+
+def test_collate_rejects_unsupported_keys() -> None:
+    # given
+    first = request_inputs(1, 2)
+    first["token_type_ids"] = torch.zeros(1, 2, dtype=torch.long)
+    second = request_inputs(3, 4)
+    second["token_type_ids"] = torch.zeros(1, 2, dtype=torch.long)
+
+    # when / then
+    with pytest.raises(InputsCollationError):
+        collate_left_padded_inputs(
+            inputs_list=[first, second], pad_token_id=PAD_TOKEN_ID
+        )
+
+
+def test_collate_requires_pad_token_when_padding_is_needed() -> None:
+    # when / then
+    with pytest.raises(InputsCollationError):
+        collate_left_padded_inputs(
+            inputs_list=[request_inputs(1, 2, 3), request_inputs(4)],
+            pad_token_id=None,
+        )
+
+
+def test_collate_requires_attention_mask_when_padding_is_needed() -> None:
+    # given
+    first = {"input_ids": torch.tensor([[1, 2, 3]])}
+    second = {"input_ids": torch.tensor([[4]])}
+
+    # when / then
+    with pytest.raises(InputsCollationError):
+        collate_left_padded_inputs(
+            inputs_list=[first, second], pad_token_id=PAD_TOKEN_ID
+        )
+
+
+def test_collate_frame_padding_rejects_mismatched_image_shapes() -> None:
+    # given
+    first = request_inputs(1, 2)
+    first["pixel_values"] = torch.randn(1, 2, 3, 8, 8)
+    second = request_inputs(3, 4)
+    second["pixel_values"] = torch.randn(1, 2, 3, 16, 16)
+
+    # when / then
+    with pytest.raises(InputsCollationError):
+        collate_left_padded_inputs(
+            inputs_list=[first, second],
+            pad_token_id=PAD_TOKEN_ID,
+            frame_pad_keys=("pixel_values",),
+        )
+
+
+class _FakeTokenizer:
+    pad_token_id = PAD_TOKEN_ID
+    eos_token_id = 2
+
+
+class _FakeProcessor:
+    tokenizer = _FakeTokenizer()
+
+
+class _FakeVLM(DynamicBatchingMixin):
+    def __init__(self):
+        self._processor = _FakeProcessor()
+        self.runner_calls = []
+
+    def _run_locked_generation(self, inputs: dict, gen_kwargs: dict) -> torch.Tensor:
+        self.runner_calls.append((inputs, dict(gen_kwargs)))
+        rows = [
+            [int(row[-1]) * 10 + step for step in range(1, gen_kwargs["max_new_tokens"] + 1)]
+            for row in inputs["input_ids"]
+        ]
+        return torch.tensor(rows, dtype=torch.long)
+
+
+def test_mixin_dynamic_batching_disabled_by_default() -> None:
+    # given
+    model = _FakeVLM()
+
+    # when / then
+    assert model._dynamic_batching_enabled() is False
+    assert getattr(model, "_dynamic_batcher", None) is None
+
+
+def test_mixin_reflects_configuration_flag(monkeypatch) -> None:
+    # given
+    model = _FakeVLM()
+    monkeypatch.setattr(
+        configuration, "INFERENCE_MODELS_DYNAMIC_BATCHING_ENABLED", True
+    )
+
+    # when / then
+    assert model._dynamic_batching_enabled() is True
+
+
+def test_mixin_creates_single_batcher_per_instance(monkeypatch) -> None:
+    # given
+    monkeypatch.setattr(configuration, "INFERENCE_MODELS_DYNAMIC_BATCH_MAX_SIZE", 4)
+    model = _FakeVLM()
+
+    # when - racing threads asking for the batcher
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        batchers = list(
+            executor.map(lambda _: model._get_dynamic_batcher(), range(16))
+        )
+
+    # then
+    assert all(batcher is batchers[0] for batcher in batchers)
+    assert batchers[0]._pad_token_id == PAD_TOKEN_ID
+    assert batchers[0]._eos_token_id == 2
+    assert batchers[0]._max_batch_size == 4
+
+
+def test_mixin_submit_round_trip(monkeypatch) -> None:
+    # given
+    monkeypatch.setattr(
+        configuration, "INFERENCE_MODELS_DYNAMIC_BATCHING_ENABLED", True
+    )
+    model = _FakeVLM()
+
+    # when
+    result = model._submit_to_dynamic_batcher(
+        inputs=request_inputs(3), gen_kwargs={"max_new_tokens": 2, "do_sample": False}
+    )
+
+    # then
+    assert result.tolist() == expected_result(3, 2)
+    assert len(model.runner_calls) == 1
+
+
+def test_batcher_thread_exits_when_owning_model_is_garbage_collected(
+    monkeypatch,
+) -> None:
+    # given
+    monkeypatch.setattr(
+        configuration, "INFERENCE_MODELS_DYNAMIC_BATCHING_ENABLED", True
+    )
+    monkeypatch.setattr(DynamicBatcher, "_IDLE_LIVENESS_INTERVAL_S", 0.05)
+    model = _FakeVLM()
+    result = model._submit_to_dynamic_batcher(
+        inputs=request_inputs(3), gen_kwargs={"max_new_tokens": 2, "do_sample": False}
+    )
+    assert result.tolist() == expected_result(3, 2)
+    batcher = model._get_dynamic_batcher()
+    thread = batcher._thread
+    assert thread.is_alive()
+
+    # when - the owning wrapper gets released (e.g. model cache eviction)
+    del model
+    gc.collect()
+
+    # then - the batcher thread does not keep the model alive and exits
+    wait_for(lambda: not thread.is_alive(), timeout=5.0)
+
+
+def test_glm_ocr_generate_keeps_lock_path_when_batching_disabled() -> None:
+    # given
+    from inference_models.models.glm_ocr.glm_ocr_hf import GlmOcrHF
+
+    model = MagicMock()
+    model.generate.return_value = torch.tensor([[11, 12, 21, 22]])
+    glm_ocr = GlmOcrHF(model=model, processor=MagicMock(), device=MagicMock())
+
+    # when
+    result = glm_ocr.generate(
+        inputs={"input_ids": torch.tensor([[11, 12]])},
+        max_new_tokens=4,
+    )
+
+    # then - no batcher is created when the feature flag is off
+    assert getattr(glm_ocr, "_dynamic_batcher", None) is None
+    assert result.tolist() == [[21, 22]]
+
+
+def test_glm_ocr_generate_routes_through_batcher_when_enabled(monkeypatch) -> None:
+    # given
+    from inference_models.models.glm_ocr.glm_ocr_hf import GlmOcrHF
+
+    monkeypatch.setattr(
+        configuration, "INFERENCE_MODELS_DYNAMIC_BATCHING_ENABLED", True
+    )
+    model = MagicMock()
+    model.generate.return_value = torch.tensor([[11, 12, 21, 22]])
+    processor = MagicMock()
+    processor.tokenizer.pad_token_id = PAD_TOKEN_ID
+    processor.tokenizer.eos_token_id = 2
+    glm_ocr = GlmOcrHF(model=model, processor=processor, device=MagicMock())
+
+    # when
+    result = glm_ocr.generate(
+        inputs={"input_ids": torch.tensor([[11, 12]])},
+        max_new_tokens=4,
+    )
+
+    # then
+    assert getattr(glm_ocr, "_dynamic_batcher", None) is not None
+    assert result.tolist() == [[21, 22]]
+    assert model.generate.call_args.kwargs["max_new_tokens"] == 4

--- a/inference_models/tests/unit_tests/models/test_glm_ocr_hf.py
+++ b/inference_models/tests/unit_tests/models/test_glm_ocr_hf.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock
 
 import numpy as np
+import torch
 
 from inference_models.configuration import (
     INFERENCE_MODELS_GLM_OCR_DEFAULT_MAX_NEW_TOKENS,
@@ -22,3 +23,35 @@ def test_generate_uses_default_max_new_tokens_when_none_is_given() -> None:
         INFERENCE_MODELS_GLM_OCR_DEFAULT_MAX_NEW_TOKENS
     )
     assert result.tolist() == [[21, 22]]
+
+
+def test_pre_process_generation_drops_token_type_ids() -> None:
+    # given - the GLM checkpoint ships a bare `PreTrainedTokenizerFast`, whose
+    # default `model_input_names` makes `apply_chat_template` emit
+    # `token_type_ids` - the model does not consume it and the dynamic batcher
+    # cannot collate it
+    input_ids = torch.tensor([[11, 12]], dtype=torch.long)
+    processor = MagicMock()
+    processor.apply_chat_template.return_value = {
+        "input_ids": input_ids,
+        "attention_mask": torch.ones_like(input_ids),
+        "token_type_ids": torch.zeros_like(input_ids),
+        "pixel_values": torch.randn(4, 8),
+        "image_grid_thw": torch.tensor([[1, 2, 2]]),
+    }
+    glm_ocr = GlmOcrHF(
+        model=MagicMock(), processor=processor, device=torch.device("cpu")
+    )
+
+    # when
+    result = glm_ocr.pre_process_generation(
+        images=np.zeros((2, 2, 3), dtype=np.uint8)
+    )
+
+    # then
+    assert set(result.keys()) == {
+        "input_ids",
+        "attention_mask",
+        "pixel_values",
+        "image_grid_thw",
+    }


### PR DESCRIPTION
## What

1. **Per-model dynamic micro-batching** for the HF VLM wrappers (qwen3_5/qwen3vl/qwen25vl/glm_ocr/paligemma/smolvlm): concurrent same-model requests collate (left-padded) into one batched `generate()`, split per request, trimmed to each request's `max_new_tokens`; serial fallback isolates poisoned requests. **Off by default** (`INFERENCE_MODELS_DYNAMIC_BATCHING_ENABLED`).
2. **Dockerfile.onnx.gpu fix (important standalone)**: the builder installed `inference_models` *dependencies* from the repo lock but the package *content* from PyPI — local changes to `inference_models/` silently never shipped in GPU images. Now copies repo source over dist-packages.
3. **glm-ocr fix**: its bare tokenizer emits `token_type_ids` which broke batch collation (silent serial fallback); GLM-4V's forward never reads it — dropped in preprocessing (output-neutral).
4. `HTTP_API_THREADPOOL_WORKERS` env to raise the anyio sync-handler cap (hidden default 40).

## Staging results — honest
- smolvlm2: **3.3×** (3.35 RPS @ c16). 
- glm-ocr: batches form, but unbounded `max_new_tokens` → slowest-member tax → p95 224–437s + timeouts. **Worse than serial for tails.**

## Status
Per team decision the flag stays **off** and the HF multi-adapter iteration is skipped — vLLM pools (companion PR) are the throughput path. Before any future enablement this needs per-family flags + a batched-mode token cap. The Dockerfile and glm fixes are valuable regardless and are the main reason to land this.

373 tests passed (27 new batcher tests: windows, signature grouping, trimming, poison isolation, 64-thread stress).