### PR TITLE
fix pipeline flush performance regression

### DIFF
--- a/inference/core/interfaces/stream/model_handlers/workflows.py
+++ b/inference/core/interfaces/stream/model_handlers/workflows.py
@@ -36,6 +36,7 @@ class WorkflowRunner:
         self,
         video_frames: List[VideoFrame],
         defer_stream_pipeline_flush: bool = False,
+        resolve_output_futures: bool = True,
     ) -> List[dict]:
         workflows_parameters, fps = self._build_workflows_parameters(
             video_frames=video_frames
@@ -46,6 +47,7 @@ class WorkflowRunner:
             serialize_results=self._serialize_results,
             _is_preview=self._is_preview,
             defer_stream_pipeline_flush=defer_stream_pipeline_flush,
+            resolve_output_futures=resolve_output_futures,
         )
 
     def _flush_stream_pipeline(self, video_frames: List[VideoFrame]) -> List[dict]:
@@ -115,9 +117,13 @@ class PipelinedWorkflowRunner:
     def __call__(
         self, video_frames: List[VideoFrame]
     ) -> Optional[InferenceHandlerResult]:
+        # Resolving RF-DETR output futures here serializes postprocess before the
+        # next frame can launch. The stream dispatcher resolves them after the
+        # frame buffer delay, when they should already be ready.
         predictions = self._workflow_runner._run_workflow(
             video_frames=video_frames,
             defer_stream_pipeline_flush=True,
+            resolve_output_futures=self._workflow_runner._serialize_results,
         )
         stream_buffer_depth = self._stream_buffer_depth()
         if stream_buffer_depth <= 0:

--- a/inference/core/workflows/execution_engine/core.py
+++ b/inference/core/workflows/execution_engine/core.py
@@ -75,6 +75,7 @@ class ExecutionEngine(BaseExecutionEngine):
         _is_preview: bool = False,
         serialize_results: bool = False,
         defer_stream_pipeline_flush: bool = False,
+        resolve_output_futures: bool = True,
     ) -> List[Dict[str, Any]]:
         return self._engine.run(
             runtime_parameters=runtime_parameters,
@@ -82,6 +83,7 @@ class ExecutionEngine(BaseExecutionEngine):
             _is_preview=_is_preview,
             serialize_results=serialize_results,
             defer_stream_pipeline_flush=defer_stream_pipeline_flush,
+            resolve_output_futures=resolve_output_futures,
         )
 
     def flush_stream_pipeline(

--- a/inference/core/workflows/execution_engine/entities/engine.py
+++ b/inference/core/workflows/execution_engine/entities/engine.py
@@ -31,5 +31,7 @@ class BaseExecutionEngine(ABC):
         fps: float = 0,
         _is_preview: bool = False,
         serialize_results: bool = False,
+        defer_stream_pipeline_flush: bool = False,
+        resolve_output_futures: bool = True,
     ) -> List[Dict[str, Any]]:
         pass

--- a/inference/core/workflows/execution_engine/v1/core.py
+++ b/inference/core/workflows/execution_engine/v1/core.py
@@ -122,6 +122,7 @@ class ExecutionEngineV1(BaseExecutionEngine):
         _is_preview: bool = False,
         serialize_results: bool = False,
         defer_stream_pipeline_flush: bool = False,
+        resolve_output_futures: bool = True,
     ) -> List[Dict[str, Any]]:
         self._profiler.start_workflow_run()
         runtime_parameters = assemble_runtime_parameters(
@@ -156,6 +157,7 @@ class ExecutionEngineV1(BaseExecutionEngine):
             executor=self._executor,
             step_error_handler=self._step_error_handler,
             defer_stream_pipeline_flush=defer_stream_pipeline_flush,
+            resolve_output_futures=resolve_output_futures,
         )
         self._profiler.end_workflow_run()
         return result

