### PR TITLE
Add mask_format attribute to InstanceSegmentationPredictionDC

### DIFF
--- a/inference/core/entities/responses/inference.py
+++ b/inference/core/entities/responses/inference.py
@@ -303,6 +303,7 @@ class InstanceSegmentationPredictionDC:
     class_name: str  # serialized as "class" in the dict form
     class_id: int
     points: list  # list[PointDC]
+    mask_format: Literal["polygon"] = "polygon"
     detection_id: str = field(default_factory=lambda: str(uuid4()))
     parent_id: object = None
     class_confidence: object = None
@@ -337,6 +338,7 @@ def _is_pred_dc_to_dict(p: InstanceSegmentationPredictionDC) -> dict:
         "class_id": p.class_id,
         "detection_id": p.detection_id,
         "points": [{"x": pt.x, "y": pt.y} for pt in p.points],
+        "mask_format": p.mask_format,
     }
     if p.class_confidence is not None:
         d["class_confidence"] = p.class_confidence

--- a/tests/inference/unit_tests/core/entities/test_inference_response_dc.py
+++ b/tests/inference/unit_tests/core/entities/test_inference_response_dc.py
@@ -1,0 +1,159 @@
+import pytest
+
+from inference.core.entities.responses.inference import (
+    InferenceResponseImage,
+    InferenceResponseImageDC,
+    InstanceSegmentationInferenceResponse,
+    InstanceSegmentationInferenceResponseDC,
+    InstanceSegmentationPrediction,
+    InstanceSegmentationPredictionDC,
+    Point,
+    PointDC,
+    _is_pred_dc_to_dict,
+    _is_response_dc_to_dict,
+)
+
+
+def _pydantic_prediction(
+    *,
+    class_name: str = "car",
+    detection_id: str = "detection-1",
+    optional_fields: dict | None = None,
+) -> InstanceSegmentationPrediction:
+    fields = {
+        "x": 1.0,
+        "y": 2.0,
+        "width": 3.0,
+        "height": 4.0,
+        "confidence": 0.9,
+        "class_id": 1,
+        "points": [Point(x=1.0, y=2.0), Point(x=3.0, y=4.0)],
+        "detection_id": detection_id,
+        **{"class": class_name},
+    }
+    if optional_fields:
+        fields.update(optional_fields)
+    return InstanceSegmentationPrediction(**fields)
+
+
+def _dc_prediction(
+    *,
+    class_name: str = "car",
+    detection_id: str = "detection-1",
+    optional_fields: dict | None = None,
+) -> InstanceSegmentationPredictionDC:
+    fields = {
+        "x": 1.0,
+        "y": 2.0,
+        "width": 3.0,
+        "height": 4.0,
+        "confidence": 0.9,
+        "class_name": class_name,
+        "class_id": 1,
+        "points": [PointDC(x=1.0, y=2.0), PointDC(x=3.0, y=4.0)],
+        "detection_id": detection_id,
+    }
+    if optional_fields:
+        fields.update(optional_fields)
+    return InstanceSegmentationPredictionDC(**fields)
+
+
+def _pydantic_response(
+    predictions: list[InstanceSegmentationPrediction],
+    *,
+    inference_id: str | None = "inference-1",
+    frame_id: int | None = 1,
+    time: float | None = 0.01,
+) -> InstanceSegmentationInferenceResponse:
+    return InstanceSegmentationInferenceResponse(
+        predictions=predictions,
+        image=InferenceResponseImage(width=640, height=480),
+        inference_id=inference_id,
+        frame_id=frame_id,
+        time=time,
+    )
+
+
+def _dc_response(
+    predictions: list[InstanceSegmentationPredictionDC],
+    *,
+    inference_id: str | None = "inference-1",
+    frame_id: int | None = 1,
+    time: float | None = 0.01,
+) -> InstanceSegmentationInferenceResponseDC:
+    return InstanceSegmentationInferenceResponseDC(
+        predictions=predictions,
+        image=InferenceResponseImageDC(width=640, height=480),
+        inference_id=inference_id,
+        frame_id=frame_id,
+        time=time,
+    )
+
+
+@pytest.mark.parametrize(
+    "optional_prediction_fields",
+    [
+        {},
+        {"parent_id": "parent-1", "class_confidence": 0.8},
+    ],
+    ids=["minimal", "with_optional_fields"],
+)
+def test_instance_segmentation_dc_dump_matches_pydantic_model_dump(
+    optional_prediction_fields: dict,
+) -> None:
+    dc_response = _dc_response(
+        predictions=[_dc_prediction(optional_fields=optional_prediction_fields)]
+    )
+    pydantic_response = _pydantic_response(
+        predictions=[_pydantic_prediction(optional_fields=optional_prediction_fields)]
+    )
+
+    assert _is_response_dc_to_dict(dc_response) == pydantic_response.model_dump(
+        by_alias=True,
+        exclude_none=True,
+    )
+
+
+def test_instance_segmentation_dc_dump_matches_pydantic_empty_predictions() -> None:
+    dc_response = _dc_response(predictions=[])
+    pydantic_response = _pydantic_response(predictions=[])
+
+    assert _is_response_dc_to_dict(dc_response) == pydantic_response.model_dump(
+        by_alias=True,
+        exclude_none=True,
+    )
+
+
+def test_is_pred_dc_to_dict_includes_mask_format_even_when_default() -> None:
+    prediction = _dc_prediction()
+
+    result = _is_pred_dc_to_dict(prediction)
+
+    assert result["mask_format"] == "polygon"
+
+
+def test_workflow_dc_path_emits_mask_format_in_prediction_dicts() -> None:
+    # Mirrors InstanceSegmentationPredictionDC construction in
+    # InferenceModelsInstanceSegmentationAdapter._build_responses_from_detections.
+    response = InstanceSegmentationInferenceResponseDC(
+        predictions=[
+            InstanceSegmentationPredictionDC(
+                x=10.0,
+                y=20.0,
+                width=30.0,
+                height=40.0,
+                confidence=0.95,
+                class_name="person",
+                class_id=0,
+                points=[PointDC(x=1.0, y=2.0), PointDC(x=3.0, y=4.0)],
+            )
+        ],
+        image=InferenceResponseImageDC(width=640, height=480),
+    )
+
+    dumped = _is_response_dc_to_dict(response)
+
+    assert all(
+        prediction["mask_format"] == "polygon"
+        for prediction in dumped["predictions"]
+    )


