### PR TITLE
Enhance Triton JIT exception handling in RF-DETR model

### DIFF
--- a/inference_models/inference_models/models/rfdetr/triton_jit_fallback.py
+++ b/inference_models/inference_models/models/rfdetr/triton_jit_fallback.py
@@ -8,13 +8,23 @@ from typing import Set
 
 logger = logging.getLogger(__name__)
 
+_triton_jit_exception_types: list[type[BaseException]] = []
+
 try:
     from triton.runtime.errors import OutOfResources as _OutOfResources
+
+    _triton_jit_exception_types.append(_OutOfResources)
+except ImportError:  # pragma: no cover - optional at import time
+    pass
+
+try:
     from triton.runtime.errors import PTXASError as _PTXASError
 
-    _TRITON_JIT_EXCEPTION_TYPES = (_PTXASError, _OutOfResources)
+    _triton_jit_exception_types.append(_PTXASError)
 except ImportError:  # pragma: no cover - optional at import time
-    _TRITON_JIT_EXCEPTION_TYPES = ()
+    pass
+
+_TRITON_JIT_EXCEPTION_TYPES = tuple(_triton_jit_exception_types)
 
 _RUNTIME_ERROR_MARKERS = (
     "c compiler",

--- a/inference_models/tests/unit_tests/models/rfdetr/test_triton_jit_fallback.py
+++ b/inference_models/tests/unit_tests/models/rfdetr/test_triton_jit_fallback.py
@@ -1,4 +1,7 @@
+import importlib
 import logging
+import sys
+from types import ModuleType
 
 import numpy as np
 import pytest
@@ -119,6 +122,67 @@ def test_is_triton_jit_failure_detects_out_of_resources_type() -> None:
     exc = OutOfResources(required=131072, limit=101376, name="shared memory")
 
     assert is_triton_jit_failure(exc)
+
+
+def _reload_triton_jit_fallback_with_fake_errors(
+    *,
+    monkeypatch: pytest.MonkeyPatch,
+    error_classes: dict[str, type[BaseException]],
+):
+    fake_errors = ModuleType("triton.runtime.errors")
+    for name, cls in error_classes.items():
+        setattr(fake_errors, name, cls)
+
+    fake_runtime = ModuleType("triton.runtime")
+    fake_runtime.errors = fake_errors
+    fake_triton = ModuleType("triton")
+    fake_triton.runtime = fake_runtime
+
+    monkeypatch.setitem(sys.modules, "triton", fake_triton)
+    monkeypatch.setitem(sys.modules, "triton.runtime", fake_runtime)
+    monkeypatch.setitem(sys.modules, "triton.runtime.errors", fake_errors)
+
+    import inference_models.models.rfdetr.triton_jit_fallback as fallback_mod
+
+    reloaded_fallback_mod = importlib.reload(fallback_mod)
+
+    return reloaded_fallback_mod
+
+
+@pytest.fixture
+def triton_jit_fallback_module():
+    import inference_models.models.rfdetr.triton_jit_fallback as fallback_mod
+
+    yield fallback_mod
+
+    importlib.reload(fallback_mod)
+
+
+def test_triton_jit_exception_types_import_independently(
+    monkeypatch: pytest.MonkeyPatch,
+    triton_jit_fallback_module,
+) -> None:
+    class FakeOutOfResources(Exception):
+        pass
+
+    class FakePTXASError(Exception):
+        pass
+
+    fallback_mod = _reload_triton_jit_fallback_with_fake_errors(
+        monkeypatch=monkeypatch,
+        error_classes={"OutOfResources": FakeOutOfResources},
+    )
+
+    assert fallback_mod._TRITON_JIT_EXCEPTION_TYPES == (FakeOutOfResources,)
+    assert fallback_mod.is_triton_jit_failure(FakeOutOfResources())
+
+    fallback_mod = _reload_triton_jit_fallback_with_fake_errors(
+        monkeypatch=monkeypatch,
+        error_classes={"PTXASError": FakePTXASError},
+    )
+
+    assert fallback_mod._TRITON_JIT_EXCEPTION_TYPES == (FakePTXASError,)
+    assert fallback_mod.is_triton_jit_failure(FakePTXASError())
 
 
 def test_warn_triton_jit_fallback_logs_once(caplog: pytest.LogCaptureFixture) -> None:


### PR DESCRIPTION
## What does this PR do?

Follow-up to #2465 (commit `af9eda346`): Triton JIT fallback to the RF-DETR reference path on recognized compile-time failures.

`triton_jit_fallback.py` imported `OutOfResources` and `PTXASError` in a single `try` block. On Triton 3.2.0, `PTXASError` is absent while `OutOfResources` is present, so the combined import failed and `_TRITON_JIT_EXCEPTION_TYPES` was left empty. That broke fallback for typed `OutOfResources` exceptions (shared-memory / register-limit JIT failures), which are not `RuntimeError` instances and therefore were not caught by the message-marker path.

This PR imports each Triton exception class independently and builds `_TRITON_JIT_EXCEPTION_TYPES` from whichever symbols are available at import time. `is_triton_jit_failure()` behavior is otherwise unchanged: recognized exception types are matched first, then `RuntimeError` messages containing known JIT markers (`"c compiler"`, `"ptxas"`, `"out of resource"`, etc.).

**Main elements:**
- `inference_models/models/rfdetr/triton_jit_fallback.py` — independent optional imports for `OutOfResources` and `PTXASError`
- `inference_models/tests/unit_tests/models/rfdetr/test_triton_jit_fallback.py` — import-matrix test via module reload with fake `triton.runtime.errors`

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other:

## Testing

### Unit tests

- `test_triton_jit_exception_types_import_independently` — reloads `triton_jit_fallback` with fake Triton error modules where only `OutOfResources` or only `PTXASError` exists, asserting each is registered independently
- Existing `test_triton_jit_fallback.py` coverage retained (message markers, warn-once logging, preprocess/postprocess fallback paths)

### Integration tests

- None for this PR.

### Other

```bash
pytest inference_models/tests/unit_tests/models/rfdetr/test_triton_jit_fallback.py -v
```

Result: 7 passed, 2 skipped (CUDA / Triton not available locally).

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [ ] I have updated the documentation accordingly (if applicable)

## Additional Context

- Affects only opt-in RF-DETR Triton preprocess/postprocess paths behind existing flags; no API shape changes.
- Realistic failure mode: Triton kernel JIT hits hardware resource limits → `OutOfResources` raised → should fall back to reference implementation instead of crashing inference.
- Prior automated review flagged `test_is_triton_jit_failure_detects_out_of_resources_type` failing on Triton 3.2.0; the import-matrix test covers that scenario without requiring a specific Triton install in CI.
