### PR TITLE
Bridge inference-models registry keys

### DIFF
--- a/inference/core/registries/roboflow.py
+++ b/inference/core/registries/roboflow.py
@@ -83,12 +83,6 @@ FINE_TUNED_SAM3_DEPLOYMENT_ERROR = (
     "Please use a workflow or self-host the server."
 )
 
-CLASSIFICATION_TASK_TYPES = {
-    "classification",
-    "multi-class-classification",
-    "multi-label-classification",
-}
-
 
 class RoboflowModelRegistry(ModelRegistry):
     """A Roboflow-specific model registry which gets the model type using the model id,
@@ -218,13 +212,12 @@ def get_model_type(
     )
 
     if cached_metadata is not None:
-        cached_project_task_type = _normalize_project_task_type(cached_metadata[0])
         _ensure_model_supported_on_this_deployment(
             model_id=model_id,
-            project_task_type=cached_project_task_type,
+            project_task_type=cached_metadata[0],
             model_type=cached_metadata[1],
         )
-        return cached_project_task_type, cached_metadata[1]
+        return cached_metadata[0], cached_metadata[1]
     if version_id == STUB_VERSION_ID:
         if api_key is None:
             raise MissingApiKeyError(
@@ -272,8 +265,6 @@ def get_model_type(
     if api_data is None:
         raise ModelArtefactError("Error loading model artifacts from Roboflow API.")
 
-    project_task_type = _normalize_project_task_type(project_task_type)
-
     # some older projects do not have type field - hence defaulting
     model_type = api_data.get("modelType")
     if model_type is None or model_type == "ort":
@@ -298,14 +289,6 @@ def get_model_type(
     return project_task_type, model_type
 
 
-def _normalize_project_task_type(
-    project_task_type: Optional[TaskType],
-) -> Optional[TaskType]:
-    if project_task_type in CLASSIFICATION_TASK_TYPES:
-        return "classification"
-    return project_task_type
-
-
 def _ensure_model_supported_on_this_deployment(
     model_id: ModelID,
     project_task_type: TaskType,
@@ -313,7 +296,7 @@ def _ensure_model_supported_on_this_deployment(
 ) -> None:
     if SAM3_FINE_TUNED_MODELS_ENABLED:
         return None
-    if model_type != "sam3-large":
+    if model_type not in {"sam3", "sam3-large"}:
         return None
     if project_task_type != "instance-segmentation":
         return None

--- a/inference/models/utils.py
+++ b/inference/models/utils.py
@@ -824,6 +824,9 @@ if USE_INFERENCE_MODELS:
                 ROBOFLOW_MODEL_TYPES[("vlm", "qwen_3_5")] = (
                     InferenceModelsQwen35VLAdapter
                 )
+                ROBOFLOW_MODEL_TYPES[("vlm", "qwen3_5")] = (
+                    InferenceModelsQwen35VLAdapter
+                )
             elif task == "embed" and variant == "sam":
                 from inference.models.sam.segment_anything_inference_models import (
                     InferenceModelsSAMAdapter,
@@ -848,6 +851,9 @@ if USE_INFERENCE_MODELS:
                 )
 
                 ROBOFLOW_MODEL_TYPES[(task, variant)] = InferenceModelsSAM3Adapter
+                ROBOFLOW_MODEL_TYPES[("instance-segmentation", "sam3")] = (
+                    InferenceModelsSAM3Adapter
+                )
                 ROBOFLOW_MODEL_TYPES[("instance-segmentation", "sam3-large")] = (
                     InferenceModelsSAM3Adapter
                 )
@@ -857,6 +863,9 @@ if USE_INFERENCE_MODELS:
                 )
 
                 ROBOFLOW_MODEL_TYPES[(task, variant)] = (
+                    InferenceModelsSAM3InteractiveAdapter
+                )
+                ROBOFLOW_MODEL_TYPES[("interactive-instance-segmentation", "sam3")] = (
                     InferenceModelsSAM3InteractiveAdapter
                 )
             elif task == "embed" and variant == "clip":
@@ -892,6 +901,9 @@ if USE_INFERENCE_MODELS:
                 )
 
                 ROBOFLOW_MODEL_TYPES[(task, variant)] = InferenceModelsGazeAdapter
+                ROBOFLOW_MODEL_TYPES[("gaze-detection", "l2cs-net")] = (
+                    InferenceModelsGazeAdapter
+                )
             elif task in {"lmm", "text-image-pairs"} and (
                 variant.startswith("smolvlm-2.2b")
                 or variant.startswith("smolvlm2")
@@ -965,6 +977,9 @@ if USE_INFERENCE_MODELS:
                 ROBOFLOW_MODEL_TYPES[(task, variant)] = (
                     InferenceModelsGroundingDINOAdapter
                 )
+                ROBOFLOW_MODEL_TYPES[
+                    ("open-vocabulary-object-detection", "grounding-dino")
+                ] = InferenceModelsGroundingDINOAdapter
             elif task == "embed" and variant == "perception_encoder":
                 from inference.models.perception_encoder.perception_encoder_inference_models import (
                     InferenceModelsPerceptionEncoderAdapter,
@@ -989,6 +1004,80 @@ if USE_INFERENCE_MODELS:
                 f"falling back to regular `inference` stack - error: {e}",
                 category=InferenceModelsStackMissing,
             )
+
+    # Exact (taskType, modelArchitecture) tuples returned by
+    # /models/v1/external/stat for entries backed by generic inference-models
+    # adapters. These complement the legacy variant aliases above.
+    ROBOFLOW_MODEL_TYPES.update(
+        {
+            ("object-detection", "rfdetr"): InferenceModelsObjectDetectionAdapter,
+            ("object-detection", "yolo26"): InferenceModelsObjectDetectionAdapter,
+            ("object-detection", "yololite"): InferenceModelsObjectDetectionAdapter,
+            ("object-detection", "yolonas"): InferenceModelsObjectDetectionAdapter,
+            ("object-detection", "yolov10"): InferenceModelsObjectDetectionAdapter,
+            ("object-detection", "yolov11"): InferenceModelsObjectDetectionAdapter,
+            ("object-detection", "yolov12"): InferenceModelsObjectDetectionAdapter,
+            ("object-detection", "yolov5"): InferenceModelsObjectDetectionAdapter,
+            ("object-detection", "yolov8"): InferenceModelsObjectDetectionAdapter,
+            ("object-detection", "yolov9"): InferenceModelsObjectDetectionAdapter,
+            ("instance-segmentation", "rfdetr"): (
+                InferenceModelsInstanceSegmentationAdapter
+            ),
+            ("instance-segmentation", "segment-anything-2-rt"): (
+                InferenceModelsInstanceSegmentationAdapter
+            ),
+            ("instance-segmentation", "yolact"): (
+                InferenceModelsInstanceSegmentationAdapter
+            ),
+            ("instance-segmentation", "yolo26"): (
+                InferenceModelsInstanceSegmentationAdapter
+            ),
+            ("instance-segmentation", "yolov11"): (
+                InferenceModelsInstanceSegmentationAdapter
+            ),
+            ("instance-segmentation", "yolov5"): (
+                InferenceModelsInstanceSegmentationAdapter
+            ),
+            ("instance-segmentation", "yolov7"): (
+                InferenceModelsInstanceSegmentationAdapter
+            ),
+            ("instance-segmentation", "yolov8"): (
+                InferenceModelsInstanceSegmentationAdapter
+            ),
+            ("keypoint-detection", "rfdetr"): (
+                InferenceModelsKeyPointsDetectionAdapter
+            ),
+            ("keypoint-detection", "yolo26"): (
+                InferenceModelsKeyPointsDetectionAdapter
+            ),
+            ("keypoint-detection", "yolov11"): (
+                InferenceModelsKeyPointsDetectionAdapter
+            ),
+            ("keypoint-detection", "yolov8"): (
+                InferenceModelsKeyPointsDetectionAdapter
+            ),
+            ("semantic-segmentation", "deep-lab-v3-plus"): (
+                InferenceModelsSemanticSegmentationAdapter
+            ),
+            ("semantic-segmentation", "yolo26"): (
+                InferenceModelsSemanticSegmentationAdapter
+            ),
+            ("classification", "dinov3_probe"): InferenceModelsClassificationAdapter,
+            ("classification", "resnet"): InferenceModelsClassificationAdapter,
+            ("classification", "vit"): InferenceModelsClassificationAdapter,
+            ("classification", "yolov11"): InferenceModelsClassificationAdapter,
+            ("classification", "yolov8"): InferenceModelsClassificationAdapter,
+            ("multi-label-classification", "dinov3_probe"): (
+                InferenceModelsClassificationAdapter
+            ),
+            ("multi-label-classification", "resnet"): (
+                InferenceModelsClassificationAdapter
+            ),
+            ("multi-label-classification", "vit"): (
+                InferenceModelsClassificationAdapter
+            ),
+        }
+    )
 
     # YOLO26 semantic segmentation is inference_models-only (no legacy implementation),
     # so we add entries directly rather than swapping existing ones.
@@ -1047,6 +1136,7 @@ if USE_INFERENCE_MODELS:
                 InferenceModelsQwen35VLAdapter
             )
         ROBOFLOW_MODEL_TYPES[("vlm", "qwen_3_5")] = InferenceModelsQwen35VLAdapter
+        ROBOFLOW_MODEL_TYPES[("vlm", "qwen3_5")] = InferenceModelsQwen35VLAdapter
 
     if GLM_OCR_ENABLED:
         from inference.models.glm_ocr.glm_ocr_inference_models import (

--- a/tests/inference/unit_tests/core/registries/test_roboflow.py
+++ b/tests/inference/unit_tests/core/registries/test_roboflow.py
@@ -298,7 +298,7 @@ def test_get_model_type_when_classification_subtype_is_cached(
     result = get_model_type(model_id="some/1", api_key="my_api_key")
 
     # then
-    assert result == ("classification", "vit")
+    assert result == ("multi-label-classification", "vit")
 
 
 @mock.patch.object(roboflow, "SAM3_FINE_TUNED_MODELS_ENABLED", False)
@@ -381,6 +381,40 @@ def test_get_model_type_when_fine_tuned_sam3_is_requested_and_disabled(
         service_secret=None,
         endpoint_type=ModelEndpointType.ORT,
         device_id=GLOBAL_DEVICE_ID,
+    )
+
+
+@mock.patch.object(roboflow, "SAM3_FINE_TUNED_MODELS_ENABLED", False)
+@mock.patch.object(roboflow, "get_model_metadata_from_inference_models_registry")
+@mock.patch.object(roboflow, "construct_model_type_cache_path")
+@mock.patch.object(roboflow, "USE_INFERENCE_MODELS", True)
+def test_get_model_type_when_sam3_from_new_model_registry_is_requested_and_disabled(
+    construct_model_type_cache_path_mock: MagicMock,
+    get_model_metadata_from_inference_models_registry_mock: MagicMock,
+    empty_local_dir: str,
+) -> None:
+    # given
+    metadata_path = os.path.join(empty_local_dir, "model_type.json")
+    construct_model_type_cache_path_mock.return_value = metadata_path
+    get_model_metadata_from_inference_models_registry_mock.return_value = {
+        "modelType": "sam3",
+        "taskType": "instance-segmentation",
+    }
+
+    # when / then
+    with pytest.raises(ModelDeploymentNotSupportedError) as error:
+        get_model_type(
+            model_id="workspace/123",
+            api_key="my_api_key",
+        )
+
+    assert str(error.value) == FINE_TUNED_SAM3_DEPLOYMENT_ERROR
+    assert not os.path.exists(metadata_path)
+    get_model_metadata_from_inference_models_registry_mock.assert_called_once_with(
+        api_key="my_api_key",
+        model_id="workspace/123",
+        countinference=None,
+        service_secret=None,
     )
 
 
@@ -523,11 +557,11 @@ def test_get_model_type_when_new_model_registry_returns_classification_subtype(
     )
 
     # then
-    assert result == ("classification", "vit")
+    assert result == ("multi-label-classification", "vit")
     with open(metadata_path) as f:
         persisted_metadata = json.load(f)
     assert persisted_metadata["model_type"] == "vit"
-    assert persisted_metadata["project_task_type"] == "classification"
+    assert persisted_metadata["project_task_type"] == "multi-label-classification"
 
 
 @mock.patch.object(roboflow, "get_roboflow_model_data")

--- a/tests/inference/unit_tests/models/test_inference_models_registry_bridge.py
+++ b/tests/inference/unit_tests/models/test_inference_models_registry_bridge.py
@@ -1,0 +1,40 @@
+import pytest
+
+from inference.core.env import USE_INFERENCE_MODELS
+from inference.models.utils import ROBOFLOW_MODEL_TYPES
+
+
+@pytest.mark.skipif(
+    not USE_INFERENCE_MODELS,
+    reason="Registry bridge only applies when USE_INFERENCE_MODELS is enabled.",
+)
+def test_inference_models_registry_pairs_are_registered_in_outer_lookup() -> None:
+    expected_pairs = {
+        ("classification", "resnet"),
+        ("multi-label-classification", "dinov3_probe"),
+        ("multi-label-classification", "resnet"),
+        ("multi-label-classification", "vit"),
+        ("instance-segmentation", "segment-anything-2-rt"),
+        ("semantic-segmentation", "deep-lab-v3-plus"),
+    }
+
+    missing_pairs = expected_pairs.difference(ROBOFLOW_MODEL_TYPES)
+
+    assert missing_pairs == set()
+
+
+@pytest.mark.skipif(
+    not USE_INFERENCE_MODELS,
+    reason="Registry bridge only applies when USE_INFERENCE_MODELS is enabled.",
+)
+def test_inference_models_registry_bridge_preserves_legacy_outer_aliases() -> None:
+    expected_legacy_pairs = {
+        ("classification", "resnet50"),
+        ("classification", "vit"),
+        ("object-detection", "rfdetr-nano"),
+        ("semantic-segmentation", "deeplabv3plus"),
+    }
+
+    missing_pairs = expected_legacy_pairs.difference(ROBOFLOW_MODEL_TYPES)
+
+    assert missing_pairs == set()


### PR DESCRIPTION
## Summary
- Add explicit model-stat tuple aliases for inference-models-backed adapters when USE_INFERENCE_MODELS is enabled.
- Preserve existing legacy outer aliases while accepting exact stat endpoint literals like (multi-label-classification, vit), (classification, resnet), and (gaze-detection, l2cs-net).
- Let get_model_type preserve stat taskType values instead of normalizing classification subtypes, and keep the SAM3 deployment guard working when stat returns modelArchitecture=sam3.

## Notes
- This intentionally hardcodes supported outer adapter tuples instead of dynamically iterating inference_models.REGISTERED_MODELS, so it matches the existing registry style.
- Inner registry entries without an outer adapter path, like gemma-4 and SAM video variants, are not registered here.

## Testing
- /Users/hansent/code/inference/.venv/bin/python -m black --check inference/models/utils.py inference/core/registries/roboflow.py tests/inference/unit_tests/core/registries/test_roboflow.py tests/inference/unit_tests/models/test_inference_models_registry_bridge.py
- /Users/hansent/code/inference/.venv/bin/python -m pytest tests/inference/unit_tests/core/registries/test_roboflow.py -q
- USE_INFERENCE_MODELS=true /Users/hansent/code/inference/.venv/bin/python -m pytest tests/inference/unit_tests/models/test_inference_models_registry_bridge.py -q