### PR DESCRIPTION
## What does this PR do?

Part of the RF-DETR stream-pipeline review follow-ups for `codeflash-rfdetr-seg-optimization` (review item 1 from PR #2464 / #2476).

The workflow fast path builds `InstanceSegmentationPredictionDC` responses and serializes them with `_is_pred_dc_to_dict` / `_is_response_dc_to_dict`, claiming bit-equivalence with the pydantic `model_dump(by_alias=True, exclude_none=True)` output. That contract was violated: pydantic’s `InstanceSegmentationPrediction` always includes `"mask_format": "polygon"` (a non-`None` default), but the dataclass dict omitted the field entirely. Downstream workflow code today consumes polygon `points` and does not read `mask_format`, so this was a silent schema drift risk rather than an active parity failure — but it would break field-by-field comparisons and any future consumer that expects the full inference schema.

This PR adds `mask_format: Literal["polygon"] = "polygon"` to `InstanceSegmentationPredictionDC` and emits it from `_is_pred_dc_to_dict`. The workflow DC path only ever produces polygon masks (`points`), so the value is always `"polygon"`. No RLE dataclass twin is introduced; the RLE response path continues to use pydantic `model_dump`.

**Main elements:**
- `inference/core/entities/responses/inference.py` — `mask_format` on `InstanceSegmentationPredictionDC` and in `_is_pred_dc_to_dict`
- `tests/inference/unit_tests/core/entities/test_inference_response_dc.py` — parity and regression tests (new file)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other:

## Testing

### Unit tests

- `test_instance_segmentation_dc_dump_matches_pydantic_model_dump` — parametrized full-response parity (minimal required fields and with optional `parent_id` / `class_confidence`)
- `test_instance_segmentation_dc_dump_matches_pydantic_empty_predictions` — empty `predictions` list
- `test_is_pred_dc_to_dict_includes_mask_format_even_when_default` — explicit `mask_format` assertion on the field that regressed
- `test_workflow_dc_path_emits_mask_format_in_prediction_dicts` — adapter-style `InstanceSegmentationPredictionDC` construction through `_is_response_dc_to_dict`

### Integration tests

- None for this PR.

### Other

```bash
uv run pytest tests/inference/unit_tests/core/entities/test_inference_response_dc.py -q
# 5 passed
```

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where necessary, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have updated the documentation accordingly (if applicable)

## Additional Context

- **Base branch:** `codeflash-rfdetr-seg-optimization`
- **Branch:** `fix/mask-format-dc-parity`
- Scoped fix for review item 1 only; remaining stream-pipeline review items (Future resolvers, frame alignment, timeouts, etc.) are out of scope for this PR.
