### PR TITLE
restore SAM3 interactive fast path for repeated clicks

### DIFF
--- a/inference/core/env.py
+++ b/inference/core/env.py
@@ -552,6 +552,9 @@ SAM3_IMAGE_SIZE = int(os.getenv("SAM3_IMAGE_SIZE", 1008))
 # SAM3_REPO_PATH = os.getenv("SAM3_REPO_PATH", "/home/hansent/sam3")
 SAM3_MAX_EMBEDDING_CACHE_SIZE = int(os.getenv("SAM3_MAX_EMBEDDING_CACHE_SIZE", 100))
 SAM3_MAX_LOGITS_CACHE_SIZE = int(os.getenv("SAM3_MAX_LOGITS_CACHE_SIZE", 1000))
+SAM3_INTERACTIVE_CACHE_SEND_TO_CPU = str2bool(
+    os.getenv("SAM3_INTERACTIVE_CACHE_SEND_TO_CPU", True)
+)
 DISABLE_SAM3_LOGITS_CACHE = str2bool(os.getenv("DISABLE_SAM3_LOGITS_CACHE", False))
 
 # EasyOCR version ID, default is "english_g2"

--- a/inference/models/sam3/visual_segmentation_inference_models.py
+++ b/inference/models/sam3/visual_segmentation_inference_models.py
@@ -36,6 +36,7 @@ from inference.core.utils.image_utils import load_image_rgb
 from inference.core.utils.postprocess import masks2multipoly
 from inference.usage_tracking.collector import usage_collector
 from inference_models import AutoModel
