### PR TITLE
feat(webrtc-sdk): surface per-frame server errors to client

### DIFF
--- a/examples/webrtc_sdk/video_file_basic.py
+++ b/examples/webrtc_sdk/video_file_basic.py
@@ -131,6 +131,12 @@ def main() -> None:
     # def on_predictions(predictions: dict, metadata: VideoMetadata):
     #     print(f"Frame {metadata.frame_id} predictions: {predictions}")
 
+    # Per-frame error handler — fires only for frames the server reported errors
+    # for (workflow execution failures, output serialization failures, etc).
+    @session.on_error
+    def on_frame_error(errors, metadata: VideoMetadata):
+        print(f"Frame {metadata.frame_id} errors: {errors}")
+
     # Run the session (auto-starts, blocks until close() is called or stream ends)
     # Automatically closes on exception or when stream ends
     session.run()

--- a/inference_sdk/webrtc/session.py
+++ b/inference_sdk/webrtc/session.py
@@ -10,7 +10,7 @@ import queue
 import struct
 import threading
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
 from queue import Queue
@@ -89,6 +89,10 @@ class VideoMetadata:
         time_base: Time base for interpreting pts values (optional)
         declared_fps: Declared/expected frames per second (optional)
         measured_fps: Measured actual frames per second (optional)
+        errors: Per-frame errors reported by the server (workflow execution
+            failures, output serialization failures, etc). Empty list means
+            the frame processed cleanly. Subscribe with `@session.on_error`
+            to react only to error frames.
     """
 
     frame_id: int
@@ -97,6 +101,7 @@ class VideoMetadata:
     time_base: Optional[float] = None
     declared_fps: Optional[float] = None
     measured_fps: Optional[float] = None
+    errors: List[str] = field(default_factory=list)
 
 
 class _VideoStream:
@@ -196,6 +201,7 @@ class WebRTCSession:
         self._frame_handlers: List[Callable] = []
         self._data_field_handlers: Dict[str, List[Callable]] = {}
         self._data_global_handler: Optional[Callable] = None
+        self._error_handlers: List[Callable] = []
 
         # Chunk reassembly for binary messages
         self._chunk_reassembler = ChunkReassembler()
@@ -255,12 +261,17 @@ class WebRTCSession:
                 raise RuntimeError("Cannot use closed WebRTCSession")
 
     def _parse_video_metadata(
-        self, video_metadata_dict: Optional[dict]
+        self,
+        video_metadata_dict: Optional[dict],
+        errors: Optional[List[str]] = None,
     ) -> Optional[VideoMetadata]:
         """Parse video metadata from message dict.
 
         Args:
             video_metadata_dict: Dictionary containing video metadata fields
+            errors: Per-frame errors reported by the server alongside the
+                metadata (e.g. workflow execution failures). Attached to the
+                returned VideoMetadata so handlers can react to them.
 
         Returns:
             VideoMetadata instance or None if parsing fails or dict is None
@@ -276,6 +287,7 @@ class WebRTCSession:
                 time_base=video_metadata_dict.get("time_base"),
                 declared_fps=video_metadata_dict.get("declared_fps"),
                 measured_fps=video_metadata_dict.get("measured_fps"),
+                errors=list(errors) if errors else [],
             )
         except (KeyError, ValueError, TypeError) as e:
             logger.warning(f"Failed to parse video_metadata: {e}")
@@ -458,6 +470,36 @@ class WebRTCSession:
             return fn
 
         return decorator
