### PR TITLE
Shrink JetPack 6.2 image 20% (6.56→5.22GB) and fix Orin (sm87) flash-attn + bitsandbytes

### DIFF
--- a/.github/workflows/docker.jetson.6.2.0.yml
+++ b/.github/workflows/docker.jetson.6.2.0.yml
@@ -26,7 +26,10 @@ jobs:
     runs-on:
       labels: depot-ubuntu-24.04-4
       group: public-depot
-    timeout-minutes: 360
+    # 480: the layer-cache chain rebuilds fully when early builder steps change
+    # (BuildKit cache mounts still soften the PyTorch/ORT/OpenCV compiles), and
+    # flash-attn (no cache mount) takes hours alone at MAX_JOBS=4.
+    timeout-minutes: 480
     permissions:
       id-token: write
       contents: read

--- a/docker/dockerfiles/Dockerfile.onnx.jetson.6.2.0
+++ b/docker/dockerfiles/Dockerfile.onnx.jetson.6.2.0
@@ -49,10 +49,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=apt-cache-jp62-bu
     python3-dev \
     python3-pip \
     libopenblas-dev \
-    libproj-dev \
-    libsqlite3-dev \
     libtiff-dev \
-    libcurl4-openssl-dev \
     libssl-dev \
     zlib1g-dev \
     libxext6 \
@@ -95,18 +92,10 @@ RUN python3 -m pip install --upgrade pip setuptools wheel && \
 RUN curl -LsSf https://astral.sh/uv/install.sh | env INSTALLER_NO_MODIFY_PATH=1 sh && \
     ln -s /root/.local/bin/uv /usr/local/bin/uv
 
-# Compile GDAL from source.
-# NOTE: the runtime stage no longer ships this GDAL (rasterio bundles its own);
-# the build is kept only to avoid invalidating the layer-cache chain of the
-# expensive PyTorch/ORT/OpenCV compiles below. Remove in a follow-up that
-# accepts a one-off full rebuild.
-WORKDIR /build/gdal
-RUN wget https://github.com/OSGeo/gdal/releases/download/v3.11.5/gdal-3.11.5.tar.gz && \
-    tar -xzf gdal-3.11.5.tar.gz && \
-    cd gdal-3.11.5 && mkdir build && cd build && \
-    cmake .. -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local -DBUILD_PYTHON_BINDINGS=OFF && \
-    ninja && ninja install && ldconfig && \
-    cd ../.. && rm -rf gdal-3.11.5*
+# No from-source GDAL: rasterio (the only GDAL consumer, via
+# requirements.sam.txt) bundles its own libgdal/proj/data as a manylinux
+# wheel, nothing in this image or in roboflow-edge links the system GDAL
+# (verified via ldd scans, live deletion test, and edge repo/image audit).
 
 # Compile PyTorch from source with Jetson optimizations.
 # Clone is in its own RUN so the build/ cache mount in the next RUN can overlay
@@ -254,6 +243,19 @@ RUN uv pip install --system --break-system-packages --index-strategy unsafe-best
     "transformers>=4.57.3,<5.9.0" \
     packaging \
     && rm -rf ~/.cache/uv
+
+# Rebuild the bitsandbytes CUDA backend for Orin (sm87). The PyPI aarch64
+# wheel ships sm90-only kernels, so every GPU quantization op (the VLM
+# use_quantization paths) fails on Orin with "named symbol not found".
+# Replaces the wheel's lib in place; the version must match the wheel pin
+# resolved by the requirements above.
+RUN BNB_VERSION=$(python3 -c "import importlib.metadata as m; print(m.version('bitsandbytes'))") && \
+    git clone --depth 1 --branch ${BNB_VERSION} https://github.com/bitsandbytes-foundation/bitsandbytes.git /build/bitsandbytes-src && \
+    cd /build/bitsandbytes-src && \
+    cmake -DCOMPUTE_BACKEND=cuda -DCOMPUTE_CAPABILITY="87" . && \
+    make -j4 && \
+    cp bitsandbytes/libbitsandbytes_cuda*.so /usr/local/lib/python3.10/dist-packages/bitsandbytes/ && \
+    cd / && rm -rf /build/bitsandbytes-src
 
 # Build inference packages
 WORKDIR /build/inference
@@ -526,13 +528,16 @@ COPY --from=builder /usr/lib/aarch64-linux-gnu/libcudnn*.so.*.*.* /usr/local/cud
 # libnvinfer + libnvinfer_plugin (+libnvonnxparser); builder_resource is required
 # for on-device engine builds (ORT_TENSORRT_ENGINE_CACHE_ENABLE=1); lean is kept
 # because inference_models' engine builder sets trt.BuilderFlag.VERSION_COMPATIBLE.
-# Excluded as unreferenced: libnvinfer_dispatch, libnvinfer_vc_plugin.
+# vc_plugin is kept alongside lean (TRT plugins inside version-compatible
+# engines resolve through it). Excluded as unreferenced: libnvinfer_dispatch
+# (the dispatch runtime; nothing loads VC engines via dispatch here).
 # No libnvparsers COPY: TensorRT 10.x removed it (the old glob matched nothing
 # and produced an empty layer; strict BuildKit fails on unmatched COPY globs).
 COPY --from=builder /usr/lib/aarch64-linux-gnu/libnvinfer.so.*.*.* \
      /usr/lib/aarch64-linux-gnu/libnvinfer_plugin.so.*.*.* \
      /usr/lib/aarch64-linux-gnu/libnvinfer_builder_resource.so.*.*.* \
      /usr/lib/aarch64-linux-gnu/libnvinfer_lean.so.*.*.* \
