### PR TITLE
fix(workflows): keep consensus masks boolean

### DIFF
--- a/inference/core/workflows/core_steps/fusion/detections_consensus/v1.py
+++ b/inference/core/workflows/core_steps/fusion/detections_consensus/v1.py
@@ -471,7 +471,7 @@ def get_consensus_for_single_detection(
     if detection.mask is not None:
         for matched_value in detections_with_max_overlap.values():
             if matched_value[0].mask is None:
-                matched_value[0].mask = np.zeros(detection.mask.shape)
+                matched_value[0].mask = np.zeros(detection.mask.shape, dtype=bool)
     else:
         shape = None
         for d in detections_with_max_overlap.values():
@@ -481,8 +481,8 @@ def get_consensus_for_single_detection(
         if shape:
             for d in detections_with_max_overlap.values():
                 if d[0].mask is None:
-                    d[0].mask = np.zeros(shape)
-            detection.mask = np.zeros(shape)
+                    d[0].mask = np.zeros(shape, dtype=bool)
+            detection.mask = np.zeros(shape, dtype=bool)
     detections_to_merge = sv.Detections.merge(
         [detection]
         + [matched_value[0] for matched_value in detections_with_max_overlap.values()]
@@ -690,7 +690,7 @@ def get_intersection_mask(detections: sv.Detections) -> np.ndarray:
 
 
 def get_union_mask(detections: sv.Detections) -> np.ndarray:
-    return np.sum(detections.mask, axis=0)
+    return np.any(detections.mask, axis=0)
 
 
 def get_smallest_mask(detections: sv.Detections) -> np.ndarray:


### PR DESCRIPTION
Follow-up to #2432: the `detections_consensus` block still produces non-bool masks in two spots. The mask back-filling for partially-masked merge groups uses `np.zeros(shape)`, which is float64, and `get_union_mask` returns `np.sum(masks, axis=0)`, which is int64. Both flow into `sv.Detections`, which emits the same deprecation warning #2432 was cleaning up (three warnings per consensus call when one source has masks and another does not) and has announced the warning will become a `ValueError`.

The fix is `dtype=bool` on the three `np.zeros` calls and `np.any` for the union (mirroring `get_intersection_mask`'s `np.all` right above it). Outputs are unchanged: I snapshotted consensus results (xyxy, confidence, mask nonzero patterns) on the same inputs before and after and they are identical, with the warning count going from six to zero. The int-valued union also double-counted overlap pixels in downstream `Detections.area`; the bool mask fixes that.