### PR TITLE
Add Switch Case flow-control block with per-case execution branches

### DIFF
--- a/docs/workflows/execution_engine_changelog.md
+++ b/docs/workflows/execution_engine_changelog.md
@@ -2,6 +2,27 @@
 
 Below you can find the changelog for Execution Engine.
 
+## Execution Engine `v1.11.0` | inference `v1.3.1`
+
+**What changed**
+
+* **Per-case execution branches for dict step selectors** — When a flow-control block
+  declares step selectors inside a `Dict[str, StepSelector]` property (rather than a
+  `List[StepSelector]`), the compiler now creates a distinct execution branch per
+  dictionary key. Previously every selector in a single property shared one branch, so
+  a block could not route to its targets independently. Branch names now include the
+  dictionary key (e.g. `Branch[$steps.switch -> cases[red]]`). Selectors held in list
+  properties (such as `next_steps`) keep the prior shared-branch behavior, so existing
+  blocks are unaffected. This change is what enables the new
+  `roboflow_core/switch_case@v1` block (`graph_constructor.establish_control_flow_edge`).
+
+* **Fix: non-SIMD flow-control masks with repeated branch names** — A non-SIMD
+  flow-control step that selected more than one target through a single list property
+  raised `Attempted to re-register maks for execution branch`. Branch-mask registration
+  now deduplicates branch names before registering, fixing the crash (affected e.g.
+  `ContinueIf` with multiple `next_steps`;
+  `execution_data_manager.manager._register_control_flow_output_for_non_simd_step`).
+
 ## Execution Engine `v1.10.1` | inference `v1.2.12`
 
 **What changed**