--- a/inference/core/workflows/execution_engine/v1/executor/core.py
+++ b/inference/core/workflows/execution_engine/v1/executor/core.py
@@ -101,6 +101,7 @@ def run_workflow(
     executor: Optional[ThreadPoolExecutor] = None,
     step_error_handler: Optional[Callable[[Exception], None]] = None,
     defer_stream_pipeline_flush: bool = False,
+    resolve_output_futures: bool = True,
 ) -> List[Dict[str, Any]]:
     with start_span("workflow.run"):
         return _run_workflow(
@@ -113,6 +114,7 @@ def run_workflow(
             executor=executor,
             step_error_handler=step_error_handler,
             defer_stream_pipeline_flush=defer_stream_pipeline_flush,
+            resolve_output_futures=resolve_output_futures,
         )
 
 
@@ -126,6 +128,7 @@ def _run_workflow(
     executor: Optional[ThreadPoolExecutor] = None,
     step_error_handler: Optional[Callable[[Exception], None]] = None,
     defer_stream_pipeline_flush: bool = False,
+    resolve_output_futures: bool = True,
 ) -> List[Dict[str, Any]]:
     execution_data_manager = ExecutionDataManager.init(
         execution_graph=workflow.execution_graph,
@@ -168,6 +171,7 @@ def _run_workflow(
                 execution_data_manager=execution_data_manager,
                 serialize_results=serialize_results,
                 kinds_serializers=kinds_serializers,
+                resolve_output_futures=resolve_output_futures,
             )
     finally:
         if not defer_stream_pipeline_flush:

--- a/inference/core/workflows/execution_engine/v1/executor/output_constructor.py
+++ b/inference/core/workflows/execution_engine/v1/executor/output_constructor.py
@@ -1,6 +1,7 @@
 import traceback
 from collections import defaultdict
 from concurrent.futures import Future
+from threading import Lock
 from typing import Any, Callable, Dict, List, Optional, Set, Union
 
 import numpy as np
@@ -13,6 +14,10 @@ from inference.core.workflows.core_steps.common.utils import (
 )
 from inference.core.workflows.errors import AssumptionError, ExecutionEngineRuntimeError
 from inference.core.workflows.execution_engine.constants import (
+    IMAGE_DIMENSIONS_KEY,
+    ROOT_PARENT_COORDINATES_KEY,
+    ROOT_PARENT_DIMENSIONS_KEY,
+    SCALING_RELATIVE_TO_ROOT_PARENT_KEY,
     TOP_LEVEL_LINEAGES_KEY,
     WORKFLOW_INPUT_BATCH_LINEAGE_ID,
 )
@@ -40,6 +45,7 @@ def construct_workflow_output(
     execution_data_manager: ExecutionDataManager,
     serialize_results: bool,
     kinds_serializers: Dict[str, Callable[[Any], Any]],
+    resolve_output_futures: bool = True,
 ) -> List[Dict[str, Any]]:
     # Maybe we should make blocks to change coordinates systems:
     # https://github.com/roboflow/inference/issues/440
@@ -64,7 +70,8 @@ def construct_workflow_output(
         if output.name in batch_oriented_outputs:
             continue
         data_piece = execution_data_manager.get_non_batch_data(selector=output.selector)
-        data_piece = _maybe_resolve_output_futures(data_piece)
+        if resolve_output_futures:
+            data_piece = _maybe_resolve_output_futures(data_piece)
         if serialize_results:
             output_kind = kinds_of_output_nodes[output.name]
             data_piece = serialize_data_piece(
@@ -110,6 +117,7 @@ def construct_workflow_output(
         non_batch_outputs=non_batch_outputs,
         dimensionality_for_output_nodes=dimensionality_for_output_nodes,
         batch_oriented_outputs=batch_oriented_outputs,
+        resolve_output_futures=resolve_output_futures,
     )
     if len(results) == 0 and len(outputs_for_generated_lineage) > 0:
         results.append({})
@@ -125,6 +133,7 @@ def construct_workflow_output(
                 kinds_serializers=kinds_serializers,
                 kinds_of_output_nodes=kinds_of_output_nodes,
                 dimensionality_for_output_nodes=dimensionality_for_output_nodes,
+                resolve_output_futures=resolve_output_futures,
             )
         )
         for output in results:
@@ -145,6 +154,7 @@ def create_outputs_for_input_induced_lineages(
     non_batch_outputs: Dict[str, Any],
     dimensionality_for_output_nodes: Dict[str, int],
     batch_oriented_outputs: Set[str],
+    resolve_output_futures: bool = True,
 ) -> List[Dict[str, Any]]:
     outputs_arrays: Dict[str, Optional[list]] = {
         name: create_array(indices=np.array(indices))
@@ -171,12 +181,13 @@ def create_outputs_for_input_induced_lineages(
             indices=indices,
         )
         for index, data_piece in zip(indices, data):
-            data_piece = _maybe_resolve_output_futures(data_piece)
-            if (
-                name in outputs_requested_in_parent_coordinates
-                and data_contains_sv_detections(data=data_piece)
-            ):
-                data_piece = convert_sv_detections_coordinates(data=data_piece)
+            data_piece = _prepare_data_piece_for_output(
+                data_piece=data_piece,
+                resolve_output_futures=resolve_output_futures,
+                convert_to_parent_coordinates=(
+                    name in outputs_requested_in_parent_coordinates
+                ),
+            )
             if serialize_results:
                 output_kind = kinds_of_output_nodes[name]
                 data_piece = serialize_data_piece(
@@ -242,6 +253,7 @@ def create_outputs_for_generated_lineage_outputs(
         str, Union[List[Union[Kind, str]], Dict[str, List[Union[Kind, str]]]]
     ],
     dimensionality_for_output_nodes: Dict[str, int],
+    resolve_output_futures: bool = True,
 ) -> Dict[str, List[Any]]:
     outputs_arrays: Dict[str, Optional[list]] = {
         name: create_array(indices=np.array(indices))
@@ -266,12 +278,13 @@ def create_outputs_for_generated_lineage_outputs(
             indices=indices,
         )
         for index, data_piece in zip(indices, data):
-            data_piece = _maybe_resolve_output_futures(data_piece)
-            if (
-                name in outputs_requested_in_parent_coordinates
-                and data_contains_sv_detections(data=data_piece)
-            ):
-                data_piece = convert_sv_detections_coordinates(data=data_piece)
+            data_piece = _prepare_data_piece_for_output(
+                data_piece=data_piece,
+                resolve_output_futures=resolve_output_futures,
+                convert_to_parent_coordinates=(
+                    name in outputs_requested_in_parent_coordinates
+                ),
+            )
             if serialize_results:
                 output_kind = kinds_of_output_nodes[name]
                 data_piece = serialize_data_piece(
@@ -314,6 +327,85 @@ def create_outputs_for_generated_lineage_outputs(
                 element = array[i]
             results[name].append(element)
     return results
+
+
+class _DeferredResolvedOutput(Future):
+    def __init__(
+        self,
+        value: Any,
+        transform: Callable[[Any], Any],
+    ) -> None:
+        super().__init__()
+        self._value = value
+        self._transform = transform
+        self._resolution_lock = Lock()
+
+    def result(self, timeout: Optional[float] = None) -> Any:
+        if not self.done():
+            with self._resolution_lock:
+                if not self.done():
+                    try:
+                        resolved_value = _resolve_output_futures(value=self._value)
+                        self.set_result(self._transform(resolved_value))
+                    except BaseException as error:
+                        self.set_exception(error)
+        return super().result(timeout=timeout)
+
+
+def _prepare_data_piece_for_output(
+    data_piece: Any,
+    resolve_output_futures: bool,
+    convert_to_parent_coordinates: bool,
+) -> Any:
+    if resolve_output_futures:
+        data_piece = _maybe_resolve_output_futures(value=data_piece)
+    elif convert_to_parent_coordinates and _output_contains_future(value=data_piece):
+        return _DeferredResolvedOutput(
+            value=data_piece,
+            transform=_convert_sv_detections_coordinates_if_present,
+        )
+    if convert_to_parent_coordinates:
+        return _convert_sv_detections_coordinates_if_present(data=data_piece)
+    return data_piece
+
+
+def _convert_sv_detections_coordinates_if_present(data: Any) -> Any:
+    if data_needs_sv_detections_coordinate_conversion(data=data):
+        return convert_sv_detections_coordinates(data=data)
+    return data
+
+
+def data_needs_sv_detections_coordinate_conversion(data: Any) -> bool:
+    if isinstance(data, sv.Detections):
+        return _sv_detections_need_root_coordinate_conversion(detections=data)
+    if isinstance(data, (list, tuple)):
+        return any(data_needs_sv_detections_coordinate_conversion(data=e) for e in data)
+    if isinstance(data, dict):
+        return any(
+            data_needs_sv_detections_coordinate_conversion(data=e)
+            for e in data.values()
+        )
+    return False
+
+
+def _sv_detections_need_root_coordinate_conversion(detections: sv.Detections) -> bool:
+    if len(detections) == 0:
+        return False
+    root_coordinates = detections.data.get(ROOT_PARENT_COORDINATES_KEY)
+    if root_coordinates is None:
+        return False
+    if np.any(np.asarray(root_coordinates) != 0):
+        return True
+    root_dimensions = detections.data.get(ROOT_PARENT_DIMENSIONS_KEY)
+    image_dimensions = detections.data.get(IMAGE_DIMENSIONS_KEY)
+    if (
+        root_dimensions is not None
+        and image_dimensions is not None
+        and not np.array_equal(root_dimensions, image_dimensions)
+    ):
+        return True
+    root_scale = detections.data.get(SCALING_RELATIVE_TO_ROOT_PARENT_KEY)
+    return root_scale is not None and not np.allclose(root_scale, 1.0)
 
 
 def _resolve_output_futures(value: Any) -> Any:

--- a/tests/inference/unit_tests/core/interfaces/stream/test_workflows.py
+++ b/tests/inference/unit_tests/core/interfaces/stream/test_workflows.py
@@ -55,6 +55,7 @@ class _FakeExecutionEngine:
         serialize_results,
         _is_preview,
         defer_stream_pipeline_flush=False,
+        resolve_output_futures=True,
     ):
         frame_number = runtime_parameters["image"][0]["video_metadata"].frame_number
         self.calls.append(
@@ -64,6 +65,7 @@ class _FakeExecutionEngine:
                 "serialize_results": serialize_results,
                 "is_preview": _is_preview,
                 "defer_stream_pipeline_flush": defer_stream_pipeline_flush,
+                "resolve_output_futures": resolve_output_futures,
             }
         )
         prediction_frame = frame_number - self._stream_buffer_depth
@@ -120,6 +122,7 @@ class _FakeLateActivatingExecutionEngine:
         serialize_results,
         _is_preview,
         defer_stream_pipeline_flush=False,
+        resolve_output_futures=True,
     ):
         frame_number = runtime_parameters["image"][0]["video_metadata"].frame_number
         # Real RF-DETR workflow steps only know whether stream pipelining is
@@ -156,12 +159,14 @@ class _FakeDownstreamPipelinedExecutionEngine:
         serialize_results,
         _is_preview,
         defer_stream_pipeline_flush=False,
+        resolve_output_futures=True,
     ):
         frame_number = runtime_parameters["image"][0]["video_metadata"].frame_number
         self.calls.append(
             {
                 "frame_number": frame_number,
                 "defer_stream_pipeline_flush": defer_stream_pipeline_flush,
+                "resolve_output_futures": resolve_output_futures,
             }
         )
         if defer_stream_pipeline_flush:
@@ -295,6 +300,7 @@ def test_workflow_runner_without_stream_buffering_returns_current_frame() -> Non
             "serialize_results": True,
             "is_preview": True,
             "defer_stream_pipeline_flush": False,
+            "resolve_output_futures": True,
         }
     ]
 
@@ -355,6 +361,7 @@ def test_workflow_runner_buffers_frames_until_delayed_prediction_arrives() -> No
             "serialize_results": False,
             "is_preview": False,
             "defer_stream_pipeline_flush": True,
+            "resolve_output_futures": False,
         },
         {
             "frame_number": 2,
@@ -362,6 +369,7 @@ def test_workflow_runner_buffers_frames_until_delayed_prediction_arrives() -> No
             "serialize_results": False,
             "is_preview": False,
             "defer_stream_pipeline_flush": True,
+            "resolve_output_futures": False,
         },
     ]
 
