### PR TITLE
fix(ent-1352): cast GLM-OCR processor inputs to model dtype on Jetson

### DIFF
--- a/inference_models/docs/changelog.md
+++ b/inference_models/docs/changelog.md
@@ -1,20 +1,21 @@
 # Changelog
 
-## `0.29.3`
 
-### Fixed
-
-- Incompatibility with `supervision==0.29.0` due to init param in `sv.KeyPoints(...)`
-
-
-
-## `0.29.3`
+## `0.29.4`
 
 ### Fixed
 
 - Fixed GLM-OCR dtype mismatch on Jetson by casting HuggingFace processor floating-point
 inputs to the model dtype resolved for the target device (bfloat16 on supported CUDA hardware,
 otherwise float16).
+
+---
+
+## `0.29.3`
+
+### Fixed
+
+- Incompatibility with `supervision==0.29.0` due to init param in `sv.KeyPoints(...)`
 
 ---
 

--- a/inference_models/docs/changelog.md
+++ b/inference_models/docs/changelog.md
@@ -1,6 +1,16 @@
 # Changelog
 
 
+## `0.29.3`
+
+### Fixed
+
+- Fixed GLM-OCR dtype mismatch on Jetson by casting HuggingFace processor floating-point
+inputs to the model dtype resolved for the target device (bfloat16 on supported CUDA hardware,
+otherwise float16).
+
+---
+
 ## `0.29.2`
 
 ### Fixed

--- a/inference_models/docs/models/glm-ocr.md
+++ b/inference_models/docs/models/glm-ocr.md
@@ -51,7 +51,8 @@ Pre-trained GLM-OCR models are available via the Roboflow API and **require a Ro
 | `glm-ocr` | GLM-OCR vision-language model for text recognition |
 
 !!! warning "GPU Required"
-    GLM-OCR uses bfloat16 precision and requires GPU acceleration. CPU inference is not supported.
+    GLM-OCR requires GPU acceleration. CPU inference is not supported.
+    On CUDA, the model uses bfloat16 when the device supports it, otherwise float16.
 
 ## Supported Backends
 