--- a/inference/core/workflows/core_steps/flow_control/switch_case/v1.py
+++ b/inference/core/workflows/core_steps/flow_control/switch_case/v1.py
@@ -1,0 +1,180 @@
+from typing import Any, Dict, List, Literal, Optional, Type, Union
+
+from pydantic import ConfigDict, Field, model_validator
+
+from inference.core.workflows.execution_engine.entities.base import OutputDefinition
+from inference.core.workflows.execution_engine.entities.types import (
+    Selector,
+    StepSelector,
+)
+from inference.core.workflows.execution_engine.v1.entities import FlowControl
+from inference.core.workflows.prototypes.block import (
+    BlockResult,
+    WorkflowBlock,
+    WorkflowBlockManifest,
+)
+
+LONG_DESCRIPTION = """
+Route workflow execution to one of several branches by matching an input value against a set of
+case values, similar to a switch-case statement in programming, enabling multi-way branching,
+value-based routing, and decision trees without chaining multiple Continue If blocks.
+
+## How This Block Works
+
+This block compares a single input value against the keys of a case mapping and directs execution
+to the step associated with the first matching case. The block:
+
+1. Takes a `value` input (typically a selector referencing a workflow input or a step output, e.g.
+   a classification result) and converts it to a string
+2. Looks the string up in the `cases` mapping, where each key is a case value and each value is the
+   step to execute when that case matches (e.g. `{"red": "$steps.on_red", "blue": "$steps.on_blue"}`)
+3. If `case_insensitive` is enabled, the comparison ignores letter case
+4. If a case matches, execution continues to that case's step and all other branches terminate
+5. If no case matches, execution continues to the steps listed in `default_next_steps`
+6. If no case matches and `default_next_steps` is empty, the branch terminates
+
+Because the input value is converted to a string before matching, non-string values match their
+string representation: `True` matches the key `"True"`, `1.0` matches `"1.0"` (not `"1"`), and a
+missing/None value matches `"None"`. Each target step may appear at most once across `cases` and
+`default_next_steps` — to route several case values to the same logic, point each case at its own
+step or normalize the value upstream (e.g. with an Expression block).
+
+## Common Use Cases
+
+- **Routing by classification result**: Send images down different processing paths based on the
+  top class predicted by a classification model (e.g. "damaged" → alert branch, "ok" → logging
+  branch, anything else → default review branch)
+- **Mode-based pipelines**: Use a workflow input parameter (e.g. `$inputs.mode`) to select between
+  alternative processing branches at runtime without editing the workflow
+- **Multi-way alerting**: Route to different notification blocks (email, Slack, webhook) depending
+  on a severity or category value computed earlier in the workflow
+- **Replacing chained conditions**: Collapse a ladder of Continue If blocks comparing the same
+  value against different constants into a single, easier-to-read block
+
+## Connecting to Other Blocks
+
+This block controls workflow execution flow and can be connected:
+
+- **After classification or detection blocks** to branch on predicted classes, counts, or other
+  prediction properties (often via a Property Definition or Expression block that extracts the
+  value to switch on)
+- **After workflow inputs** to select a branch from a runtime parameter
+- **Before any downstream blocks** (models, notifications, sinks) that should only run for a
+  specific case — each case target becomes the head of its own execution branch
+- **With a default branch** wired via `default_next_steps` to handle unmatched values, or left
+  empty to simply stop when nothing matches
+"""
+
+SHORT_DESCRIPTION = "Route execution to one of several branches based on the value of an input."
+
+
+class BlockManifest(WorkflowBlockManifest):
+    model_config = ConfigDict(
+        json_schema_extra={
+            "name": "Switch Case",
+            "version": "v1",
+            "short_description": SHORT_DESCRIPTION,
+            "long_description": LONG_DESCRIPTION,
+            "license": "Apache-2.0",
+            "block_type": "flow_control",
+            "ui_manifest": {
+                "section": "flow_control",
+                "icon": "far fa-split",
+                "blockPriority": 4,
+                "popular": True,
+            },
+        }
+    )
+    type: Literal["roboflow_core/switch_case@v1", "SwitchCase"]
+    value: Union[Selector(), str, int, float, bool] = Field(
+        title="Value",
+        description="Value to match against the case keys. Typically a selector referencing a "
+        "workflow input or a step output (e.g. $inputs.mode or $steps.classifier.top). The value "
+        "is converted to a string before comparison, so booleans match keys 'True'/'False', "
+        "1.0 matches '1.0' and a None value matches 'None'.",
+        examples=["$steps.classifier.top", "$inputs.mode", "red"],
+    )
+    cases: Dict[str, StepSelector] = Field(
+        title="Cases",
+        description="Mapping of case value to the step that should execute when `value` matches "
+        "it, e.g. {\"red\": \"$steps.on_red\", \"blue\": \"$steps.on_blue\"}. Each target step "
+        "may appear at most once across `cases` and `default_next_steps`.",
+        examples=[{"red": "$steps.on_red", "blue": "$steps.on_blue"}],
+        default_factory=dict,
+    )
+    case_insensitive: bool = Field(
+        title="Case Insensitive",
+        description="When enabled, case values are matched ignoring letter case "
+        "(e.g. value 'RED' matches case key 'red').",
+        default=False,
+        examples=[False],
+    )
+    default_next_steps: List[StepSelector] = Field(
+        title="Default Steps",
+        description="Steps to execute when no case matches. Leave empty to terminate the branch "
+        "when nothing matches.",
+        examples=[["$steps.fallback"]],
+        default_factory=list,
+    )
+
+    @model_validator(mode="after")
+    def validate_targets_and_keys(self) -> "BlockManifest":
+        targets = list(self.cases.values()) + list(self.default_next_steps)
+        seen, duplicated = set(), set()
+        for target in targets:
+            if target in seen:
+                duplicated.add(target)
+            seen.add(target)
+        if duplicated:
+            raise ValueError(
+                f"Each step may be targeted at most once across `cases` and "
+                f"`default_next_steps`. Duplicated targets: {sorted(duplicated)}"
+            )
+        if self.case_insensitive:
+            lowered_keys = [key.lower() for key in self.cases]
+            if len(set(lowered_keys)) != len(lowered_keys):
+                raise ValueError(
+                    "`cases` contains keys that collide when case_insensitive is enabled"
+                )
+        return self
+
+    @classmethod
+    def describe_outputs(cls) -> List[OutputDefinition]:
+        return []
+
+    @classmethod
+    def get_execution_engine_compatibility(cls) -> Optional[str]:
+        return ">=1.3.0,<2.0.0"
+
+
+class SwitchCaseBlockV1(WorkflowBlock):
+
+    @classmethod
+    def get_manifest(cls) -> Type[WorkflowBlockManifest]:
+        return BlockManifest
+
+    def run(
+        self,
+        value: Any,
+        cases: Dict[str, StepSelector],
+        case_insensitive: bool,
+        default_next_steps: List[StepSelector],
+    ) -> BlockResult:
+        coerced_value = str(value)
+        if case_insensitive:
+            coerced_value = coerced_value.lower()
+            matched_step = next(
+                (
+                    target
+                    for case_key, target in cases.items()
+                    if case_key.lower() == coerced_value
+                ),
+                None,
+            )
+        else:
+            matched_step = cases.get(coerced_value)
+        if matched_step is not None:
+            return FlowControl(mode="select_step", context=[matched_step])
+        if default_next_steps:
+            return FlowControl(mode="select_step", context=default_next_steps)
+        return FlowControl(mode="terminate_branch")

