### PR TITLE
Fix Batch-wrapped Future leak in workflow output construction

### DIFF
--- a/inference/core/workflows/execution_engine/v1/executor/execution_data_manager/step_input_assembler.py
+++ b/inference/core/workflows/execution_engine/v1/executor/execution_data_manager/step_input_assembler.py
@@ -1,4 +1,3 @@
-from concurrent.futures import Future
 from dataclasses import dataclass
 from typing import Any, Dict, Generator, List, Optional, Set, Tuple, TypeVar, Union
 
@@ -25,6 +24,11 @@ from inference.core.workflows.execution_engine.v1.executor.execution_data_manage
 from inference.core.workflows.execution_engine.v1.executor.execution_data_manager.execution_cache import (
     ExecutionCache,
 )
+from inference.core.workflows.execution_engine.v1.executor.utils import (
+    contains_future,
+    maybe_resolve_futures,
+    resolve_futures,
+)
 
 T = TypeVar("T")
 
@@ -42,40 +46,21 @@ class NonBatchModeSIMDStepInput:
 
 
 def _resolve_step_output_futures(value: Any) -> Any:
-    if isinstance(value, Future):
-        return _resolve_step_output_futures(value.result())
-    if isinstance(value, Batch):
-        return Batch.init(
-            content=[_resolve_step_output_futures(element) for element in value],
-            indices=value.indices,
-        )
-    if isinstance(value, list):
-        return [_resolve_step_output_futures(element) for element in value]
-    if isinstance(value, tuple):
-        return tuple(_resolve_step_output_futures(element) for element in value)
-    if isinstance(value, dict):
-        return {
-            key: _resolve_step_output_futures(element) for key, element in value.items()
-        }
-    return value
+    return resolve_futures(
+        value=value,
+        context="workflow_execution | step_input_assembling",
+    )
 
 
 def _step_output_contains_future(value: Any) -> bool:
-    if isinstance(value, Future):
-        return True
-    if isinstance(value, Batch):
-        return any(_step_output_contains_future(element) for element in value)
-    if isinstance(value, list) or isinstance(value, tuple):
-        return any(_step_output_contains_future(element) for element in value)
-    if isinstance(value, dict):
-        return any(_step_output_contains_future(element) for element in value.values())
-    return False
+    return contains_future(value=value)
 
 
 def _maybe_resolve_step_output_futures(value: Any) -> Any:
-    if not _step_output_contains_future(value):
-        return value
-    return _resolve_step_output_futures(value)
+    return maybe_resolve_futures(
+        value=value,
+        context="workflow_execution | step_input_assembling",
+    )
 
 
 def construct_non_simd_step_input(

--- a/inference/core/workflows/execution_engine/v1/executor/output_constructor.py
+++ b/inference/core/workflows/execution_engine/v1/executor/output_constructor.py
@@ -1,6 +1,5 @@
 import traceback
 from collections import defaultdict
-from concurrent.futures import Future
 from typing import Any, Callable, Dict, List, Optional, Set, Union
 
 import numpy as np
@@ -31,6 +30,11 @@ from inference.core.workflows.execution_engine.v1.executor.execution_data_manage
 )
 from inference.core.workflows.execution_engine.v1.executor.execution_data_manager.manager import (
     ExecutionDataManager,
+)
+from inference.core.workflows.execution_engine.v1.executor.utils import (
+    contains_future,
+    maybe_resolve_futures,
+    resolve_futures,
 )
 
 
