### PR TITLE
fix: remove mutable default arguments

### DIFF
--- a/inference/core/models/instance_segmentation_base.py
+++ b/inference/core/models/instance_segmentation_base.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Tuple, Union
+from typing import Any, List, Optional, Tuple, Union
 
 import numpy as np
 
@@ -221,7 +221,7 @@ class InstanceSegmentationBaseOnnxRoboflowInferenceModel(OnnxRoboflowInferenceMo
         predictions: List[List[List[float]]],
         masks: List[List[List[float]]],
         img_dims: List[Tuple[int, int]],
-        class_filter: List[str] = [],
+        class_filter: Optional[List[str]] = None,
         **kwargs,
     ) -> Union[
         InstanceSegmentationInferenceResponse,
@@ -234,7 +234,7 @@ class InstanceSegmentationBaseOnnxRoboflowInferenceModel(OnnxRoboflowInferenceMo
             predictions (List[List[List[float]]]): List of prediction data, one for each image.
             masks (List[List[List[float]]]): List of masks corresponding to the predictions.
             img_dims (List[Tuple[int, int]]): List of image dimensions corresponding to the processed images.
-            class_filter (List[str], optional): List of class names to filter predictions by. Defaults to an empty list (no filtering).
+            class_filter (Optional[List[str]]): List of class names to filter predictions by. Defaults to None (no filtering).
 
         Returns:
             Union[InstanceSegmentationInferenceResponse, List[InstanceSegmentationInferenceResponse]]: A single instance segmentation response or a list of instance segmentation responses based on the number of processed images.

--- a/inference/core/models/utils/keypoints.py
+++ b/inference/core/models/utils/keypoints.py
@@ -1,15 +1,11 @@
-from typing import Dict, List, Optional
+from typing import Dict, List
 
 from inference.core.entities.responses.inference import Keypoint
 from inference.core.exceptions import ModelArtefactError
 
 
-def superset_keypoints_count(
-    keypoints_metadata: Optional[Dict[int, Dict[int, str]]] = None,
-) -> int:
+def superset_keypoints_count(keypoints_metadata: Dict[int, Dict[int, str]]) -> int:
     """Returns the number of keypoints in the superset."""
-    if keypoints_metadata is None:
-        raise ModelArtefactError("Keypoints metadata not available.")
     max_keypoints = 0
     for keypoints in keypoints_metadata.values():
         if len(keypoints) > max_keypoints:

--- a/inference/core/models/utils/keypoints.py
+++ b/inference/core/models/utils/keypoints.py
@@ -1,11 +1,15 @@
-from typing import List
+from typing import Dict, List, Optional
 
 from inference.core.entities.responses.inference import Keypoint
 from inference.core.exceptions import ModelArtefactError
 
 
-def superset_keypoints_count(keypoints_metadata={}) -> int:
+def superset_keypoints_count(
+    keypoints_metadata: Optional[Dict[int, Dict[int, str]]] = None,
+) -> int:
     """Returns the number of keypoints in the superset."""
+    if keypoints_metadata is None:
+        raise ModelArtefactError("Keypoints metadata not available.")
     max_keypoints = 0
     for keypoints in keypoints_metadata.values():
         if len(keypoints) > max_keypoints:

--- a/inference/core/workflows/execution_engine/v1/compiler/core.py
+++ b/inference/core/workflows/execution_engine/v1/compiler/core.py
@@ -117,8 +117,10 @@ def compile_workflow_graph(
     workflow_definition: dict,
     execution_engine_version: Optional[Version] = None,
     profiler: Optional[WorkflowsProfiler] = None,
-    init_parameters: Dict[str, Union[Any, Callable[[None], Any]]] = {},
+    init_parameters: Optional[Dict[str, Union[Any, Callable[[None], Any]]]] = None,
 ) -> GraphCompilationResult:
+    if init_parameters is None:
+        init_parameters = {}
     key = COMPILATION_CACHE.get_hash_key(
         workflow_definition=workflow_definition,
         execution_engine_version=execution_engine_version,

--- a/inference/models/depth_anything_v3/architecture/dinov2.py
+++ b/inference/models/depth_anything_v3/architecture/dinov2.py
@@ -10,7 +10,7 @@
 
 import logging
 import math
-from typing import List, Sequence, Tuple, Union
+from typing import List, Optional, Sequence, Tuple, Union
 
 import torch
 import torch.nn as nn
@@ -221,8 +221,10 @@ class DinoVisionTransformer(nn.Module):
         return pos, pos_nodiff
 
     def _get_intermediate_layers_not_chunked(
-        self, x, n=1, export_feat_layers=[], **kwargs
+        self, x, n=1, export_feat_layers=None, **kwargs
     ):
+        if export_feat_layers is None:
+            export_feat_layers = []
         B, S, _, H, W = x.shape
         x = self.prepare_tokens_with_masks(x)
         output, total_block_len, aux_output = [], len(self.blocks), []
@@ -294,9 +296,11 @@ class DinoVisionTransformer(nn.Module):
         self,
         x: torch.Tensor,
         n: Union[int, Sequence] = 1,
-        export_feat_layers: List[int] = [],
+        export_feat_layers: Optional[List[int]] = None,
         **kwargs,
     ) -> Tuple[Union[torch.Tensor, Tuple[torch.Tensor]]]:
+        if export_feat_layers is None:
+            export_feat_layers = []
         outputs, aux_outputs = self._get_intermediate_layers_not_chunked(
             x, n, export_feat_layers=export_feat_layers, **kwargs
         )

--- a/inference/models/sam/segment_anything.py
+++ b/inference/models/sam/segment_anything.py
@@ -194,8 +194,8 @@ class SegmentAnything(RoboflowCoreModel):
         mask_input: Optional[Union[np.ndarray, List[List[List[float]]]]] = None,
         mask_input_format: Optional[str] = "json",
         orig_im_size: Optional[List[int]] = None,
-        point_coords: Optional[List[List[float]]] = [],
-        point_labels: Optional[List[int]] = [],
+        point_coords: Optional[List[List[float]]] = None,
+        point_labels: Optional[List[int]] = None,
         use_mask_input_cache: Optional[bool] = True,
         **kwargs,
     ):
@@ -213,8 +213,8 @@ class SegmentAnything(RoboflowCoreModel):
             mask_input (Optional[Union[np.ndarray, List[List[List[float]]]]]): Input mask for the image.
             mask_input_format (Optional[str]): Format of the provided mask input; either 'json' or 'binary'. Defaults to 'json'.
             orig_im_size (Optional[List[int]]): Original size of the image when providing embeddings directly.
-            point_coords (Optional[List[List[float]]]): Coordinates of points in the image. Defaults to an empty list.
-            point_labels (Optional[List[int]]): Labels associated with the provided points. Defaults to an empty list.
+            point_coords (Optional[List[List[float]]]): Coordinates of points in the image. Defaults to None (no points).
+            point_labels (Optional[List[int]]): Labels associated with the provided points. Defaults to None (no labels).
             use_mask_input_cache (Optional[bool]): Flag to determine if cached mask input should be used. Defaults to True.
             **kwargs: Additional keyword arguments.
 
@@ -254,7 +254,7 @@ class SegmentAnything(RoboflowCoreModel):
             elif embeddings_format == "binary":
                 embedding = np.load(BytesIO(embeddings))
 
-        point_coords = point_coords
+        point_coords = list(point_coords) if point_coords is not None else []
         point_coords.append([0, 0])
         point_coords = np.array(point_coords, dtype=np.float32)
         point_coords = np.expand_dims(point_coords, axis=0)
@@ -263,7 +263,7 @@ class SegmentAnything(RoboflowCoreModel):
             original_image_size,
         )
 