+from inference_models.errors import ModelInputError
 from inference_models.models.sam3.cache import (
     Sam3ImageEmbeddingsInMemoryCache,
     Sam3LowResolutionMasksInMemoryCache,
@@ -71,13 +72,15 @@ class InferenceModelsSAM3InteractiveAdapter(Model):
         self.api_key = api_key if api_key else API_KEY
         self.task_type = "unsupervised-segmentation"
 
+        # Keep interactive embeddings/logits on GPU to match legacy click latency;
+        # make CPU spill configurable if memory pressure shows up.
         sam3_image_embeddings_cache = Sam3ImageEmbeddingsInMemoryCache.init(
             size_limit=embedding_cache_size,
-            send_to_cpu=True,
+            send_to_cpu=False,
         )
         sam3_low_resolution_masks_cache = Sam3LowResolutionMasksInMemoryCache.init(
             size_limit=low_res_logits_cache_size,
-            send_to_cpu=True,
+            send_to_cpu=False,
         )
         extra_weights_provider_headers = get_extra_weights_provider_headers(
             countinference=kwargs.get("countinference"),
@@ -170,7 +173,6 @@ class InferenceModelsSAM3InteractiveAdapter(Model):
             load_logits_from_cache and not DISABLE_SAM3_LOGITS_CACHE
         )
         save_logits_to_cache = save_logits_to_cache and not DISABLE_SAM3_LOGITS_CACHE
-        loaded_image = self.preproc_image(image)
 
         if prompts is not None:
             if isinstance(prompts, dict):
@@ -188,9 +190,7 @@ class InferenceModelsSAM3InteractiveAdapter(Model):
         if mask_input is not None and isinstance(mask_input, list):
             mask_input = np.array(mask_input)
 
-        prediction = self._model.segment_with_visual_prompts(
-            images=loaded_image,
-            image_hashes=image_id,
+        segment_kwargs = dict(
             point_coordinates=args["point_coords"],
             point_labels=args["point_labels"],
             boxes=args["box"],
@@ -200,7 +200,26 @@ class InferenceModelsSAM3InteractiveAdapter(Model):
             load_from_mask_input_cache=load_logits_from_cache,
             save_to_mask_input_cache=save_logits_to_cache,
             use_embeddings_cache=True,
-        )[0]
+        )
+
+        prediction = None
+        if image_id is not None:
+            # Fast path: skip image decode/preproc when embeddings are already cached.
+            # NOTE: match the cache-miss message so other ModelInputErrors (bad prompt
+            # shape, invalid hash usage) propagate instead of silently re-decoding.
+            try:
+                prediction = self._model.segment_with_visual_prompts(
+                    images=None, image_hashes=image_id, **segment_kwargs
+                )[0]
+            except ModelInputError as error:
+                if "no embeddings were found in the cache" not in str(error):
+                    raise
+                prediction = None
+        if prediction is None:
+            loaded_image = self.preproc_image(image)
+            prediction = self._model.segment_with_visual_prompts(
+                images=loaded_image, image_hashes=image_id, **segment_kwargs
+            )[0]
         # SAM3Torch already selects the most confident of the multimask proposals
         # for each prompt, so masks/scores/logits arrive with exactly one entry
         # per prompt. Reducing again here would collapse a multi-prompt request

--- a/inference/models/sam3/visual_segmentation_inference_models.py
+++ b/inference/models/sam3/visual_segmentation_inference_models.py
@@ -26,6 +26,7 @@ from inference.core.env import (
     DEVICE,
     DISABLE_SAM3_LOGITS_CACHE,
     DISABLED_INFERENCE_MODELS_BACKENDS,
+    SAM3_INTERACTIVE_CACHE_SEND_TO_CPU,
     SAM3_MAX_EMBEDDING_CACHE_SIZE,
     SAM3_MAX_LOGITS_CACHE_SIZE,
     VALID_INFERENCE_MODELS_BACKENDS,
@@ -72,15 +73,13 @@ class InferenceModelsSAM3InteractiveAdapter(Model):
         self.api_key = api_key if api_key else API_KEY
         self.task_type = "unsupervised-segmentation"
 
-        # Keep interactive embeddings/logits on GPU to match legacy click latency;
-        # make CPU spill configurable if memory pressure shows up.
         sam3_image_embeddings_cache = Sam3ImageEmbeddingsInMemoryCache.init(
             size_limit=embedding_cache_size,
-            send_to_cpu=False,
+            send_to_cpu=SAM3_INTERACTIVE_CACHE_SEND_TO_CPU,
         )
         sam3_low_resolution_masks_cache = Sam3LowResolutionMasksInMemoryCache.init(
             size_limit=low_res_logits_cache_size,
-            send_to_cpu=False,
+            send_to_cpu=SAM3_INTERACTIVE_CACHE_SEND_TO_CPU,
         )
         extra_weights_provider_headers = get_extra_weights_provider_headers(
             countinference=kwargs.get("countinference"),

--- a/tests/inference/unit_tests/models/test_sam3_visual_segmentation.py
+++ b/tests/inference/unit_tests/models/test_sam3_visual_segmentation.py
@@ -139,3 +139,92 @@ def test_segment_image_forwards_all_prompts_to_model(
     boxes = call_kwargs["boxes"]
     assert boxes.shape == (2, 4)
     np.testing.assert_allclose(boxes, [[8, 8, 12, 12], [26, 26, 34, 34]])
+
+
+def _single_prediction() -> SimpleNamespace:
+    return SimpleNamespace(
+        masks=torch.rand(1, 8, 8),
+        scores=torch.tensor([0.7]),
+        logits=torch.rand(1, 16, 16),
+    )
+
+
+_CACHE_MISS_MESSAGE = (
+    "Attempted to use SAM3 model segment_with_visual_prompts(...) method providing "
+    "`image_hashes` for which no embeddings were found in the cache."
+)
+
+
+def test_segment_image_with_cached_image_id_skips_preprocessing(
+    adapter_module: ModuleType,
+) -> None:
+    # given
+    adapter = _build_adapter(adapter_module, _single_prediction())
+    adapter.preproc_image = MagicMock()
+
+    # when
+    adapter.segment_image(image=object(), image_id="abc")
+
+    # then
+    adapter.preproc_image.assert_not_called()
+    adapter._model.segment_with_visual_prompts.assert_called_once()
+    call_kwargs = adapter._model.segment_with_visual_prompts.call_args.kwargs
+    assert call_kwargs["images"] is None
+    assert call_kwargs["image_hashes"] == "abc"
+
+
+def test_segment_image_falls_back_to_preprocessing_on_cache_miss(
+    adapter_module: ModuleType,
+) -> None:
+    # given
+    adapter = _build_adapter(adapter_module, _single_prediction())
+    adapter._model.segment_with_visual_prompts.side_effect = [
+        adapter_module.ModelInputError(message=_CACHE_MISS_MESSAGE),
+        [_single_prediction()],
+    ]
+    loaded_image = object()
+    adapter.preproc_image = MagicMock(return_value=loaded_image)
+
+    # when
+    adapter.segment_image(image=object(), image_id="abc")
+
+    # then
+    adapter.preproc_image.assert_called_once()
+    assert adapter._model.segment_with_visual_prompts.call_count == 2
+    call_kwargs = adapter._model.segment_with_visual_prompts.call_args.kwargs
+    assert call_kwargs["images"] is loaded_image
+    assert call_kwargs["image_hashes"] == "abc"
+
+
+def test_segment_image_propagates_non_cache_miss_input_error(
+    adapter_module: ModuleType,
+) -> None:
+    # given
+    adapter = _build_adapter(adapter_module, _single_prediction())
+    adapter._model.segment_with_visual_prompts.side_effect = (
+        adapter_module.ModelInputError(message="invalid point shape")
+    )
+    adapter.preproc_image = MagicMock()
+
+    # when / then
+    with pytest.raises(adapter_module.ModelInputError):
+        adapter.segment_image(image=object(), image_id="abc")
+    adapter.preproc_image.assert_not_called()
+
+
+def test_adapter_init_keeps_caches_on_gpu(adapter_module: ModuleType) -> None:
+    # when
+    with patch.object(
+        adapter_module.Sam3ImageEmbeddingsInMemoryCache, "init"
+    ) as emb_init, patch.object(
+        adapter_module.Sam3LowResolutionMasksInMemoryCache, "init"
+    ) as masks_init, patch.object(
+        adapter_module.AutoModel, "from_pretrained"
+    ), patch.object(
+        adapter_module, "get_extra_weights_provider_headers"
+    ):
+        adapter_module.InferenceModelsSAM3InteractiveAdapter(api_key="k")
+
+    # then
+    assert emb_init.call_args.kwargs["send_to_cpu"] is False
+    assert masks_init.call_args.kwargs["send_to_cpu"] is False

--- a/tests/inference/unit_tests/models/test_sam3_visual_segmentation.py
+++ b/tests/inference/unit_tests/models/test_sam3_visual_segmentation.py
@@ -212,7 +212,10 @@ def test_segment_image_propagates_non_cache_miss_input_error(
     adapter.preproc_image.assert_not_called()
 
 
-def test_adapter_init_keeps_caches_on_gpu(adapter_module: ModuleType) -> None:
+@pytest.mark.parametrize("send_to_cpu", [True, False])
+def test_adapter_init_honors_cache_device_setting(
+    adapter_module: ModuleType, send_to_cpu: bool
+) -> None:
     # when
     with patch.object(
         adapter_module.Sam3ImageEmbeddingsInMemoryCache, "init"
@@ -222,9 +225,11 @@ def test_adapter_init_keeps_caches_on_gpu(adapter_module: ModuleType) -> None:
         adapter_module.AutoModel, "from_pretrained"
     ), patch.object(
         adapter_module, "get_extra_weights_provider_headers"
+    ), patch.object(
+        adapter_module, "SAM3_INTERACTIVE_CACHE_SEND_TO_CPU", send_to_cpu
     ):
         adapter_module.InferenceModelsSAM3InteractiveAdapter(api_key="k")
 
     # then
-    assert emb_init.call_args.kwargs["send_to_cpu"] is False
-    assert masks_init.call_args.kwargs["send_to_cpu"] is False
+    assert emb_init.call_args.kwargs["send_to_cpu"] is send_to_cpu
+    assert masks_init.call_args.kwargs["send_to_cpu"] is send_to_cpu


### PR DESCRIPTION
## What does this PR do?

This change restores the SAM3 interactive fast path for repeated clicks. When
  image_id is provided, the adapter now tries cached embeddings before decoding/
  preprocessing the image, falling back to image input only on cache miss.

  It also keeps SAM3 interactive embedding/logit caches on GPU to match legacy click
  latency behavior, and adds unit coverage for cache hit, cache miss fallback, error
  propagation, and cache placement.

## Type of Change

- Bug fix (non-breaking change that fixes an issue)

## Testing

- [ ] I have tested this change

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)

## Additional Context

<!-- Add any other context, screenshots, or notes about the PR here -->
