### PR TITLE
Set ERROR state and emit poison pill on video source failures so recovery fires

### DIFF
--- a/inference/core/interfaces/camera/video_source.py
+++ b/inference/core/interfaces/camera/video_source.py
@@ -609,31 +609,37 @@ class VideoSource:
 
     def _start(self) -> None:
         self._change_state(target_state=StreamState.INITIALISING)
-        if callable(self._stream_reference):
-            self._video = self._stream_reference()
-        elif _is_test_pattern_reference(self._stream_reference):
-            from inference.core.interfaces.camera.test_pattern_producer import (
-                TestPatternStreamProducer,
-            )
+        try:
+            if callable(self._stream_reference):
+                self._video = self._stream_reference()
+            elif _is_test_pattern_reference(self._stream_reference):
+                from inference.core.interfaces.camera.test_pattern_producer import (
+                    TestPatternStreamProducer,
+                )
 
-            self._video = TestPatternStreamProducer()
-        else:
-            self._video = CV2VideoFrameProducer(self._stream_reference)
-        if not self._video.isOpened():
+                self._video = TestPatternStreamProducer()
+            else:
+                self._video = CV2VideoFrameProducer(self._stream_reference)
+            if not self._video.isOpened():
+                raise SourceConnectionError(
+                    f"Cannot connect to video source under reference: {self._stream_reference}"
+                )
+            self._video.initialize_source_properties(self._video_source_properties)
+            self._source_properties = self._video.discover_source_properties()
+            self._video_consumer.reset(source_properties=self._source_properties)
+            if self._source_properties.is_file:
+                self._set_file_mode_consumption_strategies()
+            else:
+                self._set_stream_mode_consumption_strategies()
+            self._playback_allowed.set()
+            self._stream_consumption_thread = Thread(target=self._consume_video)
+            self._stream_consumption_thread.start()
+        except Exception:
+            # Any startup failure (factory raises, cannot connect, property
+            # discovery fails) leaves the source in ERROR, not INITIALISING, so
+            # recovery (which keys off ERROR) fires. Re-raise for the caller.
             self._change_state(target_state=StreamState.ERROR)
-            raise SourceConnectionError(
-                f"Cannot connect to video source under reference: {self._stream_reference}"
-            )
-        self._video.initialize_source_properties(self._video_source_properties)
-        self._source_properties = self._video.discover_source_properties()
-        self._video_consumer.reset(source_properties=self._source_properties)
-        if self._source_properties.is_file:
-            self._set_file_mode_consumption_strategies()
-        else:
-            self._set_stream_mode_consumption_strategies()
-        self._playback_allowed.set()
-        self._stream_consumption_thread = Thread(target=self._consume_video)
-        self._stream_consumption_thread.start()
+            raise
 
     def _terminate(
         self, wait_on_frames_consumption: bool, purge_frames_buffer: bool
@@ -717,6 +723,10 @@ class VideoSource:
             logger.info(f"Video consumption finished")
         except Exception as error:
             self._change_state(target_state=StreamState.ERROR)
+            # Emit a poison pill so a consumer blocked on read_frame gets
+            # end-of-stream instead of timing out forever; ERROR is
+            # restart-eligible, so reconnection fires.
+            self._frames_buffer.put(POISON_PILL)
             payload = {
                 "source_id": self._source_id,
                 "error_type": error.__class__.__name__,

--- a/tests/inference/unit_tests/core/interfaces/camera/test_video_source.py
+++ b/tests/inference/unit_tests/core/interfaces/camera/test_video_source.py
@@ -1372,3 +1372,52 @@ def test_source_properties_initialized_on_video_source_using_string_values(
         ],
         any_order=True,
     )
+
+
+def test_video_source_sets_error_state_when_producer_factory_raises() -> None:
+    # given - a callable producer reference whose construction fails (e.g. a
+    # camera __init__ that blocks out or raises), which must land the source in
+    # ERROR so recovery (which keys off ERROR) can fire.
+    def failing_factory():
+        raise RuntimeError("camera busy")
+
+    source = VideoSource.init(video_reference=failing_factory)
+
+    # when
+    with pytest.raises(RuntimeError):
+        source.start()
+
+    # then
+    assert (
+        source.describe_source().state is StreamState.ERROR
+    ), "A failed producer construction must land the source in ERROR, not INITIALISING"
+
+
+def test_consume_video_emits_poison_pill_on_consume_error() -> None:
+    # given - a source whose consume thread crashes mid-stream
+    from inference.core.interfaces.camera.exceptions import EndOfStreamError
+
+    source = VideoSource.init(video_reference="dummy")
+    source._video = MagicMock()
+    source._video.isOpened.return_value = True
+    source._source_properties = SourceProperties(
+        width=100,
+        height=100,
+        total_frames=-1,
+        is_file=False,
+        fps=30,
+        timestamp_created=None,
+    )
+    source._video_consumer = MagicMock()
+    source._video_consumer.consume_frame.side_effect = RuntimeError("decode blew up")
+    source._playback_allowed.set()
+
+    # when - run the consume loop body directly (it owns the except handler)
+    source._consume_video()
+
+    # then - state went ERROR and a poison pill is queued so a blocked consumer
+    # gets EndOfStreamError (and the multiplexer can reconnect) instead of
+    # timing out forever.
+    assert source._state is StreamState.ERROR
+    with pytest.raises(EndOfStreamError):
+        source.read_frame(timeout=0.0)


### PR DESCRIPTION
## Problem

A `VideoSource` could be left silently wedged so that downstream reconnection (which keys off `ERROR` / end-of-stream) never triggered:

- **`_start()`** left the source in `INITIALISING` rather than `ERROR` when the producer factory raised, the source could not connect, or property discovery failed — while the exception propagated. The docstring already promises `ERROR` on connection failure; only the `isOpened()` path honored it.
- **`_consume_video()`** set `ERROR` on a consume-thread crash but never put a `POISON_PILL`, so a consumer blocked on `read_frame` timed out forever (returning `None`) and the multiplexer never saw end-of-stream to reconnect. `ERROR` is restart-eligible, so the reconnection path should fire.

This is the inference-layer half of a stuck-camera incident: a Basler producer whose `__init__` blocks out (camera "in use") leaves the pipeline stuck in `INITIALISING`/serving a frozen frame with no recovery.

## Fix

- Wrap the `_start()` startup body so any failure transitions to `ERROR` before re-raising.
- Emit a `POISON_PILL` in the `_consume_video()` error branch so blocked consumers get `EndOfStreamError` and reconnection runs.

## Tests

Adds two unit tests (producer-factory-raises → `ERROR`; consume crash → poison pill + `ERROR`). Full `test_video_source.py` suite passes (48).

> Needs on-hardware validation with real cameras before relying on it in production.