+     /usr/lib/aarch64-linux-gnu/libnvinfer_vc_plugin.so.*.*.* \
      /usr/local/cuda/lib64/
 COPY --from=builder /usr/lib/aarch64-linux-gnu/libnvonnxparser*.so.*.*.* /usr/local/cuda/lib64/
 COPY --from=builder /usr/lib/aarch64-linux-gnu/nvidia/libnvdla_compiler.so* /usr/local/cuda/lib64/

--- a/docker/dockerfiles/Dockerfile.onnx.jetson.6.2.0
+++ b/docker/dockerfiles/Dockerfile.onnx.jetson.6.2.0
@@ -489,17 +489,23 @@ ENV LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 
 # CUDA runtime libraries, exact files (not globs: the source dir mixes real
 # files and symlinks, and COPY dereferences symlinks, which would triple-copy
-# every library). The 20 libs below are the complete set referenced by
+# every library). The libs below are the complete set referenced by
 # torch/onnxruntime/cv2/pycuda/cudnn/TensorRT (readelf NEEDED + dlopen-string
-# scan). Deliberately not shipped (unreferenced): cusolverMg, npps, cufile,
-# nvfatbin, nvblas, nppisu, cufftw, nvToolsExt, cupti.
+# scan). The nine npp* imaging libs are shipped solely for cv2's CUDA modules
+# (kept as a supported acceleration surface). Deliberately not shipped
+# (unreferenced): cusolverMg, npps, cufile, nvfatbin, nvblas, nppisu, cufftw,
+# nvToolsExt, cupti. Also not shipped:
+# libcusolver (139MB) - torch only dlopens it lazily via libtorch_cuda_linalg
+# for linalg factorizations (inv/svd/cholesky), which nothing in this codebase
+# calls (the only torch.linalg use is linalg.norm, a reduction); verified
+# on-device that conv/LSTM/matmul/linalg.norm work without it. nvJitLink stays:
+# libcusparse has a NEEDED entry on it.
 COPY --from=cuda_rt \
      /usr/local/cuda-12.6/targets/aarch64-linux/lib/libcudart.so.12.6.68 \
      /usr/local/cuda-12.6/targets/aarch64-linux/lib/libcublas.so.12.6.1.4 \
      /usr/local/cuda-12.6/targets/aarch64-linux/lib/libcublasLt.so.12.6.1.4 \
      /usr/local/cuda-12.6/targets/aarch64-linux/lib/libcufft.so.11.2.6.59 \
      /usr/local/cuda-12.6/targets/aarch64-linux/lib/libcurand.so.10.3.7.68 \
-     /usr/local/cuda-12.6/targets/aarch64-linux/lib/libcusolver.so.11.6.4.69 \
      /usr/local/cuda-12.6/targets/aarch64-linux/lib/libcusparse.so.12.5.3.3 \
      /usr/local/cuda-12.6/targets/aarch64-linux/lib/libnvJitLink.so.12.6.68 \
      /usr/local/cuda-12.6/targets/aarch64-linux/lib/libnvrtc.so.12.6.68 \

--- a/docker/dockerfiles/Dockerfile.onnx.jetson.6.2.0
+++ b/docker/dockerfiles/Dockerfile.onnx.jetson.6.2.0
@@ -95,7 +95,11 @@ RUN python3 -m pip install --upgrade pip setuptools wheel && \
 RUN curl -LsSf https://astral.sh/uv/install.sh | env INSTALLER_NO_MODIFY_PATH=1 sh && \
     ln -s /root/.local/bin/uv /usr/local/bin/uv
 
-# Compile GDAL from source
+# Compile GDAL from source.
+# NOTE: the runtime stage no longer ships this GDAL (rasterio bundles its own);
+# the build is kept only to avoid invalidating the layer-cache chain of the
+# expensive PyTorch/ORT/OpenCV compiles below. Remove in a follow-up that
+# accepts a one-off full rebuild.
 WORKDIR /build/gdal
 RUN wget https://github.com/OSGeo/gdal/releases/download/v3.11.5/gdal-3.11.5.tar.gz && \
     tar -xzf gdal-3.11.5.tar.gz && \
@@ -204,11 +208,13 @@ RUN --mount=type=cache,target=/build/onnxruntime/onnxruntime/build/cuda12,sharin
         --cmake_extra_defines CMAKE_POLICY_VERSION_MINIMUM=3.5 && \
     python3 -m pip install --break-system-packages build/cuda12/Release/dist/onnxruntime_gpu-*.whl
 
-# Install flash-attn package (requires CUDA-enabled PyTorch already installed)
-# Limit MAX_JOBS to prevent timeout during CUDA kernel compilation
-# Using 2.8.3 - removed legacy features (rotary, xentropy, fused_softmax, ft_attention) for faster builds
-RUN export MAX_JOBS=4 && \
-    python3 -m pip install --break-system-packages --no-build-isolation flash-attn==2.8.3
+# flash-attn is intentionally NOT installed: its wheel/source default builds
+# target sm80/sm90 only, and on Orin (sm87) every kernel launch fails with
+# "no kernel image is available" (verified on the published image). Worse,
+# transformers' is_flash_attn_2_available() returned True, so PaliGemma/Qwen-VL
+# selected flash_attention_2 and crashed at inference; without the package they
+# fall back to eager/SDPA, which works. (A future perf PR can reinstate it with
+# FLASH_ATTN_CUDA_ARCHS=87.) Removing it also saves ~390MB.
 
 # Copy requirements files (done after compilation to improve cache efficiency)
 WORKDIR /build/reqs
@@ -248,7 +254,7 @@ RUN uv pip install --system --break-system-packages --index-strategy unsafe-best
 WORKDIR /build/inference
 COPY . .
 RUN ln -sf /usr/bin/python3 /usr/bin/python && \
