### PR TITLE
[codex] Make OWLv2 cache CPU offload configurable

### DIFF
--- a/inference/core/env.py
+++ b/inference/core/env.py
@@ -115,6 +115,9 @@ OWLV2_IMAGE_CACHE_SIZE = int(os.getenv("OWLV2_IMAGE_CACHE_SIZE", 10000))
 # OWLv2 model cache size, default is 100 as memory is num_prompts * ~4kb and num_prompts is rarely above 1000 (but could be much higher)
 OWLV2_MODEL_CACHE_SIZE = int(os.getenv("OWLV2_MODEL_CACHE_SIZE", 100))
 
+# OWLv2 cache device placement, default sends cached embeddings to CPU to reduce GPU memory pressure
+OWLV2_CACHE_SEND_TO_CPU = str2bool(os.getenv("OWLV2_CACHE_SEND_TO_CPU", True))
+
 # OWLv2 CPU image cache size, default is 10000
 OWLV2_CPU_IMAGE_CACHE_SIZE = int(os.getenv("OWLV2_CPU_IMAGE_CACHE_SIZE", 1000))
 

--- a/inference/models/owlv2/owlv2_inference_models.py
+++ b/inference/models/owlv2/owlv2_inference_models.py
@@ -18,6 +18,7 @@ from inference.core.env import (
     API_KEY,
     DISABLED_INFERENCE_MODELS_BACKENDS,
     MAX_DETECTIONS,
+    OWLV2_CACHE_SEND_TO_CPU,
     OWLV2_COMPILE_MODEL,
     OWLV2_IMAGE_CACHE_SIZE,
     OWLV2_MODEL_CACHE_SIZE,
@@ -65,11 +66,11 @@ class Owlv2AdapterSingleton:
         if huggingface_id not in cls._instances:
             owlv2_class_embeddings_cache = InMemoryOwlV2ClassEmbeddingsCache.init(
                 size_limit=OWLV2_MODEL_CACHE_SIZE,
-                send_to_cpu=True,
+                send_to_cpu=OWLV2_CACHE_SEND_TO_CPU,
             )
             owlv2_images_embeddings_cache = InMemoryOwlV2ImageEmbeddingsCache.init(
                 size_limit=OWLV2_IMAGE_CACHE_SIZE,
-                send_to_cpu=True,
+                send_to_cpu=OWLV2_CACHE_SEND_TO_CPU,
             )
             weights_provider_extra_headers = get_extra_weights_provider_headers()
             if (

--- a/tests/inference/unit_tests/models/test_owlv2_inference_models.py
+++ b/tests/inference/unit_tests/models/test_owlv2_inference_models.py
@@ -1,0 +1,33 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from inference.models.owlv2 import owlv2_inference_models
+
+
+@pytest.mark.parametrize("send_to_cpu", [True, False])
+def test_adapter_singleton_honors_cache_device_setting(send_to_cpu: bool) -> None:
+    owlv2_inference_models.Owlv2AdapterSingleton._instances.clear()
+    owlv2_inference_models.PRELOADED_HF_MODELS.clear()
+
+    with patch.object(
+        owlv2_inference_models.InMemoryOwlV2ClassEmbeddingsCache, "init"
+    ) as class_cache_init, patch.object(
+        owlv2_inference_models.InMemoryOwlV2ImageEmbeddingsCache, "init"
+    ) as image_cache_init, patch.object(
+        owlv2_inference_models.AutoModel,
+        "from_pretrained",
+        return_value=MagicMock(),
+    ), patch.object(
+        owlv2_inference_models, "get_extra_weights_provider_headers", return_value=None
+    ), patch.object(
+        owlv2_inference_models, "OWLV2_CACHE_SEND_TO_CPU", send_to_cpu
+    ), patch.object(
+        owlv2_inference_models, "OWLV2_COMPILE_MODEL", False
+    ):
+        owlv2_inference_models.Owlv2AdapterSingleton(
+            f"owlv2/test-cache-device-{send_to_cpu}", api_key="test-key"
+        )
+
+    assert class_cache_init.call_args.kwargs["send_to_cpu"] is send_to_cpu
+    assert image_cache_init.call_args.kwargs["send_to_cpu"] is send_to_cpu


### PR DESCRIPTION
## Summary

- adds `OWLV2_CACHE_SEND_TO_CPU`
- wires the flag into the inference-models OWLv2 class and image embedding caches
- adds a unit test covering both cache placement settings

## Why

The inference-models OWLv2 adapter always sent cached embeddings to CPU. That preserves GPU memory, but warm cache hits still pay host-to-device copy cost. This makes the behavior configurable so serverless GPU pools can keep OWLv2 caches resident on GPU when latency is more important than cache memory pressure.

The default remains `True`, matching current behavior.

## Validation

- `git diff --check`
- `/Users/hansent/code/inference/.venv/bin/python -m pytest tests/inference/unit_tests/models/test_owlv2_inference_models.py`
- `/Users/hansent/code/inference/.venv/bin/python -m black --check inference/core/env.py inference/models/owlv2/owlv2_inference_models.py tests/inference/unit_tests/models/test_owlv2_inference_models.py`
- `/Users/hansent/code/inference/.venv/bin/python -m isort --check-only inference/core/env.py inference/models/owlv2/owlv2_inference_models.py tests/inference/unit_tests/models/test_owlv2_inference_models.py`

## Deployment Note

Once this lands in an inference image, serverless can opt into the latency path by setting `OWLV2_CACHE_SEND_TO_CPU=False` on the OWLv2-serving GPU consumer pool.
