### PR TITLE
feat(sam3): make interactive cache CPU offload configurable

### DIFF
--- a/inference/core/env.py
+++ b/inference/core/env.py
@@ -553,6 +553,17 @@ SAM3_IMAGE_SIZE = int(os.getenv("SAM3_IMAGE_SIZE", 1008))
 SAM3_MAX_EMBEDDING_CACHE_SIZE = int(os.getenv("SAM3_MAX_EMBEDDING_CACHE_SIZE", 100))
 SAM3_MAX_LOGITS_CACHE_SIZE = int(os.getenv("SAM3_MAX_LOGITS_CACHE_SIZE", 1000))
 DISABLE_SAM3_LOGITS_CACHE = str2bool(os.getenv("DISABLE_SAM3_LOGITS_CACHE", False))
+# When True, cached SAM3 image embeddings / low-res masks are offloaded to CPU RAM,
+# which saves GPU memory but forces a host->device copy on every cache hit (i.e. on
+# each interactive click for the same image). Set to False to keep them resident on
+# the GPU and avoid that per-click transfer, at the cost of higher VRAM usage.
+# Defaults to True to preserve existing behavior.
+SAM3_EMBEDDING_CACHE_OFFLOAD_TO_CPU = str2bool(
+    os.getenv("SAM3_EMBEDDING_CACHE_OFFLOAD_TO_CPU", True)
+)
+SAM3_LOGITS_CACHE_OFFLOAD_TO_CPU = str2bool(
+    os.getenv("SAM3_LOGITS_CACHE_OFFLOAD_TO_CPU", True)
+)
 
 # EasyOCR version ID, default is "english_g2"
 EASYOCR_VERSION_ID = os.getenv("EASYOCR_VERSION_ID", "english_g2")

--- a/inference/models/sam3/visual_segmentation_inference_models.py
+++ b/inference/models/sam3/visual_segmentation_inference_models.py
@@ -26,6 +26,8 @@ from inference.core.env import (
     DEVICE,
     DISABLE_SAM3_LOGITS_CACHE,
     DISABLED_INFERENCE_MODELS_BACKENDS,
+    SAM3_EMBEDDING_CACHE_OFFLOAD_TO_CPU,
+    SAM3_LOGITS_CACHE_OFFLOAD_TO_CPU,
     SAM3_MAX_EMBEDDING_CACHE_SIZE,
     SAM3_MAX_LOGITS_CACHE_SIZE,
     VALID_INFERENCE_MODELS_BACKENDS,
@@ -73,11 +75,11 @@ class InferenceModelsSAM3InteractiveAdapter(Model):
 
         sam3_image_embeddings_cache = Sam3ImageEmbeddingsInMemoryCache.init(
             size_limit=embedding_cache_size,
-            send_to_cpu=True,
+            send_to_cpu=SAM3_EMBEDDING_CACHE_OFFLOAD_TO_CPU,
         )
         sam3_low_resolution_masks_cache = Sam3LowResolutionMasksInMemoryCache.init(
             size_limit=low_res_logits_cache_size,
-            send_to_cpu=True,
+            send_to_cpu=SAM3_LOGITS_CACHE_OFFLOAD_TO_CPU,
         )
         extra_weights_provider_headers = get_extra_weights_provider_headers(
             countinference=kwargs.get("countinference"),


### PR DESCRIPTION
## Problem

Interactive SAM3 segmentation (e.g. the app's smart-polygon tool) got slower after the SAM3 engine was rewritten in #1946 and the workload moved onto a shared multi-model GPU pool. Smart-poly fires many clicks on the **same image**; the expensive image encoder should run once and every subsequent click should reuse the cached embedding cheaply.

Measured in prod (`/sam3/visual_segment`, end-to-end): **p50 243 ms, p90 943 ms, p99 2.65 s** — a real interactive tail.

## Root cause

The cache reuse itself is fine — the embedding **is** reused across clicks (stable `sha1(image.tobytes())` key, persistent adapter instance, idempotent `add_model`; the encoder is not recomputed). The regression is **where the cached tensors live between clicks**:

- The interactive adapter hardcodes `send_to_cpu=True` on both caches:
  - `inference/models/sam3/visual_segmentation_inference_models.py:76` (image embeddings)
  - `:80` (low-res masks)
- With that flag, `save_embeddings` offloads to CPU (`inference_models/.../sam3/cache.py:37-38`, masks at `:109-110`) and every cache **hit** re-uploads the full state to the GPU (`sam3_torch.py:232,360`, `entities.py:13-29`).
- The legacy path kept these resident on the GPU and returned them transfer-free (`inference/models/sam3/visual_segmentation.py:154-157`).

Net: each repeat click now pays a multi-MB host→device copy that the legacy engine never did. Offloading to CPU saves GPU memory (useful when packing many models per GPU), but it costs latency on the interactive hot path.

## Change

Expose the offload as two env flags, **defaulting to `True`** so current behavior is unchanged:

- `SAM3_EMBEDDING_CACHE_OFFLOAD_TO_CPU`
- `SAM3_LOGITS_CACHE_OFFLOAD_TO_CPU`

Deployments with GPU headroom and a bounded/pinned SAM3 cache can set the embedding flag to `False` to keep embeddings on-GPU and drop the per-click copy, trading VRAM for latency. Split into two flags because the logits cache defaults to a much larger size (1000) than the embedding cache, so they have very different VRAM footprints — the embedding flag is the high-value, low-VRAM win.

## Validation

- `py_compile` clean; existing `send_to_cpu=False` behavior is covered by `inference_models/tests/unit_tests/models/test_sam3_cache.py`.
- ⚠️ **Draft — not yet benchmarked.** The latency win is predicted from the mechanism, not yet measured. Before un-drafting: A/B replay an identical visual_segment click sequence with the flag on vs off, recording cold-first vs warm-subsequent latency, and confirm VRAM headroom on the target GPU (L40S 48 GB with SAM3 pinned and embedding cache = 10 is expected to be fine).

## Companion change (separate repo)

To actually take effect for serverless, async-serverless GPU-consumer values need `SAM3_EMBEDDING_CACHE_OFFLOAD_TO_CPU: "False"` once this releases — will open that PR against `async-serverless` as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)