@@ -431,8 +439,16 @@ def test_pipelined_workflow_runner_preserves_frame_alignment_for_downstream_step
     assert flushed_results[0].predictions == [{"result": "downstream-frame-2"}]
     assert flushed_results[0].video_frames == [frame_2]
     assert engine.calls == [
-        {"frame_number": 1, "defer_stream_pipeline_flush": True},
-        {"frame_number": 2, "defer_stream_pipeline_flush": True},
+        {
+            "frame_number": 1,
+            "defer_stream_pipeline_flush": True,
+            "resolve_output_futures": False,
+        },
+        {
+            "frame_number": 2,
+            "defer_stream_pipeline_flush": True,
+            "resolve_output_futures": False,
+        },
     ]
     assert engine.flush_calls == [2]
 

--- a/tests/workflows/unit_tests/execution_engine/executor/test_output_constructor.py
+++ b/tests/workflows/unit_tests/execution_engine/executor/test_output_constructor.py
@@ -1,3 +1,4 @@
+from concurrent.futures import Future
 from typing import Any, List, Optional
 from unittest.mock import MagicMock
 
@@ -30,6 +31,12 @@ from inference.core.workflows.execution_engine.v1.executor.output_constructor im
     place_data_in_array,
     serialize_data_piece,
 )
+
+
+def _completed_future(value: Any) -> Future:
+    future = Future()
+    future.set_result(value)
+    return future
 
 
 def test_data_contains_sv_detections_when_no_sv_detections_provided() -> None:
@@ -431,6 +438,121 @@ def test_construct_workflow_output_when_no_batch_outputs_present() -> None:
 
     # then
     assert result == [{"a": "a_value", "b": "b_value"}]
+
+
+def test_construct_workflow_output_resolves_futures_by_default() -> None:
+    # given
+    execution_data_manager = MagicMock()
+    workflow_outputs = [
+        JsonField(type="JsonField", name="a", selector="$steps.some.a"),
+    ]
+    execution_graph = DiGraph()
+    execution_graph.add_node(
+        "$outputs.a",
+        node_compilation_output=OutputNode(
+            node_category=NodeCategory.OUTPUT_NODE,
+            name=workflow_outputs[0].name,
+            selector=workflow_outputs[0].selector,
+            data_lineage=[],
+            output_manifest=workflow_outputs[0],
+        ),
+    )
+    execution_data_manager.get_selector_indices.return_value = None
+    execution_data_manager.get_non_batch_data.return_value = {
+        "predictions": _completed_future(["resolved"])
+    }
+
+    # when
+    result = construct_workflow_output(
+        workflow_outputs=workflow_outputs,
+        execution_graph=execution_graph,
+        execution_data_manager=execution_data_manager,
+        serialize_results=False,
+        kinds_serializers=KINDS_SERIALIZERS,
+    )
+
+    # then
+    assert result == [{"a": {"predictions": ["resolved"]}}]
+
+
+def test_construct_workflow_output_can_defer_future_resolution() -> None:
+    # given
+    execution_data_manager = MagicMock()
+    workflow_outputs = [
+        JsonField(type="JsonField", name="a", selector="$steps.some.a"),
+    ]
+    execution_graph = DiGraph()
+    execution_graph.add_node(
+        "$outputs.a",
+        node_compilation_output=OutputNode(
+            node_category=NodeCategory.OUTPUT_NODE,
+            name=workflow_outputs[0].name,
+            selector=workflow_outputs[0].selector,
+            data_lineage=[],
+            output_manifest=workflow_outputs[0],
+        ),
+    )
+    predictions = _completed_future(["resolved"])
+    execution_data_manager.get_selector_indices.return_value = None
+    execution_data_manager.get_non_batch_data.return_value = {"predictions": predictions}
+
+    # when
+    result = construct_workflow_output(
+        workflow_outputs=workflow_outputs,
+        execution_graph=execution_graph,
+        execution_data_manager=execution_data_manager,
+        serialize_results=False,
+        kinds_serializers=KINDS_SERIALIZERS,
+        resolve_output_futures=False,
+    )
+
+    # then
+    assert result == [{"a": {"predictions": predictions}}]
+
+
+def test_construct_workflow_output_defers_coordinate_conversion_with_future_output() -> (
+    None
+):
+    # given
+    execution_data_manager = MagicMock()
+    workflow_outputs = [
+        JsonField(type="JsonField", name="a", selector="$steps.some.a"),
+    ]
+    execution_graph = DiGraph()
+    execution_graph.add_node(
+        "$outputs.a",
+        node_compilation_output=OutputNode(
+            node_category=NodeCategory.OUTPUT_NODE,
+            name=workflow_outputs[0].name,
+            selector=workflow_outputs[0].selector,
+            data_lineage=["<workflow_input>"],
+            output_manifest=workflow_outputs[0],
+        ),
+    )
+    execution_graph.graph[TOP_LEVEL_LINEAGES_KEY] = WORKFLOW_INPUT_BATCH_LINEAGE_ID
+    execution_data_manager.get_selector_indices.return_value = [(0,)]
+    execution_data_manager.get_batch_data.return_value = [
+        {"predictions": _completed_future(assembly_sv_detections())}
+    ]
+    execution_data_manager.get_lineage_indices.return_value = [(0,)]
+
+    # when
+    result = construct_workflow_output(
+        workflow_outputs=workflow_outputs,
+        execution_graph=execution_graph,
+        execution_data_manager=execution_data_manager,
+        serialize_results=False,
+        kinds_serializers=KINDS_SERIALIZERS,
+        resolve_output_futures=False,
+    )
+
+    # then
+    deferred_output = result[0]["a"]
+    assert isinstance(deferred_output, Future)
+    resolved_output = deferred_output.result()
+    assert_transformed_detections_matches_expectation(
+        result=resolved_output["predictions"]
+    )
 
 
 def test_construct_workflow_output_when_batch_outputs_present() -> None:


### PR DESCRIPTION
## What does this PR do?

Fixes the RF-DETR stream pipeline regression where workflow output construction eagerly resolved Future-backed outputs. That forced response finalization/postprocess to complete before the next frame could continue through the pipeline, reducing the expected pipelining gain.

This PR adds an option to defer workflow output Future resolution for pipelined workflow execution, while preserving the default eager-resolution behavior for normal workflow calls. It also preserves parent-coordinate conversion correctness for deferred `sv.Detections` outputs by applying conversion after the Future resolves when needed.

**Related Issue(s):** N/A

## Type of Change

- Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] I have tested this change locally
- [x] I have added/updated tests for this change

**Test details:**

- `PYTHONPATH=/app/helloworld/inference:/app/helloworld/inference/inference_models python -m pytest -q tests/workflows/unit_tests/execution_engine/executor/test_output_constructor.py tests/workflows/unit_tests/execution_engine/executor/execution_data_manager/test_step_output_future_resolution.py tests/workflows/unit_tests/execution_engine/executor/test_stream_pipeline_flush.py tests/inference/unit_tests/core/interfaces/stream/test_workflows.py`
  - `41 passed`
- `PYTHONPATH=/app/helloworld/inference:/app/helloworld/inference/inference_models python -m pytest -q tests/workflows/integration_tests/execution/test_workflow_with_model_running_on_relative_static_crop.py tests/workflows/integration_tests/execution/test_workflow_with_per_class_confidence_filter.py`
  - `6 passed`
- Correctness parity on `london_1920_1080_30fps.mp4` with `rfdetr-seg-small`:
  - `704 / 704` frames compared
  - `12208 / 12208` detections matched for both `raw_predictions` and `predictions`
  - mean/min box IoU: `1.000000 / 1.000000`
  - max score delta: `0.000e+00`
- Optimized workload after fix:
  - no nsys: `704` frames, `23.92s`, `29.43 FPS`
  - nsys: `704` frames, `26.98s`, `26.10 FPS`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [ ] I have updated the documentation accordingly (if applicable)

## Additional Context

The key behavior change is scoped to pipelined workflow execution. Default workflow output construction still resolves output futures eagerly.

The guarded coordinate-conversion path is needed because deferred Future outputs may still need conversion into parent/root coordinates after resolution, especially for cropped/scaled workflow inputs.
