### PR TITLE
Enhance sv_detections_to_root_coordinates function to shift polygon c…

### DIFF
--- a/inference/core/workflows/core_steps/common/utils.py
+++ b/inference/core/workflows/core_steps/common/utils.py
@@ -463,6 +463,11 @@ def sv_detections_to_root_coordinates(
         for keypoints in detections_copy[keypoints_key]:
             if len(keypoints):
                 keypoints += [shift_x, shift_y]
+    if POLYGON_KEY_IN_SV_DETECTIONS in detections_copy.data:
+        polygon_shift = np.asarray([shift_x, shift_y])
+        detections_copy.data[POLYGON_KEY_IN_SV_DETECTIONS] = (
+            detections_copy.data[POLYGON_KEY_IN_SV_DETECTIONS] + polygon_shift
+        )
     if detections_copy.mask is not None:
         origin_mask_base = np.full((origin_height, origin_width), False)
         new_anchored_masks = np.array(

--- a/tests/workflows/unit_tests/core_steps/common/test_utils.py
+++ b/tests/workflows/unit_tests/core_steps/common/test_utils.py
@@ -23,6 +23,9 @@ from inference.core.workflows.execution_engine.entities.base import (
     OriginCoordinatesSystem,
     WorkflowImageData,
 )
+from inference.core.workflows.execution_engine.constants import (
+    POLYGON_KEY_IN_SV_DETECTIONS,
+)
 
 
 def test_attach_prediction_type_info_for_non_empty_predictions() -> None:
@@ -466,6 +469,12 @@ def test_sv_detections_to_root_coordinates_when_shift_is_needed() -> None:
             "keypoints_xy": np.array(
                 [np.array([[10, 20], [20, 30]]), np.array([])], dtype="object"
             ),
+            POLYGON_KEY_IN_SV_DETECTIONS: np.array(
+                [
+                    [[25, 50], [75, 50], [75, 150], [25, 150]],
+                    [[50, 125], [100, 125], [100, 225], [50, 225]],
+                ]
+            ),
         },
     )
 
@@ -543,6 +552,25 @@ def test_sv_detections_to_root_coordinates_when_shift_is_needed() -> None:
     assert (
         result["keypoints_xy"][1] == np.array([])
     ).all(), "Expected empty keypoints xy to be left as is"
+    assert np.allclose(
+        result[POLYGON_KEY_IN_SV_DETECTIONS],
+        np.array(
+            [
+                [
+                    [50 + 25, 100 + 50],
+                    [50 + 75, 100 + 50],
+                    [50 + 75, 100 + 150],
+                    [50 + 25, 100 + 150],
+                ],
+                [
+                    [50 + 50, 100 + 125],
+                    [50 + 100, 100 + 125],
+                    [50 + 100, 100 + 225],
+                    [50 + 50, 100 + 225],
+                ],
+            ]
+        ),
+    ), "Expected polygon metadata to be shifted into root coordinates"
 
 
 def test_sv_detections_to_root_coordinates_when_scale_and_shift_is_needed() -> None:
@@ -584,6 +612,12 @@ def test_sv_detections_to_root_coordinates_when_scale_and_shift_is_needed() -> N
                 [np.array([[10, 20], [20, 30]]), np.array([])], dtype="object"
             ),
             "image_dimensions": np.array([[200, 100], [200, 100]]),
+            POLYGON_KEY_IN_SV_DETECTIONS: np.array(
+                [
+                    [[25, 50], [75, 50], [75, 150], [25, 150]],
+                    [[50, 125], [100, 125], [100, 225], [50, 225]],
+                ]
+            ),
         },
     )
 
@@ -667,6 +701,25 @@ def test_sv_detections_to_root_coordinates_when_scale_and_shift_is_needed() -> N
     assert (
         result["keypoints_xy"][1] == np.array([])
     ).all(), "Expected empty keypoints xy to be left as is"
+    assert np.allclose(
+        result[POLYGON_KEY_IN_SV_DETECTIONS],
+        np.array(
+            [
+                [
+                    [50 + 2 * 25, 100 + 2 * 50],
+                    [50 + 2 * 75, 100 + 2 * 50],
+                    [50 + 2 * 75, 100 + 2 * 150],
+                    [50 + 2 * 25, 100 + 2 * 150],
+                ],
+                [
+                    [50 + 2 * 50, 100 + 2 * 125],
+                    [50 + 2 * 100, 100 + 2 * 125],
+                    [50 + 2 * 100, 100 + 2 * 225],
+                    [50 + 2 * 50, 100 + 2 * 225],
+                ],
+            ]
+        ),
+    ), "Expected polygon metadata to be scaled and shifted into root coordinates"
     assert np.allclose(
         result["image_dimensions"], np.array([[1024, 512], [1024, 512]])
     ), "Expected image dimensions to be root dimensions"


### PR DESCRIPTION
## What does this PR do?

Workflows that run RF-DETR on a cropped image and export predictions in parent (root) coordinates showed a coordinate-frame mismatch on the optimized sparse-RLE path: bounding boxes were correct, but exported polygon/`points` were offset by the crop origin (e.g. 192px / 108px). That happened because `sv_detections_to_root_coordinates()` already promoted `xyxy`, masks, and keypoints to the root frame, but left `POLYGON_KEY_IN_SV_DETECTIONS` in crop-local coordinates. Serializers prefer that metadata when present, so exported outputs were inconsistent even though on-crop visualizations looked fine.

This PR shifts `polygon` metadata by the same `ROOT_PARENT_COORDINATES` offset inside `sv_detections_to_root_coordinates()`, alongside the existing geometry transforms. Intermediate workflow blocks (e.g. `dynamic_crop`, `vision_events`) are unchanged — they intentionally operate in the parent image's frame. The fix targets the export boundary where detections are promoted to root coordinates.

**Main elements:**
- `inference/core/workflows/core_steps/common/utils.py` — shift `POLYGON_KEY_IN_SV_DETECTIONS` in `sv_detections_to_root_coordinates()`
- `tests/workflows/unit_tests/core_steps/common/test_utils.py` — assert polygon metadata is shifted (and scaled) with other detection fields

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other:

## Testing

### Unit tests

- `sv_detections_to_root_coordinates()` shifts `POLYGON_KEY_IN_SV_DETECTIONS` when only a translation is needed
- `sv_detections_to_root_coordinates()` shifts polygon metadata correctly when scale + translation are both applied

### Integration tests

- None for this PR.

### Other

- `pytest tests/workflows/unit_tests/core_steps/common/test_utils.py -k "sv_detections_to_root_coordinates"`
- Parity check: `development/stream_interface/codeflash-optimization-compare-visualization-parity.py` (baseline vs optimized export coordinates align)

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where necessary, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have updated the documentation accordingly (if applicable)

## Additional Context

Alternative approach (discarding stale polygon metadata for sparse-RLE predictions) was considered but rejected: shifting preserves metadata for downstream consumers (`vision_events`, serializers, query language) instead of silently dropping it. Mid-pipeline blocks like `vision_events` are unaffected — they already expect detections in the wired parent image's frame and do not go through output construction.