+
+    def on_error(self, callback: Callable) -> Callable:
+        """Decorator to register per-frame error handlers.
+
+        The server reports per-frame errors alongside each data channel
+        message (workflow execution failures, output serialization failures,
+        etc.). Handlers registered here are invoked **only** for frames whose
+        error list is non-empty.
+
+        Handler signature options:
+            handler(errors: List[str], metadata: VideoMetadata)
+            handler(errors: List[str])
+
+        Example:
+            @session.on_error
+            def on_err(errors: List[str], metadata: VideoMetadata):
+                logger.error(f"frame {metadata.frame_id} failed: {errors}")
+                session.close()  # bail out on first error
+
+        Notes:
+            - These errors are *server-reported* per-frame failures. They do
+              NOT include connection failures, ICE failures, or setup errors;
+              those surface as exceptions from `run()` or as ERROR-level log
+              lines from the SDK.
+            - Errors are also attached to `VideoMetadata.errors` for every
+              frame, so existing `@on_data` / `@on_frame` handlers can inspect
+              `metadata.errors` directly without registering a separate hook.
+        """
+        self._error_handlers.append(callback)
+        return callback
 
     def run(self) -> None:
         """Block and process frames until close() is called or stream ends.
@@ -812,10 +854,24 @@ class WebRTCSession:
                         pass
                     return
 
-                # Extract video metadata if present (for data handlers)
+                # Extract video metadata if present (for data handlers).
+                # Errors are merged into the metadata so any handler can read
+                # `metadata.errors`; dedicated `@on_error` handlers fire below.
+                errors = parsed_message.get("errors") or []
                 metadata = self._parse_video_metadata(
-                    parsed_message.get("video_metadata")
+                    parsed_message.get("video_metadata"),
+                    errors=errors,
                 )
+
+                # Dispatch per-frame error handlers (only when errors present)
+                if errors and self._error_handlers:
+                    for handler in list(self._error_handlers):
+                        try:
+                            self._invoke_data_handler(handler, errors, metadata)
+                        except Exception:
+                            logger.warning(
+                                "Error calling on_error handler", exc_info=True
+                            )
 
                 # Get serialized output data
                 serialized_data = parsed_message.get("serialized_output_data")

--- a/tests/inference_sdk/unit_tests/webrtc/test_session_lifecycle.py
+++ b/tests/inference_sdk/unit_tests/webrtc/test_session_lifecycle.py
@@ -223,6 +223,30 @@ class TestDecorators:
         assert "predictions" in mock_session._data_field_handlers
         assert handle_predictions in mock_session._data_field_handlers["predictions"]
 
+    def test_on_error_registers_handler(self, mock_session):
+        """Test registering per-frame error handler."""
+
+        @mock_session.on_error
+        def handle_err(errors, metadata):
+            pass
+
+        assert handle_err in mock_session._error_handlers
+
+    def test_parse_video_metadata_attaches_errors(self, mock_session):
+        """Errors passed alongside metadata are surfaced on VideoMetadata."""
+        md = mock_session._parse_video_metadata(
+            {"frame_id": 7, "received_at": datetime.now().isoformat()},
+            errors=["workflow block X failed"],
+        )
+        assert md is not None
+        assert md.frame_id == 7
+        assert md.errors == ["workflow block X failed"]
+
+    def test_video_metadata_default_errors_is_empty(self):
+        """VideoMetadata constructed without errors defaults to an empty list."""
+        md = VideoMetadata(frame_id=1, received_at=datetime.now())
+        assert md.errors == []
+
 
 class TestVideoStream:
     """Tests for video stream iterator."""


### PR DESCRIPTION
## Summary

The WebRTC server already sends an `errors: List[str]` field on every data channel message — `inference/core/interfaces/webrtc_worker/webrtc.py` builds it from workflow execution failures and output serialization failures per frame, then puts it on the wire alongside `serialized_output_data` and `video_metadata`.

The SDK on the receiving end parsed only `serialized_output_data` and `video_metadata` and **dropped `errors` on the floor** (`inference_sdk/webrtc/session.py:817-821`). So per-frame failures were invisible to anything using the SDK — `session.run()` would complete "successfully" even when every frame had errored, and the example at `examples/webrtc_sdk/video_file_basic.py` had no way to surface a broken workflow.

This PR closes that gap.

## What changed

- **`VideoMetadata.errors: List[str]`** — populated from the message's `errors` field on every frame. Empty list when clean. Existing `@on_data` / `@on_frame` handlers can read `metadata.errors` directly without registering anything new.
- **`@session.on_error` decorator** — registers callbacks that fire **only** for frames whose error list is non-empty. Same signature options as `@on_data`: `handler(errors, metadata)` or `handler(errors)`. Multiple handlers supported.
- **Example updated** — `examples/webrtc_sdk/video_file_basic.py` demonstrates the new hook.

## Test plan
- [x] `pytest tests/inference_sdk/unit_tests/webrtc/test_session_lifecycle.py` — 23 passed (20 existing + 3 new).
- [x] New tests cover: `on_error` decorator registration, `_parse_video_metadata` attaching errors, `VideoMetadata.errors` defaulting to empty list.
- [x] Manual: run the updated `video_file_basic.py` against a workflow with a deliberately-failing block; confirm the `on_error` handler prints the server's per-frame error.