### PR TITLE
Update serverless workflow block availability

### DIFF
--- a/inference/core/workflows/core_steps/models/foundation/qwen/v1.py
+++ b/inference/core/workflows/core_steps/models/foundation/qwen/v1.py
@@ -56,7 +56,7 @@ class BlockManifest(WorkflowBlockManifest):
             "name": "Qwen2.5-VL",
             "version": "v1",
             "deprecated": True,
-            "deprecation_message": "Use the unified Qwen-VL block (`roboflow_core/qwen_vlm@v1`), which exposes Qwen 2.5 VL alongside other Qwen variants and the OpenRouter passthrough.",
+            "deprecation_message": "Use the unified Qwen-VL block (`roboflow_core/qwen_vlm@v1`) for currently available native Qwen variants and the OpenRouter passthrough.",
             "short_description": "Run Qwen2.5-VL on an image.",
             "long_description": (
                 "This workflow block runs Qwen2.5-VL—a vision language model that accepts an image "
@@ -131,6 +131,21 @@ class BlockManifest(WorkflowBlockManifest):
                         "QWEN_2_5_ENABLED=False on Roboflow Hosted Serverless: "
                         "the Qwen 2.5 VL endpoint is not registered, so "
                         "run_remotely() returns 404."
+                    ),
+                    applies_to_runtimes=[Runtime.HOSTED_SERVERLESS],
+                    applies_to_step_execution_modes=[StepExecutionMode.REMOTE],
+                )
+            )
+        else:
+            restrictions.append(
+                RuntimeRestriction(
+                    severity=Severity.HARD,
+                    note=(
+                        "Qwen 2.5 VL 7B is currently unavailable on Roboflow "
+                        "Hosted Serverless: the endpoint is registered, but "
+                        "model package loading fails because a required model "
+                        "artifact is missing. Use the unified Qwen-VL block "
+                        "with Qwen 3 or Qwen 3.5 native variants instead."
                     ),
                     applies_to_runtimes=[Runtime.HOSTED_SERVERLESS],
                     applies_to_step_execution_modes=[StepExecutionMode.REMOTE],

--- a/inference/core/workflows/core_steps/models/foundation/qwen_vlm/v1.py
+++ b/inference/core/workflows/core_steps/models/foundation/qwen_vlm/v1.py
@@ -1,7 +1,7 @@
 """Unified Qwen-VL workflow block.
 
-Subsumes the older per-version Qwen blocks (`qwen25vl@v1`, `qwen3vl@v1`,
-`qwen3_5vl@v1`, `qwen3_5_openrouter@v1`, `qwen3_6_openrouter@v1`) into a
+Subsumes the active per-version Qwen blocks (`qwen3vl@v1`, `qwen3_5vl@v1`,
+`qwen3_5_openrouter@v1`, `qwen3_6_openrouter@v1`) into a
 single block where the user picks:
 
 * a ``backend`` — "Native (Roboflow)" or "OpenRouter"
@@ -82,10 +82,6 @@ from inference_sdk import InferenceHTTPClient
 
 MODEL_VARIANTS: Dict[str, Dict[str, str]] = {
     # Native — small models that run on Roboflow infrastructure.
-    "Qwen 2.5 VL 7B": {
-        "backend": "native",
-        "model_id": "qwen25-vl-7b",
-    },
     "Qwen 3 VL 2B": {
         "backend": "native",
         "model_id": "qwen3vl-2b-instruct",
@@ -139,10 +135,14 @@ MODEL_VARIANTS: Dict[str, Dict[str, str]] = {
         "backend": "openrouter",
         "model_id": "qwen/qwen3.6-plus",
     },
-    # Note: Qwen 3.6 Max Preview is intentionally excluded — it's a text-only
+    # Note: Qwen 2.5 VL 7B and Qwen 3.5 VL 4B both have native Roboflow
+    # endpoints, but are intentionally excluded from this unified picker until
+    # hosted serverless package loading is reliable for those variants.
+    #
+    # Qwen 3.6 Max Preview is also intentionally excluded — it's a text-only
     # model on OpenRouter (no image-input endpoints), so it can't satisfy a
-    # VLM block. If/when OpenRouter ships a vision-capable Max variant, add
-    # it back here.
+    # VLM block. If/when OpenRouter ships a vision-capable Max variant, add it
+    # back here.
 }
 
 ModelVersion = Literal[tuple(MODEL_VARIANTS.keys())]
@@ -360,7 +360,7 @@ You can specify arbitrary text prompts or predefined ones, the block supports th
 
 #### 🛠️ Backend selection
 
-* **Native (Roboflow)** — small Qwen-VL models (0.8B–7B) run on the same infrastructure as
+* **Native (Roboflow)** — small Qwen-VL models run on the same infrastructure as
   your other Roboflow models. Lower latency. Recommended for tasks
   like OCR, captioning, and visual question answering.
 

--- a/inference/core/workflows/core_steps/models/foundation/segment_anything3_3d/v1.py
+++ b/inference/core/workflows/core_steps/models/foundation/segment_anything3_3d/v1.py
@@ -137,6 +137,21 @@ class BlockManifest(WorkflowBlockManifest):
                     applies_to_step_execution_modes=[StepExecutionMode.REMOTE],
                 )
             )
+        else:
+            restrictions.append(
+                RuntimeRestriction(
+                    severity=Severity.HARD,
+                    note=(
+                        "SAM3 3D is currently unavailable on Roboflow Hosted "
+                        "Serverless: the route is enabled, but requests fail "
+                        "at the hosted edge/origin before reaching the "
+                        "inference application. Use a dedicated or self-hosted "
+                        "GPU runtime while serverless support is being debugged."
+                    ),
+                    applies_to_runtimes=[Runtime.HOSTED_SERVERLESS],
+                    applies_to_step_execution_modes=[StepExecutionMode.REMOTE],
+                )
+            )
         return restrictions
 
 

--- a/tests/workflows/unit_tests/core_steps/models/foundation/test_qwen25vl.py
+++ b/tests/workflows/unit_tests/core_steps/models/foundation/test_qwen25vl.py
@@ -1,0 +1,37 @@
+"""Tests for the deprecated native Qwen2.5-VL workflow block."""
+
+import inference.core.workflows.core_steps.models.foundation.qwen.v1 as qwen25
+
+
+def test_get_restrictions_marks_hosted_serverless_package_issue_when_enabled(
+    monkeypatch,
+):
+    monkeypatch.setattr(qwen25, "QWEN_2_5_ENABLED", True)
+
+    restrictions = [
+        restriction.to_dict() for restriction in qwen25.BlockManifest.get_restrictions()
+    ]
+
+    assert any(
+        restriction["severity"] == "hard"
+        and restriction.get("applies_to_runtimes") == ["hosted_serverless"]
+        and restriction.get("applies_to_step_execution_modes") == ["remote"]
+        and "model package loading fails" in restriction["note"]
+        for restriction in restrictions
+    )
+
+
+def test_get_restrictions_reports_hosted_serverless_disabled_flag(monkeypatch):
+    monkeypatch.setattr(qwen25, "QWEN_2_5_ENABLED", False)
+
+    restrictions = [
+        restriction.to_dict() for restriction in qwen25.BlockManifest.get_restrictions()
+    ]
+
+    assert any(
+        restriction["severity"] == "hard"
+        and restriction.get("applies_to_runtimes") == ["hosted_serverless"]
+        and restriction.get("applies_to_step_execution_modes") == ["remote"]
+        and "QWEN_2_5_ENABLED=False" in restriction["note"]
+        for restriction in restrictions
+    )

--- a/tests/workflows/unit_tests/core_steps/models/foundation/test_qwen_vlm.py
+++ b/tests/workflows/unit_tests/core_steps/models/foundation/test_qwen_vlm.py
@@ -11,6 +11,8 @@ from inference.core.workflows.core_steps.models.foundation.qwen_vlm.v1 import (
     DEFAULT_NATIVE_MODEL_VERSION,
     FINE_TUNED_NATIVE_LABEL,
     MODEL_VARIANTS,
+    NATIVE_SUPPORTED_VARIANTS,
+    NATIVE_VARIANT_LABELS,
     BlockManifest,
     QwenVlmBlockV1,
     _build_native_prompt,
@@ -164,6 +166,16 @@ def test_all_variants_have_valid_backend():
     for label, info in MODEL_VARIANTS.items():
         assert info["backend"] in ("native", "openrouter"), label
         assert info["model_id"], label
+
+
+def test_native_variants_only_advertise_serverless_supported_models():
+    assert "Qwen 2.5 VL 7B" not in NATIVE_VARIANT_LABELS
+    assert "qwen25-vl-7b" not in NATIVE_SUPPORTED_VARIANTS
+    assert "Qwen 3.5 VL 4B" not in NATIVE_VARIANT_LABELS
+    assert "qwen3_5-4b" not in NATIVE_SUPPORTED_VARIANTS
+    assert {"qwen3vl-2b-instruct", "qwen3_5-0.8b", "qwen3_5-2b"}.issubset(
+        set(NATIVE_SUPPORTED_VARIANTS)
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -333,7 +345,7 @@ def test_run_local_native_enable_thinking_silently_ignored_on_unsupported_model(
     )
     block.run(
         **_base_run_kwargs(
-            model_version="Qwen 2.5 VL 7B",
+            model_version="Qwen 3 VL 2B",
             task_type="unconstrained",
             prompt="hi",
             enable_thinking=True,

--- a/tests/workflows/unit_tests/core_steps/models/foundation/test_segment_anything3_3d.py
+++ b/tests/workflows/unit_tests/core_steps/models/foundation/test_segment_anything3_3d.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 import pytest
 
+import inference.core.workflows.core_steps.models.foundation.segment_anything3_3d.v1 as sam3_3d
 from inference.core.workflows.core_steps.common.entities import StepExecutionMode
 from inference.core.workflows.core_steps.models.foundation.segment_anything3_3d.v1 import (
     BlockManifest,
@@ -58,6 +59,24 @@ def test_manifest_parsing_valid():
     }
     result = BlockManifest.model_validate(data)
     assert result.type == "roboflow_core/segment_anything3_3d_objects@v1"
+
+
+def test_get_restrictions_marks_hosted_serverless_unavailable_when_enabled(
+    monkeypatch,
+):
+    monkeypatch.setattr(sam3_3d, "SAM3_3D_OBJECTS_ENABLED", True)
+
+    restrictions = [
+        restriction.to_dict() for restriction in BlockManifest.get_restrictions()
+    ]
+
+    assert any(
+        restriction["severity"] == "hard"
+        and restriction.get("applies_to_runtimes") == ["hosted_serverless"]
+        and restriction.get("applies_to_step_execution_modes") == ["remote"]
+        and "route is enabled" in restriction["note"]
+        for restriction in restrictions
+    )
 
 
 def test_run_locally(mock_model_manager, mock_workflow_image_data, mock_mask_input):


### PR DESCRIPTION
## Summary
- remove Qwen 2.5 VL 7B from the unified Qwen-VL native picker/supported variants while the hosted serverless package artifact is broken
- mark the deprecated Qwen2.5-VL block as hard-restricted for Hosted Serverless remote execution when the route is enabled but package loading fails
- mark SAM3 3D as hard-restricted for Hosted Serverless remote execution while serverless requests are failing before the inference app
- add focused tests for Qwen native variant advertisement and hosted serverless restrictions

Depth estimation and Perception Encoder already use the runtime restriction pattern from #2374 and are now flag-aware when enabled, so this PR does not touch those runtime paths.

## Notes
The runtime compatibility API is block-level today, not per-dropdown-option. For Qwen 3.5 VL 4B, the unified Qwen block continues to omit that native variant rather than marking the whole Qwen block unavailable, because Qwen 3 VL 2B and Qwen 3.5 VL 0.8B/2B are working.

## Validation
- `python -m py_compile inference/core/workflows/core_steps/models/foundation/qwen_vlm/v1.py inference/core/workflows/core_steps/models/foundation/qwen/v1.py inference/core/workflows/core_steps/models/foundation/segment_anything3_3d/v1.py tests/workflows/unit_tests/core_steps/models/foundation/test_qwen_vlm.py tests/workflows/unit_tests/core_steps/models/foundation/test_segment_anything3_3d.py tests/workflows/unit_tests/core_steps/models/foundation/test_qwen25vl.py`
- `/Users/hansent/code/inference/.venv/bin/python -m pytest tests/workflows/unit_tests/core_steps/models/foundation/test_qwen_vlm.py tests/workflows/unit_tests/core_steps/models/foundation/test_qwen25vl.py tests/workflows/unit_tests/core_steps/models/foundation/test_segment_anything3_3d.py` (30 passed)
- `/Users/hansent/code/inference/.venv/bin/isort --check-only ...`
- `/Users/hansent/code/inference/.venv/bin/black --check ...`
- `git diff --check`