@@ -325,31 +329,21 @@ def create_outputs_for_generated_lineage_outputs(
 
 
 def _resolve_output_futures(value: Any) -> Any:
-    if isinstance(value, Future):
-        return _resolve_output_futures(value.result())
-    if isinstance(value, list):
-        return [_resolve_output_futures(element) for element in value]
-    if isinstance(value, tuple):
-        return tuple(_resolve_output_futures(element) for element in value)
-    if isinstance(value, dict):
-        return {key: _resolve_output_futures(element) for key, element in value.items()}
-    return value
+    return resolve_futures(
+        value=value,
+        context="workflow_execution | output_construction",
+    )
 
 
 def _output_contains_future(value: Any) -> bool:
-    if isinstance(value, Future):
-        return True
-    if isinstance(value, (list, tuple)):
-        return any(_output_contains_future(element) for element in value)
-    if isinstance(value, dict):
-        return any(_output_contains_future(element) for element in value.values())
-    return False
+    return contains_future(value=value)
 
 
 def _maybe_resolve_output_futures(value: Any) -> Any:
-    if not _output_contains_future(value):
-        return value
-    return _resolve_output_futures(value)
+    return maybe_resolve_futures(
+        value=value,
+        context="workflow_execution | output_construction",
+    )
 
 
 def create_array(indices: np.ndarray) -> Optional[list]:

--- a/inference/core/workflows/execution_engine/v1/executor/utils.py
+++ b/inference/core/workflows/execution_engine/v1/executor/utils.py
@@ -1,5 +1,7 @@
-from concurrent.futures import ThreadPoolExecutor
-from typing import Callable, Generator, Iterable, List, Optional, TypeVar
+from concurrent.futures import Future, ThreadPoolExecutor
+from typing import Any, Callable, Generator, Iterable, List, Optional, TypeVar
+
+from inference.core.workflows.execution_engine.entities.base import Batch
 
 T = TypeVar("T")
 
@@ -35,3 +37,47 @@ def create_batches(
 
 def _run(fun: Callable[[], T]) -> T:
     return fun()
+
+
+def resolve_futures(
+    value: Any,
+    context: str = "workflow_execution | future_resolution",
+) -> Any:
+    if isinstance(value, Future):
+        return resolve_futures(value.result(), context=context)
+    if isinstance(value, Batch):
+        return Batch.init(
+            content=[resolve_futures(element, context=context) for element in value],
+            indices=value.indices,
+        )
+    if isinstance(value, list):
+        return [resolve_futures(element, context=context) for element in value]
+    if isinstance(value, tuple):
+        return tuple(resolve_futures(element, context=context) for element in value)
+    if isinstance(value, dict):
+        return {
+            key: resolve_futures(element, context=context)
+            for key, element in value.items()
+        }
+    return value
+
+
+def contains_future(value: Any) -> bool:
+    if isinstance(value, Future):
+        return True
+    if isinstance(value, Batch):
+        return any(contains_future(element) for element in value)
+    if isinstance(value, (list, tuple)):
+        return any(contains_future(element) for element in value)
+    if isinstance(value, dict):
+        return any(contains_future(element) for element in value.values())
+    return False
+
+
+def maybe_resolve_futures(
+    value: Any,
+    context: str = "workflow_execution | future_resolution",
+) -> Any:
+    if not contains_future(value):
+        return value
+    return resolve_futures(value=value, context=context)

--- a/tests/workflows/unit_tests/execution_engine/executor/test_future_resolution_utils.py
+++ b/tests/workflows/unit_tests/execution_engine/executor/test_future_resolution_utils.py
@@ -1,0 +1,81 @@
+from concurrent.futures import Future
+
+import pytest
+
+from inference.core.workflows.execution_engine.entities.base import Batch
+from inference.core.workflows.execution_engine.v1.executor.utils import (
+    contains_future,
+    maybe_resolve_futures,
+    resolve_futures,
+)
+
+
+def _completed_future(value):
+    future = Future()
+    future.set_result(value)
+    return future
+
+
+def _failed_future(error):
+    future = Future()
+    future.set_exception(error)
+    return future
+
+
+def test_contains_future_detects_future_inside_batch() -> None:
+    batch = Batch.init(content=[_completed_future("resolved")], indices=[(0,)])
+
+    assert contains_future(batch) is True
+
+
+def test_contains_future_returns_false_for_resolved_batch() -> None:
+    batch = Batch.init(content=["resolved"], indices=[(0,)])
+
+    assert contains_future(batch) is False
+
+
+def test_resolve_futures_resolves_future_inside_batch() -> None:
+    batch = Batch.init(
+        content=[_completed_future("first"), _completed_future("second")],
+        indices=[(0,), (1,)],
+    )
+
+    resolved = resolve_futures(batch)
+
+    assert isinstance(resolved, Batch)
+    assert list(resolved) == ["first", "second"]
+    assert resolved.indices == [(0,), (1,)]
+
+
+def test_resolve_futures_resolves_batch_nested_in_dict() -> None:
+    value = {
+        "predictions": Batch.init(
+            content=[_completed_future({"frame": 0})],
+            indices=[(0,)],
+        )
+    }
+
+    resolved = resolve_futures(value)
+
+    resolved_batch = resolved["predictions"]
+    assert isinstance(resolved_batch, Batch)
+    assert list(resolved_batch) == [{"frame": 0}]
+    assert resolved_batch.indices == [(0,)]
+
+
+def test_maybe_resolve_futures_is_noop_without_futures() -> None:
+    value = Batch.init(content=[{"frame": 0}], indices=[(0,)])
+
+    resolved = maybe_resolve_futures(value)
+
+    assert resolved is value
+
+
+def test_resolve_futures_propagates_future_exception() -> None:
+    resolution_error = RuntimeError("future resolution failed")
+    batch = Batch.init(content=[_failed_future(resolution_error)], indices=[(0,)])
+
+    with pytest.raises(RuntimeError) as error_info:
+        resolve_futures(batch)
+
+    assert error_info.value is resolution_error

--- a/tests/workflows/unit_tests/execution_engine/executor/test_output_constructor.py
+++ b/tests/workflows/unit_tests/execution_engine/executor/test_output_constructor.py
@@ -13,7 +13,7 @@ from inference.core.workflows.execution_engine.constants import (
     TOP_LEVEL_LINEAGES_KEY,
     WORKFLOW_INPUT_BATCH_LINEAGE_ID,
 )
-from inference.core.workflows.execution_engine.entities.base import JsonField
+from inference.core.workflows.execution_engine.entities.base import Batch, JsonField
 from inference.core.workflows.execution_engine.entities.types import (
     IMAGE_KIND,
     INTEGER_KIND,
@@ -31,6 +31,7 @@ from inference.core.workflows.execution_engine.v1.executor.output_constructor im
     place_data_in_array,
     serialize_data_piece,
 )
+from inference.core.workflows.execution_engine.v1.executor.utils import contains_future
 
 
 def _completed_future(value: Any) -> Future:
@@ -475,6 +476,45 @@ def test_construct_workflow_output_resolves_futures_by_default() -> None:
     assert result == [{"a": {"predictions": ["resolved"]}}]
 
 
+def test_construct_workflow_output_resolves_batch_wrapped_futures() -> None:
+    # given
+    execution_data_manager = MagicMock()
+    workflow_outputs = [
+        JsonField(type="JsonField", name="a", selector="$steps.some.a"),
+    ]
+    execution_graph = DiGraph()
+    execution_graph.add_node(
+        "$outputs.a",
+        node_compilation_output=OutputNode(
+            node_category=NodeCategory.OUTPUT_NODE,
+            name=workflow_outputs[0].name,
+            selector=workflow_outputs[0].selector,
+            data_lineage=[],
+            output_manifest=workflow_outputs[0],
+        ),
+    )
+    execution_data_manager.get_selector_indices.return_value = None
+    execution_data_manager.get_non_batch_data.return_value = Batch.init(
+        content=[_completed_future("resolved")],
+        indices=[(0,)],
+    )
+
+    # when
+    result = construct_workflow_output(
+        workflow_outputs=workflow_outputs,
+        execution_graph=execution_graph,
+        execution_data_manager=execution_data_manager,
+        serialize_results=False,
+        kinds_serializers=KINDS_SERIALIZERS,
+    )
+
+    # then
+    resolved_batch = result[0]["a"]
+    assert isinstance(resolved_batch, Batch)
+    assert list(resolved_batch) == ["resolved"]
+    assert resolved_batch.indices == [(0,)]
+
+
 def test_construct_workflow_output_can_defer_future_resolution() -> None:
     # given
     execution_data_manager = MagicMock()
@@ -508,6 +548,45 @@ def test_construct_workflow_output_can_defer_future_resolution() -> None:
 
     # then
     assert result == [{"a": {"predictions": predictions}}]
+
+
+def test_construct_workflow_output_defers_batch_wrapped_futures() -> None:
+    # given
+    execution_data_manager = MagicMock()
+    workflow_outputs = [
+        JsonField(type="JsonField", name="a", selector="$steps.some.a"),
+    ]
+    execution_graph = DiGraph()
+    execution_graph.add_node(
+        "$outputs.a",
+        node_compilation_output=OutputNode(
+            node_category=NodeCategory.OUTPUT_NODE,
+            name=workflow_outputs[0].name,
+            selector=workflow_outputs[0].selector,
+            data_lineage=[],
+            output_manifest=workflow_outputs[0],
+        ),
+    )
+    deferred_batch = Batch.init(
+        content=[_completed_future("resolved")],
+        indices=[(0,)],
+    )
+    execution_data_manager.get_selector_indices.return_value = None
+    execution_data_manager.get_non_batch_data.return_value = deferred_batch
+
+    # when
+    result = construct_workflow_output(
+        workflow_outputs=workflow_outputs,
+        execution_graph=execution_graph,
+        execution_data_manager=execution_data_manager,
+        serialize_results=False,
+        kinds_serializers=KINDS_SERIALIZERS,
+        resolve_output_futures=False,
+    )
+
+    # then
+    assert result == [{"a": deferred_batch}]
+    assert contains_future(result[0]["a"]) is True
 
 
 def test_construct_workflow_output_when_batch_outputs_present() -> None:


### PR DESCRIPTION
## What does this PR do?

Part of the RF-DETR stream-pipeline review follow-ups for `codeflash-rfdetr-seg-optimization` (review item 2 from PR #2464 / #2476).

Workflow steps can return deferred results as `concurrent.futures.Future` objects. Before a value leaves the execution engine, those futures must be detected and resolved recursively. Two near-identical helper trios existed — in `step_input_assembler.py` and `output_constructor.py` — and they had diverged: the step-input copy handled `Batch`, the output copy did not. Because `Batch` is not a `list` subclass, a `Future` nested inside a `Batch` reaching `output_constructor` was reported as "no future" and could leak unresolved into the final workflow output.

This PR centralizes future detection and resolution in `executor/utils.py` (`contains_future`, `resolve_futures`, `maybe_resolve_futures`) with `Batch`-aware recursion, and wires both call sites to the shared helpers. The step-input path behavior is unchanged; the output path now correctly resolves `Batch`-wrapped futures. Timeouts on `.result()` (review item 4) are intentionally out of scope for this PR.

**Main elements:**
- `inference/core/workflows/execution_engine/v1/executor/utils.py` — shared `contains_future` / `resolve_futures` / `maybe_resolve_futures`
- `inference/core/workflows/execution_engine/v1/executor/execution_data_manager/step_input_assembler.py` — delegates to shared helpers
- `inference/core/workflows/execution_engine/v1/executor/output_constructor.py` — delegates to shared helpers
- `tests/workflows/unit_tests/execution_engine/executor/test_future_resolution_utils.py` — direct unit tests for shared helpers (new file)
- `tests/workflows/unit_tests/execution_engine/executor/test_output_constructor.py` — integration tests for resolve and defer paths with `Batch[Future]`

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other:

## Testing

### Unit tests

- `test_future_resolution_utils.py` — `contains_future` / `resolve_futures` / `maybe_resolve_futures` with `Batch`, nested `Batch` in `dict`, no-op without futures, exception propagation
- `test_construct_workflow_output_resolves_batch_wrapped_futures` — `construct_workflow_output` resolves `Batch[Future]` by default
- `test_construct_workflow_output_defers_batch_wrapped_futures` — `resolve_output_futures=False` leaves `Future` inside `Batch` (defer contract)
- Existing `test_step_output_future_resolution.py` — regression guard for step-input path after deduplication

### Integration tests

- None for this PR.

### Other

```bash
PYTHONPATH="inference_models:${PYTHONPATH}" uv run pytest \
  tests/workflows/unit_tests/execution_engine/executor/test_future_resolution_utils.py \
  tests/workflows/unit_tests/execution_engine/executor/test_output_constructor.py::test_construct_workflow_output_resolves_batch_wrapped_futures \
  tests/workflows/unit_tests/execution_engine/executor/test_output_constructor.py::test_construct_workflow_output_defers_batch_wrapped_futures \
  tests/workflows/unit_tests/execution_engine/executor/execution_data_manager/test_step_output_future_resolution.py \
  -q
# 13 passed
```

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where necessary, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have updated the documentation accordingly (if applicable)

## Additional Context

- **Base branch:** `codeflash-rfdetr-seg-optimization`
- **Branch:** `fix/batch-wrapped-future-resolution`
- Scoped fix for review item 2 only. Future `.result()` timeouts (item 4) will build on the shared `resolve_futures` helper in a follow-up PR.
