### PR TITLE
[codex] Honor query api key for depth estimation loads

### DIFF
--- a/inference/core/interfaces/http/http_api.py
+++ b/inference/core/interfaces/http/http_api.py
@@ -3687,6 +3687,8 @@ class HttpInterface(BaseInterface):
                         DepthEstimationResponse: The response containing the normalized depth map and optional visualization.
                     """
                     logger.debug(f"Reached /infer/depth-estimation")
+                    if api_key is not None:
+                        inference_request.api_key = api_key
                     depth_model_id = inference_request.model_id
                     self.model_manager.add_model(
                         depth_model_id,

--- a/tests/inference/unit_tests/core/interfaces/http/test_http_api.py
+++ b/tests/inference/unit_tests/core/interfaces/http/test_http_api.py
@@ -237,6 +237,54 @@ def test_infer_lmm_with_model_id_uses_alias_registry_key(monkeypatch) -> None:
     assert inference_request.api_key == "query-api-key"
 
 
+def test_depth_estimation_uses_query_api_key_for_model_loading(monkeypatch) -> None:
+    import inference.core.interfaces.http.http_api as http_api
+
+    monkeypatch.setattr(http_api, "InferenceInstrumentator", _DummyInstrumentator)
+    monkeypatch.setattr(
+        http_api.usage_collector,
+        "async_push_usage_payloads",
+        AsyncMock(),
+    )
+    monkeypatch.setattr(http_api, "DEPTH_ESTIMATION_ENABLED", True)
+    monkeypatch.setattr(http_api, "DEDICATED_DEPLOYMENT_WORKSPACE_URL", None)
+    model_manager = MagicMock()
+    model_manager.pingback = None
+    model_manager.num_errors = 0
+    model_manager.infer_from_request_sync.return_value = {
+        "normalized_depth": [[0.0]],
+        "image": "depth-image",
+    }
+
+    interface = http_api.HttpInterface(model_manager=model_manager)
+
+    with TestClient(interface.app) as client:
+        response = client.post(
+            "/infer/depth-estimation",
+            params={"api_key": "query-api-key"},
+            json={
+                "model_id": "depth-anything-v3/small",
+                "image": {
+                    "type": "url",
+                    "value": "https://example.com/test.jpg",
+                },
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {"normalized_depth": [[0.0]], "image": "depth-image"}
+    model_manager.add_model.assert_called_once_with(
+        "depth-anything-v3/small",
+        "query-api-key",
+        countinference=None,
+        service_secret=None,
+    )
+    model_manager.infer_from_request_sync.assert_called_once()
+    inference_request = model_manager.infer_from_request_sync.call_args.args[1]
+    assert inference_request.model_id == "depth-anything-v3/small"
+    assert inference_request.api_key == "query-api-key"
+
+
 def test_serverless_auth_middleware_logs_request_received_with_execution_id(
     monkeypatch,
 ) -> None:

--- a/tests/inference/unit_tests/core/interfaces/http/test_http_api.py
+++ b/tests/inference/unit_tests/core/interfaces/http/test_http_api.py
@@ -29,6 +29,25 @@ class _DummyResponse(BaseModel):
     ok: bool = True
 
 
+class _DummyArray:
+    def __init__(self, value):
+        self._value = value
+
+    def tolist(self):
+        return self._value
+
+
+class _DummyImage:
+    base64_image = "depth-image"
+
+
+class _DummyDepthResponse:
+    response = {
+        "normalized_depth": _DummyArray([[0.0]]),
+        "image": _DummyImage(),
+    }
+
+
 def _make_inference_request() -> dict:
     return {
         "model_id": "florence-2-base",
@@ -251,10 +270,7 @@ def test_depth_estimation_uses_query_api_key_for_model_loading(monkeypatch) -> N
     model_manager = MagicMock()
     model_manager.pingback = None
     model_manager.num_errors = 0
-    model_manager.infer_from_request_sync.return_value = {
-        "normalized_depth": [[0.0]],
-        "image": "depth-image",
-    }
+    model_manager.infer_from_request_sync.return_value = _DummyDepthResponse()
 
     interface = http_api.HttpInterface(model_manager=model_manager)
 


### PR DESCRIPTION
## Summary

Fix `/infer/depth-estimation` so it honors the `api_key` query parameter when loading the model, matching the behavior used by other core/foundation model endpoints.

## Root Cause

Workflow remote execution uses `InferenceHTTPClient` in v0 mode, which sends the API key on the URL as `?api_key=...` and sends the depth model id in the JSON body. The depth estimation route accepted the query parameter but did not copy it onto `inference_request` before calling `model_manager.add_model(...)`. On cold loads, the model weights provider then called `/models/v1/external/weights` without an `Authorization` header, causing serverless workflow requests to fail with `UnauthorizedModelAccessError` until the same model was warmed by a direct request that included `api_key` in the JSON body.

## Changes

- Copy query-param `api_key` onto the `DepthEstimationRequest` before model loading.
- Add a regression test that posts to `/infer/depth-estimation?api_key=...` with no body `api_key` and asserts `add_model()` receives the query key.

## Validation

- `git diff --check`
- `python -m py_compile inference/core/interfaces/http/http_api.py tests/inference/unit_tests/core/interfaces/http/test_http_api.py`
- `/Users/hansent/code/inference/.venv/bin/python -m black --check inference/core/interfaces/http/http_api.py tests/inference/unit_tests/core/interfaces/http/test_http_api.py`

Tried the focused pytest locally with `/Users/hansent/code/inference/.venv`, but that local environment fails while importing existing HTTP API tests because `trackers.BoTSORTTracker` is missing. An adjacent pre-existing test (`test_infer_lmm_with_model_id_uses_alias_registry_key`) fails at the same import, so this appears to be a local dependency mismatch rather than this change.