-    python -m pip install wheel twine requests && \
+    python -m pip install wheel && \
     rm -f dist/* && \
     python .release/pypi/inference.core.setup.py bdist_wheel && \
     python .release/pypi/inference.gpu.setup.py bdist_wheel && \
@@ -337,13 +343,53 @@ RUN python3 -m pip uninstall -y boto3 botocore && \
 # Remove test directories, development tools, and unnecessary packages to reduce image size
 # This happens AFTER all package installations to ensure everything gets cleaned
 # Note: Keep numpy/torch test dirs (public APIs depend on them), keep .pyi files (lazy_loader needs them)
+# The pip uninstalls double as a safety net: packages never installed are skipped
+# with a warning (exit 0), so this block is idempotent across image variants.
+# ---- image-slim cleanup (re-executed verbatim by the local donor harness) ----
 RUN cd /usr/local/lib/python3.10/dist-packages && \
+    # Build-time tooling leaked in via pytorch/onnxruntime build requirements;
+    # none has a runtime reverse-dependency (cmake pip pkg alone is 82MB)
+    python3 -m pip uninstall -y cmake lintrunner hypothesis expecttest types-dataclasses astunparse optree \
+        twine keyring readme-renderer nh3 docutils id jeepney SecretStorage \
+        jaraco.classes jaraco.context jaraco.functools || true && \
+    # jupyterlab is no longer installed (dropped from requirements.jetson.txt: every
+    # consuming dockerfile deleted it post-install anyway); remove its dependency
+    # closure, which has zero runtime reverse-dependencies. Deliberately kept:
+    # defusedxml (supervision/doctr), websockets (uvicorn), websocket-client (docker SDK).
+    python3 -m pip uninstall -y babel jedi parso ipython pyzmq nbconvert nbclient nbformat \
+        prompt-toolkit terminado argon2-cffi argon2-cffi-bindings send2trash json5 overrides \
+        pexpect ptyprocess fqdn isoduration jsonpointer uri-template webcolors \
+        rfc3339-validator rfc3986-validator rfc3987 python-json-logger comm matplotlib-inline \
+        stack-data executing asttokens pure-eval fastjsonschema arrow mistune tinycss2 bleach \
+        pandocfilters jupyterlab-pygments tornado traitlets jupyter-core jupyter-client \
+        jupyter-server jupyter-events jupyter-server-terminals jupyter-lsp notebook-shim async-lru || true && \
     find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true && \
-    rm -rf debugpy* jupyterlab* jupyter_* notebook* ipython* ipykernel* || true && \
+    rm -rf debugpy* jupyterlab* jupyter_* notebook* ipython* IPython* ipykernel* || true && \
     rm -rf onnx/backend/test onnx/test || true && \
     rm -rf scipy/*/tests pandas/tests || true && \
-    rm -rf */examples */benchmarks */docs || true && \
-    rm -rf skimage/data || true
+    # boto3/docs and botocore/docs are importable code (boto3.resources.factory
+    # -> boto3.docs; boto3 -> botocore.docs.docstring), not documentation - the
+    # old image only survived this glob because boto3/botocore were reinstalled
+    # afterwards in the runtime stage
+    find . -mindepth 2 -maxdepth 2 -type d \( -name examples -o -name benchmarks -o -name docs \) -not -path './botocore/docs' -not -path './boto3/docs' -exec rm -rf {} + 2>/dev/null || true && \
+    rm -rf skimage/data || true && \
+    # Residual nested test dirs (numpy/torch kept per the note above)
+    find . -type d \( -name tests -o -name test \) -not -path './numpy/*' -not -path './torch/*' -exec rm -rf {} + 2>/dev/null || true && \
+    # bitsandbytes ships CUDA fatbins for ~10 CUDA versions; keep only CUDA 12.6 (+cpu).
+    # (bnb selects exactly one lib at import based on the detected CUDA version.)
+    ( cd bitsandbytes 2>/dev/null && ls libbitsandbytes_cuda*.so 2>/dev/null | grep -v cuda126 | xargs -r rm -f ) || true && \
+    # torch C++ headers only serve torch.utils.cpp_extension JIT and the runtime
+    # image ships no compiler; torch/bin holds two identical 5MB protoc copies
+    rm -rf torch/include torch/bin/protoc* || true && \
+    # The ORT python binding statically links the runtime; the separate C-API
+    # libonnxruntime.so has zero NEEDED references in the image
+    rm -f onnxruntime/capi/libonnxruntime.so* || true && \
+    # Strip symbol tables from ELF .so files, EXCLUDING auditwheel-vendored *.libs
+    # dirs: stripping patchelf-rewritten libs corrupts them ("ELF load command
+    # address/offset not page-aligned"). Verified on-device incl. CUDA paths.
+    find /usr/local/lib/python3.10/dist-packages /usr/local/lib /usr/lib/python3.10/dist-packages \
+        -name '*.so*' -type f | grep -vE '/[^/]+\.libs/' | xargs -r -n32 -P4 strip --strip-unneeded 2>/dev/null || true
+# ---- end image-slim cleanup ----
 
 # Stage 2: Runtime
 FROM nvcr.io/nvidia/l4t-cuda:12.6.11-runtime
@@ -356,15 +402,22 @@ WORKDIR /app
 RUN ln -sf /usr/bin/python3 /usr/bin/python
 
 # Install runtime dependencies (cache id is runtime-specific, distinct from builder).
+# Trimmed relative to the original list (all verified unreferenced on-device):
+#   file (libmagic; nothing executes it), libproj22 (+proj-data; only served the
+#   removed system GDAL - rasterio bundles its own proj), python3-pip (pip already
+#   ships in dist-packages and the runtime stage no longer runs pip),
+#   gstreamer1.0-tools (debug CLIs), python3-gi + gir1.2-* (no `import gi`
+#   anywhere; cv2 links the GStreamer C libs directly), libatlas3-base (zero .so
+#   NEEDs ATLAS; BLAS is libopenblas0).
+# The dpkg path-exclude keeps docs/man/locale out of every package this layer installs.
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=apt-cache-jp62-runtime-${TARGETARCH} \
     --mount=type=cache,target=/var/lib/apt,sharing=locked,id=apt-lib-jp62-runtime-${TARGETARCH} \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache && \
+    printf 'path-exclude /usr/share/doc/*\npath-exclude /usr/share/man/*\npath-exclude /usr/share/locale/*\n' > /etc/dpkg/dpkg.cfg.d/01-nodoc && \
     apt-get update -y && \
     apt-get install -y --no-install-recommends \
-    file \
     libopenblas0 \
-    libproj22 \
     libsqlite3-0 \
     libtiff5 \
     libcurl4 \
@@ -372,7 +425,6 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=apt-cache-jp62-ru
     zlib1g \
     libgomp1 \
     python3 \
-    python3-pip \
     libxext6 \
     libvips42 \
     libglib2.0-0 \
@@ -390,33 +442,35 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=apt-cache-jp62-ru
     libgstreamer1.0-0 \
     libgstreamer-plugins-base1.0-0 \
     gstreamer1.0-plugins-base \
-    gstreamer1.0-plugins-good \
-    gstreamer1.0-tools \
-    python3-gi \
-    gir1.2-gstreamer-1.0 \
-    gir1.2-gst-plugins-base-1.0 \
-    libatlas3-base
+    gstreamer1.0-plugins-good
 
-# Copy GDAL (skip headers - not needed in runtime)
-COPY --from=builder /usr/local/bin/gdal* /usr/local/bin/
-COPY --from=builder /usr/local/bin/ogr* /usr/local/bin/
-COPY --from=builder /usr/local/bin/gnm* /usr/local/bin/
-COPY --from=builder /usr/local/lib/libgdal* /usr/local/lib/
-COPY --from=builder /usr/local/share/gdal /usr/local/share/gdal
-
-ENV GDAL_DATA=/usr/local/share/gdal
+# No system GDAL: rasterio (the only GDAL consumer, via requirements.sam.txt)
+# installs as a manylinux wheel with its own bundled libgdal/libproj/gdal-data;
+# zero .so in the image links the from-source libgdal (verified via ldd scan +
+# live deletion test). GDAL_DATA must stay unset or it would override
+# rasterio's bundled data directory and break CRS handling.
 ENV LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 
 # Copy CUDA libraries (only versioned files, then create symlinks to save ~2GB).
 # No libnvToolsExt COPY: the builder keeps it elsewhere (the old glob matched
 # nothing) and the l4t-cuda runtime base already ships it.
+# No libcupti COPY: torch is built USE_KINETO=0 USE_CUPTI_SO=0 and an aggregate
+# readelf NEEDED scan over every .so in the image found zero cupti references.
 COPY --from=builder /usr/lib/aarch64-linux-gnu/libcudnn*.so.*.*.* /usr/local/cuda/lib64/
-COPY --from=builder /usr/local/cuda/targets/aarch64-linux/lib/libcupti*.so.*.*.* /usr/local/cuda/lib64/
 
 # TensorRT libraries (only versioned files, then create symlinks).
+# Explicit list instead of the old libnvinfer* glob: the ORT TensorRT EP NEEDs
+# libnvinfer + libnvinfer_plugin (+libnvonnxparser); builder_resource is required
+# for on-device engine builds (ORT_TENSORRT_ENGINE_CACHE_ENABLE=1); lean is kept
+# because inference_models' engine builder sets trt.BuilderFlag.VERSION_COMPATIBLE.
+# Excluded as unreferenced: libnvinfer_dispatch, libnvinfer_vc_plugin.
 # No libnvparsers COPY: TensorRT 10.x removed it (the old glob matched nothing
 # and produced an empty layer; strict BuildKit fails on unmatched COPY globs).
-COPY --from=builder /usr/lib/aarch64-linux-gnu/libnvinfer*.so.*.*.* /usr/local/cuda/lib64/
+COPY --from=builder /usr/lib/aarch64-linux-gnu/libnvinfer.so.*.*.* \
+     /usr/lib/aarch64-linux-gnu/libnvinfer_plugin.so.*.*.* \
+     /usr/lib/aarch64-linux-gnu/libnvinfer_builder_resource.so.*.*.* \
+     /usr/lib/aarch64-linux-gnu/libnvinfer_lean.so.*.*.* \
+     /usr/local/cuda/lib64/
 COPY --from=builder /usr/lib/aarch64-linux-gnu/libnvonnxparser*.so.*.*.* /usr/local/cuda/lib64/
 COPY --from=builder /usr/lib/aarch64-linux-gnu/nvidia/libnvdla_compiler.so* /usr/local/cuda/lib64/
 
