### PR TITLE
fix(runtime-introspection): fall back to L4T version for driver_version on Jetson

### DIFF
--- a/inference_models/inference_models/runtime_introspection/core.py
+++ b/inference_models/inference_models/runtime_introspection/core.py
@@ -368,7 +368,14 @@ def get_driver_version() -> Optional[Version]:
         if match:
             return Version(match.group(1))
     except Exception:
-        return None
+        pass
+    # `/proc/driver/nvidia/version` is only created by the NVIDIA (open) kernel
+    # module. Tegra/Jetson devices running the legacy `nvgpu` driver never expose
+    # it, so fall back to the L4T BSP version, which is the effective GPU driver
+    # version on those devices.
+    if is_running_on_jetson():
+        return get_l4t_version()
+    return None
 
 
 @cache

--- a/inference_models/tests/unit_tests/runtime_introspection/test_core.py
+++ b/inference_models/tests/unit_tests/runtime_introspection/test_core.py
@@ -606,7 +606,9 @@ def test_get_driver_version_when_file_not_found() -> None:
     # given
     get_driver_version.cache_clear()
     try:
-        with mock.patch("builtins.open") as open_mock:
+        with mock.patch("builtins.open") as open_mock, mock.patch.object(
+            core, "is_running_on_jetson", return_value=False
+        ):
             open_mock.side_effect = FileNotFoundError()
             # when
             result = get_driver_version()
@@ -622,7 +624,9 @@ def test_get_driver_version_when_file_not_parsable() -> None:
     get_driver_version.cache_clear()
     mocked_open_results = mock_open(read_data="invalid")
     try:
-        with mock.patch("builtins.open", mocked_open_results):
+        with mock.patch("builtins.open", mocked_open_results), mock.patch.object(
+            core, "is_running_on_jetson", return_value=False
+        ):
             # when
             result = get_driver_version()
     finally:
@@ -649,6 +653,25 @@ GCC version:  collect2: error: ld returned 1 exit status
 
     # then
     assert result == Version("540.4.0")
+
+
+def test_get_driver_version_falls_back_to_l4t_version_on_jetson_when_file_missing() -> (
+    None
+):
+    # given
+    get_driver_version.cache_clear()
+    try:
+        with mock.patch("builtins.open") as open_mock, mock.patch.object(
+            core, "is_running_on_jetson", return_value=True
+        ), mock.patch.object(core, "get_l4t_version", return_value=Version("36.4.0")):
+            open_mock.side_effect = FileNotFoundError()
+            # when
+            result = get_driver_version()
+    finally:
+        get_driver_version.cache_clear()
+
+    # then
+    assert result == Version("36.4.0")
 
 
 def test_is_trt_python_package_available_when_trt_cannot_be_imported() -> None:


### PR DESCRIPTION
## Problem

On-device TRT model-package registration fails on Jetson devices that use the legacy `nvgpu` GPU driver:

```
RF API responded with status: 400 - error message:
{ "message": "Error: Invalid model package manifest: must match one of the supported package types" }
```

### Root cause

`get_driver_version()` (`runtime_introspection/core.py`) reads the GPU driver version **only** from `/proc/driver/nvidia/version`. That procfs file is created by the NVIDIA (open) kernel module; Jetson/Tegra devices running the legacy `nvgpu` driver never create it, so the function returns `None`.

The inference compiler then builds the Jetson manifest with `driver_version=str(runtime_xray.driver_version)` → the literal string `"None"`:

```json
{"type":"jetson-machine-specs-v1","l4tVersion":"36.4.0","deviceName":"nvidia-jetson-orin-nx","driverVersion":"None"}
```

The platform manifest validator requires `driverVersion` to match a version regex, so `"None"` is rejected and the alternatives match fails → HTTP 400. The field is a required `str` (not `Optional`), so the client cannot omit it either.

This is environment-dependent: on Jetsons running the NVIDIA **open** kernel module, `/proc/driver/nvidia/version` exists (cf. `test_get_driver_version_when_file_parsable`, which mocks `"NVIDIA UNIX Open Kernel Module for aarch64 540.4.0"`), so registration works there. On `nvgpu`-driver devices it does not.

### Repro (Jetson Orin NX, L4T r36.4.4, `nvgpu` driver)

```
x_ray_runtime_environment().driver_version  -> None
/proc/driver/nvidia/version                 -> No such file or directory   (nvidia.ko not loaded; nvgpu is)
/etc/nv_tegra_release                        -> present; get_l4t_version() == Version('36.4.0')
```

## Fix

When `/proc/driver/nvidia/version` is absent/unparsable **and** the device is a Jetson, fall back to the L4T BSP version (`/etc/nv_tegra_release` via `get_l4t_version()`) — the effective GPU driver version on Tegra. Non-Jetson behavior is unchanged (still returns `None`).

## Validation (on a real `nvgpu` Jetson)

Verified on a live iCAM-540 (Orin NX, Avocado OS, L4T r36.4.4) by hot-patching the running inference container with this exact logic and restarting the pipeline with `USE_INFERENCE_MODELS=True`:

- `get_driver_version()` → `Version('36.4.0')` (was `None`)
- the manifest now carries `driverVersion: "36.4.0"` (was `"None"`)
- **400 "Invalid model package manifest" count since restart: `0`** (previously every compile cycle)

The manifest-validation failure is fully eliminated by this change.

## A related, separate issue this surfaced (not fixed here)

With the 400 gone, the device's TRT engine built successfully and the registration request finally reached the server — which then returned **403 `OperationForbiddenError`: "Currently it is only possible to externally manipulate model packages for fine-tuned models."**

This is **by design** and unrelated to this fix:

- The external (device) registration path only permits **fine-tuned** models; **foundation models** (here `rfdetr-nano` = COCO) cannot be device-registered.
- Foundation-model TRT packages are **pre-seeded centrally** and devices download them — which is why production works (packages seeded) while a staging workspace without seeded packages returns 403 and the engine falls back to `onnx_cuda`.

Net effect of this PR: it unblocks **on-device TRT compilation + registration for fine-tuned models on legacy-`nvgpu` Jetsons**, which previously failed at the 400 before ever reaching the registration logic. Foundation-model seeding in non-prod environments is a separate platform task.

## Tests

- **new** `test_get_driver_version_falls_back_to_l4t_version_on_jetson_when_file_missing`
- `test_get_driver_version_when_file_not_found` / `_when_file_not_parsable` now pin the non-Jetson path explicitly (`is_running_on_jetson() == False` → `None`)
- existing `_when_file_parsable` unchanged (discrete / open-kernel-module path still returns the parsed version)

## CI note

The failing `build-dev-test` workflow jobs are **unrelated to this change**. They fail at `inference/core/workflows/core_steps/visualizations/keypoint/v1.py:267` with `TypeError: KeyPoints.__init__() got an unexpected keyword argument 'confidence'` — caused by `supervision 0.29.0` (published 2026-06-15 21:46Z), which dropped the `confidence` kwarg from `sv.KeyPoints`. The same workflow passed on `main` at 17:45Z on identical code and broke ~5h later once `supervision` floated to 0.29.0; this PR touches no workflow or supervision code. The supervision compatibility fix belongs on `main` (pin or adapt to the new `KeyPoints` API) and is out of scope here.
