### PR TITLE
[codex] Route depth model id through inference path

### DIFF
--- a/inference/core/exceptions.py
+++ b/inference/core/exceptions.py
@@ -119,6 +119,10 @@ class InvalidModelIDError(Exception):
     pass
 
 
+class RequestDataContradiction(Exception):
+    pass
+
+
 class MalformedRoboflowAPIResponseError(Exception):
     pass
 

--- a/inference/core/interfaces/http/error_handlers.py
+++ b/inference/core/interfaces/http/error_handlers.py
@@ -26,6 +26,7 @@ from inference.core.exceptions import (
     PaymentRequiredError,
     PostProcessingError,
     PreProcessingError,
+    RequestDataContradiction,
     RoboflowAPIConnectionError,
     RoboflowAPIForbiddenError,
     RoboflowAPINotAuthorizedError,
@@ -176,6 +177,14 @@ def with_route_exceptions(route):
                 content={
                     "message": f"Error with model input. Cause: {error}",
                     "help_url": error.help_url,
+                },
+            )
+        except RequestDataContradiction as error:
+            logger.exception("%s: %s", type(error).__name__, error)
+            resp = JSONResponse(
+                status_code=400,
+                content={
+                    "message": str(error),
                 },
             )
         except InvalidModelIDError as error:
@@ -623,6 +632,14 @@ def with_route_exceptions_async(route):
                 content={
                     "message": f"Error with model input. Cause: {error}",
                     "help_url": error.help_url,
+                },
+            )
+        except RequestDataContradiction as error:
+            logger.exception("%s: %s", type(error).__name__, error)
+            resp = JSONResponse(
+                status_code=400,
+                content={
+                    "message": str(error),
                 },
             )
         except InvalidModelIDError as error:

--- a/inference/core/interfaces/http/http_api.py
+++ b/inference/core/interfaces/http/http_api.py
@@ -3657,6 +3657,55 @@ class HttpInterface(BaseInterface):
 
             if DEPTH_ESTIMATION_ENABLED:
 
