### PR TITLE
Handle FPS regression with prediction parity kept intact

### DIFF
--- a/inference/core/interfaces/stream/inference_pipeline.py
+++ b/inference/core/interfaces/stream/inference_pipeline.py
@@ -62,6 +62,7 @@ from inference.core.managers.decorators.fixed_size_cache import WithFixedSizeCac
 from inference.core.registries.roboflow import RoboflowModelRegistry
 from inference.core.utils.function import experimental
 from inference.core.workflows.core_steps.common.entities import StepExecutionMode
+from inference.core.workflows.execution_engine.entities.base import CoordinatesSystem
 from inference.core.workflows.execution_engine.profiling.core import (
     BaseWorkflowsProfiler,
     NullWorkflowsProfiler,
@@ -570,6 +571,9 @@ class InferencePipeline:
                 newest version for the request. Only applies for Workflows definitions saved on Roboflow platform.
             serialize_results (bool): Boolean flag to decide if ExecutionEngine run should serialize workflow
                 results for each frame. If that is set true, sinks will receive serialized workflow responses.
+                When False, output futures are resolved in the dispatch thread and detections in workflow
+                outputs declared with `coordinates_system: parent` are converted to root coordinates at
+                dispatch time instead of in the execution engine.
             predictions_queue_size int: Size of buffer for predictions that are ready for dispatching
                 default value is taken from INFERENCE_PIPELINE_PREDICTIONS_QUEUE_SIZE env variable
             decoding_buffer_size (int): size of video source decoding buffer
@@ -606,6 +610,8 @@ class InferencePipeline:
             raise ValueError(
                 "Either (`workspace_name`, `workflow_id`) or `workflow_specification` must be provided."
             )
+        workflow_parent_coordinate_outputs = frozenset()
+        workflow_defer_output_coordinate_conversion = False
         try:
             from inference.core.interfaces.stream.model_handlers.workflows import (
                 WorkflowRunner,
@@ -670,6 +676,12 @@ class InferencePipeline:
                 workflow_runner=workflow_runner,
                 execution_engine=execution_engine,
             )
+            workflow_parent_coordinate_outputs = (
+                _workflow_parent_coordinate_output_names(
+                    workflow_specification=workflow_specification,
+                )
+            )
+            workflow_defer_output_coordinate_conversion = not serialize_results
         except ImportError as error:
             raise CannotInitialiseModelError(
                 f"Could not initialise workflow processing due to lack of dependencies required. "
@@ -697,6 +709,10 @@ class InferencePipeline:
             batch_collection_timeout=batch_collection_timeout,
             predictions_queue_size=predictions_queue_size,
             decoding_buffer_size=decoding_buffer_size,
+            workflow_parent_coordinate_outputs=workflow_parent_coordinate_outputs,
+            workflow_defer_output_coordinate_conversion=(
+                workflow_defer_output_coordinate_conversion
+            ),
         )
 
     @classmethod
@@ -717,6 +733,8 @@ class InferencePipeline:
         sink_mode: SinkMode = SinkMode.ADAPTIVE,
         predictions_queue_size: int = PREDICTIONS_QUEUE_SIZE,
         decoding_buffer_size: int = DEFAULT_BUFFER_SIZE,
+        workflow_parent_coordinate_outputs: Optional[frozenset[str]] = None,
+        workflow_defer_output_coordinate_conversion: bool = False,
     ) -> "InferencePipeline":
         """
         This class creates the abstraction for making inferences from given workflow against video stream.
@@ -787,6 +805,15 @@ class InferencePipeline:
                 default value is taken from INFERENCE_PIPELINE_PREDICTIONS_QUEUE_SIZE env variable
             decoding_buffer_size (int): size of video source decoding buffer
                 default value is taken from VIDEO_SOURCE_BUFFER_SIZE env variable
+            workflow_parent_coordinate_outputs (Optional[frozenset[str]]): Names of workflow outputs whose
+                `coordinates_system` is `parent`. Used by the dispatch thread to convert `sv.Detections`
+                to root coordinates when coordinate conversion is deferred. Populated automatically by
+                `init_with_workflow(...)`; only needed when constructing the pipeline via
+                `init_with_custom_logic(...)` with a workflow-backed handler.
+            workflow_defer_output_coordinate_conversion (bool): When True, parent-coordinate conversion
+                for workflow detections is applied in `_dispatch_inference_results(...)` after futures
+                are resolved, rather than in the execution engine output constructor. Set automatically
+                to `not serialize_results` by `init_with_workflow(...)`.
 
         Other ENV variables involved in low-level configuration:
         * INFERENCE_PIPELINE_PREDICTIONS_QUEUE_SIZE - size of buffer for predictions that are ready for dispatching
@@ -841,6 +868,10 @@ class InferencePipeline:
             on_pipeline_end=on_pipeline_end,
             batch_collection_timeout=batch_collection_timeout,
             sink_mode=sink_mode,
+            workflow_parent_coordinate_outputs=workflow_parent_coordinate_outputs,
+            workflow_defer_output_coordinate_conversion=(
+                workflow_defer_output_coordinate_conversion
+            ),
         )
 
     def __init__(
@@ -856,6 +887,8 @@ class InferencePipeline:
         max_fps: Optional[float] = None,
         batch_collection_timeout: Optional[float] = None,
         sink_mode: SinkMode = SinkMode.ADAPTIVE,
+        workflow_parent_coordinate_outputs: Optional[frozenset[str]] = None,
+        workflow_defer_output_coordinate_conversion: bool = False,
     ):
         self._on_video_frame = on_video_frame
         self._video_sources = video_sources
@@ -873,6 +906,12 @@ class InferencePipeline:
         self._on_pipeline_end = on_pipeline_end
         self._batch_collection_timeout = batch_collection_timeout
         self._sink_mode = sink_mode
+        self._workflow_parent_coordinate_outputs = (
+            workflow_parent_coordinate_outputs or frozenset()
+        )
+        self._workflow_defer_output_coordinate_conversion = (
+            workflow_defer_output_coordinate_conversion
+        )
 
     def start(self, use_main_thread: bool = True) -> None:
         self._stop = False
@@ -989,6 +1028,11 @@ class InferencePipeline:
             predictions, video_frames = inference_results
             if _rfdetr_stream_pipeline_enabled():
                 predictions = _resolve_prediction_futures(predictions)
+                if self._workflow_defer_output_coordinate_conversion:
+                    predictions = _apply_workflow_parent_coordinate_conversion(
+                        predictions=predictions,
+                        parent_output_names=self._workflow_parent_coordinate_outputs,
+                    )
             if self._on_prediction is not None:
                 self._handle_predictions_dispatching(
                     predictions=predictions,
@@ -1186,6 +1230,55 @@ def _resolve_prediction_futures(value: Any) -> Any:
             key: _resolve_prediction_futures(element) for key, element in value.items()
         }
     return value
+
+
+def _workflow_parent_coordinate_output_names(
+    workflow_specification: Optional[dict],
+) -> frozenset[str]:
+    if workflow_specification is None:
+        return frozenset()
+    parent_output_names = set()
+    for output in workflow_specification.get("outputs", []):
+        coordinates_system = output.get(
+            "coordinates_system",
+            CoordinatesSystem.PARENT.value,
+        )
+        if coordinates_system in (
+            CoordinatesSystem.PARENT,
+            CoordinatesSystem.PARENT.value,
+        ):
+            parent_output_names.add(output["name"])
+    return frozenset(parent_output_names)
+
+
+def _apply_workflow_parent_coordinate_conversion(
+    predictions: Any,
+    parent_output_names: frozenset[str],
+) -> Any:
+    if not parent_output_names:
+        return predictions
+    from inference.core.workflows.execution_engine.v1.executor.output_constructor import (
+        convert_sv_detections_coordinates,
+    )
+
+    if isinstance(predictions, list):
+        return [
+            _apply_workflow_parent_coordinate_conversion(
+                predictions=item,
+                parent_output_names=parent_output_names,
+            )
+            for item in predictions
+        ]
+    if isinstance(predictions, dict):
+        converted = dict(predictions)
+        for output_name in parent_output_names:
+            if output_name not in converted:
+                continue
+            converted[output_name] = convert_sv_detections_coordinates(
+                data=converted[output_name]
+            )
+        return converted
+    return predictions
 
 
 def _rfdetr_stream_pipeline_enabled() -> bool:

--- a/inference/core/interfaces/stream/model_handlers/workflows.py
+++ b/inference/core/interfaces/stream/model_handlers/workflows.py
@@ -36,6 +36,7 @@ class WorkflowRunner:
         self,
         video_frames: List[VideoFrame],
         defer_stream_pipeline_flush: bool = False,
+        resolve_output_futures: bool = True,
     ) -> List[dict]:
         workflows_parameters, fps = self._build_workflows_parameters(
             video_frames=video_frames
@@ -46,6 +47,7 @@ class WorkflowRunner:
             serialize_results=self._serialize_results,
             _is_preview=self._is_preview,
             defer_stream_pipeline_flush=defer_stream_pipeline_flush,
+            resolve_output_futures=resolve_output_futures,
         )
 
     def _flush_stream_pipeline(self, video_frames: List[VideoFrame]) -> List[dict]:
@@ -115,9 +117,13 @@ class PipelinedWorkflowRunner:
     def __call__(
         self, video_frames: List[VideoFrame]
     ) -> Optional[InferenceHandlerResult]:
+        # Resolving RF-DETR output futures here serializes postprocess before the
+        # next frame can launch. The stream dispatcher resolves them after the
+        # frame buffer delay, when they should already be ready.
         predictions = self._workflow_runner._run_workflow(
             video_frames=video_frames,
             defer_stream_pipeline_flush=True,
+            resolve_output_futures=self._workflow_runner._serialize_results,
         )
         stream_buffer_depth = self._stream_buffer_depth()
         if stream_buffer_depth <= 0:

--- a/inference/core/workflows/execution_engine/core.py
+++ b/inference/core/workflows/execution_engine/core.py
@@ -75,6 +75,7 @@ class ExecutionEngine(BaseExecutionEngine):
         _is_preview: bool = False,
         serialize_results: bool = False,
         defer_stream_pipeline_flush: bool = False,
+        resolve_output_futures: bool = True,
     ) -> List[Dict[str, Any]]:
         return self._engine.run(
             runtime_parameters=runtime_parameters,
@@ -82,6 +83,7 @@ class ExecutionEngine(BaseExecutionEngine):
             _is_preview=_is_preview,
             serialize_results=serialize_results,
             defer_stream_pipeline_flush=defer_stream_pipeline_flush,
+            resolve_output_futures=resolve_output_futures,
         )
 
     def flush_stream_pipeline(

--- a/inference/core/workflows/execution_engine/entities/engine.py
+++ b/inference/core/workflows/execution_engine/entities/engine.py
@@ -31,5 +31,7 @@ class BaseExecutionEngine(ABC):
         fps: float = 0,
         _is_preview: bool = False,
         serialize_results: bool = False,
+        defer_stream_pipeline_flush: bool = False,
+        resolve_output_futures: bool = True,
     ) -> List[Dict[str, Any]]:
         pass

--- a/inference/core/workflows/execution_engine/v1/core.py
+++ b/inference/core/workflows/execution_engine/v1/core.py
@@ -122,6 +122,7 @@ class ExecutionEngineV1(BaseExecutionEngine):
         _is_preview: bool = False,
         serialize_results: bool = False,
         defer_stream_pipeline_flush: bool = False,
+        resolve_output_futures: bool = True,
     ) -> List[Dict[str, Any]]:
         self._profiler.start_workflow_run()
         runtime_parameters = assemble_runtime_parameters(
@@ -156,6 +157,7 @@ class ExecutionEngineV1(BaseExecutionEngine):
             executor=self._executor,
             step_error_handler=self._step_error_handler,
             defer_stream_pipeline_flush=defer_stream_pipeline_flush,
+            resolve_output_futures=resolve_output_futures,
         )
         self._profiler.end_workflow_run()
         return result

--- a/inference/core/workflows/execution_engine/v1/executor/core.py
+++ b/inference/core/workflows/execution_engine/v1/executor/core.py
@@ -101,6 +101,7 @@ def run_workflow(
     executor: Optional[ThreadPoolExecutor] = None,
     step_error_handler: Optional[Callable[[Exception], None]] = None,
     defer_stream_pipeline_flush: bool = False,
+    resolve_output_futures: bool = True,
 ) -> List[Dict[str, Any]]:
     with start_span("workflow.run"):
         return _run_workflow(
@@ -113,6 +114,7 @@ def run_workflow(
             executor=executor,
             step_error_handler=step_error_handler,
             defer_stream_pipeline_flush=defer_stream_pipeline_flush,
+            resolve_output_futures=resolve_output_futures,
         )
 
 
@@ -126,6 +128,7 @@ def _run_workflow(
     executor: Optional[ThreadPoolExecutor] = None,
     step_error_handler: Optional[Callable[[Exception], None]] = None,
     defer_stream_pipeline_flush: bool = False,
+    resolve_output_futures: bool = True,
 ) -> List[Dict[str, Any]]:
     execution_data_manager = ExecutionDataManager.init(
         execution_graph=workflow.execution_graph,
@@ -168,6 +171,7 @@ def _run_workflow(
                 execution_data_manager=execution_data_manager,
                 serialize_results=serialize_results,
                 kinds_serializers=kinds_serializers,
+                resolve_output_futures=resolve_output_futures,
             )
     finally:
         if not defer_stream_pipeline_flush:

--- a/inference/core/workflows/execution_engine/v1/executor/output_constructor.py
+++ b/inference/core/workflows/execution_engine/v1/executor/output_constructor.py
@@ -40,6 +40,7 @@ def construct_workflow_output(
     execution_data_manager: ExecutionDataManager,
     serialize_results: bool,
     kinds_serializers: Dict[str, Callable[[Any], Any]],
+    resolve_output_futures: bool = True,
 ) -> List[Dict[str, Any]]:
     # Maybe we should make blocks to change coordinates systems:
     # https://github.com/roboflow/inference/issues/440
@@ -64,7 +65,8 @@ def construct_workflow_output(
         if output.name in batch_oriented_outputs:
             continue
         data_piece = execution_data_manager.get_non_batch_data(selector=output.selector)
-        data_piece = _maybe_resolve_output_futures(data_piece)
+        if resolve_output_futures:
+            data_piece = _maybe_resolve_output_futures(data_piece)
         if serialize_results:
             output_kind = kinds_of_output_nodes[output.name]
             data_piece = serialize_data_piece(
@@ -110,6 +112,7 @@ def construct_workflow_output(
         non_batch_outputs=non_batch_outputs,
         dimensionality_for_output_nodes=dimensionality_for_output_nodes,
         batch_oriented_outputs=batch_oriented_outputs,
+        resolve_output_futures=resolve_output_futures,
     )
     if len(results) == 0 and len(outputs_for_generated_lineage) > 0:
         results.append({})
@@ -125,6 +128,7 @@ def construct_workflow_output(
                 kinds_serializers=kinds_serializers,
                 kinds_of_output_nodes=kinds_of_output_nodes,
                 dimensionality_for_output_nodes=dimensionality_for_output_nodes,
+                resolve_output_futures=resolve_output_futures,
             )
         )
         for output in results:
@@ -145,6 +149,7 @@ def create_outputs_for_input_induced_lineages(
     non_batch_outputs: Dict[str, Any],
     dimensionality_for_output_nodes: Dict[str, int],
     batch_oriented_outputs: Set[str],
+    resolve_output_futures: bool = True,
 ) -> List[Dict[str, Any]]:
     outputs_arrays: Dict[str, Optional[list]] = {
         name: create_array(indices=np.array(indices))
@@ -171,7 +176,8 @@ def create_outputs_for_input_induced_lineages(
             indices=indices,
         )
         for index, data_piece in zip(indices, data):
-            data_piece = _maybe_resolve_output_futures(data_piece)
+            if resolve_output_futures:
+                data_piece = _maybe_resolve_output_futures(data_piece)
             if (
                 name in outputs_requested_in_parent_coordinates
                 and data_contains_sv_detections(data=data_piece)
@@ -242,6 +248,7 @@ def create_outputs_for_generated_lineage_outputs(
         str, Union[List[Union[Kind, str]], Dict[str, List[Union[Kind, str]]]]
     ],
     dimensionality_for_output_nodes: Dict[str, int],
+    resolve_output_futures: bool = True,
 ) -> Dict[str, List[Any]]:
     outputs_arrays: Dict[str, Optional[list]] = {
         name: create_array(indices=np.array(indices))
@@ -266,7 +273,8 @@ def create_outputs_for_generated_lineage_outputs(
             indices=indices,
         )
         for index, data_piece in zip(indices, data):
-            data_piece = _maybe_resolve_output_futures(data_piece)
+            if resolve_output_futures:
+                data_piece = _maybe_resolve_output_futures(data_piece)
             if (
                 name in outputs_requested_in_parent_coordinates
                 and data_contains_sv_detections(data=data_piece)

--- a/tests/inference/unit_tests/core/interfaces/stream/test_interface_pipeline.py
+++ b/tests/inference/unit_tests/core/interfaces/stream/test_interface_pipeline.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
+import supervision as sv
 
 from inference.core.active_learning.middlewares import ThreadingActiveLearningMiddleware
 from inference.core.cache import MemoryCache
@@ -35,7 +36,9 @@ from inference.core.interfaces.stream.entities import (
 )
 from inference.core.interfaces.stream.inference_pipeline import (
     InferencePipeline,
+    _apply_workflow_parent_coordinate_conversion,
     _resolve_prediction_futures,
+    _workflow_parent_coordinate_output_names,
 )
 from inference.core.interfaces.stream.model_handlers.roboflow_models import (
     default_process_frame,
@@ -212,6 +215,119 @@ def test_resolve_prediction_futures_recursively_resolves_nested_values() -> None
     assert _resolve_prediction_futures((outer, {"raw": inner})) == (
         {"detections": ["resolved"]},
         {"raw": "resolved"},
+    )
+
+
+def test_resolve_prediction_futures_recursively_resolves_nested_values() -> None:
+    inner = Future()
+    inner.set_result("resolved")
+    outer = Future()
+    outer.set_result({"detections": [inner]})
+
+    assert _resolve_prediction_futures((outer, {"raw": inner})) == (
+        {"detections": ["resolved"]},
+        {"raw": "resolved"},
+    )
+
+
+def test_workflow_parent_coordinate_output_names_defaults_to_parent_outputs() -> None:
+    workflow_specification = {
+        "outputs": [
+            {"name": "predictions", "selector": "$steps.model.predictions"},
+            {
+                "name": "crop_predictions",
+                "selector": "$steps.crop.predictions",
+                "coordinates_system": "own",
+            },
+            {"name": "visualization", "selector": "$steps.viz.image"},
+        ]
+    }
+
+    assert _workflow_parent_coordinate_output_names(
+        workflow_specification=workflow_specification
+    ) == frozenset({"predictions", "visualization"})
+
+
+def _detections_with_root_shift() -> sv.Detections:
+    return sv.Detections(
+        xyxy=np.array([[25.0, 50.0, 75.0, 150.0]]),
+        data={
+            "parent_coordinates": np.array([[10.0, 20.0]]),
+            "root_parent_coordinates": np.array([[50.0, 100.0]]),
+            "root_parent_dimensions": np.array([[512.0, 1024.0]]),
+            "root_parent_id": np.array(["root"]),
+        },
+    )
+
+
+def test_apply_workflow_parent_coordinate_conversion_shifts_parent_outputs() -> None:
+    detections = _detections_with_root_shift()
+    predictions = {
+        "predictions": detections,
+        "crop_predictions": sv.Detections(
+            xyxy=np.array([[5.0, 10.0, 15.0, 20.0]]),
+            data={
+                "parent_coordinates": np.array([[10.0, 20.0]]),
+                "root_parent_coordinates": np.array([[50.0, 100.0]]),
+                "root_parent_dimensions": np.array([[512.0, 1024.0]]),
+                "root_parent_id": np.array(["root"]),
+            },
+        ),
+    }
+
+    converted = _apply_workflow_parent_coordinate_conversion(
+        predictions=predictions,
+        parent_output_names=frozenset({"predictions"}),
+    )
+
+    assert np.allclose(
+        converted["predictions"].xyxy,
+        np.array([[75.0, 150.0, 125.0, 250.0]]),
+    )
+    assert np.allclose(
+        converted["crop_predictions"].xyxy,
+        np.array([[5.0, 10.0, 15.0, 20.0]]),
+    )
+
+
+def test_dispatch_inference_results_applies_deferred_parent_coordinate_conversion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    detections = _detections_with_root_shift()
+    prediction_future = Future()
+    prediction_future.set_result({"predictions": detections})
+    frame = VideoFrame(
+        image=np.zeros((8, 8, 3), dtype=np.uint8),
+        frame_id=1,
+        frame_timestamp=datetime.now(),
+        source_id=0,
+    )
+    dispatched = []
+
+    def on_prediction(prediction: dict, video_frame: VideoFrame) -> None:
+        dispatched.append((prediction, video_frame))
+
+    pipeline = object.__new__(InferencePipeline)
+    pipeline._predictions_queue = Queue()
+    pipeline._on_prediction = on_prediction
+    pipeline._workflow_parent_coordinate_outputs = frozenset({"predictions"})
+    pipeline._workflow_defer_output_coordinate_conversion = True
+    pipeline._handle_predictions_dispatching = InferencePipeline._handle_predictions_dispatching.__get__(
+        pipeline, InferencePipeline
+    )
+    monkeypatch.setattr(
+        "inference.core.interfaces.stream.inference_pipeline._rfdetr_stream_pipeline_enabled",
+        lambda: True,
+    )
+
+    pipeline._predictions_queue.put(([{"predictions": prediction_future}], [frame]))
+    pipeline._predictions_queue.put(None)
+    pipeline._dispatch_inference_results()
+
+    assert len(dispatched) == 1
+    assert np.allclose(
+        dispatched[0][0]["predictions"].xyxy,
+        np.array([[75.0, 150.0, 125.0, 250.0]]),
     )
 
 

--- a/tests/inference/unit_tests/core/interfaces/stream/test_workflows.py
+++ b/tests/inference/unit_tests/core/interfaces/stream/test_workflows.py
@@ -55,6 +55,7 @@ class _FakeExecutionEngine:
         serialize_results,
         _is_preview,
         defer_stream_pipeline_flush=False,
+        resolve_output_futures=True,
     ):
         frame_number = runtime_parameters["image"][0]["video_metadata"].frame_number
         self.calls.append(
@@ -64,6 +65,7 @@ class _FakeExecutionEngine:
                 "serialize_results": serialize_results,
                 "is_preview": _is_preview,
                 "defer_stream_pipeline_flush": defer_stream_pipeline_flush,
+                "resolve_output_futures": resolve_output_futures,
             }
         )
         prediction_frame = frame_number - self._stream_buffer_depth
@@ -120,6 +122,7 @@ class _FakeLateActivatingExecutionEngine:
         serialize_results,
         _is_preview,
         defer_stream_pipeline_flush=False,
+        resolve_output_futures=True,
     ):
         frame_number = runtime_parameters["image"][0]["video_metadata"].frame_number
         # Real RF-DETR workflow steps only know whether stream pipelining is
@@ -156,12 +159,14 @@ class _FakeDownstreamPipelinedExecutionEngine:
         serialize_results,
         _is_preview,
         defer_stream_pipeline_flush=False,
+        resolve_output_futures=True,
     ):
         frame_number = runtime_parameters["image"][0]["video_metadata"].frame_number
         self.calls.append(
             {
                 "frame_number": frame_number,
                 "defer_stream_pipeline_flush": defer_stream_pipeline_flush,
+                "resolve_output_futures": resolve_output_futures,
             }
         )
         if defer_stream_pipeline_flush:
@@ -295,6 +300,7 @@ def test_workflow_runner_without_stream_buffering_returns_current_frame() -> Non
             "serialize_results": True,
             "is_preview": True,
             "defer_stream_pipeline_flush": False,
+            "resolve_output_futures": True,
         }
     ]
 
@@ -355,6 +361,7 @@ def test_workflow_runner_buffers_frames_until_delayed_prediction_arrives() -> No
             "serialize_results": False,
             "is_preview": False,
             "defer_stream_pipeline_flush": True,
+            "resolve_output_futures": False,
         },
         {
             "frame_number": 2,
@@ -362,6 +369,7 @@ def test_workflow_runner_buffers_frames_until_delayed_prediction_arrives() -> No
             "serialize_results": False,
             "is_preview": False,
             "defer_stream_pipeline_flush": True,
+            "resolve_output_futures": False,
         },
     ]
 
@@ -431,8 +439,16 @@ def test_pipelined_workflow_runner_preserves_frame_alignment_for_downstream_step
     assert flushed_results[0].predictions == [{"result": "downstream-frame-2"}]
     assert flushed_results[0].video_frames == [frame_2]
     assert engine.calls == [
-        {"frame_number": 1, "defer_stream_pipeline_flush": True},
-        {"frame_number": 2, "defer_stream_pipeline_flush": True},
+        {
+            "frame_number": 1,
+            "defer_stream_pipeline_flush": True,
+            "resolve_output_futures": False,
+        },
+        {
+            "frame_number": 2,
+            "defer_stream_pipeline_flush": True,
+            "resolve_output_futures": False,
+        },
     ]
     assert engine.flush_calls == [2]
 

--- a/tests/workflows/unit_tests/execution_engine/executor/test_output_constructor.py
+++ b/tests/workflows/unit_tests/execution_engine/executor/test_output_constructor.py
@@ -1,3 +1,4 @@
+from concurrent.futures import Future
 from typing import Any, List, Optional
 from unittest.mock import MagicMock
 
@@ -30,6 +31,12 @@ from inference.core.workflows.execution_engine.v1.executor.output_constructor im
     place_data_in_array,
     serialize_data_piece,
 )
+
+
+def _completed_future(value: Any) -> Future:
+    future = Future()
+    future.set_result(value)
+    return future
 
 
 def test_data_contains_sv_detections_when_no_sv_detections_provided() -> None:
@@ -431,6 +438,76 @@ def test_construct_workflow_output_when_no_batch_outputs_present() -> None:
 
     # then
     assert result == [{"a": "a_value", "b": "b_value"}]
+
+
+def test_construct_workflow_output_resolves_futures_by_default() -> None:
+    # given
+    execution_data_manager = MagicMock()
+    workflow_outputs = [
+        JsonField(type="JsonField", name="a", selector="$steps.some.a"),
+    ]
+    execution_graph = DiGraph()
+    execution_graph.add_node(
+        "$outputs.a",
+        node_compilation_output=OutputNode(
+            node_category=NodeCategory.OUTPUT_NODE,
+            name=workflow_outputs[0].name,
+            selector=workflow_outputs[0].selector,
+            data_lineage=[],
+            output_manifest=workflow_outputs[0],
+        ),
+    )
+    execution_data_manager.get_selector_indices.return_value = None
+    execution_data_manager.get_non_batch_data.return_value = {
+        "predictions": _completed_future(["resolved"])
+    }
+
+    # when
+    result = construct_workflow_output(
+        workflow_outputs=workflow_outputs,
+        execution_graph=execution_graph,
+        execution_data_manager=execution_data_manager,
+        serialize_results=False,
+        kinds_serializers=KINDS_SERIALIZERS,
+    )
+
+    # then
+    assert result == [{"a": {"predictions": ["resolved"]}}]
+
+
+def test_construct_workflow_output_can_defer_future_resolution() -> None:
+    # given
+    execution_data_manager = MagicMock()
+    workflow_outputs = [
+        JsonField(type="JsonField", name="a", selector="$steps.some.a"),
+    ]
+    execution_graph = DiGraph()
+    execution_graph.add_node(
+        "$outputs.a",
+        node_compilation_output=OutputNode(
+            node_category=NodeCategory.OUTPUT_NODE,
+            name=workflow_outputs[0].name,
+            selector=workflow_outputs[0].selector,
+            data_lineage=[],
+            output_manifest=workflow_outputs[0],
+        ),
+    )
+    predictions = _completed_future(["resolved"])
+    execution_data_manager.get_selector_indices.return_value = None
+    execution_data_manager.get_non_batch_data.return_value = {"predictions": predictions}
+
+    # when
+    result = construct_workflow_output(
+        workflow_outputs=workflow_outputs,
+        execution_graph=execution_graph,
+        execution_data_manager=execution_data_manager,
+        serialize_results=False,
+        kinds_serializers=KINDS_SERIALIZERS,
+        resolve_output_futures=False,
+    )
+
+    # then
+    assert result == [{"a": {"predictions": predictions}}]
 
 
 def test_construct_workflow_output_when_batch_outputs_present() -> None:


### PR DESCRIPTION
## Summary
Fixes a prediction parity regression in stream workflows when output futures are deferred (`serialize_results=False`).

With https://github.com/roboflow/inference/pull/2470 change the stream pipeline resolves workflow output `Future`s in the dispatch thread instead of the inference thread. That restores throughput, but it also skipped a step: converting `sv.Detections` in `coordinates_system: parent` outputs to root coordinates. That conversion still ran in `output_constructor` only when futures were resolved eagerly.

In multistep workflows (e.g. crop → RF-DETR seg → visualization), the optimized path (`RFDETR_PIPELINE_DEPTH=2`) therefore returned crop-local `xyxy` boxes while the baseline path (`depth=1`) returned root-frame coordinates. Parity failed with systematic offsets matching crop margins (e.g. Δx≈64, Δy≈36 on 640×360).

## Fix

When `init_with_workflow(..., serialize_results=False)`:
1. Record workflow output names that use `coordinates_system: parent` (the default for `JsonField`).
2. Set `_workflow_defer_output_coordinate_conversion = not serialize_results`.
3. In `_dispatch_inference_results`, `after _resolve_prediction_futures()`, call the same `convert_sv_detections_coordinates()` helper used by `output_constructor` for those outputs.
When `serialize_results=True`, behavior is unchanged — conversion remains in `output_constructor` to avoid double-conversion.

## Test plan

- [x] Unit tests for output-name extraction, parent-only conversion, and dispatch-path integration
- [x] Remote visualization parity on Orin AGX (orin-agx-jp62), 640×360 video, contrib-pr-2470:
- Before fix: parity failed (rfdetr-trt-visualization-parity-20260618-012207)
- After fix: parity ok (rfdetr-trt-visualization-parity-20260618-020134)