@@ -447,10 +501,10 @@ RUN rm -rf /root/.cache/gstreamer-1.0 /home/*/.cache/gstreamer-1.0 2>/dev/null |
 
 # Copy Python packages
 COPY --from=builder /usr/local/lib/python3.10/dist-packages /usr/local/lib/python3.10/dist-packages
+# tensorrt_dispatch python pkg dropped along with libnvinfer_dispatch (zero
+# imports repo-wide); tensorrt_lean kept to match libnvinfer_lean above.
 COPY --from=builder /usr/lib/python3.10/dist-packages/tensorrt /usr/local/lib/python3.10/dist-packages/tensorrt
 COPY --from=builder /usr/lib/python3.10/dist-packages/tensorrt-10.7.0.dist-info /usr/local/lib/python3.10/dist-packages/tensorrt-10.7.0.dist-info
-COPY --from=builder /usr/lib/python3.10/dist-packages/tensorrt_dispatch /usr/local/lib/python3.10/dist-packages/tensorrt_dispatch
-COPY --from=builder /usr/lib/python3.10/dist-packages/tensorrt_dispatch-10.7.0.dist-info /usr/local/lib/python3.10/dist-packages/tensorrt_dispatch-10.7.0.dist-info
 COPY --from=builder /usr/lib/python3.10/dist-packages/tensorrt_lean /usr/local/lib/python3.10/dist-packages/tensorrt_lean
 COPY --from=builder /usr/lib/python3.10/dist-packages/tensorrt_lean-10.7.0.dist-info /usr/local/lib/python3.10/dist-packages/tensorrt_lean-10.7.0.dist-info
 COPY --from=builder /usr/local/bin/inference /usr/local/bin/inference

--- a/docker/dockerfiles/Dockerfile.onnx.jetson.6.2.0
+++ b/docker/dockerfiles/Dockerfile.onnx.jetson.6.2.0
@@ -208,13 +208,18 @@ RUN --mount=type=cache,target=/build/onnxruntime/onnxruntime/build/cuda12,sharin
         --cmake_extra_defines CMAKE_POLICY_VERSION_MINIMUM=3.5 && \
     python3 -m pip install --break-system-packages build/cuda12/Release/dist/onnxruntime_gpu-*.whl
 
-# flash-attn is intentionally NOT installed: its wheel/source default builds
-# target sm80/sm90 only, and on Orin (sm87) every kernel launch fails with
-# "no kernel image is available" (verified on the published image). Worse,
-# transformers' is_flash_attn_2_available() returned True, so PaliGemma/Qwen-VL
-# selected flash_attention_2 and crashed at inference; without the package they
-# fall back to eager/SDPA, which works. (A future perf PR can reinstate it with
-# FLASH_ATTN_CUDA_ARCHS=87.) Removing it also saves ~390MB.
+# Install flash-attn, built for Orin's actual architecture (sm87).
+# The previous build used the default arch list (sm80;sm90), so every kernel
+# launch on Orin failed with "no kernel image is available" - and because the
+# package still imported, transformers' is_flash_attn_2_available() returned
+# True and PaliGemma/Qwen-VL selected flash_attention_2, then crashed at
+# inference. Building for sm87 makes the feature actually work and the
+# single-arch binary is ~195MB smaller than the old dual-arch one.
+# Limit MAX_JOBS to prevent timeout/OOM during CUDA kernel compilation.
+# Using 2.8.3 - removed legacy features (rotary, xentropy, fused_softmax, ft_attention) for faster builds
+RUN export MAX_JOBS=4 && \
+    export FLASH_ATTN_CUDA_ARCHS="87" TORCH_CUDA_ARCH_LIST="8.7" && \
+    python3 -m pip install --break-system-packages --no-build-isolation flash-attn==2.8.3
 
 # Copy requirements files (done after compilation to improve cache efficiency)
 WORKDIR /build/reqs
@@ -391,11 +396,34 @@ RUN cd /usr/local/lib/python3.10/dist-packages && \
         -name '*.so*' -type f | grep -vE '/[^/]+\.libs/' | xargs -r -n32 -P4 strip --strip-unneeded 2>/dev/null || true
 # ---- end image-slim cleanup ----
 
-# Stage 2: Runtime
-FROM nvcr.io/nvidia/l4t-cuda:12.6.11-runtime
+# CUDA runtime library donor stage: pinned to the exact image the runtime
+# stage previously used as its base, so library versions stay bit-identical.
+FROM nvcr.io/nvidia/l4t-cuda:12.6.11-runtime AS cuda_rt
+
+# Stage 2: Runtime.
+# Plain ubuntu:22.04 (the same distro the l4t-cuda base wraps) instead of
+# l4t-cuda:12.6.11-runtime: the base shipped 1.8GB of CUDA libraries plus a
+# ~210MB mesa/freeglut-dev layer, of which only the 20 libraries COPY'd below
+# are actually referenced (readelf NEEDED + dlopen-string scan over every .so
+# in the image). Net ~300MB smaller. GPU/BSP access is unchanged: on JetPack 6
+# the nvidia-container-runtime injects libcuda/tegra libs from the host at
+# container start, driven by the NVIDIA_* envs replicated below.
+FROM ubuntu:22.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 ENV LANG=en_US.UTF-8
+
+# Replicated verbatim from the l4t-cuda:12.6.11-runtime base / published image.
+ENV NVIDIA_VISIBLE_DEVICES=all \
+    NVIDIA_DRIVER_CAPABILITIES=compute,utility \
+    NVIDIA_REQUIRE_CUDA="cuda>=12.6" \
+    NVIDIA_REQUIRE_JETPACK_HOST_MOUNTS=base-only \
+    NVIDIA_PRODUCT_NAME=CUDA \
+    PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+# Library search paths the l4t-cuda base provided via ld.so.conf.d (tegra/nvidia
+# dirs are populated by the host mounts injected at container start).
+RUN printf '/usr/local/cuda/lib64\n/usr/lib/aarch64-linux-gnu/tegra\n/usr/lib/aarch64-linux-gnu/tegra-egl\n/usr/lib/aarch64-linux-gnu/nvidia\n/usr/lib/aarch64-linux-gnu/gstreamer-1.0\n' > /etc/ld.so.conf.d/nvidia-tegra.conf
 
 WORKDIR /app
 
@@ -409,6 +437,9 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python
 #   gstreamer1.0-tools (debug CLIs), python3-gi + gir1.2-* (no `import gi`
 #   anywhere; cv2 links the GStreamer C libs directly), libatlas3-base (zero .so
 #   NEEDs ATLAS; BLAS is libopenblas0).
+# libegl1/libgles2 (glvnd loaders, ~1.8MB) are required by the host-injected NV
+# GStreamer plugins (nvarguscamerasrc/nvivafilter/nveglglessink/...); the actual
+# EGL/GLES drivers come from the host's tegra-egl mount at container start.
 # The dpkg path-exclude keeps docs/man/locale out of every package this layer installs.
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=apt-cache-jp62-runtime-${TARGETARCH} \
     --mount=type=cache,target=/var/lib/apt,sharing=locked,id=apt-lib-jp62-runtime-${TARGETARCH} \
@@ -417,6 +448,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=apt-cache-jp62-ru
     printf 'path-exclude /usr/share/doc/*\npath-exclude /usr/share/man/*\npath-exclude /usr/share/locale/*\n' > /etc/dpkg/dpkg.cfg.d/01-nodoc && \
     apt-get update -y && \
     apt-get install -y --no-install-recommends \
+    tzdata \
     libopenblas0 \
     libsqlite3-0 \
     libtiff5 \
@@ -442,7 +474,9 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=apt-cache-jp62-ru
     libgstreamer1.0-0 \
     libgstreamer-plugins-base1.0-0 \
     gstreamer1.0-plugins-base \
-    gstreamer1.0-plugins-good
+    gstreamer1.0-plugins-good \
+    libegl1 \
+    libgles2
 
 # No system GDAL: rasterio (the only GDAL consumer, via requirements.sam.txt)
 # installs as a manylinux wheel with its own bundled libgdal/libproj/gdal-data;
@@ -451,9 +485,38 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=apt-cache-jp62-ru
 # rasterio's bundled data directory and break CRS handling.
 ENV LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 
+# CUDA runtime libraries, exact files (not globs: the source dir mixes real
+# files and symlinks, and COPY dereferences symlinks, which would triple-copy
+# every library). The 20 libs below are the complete set referenced by
+# torch/onnxruntime/cv2/pycuda/cudnn/TensorRT (readelf NEEDED + dlopen-string
+# scan). Deliberately not shipped (unreferenced): cusolverMg, npps, cufile,
+# nvfatbin, nvblas, nppisu, cufftw, nvToolsExt, cupti.
+COPY --from=cuda_rt \
+     /usr/local/cuda-12.6/targets/aarch64-linux/lib/libcudart.so.12.6.68 \
+     /usr/local/cuda-12.6/targets/aarch64-linux/lib/libcublas.so.12.6.1.4 \
+     /usr/local/cuda-12.6/targets/aarch64-linux/lib/libcublasLt.so.12.6.1.4 \
+     /usr/local/cuda-12.6/targets/aarch64-linux/lib/libcufft.so.11.2.6.59 \
+     /usr/local/cuda-12.6/targets/aarch64-linux/lib/libcurand.so.10.3.7.68 \
+     /usr/local/cuda-12.6/targets/aarch64-linux/lib/libcusolver.so.11.6.4.69 \
+     /usr/local/cuda-12.6/targets/aarch64-linux/lib/libcusparse.so.12.5.3.3 \
+     /usr/local/cuda-12.6/targets/aarch64-linux/lib/libnvJitLink.so.12.6.68 \
+     /usr/local/cuda-12.6/targets/aarch64-linux/lib/libnvrtc.so.12.6.68 \
+     /usr/local/cuda-12.6/targets/aarch64-linux/lib/libnvrtc-builtins.so.12.6.68 \
+     /usr/local/cuda-12.6/targets/aarch64-linux/lib/libnppc.so.12.3.1.54 \
+     /usr/local/cuda-12.6/targets/aarch64-linux/lib/libnppial.so.12.3.1.54 \
+     /usr/local/cuda-12.6/targets/aarch64-linux/lib/libnppicc.so.12.3.1.54 \
+     /usr/local/cuda-12.6/targets/aarch64-linux/lib/libnppidei.so.12.3.1.54 \
+     /usr/local/cuda-12.6/targets/aarch64-linux/lib/libnppif.so.12.3.1.54 \
+     /usr/local/cuda-12.6/targets/aarch64-linux/lib/libnppig.so.12.3.1.54 \
+     /usr/local/cuda-12.6/targets/aarch64-linux/lib/libnppim.so.12.3.1.54 \
+     /usr/local/cuda-12.6/targets/aarch64-linux/lib/libnppist.so.12.3.1.54 \
+     /usr/local/cuda-12.6/targets/aarch64-linux/lib/libnppitc.so.12.3.1.54 \
+     /usr/local/cuda-12.6/targets/aarch64-linux/lib/libcudla.so.1.0.0 \
+     /usr/local/cuda/lib64/
+
 # Copy CUDA libraries (only versioned files, then create symlinks to save ~2GB).
 # No libnvToolsExt COPY: the builder keeps it elsewhere (the old glob matched
-# nothing) and the l4t-cuda runtime base already ships it.
+# nothing) and zero .so in the image references it.
 # No libcupti COPY: torch is built USE_KINETO=0 USE_CUPTI_SO=0 and an aggregate
 # readelf NEEDED scan over every .so in the image found zero cupti references.
 COPY --from=builder /usr/lib/aarch64-linux-gnu/libcudnn*.so.*.*.* /usr/local/cuda/lib64/
@@ -482,14 +545,17 @@ COPY --from=builder /usr/lib/aarch64-linux-gnu/nvidia/libnvdla_compiler.so* /usr
 # be configured to mount them; without that, cv2 here can dispatch a GStreamer
 # pipeline but `nvv4l2decoder` / `nvvidconv` / `nvjpegenc` won't resolve.
 
-# Create symlinks for cuDNN and TensorRT (saves ~2GB by not duplicating files)
+# Create symlinks for CUDA/cuDNN/TensorRT (saves ~2GB by not duplicating files).
+# libnvrtc-builtins needs its two-level soname on top of the .so/.so.MAJ links
+# the loop creates: libnvrtc dlopens it as libnvrtc-builtins.so.12.6.
 RUN cd /usr/local/cuda/lib64 && \
     for lib in *.so.*.*.*; do \
         base=$(echo $lib | sed 's/\.so\..*/\.so/') && \
         maj=$(echo $lib | sed 's/\(.*\.so\.[0-9]*\)\..*/\1/') && \
         ln -sf $lib $maj && \
         ln -sf $lib $base; \
-    done
+    done && \
+    ln -sf libnvrtc-builtins.so.12.6.68 libnvrtc-builtins.so.12.6
 
 ENV LD_LIBRARY_PATH=/usr/local/cuda/lib64:$LD_LIBRARY_PATH
 RUN ldconfig