--- a/inference/core/workflows/core_steps/flow_control/switch_case/v1.py
+++ b/inference/core/workflows/core_steps/flow_control/switch_case/v1.py
@@ -101,6 +101,7 @@ class BlockManifest(WorkflowBlockManifest):
         "may appear at most once across `cases` and `default_next_steps`.",
         examples=[{"red": "$steps.on_red", "blue": "$steps.on_blue"}],
         default_factory=dict,
+        json_schema_extra={"always_visible": True},
     )
     case_insensitive: bool = Field(
         title="Case Insensitive",

--- a/inference/core/workflows/core_steps/flow_control/switch_case/v1.py
+++ b/inference/core/workflows/core_steps/flow_control/switch_case/v1.py
@@ -147,7 +147,9 @@ class BlockManifest(WorkflowBlockManifest):
 
     @classmethod
     def get_execution_engine_compatibility(cls) -> Optional[str]:
-        return ">=1.3.0,<2.0.0"
+        # Requires per-key execution branches for dict step selectors, added in
+        # Execution Engine v1.11.0.
+        return ">=1.11.0,<2.0.0"
 
 
 class SwitchCaseBlockV1(WorkflowBlock):

--- a/inference/core/workflows/core_steps/flow_control/switch_case/v1.py
+++ b/inference/core/workflows/core_steps/flow_control/switch_case/v1.py
@@ -65,7 +65,9 @@ This block controls workflow execution flow and can be connected:
   empty to simply stop when nothing matches
 """
 
-SHORT_DESCRIPTION = "Route execution to one of several branches based on the value of an input."
+SHORT_DESCRIPTION = (
+    "Route execution to one of several branches based on the value of an input."
+)
 
 
 class BlockManifest(WorkflowBlockManifest):
@@ -97,7 +99,7 @@ class BlockManifest(WorkflowBlockManifest):
     cases: Dict[str, StepSelector] = Field(
         title="Cases",
         description="Mapping of case value to the step that should execute when `value` matches "
-        "it, e.g. {\"red\": \"$steps.on_red\", \"blue\": \"$steps.on_blue\"}. Each target step "
+        'it, e.g. {"red": "$steps.on_red", "blue": "$steps.on_blue"}. Each target step '
         "may appear at most once across `cases` and `default_next_steps`.",
         examples=[{"red": "$steps.on_red", "blue": "$steps.on_blue"}],
         default_factory=dict,

--- a/inference/core/workflows/core_steps/loader.py
+++ b/inference/core/workflows/core_steps/loader.py
@@ -153,6 +153,9 @@ from inference.core.workflows.core_steps.flow_control.inner_workflow.v1 import (
 from inference.core.workflows.core_steps.flow_control.rate_limiter.v1 import (
     RateLimiterBlockV1,
 )
+from inference.core.workflows.core_steps.flow_control.switch_case.v1 import (
+    SwitchCaseBlockV1,
+)
 from inference.core.workflows.core_steps.formatters.csv.v1 import CSVFormatterBlockV1
 from inference.core.workflows.core_steps.formatters.current_time.v1 import (
     CurrentTimeBlockV1,
@@ -817,6 +820,7 @@ def load_blocks() -> List[Type[WorkflowBlock]]:
         ContinueIfBlockV1,
         InnerWorkflowBlockV1,
         RateLimiterBlockV1,
+        SwitchCaseBlockV1,
         PerspectiveCorrectionBlockV1,
         DeltaFilterBlockV1,
         CameraCalibrationBlockV1,

--- a/inference/core/workflows/execution_engine/v1/compiler/graph_constructor.py
+++ b/inference/core/workflows/execution_engine/v1/compiler/graph_constructor.py
@@ -388,7 +388,14 @@ def establish_control_flow_edge(
             f"that situation creates ambiguity in selecting execution branch.",
             context="workflow_compilation | execution_graph_construction",
         )
-    execution_branch_name = f"Branch[{source_step_selector} -> {target_step_parsed_selector.definition.property_name}]"
+    # Selectors held in dict properties (e.g. switch-case mappings) each spawn their own
+    # execution branch, so flow-control blocks can select targets independently. Selectors
+    # in list properties (e.g. `next_steps`) share a single branch - they are selected
+    # together or not at all.
+    property_name = target_step_parsed_selector.definition.property_name
+    if target_step_parsed_selector.key is not None:
+        property_name = f"{property_name}[{target_step_parsed_selector.key}]"
+    execution_branch_name = f"Branch[{source_step_selector} -> {property_name}]"
     source_compilation_data.child_execution_branches[target_step_selector] = (
         execution_branch_name
     )

--- a/inference/core/workflows/execution_engine/v1/core.py
+++ b/inference/core/workflows/execution_engine/v1/core.py
@@ -29,7 +29,7 @@ from inference.core.workflows.execution_engine.v1.step_error_handlers import (
     legacy_step_error_handler,
 )
 
-EXECUTION_ENGINE_V1_VERSION = Version("1.10.1")
+EXECUTION_ENGINE_V1_VERSION = Version("1.11.0")
 
 DEFAULT_WORKFLOWS_STEP_ERROR_HANDLER = os.getenv(
     "DEFAULT_WORKFLOWS_STEP_ERROR_HANDLER", "extended_roboflow_errors"

--- a/inference/core/workflows/execution_engine/v1/executor/execution_data_manager/manager.py
+++ b/inference/core/workflows/execution_engine/v1/executor/execution_data_manager/manager.py
@@ -569,7 +569,9 @@ class ExecutionDataManager:
         for target_step, branch_name in step_node.child_execution_branches.items():
             if target_step in selected_steps:
                 selected_execution_branches.add(branch_name)
-        for branch_name in step_node.child_execution_branches.values():
+        # multiple targets may share one execution branch (selectors kept in a list
+        # property), so deduplicate to avoid re-registering the same mask
+        for branch_name in set(step_node.child_execution_branches.values()):
             mask = branch_name in selected_execution_branches
             logger.debug(f"NON-SIMD flow control -> {branch_name}: {mask}")
             self._branching_manager.register_non_batch_mask(

--- a/tests/inference/hosted_platform_tests/test_workflows.py
+++ b/tests/inference/hosted_platform_tests/test_workflows.py
@@ -129,7 +129,7 @@ def test_get_versions_of_execution_engine(object_detection_service_url: str) -> 
     # then
     response.raise_for_status()
     response_data = response.json()
-    assert response_data["versions"] == ["1.10.1"]
+    assert response_data["versions"] == ["1.11.0"]
 
 
 FUNCTION = """

--- a/tests/inference/integration_tests/test_workflow_endpoints.py
+++ b/tests/inference/integration_tests/test_workflow_endpoints.py
@@ -691,7 +691,7 @@ def test_get_versions_of_execution_engine(server_url: str) -> None:
     # then
     response.raise_for_status()
     response_data = response.json()
-    assert response_data["versions"] == ["1.10.1"]
+    assert response_data["versions"] == ["1.11.0"]
 
 
 def test_getting_block_schema_using_get_endpoint(server_url) -> None:

--- a/tests/workflows/integration_tests/execution/test_workflow_with_flow_control.py
+++ b/tests/workflows/integration_tests/execution/test_workflow_with_flow_control.py
@@ -1232,3 +1232,102 @@ def test_workflow_with_stacked_flow_control(
     assert result[0]["output"] == "a, c"
     assert result[1]["output"] == None
     assert result[2]["output"] == "a, c"
+
+
+WORKFLOW_WITH_NON_SIMD_CONTINUE_IF_AND_MULTIPLE_NEXT_STEPS = {
+    "version": "1.0",
+    "inputs": [{"type": "WorkflowParameter", "name": "some"}],
+    "steps": [
+        {
+            "type": "ContinueIf",
+            "name": "gate",
+            "condition_statement": {
+                "type": "StatementGroup",
+                "statements": [
+                    {
+                        "type": "BinaryStatement",
+                        "left_operand": {
+                            "type": "DynamicOperand",
+                            "operand_name": "left",
+                        },
+                        "comparator": {"type": "(Number) =="},
+                        "right_operand": {"type": "StaticOperand", "value": 1},
+                    }
+                ],
+            },
+            "evaluation_parameters": {"left": "$inputs.some"},
+            "next_steps": ["$steps.first_expression", "$steps.second_expression"],
+        },
+        {
+            "type": "Expression",
+            "name": "first_expression",
+            "data": {"value": "$inputs.some"},
+            "switch": {
+                "type": "CasesDefinition",
+                "cases": [],
+                "default": {"type": "StaticCaseResult", "value": "EXECUTED FIRST!"},
+            },
+        },
+        {
+            "type": "Expression",
+            "name": "second_expression",
+            "data": {"value": "$inputs.some"},
+            "switch": {
+                "type": "CasesDefinition",
+                "cases": [],
+                "default": {"type": "StaticCaseResult", "value": "EXECUTED SECOND!"},
+            },
+        },
+    ],
+    "outputs": [
+        {
+            "type": "JsonField",
+            "name": "first_expression",
+            "selector": "$steps.first_expression.output",
+        },
+        {
+            "type": "JsonField",
+            "name": "second_expression",
+            "selector": "$steps.second_expression.output",
+        },
+    ],
+}
+
+
+@pytest.mark.parametrize(
+    "some, expected_first, expected_second",
+    [
+        (1, "EXECUTED FIRST!", "EXECUTED SECOND!"),
+        (0, None, None),
+    ],
+    ids=["condition_met_executes_both_next_steps", "condition_not_met_terminates_both"],
+)
+def test_non_simd_continue_if_with_multiple_next_steps(
+    some: int,
+    expected_first,
+    expected_second,
+) -> None:
+    """
+    Regression test: a non-SIMD flow-control step with more than one selector in
+    `next_steps` used to crash with "Attempted to re-register maks for execution
+    branch" - all selectors of a list property share a single execution branch and
+    the mask was registered once per selector instead of once per branch.
+    """
+    # given
+    execution_engine = ExecutionEngine.init(
+        workflow_definition=WORKFLOW_WITH_NON_SIMD_CONTINUE_IF_AND_MULTIPLE_NEXT_STEPS,
+        init_parameters={
+            "workflows_core.model_manager": None,
+            "workflows_core.api_key": None,
+            "workflows_core.step_execution_mode": StepExecutionMode.LOCAL,
+        },
+        max_concurrent_steps=WORKFLOWS_MAX_CONCURRENT_STEPS,
+    )
+
+    # when
+    result = execution_engine.run(runtime_parameters={"some": some})
+
+    # then
+    assert result == [
+        {"first_expression": expected_first, "second_expression": expected_second}
+    ]

--- a/tests/workflows/integration_tests/execution/test_workflow_with_switch_case.py
+++ b/tests/workflows/integration_tests/execution/test_workflow_with_switch_case.py
@@ -1,8 +1,8 @@
 import pytest
 
 from inference.core.env import WORKFLOWS_MAX_CONCURRENT_STEPS
-from inference.core.workflows.errors import WorkflowSyntaxError
 from inference.core.workflows.core_steps.common.entities import StepExecutionMode
+from inference.core.workflows.errors import WorkflowSyntaxError
 from inference.core.workflows.execution_engine.core import ExecutionEngine
 
 SWITCH_CASE_WORKFLOW = {
@@ -99,9 +99,9 @@ def test_switch_case_routes_to_expected_branch(
     # then
     assert isinstance(result, list), "Expected result to be list"
     assert len(result) == 1, "Single (non-batch) result expected"
-    assert result[0] == expected, (
-        f"Expected only the branch matching '{routing_value}' to execute"
-    )
+    assert (
+        result[0] == expected
+    ), f"Expected only the branch matching '{routing_value}' to execute"
 
 
 def test_switch_case_terminates_branch_when_no_match_and_no_default() -> None:
@@ -110,11 +110,7 @@ def test_switch_case_terminates_branch_when_no_match_and_no_default() -> None:
     workflow_definition = {
         **SWITCH_CASE_WORKFLOW,
         "steps": [
-            (
-                {**step, "default_next_steps": []}
-                if step["name"] == "switch"
-                else step
-            )
+            ({**step, "default_next_steps": []} if step["name"] == "switch" else step)
             for step in SWITCH_CASE_WORKFLOW["steps"]
             if step["name"] != "on_default"
         ],

--- a/tests/workflows/integration_tests/execution/test_workflow_with_switch_case.py
+++ b/tests/workflows/integration_tests/execution/test_workflow_with_switch_case.py
@@ -1,0 +1,157 @@
+import pytest
+
+from inference.core.env import WORKFLOWS_MAX_CONCURRENT_STEPS
+from inference.core.workflows.errors import WorkflowSyntaxError
+from inference.core.workflows.core_steps.common.entities import StepExecutionMode
+from inference.core.workflows.execution_engine.core import ExecutionEngine
+
+SWITCH_CASE_WORKFLOW = {
+    "version": "1.0",
+    "inputs": [
+        {"type": "WorkflowParameter", "name": "routing_value"},
+    ],
+    "steps": [
+        {
+            "type": "roboflow_core/switch_case@v1",
+            "name": "switch",
+            "value": "$inputs.routing_value",
+            "cases": {
+                "a": "$steps.on_a",
+                "b": "$steps.on_b",
+            },
+            "default_next_steps": ["$steps.on_default"],
+        },
+        {
+            "type": "Expression",
+            "name": "on_a",
+            "data": {"value": "$inputs.routing_value"},
+            "switch": {
+                "type": "CasesDefinition",
+                "cases": [],
+                "default": {"type": "StaticCaseResult", "value": "EXECUTED A!"},
+            },
+        },
+        {
+            "type": "Expression",
+            "name": "on_b",
+            "data": {"value": "$inputs.routing_value"},
+            "switch": {
+                "type": "CasesDefinition",
+                "cases": [],
+                "default": {"type": "StaticCaseResult", "value": "EXECUTED B!"},
+            },
+        },
+        {
+            "type": "Expression",
+            "name": "on_default",
+            "data": {"value": "$inputs.routing_value"},
+            "switch": {
+                "type": "CasesDefinition",
+                "cases": [],
+                "default": {"type": "StaticCaseResult", "value": "EXECUTED DEFAULT!"},
+            },
+        },
+    ],
+    "outputs": [
+        {"type": "JsonField", "name": "on_a", "selector": "$steps.on_a.output"},
+        {"type": "JsonField", "name": "on_b", "selector": "$steps.on_b.output"},
+        {
+            "type": "JsonField",
+            "name": "on_default",
+            "selector": "$steps.on_default.output",
+        },
+    ],
+}
+
+
+def _init_engine(workflow_definition: dict) -> ExecutionEngine:
+    return ExecutionEngine.init(
+        workflow_definition=workflow_definition,
+        init_parameters={
+            "workflows_core.model_manager": None,
+            "workflows_core.api_key": None,
+            "workflows_core.step_execution_mode": StepExecutionMode.LOCAL,
+        },
+        max_concurrent_steps=WORKFLOWS_MAX_CONCURRENT_STEPS,
+    )
+
+
+@pytest.mark.parametrize(
+    "routing_value, expected",
+    [
+        ("a", {"on_a": "EXECUTED A!", "on_b": None, "on_default": None}),
+        ("b", {"on_a": None, "on_b": "EXECUTED B!", "on_default": None}),
+        ("c", {"on_a": None, "on_b": None, "on_default": "EXECUTED DEFAULT!"}),
+    ],
+    ids=["case_a_matches", "case_b_matches", "no_match_routes_to_default"],
+)
+def test_switch_case_routes_to_expected_branch(
+    routing_value: str, expected: dict
+) -> None:
+    # given
+    execution_engine = _init_engine(SWITCH_CASE_WORKFLOW)
+
+    # when
+    result = execution_engine.run(
+        runtime_parameters={"routing_value": routing_value},
+    )
+
+    # then
+    assert isinstance(result, list), "Expected result to be list"
+    assert len(result) == 1, "Single (non-batch) result expected"
+    assert result[0] == expected, (
+        f"Expected only the branch matching '{routing_value}' to execute"
+    )
+
+
+def test_switch_case_terminates_branch_when_no_match_and_no_default() -> None:
+    # given - on_default step removed entirely: without a flow-control edge it would
+    # execute unconditionally as an independent step
+    workflow_definition = {
+        **SWITCH_CASE_WORKFLOW,
+        "steps": [
+            (
+                {**step, "default_next_steps": []}
+                if step["name"] == "switch"
+                else step
+            )
+            for step in SWITCH_CASE_WORKFLOW["steps"]
+            if step["name"] != "on_default"
+        ],
+        "outputs": [
+            output
+            for output in SWITCH_CASE_WORKFLOW["outputs"]
+            if output["name"] != "on_default"
+        ],
+    }
+    execution_engine = _init_engine(workflow_definition)
+
+    # when
+    result = execution_engine.run(
+        runtime_parameters={"routing_value": "unmatched"},
+    )
+
+    # then
+    assert result == [
+        {"on_a": None, "on_b": None}
+    ], "Expected all case branches terminated when nothing matches and no default is set"
+
+
+def test_switch_case_compilation_fails_on_duplicated_targets() -> None:
+    # given
+    workflow_definition = {
+        **SWITCH_CASE_WORKFLOW,
+        "steps": [
+            (
+                {**step, "cases": {"a": "$steps.on_a", "alias_of_a": "$steps.on_a"}}
+                if step["name"] == "switch"
+                else step
+            )
+            for step in SWITCH_CASE_WORKFLOW["steps"]
+        ],
+    }
+
+    # when / then
+    with pytest.raises(WorkflowSyntaxError) as error:
+        _init_engine(workflow_definition)
+    assert "targeted at most once" in str(error.value.inner_error)

--- a/tests/workflows/unit_tests/core_steps/control_flow/test_switch_case.py
+++ b/tests/workflows/unit_tests/core_steps/control_flow/test_switch_case.py
@@ -1,0 +1,250 @@
+import pytest
+from pydantic import ValidationError
+
+from inference.core.workflows.core_steps.flow_control.switch_case.v1 import (
+    BlockManifest,
+    SwitchCaseBlockV1,
+)
+from inference.core.workflows.execution_engine.v1.entities import FlowControl
+
+
+@pytest.mark.parametrize(
+    "value", ["$inputs.mode", "$steps.classifier.top", "red", 5, 1.5, True]
+)
+def test_switch_case_manifest_parsing_when_input_is_valid(value) -> None:
+    # given
+    raw_manifest = {
+        "type": "roboflow_core/switch_case@v1",
+        "name": "switch",
+        "value": value,
+        "cases": {"red": "$steps.on_red", "blue": "$steps.on_blue"},
+        "default_next_steps": ["$steps.fallback"],
+    }
+
+    # when
+    result = BlockManifest.model_validate(raw_manifest)
+
+    # then
+    assert result == BlockManifest(
+        type="roboflow_core/switch_case@v1",
+        name="switch",
+        value=value,
+        cases={"red": "$steps.on_red", "blue": "$steps.on_blue"},
+        default_next_steps=["$steps.fallback"],
+    )
+
+
+def test_switch_case_manifest_parsing_when_cases_and_default_are_omitted() -> None:
+    # given
+    raw_manifest = {
+        "type": "roboflow_core/switch_case@v1",
+        "name": "switch",
+        "value": "$inputs.mode",
+    }
+
+    # when
+    result = BlockManifest.model_validate(raw_manifest)
+
+    # then
+    assert result.cases == {}
+    assert result.default_next_steps == []
+
+
+def test_switch_case_manifest_parsing_when_target_duplicated_across_cases() -> None:
+    # given
+    raw_manifest = {
+        "type": "roboflow_core/switch_case@v1",
+        "name": "switch",
+        "value": "$inputs.mode",
+        "cases": {"red": "$steps.on_red", "crimson": "$steps.on_red"},
+    }
+
+    # when
+    with pytest.raises(ValidationError):
+        _ = BlockManifest.model_validate(raw_manifest)
+
+
+def test_switch_case_manifest_parsing_when_target_duplicated_between_cases_and_default() -> (
+    None
+):
+    # given
+    raw_manifest = {
+        "type": "roboflow_core/switch_case@v1",
+        "name": "switch",
+        "value": "$inputs.mode",
+        "cases": {"red": "$steps.on_red"},
+        "default_next_steps": ["$steps.on_red"],
+    }
+
+    # when
+    with pytest.raises(ValidationError):
+        _ = BlockManifest.model_validate(raw_manifest)
+
+
+def test_switch_case_manifest_parsing_when_keys_collide_case_insensitively() -> None:
+    # given
+    raw_manifest = {
+        "type": "roboflow_core/switch_case@v1",
+        "name": "switch",
+        "value": "$inputs.mode",
+        "cases": {"Red": "$steps.on_red", "red": "$steps.on_other"},
+        "case_insensitive": True,
+    }
+
+    # when
+    with pytest.raises(ValidationError):
+        _ = BlockManifest.model_validate(raw_manifest)
+
+
+def test_switch_case_manifest_parsing_when_colliding_keys_allowed_case_sensitively() -> (
+    None
+):
+    # given
+    raw_manifest = {
+        "type": "roboflow_core/switch_case@v1",
+        "name": "switch",
+        "value": "$inputs.mode",
+        "cases": {"Red": "$steps.on_red", "red": "$steps.on_other"},
+        "case_insensitive": False,
+    }
+
+    # when
+    result = BlockManifest.model_validate(raw_manifest)
+
+    # then
+    assert result.cases == {"Red": "$steps.on_red", "red": "$steps.on_other"}
+
+
+def test_switch_case_manifest_parsing_when_case_target_is_not_step_selector() -> None:
+    # given
+    raw_manifest = {
+        "type": "roboflow_core/switch_case@v1",
+        "name": "switch",
+        "value": "$inputs.mode",
+        "cases": {"red": "$inputs.on_red"},
+    }
+
+    # when
+    with pytest.raises(ValidationError):
+        _ = BlockManifest.model_validate(raw_manifest)
+
+
+def test_switch_case_run_when_case_matches() -> None:
+    # given
+    block = SwitchCaseBlockV1()
+
+    # when
+    result = block.run(
+        value="red",
+        cases={"red": "$steps.on_red", "blue": "$steps.on_blue"},
+        case_insensitive=False,
+        default_next_steps=["$steps.fallback"],
+    )
+
+    # then
+    assert result == FlowControl(mode="select_step", context=["$steps.on_red"])
+
+
+def test_switch_case_run_when_no_case_matches_and_default_defined() -> None:
+    # given
+    block = SwitchCaseBlockV1()
+
+    # when
+    result = block.run(
+        value="green",
+        cases={"red": "$steps.on_red", "blue": "$steps.on_blue"},
+        case_insensitive=False,
+        default_next_steps=["$steps.fallback"],
+    )
+
+    # then
+    assert result == FlowControl(mode="select_step", context=["$steps.fallback"])
+
+
+def test_switch_case_run_when_no_case_matches_and_default_empty() -> None:
+    # given
+    block = SwitchCaseBlockV1()
+
+    # when
+    result = block.run(
+        value="green",
+        cases={"red": "$steps.on_red"},
+        case_insensitive=False,
+        default_next_steps=[],
+    )
+
+    # then
+    assert result == FlowControl(mode="terminate_branch")
+
+
+def test_switch_case_run_when_case_insensitive_match() -> None:
+    # given
+    block = SwitchCaseBlockV1()
+
+    # when
+    result = block.run(
+        value="RED",
+        cases={"red": "$steps.on_red"},
+        case_insensitive=True,
+        default_next_steps=["$steps.fallback"],
+    )
+
+    # then
+    assert result == FlowControl(mode="select_step", context=["$steps.on_red"])
+
+
+def test_switch_case_run_when_case_sensitive_mismatch() -> None:
+    # given
+    block = SwitchCaseBlockV1()
+
+    # when
+    result = block.run(
+        value="RED",
+        cases={"red": "$steps.on_red"},
+        case_insensitive=False,
+        default_next_steps=["$steps.fallback"],
+    )
+
+    # then
+    assert result == FlowControl(mode="select_step", context=["$steps.fallback"])
+
+
+@pytest.mark.parametrize(
+    "value,matching_key",
+    [
+        (None, "None"),
+        (5, "5"),
+        (True, "True"),
+        (1.0, "1.0"),
+    ],
+)
+def test_switch_case_run_coerces_value_to_string(value, matching_key) -> None:
+    # given
+    block = SwitchCaseBlockV1()
+
+    # when
+    result = block.run(
+        value=value,
+        cases={matching_key: "$steps.on_match"},
+        case_insensitive=False,
+        default_next_steps=[],
+    )
+
+    # then
+    assert result == FlowControl(mode="select_step", context=["$steps.on_match"])
+
+
+def test_switch_case_run_when_no_cases_defined() -> None:
+    # given
+    block = SwitchCaseBlockV1()
+
+    # when
+    result = block.run(
+        value="anything",
+        cases={},
+        case_insensitive=False,
+        default_next_steps=["$steps.fallback"],
+    )
+
+    # then
+    assert result == FlowControl(mode="select_step", context=["$steps.fallback"])


### PR DESCRIPTION
## Description

Adds `roboflow_core/switch_case@v1`, a flow-control block that routes execution to one of several branches by matching an input value against case keys — a multi-way alternative to chaining Continue If blocks.

**Block semantics**
- `value` (selector or literal) is string-coerced and matched against the keys of `cases: Dict[str, StepSelector]` (e.g. `{"red": "$steps.on_red"}`); optional `case_insensitive` toggle.
- On match, execution continues to that case's step only; otherwise `default_next_steps` runs; if that is empty the branch terminates.
- A manifest validator rejects duplicate targets across `cases` + `default_next_steps` (each target step may be referenced at most once per flow-control step — engine constraint) and case-key collisions under case-insensitive matching, with readable errors instead of the engine's compile-time one.
- `cases` is a flat dict because selector discovery only finds step selectors one level deep (`schema_parser.py` ignores nested references).

**Execution engine changes (required for per-case branching)**
1. `graph_constructor.py`: selectors held in **dict** properties now get a unique execution branch per key (`Branch[$steps.switch -> cases[red]]`). Previously all selectors in one property shared a single branch, so selecting one case would have activated every case target. **List** properties (`next_steps`) keep the shared-branch behavior — ContinueIf semantics are unchanged.
2. `execution_data_manager/manager.py`: deduplicate branch names when registering non-SIMD flow-control masks. This fixes a **pre-existing bug**: any non-SIMD flow-control step with two or more `next_steps` crashed with "Attempted to re-register maks for execution branch" (reproducible on main with plain ContinueIf; regression test added).

**UI metadata**: `cases` is marked `always_visible` so the builder renders it as a primary field. Companion frontend PR in roboflow/roboflow adds per-case connection handles in the workflow builder.

## Testing

- 22 unit tests (`tests/workflows/unit_tests/core_steps/control_flow/test_switch_case.py`): manifest validation + run() behavior incl. coercion edge cases (`True`→"True", `None`→"None", `1.0`→"1.0").
- 5 integration tests (`test_workflow_with_switch_case.py`): case match / default / terminate routing through `ExecutionEngine`, plus compile-time duplicate-target failure.
- 2 regression tests for the multi-`next_steps` ContinueIf fix (`test_workflow_with_flow_control.py`).
- Full `tests/workflows/unit_tests/execution_engine/` suite passes (542 total in the affected areas).
- Manually verified end-to-end through a local HTTP server (`/workflows/run`) and from the workflow builder UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)