### PR TITLE
Add serverless usc1 hostnames to SDK hosted-API URL list

### DIFF
--- a/inference_sdk/config.py
+++ b/inference_sdk/config.py
@@ -146,6 +146,8 @@ ALL_ROBOFLOW_API_URLS = {
     "https://infer.roboflow.com",
     "https://serverless.roboflow.com",
     "https://serverless.roboflow.one",
+    "https://serverless.usc1.roboflow.com",
+    "https://serverless.usc1.roboflow.one",
     "https://asyncinfer.roboflow.com",
     "https://asyncinfer.roboflow.one",
 }


### PR DESCRIPTION
## What does this PR do?

Adds `https://serverless.usc1.roboflow.com` and `https://serverless.usc1.roboflow.one` to `ALL_ROBOFLOW_API_URLS` in `inference_sdk/config.py`.

`InferenceHTTPClient` selects API v0 (hosted platform protocol) only for URLs in this list; any other URL is treated as a self-hosted server (v1), where the SDK manages models via `GET /model/registry` + `POST /model/add`. The serverless deployments do not expose `/model/add` — the request falls into the legacy `/{dataset_id}/{version_id}` route, which interprets `model/add` as a model ID and fails with a 403 `RoboflowAPIForbiddenError`.

**Related Issue(s):** —

## Type of Change

- Bug fix (non-breaking change that fixes an issue)

## Testing

- [ ] I have tested this change locally
- [ ] I have added/updated tests for this change

**Test details:**
Verified `_determine_client_mode` resolves the new hostnames to v0 and that unrelated URLs still resolve to v1. Reproduced the original failure against the new staging deployment (`serverless.usc1.roboflow.one`): v1 mode fails on `POST /model/add` with 403, while v0 mode (`client.select_api_v0()`) works end to end.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where necessary, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have updated the documentation accordingly (if applicable)

## Additional Context

Until this ships in a release, the workaround for SDK users on the usc1 hostnames is `InferenceHTTPClient(...).select_api_v0()`.