-        point_labels = point_labels
+        point_labels = list(point_labels) if point_labels is not None else []
         point_labels.append(-1)
         point_labels = np.array(point_labels, dtype=np.float32)
         point_labels = np.expand_dims(point_labels, axis=0)

--- a/tests/inference/unit_tests/core/models/utils/test_keypoints.py
+++ b/tests/inference/unit_tests/core/models/utils/test_keypoints.py
@@ -1,10 +1,23 @@
-from typing import List
+import pytest
 
 from inference.core.entities.responses.inference import Keypoint
+from inference.core.exceptions import ModelArtefactError
 from inference.core.models.utils.keypoints import (
     model_keypoints_to_response,
     superset_keypoints_count,
 )
+
+
+def test_superset_keypoints_count_without_metadata_raises() -> None:
+    # Missing metadata means model artefacts were not loaded; fail loudly like
+    # model_keypoints_to_response does, instead of silently reporting 0 keypoints.
+    with pytest.raises(ModelArtefactError):
+        superset_keypoints_count()
+
+
+def test_superset_keypoints_count_with_empty_metadata_returns_zero() -> None:
+    # Empty (but provided) metadata is a valid input with zero keypoints.
+    assert superset_keypoints_count({}) == 0
 
 
 def test_superset_keypoints_count() -> None:

--- a/tests/inference/unit_tests/core/models/utils/test_keypoints.py
+++ b/tests/inference/unit_tests/core/models/utils/test_keypoints.py
@@ -1,22 +1,12 @@
-import pytest
-
 from inference.core.entities.responses.inference import Keypoint
-from inference.core.exceptions import ModelArtefactError
 from inference.core.models.utils.keypoints import (
     model_keypoints_to_response,
     superset_keypoints_count,
 )
 
 
-def test_superset_keypoints_count_without_metadata_raises() -> None:
-    # Missing metadata means model artefacts were not loaded; fail loudly like
-    # model_keypoints_to_response does, instead of silently reporting 0 keypoints.
-    with pytest.raises(ModelArtefactError):
-        superset_keypoints_count()
-
-
 def test_superset_keypoints_count_with_empty_metadata_returns_zero() -> None:
-    # Empty (but provided) metadata is a valid input with zero keypoints.
+    # Empty metadata is a valid input with zero keypoints.
     assert superset_keypoints_count({}) == 0
 
 


### PR DESCRIPTION
## What does this PR do?

Running `ruff check --select B006` over the codebase (the repo currently only enforces black) turns up seven signatures using a shared mutable default (`[]` or `{}`). Most of them never mutate the argument, so those are defensive cleanups, but the SAM pair is a live bug: `SegmentAnything.segment_image` appends a padding point to `point_coords` and a `-1` to `point_labels` in place, so any caller relying on the defaults grows the shared lists by one entry per call. The prompt silently accumulates phantom `[0, 0]` points for the lifetime of the process. The HTTP route is mostly shielded because the request entity always sends explicit values, but an explicit JSON `null` for `point_coords` / `point_labels` reached `None.append` and crashed with `AttributeError`. Both paths are now handled: `None` falls back to an empty list, and caller-provided lists are copied before padding instead of being mutated.

For `superset_keypoints_count` the parameter is now simply required: its single caller always passes the argument, so the default was never exercised.

Touched signatures:

- `SegmentAnything.segment_image`: `point_coords`, `point_labels`
- `InstanceSegmentationBaseOnnxRoboflowInferenceModel.make_response`: `class_filter`
- `compile_workflow_graph`: `init_parameters`
- `DinoVisionTransformer.get_intermediate_layers` / `_get_intermediate_layers_not_chunked`: `export_feat_layers`
- `superset_keypoints_count`: `keypoints_metadata` (now required)

## Type of Change

- Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] I have tested this change locally
- [x] I have added/updated tests for this change

**Test details:**

A behavioral test in `tests/inference/unit_tests/core/models/utils/test_keypoints.py` checks that empty `{}` metadata returns 0. `ruff check --select B006 inference/` is clean after the change; existing keypoints, compiler, and models unit tests pass.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [ ] I have updated the documentation accordingly (if applicable)