--- a/docker/dockerfiles/Dockerfile.onnx.jetson.6.2.0
+++ b/docker/dockerfiles/Dockerfile.onnx.jetson.6.2.0
@@ -328,6 +328,12 @@ RUN --mount=type=cache,target=/build/opencv/opencv-${OPENCV_VERSION}/release,sha
     # with a recursion error rather than at runtime on the device.
     env -u PYTHONPATH python3 -c "import sys; sys.path = [p for p in sys.path if '/build' not in p]; import cv2; info = cv2.getBuildInformation(); assert 'YES' in info.split('GStreamer:')[1].split(chr(10))[0], 'GStreamer not enabled'; assert 'YES' in info.split('FFMPEG:')[1].split(chr(10))[0], 'FFMPEG not enabled'; print('cv2 ' + cv2.__version__ + ' OK from install path; GStreamer + FFmpeg + CUDA enabled')"
 
+# Pin boto3/botocore last so the final versions win regardless of what the
+# requirement sets resolved to (previously done as an extra layer in the
+# runtime stage, which shipped both copies).
+RUN python3 -m pip uninstall -y boto3 botocore && \
+    python3 -m pip install "boto3>=1.40.0,<=1.41.5" "botocore>=1.40.0,<=1.41.5"
+
 # Remove test directories, development tools, and unnecessary packages to reduce image size
 # This happens AFTER all package installations to ensure everything gets cleaned
 # Note: Keep numpy/torch test dirs (public APIs depend on them), keep .pyi files (lazy_loader needs them)
