### PR TITLE
Fix mobile drawer/menu showing on index page

### DIFF
--- a/theme/main.html
+++ b/theme/main.html
@@ -11,7 +11,11 @@
     height: 0;
     margin: 0;
     padding: 0;
-    overflow: hidden;
+    overflow: visible;
+  }
+
+  [data-md-toggle=drawer]:checked ~ .md-container .md-sidebar--primary {
+    display: block;
   }
 </style>
 <script>


### PR DESCRIPTION
Fix mobile drawer/menu showing on index page
Before
<img width="869" height="782" alt="image" src="https://github.com/user-attachments/assets/cfb4a28c-ed2d-4c35-bf23-193d52d2127e" />
**After**
<img width="653" height="559" alt="image" src="https://github.com/user-attachments/assets/d94bde40-9a76-47ec-8a39-ada474d71e1f" />