+                def _infer_depth_estimation(
+                    inference_request: DepthEstimationRequest,
+                    request: Request,
+                    api_key: Optional[str] = None,
+                    countinference: Optional[bool] = None,
+                    service_secret: Optional[str] = None,
+                    model_id: Optional[str] = None,
+                ) -> DepthEstimationResponse:
+                    if model_id is not None:
+                        fields_set = getattr(
+                            inference_request,
+                            "model_fields_set",
+                            getattr(inference_request, "__fields_set__", set()),
+                        )
+                        if (
+                            "model_id" in fields_set
+                            and inference_request.model_id is not None
+                            and inference_request.model_id != model_id
+                        ):
+                            raise HTTPException(
+                                status_code=400,
+                                detail=f"Model ID mismatch: path specifies '{model_id}' but request body specifies '{inference_request.model_id}'",
+                            )
+                        inference_request.model_id = model_id
+                    if api_key is not None:
+                        inference_request.api_key = api_key
+                    depth_model_id = inference_request.model_id
+                    self.model_manager.add_model(
+                        depth_model_id,
+                        inference_request.api_key,
+                        countinference=countinference,
+                        service_secret=service_secret,
+                    )
+                    response = self.model_manager.infer_from_request_sync(
+                        depth_model_id, inference_request
+                    )
+                    if LAMBDA:
+                        actor = request.scope["aws.event"]["requestContext"][
+                            "authorizer"
+                        ]["lambda"]["actor"]
+                        trackUsage(depth_model_id, actor)
+
+                    # Extract data from nested response structure
+                    depth_data = response.response
+                    return DepthEstimationResponse(
+                        normalized_depth=depth_data["normalized_depth"].tolist(),
+                        image=depth_data["image"].base64_image,
+                    )
+
                 @app.post(
                     "/infer/depth-estimation",
                     response_model=DepthEstimationResponse,
@@ -3687,31 +3736,49 @@ class HttpInterface(BaseInterface):
                         DepthEstimationResponse: The response containing the normalized depth map and optional visualization.
                     """
                     logger.debug(f"Reached /infer/depth-estimation")
-                    if api_key is not None:
-                        inference_request.api_key = api_key
-                    depth_model_id = inference_request.model_id
-                    self.model_manager.add_model(
-                        depth_model_id,
-                        inference_request.api_key,
+                    return _infer_depth_estimation(
+                        inference_request=inference_request,
+                        request=request,
+                        api_key=api_key,
                         countinference=countinference,
                         service_secret=service_secret,
                     )
-                    response = self.model_manager.infer_from_request_sync(
-                        depth_model_id, inference_request
-                    )
-                    if LAMBDA:
-                        actor = request.scope["aws.event"]["requestContext"][
-                            "authorizer"
-                        ]["lambda"]["actor"]
-                        trackUsage(depth_model_id, actor)
 
-                    # Extract data from nested response structure
-                    depth_data = response.response
-                    depth_response = DepthEstimationResponse(
-                        normalized_depth=depth_data["normalized_depth"].tolist(),
-                        image=depth_data["image"].base64_image,
+                @app.post(
+                    "/infer/depth-estimation/{model_id:path}",
+                    response_model=DepthEstimationResponse,
+                    summary="Depth Estimation with model ID in path",
+                    description="Run depth estimation. Model ID is specified in the URL path and can contain slashes.",
+                )
+                @with_route_exceptions
+                @usage_collector("request")
+                def depth_estimation_with_model_id(
+                    model_id: str,
+                    inference_request: DepthEstimationRequest,
+                    request: Request,
+                    api_key: Optional[str] = Query(
+                        None,
+                        description="Roboflow API Key that will be passed to the model during initialization for artifact retrieval",
+                    ),
+                    countinference: Optional[bool] = None,
+                    service_secret: Optional[str] = None,
+                ):
+                    """
+                    Generate a depth map with the model identifier in the path.
+
+                    The model_id can be specified in the URL path. If model_id is also
+                    explicitly provided in the request body, it must match the path
+                    parameter.
+                    """
+                    logger.debug(f"Reached /infer/depth-estimation/{model_id}")
+                    return _infer_depth_estimation(
+                        inference_request=inference_request,
+                        request=request,
+                        api_key=api_key,
+                        countinference=countinference,
+                        service_secret=service_secret,
+                        model_id=model_id,
                     )
-                    return depth_response
 
             if CORE_MODEL_TROCR_ENABLED:
 

--- a/inference/core/interfaces/http/http_api.py
+++ b/inference/core/interfaces/http/http_api.py
@@ -3687,6 +3687,8 @@ class HttpInterface(BaseInterface):
                         DepthEstimationResponse: The response containing the normalized depth map and optional visualization.
                     """
                     logger.debug(f"Reached /infer/depth-estimation")
+                    if api_key is not None:
+                        inference_request.api_key = api_key
                     depth_model_id = inference_request.model_id
                     self.model_manager.add_model(
                         depth_model_id,

--- a/inference/core/interfaces/http/http_api.py
+++ b/inference/core/interfaces/http/http_api.py
@@ -208,6 +208,7 @@ from inference.core.exceptions import (
     InputImageLoadError,
     MissingApiKeyError,
     MissingServiceSecretError,
+    RequestDataContradiction,
     RoboflowAPINotAuthorizedError,
     RoboflowAPINotNotFoundError,
     WebRTCConfigurationError,
@@ -3669,16 +3670,18 @@ class HttpInterface(BaseInterface):
                         fields_set = getattr(
                             inference_request,
                             "model_fields_set",
-                            getattr(inference_request, "__fields_set__", set()),
+                            getattr(
+                                inference_request, "__pydantic_fields_set__", set()
+                            ),
                         )
                         if (
                             "model_id" in fields_set
                             and inference_request.model_id is not None
                             and inference_request.model_id != model_id
                         ):
-                            raise HTTPException(
-                                status_code=400,
-                                detail=f"Model ID mismatch: path specifies '{model_id}' but request body specifies '{inference_request.model_id}'",
+                            raise RequestDataContradiction(
+                                f"Model ID mismatch: path specifies '{model_id}' but request body "
+                                f"specifies '{inference_request.model_id}'",
                             )
                         inference_request.model_id = model_id
                     if api_key is not None:
@@ -3736,38 +3739,13 @@ class HttpInterface(BaseInterface):
                         DepthEstimationResponse: The response containing the normalized depth map and optional visualization.
                     """
                     logger.debug(f"Reached /infer/depth-estimation")
-                    # return _infer_depth_estimation(
-                    #     inference_request=inference_request,
-                    #     request=request,
-                    #     api_key=api_key,
-                    #     countinference=countinference,
-                    #     service_secret=service_secret,
-                    # )
-                    if api_key is not None:
-                        inference_request.api_key = api_key
-                    depth_model_id = inference_request.model_id
-                    self.model_manager.add_model(
-                        depth_model_id,
-                        inference_request.api_key,
+                    return _infer_depth_estimation(
+                        inference_request=inference_request,
+                        request=request,
+                        api_key=api_key,
                         countinference=countinference,
                         service_secret=service_secret,
                     )
-                    response = self.model_manager.infer_from_request_sync(
-                        depth_model_id, inference_request
-                    )
-                    if LAMBDA:
-                        actor = request.scope["aws.event"]["requestContext"][
-                            "authorizer"
-                        ]["lambda"]["actor"]
-                        trackUsage(depth_model_id, actor)
-
-                    # Extract data from nested response structure
-                    depth_data = response.response
-                    depth_response = DepthEstimationResponse(
-                        normalized_depth=depth_data["normalized_depth"].tolist(),
-                        image=depth_data["image"].base64_image,
-                    )
-                    return depth_response
 
                 @app.post(
                     "/infer/depth-estimation/{model_id:path}",
@@ -3778,15 +3756,15 @@ class HttpInterface(BaseInterface):
                 @with_route_exceptions
                 @usage_collector("request")
                 def depth_estimation_with_model_id(
-                        model_id: str,
-                        inference_request: DepthEstimationRequest,
-                        request: Request,
-                        api_key: Optional[str] = Query(
-                            None,
-                            description="Roboflow API Key that will be passed to the model during initialization for artifact retrieval",
-                        ),
-                        countinference: Optional[bool] = None,
-                        service_secret: Optional[str] = None,
+                    model_id: str,
+                    inference_request: DepthEstimationRequest,
+                    request: Request,
+                    api_key: Optional[str] = Query(
+                        None,
+                        description="Roboflow API Key that will be passed to the model during initialization for artifact retrieval",
+                    ),
+                    countinference: Optional[bool] = None,
+                    service_secret: Optional[str] = None,
                 ):
                     """
                     Generate a depth map with the model identifier in the path.

--- a/inference/core/workflows/core_steps/models/foundation/depth_estimation/v1.py
+++ b/inference/core/workflows/core_steps/models/foundation/depth_estimation/v1.py
@@ -214,6 +214,7 @@ class DepthEstimationBlockV1(WorkflowBlock):
             result = client.depth_estimation(
                 inference_input=single_image.base64_image,
                 model_id=model_version,
+                model_id_in_path=True,
             )
             # Convert the result back to the expected format
             # Remote returns: {"normalized_depth": [...], "image": hex_string}

--- a/inference_sdk/http/client.py
+++ b/inference_sdk/http/client.py
@@ -1700,6 +1700,7 @@ class InferenceHTTPClient:
         self,
         inference_input: Union[ImagesReference, List[ImagesReference]],
         model_id: str = "depth-anything-v3/small",
+        model_id_in_path: bool = False,
     ) -> Union[dict, List[dict]]:
         """Run depth estimation on input image(s).
 
@@ -1714,6 +1715,10 @@ class InferenceHTTPClient:
                 - "depth-anything-v2/small"
                 - "depth-anything-v3/small"
                 - "depth-anything-v3/base"
+            model_id_in_path (bool, optional): If True, includes model_id in the URL path
+                (e.g., /infer/depth-estimation/depth-anything-v3/small), which enables
+                path-based routing. If False (default), model_id is only sent in the
+                request body.
 
         Returns:
             Union[dict, List[dict]]: Depth estimation results containing:
@@ -1725,9 +1730,13 @@ class InferenceHTTPClient:
             HTTPClientError: If there is an error with the server connection.
         """
         extra_payload = {"model_id": model_id}
+        if model_id_in_path:
+            endpoint = f"/infer/depth-estimation/{model_id}"
+        else:
+            endpoint = "/infer/depth-estimation"
         result = self._post_images(
             inference_input=inference_input,
-            endpoint="/infer/depth-estimation",
+            endpoint=endpoint,
             extra_payload=extra_payload,
         )
         return result
@@ -1737,6 +1746,7 @@ class InferenceHTTPClient:
         self,
         inference_input: Union[ImagesReference, List[ImagesReference]],
         model_id: str = "depth-anything-v3/small",
+        model_id_in_path: bool = False,
     ) -> Union[dict, List[dict]]:
         """Run depth estimation on input image(s) asynchronously.
 
@@ -1745,6 +1755,9 @@ class InferenceHTTPClient:
                 for depth estimation.
             model_id (str, optional): The depth estimation model to use. Defaults to
                 "depth-anything-v3/small".
+            model_id_in_path (bool, optional): If True, includes model_id in the URL path
+                for path-based routing. If False (default), model_id is only sent in the
+                request body.
 
         Returns:
             Union[dict, List[dict]]: Depth estimation results.
@@ -1754,9 +1767,13 @@ class InferenceHTTPClient:
             HTTPClientError: If there is an error with the server connection.
         """
         extra_payload = {"model_id": model_id}
+        if model_id_in_path:
+            endpoint = f"/infer/depth-estimation/{model_id}"
+        else:
+            endpoint = "/infer/depth-estimation"
         result = await self._post_images_async(
             inference_input=inference_input,
-            endpoint="/infer/depth-estimation",
+            endpoint=endpoint,
             extra_payload=extra_payload,
         )
         return result

--- a/requirements/requirements.cpu.txt
+++ b/requirements/requirements.cpu.txt
@@ -1,3 +1,3 @@
 onnxruntime>=1.15.1,<1.22.0
 nvidia-ml-py<13.0.0
-inference-models[torch-cpu,onnx-cpu]~=0.29.0  # keep in sync between requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt
+inference-models[torch-cpu,onnx-cpu]~=0.29.2  # keep in sync between requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt

--- a/requirements/requirements.gpu.txt
+++ b/requirements/requirements.gpu.txt
@@ -1,2 +1,2 @@
 onnxruntime-gpu>=1.15.1,<1.22.0
-inference-models[torch-cu124,onnx-cu12]~=0.29.0 # keep in sync between requirements.jetson requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt
+inference-models[torch-cu124,onnx-cu12]~=0.29.2 # keep in sync between requirements.jetson requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt

--- a/requirements/requirements.jetson.txt
+++ b/requirements/requirements.jetson.txt
@@ -1,3 +1,3 @@
 pypdfium2>=4.11.0,<5.0.0
 PyYAML~=6.0.0
-inference-models~=0.29.0  # keep in sync between requirements.jetson requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt
+inference-models~=0.29.2  # keep in sync between requirements.jetson requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt

--- a/requirements/requirements.vino.txt
+++ b/requirements/requirements.vino.txt
@@ -1,2 +1,2 @@
 onnxruntime-openvino>=1.15.0,<1.22.0
-inference-models[torch-cpu]~=0.29.0  # keep in sync between requirements.jetson requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt
+inference-models[torch-cpu]~=0.29.2  # keep in sync between requirements.jetson requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt

--- a/tests/inference/unit_tests/core/interfaces/http/test_http_api.py
+++ b/tests/inference/unit_tests/core/interfaces/http/test_http_api.py
@@ -237,6 +237,54 @@ def test_infer_lmm_with_model_id_uses_alias_registry_key(monkeypatch) -> None:
     assert inference_request.api_key == "query-api-key"
 
 
+def test_depth_estimation_uses_query_api_key_for_model_loading(monkeypatch) -> None:
+    import inference.core.interfaces.http.http_api as http_api
+
+    monkeypatch.setattr(http_api, "InferenceInstrumentator", _DummyInstrumentator)
+    monkeypatch.setattr(
+        http_api.usage_collector,
+        "async_push_usage_payloads",
+        AsyncMock(),
+    )
+    monkeypatch.setattr(http_api, "DEPTH_ESTIMATION_ENABLED", True)
+    monkeypatch.setattr(http_api, "DEDICATED_DEPLOYMENT_WORKSPACE_URL", None)
+    model_manager = MagicMock()
+    model_manager.pingback = None
+    model_manager.num_errors = 0
+    model_manager.infer_from_request_sync.return_value = {
+        "normalized_depth": [[0.0]],
+        "image": "depth-image",
+    }
+
+    interface = http_api.HttpInterface(model_manager=model_manager)
+
+    with TestClient(interface.app) as client:
+        response = client.post(
+            "/infer/depth-estimation",
+            params={"api_key": "query-api-key"},
+            json={
+                "model_id": "depth-anything-v3/small",
+                "image": {
+                    "type": "url",
+                    "value": "https://example.com/test.jpg",
+                },
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {"normalized_depth": [[0.0]], "image": "depth-image"}
+    model_manager.add_model.assert_called_once_with(
+        "depth-anything-v3/small",
+        "query-api-key",
+        countinference=None,
+        service_secret=None,
+    )
+    model_manager.infer_from_request_sync.assert_called_once()
+    inference_request = model_manager.infer_from_request_sync.call_args.args[1]
+    assert inference_request.model_id == "depth-anything-v3/small"
+    assert inference_request.api_key == "query-api-key"
+
+
 def test_serverless_auth_middleware_logs_request_received_with_execution_id(
     monkeypatch,
 ) -> None:

--- a/tests/inference/unit_tests/core/interfaces/http/test_http_api.py
+++ b/tests/inference/unit_tests/core/interfaces/http/test_http_api.py
@@ -29,6 +29,25 @@ class _DummyResponse(BaseModel):
     ok: bool = True
 
 
+class _DummyArray:
+    def __init__(self, value):
+        self._value = value
+
+    def tolist(self):
+        return self._value
+
+
+class _DummyImage:
+    base64_image = "depth-image"
+
+
+class _DummyDepthResponse:
+    response = {
+        "normalized_depth": _DummyArray([[0.0]]),
+        "image": _DummyImage(),
+    }
+
+
 def _make_inference_request() -> dict:
     return {
         "model_id": "florence-2-base",
@@ -251,10 +270,7 @@ def test_depth_estimation_uses_query_api_key_for_model_loading(monkeypatch) -> N
     model_manager = MagicMock()
     model_manager.pingback = None
     model_manager.num_errors = 0
-    model_manager.infer_from_request_sync.return_value = {
-        "normalized_depth": [[0.0]],
-        "image": "depth-image",
-    }
+    model_manager.infer_from_request_sync.return_value = _DummyDepthResponse()
 
     interface = http_api.HttpInterface(model_manager=model_manager)
 

--- a/tests/inference/unit_tests/core/interfaces/http/test_http_api.py
+++ b/tests/inference/unit_tests/core/interfaces/http/test_http_api.py
@@ -301,6 +301,91 @@ def test_depth_estimation_uses_query_api_key_for_model_loading(monkeypatch) -> N
     assert inference_request.api_key == "query-api-key"
 
 
+def test_depth_estimation_with_model_id_path_sets_request_model_id(monkeypatch) -> None:
+    import inference.core.interfaces.http.http_api as http_api
+
+    monkeypatch.setattr(http_api, "InferenceInstrumentator", _DummyInstrumentator)
+    monkeypatch.setattr(
+        http_api.usage_collector,
+        "async_push_usage_payloads",
+        AsyncMock(),
+    )
+    monkeypatch.setattr(http_api, "DEPTH_ESTIMATION_ENABLED", True)
+    monkeypatch.setattr(http_api, "DEDICATED_DEPLOYMENT_WORKSPACE_URL", None)
+    model_manager = MagicMock()
+    model_manager.pingback = None
+    model_manager.num_errors = 0
+    model_manager.infer_from_request_sync.return_value = _DummyDepthResponse()
+
+    interface = http_api.HttpInterface(model_manager=model_manager)
+
+    with TestClient(interface.app) as client:
+        response = client.post(
+            "/infer/depth-estimation/depth-anything-v3/small",
+            params={"api_key": "query-api-key"},
+            json={
+                "image": {
+                    "type": "url",
+                    "value": "https://example.com/test.jpg",
+                },
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {"normalized_depth": [[0.0]], "image": "depth-image"}
+    model_manager.add_model.assert_called_once_with(
+        "depth-anything-v3/small",
+        "query-api-key",
+        countinference=None,
+        service_secret=None,
+    )
+    model_manager.infer_from_request_sync.assert_called_once()
+    inference_request = model_manager.infer_from_request_sync.call_args.args[1]
+    assert inference_request.model_id == "depth-anything-v3/small"
+    assert inference_request.api_key == "query-api-key"
+
+
+def test_depth_estimation_with_model_id_path_rejects_body_mismatch(
+    monkeypatch,
+) -> None:
+    import inference.core.interfaces.http.http_api as http_api
+
+    monkeypatch.setattr(http_api, "InferenceInstrumentator", _DummyInstrumentator)
+    monkeypatch.setattr(
+        http_api.usage_collector,
+        "async_push_usage_payloads",
+        AsyncMock(),
+    )
+    monkeypatch.setattr(http_api, "DEPTH_ESTIMATION_ENABLED", True)
+    monkeypatch.setattr(http_api, "DEDICATED_DEPLOYMENT_WORKSPACE_URL", None)
+    model_manager = MagicMock()
+    model_manager.pingback = None
+    model_manager.num_errors = 0
+
+    interface = http_api.HttpInterface(model_manager=model_manager)
+
+    with TestClient(interface.app) as client:
+        response = client.post(
+            "/infer/depth-estimation/depth-anything-v3/small",
+            params={"api_key": "query-api-key"},
+            json={
+                "model_id": "depth-anything-v3/base",
+                "image": {
+                    "type": "url",
+                    "value": "https://example.com/test.jpg",
+                },
+            },
+        )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == (
+        "Model ID mismatch: path specifies 'depth-anything-v3/small' "
+        "but request body specifies 'depth-anything-v3/base'"
+    )
+    model_manager.add_model.assert_not_called()
+    model_manager.infer_from_request_sync.assert_not_called()
+
+
 def test_serverless_auth_middleware_logs_request_received_with_execution_id(
     monkeypatch,
 ) -> None:

--- a/tests/inference/unit_tests/core/interfaces/http/test_http_api.py
+++ b/tests/inference/unit_tests/core/interfaces/http/test_http_api.py
@@ -377,7 +377,7 @@ def test_depth_estimation_with_model_id_path_rejects_body_mismatch(
         )
 
     assert response.status_code == 400
-    assert response.json()["detail"] == (
+    assert response.json()["message"] == (
         "Model ID mismatch: path specifies 'depth-anything-v3/small' "
         "but request body specifies 'depth-anything-v3/base'"
     )

--- a/tests/inference_sdk/unit_tests/http/test_client.py
+++ b/tests/inference_sdk/unit_tests/http/test_client.py
@@ -3674,6 +3674,33 @@ def test_infer_lmm_when_generation_parameters_given(
     }
 
 
+@mock.patch.object(client, "load_static_inference_input")
+def test_depth_estimation_when_model_id_in_path(
+    load_static_inference_input_mock: MagicMock,
+    requests_mock: Mocker,
+) -> None:
+    api_url = "http://some.com"
+    http_client = InferenceHTTPClient(api_key="my-api-key", api_url=api_url)
+    load_static_inference_input_mock.return_value = [("base64_image", 0.5)]
+    requests_mock.post(
+        f"{api_url}/infer/depth-estimation/depth-anything-v3/small",
+        json={"normalized_depth": [[0.0]], "image": "depth-image"},
+    )
+
+    result = http_client.depth_estimation(
+        inference_input="/some/image.jpg",
+        model_id="depth-anything-v3/small",
+        model_id_in_path=True,
+    )
+
+    assert result == {"normalized_depth": [[0.0]], "image": "depth-image"}
+    assert requests_mock.request_history[0].json() == {
+        "api_key": "my-api-key",
+        "image": {"type": "base64", "value": "base64_image"},
+        "model_id": "depth-anything-v3/small",
+    }
+
+
 @mock.patch.object(client, "load_nested_batches_of_inference_input")
 @pytest.mark.parametrize(
     "legacy_endpoints, endpoint_to_use, parameter_name",

--- a/tests/workflows/unit_tests/core_steps/models/foundation/test_depth_estimation.py
+++ b/tests/workflows/unit_tests/core_steps/models/foundation/test_depth_estimation.py
@@ -105,4 +105,8 @@ def test_run_remotely_calls_depth_estimation(
     assert len(result) == 1
     assert "normalized_depth" in result[0]
     assert "image" in result[0]
-    mock_client.depth_estimation.assert_called_once()
+    mock_client.depth_estimation.assert_called_once_with(
+        inference_input=mock_workflow_image_data.base64_image,
+        model_id="depth-anything-v3/small",
+        model_id_in_path=True,
+    )


### PR DESCRIPTION
## Summary

Add a path-model-id variant for depth estimation, mirroring the `/infer/lmm/{model_id}` pattern so serverless can route queue names by concrete model path.

This PR is stacked on #2445 (`codex/depth-query-api-key`) because remote workflow execution still needs the query `api_key` propagation fix from that PR for cold model loads.

## Changes

- Add `POST /infer/depth-estimation/{model_id:path}`.
- Validate explicit body `model_id` against the path model id, matching the LMM behavior.
- Let path `model_id` override the depth request model default when body `model_id` was omitted.
- Add `model_id_in_path` to `InferenceHTTPClient.depth_estimation()` and `depth_estimation_async()`.
- Update the depth workflow block remote execution path to call `depth_estimation(..., model_id_in_path=True)`.
- Add route, SDK, and workflow regression tests.

## Validation

Passed:

- `git diff --check`
- `python -m py_compile inference/core/interfaces/http/http_api.py inference_sdk/http/client.py inference/core/workflows/core_steps/models/foundation/depth_estimation/v1.py tests/inference/unit_tests/core/interfaces/http/test_http_api.py tests/inference_sdk/unit_tests/http/test_client.py tests/workflows/unit_tests/core_steps/models/foundation/test_depth_estimation.py`
- `/Users/hansent/code/inference/.venv/bin/python -m black --check inference/core/interfaces/http/http_api.py inference_sdk/http/client.py inference/core/workflows/core_steps/models/foundation/depth_estimation/v1.py tests/inference/unit_tests/core/interfaces/http/test_http_api.py tests/inference_sdk/unit_tests/http/test_client.py tests/workflows/unit_tests/core_steps/models/foundation/test_depth_estimation.py`
- `/Users/hansent/code/inference/.venv/bin/python -m pytest tests/inference_sdk/unit_tests/http/test_client.py::test_depth_estimation_when_model_id_in_path tests/workflows/unit_tests/core_steps/models/foundation/test_depth_estimation.py::test_run_remotely_calls_depth_estimation`

Local HTTP route tests are still blocked by the reused local venv before route import because `trackers.BoTSORTTracker` is missing. The blocked command was:

`/Users/hansent/code/inference/.venv/bin/python -m pytest tests/inference/unit_tests/core/interfaces/http/test_http_api.py::test_depth_estimation_uses_query_api_key_for_model_loading tests/inference/unit_tests/core/interfaces/http/test_http_api.py::test_depth_estimation_with_model_id_path_sets_request_model_id tests/inference/unit_tests/core/interfaces/http/test_http_api.py::test_depth_estimation_with_model_id_path_rejects_body_mismatch`

## Follow-up

Once this endpoint is deployed, async-serverless may need a values/router follow-up if we want cold-sub bypass or consumer pool matching to treat `/infer/depth-estimation/*` as a prefix rather than only exact `/infer/depth-estimation`. The producer OpenAPI matcher should recognize the path route from inference, but current Crusoe cold-sub bypass entries are exact for depth.