@@ -401,15 +407,17 @@ COPY --from=builder /usr/local/share/gdal /usr/local/share/gdal
 ENV GDAL_DATA=/usr/local/share/gdal
 ENV LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 
-# Copy CUDA libraries (only versioned files, then create symlinks to save ~2GB)
+# Copy CUDA libraries (only versioned files, then create symlinks to save ~2GB).
+# No libnvToolsExt COPY: the builder keeps it elsewhere (the old glob matched
+# nothing) and the l4t-cuda runtime base already ships it.
 COPY --from=builder /usr/lib/aarch64-linux-gnu/libcudnn*.so.*.*.* /usr/local/cuda/lib64/
 COPY --from=builder /usr/local/cuda/targets/aarch64-linux/lib/libcupti*.so.*.*.* /usr/local/cuda/lib64/
-COPY --from=builder /usr/local/cuda/targets/aarch64-linux/lib/libnvToolsExt*.so.*.*.* /usr/local/cuda/lib64/
 
-# TensorRT libraries (only versioned files, then create symlinks)
+# TensorRT libraries (only versioned files, then create symlinks).
+# No libnvparsers COPY: TensorRT 10.x removed it (the old glob matched nothing
+# and produced an empty layer; strict BuildKit fails on unmatched COPY globs).
 COPY --from=builder /usr/lib/aarch64-linux-gnu/libnvinfer*.so.*.*.* /usr/local/cuda/lib64/
 COPY --from=builder /usr/lib/aarch64-linux-gnu/libnvonnxparser*.so.*.*.* /usr/local/cuda/lib64/
-COPY --from=builder /usr/lib/aarch64-linux-gnu/libnvparsers*.so.*.*.* /usr/local/cuda/lib64/
 COPY --from=builder /usr/lib/aarch64-linux-gnu/nvidia/libnvdla_compiler.so* /usr/local/cuda/lib64/
 
 # NOTE: NVIDIA's gstreamer plugins (nvv4l2decoder, nvvidconv, nvjpegenc/dec) and
@@ -456,8 +464,6 @@ COPY inference_sdk inference_sdk
 COPY docker/config/gpu_http.py gpu_http.py
 COPY docker/entrypoint/run_uvicorn.sh /usr/local/bin/run_uvicorn.sh
 RUN chmod +x /usr/local/bin/run_uvicorn.sh
-
-RUN python -m pip uninstall -y boto3 botocore && python -m pip install "boto3>=1.40.0,<=1.41.5" "botocore>=1.40.0,<=1.41.5"
 
 # Environment variables
 ENV VERSION_CHECK_MODE=once \

--- a/requirements/requirements.jetson.txt
+++ b/requirements/requirements.jetson.txt
@@ -1,4 +1,3 @@
 pypdfium2>=4.11.0,<5.0.0
-jupyterlab>=4.3.0,<5.0.0
 PyYAML~=6.0.0
 inference-models~=0.29.0  # keep in sync between requirements.jetson requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt


### PR DESCRIPTION
## Result

**`roboflow/roboflow-inference-server-jetson-6.2.0`: 6.56 GB → 5.22 GB uncompressed (−20.4%), 3.27 → 2.83 GB compressed (−13.5%)** — verified on the CI-built artifact, while *fixing* three broken things on Orin. This image is also the base of `roboflow-edge-jp62`, so savings propagate downstream.

Numbers are from the depot-built test image of this branch (`1.3.1-1.3.1-micro-jp-2`), pulled and verified end-to-end on an AGX Orin (JetPack 6.2). The image targets Orin SoMs (sm_87) exclusively — every compiled component is now single-arch.

