### PR TITLE
feat(workflows): add point prompting (labeled_points kind + SAM 3 Interactive block) and fix SAM3 PVS multi-prompt bugs

### DIFF
--- a/docs/foundation/sam3.md
+++ b/docs/foundation/sam3.md
@@ -210,11 +210,10 @@ The response contains the single highest-confidence mask for the prompt: `multim
 
 ## Workflow Integration
 
-SAM 3 is fully integrated into [Inference Workflows](https://inference.roboflow.com/workflows/core_steps/). You can use the **SAM 3** block to add zero-shot instance segmentation to your pipeline.
+SAM 3 is fully integrated into [Inference Workflows](https://inference.roboflow.com/workflows/core_steps/). Two blocks are available:
 
-The Workflow block allows you to:
-- Use **Text Prompts** to segment objects by class name.
-- Use **Box Prompts** from other detection models (like YOLO) to generate precise masks for detected objects.
+- The **SAM 3** block runs concept segmentation: use **Text Prompts** to segment all instances of a class by name.
+- The **SAM 3 Interactive** block runs promptable visual segmentation (PVS): use **Point Prompts** (positive/negative clicks) and/or **Box Prompts** from other detection models (like YOLO) to segment specific objects.
 
 ### Example: Text Prompting in Workflows
 
@@ -222,6 +221,13 @@ The Workflow block allows you to:
 2. Connect an image input.
 3. In the `class_names` field, enter the classes you want to segment (e.g., `["person", "vehicle"]`).
 4. The block will output instance segmentation predictions compatible with other workflow steps.
+
+### Example: Point Prompting in Workflows
+
+1. Add a **SAM 3 Interactive** block to your workflow.
+2. Connect an image input.
+3. In the `points` field, provide labeled points (or connect a workflow input of kind `labeled_points`), e.g. `[{"x": 320, "y": 240, "positive": true}, {"x": 100, "y": 100, "positive": false}]`. Positive points mark the object to segment; negative points exclude regions to refine the mask.
+4. Optionally connect detections from another model to the `boxes` field - each box becomes a separate prompt and its class name is forwarded to the predicted mask.
 
 ## Capabilities & Features
 

--- a/inference/core/workflows/core_steps/common/deserializers.py
+++ b/inference/core/workflows/core_steps/common/deserializers.py
@@ -1,6 +1,6 @@
 import os
 from datetime import datetime
-from typing import Any, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 from uuid import uuid4
 
 import cv2
@@ -542,6 +542,44 @@ def deserialize_point_kind(parameter: str, value: Any) -> Tuple[AnyNumber, AnyNu
             context="workflow_execution | runtime_input_validation",
         )
     return value
+
+
+def deserialize_labeled_points_kind(parameter: str, value: Any) -> List[Dict[str, Any]]:
+    if not isinstance(value, list):
+        raise RuntimeInputError(
+            public_message=f"Detected runtime parameter `{parameter}` declared to hold "
+            f"list of labeled points, but invalid type of data found (`{type(value).__name__}`).",
+            context="workflow_execution | runtime_input_validation",
+        )
+    result = []
+    for raw_point in value:
+        if isinstance(raw_point, dict):
+            if "x" not in raw_point or "y" not in raw_point:
+                raise RuntimeInputError(
+                    public_message=f"Detected runtime parameter `{parameter}` declared to hold "
+                    f"list of labeled points, but at least one point misses `x` or `y` coordinate.",
+                    context="workflow_execution | runtime_input_validation",
+                )
+            x, y = raw_point["x"], raw_point["y"]
+            positive = raw_point.get("positive", True)
+        elif isinstance(raw_point, (list, tuple)) and len(raw_point) in {2, 3}:
+            x, y = raw_point[0], raw_point[1]
+            positive = raw_point[2] if len(raw_point) == 3 else True
+        else:
+            raise RuntimeInputError(
+                public_message=f"Detected runtime parameter `{parameter}` declared to hold "
+                f"list of labeled points, but at least one element is neither a dict with "
+                f"`x` and `y` keys nor a sequence of (x, y) or (x, y, positive).",
+                context="workflow_execution | runtime_input_validation",
+            )
+        if not _is_number(x) or not _is_number(y):
+            raise RuntimeInputError(
+                public_message=f"Detected runtime parameter `{parameter}` declared to hold "
+                f"list of labeled points, but at least one point coordinate is not a number.",
+                context="workflow_execution | runtime_input_validation",
+            )
+        result.append({"x": x, "y": y, "positive": bool(positive)})
+    return result
 
 
 def deserialize_zone_kind(

--- a/inference/core/workflows/core_steps/loader.py
+++ b/inference/core/workflows/core_steps/loader.py
@@ -119,6 +119,7 @@ from inference.core.workflows.core_steps.common.deserializers import (
     deserialize_float_zero_to_one_kind,
     deserialize_image_kind,
     deserialize_integer_kind,
+    deserialize_labeled_points_kind,
     deserialize_list_of_values_kind,
     deserialize_numpy_array,
     deserialize_optional_string_kind,
@@ -337,6 +338,9 @@ from inference.core.workflows.core_steps.models.foundation.segment_anything3.v2 
 )
 from inference.core.workflows.core_steps.models.foundation.segment_anything3.v3 import (
     SegmentAnything3BlockV3,
+)
+from inference.core.workflows.core_steps.models.foundation.segment_anything3_interactive.v1 import (
+    SegmentAnything3InteractiveBlockV1,
 )
 from inference.core.workflows.core_steps.models.roboflow.instance_segmentation.v4 import (
     RoboflowInstanceSegmentationModelBlockV4,
@@ -651,6 +655,7 @@ from inference.core.workflows.execution_engine.entities.types import (
     INSTANCE_SEGMENTATION_PREDICTION_KIND,
     INTEGER_KIND,
     KEYPOINT_DETECTION_PREDICTION_KIND,
+    LABELED_POINTS_KIND,
     LANGUAGE_MODEL_OUTPUT_KIND,
     LIST_OF_VALUES_KIND,
     NUMPY_ARRAY_KIND,
@@ -731,6 +736,7 @@ KINDS_DESERIALIZERS = {
     SEMANTIC_SEGMENTATION_PREDICTION_KIND.name: deserialize_rle_detections_kind,
     CLASSIFICATION_PREDICTION_KIND.name: deserialize_classification_prediction_kind,
     POINT_KIND.name: deserialize_point_kind,
+    LABELED_POINTS_KIND.name: deserialize_labeled_points_kind,
     ZONE_KIND.name: deserialize_zone_kind,
     RGB_COLOR_KIND.name: deserialize_rgb_color_kind,
     LANGUAGE_MODEL_OUTPUT_KIND.name: deserialize_string_kind,
@@ -910,6 +916,7 @@ def load_blocks() -> List[Type[WorkflowBlock]]:
         SegmentAnything3BlockV1,
         SegmentAnything3BlockV2,
         SegmentAnything3BlockV3,
+        SegmentAnything3InteractiveBlockV1,
         SegPreviewBlockV1,
         StabilityAIInpaintingBlockV1,
         StabilityAIImageGenBlockV1,
@@ -1029,6 +1036,7 @@ def load_kinds() -> List[Kind]:
         CLASSIFICATION_PREDICTION_KIND,
         DETECTIONS_OVERLAPS_KIND,
         POINT_KIND,
+        LABELED_POINTS_KIND,
         ZONE_KIND,
         OBJECT_DETECTION_PREDICTION_KIND,
         INSTANCE_SEGMENTATION_PREDICTION_KIND,

--- a/inference/core/workflows/core_steps/models/foundation/segment_anything3_interactive/v1.py
+++ b/inference/core/workflows/core_steps/models/foundation/segment_anything3_interactive/v1.py
@@ -1,0 +1,552 @@
+from typing import Any, List, Literal, Optional, Tuple, Type, Union
+
+import requests
+import supervision as sv
+from pydantic import ConfigDict, Field, model_validator
+
+from inference.core import logger
+from inference.core.entities.requests.sam2 import (
+    Box,
+    Point,
+    Sam2Prompt,
+    Sam2PromptSet,
+    Sam2SegmentationRequest,
+)
+from inference.core.entities.responses.sam2 import Sam2SegmentationPrediction
+from inference.core.env import (
+    API_BASE_URL,
+    CORE_MODEL_SAM3_ENABLED,
+    HOSTED_CORE_MODEL_URL,
+    LOCAL_INFERENCE_API_URL,
+    ROBOFLOW_INTERNAL_SERVICE_NAME,
+    ROBOFLOW_INTERNAL_SERVICE_SECRET,
+    SAM3_EXEC_MODE,
+    WORKFLOWS_REMOTE_API_TARGET,
+)
+from inference.core.managers.base import ModelManager
+from inference.core.roboflow_api import build_roboflow_api_headers
+from inference.core.utils.url_utils import wrap_url
+from inference.core.workflows.core_steps.common.entities import StepExecutionMode
+from inference.core.workflows.core_steps.common.utils import (
+    attach_parents_coordinates_to_batch_of_sv_detections,
+    attach_prediction_type_info_to_sv_detections_batch,
+    convert_inference_detections_batch_to_sv_detections,
+)
+from inference.core.workflows.core_steps.models.foundation.segment_anything2.v1 import (
+    convert_sam2_segmentation_response_to_inference_instances_seg_response,
+)
+from inference.core.workflows.execution_engine.entities.base import (
+    Batch,
+    OutputDefinition,
+    WorkflowImageData,
+)
+from inference.core.workflows.execution_engine.entities.types import (
+    BOOLEAN_KIND,
+    FLOAT_KIND,
+    IMAGE_KIND,
+    INSTANCE_SEGMENTATION_PREDICTION_KIND,
+    KEYPOINT_DETECTION_PREDICTION_KIND,
+    LABELED_POINTS_KIND,
+    OBJECT_DETECTION_PREDICTION_KIND,
+    ImageInputField,
+    Selector,
+)
+from inference.core.workflows.prototypes.block import (
+    BlockResult,
+    Runtime,
+    RuntimeRestriction,
+    Severity,
+    WorkflowBlock,
+    WorkflowBlockManifest,
+)
+from inference_sdk import InferenceHTTPClient
+
+DETECTIONS_CLASS_NAME_FIELD = "class_name"
+DETECTION_ID_FIELD = "detection_id"
+
+SAM3_INTERACTIVE_MODEL_ID = "sam3/sam3_interactive"
+
+SHORT_DESCRIPTION = (
+    "Segment a specific object with SAM3 using point and/or bounding box prompts."
+)
+
+LONG_DESCRIPTION = """
+Run the interactive (promptable visual segmentation) head of Segment Anything 3 (SAM3) on an image.
+
+Unlike the SAM 3 concept segmentation block (which takes text or exemplar prompts and returns
+ALL instances of a concept), this block performs SAM2-style interactive segmentation: each prompt
+targets ONE object and the model returns a single mask for it.
+
+Two prompt inputs are supported (at least one must be provided):
+- **points**: a list of labeled 2D points defining a single object. Positive points mark the
+  object to segment, negative points mark regions to exclude (useful to refine the mask).
+- **boxes**: detections from another model. Each bounding box becomes a separate prompt and
+  the model segments the object inside it. Class names of the boxes are forwarded to the
+  predicted masks.
+"""
+
+
+def _as_sam2_points(points: List[Any]) -> List[Point]:
+    """Normalise points given as dicts or (x, y[, positive]) sequences into Sam2 Points."""
+    result = []
+    for raw_point in points:
+        if isinstance(raw_point, Point):
+            result.append(raw_point)
+            continue
+        if isinstance(raw_point, dict):
+            if "x" not in raw_point or "y" not in raw_point:
+                raise ValueError(
+                    f"Each point prompt must define `x` and `y` coordinates - got: {raw_point}"
+                )
+            x, y = raw_point["x"], raw_point["y"]
+            positive = raw_point.get("positive", True)
+        elif isinstance(raw_point, (list, tuple)) and len(raw_point) in {2, 3}:
+            x, y = raw_point[0], raw_point[1]
+            positive = raw_point[2] if len(raw_point) == 3 else True
+        else:
+            raise ValueError(
+                f"Invalid point prompt: {raw_point}. Expected dict with `x`, `y` and optional "
+                f"`positive` keys, or a sequence of (x, y) or (x, y, positive)."
+            )
+        if isinstance(x, bool) or isinstance(y, bool):
+            raise ValueError(f"Point coordinates must be numbers - got: {raw_point}")
+        if not isinstance(x, (int, float)) or not isinstance(y, (int, float)):
+            raise ValueError(f"Point coordinates must be numbers - got: {raw_point}")
+        result.append(Point(x=float(x), y=float(y), positive=bool(positive)))
+    return result
+
+
+class BlockManifest(WorkflowBlockManifest):
+    model_config = ConfigDict(
+        json_schema_extra={
+            "name": "SAM 3 Interactive",
+            "version": "v1",
+            "short_description": SHORT_DESCRIPTION,
+            "long_description": LONG_DESCRIPTION,
+            "license": "Apache-2.0",
+            "block_type": "model",
+            "search_keywords": [
+                "Sam",
+                "SAM3",
+                "segment anything",
+                "segment anything 3",
+                "point prompt",
+                "interactive segmentation",
+                "PVS",
+            ],
+            "ui_manifest": {
+                "section": "model",
+                "icon": "fa-solid fa-eye",
+                "blockPriority": 9.47,
+                "needsGPU": True,
+                "inference": True,
+            },
+        },
+        protected_namespaces=(),
+    )
+
+    type: Literal["roboflow_core/sam3_interactive@v1"]
+    images: Selector(kind=[IMAGE_KIND]) = ImageInputField
+    points: Optional[Union[List[Any], Selector(kind=[LABELED_POINTS_KIND])]] = Field(
+        default=None,
+        title="Point Prompts",
+        description="Labeled points defining a single object to segment. "
+        "Each point is {'x': ..., 'y': ..., 'positive': ...} in absolute pixel coordinates - "
+        "positive points mark the object, negative points mark regions to exclude. "
+        "Plain (x, y) or (x, y, positive) sequences are also accepted.",
+        examples=[
+            [{"x": 320, "y": 240, "positive": True}],
+            "$inputs.points",
+        ],
+        json_schema_extra={"always_visible": True},
+    )
+    boxes: Optional[
+        Selector(
+            kind=[
+                OBJECT_DETECTION_PREDICTION_KIND,
+                INSTANCE_SEGMENTATION_PREDICTION_KIND,
+                KEYPOINT_DETECTION_PREDICTION_KIND,
+            ]
+        )
+    ] = Field(  # type: ignore
+        default=None,
+        description="Bounding boxes (from another model) to use as prompts - "
+        "the model segments the object inside each box",
+        examples=["$steps.object_detection_model.predictions"],
+        json_schema_extra={"always_visible": True},
+    )
+    threshold: Union[Selector(kind=[FLOAT_KIND]), float] = Field(
+        default=0.0,
+        description="Minimum confidence threshold for predicted masks",
+        examples=[0.3],
+    )
+    multimask_output: Union[Optional[bool], Selector(kind=[BOOLEAN_KIND])] = Field(
+        default=True,
+        description="Flag to determine whether to use SAM3 internal multimask or single mask mode. "
+        "For ambiguous prompts (like a single point) setting to True is recommended.",
+        examples=[True, "$inputs.multimask_output"],
+    )
+
+    @model_validator(mode="after")
+    def _validate_points(self) -> "BlockManifest":
+        if isinstance(self.points, list):
+            _as_sam2_points(self.points)
+        return self
+
+    @classmethod
+    def get_parameters_accepting_batches(cls) -> List[str]:
+        return ["images", "boxes"]
+
+    @classmethod
+    def describe_outputs(cls) -> List[OutputDefinition]:
+        return [
+            OutputDefinition(
+                name="predictions",
+                kind=[INSTANCE_SEGMENTATION_PREDICTION_KIND],
+            ),
+        ]
+
+    @classmethod
+    def get_execution_engine_compatibility(cls) -> Optional[str]:
+        return ">=1.3.0,<2.0.0"
+
+    @classmethod
+    def get_restrictions(cls) -> List[RuntimeRestriction]:
+        restrictions = [
+            RuntimeRestriction(
+                severity=Severity.HARD,
+                note="Requires a GPU; run_locally() loads a model that needs CUDA.",
+                applies_to_runtimes=[Runtime.SELF_HOSTED_CPU],
+                applies_to_step_execution_modes=[StepExecutionMode.LOCAL],
+            ),
+        ]
+        if not CORE_MODEL_SAM3_ENABLED:
+            restrictions.append(
+                RuntimeRestriction(
+                    severity=Severity.HARD,
+                    note=(
+                        "CORE_MODEL_SAM3_ENABLED=False on Roboflow Hosted "
+                        "Serverless: the SAM3 endpoint is not registered, so "
+                        "run_remotely() returns 404."
+                    ),
+                    applies_to_runtimes=[Runtime.HOSTED_SERVERLESS],
+                    applies_to_step_execution_modes=[StepExecutionMode.REMOTE],
+                )
+            )
+        return restrictions
+
+    @classmethod
+    def get_supported_model_variants(cls) -> Optional[List[str]]:
+        """Return list of model_id variants that can satisfy this block."""
+        return [SAM3_INTERACTIVE_MODEL_ID]
+
+
+class SegmentAnything3InteractiveBlockV1(WorkflowBlock):
+
+    def __init__(
+        self,
+        model_manager: ModelManager,
+        api_key: Optional[str],
+        step_execution_mode: StepExecutionMode,
+    ):
+        self._model_manager = model_manager
+        self._api_key = api_key
+        self._step_execution_mode = step_execution_mode
+
+    @classmethod
+    def get_init_parameters(cls) -> List[str]:
+        return ["model_manager", "api_key", "step_execution_mode"]
+
+    @classmethod
+    def get_manifest(cls) -> Type[WorkflowBlockManifest]:
+        return BlockManifest
+
+    def run(
+        self,
+        images: Batch[WorkflowImageData],
+        points: Optional[List[Any]],
+        boxes: Optional[Batch[sv.Detections]],
+        threshold: float,
+        multimask_output: bool,
+    ) -> BlockResult:
+        if SAM3_EXEC_MODE == "remote":
+            logger.debug(
+                "Running SAM3 Interactive via inference proxy (SAM3_EXEC_MODE=remote)"
+            )
+            return self.run_via_request(
+                images=images,
+                points=points,
+                boxes=boxes,
+                threshold=threshold,
+                multimask_output=multimask_output,
+            )
+        if self._step_execution_mode is StepExecutionMode.LOCAL:
+            return self.run_locally(
+                images=images,
+                points=points,
+                boxes=boxes,
+                threshold=threshold,
+                multimask_output=multimask_output,
+            )
+        if self._step_execution_mode is StepExecutionMode.REMOTE:
+            return self.run_remotely(
+                images=images,
+                points=points,
+                boxes=boxes,
+                threshold=threshold,
+                multimask_output=multimask_output,
+            )
+        raise ValueError(f"Unknown step execution mode: {self._step_execution_mode}")
+
+    def run_locally(
+        self,
+        images: Batch[WorkflowImageData],
+        points: Optional[List[Any]],
+        boxes: Optional[Batch[sv.Detections]],
+        threshold: float,
+        multimask_output: bool,
+    ) -> BlockResult:
+        if boxes is None:
+            boxes = [None] * len(images)
+
+        predictions = []
+        for single_image, boxes_for_image in zip(images, boxes):
+            (
+                prompts,
+                prompt_class_ids,
+                prompt_class_names,
+                prompt_detection_ids,
+            ) = self._build_prompts(boxes_for_image=boxes_for_image, points=points)
+            inference_request = Sam2SegmentationRequest(
+                image=single_image.to_inference_format(numpy_preferred=True),
+                model_id=SAM3_INTERACTIVE_MODEL_ID,
+                api_key=self._api_key,
+                source="workflow-execution",
+                prompts=Sam2PromptSet(prompts=prompts),
+                multimask_output=multimask_output,
+            )
+            self._model_manager.add_model(
+                model_id=SAM3_INTERACTIVE_MODEL_ID,
+                api_key=self._api_key,
+            )
+            segmentation_response = self._model_manager.infer_from_request_sync(
+                SAM3_INTERACTIVE_MODEL_ID, inference_request
+            )
+            prediction = (
+                convert_sam2_segmentation_response_to_inference_instances_seg_response(
+                    sam2_segmentation_predictions=segmentation_response.predictions,
+                    image=single_image,
+                    prompt_class_ids=prompt_class_ids,
+                    prompt_class_names=prompt_class_names,
+                    prompt_detection_ids=prompt_detection_ids,
+                    threshold=threshold,
+                )
+            )
+            predictions.append(prediction)
+
+        predictions = [
+            e.model_dump(by_alias=True, exclude_none=True) for e in predictions
+        ]
+        return self._post_process_result(
+            images=images,
+            predictions=predictions,
+        )
+
+    def run_remotely(
+        self,
+        images: Batch[WorkflowImageData],
+        points: Optional[List[Any]],
+        boxes: Optional[Batch[sv.Detections]],
+        threshold: float,
+        multimask_output: bool,
+    ) -> BlockResult:
+        api_url = (
+            LOCAL_INFERENCE_API_URL
+            if WORKFLOWS_REMOTE_API_TARGET != "hosted"
+            else HOSTED_CORE_MODEL_URL
+        )
+        client = InferenceHTTPClient(
+            api_url=api_url,
+            api_key=self._api_key,
+        )
+        if WORKFLOWS_REMOTE_API_TARGET == "hosted":
+            client.select_api_v0()
+
+        if boxes is None:
+            boxes = [None] * len(images)
+
+        predictions = []
+        for single_image, boxes_for_image in zip(images, boxes):
+            (
+                prompts,
+                prompt_class_ids,
+                prompt_class_names,
+                prompt_detection_ids,
+            ) = self._build_prompts(boxes_for_image=boxes_for_image, points=points)
+            result = client.sam3_visual_segment(
+                inference_input=single_image.base64_image,
+                prompts=[prompt.dict(exclude_none=True) for prompt in prompts],
+                multimask_output=multimask_output,
+            )
+            prediction = (
+                convert_sam2_segmentation_response_to_inference_instances_seg_response(
+                    sam2_segmentation_predictions=_parse_segmentation_predictions(
+                        result
+                    ),
+                    image=single_image,
+                    prompt_class_ids=prompt_class_ids,
+                    prompt_class_names=prompt_class_names,
+                    prompt_detection_ids=prompt_detection_ids,
+                    threshold=threshold,
+                )
+            )
+            predictions.append(prediction)
+
+        predictions = [
+            e.model_dump(by_alias=True, exclude_none=True) for e in predictions
+        ]
+        return self._post_process_result(
+            images=images,
+            predictions=predictions,
+        )
+
+    def run_via_request(
+        self,
+        images: Batch[WorkflowImageData],
+        points: Optional[List[Any]],
+        boxes: Optional[Batch[sv.Detections]],
+        threshold: float,
+        multimask_output: bool,
+    ) -> BlockResult:
+        endpoint = f"{API_BASE_URL}/inferenceproxy/sam3-pvs"
+
+        if boxes is None:
+            boxes = [None] * len(images)
+
+        predictions = []
+        for single_image, boxes_for_image in zip(images, boxes):
+            (
+                prompts,
+                prompt_class_ids,
+                prompt_class_names,
+                prompt_detection_ids,
+            ) = self._build_prompts(boxes_for_image=boxes_for_image, points=points)
+            payload = {
+                "image": {"type": "base64", "value": single_image.base64_image},
+                "prompts": Sam2PromptSet(prompts=prompts).dict(exclude_none=True),
+                "multimask_output": multimask_output,
+            }
+            try:
+                headers = {"Content-Type": "application/json"}
+                if ROBOFLOW_INTERNAL_SERVICE_NAME:
+                    headers["X-Roboflow-Internal-Service-Name"] = (
+                        ROBOFLOW_INTERNAL_SERVICE_NAME
+                    )
+                if ROBOFLOW_INTERNAL_SERVICE_SECRET:
+                    headers["X-Roboflow-Internal-Service-Secret"] = (
+                        ROBOFLOW_INTERNAL_SERVICE_SECRET
+                    )
+                headers = build_roboflow_api_headers(explicit_headers=headers)
+                response = requests.post(
+                    wrap_url(f"{endpoint}?api_key={self._api_key}"),
+                    json=payload,
+                    headers=headers,
+                    timeout=60,
+                )
+                response.raise_for_status()
+                resp_json = response.json()
+            except Exception as e:
+                raise Exception(f"SAM3 interactive request failed: {e}")
+
+            prediction = (
+                convert_sam2_segmentation_response_to_inference_instances_seg_response(
+                    sam2_segmentation_predictions=_parse_segmentation_predictions(
+                        resp_json
+                    ),
+                    image=single_image,
+                    prompt_class_ids=prompt_class_ids,
+                    prompt_class_names=prompt_class_names,
+                    prompt_detection_ids=prompt_detection_ids,
+                    threshold=threshold,
+                )
+            )
+            predictions.append(prediction)
+
+        predictions = [
+            e.model_dump(by_alias=True, exclude_none=True) for e in predictions
+        ]
+        return self._post_process_result(
+            images=images,
+            predictions=predictions,
+        )
+
+    @staticmethod
+    def _build_prompts(
+        boxes_for_image: Optional[sv.Detections],
+        points: Optional[List[Any]],
+    ) -> Tuple[List[Sam2Prompt], List[Optional[int]], List[str], List[Optional[str]]]:
+        prompts: List[Sam2Prompt] = []
+        prompt_class_ids: List[Optional[int]] = []
+        prompt_class_names: List[str] = []
+        prompt_detection_ids: List[Optional[str]] = []
+        if boxes_for_image is not None:
+            for xyxy, _, _, class_id, _, bbox_data in boxes_for_image:
+                x1, y1, x2, y2 = xyxy
+                width = x2 - x1
+                height = y2 - y1
+                prompts.append(
+                    Sam2Prompt(
+                        box=Box(
+                            x=float(x1 + width / 2),
+                            y=float(y1 + height / 2),
+                            width=float(width),
+                            height=float(height),
+                        )
+                    )
+                )
+                prompt_class_ids.append(class_id)
+                prompt_class_names.append(bbox_data[DETECTIONS_CLASS_NAME_FIELD])
+                prompt_detection_ids.append(bbox_data[DETECTION_ID_FIELD])
+        if points:
+            prompts.append(Sam2Prompt(points=_as_sam2_points(points)))
+            prompt_class_ids.append(0)
+            prompt_class_names.append("foreground")
+            prompt_detection_ids.append(None)
+        if not prompts:
+            raise ValueError(
+                "SAM 3 Interactive block requires at least one prompt - "
+                "provide `points` and/or `boxes` input."
+            )
+        return prompts, prompt_class_ids, prompt_class_names, prompt_detection_ids
+
+    def _post_process_result(
+        self,
+        images: Batch[WorkflowImageData],
+        predictions: List[dict],
+    ) -> BlockResult:
+        predictions = convert_inference_detections_batch_to_sv_detections(predictions)
+        predictions = attach_prediction_type_info_to_sv_detections_batch(
+            predictions=predictions,
+            prediction_type="instance-segmentation",
+        )
+        predictions = attach_parents_coordinates_to_batch_of_sv_detections(
+            images=images,
+            predictions=predictions,
+        )
+        return [{"predictions": prediction} for prediction in predictions]
+
+
+def _parse_segmentation_predictions(
+    response: Union[dict, list],
+) -> List[Sam2SegmentationPrediction]:
+    if isinstance(response, list):
+        raw_predictions = response
+    else:
+        raw_predictions = response.get("predictions", [])
+    return [
+        Sam2SegmentationPrediction(
+            masks=raw_prediction.get("masks", []),
+            confidence=raw_prediction.get("confidence", 0.0),
+        )
+        for raw_prediction in raw_predictions
+    ]

--- a/inference/core/workflows/core_steps/models/foundation/segment_anything3_interactive/v1.py
+++ b/inference/core/workflows/core_steps/models/foundation/segment_anything3_interactive/v1.py
@@ -1,4 +1,5 @@
-from typing import Any, List, Literal, Optional, Tuple, Type, Union
+from dataclasses import dataclass
+from typing import Any, List, Literal, Optional, Type, Union
 
 import requests
 import supervision as sv
@@ -309,36 +310,45 @@ class SegmentAnything3InteractiveBlockV1(WorkflowBlock):
         if boxes is None:
             boxes = [None] * len(images)
 
+        self._model_manager.add_model(
+            model_id=SAM3_INTERACTIVE_MODEL_ID,
+            api_key=self._api_key,
+        )
+
         predictions = []
         for single_image, boxes_for_image in zip(images, boxes):
-            (
-                prompts,
-                prompt_class_ids,
-                prompt_class_names,
-                prompt_detection_ids,
-            ) = self._build_prompts(boxes_for_image=boxes_for_image, points=points)
-            inference_request = Sam2SegmentationRequest(
-                image=single_image.to_inference_format(numpy_preferred=True),
-                model_id=SAM3_INTERACTIVE_MODEL_ID,
-                api_key=self._api_key,
-                source="workflow-execution",
-                prompts=Sam2PromptSet(prompts=prompts),
-                multimask_output=multimask_output,
+            groups = self._build_prompt_groups(
+                boxes_for_image=boxes_for_image, points=points
             )
-            self._model_manager.add_model(
-                model_id=SAM3_INTERACTIVE_MODEL_ID,
-                api_key=self._api_key,
+            segmentation_predictions, class_ids, class_names, detection_ids = (
+                [],
+                [],
+                [],
+                [],
             )
-            segmentation_response = self._model_manager.infer_from_request_sync(
-                SAM3_INTERACTIVE_MODEL_ID, inference_request
-            )
+            for group in groups:
+                inference_request = Sam2SegmentationRequest(
+                    image=single_image.to_inference_format(numpy_preferred=True),
+                    model_id=SAM3_INTERACTIVE_MODEL_ID,
+                    api_key=self._api_key,
+                    source="workflow-execution",
+                    prompts=Sam2PromptSet(prompts=group.prompts),
+                    multimask_output=multimask_output,
+                )
+                segmentation_response = self._model_manager.infer_from_request_sync(
+                    SAM3_INTERACTIVE_MODEL_ID, inference_request
+                )
+                segmentation_predictions.extend(segmentation_response.predictions)
+                class_ids.extend(group.class_ids)
+                class_names.extend(group.class_names)
+                detection_ids.extend(group.detection_ids)
             prediction = (
                 convert_sam2_segmentation_response_to_inference_instances_seg_response(
-                    sam2_segmentation_predictions=segmentation_response.predictions,
+                    sam2_segmentation_predictions=segmentation_predictions,
                     image=single_image,
-                    prompt_class_ids=prompt_class_ids,
-                    prompt_class_names=prompt_class_names,
-                    prompt_detection_ids=prompt_detection_ids,
+                    prompt_class_ids=class_ids,
+                    prompt_class_names=class_names,
+                    prompt_detection_ids=detection_ids,
                     threshold=threshold,
                 )
             )
@@ -377,26 +387,34 @@ class SegmentAnything3InteractiveBlockV1(WorkflowBlock):
 
         predictions = []
         for single_image, boxes_for_image in zip(images, boxes):
-            (
-                prompts,
-                prompt_class_ids,
-                prompt_class_names,
-                prompt_detection_ids,
-            ) = self._build_prompts(boxes_for_image=boxes_for_image, points=points)
-            result = client.sam3_visual_segment(
-                inference_input=single_image.base64_image,
-                prompts=[prompt.dict(exclude_none=True) for prompt in prompts],
-                multimask_output=multimask_output,
+            groups = self._build_prompt_groups(
+                boxes_for_image=boxes_for_image, points=points
             )
+            segmentation_predictions, class_ids, class_names, detection_ids = (
+                [],
+                [],
+                [],
+                [],
+            )
+            for group in groups:
+                result = client.sam3_visual_segment(
+                    inference_input=single_image.base64_image,
+                    prompts=[
+                        prompt.dict(exclude_none=True) for prompt in group.prompts
+                    ],
+                    multimask_output=multimask_output,
+                )
+                segmentation_predictions.extend(_parse_segmentation_predictions(result))
+                class_ids.extend(group.class_ids)
+                class_names.extend(group.class_names)
+                detection_ids.extend(group.detection_ids)
             prediction = (
                 convert_sam2_segmentation_response_to_inference_instances_seg_response(
-                    sam2_segmentation_predictions=_parse_segmentation_predictions(
-                        result
-                    ),
+                    sam2_segmentation_predictions=segmentation_predictions,
                     image=single_image,
-                    prompt_class_ids=prompt_class_ids,
-                    prompt_class_names=prompt_class_names,
-                    prompt_detection_ids=prompt_detection_ids,
+                    prompt_class_ids=class_ids,
+                    prompt_class_names=class_names,
+                    prompt_detection_ids=detection_ids,
                     threshold=threshold,
                 )
             )
@@ -425,48 +443,58 @@ class SegmentAnything3InteractiveBlockV1(WorkflowBlock):
 
         predictions = []
         for single_image, boxes_for_image in zip(images, boxes):
-            (
-                prompts,
-                prompt_class_ids,
-                prompt_class_names,
-                prompt_detection_ids,
-            ) = self._build_prompts(boxes_for_image=boxes_for_image, points=points)
-            payload = {
-                "image": {"type": "base64", "value": single_image.base64_image},
-                "prompts": Sam2PromptSet(prompts=prompts).dict(exclude_none=True),
-                "multimask_output": multimask_output,
-            }
-            try:
-                headers = {"Content-Type": "application/json"}
-                if ROBOFLOW_INTERNAL_SERVICE_NAME:
-                    headers["X-Roboflow-Internal-Service-Name"] = (
-                        ROBOFLOW_INTERNAL_SERVICE_NAME
+            groups = self._build_prompt_groups(
+                boxes_for_image=boxes_for_image, points=points
+            )
+            segmentation_predictions, class_ids, class_names, detection_ids = (
+                [],
+                [],
+                [],
+                [],
+            )
+            for group in groups:
+                payload = {
+                    "image": {"type": "base64", "value": single_image.base64_image},
+                    "prompts": Sam2PromptSet(prompts=group.prompts).dict(
+                        exclude_none=True
+                    ),
+                    "multimask_output": multimask_output,
+                }
+                try:
+                    headers = {"Content-Type": "application/json"}
+                    if ROBOFLOW_INTERNAL_SERVICE_NAME:
+                        headers["X-Roboflow-Internal-Service-Name"] = (
+                            ROBOFLOW_INTERNAL_SERVICE_NAME
+                        )
+                    if ROBOFLOW_INTERNAL_SERVICE_SECRET:
+                        headers["X-Roboflow-Internal-Service-Secret"] = (
+                            ROBOFLOW_INTERNAL_SERVICE_SECRET
+                        )
+                    headers = build_roboflow_api_headers(explicit_headers=headers)
+                    response = requests.post(
+                        wrap_url(f"{endpoint}?api_key={self._api_key}"),
+                        json=payload,
+                        headers=headers,
+                        timeout=60,
                     )
-                if ROBOFLOW_INTERNAL_SERVICE_SECRET:
-                    headers["X-Roboflow-Internal-Service-Secret"] = (
-                        ROBOFLOW_INTERNAL_SERVICE_SECRET
-                    )
-                headers = build_roboflow_api_headers(explicit_headers=headers)
-                response = requests.post(
-                    wrap_url(f"{endpoint}?api_key={self._api_key}"),
-                    json=payload,
-                    headers=headers,
-                    timeout=60,
-                )
-                response.raise_for_status()
-                resp_json = response.json()
-            except Exception as e:
-                raise Exception(f"SAM3 interactive request failed: {e}")
+                    response.raise_for_status()
+                    resp_json = response.json()
+                except Exception as e:
+                    raise Exception(f"SAM3 interactive request failed: {e}")
 
+                segmentation_predictions.extend(
+                    _parse_segmentation_predictions(resp_json)
+                )
+                class_ids.extend(group.class_ids)
+                class_names.extend(group.class_names)
+                detection_ids.extend(group.detection_ids)
             prediction = (
                 convert_sam2_segmentation_response_to_inference_instances_seg_response(
-                    sam2_segmentation_predictions=_parse_segmentation_predictions(
-                        resp_json
-                    ),
+                    sam2_segmentation_predictions=segmentation_predictions,
                     image=single_image,
-                    prompt_class_ids=prompt_class_ids,
-                    prompt_class_names=prompt_class_names,
-                    prompt_detection_ids=prompt_detection_ids,
+                    prompt_class_ids=class_ids,
+                    prompt_class_names=class_names,
+                    prompt_detection_ids=detection_ids,
                     threshold=threshold,
                 )
             )
@@ -481,15 +509,19 @@ class SegmentAnything3InteractiveBlockV1(WorkflowBlock):
         )
 
     @staticmethod
-    def _build_prompts(
+    def _build_prompt_groups(
         boxes_for_image: Optional[sv.Detections],
         points: Optional[List[Any]],
-    ) -> Tuple[List[Sam2Prompt], List[Optional[int]], List[str], List[Optional[str]]]:
-        prompts: List[Sam2Prompt] = []
-        prompt_class_ids: List[Optional[int]] = []
-        prompt_class_names: List[str] = []
-        prompt_detection_ids: List[Optional[str]] = []
-        if boxes_for_image is not None:
+    ) -> List["_PromptGroup"]:
+        # The SAM prompt encoder batches a request's prompts into a single
+        # tensor, so one request cannot mix box-carrying and box-less prompts -
+        # box and point prompts are therefore issued as separate requests.
+        groups: List[_PromptGroup] = []
+        if boxes_for_image is not None and len(boxes_for_image) > 0:
+            prompts: List[Sam2Prompt] = []
+            class_ids: List[Optional[int]] = []
+            class_names: List[str] = []
+            detection_ids: List[Optional[str]] = []
             for xyxy, _, _, class_id, _, bbox_data in boxes_for_image:
                 x1, y1, x2, y2 = xyxy
                 width = x2 - x1
@@ -504,20 +536,34 @@ class SegmentAnything3InteractiveBlockV1(WorkflowBlock):
                         )
                     )
                 )
-                prompt_class_ids.append(class_id)
-                prompt_class_names.append(bbox_data[DETECTIONS_CLASS_NAME_FIELD])
-                prompt_detection_ids.append(bbox_data[DETECTION_ID_FIELD])
+                class_ids.append(class_id)
+                class_names.append(bbox_data[DETECTIONS_CLASS_NAME_FIELD])
+                detection_ids.append(bbox_data[DETECTION_ID_FIELD])
+            groups.append(
+                _PromptGroup(
+                    prompts=prompts,
+                    class_ids=class_ids,
+                    class_names=class_names,
+                    detection_ids=detection_ids,
+                )
+            )
         if points:
-            prompts.append(Sam2Prompt(points=_as_sam2_points(points)))
-            prompt_class_ids.append(0)
-            prompt_class_names.append("foreground")
-            prompt_detection_ids.append(None)
-        if not prompts:
+            groups.append(
+                _PromptGroup(
+                    prompts=[Sam2Prompt(points=_as_sam2_points(points))],
+                    class_ids=[0],
+                    class_names=["foreground"],
+                    detection_ids=[None],
+                )
+            )
+        if boxes_for_image is None and not points:
             raise ValueError(
                 "SAM 3 Interactive block requires at least one prompt - "
                 "provide `points` and/or `boxes` input."
             )
-        return prompts, prompt_class_ids, prompt_class_names, prompt_detection_ids
+        # boxes input connected but no detections for this image -> no prompts,
+        # runners emit empty predictions
+        return groups
 
     def _post_process_result(
         self,
@@ -534,6 +580,14 @@ class SegmentAnything3InteractiveBlockV1(WorkflowBlock):
             predictions=predictions,
         )
         return [{"predictions": prediction} for prediction in predictions]
+
+
+@dataclass(frozen=True)
+class _PromptGroup:
+    prompts: List[Sam2Prompt]
+    class_ids: List[Optional[int]]
+    class_names: List[str]
+    detection_ids: List[Optional[str]]
 
 
 def _parse_segmentation_predictions(

--- a/inference/core/workflows/execution_engine/entities/types.py
+++ b/inference/core/workflows/execution_engine/entities/types.py
@@ -546,6 +546,33 @@ POINT_KIND = Kind(
     internal_data_type="Tuple[int, int]",
 )
 
+LABELED_POINTS_KIND_DOCS = """
+This kind represents a list of 2D points with positive/negative labels, used for interactive
+point prompting of segmentation models (like the SAM model family).
+
+Each point is a dict with `x` and `y` absolute pixel coordinates and a `positive` flag:
+positive points mark the object to segment, negative points mark regions to exclude.
+
+Example:
+```
+[
+    {"x": 300, "y": 220, "positive": true},
+    {"x": 380, "y": 260, "positive": false}
+]
+```
+
+Points may also be provided as `(x, y)` or `(x, y, positive)` sequences - missing `positive`
+labels are assumed to be positive. Runtime inputs of this kind are normalised to the dict form.
+"""
+
+LABELED_POINTS_KIND = Kind(
+    name="labeled_points",
+    description="List of 2D points with positive/negative labels",
+    docs=LABELED_POINTS_KIND_DOCS,
+    serialised_data_type="List[Dict[str, Any]]",
+    internal_data_type="List[Dict[str, Any]]",
+)
+
 CONTOURS_KIND_DOCS = """
 This kind represents a value of a list of numpy arrays where each array represents contour points.
 

--- a/inference/models/sam3/visual_segmentation_inference_models.py
+++ b/inference/models/sam3/visual_segmentation_inference_models.py
@@ -1,7 +1,7 @@
 import copy
 from io import BytesIO
 from time import perf_counter
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Union
 
 import numpy as np
 import torch
@@ -201,10 +201,14 @@ class InferenceModelsSAM3InteractiveAdapter(Model):
             save_to_mask_input_cache=save_logits_to_cache,
             use_embeddings_cache=True,
         )[0]
-        return _choose_most_confident_sam_prediction(
-            masks=prediction.masks.cpu().numpy(),
-            scores=prediction.scores.cpu().numpy(),
-            low_resolution_logits=prediction.logits.cpu().numpy(),
+        # SAM3Torch already selects the most confident of the multimask proposals
+        # for each prompt, so masks/scores/logits arrive with exactly one entry
+        # per prompt. Reducing again here would collapse a multi-prompt request
+        # into a single prediction.
+        return (
+            prediction.masks.cpu().numpy(),
+            prediction.scores.cpu().numpy(),
+            prediction.logits.cpu().numpy(),
         )
 
 
@@ -224,28 +228,6 @@ def _pad_points(args: Dict[str, Any]) -> Dict[str, Any]:
                 "Can't have point labels without corresponding point coordinates"
             )
     return args
-
-
-def _choose_most_confident_sam_prediction(
-    masks: np.ndarray,
-    scores: np.ndarray,
-    low_resolution_logits: np.ndarray,
-) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
-    if masks.ndim == 3:
-        masks = np.expand_dims(masks, axis=0)
-        scores = np.expand_dims(scores, axis=0)
-        low_resolution_logits = np.expand_dims(low_resolution_logits, axis=0)
-    selected_masks, selected_scores, selected_logits = [], [], []
-    for mask, score, low_res in zip(masks, scores, low_resolution_logits):
-        max_idx = int(np.argsort(score)[-1])
-        selected_masks.append(mask[max_idx])
-        selected_scores.append(score[max_idx].item())
-        selected_logits.append(low_res[max_idx])
-    return (
-        np.asarray(selected_masks),
-        np.asarray(selected_scores),
-        np.asarray(selected_logits),
-    )
 
 
 def _build_polygon_response(

--- a/inference_models/inference_models/models/sam3/sam3_torch.py
+++ b/inference_models/inference_models/models/sam3/sam3_torch.py
@@ -466,10 +466,10 @@ class SAM3Torch:
                 boxes_list = boxes.cpu().tolist()
             else:
                 boxes_list = boxes
-            if len(boxes_list) > 0 and isinstance(boxes_list[0], (int, float)):
-                args["box"] = boxes_list
-            else:
-                args["box"] = boxes_list[0] if boxes_list else None
+            # Either a flat [x1, y1, x2, y2] box or a [num_prompts, 4] batch -
+            # the predictor reshapes both to (-1, 2, 2), so all boxes must be
+            # forwarded (taking only the first one silently drops prompts).
+            args["box"] = boxes_list if boxes_list else None
 
         args = pad_points(args)
         if not any(args.values()):

--- a/inference_models/tests/unit_tests/models/test_sam3_torch.py
+++ b/inference_models/tests/unit_tests/models/test_sam3_torch.py
@@ -1,42 +1,56 @@
 """Unit tests for SAM3Torch interactive (PVS) prompt handling."""
 
+import importlib
 import sys
 from threading import RLock
-from unittest.mock import MagicMock
+from types import ModuleType
+from typing import Generator
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
 import torch
 
-
-def _install_sam3_package_mocks():
-    names = [
-        "sam3",
-        "sam3.eval",
-        "sam3.eval.postprocessors",
-        "sam3.model",
-        "sam3.model.sam3_image_processor",
-        "sam3.model.utils",
-        "sam3.model.utils.misc",
-        "sam3.train",
-        "sam3.train.data",
-        "sam3.train.data.collator",
-        "sam3.train.data.sam3_image_dataset",
-        "sam3.train.transforms",
-        "sam3.train.transforms.basic_for_api",
-    ]
-    for name in names:
-        sys.modules.setdefault(name, MagicMock())
-
-
-_install_sam3_package_mocks()
-
 from inference_models.models.sam3.entities import SAM3ImageEmbeddings
-from inference_models.models.sam3.sam3_torch import SAM3Torch
+
+# Meta's `sam3` package ships only with the CUDA extras (torch-cu*), so it is
+# not installed in the unit-test environment and the module under test cannot
+# be imported without stubbing it.
+_SAM3_PACKAGE_MODULES = [
+    "sam3",
+    "sam3.eval",
+    "sam3.eval.postprocessors",
+    "sam3.model",
+    "sam3.model.sam3_image_processor",
+    "sam3.model.utils",
+    "sam3.model.utils.misc",
+    "sam3.train",
+    "sam3.train.data",
+    "sam3.train.data.collator",
+    "sam3.train.data.sam3_image_dataset",
+    "sam3.train.transforms",
+    "sam3.train.transforms.basic_for_api",
+]
+
+SAM3_TORCH_MODULE = "inference_models.models.sam3.sam3_torch"
 
 
-def _build_model_with_mocked_predictor(num_prompts: int) -> SAM3Torch:
-    model = SAM3Torch.__new__(SAM3Torch)
+@pytest.fixture()
+def sam3_torch_module() -> Generator[ModuleType, None, None]:
+    """Imports the module under test with `sam3` stubbed, per test.
+
+    `patch.dict` restores `sys.modules` to its pre-test state on exit, which
+    drops both the stubs and the module imported against them - no mocked
+    modules leak into other tests.
+    """
+    stubs = {name: MagicMock() for name in _SAM3_PACKAGE_MODULES}
+    with patch.dict(sys.modules, stubs):
+        sys.modules.pop(SAM3_TORCH_MODULE, None)
+        yield importlib.import_module(SAM3_TORCH_MODULE)
+
+
+def _build_model_with_mocked_predictor(sam3_torch_module: ModuleType, num_prompts: int):
+    model = sam3_torch_module.SAM3Torch.__new__(sam3_torch_module.SAM3Torch)
     model._predict_inst_lock = RLock()
     model._model = MagicMock()
     if num_prompts == 1:
@@ -64,11 +78,13 @@ def _example_embeddings() -> SAM3ImageEmbeddings:
     )
 
 
-def test_predict_for_single_image_forwards_all_boxes():
+def test_predict_for_single_image_forwards_all_boxes(
+    sam3_torch_module: ModuleType,
+) -> None:
     """Regression test: multiple box prompts must all reach the predictor -
     previously only the first box was forwarded."""
     # given
-    model = _build_model_with_mocked_predictor(num_prompts=2)
+    model = _build_model_with_mocked_predictor(sam3_torch_module, num_prompts=2)
     boxes = np.array([[0, 0, 4, 4], [2, 2, 6, 6]])
 
     # when
@@ -86,9 +102,11 @@ def test_predict_for_single_image_forwards_all_boxes():
     assert prediction.scores.shape == (2,)
 
 
-def test_predict_for_single_image_accepts_flat_single_box():
+def test_predict_for_single_image_accepts_flat_single_box(
+    sam3_torch_module: ModuleType,
+) -> None:
     # given
-    model = _build_model_with_mocked_predictor(num_prompts=1)
+    model = _build_model_with_mocked_predictor(sam3_torch_module, num_prompts=1)
 
     # when
     prediction = model._predict_for_single_image(
@@ -105,9 +123,11 @@ def test_predict_for_single_image_accepts_flat_single_box():
     assert prediction.scores.shape == (1,)
 
 
-def test_predict_for_single_image_selects_best_proposal_per_prompt():
+def test_predict_for_single_image_selects_best_proposal_per_prompt(
+    sam3_torch_module: ModuleType,
+) -> None:
     # given
-    model = _build_model_with_mocked_predictor(num_prompts=2)
+    model = _build_model_with_mocked_predictor(sam3_torch_module, num_prompts=2)
 
     # when
     prediction = model._predict_for_single_image(

--- a/inference_models/tests/unit_tests/models/test_sam3_torch.py
+++ b/inference_models/tests/unit_tests/models/test_sam3_torch.py
@@ -1,0 +1,121 @@
+"""Unit tests for SAM3Torch interactive (PVS) prompt handling."""
+
+import sys
+from threading import RLock
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+import torch
+
+
+def _install_sam3_package_mocks():
+    names = [
+        "sam3",
+        "sam3.eval",
+        "sam3.eval.postprocessors",
+        "sam3.model",
+        "sam3.model.sam3_image_processor",
+        "sam3.model.utils",
+        "sam3.model.utils.misc",
+        "sam3.train",
+        "sam3.train.data",
+        "sam3.train.data.collator",
+        "sam3.train.data.sam3_image_dataset",
+        "sam3.train.transforms",
+        "sam3.train.transforms.basic_for_api",
+    ]
+    for name in names:
+        sys.modules.setdefault(name, MagicMock())
+
+
+_install_sam3_package_mocks()
+
+from inference_models.models.sam3.entities import SAM3ImageEmbeddings
+from inference_models.models.sam3.sam3_torch import SAM3Torch
+
+
+def _build_model_with_mocked_predictor(num_prompts: int) -> SAM3Torch:
+    model = SAM3Torch.__new__(SAM3Torch)
+    model._predict_inst_lock = RLock()
+    model._model = MagicMock()
+    if num_prompts == 1:
+        # the underlying predictor squeezes the prompt dimension for a single prompt
+        predict_inst_result = (
+            np.random.rand(3, 8, 8),
+            np.array([0.5, 0.9, 0.7]),
+            np.random.rand(3, 16, 16),
+        )
+    else:
+        predict_inst_result = (
+            np.random.rand(num_prompts, 3, 8, 8),
+            np.tile([0.5, 0.9, 0.7], (num_prompts, 1)),
+            np.random.rand(num_prompts, 3, 16, 16),
+        )
+    model._model.predict_inst.return_value = predict_inst_result
+    return model
+
+
+def _example_embeddings() -> SAM3ImageEmbeddings:
+    return SAM3ImageEmbeddings(
+        image_hash="image-hash",
+        image_size_hw=(8, 8),
+        embeddings={"state": MagicMock()},
+    )
+
+
+def test_predict_for_single_image_forwards_all_boxes():
+    """Regression test: multiple box prompts must all reach the predictor -
+    previously only the first box was forwarded."""
+    # given
+    model = _build_model_with_mocked_predictor(num_prompts=2)
+    boxes = np.array([[0, 0, 4, 4], [2, 2, 6, 6]])
+
+    # when
+    prediction = model._predict_for_single_image(
+        embeddings=_example_embeddings(),
+        original_image_size=(8, 8),
+        boxes=boxes,
+        return_logits=True,
+    )
+
+    # then
+    call_kwargs = model._model.predict_inst.call_args.kwargs
+    assert call_kwargs["box"] == [[0, 0, 4, 4], [2, 2, 6, 6]]
+    assert prediction.masks.shape == (2, 8, 8)
+    assert prediction.scores.shape == (2,)
+
+
+def test_predict_for_single_image_accepts_flat_single_box():
+    # given
+    model = _build_model_with_mocked_predictor(num_prompts=1)
+
+    # when
+    prediction = model._predict_for_single_image(
+        embeddings=_example_embeddings(),
+        original_image_size=(8, 8),
+        boxes=[0, 0, 4, 4],
+        return_logits=True,
+    )
+
+    # then
+    call_kwargs = model._model.predict_inst.call_args.kwargs
+    assert call_kwargs["box"] == [0, 0, 4, 4]
+    assert prediction.masks.shape == (1, 8, 8)
+    assert prediction.scores.shape == (1,)
+
+
+def test_predict_for_single_image_selects_best_proposal_per_prompt():
+    # given
+    model = _build_model_with_mocked_predictor(num_prompts=2)
+
+    # when
+    prediction = model._predict_for_single_image(
+        embeddings=_example_embeddings(),
+        original_image_size=(8, 8),
+        boxes=np.array([[0, 0, 4, 4], [2, 2, 6, 6]]),
+        return_logits=True,
+    )
+
+    # then - proposal scores per prompt are [0.5, 0.9, 0.7], the best is kept
+    assert torch.allclose(prediction.scores, torch.tensor([0.9, 0.9]).double())

--- a/tests/inference/unit_tests/models/test_sam3_visual_segmentation.py
+++ b/tests/inference/unit_tests/models/test_sam3_visual_segmentation.py
@@ -1,0 +1,121 @@
+"""Unit tests for the SAM3 interactive segmentation adapter (PVS serving path)."""
+
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+import torch
+
+
+def _install_sam3_package_mocks():
+    names = [
+        "sam3",
+        "sam3.eval",
+        "sam3.eval.postprocessors",
+        "sam3.model",
+        "sam3.model.sam3_image_processor",
+        "sam3.model.utils",
+        "sam3.model.utils.misc",
+        "sam3.train",
+        "sam3.train.data",
+        "sam3.train.data.collator",
+        "sam3.train.data.sam3_image_dataset",
+        "sam3.train.transforms",
+        "sam3.train.transforms.basic_for_api",
+    ]
+    for name in names:
+        sys.modules.setdefault(name, MagicMock())
+
+
+_install_sam3_package_mocks()
+
+import inference.models.sam3.visual_segmentation_inference_models as vs_module
+
+
+def _build_adapter(prediction) -> "vs_module.InferenceModelsSAM3InteractiveAdapter":
+    adapter = vs_module.InferenceModelsSAM3InteractiveAdapter.__new__(
+        vs_module.InferenceModelsSAM3InteractiveAdapter
+    )
+    adapter._model = MagicMock()
+    adapter._model.segment_with_visual_prompts.return_value = [prediction]
+    return adapter
+
+
+def test_segment_image_returns_one_prediction_per_prompt():
+    """Regression test: a request with N prompts must return N masks - the adapter
+    must not reduce across prompts (SAM3Torch already selects the best of the
+    multimask proposals for each prompt)."""
+    # given
+    prediction = SimpleNamespace(
+        masks=torch.rand(2, 8, 8),
+        scores=torch.tensor([0.9, 0.8]),
+        logits=torch.rand(2, 16, 16),
+    )
+    adapter = _build_adapter(prediction)
+
+    # when
+    masks, scores, logits = adapter.segment_image(
+        image=None,
+        prompts={
+            "prompts": [
+                {"points": [{"x": 1, "y": 1, "positive": True}]},
+                {"points": [{"x": 5, "y": 5, "positive": True}]},
+            ]
+        },
+    )
+
+    # then
+    assert masks.shape == (2, 8, 8)
+    assert scores.shape == (2,)
+    assert logits.shape == (2, 16, 16)
+    np.testing.assert_allclose(scores, [0.9, 0.8], rtol=1e-6)
+
+
+def test_segment_image_with_single_prompt_keeps_prompt_dimension():
+    # given
+    prediction = SimpleNamespace(
+        masks=torch.rand(1, 8, 8),
+        scores=torch.tensor([0.7]),
+        logits=torch.rand(1, 16, 16),
+    )
+    adapter = _build_adapter(prediction)
+
+    # when
+    masks, scores, logits = adapter.segment_image(
+        image=None,
+        prompts={"prompts": [{"points": [{"x": 1, "y": 1, "positive": True}]}]},
+    )
+
+    # then
+    assert masks.shape == (1, 8, 8)
+    assert scores.shape == (1,)
+    assert logits.shape == (1, 16, 16)
+
+
+def test_segment_image_forwards_all_prompts_to_model():
+    # given
+    prediction = SimpleNamespace(
+        masks=torch.rand(2, 8, 8),
+        scores=torch.tensor([0.9, 0.8]),
+        logits=torch.rand(2, 16, 16),
+    )
+    adapter = _build_adapter(prediction)
+
+    # when
+    _ = adapter.segment_image(
+        image=None,
+        prompts={
+            "prompts": [
+                {"box": {"x": 10, "y": 10, "width": 4, "height": 4}},
+                {"box": {"x": 30, "y": 30, "width": 8, "height": 8}},
+            ]
+        },
+    )
+
+    # then
+    call_kwargs = adapter._model.segment_with_visual_prompts.call_args.kwargs
+    boxes = call_kwargs["boxes"]
+    assert boxes.shape == (2, 4)
+    np.testing.assert_allclose(boxes, [[8, 8, 12, 12], [26, 26, 34, 34]])

--- a/tests/inference/unit_tests/models/test_sam3_visual_segmentation.py
+++ b/tests/inference/unit_tests/models/test_sam3_visual_segmentation.py
@@ -1,49 +1,65 @@
 """Unit tests for the SAM3 interactive segmentation adapter (PVS serving path)."""
 
+import importlib
 import sys
-from types import SimpleNamespace
-from unittest.mock import MagicMock
+from types import ModuleType, SimpleNamespace
+from typing import Generator
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
 import torch
 
+# Meta's `sam3` package is not installed in the unit-test environment, so the
+# adapter module (which imports it transitively via inference_models) cannot
+# be imported without stubbing it.
+_SAM3_PACKAGE_MODULES = [
+    "sam3",
+    "sam3.eval",
+    "sam3.eval.postprocessors",
+    "sam3.model",
+    "sam3.model.sam3_image_processor",
+    "sam3.model.utils",
+    "sam3.model.utils.misc",
+    "sam3.train",
+    "sam3.train.data",
+    "sam3.train.data.collator",
+    "sam3.train.data.sam3_image_dataset",
+    "sam3.train.transforms",
+    "sam3.train.transforms.basic_for_api",
+]
 
-def _install_sam3_package_mocks():
-    names = [
-        "sam3",
-        "sam3.eval",
-        "sam3.eval.postprocessors",
-        "sam3.model",
-        "sam3.model.sam3_image_processor",
-        "sam3.model.utils",
-        "sam3.model.utils.misc",
-        "sam3.train",
-        "sam3.train.data",
-        "sam3.train.data.collator",
-        "sam3.train.data.sam3_image_dataset",
-        "sam3.train.transforms",
-        "sam3.train.transforms.basic_for_api",
-    ]
-    for name in names:
-        sys.modules.setdefault(name, MagicMock())
-
-
-_install_sam3_package_mocks()
-
-import inference.models.sam3.visual_segmentation_inference_models as vs_module
+ADAPTER_MODULE = "inference.models.sam3.visual_segmentation_inference_models"
+SAM3_TORCH_MODULE = "inference_models.models.sam3.sam3_torch"
 
 
-def _build_adapter(prediction) -> "vs_module.InferenceModelsSAM3InteractiveAdapter":
-    adapter = vs_module.InferenceModelsSAM3InteractiveAdapter.__new__(
-        vs_module.InferenceModelsSAM3InteractiveAdapter
+@pytest.fixture()
+def adapter_module() -> Generator[ModuleType, None, None]:
+    """Imports the module under test with `sam3` stubbed, per test.
+
+    `patch.dict` restores `sys.modules` to its pre-test state on exit, which
+    drops both the stubs and the modules imported against them - no mocked
+    modules leak into other tests.
+    """
+    stubs = {name: MagicMock() for name in _SAM3_PACKAGE_MODULES}
+    with patch.dict(sys.modules, stubs):
+        sys.modules.pop(ADAPTER_MODULE, None)
+        sys.modules.pop(SAM3_TORCH_MODULE, None)
+        yield importlib.import_module(ADAPTER_MODULE)
+
+
+def _build_adapter(adapter_module: ModuleType, prediction):
+    adapter = adapter_module.InferenceModelsSAM3InteractiveAdapter.__new__(
+        adapter_module.InferenceModelsSAM3InteractiveAdapter
     )
     adapter._model = MagicMock()
     adapter._model.segment_with_visual_prompts.return_value = [prediction]
     return adapter
 
 
-def test_segment_image_returns_one_prediction_per_prompt():
+def test_segment_image_returns_one_prediction_per_prompt(
+    adapter_module: ModuleType,
+) -> None:
     """Regression test: a request with N prompts must return N masks - the adapter
     must not reduce across prompts (SAM3Torch already selects the best of the
     multimask proposals for each prompt)."""
@@ -53,7 +69,7 @@ def test_segment_image_returns_one_prediction_per_prompt():
         scores=torch.tensor([0.9, 0.8]),
         logits=torch.rand(2, 16, 16),
     )
-    adapter = _build_adapter(prediction)
+    adapter = _build_adapter(adapter_module, prediction)
 
     # when
     masks, scores, logits = adapter.segment_image(
@@ -73,14 +89,16 @@ def test_segment_image_returns_one_prediction_per_prompt():
     np.testing.assert_allclose(scores, [0.9, 0.8], rtol=1e-6)
 
 
-def test_segment_image_with_single_prompt_keeps_prompt_dimension():
+def test_segment_image_with_single_prompt_keeps_prompt_dimension(
+    adapter_module: ModuleType,
+) -> None:
     # given
     prediction = SimpleNamespace(
         masks=torch.rand(1, 8, 8),
         scores=torch.tensor([0.7]),
         logits=torch.rand(1, 16, 16),
     )
-    adapter = _build_adapter(prediction)
+    adapter = _build_adapter(adapter_module, prediction)
 
     # when
     masks, scores, logits = adapter.segment_image(
@@ -94,14 +112,16 @@ def test_segment_image_with_single_prompt_keeps_prompt_dimension():
     assert logits.shape == (1, 16, 16)
 
 
-def test_segment_image_forwards_all_prompts_to_model():
+def test_segment_image_forwards_all_prompts_to_model(
+    adapter_module: ModuleType,
+) -> None:
     # given
     prediction = SimpleNamespace(
         masks=torch.rand(2, 8, 8),
         scores=torch.tensor([0.9, 0.8]),
         logits=torch.rand(2, 16, 16),
     )
-    adapter = _build_adapter(prediction)
+    adapter = _build_adapter(adapter_module, prediction)
 
     # when
     _ = adapter.segment_image(

--- a/tests/workflows/unit_tests/core_steps/common/test_deserializers.py
+++ b/tests/workflows/unit_tests/core_steps/common/test_deserializers.py
@@ -13,6 +13,7 @@ from inference.core.workflows.core_steps.common.deserializers import (
     deserialize_float_zero_to_one_kind,
     deserialize_image_kind,
     deserialize_integer_kind,
+    deserialize_labeled_points_kind,
     deserialize_list_of_values_kind,
     deserialize_numpy_array,
     deserialize_optional_string_kind,
@@ -1310,3 +1311,63 @@ def test_deserialize_rle_detections_kind_with_root_parent_origin_metadata() -> N
     assert "root_parent_dimensions" in result.data
     assert np.allclose(result.data["root_parent_dimensions"], np.array([[400, 900]]))
     assert "rle_mask" in result.data
+
+
+def test_deserialize_labeled_points_kind_when_valid_dicts_given() -> None:
+    # given
+    points = [
+        {"x": 100, "y": 200, "positive": True},
+        {"x": 300, "y": 400, "positive": False},
+        {"x": 500, "y": 600},
+    ]
+
+    # when
+    result = deserialize_labeled_points_kind(parameter="some", value=points)
+
+    # then
+    assert result == [
+        {"x": 100, "y": 200, "positive": True},
+        {"x": 300, "y": 400, "positive": False},
+        {"x": 500, "y": 600, "positive": True},
+    ]
+
+
+def test_deserialize_labeled_points_kind_when_valid_sequences_given() -> None:
+    # given
+    points = [(100, 200), [300, 400, False], (500, 600, 1)]
+
+    # when
+    result = deserialize_labeled_points_kind(parameter="some", value=points)
+
+    # then
+    assert result == [
+        {"x": 100, "y": 200, "positive": True},
+        {"x": 300, "y": 400, "positive": False},
+        {"x": 500, "y": 600, "positive": True},
+    ]
+
+
+def test_deserialize_labeled_points_kind_when_not_a_list_given() -> None:
+    # when
+    with pytest.raises(RuntimeInputError):
+        _ = deserialize_labeled_points_kind(parameter="some", value="invalid")
+
+
+def test_deserialize_labeled_points_kind_when_point_misses_coordinates() -> None:
+    # when
+    with pytest.raises(RuntimeInputError):
+        _ = deserialize_labeled_points_kind(parameter="some", value=[{"x": 100}])
+
+
+def test_deserialize_labeled_points_kind_when_point_has_invalid_format() -> None:
+    # when
+    with pytest.raises(RuntimeInputError):
+        _ = deserialize_labeled_points_kind(parameter="some", value=[(1,)])
+
+
+def test_deserialize_labeled_points_kind_when_coordinates_are_not_numbers() -> None:
+    # when
+    with pytest.raises(RuntimeInputError):
+        _ = deserialize_labeled_points_kind(
+            parameter="some", value=[{"x": "a", "y": 100}]
+        )

--- a/tests/workflows/unit_tests/core_steps/models/foundation/test_segment_anything3_interactive.py
+++ b/tests/workflows/unit_tests/core_steps/models/foundation/test_segment_anything3_interactive.py
@@ -1,0 +1,257 @@
+"""Unit tests for SAM 3 Interactive block (point / box prompting via SAM3 PVS)."""
+
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+import supervision as sv
+
+from inference.core.workflows.core_steps.common.entities import StepExecutionMode
+from inference.core.workflows.core_steps.models.foundation.segment_anything3_interactive.v1 import (
+    BlockManifest,
+    SegmentAnything3InteractiveBlockV1,
+)
+from inference.core.workflows.execution_engine.entities.base import (
+    ImageParentMetadata,
+    WorkflowImageData,
+)
+
+
+@pytest.fixture
+def mock_model_manager():
+    mock = MagicMock()
+    mock_prediction = MagicMock()
+    mock_prediction.masks = [[[0, 0], [100, 0], [100, 100], [0, 100]]]
+    mock_prediction.confidence = 0.95
+    mock.infer_from_request_sync.return_value = MagicMock(predictions=[mock_prediction])
+    return mock
+
+
+@pytest.fixture
+def mock_workflow_image_data():
+    start_image = np.random.randint(0, 255, (480, 640, 3), dtype=np.uint8)
+    return WorkflowImageData(
+        parent_metadata=ImageParentMetadata(parent_id="some"),
+        numpy_image=start_image,
+    )
+
+
+def _example_detections() -> sv.Detections:
+    detections = sv.Detections(
+        xyxy=np.array([[10, 10, 50, 50]]),
+        confidence=np.array([0.9]),
+        class_id=np.array([0]),
+    )
+    detections["class_name"] = np.array(["object"])
+    detections["detection_id"] = np.array(["det_1"])
+    return detections
+
+
+def test_manifest_parsing_with_literal_points() -> None:
+    data = {
+        "type": "roboflow_core/sam3_interactive@v1",
+        "name": "sam3_interactive",
+        "images": "$inputs.image",
+        "points": [
+            {"x": 320, "y": 240, "positive": True},
+            {"x": 100, "y": 100, "positive": False},
+        ],
+    }
+    result = BlockManifest.model_validate(data)
+    assert result.type == "roboflow_core/sam3_interactive@v1"
+    assert len(result.points) == 2
+
+
+def test_manifest_parsing_with_points_selector() -> None:
+    data = {
+        "type": "roboflow_core/sam3_interactive@v1",
+        "name": "sam3_interactive",
+        "images": "$inputs.image",
+        "points": "$inputs.points",
+        "boxes": "$steps.detection.predictions",
+    }
+    result = BlockManifest.model_validate(data)
+    assert result.points == "$inputs.points"
+    assert result.boxes == "$steps.detection.predictions"
+
+
+def test_manifest_parsing_with_sequence_points() -> None:
+    data = {
+        "type": "roboflow_core/sam3_interactive@v1",
+        "name": "sam3_interactive",
+        "images": "$inputs.image",
+        "points": [[320, 240], [100, 100, False]],
+    }
+    result = BlockManifest.model_validate(data)
+    assert len(result.points) == 2
+
+
+def test_manifest_parsing_rejects_invalid_points() -> None:
+    data = {
+        "type": "roboflow_core/sam3_interactive@v1",
+        "name": "sam3_interactive",
+        "images": "$inputs.image",
+        "points": [{"x": 320}],
+    }
+    with pytest.raises(Exception):
+        _ = BlockManifest.model_validate(data)
+
+
+def test_run_raises_when_no_prompts_given(
+    mock_model_manager, mock_workflow_image_data
+) -> None:
+    block = SegmentAnything3InteractiveBlockV1(
+        model_manager=mock_model_manager,
+        api_key="test_api_key",
+        step_execution_mode=StepExecutionMode.LOCAL,
+    )
+    with pytest.raises(ValueError):
+        _ = block.run(
+            images=[mock_workflow_image_data],
+            points=None,
+            boxes=None,
+            threshold=0.0,
+            multimask_output=True,
+        )
+
+
+def test_run_locally_with_point_prompts(
+    mock_model_manager, mock_workflow_image_data
+) -> None:
+    block = SegmentAnything3InteractiveBlockV1(
+        model_manager=mock_model_manager,
+        api_key="test_api_key",
+        step_execution_mode=StepExecutionMode.LOCAL,
+    )
+
+    result = block.run(
+        images=[mock_workflow_image_data],
+        points=[
+            {"x": 320, "y": 240, "positive": True},
+            {"x": 100, "y": 100, "positive": False},
+        ],
+        boxes=None,
+        threshold=0.0,
+        multimask_output=True,
+    )
+
+    assert len(result) == 1
+    assert "predictions" in result[0]
+    mock_model_manager.add_model.assert_called_once()
+    inference_request = mock_model_manager.infer_from_request_sync.call_args[0][1]
+    prompts = inference_request.prompts.prompts
+    assert len(prompts) == 1
+    assert len(prompts[0].points) == 2
+    assert prompts[0].points[0].x == 320
+    assert prompts[0].points[0].positive is True
+    assert prompts[0].points[1].positive is False
+
+
+def test_run_locally_with_boxes_and_points(
+    mock_model_manager, mock_workflow_image_data
+) -> None:
+    block = SegmentAnything3InteractiveBlockV1(
+        model_manager=mock_model_manager,
+        api_key="test_api_key",
+        step_execution_mode=StepExecutionMode.LOCAL,
+    )
+
+    result = block.run(
+        images=[mock_workflow_image_data],
+        points=[[320, 240]],
+        boxes=[_example_detections()],
+        threshold=0.0,
+        multimask_output=True,
+    )
+
+    assert len(result) == 1
+    inference_request = mock_model_manager.infer_from_request_sync.call_args[0][1]
+    prompts = inference_request.prompts.prompts
+    # one prompt per box + one prompt for the points
+    assert len(prompts) == 2
+    assert prompts[0].box is not None
+    assert prompts[0].box.x == 30  # box centre of [10, 10, 50, 50]
+    assert prompts[1].points[0].x == 320
+
+
+@patch(
+    "inference.core.workflows.core_steps.models.foundation.segment_anything3_interactive.v1.InferenceHTTPClient"
+)
+def test_run_remotely_calls_sam3_visual_segment(
+    mock_client_cls, mock_model_manager, mock_workflow_image_data
+) -> None:
+    mock_client = MagicMock()
+    mock_client.sam3_visual_segment.return_value = {
+        "predictions": [
+            {
+                "confidence": 0.95,
+                "masks": [[[0, 0], [100, 0], [100, 100], [0, 100]]],
+            }
+        ],
+        "time": 0.1,
+    }
+    mock_client_cls.return_value = mock_client
+
+    block = SegmentAnything3InteractiveBlockV1(
+        model_manager=mock_model_manager,
+        api_key="test_api_key",
+        step_execution_mode=StepExecutionMode.REMOTE,
+    )
+
+    result = block.run(
+        images=[mock_workflow_image_data],
+        points=[{"x": 320, "y": 240, "positive": True}],
+        boxes=None,
+        threshold=0.0,
+        multimask_output=True,
+    )
+
+    assert len(result) == 1
+    assert "predictions" in result[0]
+    mock_client.sam3_visual_segment.assert_called_once()
+    call_kwargs = mock_client.sam3_visual_segment.call_args.kwargs
+    assert call_kwargs["prompts"] == [
+        {"points": [{"x": 320.0, "y": 240.0, "positive": True}]}
+    ]
+
+
+@patch(
+    "inference.core.workflows.core_steps.models.foundation.segment_anything3_interactive.v1.InferenceHTTPClient"
+)
+def test_run_remotely_with_boxes(
+    mock_client_cls, mock_model_manager, mock_workflow_image_data
+) -> None:
+    mock_client = MagicMock()
+    mock_client.sam3_visual_segment.return_value = {
+        "predictions": [
+            {
+                "confidence": 0.95,
+                "masks": [[[0, 0], [100, 0], [100, 100], [0, 100]]],
+            }
+        ],
+        "time": 0.1,
+    }
+    mock_client_cls.return_value = mock_client
+
+    block = SegmentAnything3InteractiveBlockV1(
+        model_manager=mock_model_manager,
+        api_key="test_api_key",
+        step_execution_mode=StepExecutionMode.REMOTE,
+    )
+
+    result = block.run(
+        images=[mock_workflow_image_data],
+        points=None,
+        boxes=[_example_detections()],
+        threshold=0.0,
+        multimask_output=True,
+    )
+
+    assert len(result) == 1
+    call_kwargs = mock_client.sam3_visual_segment.call_args.kwargs
+    assert call_kwargs["prompts"] == [
+        {"box": {"x": 30.0, "y": 30.0, "width": 40.0, "height": 40.0}}
+    ]
+    # class name of the box prompt should be forwarded to predicted masks
+    predictions = result[0]["predictions"]
+    assert list(predictions["class_name"]) == ["object"]

--- a/tests/workflows/unit_tests/core_steps/models/foundation/test_segment_anything3_interactive.py
+++ b/tests/workflows/unit_tests/core_steps/models/foundation/test_segment_anything3_interactive.py
@@ -165,13 +165,45 @@ def test_run_locally_with_boxes_and_points(
     )
 
     assert len(result) == 1
-    inference_request = mock_model_manager.infer_from_request_sync.call_args[0][1]
-    prompts = inference_request.prompts.prompts
-    # one prompt per box + one prompt for the points
-    assert len(prompts) == 2
-    assert prompts[0].box is not None
-    assert prompts[0].box.x == 30  # box centre of [10, 10, 50, 50]
-    assert prompts[1].points[0].x == 320
+    # box and point prompts cannot be mixed in a single SAM prompt batch,
+    # so the block issues one request per prompt group
+    assert mock_model_manager.infer_from_request_sync.call_count == 2
+    box_request = mock_model_manager.infer_from_request_sync.call_args_list[0][0][1]
+    box_prompts = box_request.prompts.prompts
+    assert len(box_prompts) == 1
+    assert box_prompts[0].box is not None
+    assert box_prompts[0].box.x == 30  # box centre of [10, 10, 50, 50]
+    assert box_prompts[0].points is None
+    points_request = mock_model_manager.infer_from_request_sync.call_args_list[1][0][1]
+    point_prompts = points_request.prompts.prompts
+    assert len(point_prompts) == 1
+    assert point_prompts[0].box is None
+    assert point_prompts[0].points[0].x == 320
+    # masks from both requests are merged into a single output
+    predictions = result[0]["predictions"]
+    assert list(predictions["class_name"]) == ["object", "foreground"]
+
+
+def test_run_locally_with_empty_detections_and_no_points(
+    mock_model_manager, mock_workflow_image_data
+) -> None:
+    block = SegmentAnything3InteractiveBlockV1(
+        model_manager=mock_model_manager,
+        api_key="test_api_key",
+        step_execution_mode=StepExecutionMode.LOCAL,
+    )
+
+    result = block.run(
+        images=[mock_workflow_image_data],
+        points=None,
+        boxes=[sv.Detections.empty()],
+        threshold=0.0,
+        multimask_output=True,
+    )
+
+    assert len(result) == 1
+    assert len(result[0]["predictions"]) == 0
+    mock_model_manager.infer_from_request_sync.assert_not_called()
 
 
 @patch(


### PR DESCRIPTION
## Description

Adds point prompting support to Workflows (per [this Slack thread](https://roboflow.slack.com/archives/C08QA59S0F5/p1781049083091209)) and fixes the SAM3 PVS multi-prompt bug found while verifying the endpoints.

### New: point prompting in Workflows

- **New `labeled_points` kind** — a list of `{"x": ..., "y": ..., "positive": true/false}` points usable as workflow inputs. Positive points mark the object to segment, negative points exclude regions. The runtime-input deserializer also accepts `(x, y)` / `(x, y, positive)` sequences and normalises them to the dict form. Registered in `load_kinds()` so the UI can discover it and build a point-picker widget.
- **New `roboflow_core/sam3_interactive@v1` block** ("SAM 3 Interactive") — drives the SAM3 PVS head (`/sam3/visual_segment`):
  - `points`: labeled points defining a single object (refinable with negative clicks)
  - `boxes`: detections from another model — one prompt per box, SAM2-style "segment what's inside this box", class names forwarded to the masks
  - Supports local, remote (SDK `sam3_visual_segment`) and `SAM3_EXEC_MODE=remote` proxy (`inferenceproxy/sam3-pvs`) execution paths, mirroring the existing SAM3 block.
- Docs: `docs/foundation/sam3.md` Workflow Integration section covers the new block.

### Fix: SAM3 PVS multi-prompt requests returned only 1 prediction

Two stacked bugs:

1. **Double best-mask selection** — `SAM3Torch` already reduces the multimask proposals per prompt and returns masks shaped `(num_prompts, H, W)`. The serving adapter (`visual_segmentation_inference_models.py`) then re-ran best-mask selection (a helper copied from the SAM2 path, where the proposals axis is still present), argmax-ing across *prompts* and collapsing every multi-prompt request to a single prediction.
2. **Box truncation** — `SAM3Torch._predict_for_single_image` forwarded only the *first* box of a multi-box prompt batch (`args["box"] = boxes_list[0]`), silently dropping the rest. The underlying predictor natively handles `(B, 4)` box batches.

### Behavior changes

- `/sam3/visual_segment` with N prompts now returns N predictions (in prompt order) instead of the single highest-scoring one. Single-prompt requests are unchanged; best-of-3 multimask selection per prompt is preserved.
- Multi-box prompt batches are fully honored (previously only the first box was segmented), including for direct `inference_models` `SAM3Torch.segment_with_visual_prompts` callers.
- The new block sends box prompts and point prompts as separate requests (a single SAM prompt batch can't mix box-carrying and box-less prompts — the prompt encoder concatenation crashes; same constraint as SAM2) and merges the masks. It emits empty predictions when the connected detector finds no boxes, instead of failing the workflow.

Note: hosted serverless keeps the old collapse-to-one behavior until a build with these fixes deploys there.

### Out of scope (other sharp edges from the verification thread)

- `boxes` without `box_labels` → 500 on `/sam3/concept_segment` (validation bug)
- `/sam3/embed_image` 404 on serverless (not routed hosted)
- UI widget for the `labeled_points` kind (frontend)

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested?

- New unit tests: block (manifest validation, prompt grouping, local/remote paths, empty-detections), `labeled_points` deserializer, serving adapter (N prompts → N predictions), `SAM3Torch` box pass-through (fails against the old code).
- Full `tests/workflows/unit_tests` suite green (3,400+ tests), `tests/inference/unit_tests/models` green, `inference_models` sam3 unit tests green.
- Code formatted with black/isort.

https://claude.ai/code/session_01Az4Ah5M2R9b7eggWato84j

---
_Generated by [Claude Code](https://claude.ai/code/session_01Az4Ah5M2R9b7eggWato84j)_