@@ -67,7 +68,7 @@ Pre-trained GLM-OCR models are available via the Roboflow API and **require a Ro
 | **Upload Weights** | ❌ Not supported |
 | **Serverless API (v2)** | ✅ [Deploy via hosted API](https://docs.roboflow.com/deploy/serverless-hosted-api-v2) |
 | **Workflows** | ✅ Use in [Workflows](https://docs.roboflow.com/workflows) via LMM block |
-| **Edge Deployment (Jetson)** | ❌ Not supported |
+| **Edge Deployment (Jetson)** | ✅ Deploy on NVIDIA Jetson devices |
 | **Self-Hosting** | ✅ Deploy with `inference-models` (GPU required) |
 
 ## Installation
@@ -147,7 +148,7 @@ GLM-OCR returns a `List[str]` containing the recognized text from the input imag
 
 ## Performance Tips
 
-1. **Use GPU** - GLM-OCR requires GPU with bfloat16 support
+1. **Use GPU** - GLM-OCR requires GPU acceleration
 2. **Flash Attention** - Automatically enabled on Ampere+ GPUs (compute capability >= 8.0) for faster inference
 3. **Adjust max_new_tokens** - Increase for longer text passages, decrease for short labels
 4. **Use convenience methods** - `recognize_text()`, `recognize_formula()`, `recognize_table()` use optimized prompts for each task

--- a/inference_models/inference_models/models/glm_ocr/glm_ocr_hf.py
+++ b/inference_models/inference_models/models/glm_ocr/glm_ocr_hf.py
@@ -49,6 +49,14 @@ def _is_ampere_plus(device: torch.device) -> bool:
     return major >= 8
 
 
+def _resolve_default_dtype(device: torch.device) -> torch.dtype:
+    if device.type == "cuda":
+        if torch.cuda.is_bf16_supported():
+            return torch.bfloat16
+        return torch.float16
+    return torch.float32
+
+
 class GlmOcrHF:
     default_dtype = torch.bfloat16
 
@@ -62,7 +70,7 @@ class GlmOcrHF:
         quantization_config: Any = None,
         **kwargs,
     ) -> "GlmOcrHF":
-        dtype = cls.default_dtype
+        dtype = _resolve_default_dtype(device)
         attn_implementation = _get_glm_ocr_attn_implementation(device)
 
         model = (
@@ -100,6 +108,7 @@ class GlmOcrHF:
         self._model = model
         self._processor = processor
         self._device = device
+        self._torch_dtype = next(model.parameters()).dtype
         self._lock = Lock()
 
     def recognize_table(
@@ -208,7 +217,11 @@ class GlmOcrHF:
         )
 
         inputs = {
-            k: v.to(self._device)
+            k: (
+                v.to(self._device, dtype=self._torch_dtype)
+                if v.is_floating_point()
+                else v.to(self._device)
+            )
             for k, v in inputs.items()
             if isinstance(v, torch.Tensor)
         }

--- a/inference_models/pyproject.toml
+++ b/inference_models/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inference-models"
-version = "0.29.3"
+version = "0.29.4"
 description = "The new inference engine for Computer Vision models"
 readme = "README.md"
 requires-python = ">=3.10,<3.13"

--- a/inference_models/tests/unit_tests/models/test_glm_ocr_hf.py
+++ b/inference_models/tests/unit_tests/models/test_glm_ocr_hf.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock
 
 import numpy as np
+import torch
 
 from inference_models.configuration import (
     INFERENCE_MODELS_GLM_OCR_DEFAULT_MAX_NEW_TOKENS,
@@ -22,3 +23,23 @@ def test_generate_uses_default_max_new_tokens_when_none_is_given() -> None:
         INFERENCE_MODELS_GLM_OCR_DEFAULT_MAX_NEW_TOKENS
     )
     assert result.tolist() == [[21, 22]]
+
+
+def test_pre_process_generation_casts_floating_point_inputs_to_model_dtype() -> None:
+    model = MagicMock()
+    model.parameters.return_value = iter([torch.tensor(0.0, dtype=torch.bfloat16)])
+    processor = MagicMock()
+    processor.apply_chat_template.return_value = {
+        "input_ids": torch.tensor([[1, 2]], dtype=torch.int64),
+        "pixel_values": torch.tensor([[[1.0]]], dtype=torch.float32),
+    }
+    glm_ocr = GlmOcrHF(
+        model=model,
+        processor=processor,
+        device=torch.device("cpu"),
+    )
+
+    inputs = glm_ocr.pre_process_generation(images=np.zeros((8, 8, 3), dtype=np.uint8))
+
+    assert inputs["input_ids"].dtype == torch.int64
+    assert inputs["pixel_values"].dtype == torch.bfloat16

--- a/requirements/requirements.cpu.txt
+++ b/requirements/requirements.cpu.txt
@@ -1,3 +1,3 @@
 onnxruntime>=1.15.1,<1.22.0
 nvidia-ml-py<13.0.0
-inference-models[torch-cpu,onnx-cpu]~=0.29.3  # keep in sync between requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt
+inference-models[torch-cpu,onnx-cpu]~=0.29.4  # keep in sync between requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt

--- a/requirements/requirements.gpu.txt
+++ b/requirements/requirements.gpu.txt
@@ -1,2 +1,2 @@
 onnxruntime-gpu>=1.15.1,<1.22.0
-inference-models[torch-cu124,onnx-cu12]~=0.29.3 # keep in sync between requirements.jetson requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt
+inference-models[torch-cu124,onnx-cu12]~=0.29.4 # keep in sync between requirements.jetson requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt

--- a/requirements/requirements.jetson.txt
+++ b/requirements/requirements.jetson.txt
@@ -1,3 +1,3 @@
 pypdfium2>=4.11.0,<5.0.0
 PyYAML~=6.0.0
-inference-models~=0.29.3  # keep in sync between requirements.jetson requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt
+inference-models~=0.29.4  # keep in sync between requirements.jetson requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt

--- a/requirements/requirements.vino.txt
+++ b/requirements/requirements.vino.txt
@@ -1,2 +1,2 @@
 onnxruntime-openvino>=1.15.0,<1.22.0
-inference-models[torch-cpu]~=0.29.3  # keep in sync between requirements.jetson requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt
+inference-models[torch-cpu]~=0.29.4  # keep in sync between requirements.jetson requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt


### PR DESCRIPTION
## What does this PR do?

Fixes a GLM-OCR dtype mismatch on Jetson edge when `USE_INFERENCE_MODELS=True`. The HuggingFace processor returns `float32` `pixel_values` while `GlmOcrHF` loads in `bfloat16`; `pre_process_generation` only moved tensors to the device without casting floating-point inputs. That mismatch surfaces as workflow `StepExecutionError` (`torch.float32` vs `torch.bfloat16`) on edge devices.

Changes in `inference_models/models/glm_ocr/glm_ocr_hf.py`:

- Add `_resolve_default_dtype(device)` (bf16 when CUDA supports it, else fp16 on GPU, float32 on CPU)
- Store model dtype on the wrapper and cast floating-point processor tensors during `pre_process_generation`
- Add unit test asserting `pixel_values` are cast to model dtype

**Related Issue(s):** [ENT-1352](https://linear.app/roboflow/issue/ENT-1352/fix-glm-ocr-float32bfloat16-dtype-mismatch-on-jetson-edge)

## Type of Change

- Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] I have tested this change locally
- [x] I have added/updated tests for this change

**Test details:**

- `pytest inference_models/tests/unit_tests/models/test_glm_ocr_hf.py` → 2 passed locally
- Patched `glm_ocr_hf.py` on Shed Jetson: before fix `pixel_values` stayed `float32` with `bfloat16` model; after fix inputs cast correctly and GLM-OCR inference succeeds
- CI `unit-tests-inference-models` (3.10 / 3.11 / 3.12) passed on this PR

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [ ] I have updated the documentation accordingly (if applicable)

## Additional Context

Reproduced while debugging Lou's Inner Pack Edge device (GE Vernova Nuclear). The `backend_selected` / `stream_start` warmup retry loop is a separate `roboflow-edge` issue. Platform `glm-ocr` weights map fix shipped in roboflow #12457. After merge, this flows to manufacturing devices via inference server image → `roboflow-edge` image → RFDM rollout.