| Change | Δ size | Note |
|---|---|---|
| flash-attn rebuilt for sm87 (was sm80/90) | −195 MB | **Fix**: kernels could not launch on Orin at all; transformers selected `flash_attention_2` and PaliGemma/Qwen-VL crashed at inference. Now verified working on-device |
| Strip symbol tables from from-source `.so`s | ~−300 MB | Excludes auditwheel `*.libs` dirs (stripping patchelf-rewritten libs corrupts them) |
| Runtime base `l4t-cuda:12.6.11-runtime` → `ubuntu:22.04` + exact CUDA lib set | −150 MB | Lib versions bit-identical (copied from a pinned l4t-cuda donor stage); NVIDIA runtime envs + tegra ld paths replicated; `libegl1`/`libgles2` added so all host-injected NV GStreamer plugins (incl. `nvarguscamerasrc`) load — verified parity with the published image |
| Drop `libcusolver` | −139 MB | Lazily dlopened by torch only for `linalg.inv/svd/cholesky`; nothing in the codebase calls them (only `linalg.norm`). Verified on-device; absent + green in the final artifact |
| Drop from-source GDAL (build + runtime copy + `libproj22`) | −127 MB | rasterio (the only consumer, via SAM) bundles its own libgdal/proj; **roboflow-edge audited: no system-GDAL usage** (code search + image inspection) |
| Purge jupyterlab dep closure + build-tool leakage (cmake pip pkg, twine closure, pytorch build reqs) | −174 MB | All verified zero runtime reverse-dependencies; `requirements.jetson.txt` drops jupyterlab (every consuming dockerfile already deleted it post-install) |
| bitsandbytes: keep only CUDA 12.6 fatbin, **rebuilt from source for sm87** | −86 MB | **Fix**: PyPI wheel ships sm90-only kernels — `quantize_4bit`/`Linear4bit` fail on Orin today; verified working on GPU in the final artifact |
| torch/include + dup protoc, unreferenced `libonnxruntime.so`, residual test dirs | −106 MB | Runtime image has no compiler, so torch cpp_extension JIT was already impossible |
| apt prune (file, python3-pip, python3-gi/gir, gstreamer1.0-tools, libatlas3-base) + docs/man/locale exclusion + TRT dispatch/cupti/dead-COPY trims + boto3 single-copy | ~−100 MB | Each backed by usage scans (e.g. zero `import gi`, zero ATLAS NEEDED entries) |

**Kept deliberately:** OpenCV CUDA modules + the nine npp libs — `cv2.cuda` is a supported acceleration surface; see the [CUDA acceleration audit & roadmap comment](https://github.com/roboflow/inference/pull/2440#issuecomment-4679779428) mapping every CPU-bound image/video path (P0 wins are mostly CPU-waste fixes: a ~330ms/frame semantic-seg PNG round-trip, EasyOCR rebuilding its Reader per request, …). Also kept: `ffmpeg` (ffprobe used by the WebRTC uploaded-video path), `libvips`, cuDNN whole (LSTM OCR dies without `libcudnn_adv` — verified), `libnvinfer_lean`+`vc_plugin` (version-compatible TRT engines), `websocket-client`/`defusedxml`/`websockets`.

**Latent bug fixed:** the cleanup glob deleted `boto3/docs`+`botocore/docs` (importable code); the published image only works because a later runtime-stage reinstall papered over it.

## Verification (all on an AGX Orin, JetPack 6.2)

On the **CI-built artifact** (`1.3.1-1.3.1-micro-jp-2`): GPU gauntlet — torch CUDA, cuDNN LSTM fp16, `linalg.norm` without cusolver, `flash_attn_func`, bitsandbytes 4-bit GPU quantization, ORT TRT/CUDA/CPU providers, `cv2.cuda.resize`, GStreamer capture with all NV plugins loading, rasterio, boto3+`botocore.docs`, tensorrt/tensorrt_lean/easyocr/doctr imports; server boot 40 s → `/info` 200, `/workflows/blocks/describe` → 204 blocks, zero log errors. ([final verification comment](https://github.com/roboflow/inference/pull/2440#issuecomment-4680771152))

In-container test suites (identical local candidate): `tests/inference/unit_tests` and `tests/workflows/unit_tests` failure sets **byte-identical to the published 1.3.0 baseline** (3 known run-as-root + 2 known OpenCV-4.13 artifacts; nothing new across 1461+3184 tests). HTTP integration suite (`tests/inference/integration_tests/`) A/B parity run baseline-vs-candidate: results posted as a follow-up comment.

## Builder notes

- Heavy compile RUNs (PyTorch/ORT) untouched; OpenCV build unchanged (still CUDA, same cache-mount id). The GDAL-block removal breaks the layer-cache chain once (accepted); workflow timeout bumped 360→480 for that one-off + the flash-attn sm87 compile. Both CI builds of this branch succeeded (full rebuild, then cache-hot).
- Remaining multi-arch weight (~1 GB of non-sm87 cubins) is locked inside NVIDIA's unified aarch64 cuDNN/cuBLAS/cuSPARSE binaries: no per-SoM packages exist for CUDA 12.6, `nvprune` is static-lib-only, and modifying vendor `.so`s violates the CUDA EULA/cuDNN SLA. JetPack 7.2's `cudnn_jit` packaging is the eventual fix.

## Follow-ups (researched, deliberately out of scope)

1. ORT `CUDA_MINIMAL` rebuild (needs ORT ≥1.20.1) + torch `USE_CUDNN=0` → would allow deleting cuDNN entirely (−955 MB) at LSTM perf cost — needs Orin benchmarks first
2. CUDA acceleration roadmap P0 items (see audit comment) — biggest per-frame latency wins found during this work
3. OTel gRPC exporter drop (−19 MB, needs 2-line telemetry change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)