### PR TITLE
Pair async RF-DETR stream responses with frame context by id

### DIFF
--- a/inference/core/entities/requests/inference.py
+++ b/inference/core/entities/requests/inference.py
@@ -28,6 +28,14 @@ class BaseRequest(BaseModel):
     start: Optional[float] = None
     source: Optional[str] = None
     source_info: Optional[str] = None
+    stream_pipeline_context_id: Optional[str] = Field(
+        default=None,
+        exclude=True,
+        repr=False,
+        description=(
+            "Internal stream-pipeline frame pairing id. Not part of the public API."
+        ),
+    )
     disable_model_monitoring: Optional[bool] = Field(
         default=False, description="If true, disables model monitoring for this request"
     )

--- a/inference/core/entities/responses/inference.py
+++ b/inference/core/entities/responses/inference.py
@@ -324,6 +324,7 @@ class InstanceSegmentationInferenceResponseDC:
     # response future through Model.infer_from_request without blocking the
     # inference thread. `_is_response_dc_to_dict` intentionally ignores it.
     _async_response_future: object = None
+    _async_response_context_id: object = None
 
 
 def _is_pred_dc_to_dict(p: InstanceSegmentationPredictionDC) -> dict:

--- a/inference/core/models/base.py
+++ b/inference/core/models/base.py
@@ -141,6 +141,11 @@ class Model(BaseInference):
         """
         t1 = perf_counter()
         kwargs = request.dict()
+        stream_pipeline_context_id = getattr(
+            request, "stream_pipeline_context_id", None
+        )
+        if stream_pipeline_context_id is not None:
+            kwargs["stream_pipeline_context_id"] = stream_pipeline_context_id
         confidence = kwargs.get("confidence")
         if isinstance(confidence, str) and not USE_INFERENCE_MODELS:
             logger.warning(

--- a/inference/core/models/inference_models_adapters.py
+++ b/inference/core/models/inference_models_adapters.py
@@ -357,7 +357,10 @@ class InferenceModelsInstanceSegmentationAdapter(Model):
         self._gpu_submit_generation = 0
         self._response_executor: Optional[ThreadPoolExecutor] = None
         self._response_futures: Deque[
-            Future[List[InstanceSegmentationInferenceResponse]]
+            Tuple[
+                Future[List[InstanceSegmentationInferenceResponse]],
+                Optional[str],
+            ]
         ] = deque()
 
     def _resolve_pipeline_depth(self) -> int:
@@ -463,7 +466,8 @@ class InferenceModelsInstanceSegmentationAdapter(Model):
         self._submit_all_pending_responses()
         responses: List[InstanceSegmentationInferenceResponse] = []
         while self._response_futures:
-            responses.extend(self._response_futures.popleft().result())
+            response_future, _ = self._response_futures.popleft()
+            responses.extend(response_future.result())
         return responses
 
     def shutdown_pipeline(self) -> None:
@@ -516,7 +520,13 @@ class InferenceModelsInstanceSegmentationAdapter(Model):
             meta,
             mapped_kwargs,
         )
-        self._response_futures.append(response_future)
+        context_id = mapped_kwargs.get("source_info")
+        self._response_futures.append(
+            (
+                response_future,
+                context_id if isinstance(context_id, str) else None,
+            )
+        )
 
     def _submit_ready_responses(self) -> None:
         while self._pending_futures:
@@ -566,14 +576,18 @@ class InferenceModelsInstanceSegmentationAdapter(Model):
                 workflow_execution=kwargs.get("source") == "workflow-execution",
             )
 
-        response_future = self._response_futures.popleft()
+        response_future, context_id = self._response_futures.popleft()
         if kwargs.get("source") == "workflow-execution":
             responses = self._empty_responses_for_metadata(
                 preprocess_return_metadata=preprocess_return_metadata,
                 workflow_execution=True,
             )
             if responses:
-                attach_async_response_future(responses[0], response_future)
+                attach_async_response_future(
+                    response=responses[0],
+                    response_future=response_future,
+                    context_id=context_id,
+                )
             return responses
         return response_future.result()
 

--- a/inference/core/models/inference_models_adapters.py
+++ b/inference/core/models/inference_models_adapters.py
@@ -74,11 +74,13 @@ from inference_models.configuration import (
     get_rfdetr_pipeline_depth,
 )
 from inference_models.models.base.async_handoff import (
+    STREAM_PIPELINE_CONTEXT_ID_KWARG,
     adapter_gpu_work_submitted,
     attach_adapter_mapped_kwargs,
     attach_async_response_future,
     get_adapter_gpu_submit_generation,
     get_adapter_mapped_kwargs,
+    get_adapter_stream_pipeline_context_id,
     get_deferred_postprocess_done_event,
     get_deferred_postprocess_finalizer,
     mark_adapter_gpu_work_submitted,
@@ -397,6 +399,7 @@ class InferenceModelsInstanceSegmentationAdapter(Model):
             and not enforce_dense_masks_in_inference_models
         ):
             kwargs["mask_format"] = "rle"
+        kwargs.pop(STREAM_PIPELINE_CONTEXT_ID_KWARG, None)
         return kwargs
 
     def preprocess(self, image: Any, **kwargs):
@@ -446,7 +449,14 @@ class InferenceModelsInstanceSegmentationAdapter(Model):
         self._submit_next_pending_gpu_work()
         pre_processing_meta = getattr(img_in, "_pre_processing_meta", None)
         fut = self._model.forward_async(img_in, pre_processing_meta, **mapped_kwargs)
-        attach_adapter_mapped_kwargs(fut, mapped_kwargs)
+        stream_pipeline_context_id = kwargs.get(STREAM_PIPELINE_CONTEXT_ID_KWARG)
+        if not isinstance(stream_pipeline_context_id, str):
+            stream_pipeline_context_id = None
+        attach_adapter_mapped_kwargs(
+            fut,
+            mapped_kwargs,
+            stream_pipeline_context_id=stream_pipeline_context_id,
+        )
         if pre_processing_meta is not None:
             self._submit_future_gpu_work(fut, pre_processing_meta, mapped_kwargs)
         self._submit_ready_responses()
@@ -520,11 +530,11 @@ class InferenceModelsInstanceSegmentationAdapter(Model):
             meta,
             mapped_kwargs,
         )
-        context_id = mapped_kwargs.get("source_info")
+        context_id = get_adapter_stream_pipeline_context_id(fut)
         self._response_futures.append(
             (
                 response_future,
-                context_id if isinstance(context_id, str) else None,
+                context_id,
             )
         )
 

--- a/inference/core/workflows/core_steps/models/roboflow/instance_segmentation/v3.py
+++ b/inference/core/workflows/core_steps/models/roboflow/instance_segmentation/v3.py
@@ -55,7 +55,10 @@ from inference.core.workflows.prototypes.block import (
     WorkflowBlockManifest,
 )
 from inference_models.configuration import get_rfdetr_pipeline_depth
-from inference_models.models.base.async_handoff import get_async_response_future
+from inference_models.models.base.async_handoff import (
+    get_async_response_context_id,
+    get_async_response_future,
+)
 from inference_sdk import InferenceConfiguration, InferenceHTTPClient
 
 LONG_DESCRIPTION = """
@@ -75,6 +78,7 @@ class _StreamPredictionContext:
     images: Batch[WorkflowImageData]
     class_filter: Optional[List[str]]
     model_id: str
+    context_id: str
 
 
 class BlockManifest(WorkflowBlockManifest):
@@ -253,6 +257,7 @@ class RoboflowInstanceSegmentationModelBlockV3(WorkflowBlock):
         self._pending_stream_prediction_contexts: Deque[_StreamPredictionContext] = (
             deque()
         )
+        self._stream_context_generation = 0
 
     @classmethod
     def get_init_parameters(cls) -> List[str]:
@@ -344,6 +349,7 @@ class RoboflowInstanceSegmentationModelBlockV3(WorkflowBlock):
             images=images,
             class_filter=class_filter,
             model_id=model_id,
+            context_id=self._build_stream_context_id(images=images),
         )
         if self.stream_pipeline_depth() > 0 and len(images) == 1:
             self._pending_stream_prediction_contexts.append(stream_context)
@@ -362,6 +368,7 @@ class RoboflowInstanceSegmentationModelBlockV3(WorkflowBlock):
             mask_decode_mode=mask_decode_mode,
             tradeoff_factor=tradeoff_factor,
             source="workflow-execution",
+            source_info=stream_context.context_id,
             enforce_dense_masks_in_inference_models=enforce_dense_masks_in_inference_models,
         )
         predictions = self._model_manager.infer_from_request_sync(
@@ -373,7 +380,13 @@ class RoboflowInstanceSegmentationModelBlockV3(WorkflowBlock):
             predictions=predictions
         )
         if async_response_future is not None:
-            stream_context = self._pop_stream_prediction_context(default=stream_context)
+            response_context_id = self._extract_async_response_context_id(
+                predictions=predictions
+            )
+            stream_context = self._pop_stream_prediction_context(
+                default=stream_context,
+                context_id=response_context_id,
+            )
             return self._submit_async_post_process_result(
                 predictions_future=async_response_future,
                 stream_context=stream_context,
@@ -391,6 +404,16 @@ class RoboflowInstanceSegmentationModelBlockV3(WorkflowBlock):
             async_response_future = get_async_response_future(prediction)
             if isinstance(async_response_future, Future):
                 return async_response_future
+        return None
+
+    def _extract_async_response_context_id(
+        self,
+        predictions: List[object],
+    ) -> Optional[str]:
+        for prediction in predictions:
+            context_id = get_async_response_context_id(prediction)
+            if context_id is not None:
+                return context_id
         return None
 
     def _get_stream_response_executor(self) -> ThreadPoolExecutor:
@@ -461,6 +484,10 @@ class RoboflowInstanceSegmentationModelBlockV3(WorkflowBlock):
             )
             for e in predictions
         ]
+        _validate_stream_prediction_alignment(
+            predictions=predictions,
+            stream_context=stream_context,
+        )
         return self._post_process_result(
             images=stream_context.images,
             predictions=predictions,
@@ -471,7 +498,22 @@ class RoboflowInstanceSegmentationModelBlockV3(WorkflowBlock):
     def _pop_stream_prediction_context(
         self,
         default: _StreamPredictionContext,
+        context_id: Optional[str],
     ) -> _StreamPredictionContext:
+        if context_id is not None:
+            for index, stream_context in enumerate(
+                self._pending_stream_prediction_contexts
+            ):
+                if stream_context.context_id != context_id:
+                    continue
+                del self._pending_stream_prediction_contexts[index]
+                return stream_context
+            if default.context_id == context_id:
+                return default
+            raise RuntimeError(
+                "Async instance-segmentation response context did not match any "
+                "pending stream frame."
+            )
         if self._pending_stream_prediction_contexts:
             return self._pending_stream_prediction_contexts.popleft()
         return default
@@ -573,6 +615,22 @@ class RoboflowInstanceSegmentationModelBlockV3(WorkflowBlock):
         if callable(shutdown_fn):
             shutdown_fn()
 
+    def _build_stream_context_id(self, images: Batch[WorkflowImageData]) -> str:
+        self._stream_context_generation += 1
+        if len(images) == 1:
+            video_metadata = images[0].video_metadata
+            return (
+                "instance-segmentation-v3:"
+                f"{video_metadata.video_identifier}:"
+                f"{video_metadata.frame_number}:"
+                f"{self._stream_context_generation}"
+            )
+        return (
+            "instance-segmentation-v3:"
+            f"batch:{len(images)}:"
+            f"{self._stream_context_generation}"
+        )
+
     def run_remotely(
         self,
         images: Batch[WorkflowImageData],
@@ -665,3 +723,47 @@ def _stream_context_indices(images: Batch[WorkflowImageData]) -> List[Tuple[int,
     if indices is not None:
         return indices
     return [(i,) for i in range(len(images))]
+
+
+def _validate_stream_prediction_alignment(
+    predictions: List[dict],
+    stream_context: _StreamPredictionContext,
+) -> None:
+    if len(predictions) != len(stream_context.images):
+        raise RuntimeError(
+            "Async instance-segmentation prediction count did not match the "
+            "stream frame batch size."
+        )
+    for prediction, image in zip(predictions, stream_context.images):
+        response_image = prediction.get("image")
+        if not isinstance(response_image, dict):
+            continue
+        image_size = _workflow_image_size(image=image)
+        if image_size is None:
+            continue
+        image_width, image_height = image_size
+        if (
+            response_image.get("width") != image_width
+            or response_image.get("height") != image_height
+        ):
+            raise RuntimeError(
+                "Async instance-segmentation response image metadata did not "
+                "match the paired stream frame."
+            )
+
+
+def _workflow_image_size(image: WorkflowImageData) -> Optional[Tuple[int, int]]:
+    try:
+        numpy_image = image.numpy_image
+    except Exception:
+        numpy_image = None
+    shape = getattr(numpy_image, "shape", None)
+    if shape is None:
+        try:
+            inference_image = image.to_inference_format(numpy_preferred=True)
+        except Exception:
+            return None
+        shape = getattr(inference_image.get("value"), "shape", None)
+    if shape is None or len(shape) < 2:
+        return None
+    return int(shape[1]), int(shape[0])

--- a/inference/core/workflows/core_steps/models/roboflow/instance_segmentation/v3.py
+++ b/inference/core/workflows/core_steps/models/roboflow/instance_segmentation/v3.py
@@ -368,7 +368,7 @@ class RoboflowInstanceSegmentationModelBlockV3(WorkflowBlock):
             mask_decode_mode=mask_decode_mode,
             tradeoff_factor=tradeoff_factor,
             source="workflow-execution",
-            source_info=stream_context.context_id,
+            stream_pipeline_context_id=stream_context.context_id,
             enforce_dense_masks_in_inference_models=enforce_dense_masks_in_inference_models,
         )
         predictions = self._model_manager.infer_from_request_sync(

--- a/inference_models/inference_models/models/base/async_handoff.py
+++ b/inference_models/inference_models/models/base/async_handoff.py
@@ -16,11 +16,15 @@ _ASYNC_RESPONSE_CONTEXT_ID_ATTR = "_async_response_context_id"
 _DEFERRED_POSTPROCESS_ATTR = "_inference_deferred_postprocess_handoff"
 
 
+STREAM_PIPELINE_CONTEXT_ID_KWARG = "stream_pipeline_context_id"
+
+
 @dataclass(frozen=True)
 class AdapterFutureContext:
     """State the inference adapter keeps on an in-flight model future."""
 
     mapped_kwargs: dict
+    stream_pipeline_context_id: Optional[str] = None
     gpu_work_submitted: bool = False
     gpu_submit_generation: Optional[int] = None
 
@@ -34,12 +38,19 @@ class DeferredPostprocessHandoff:
     finalize: Callable[[], Any]
 
 
-def attach_adapter_mapped_kwargs(future: Any, mapped_kwargs: dict) -> None:
+def attach_adapter_mapped_kwargs(
+    future: Any,
+    mapped_kwargs: dict,
+    stream_pipeline_context_id: Optional[str] = None,
+) -> None:
     """Store mapped inference kwargs on a model future."""
     setattr(
         future,
         _ADAPTER_CONTEXT_ATTR,
-        AdapterFutureContext(mapped_kwargs=dict(mapped_kwargs)),
+        AdapterFutureContext(
+            mapped_kwargs=dict(mapped_kwargs),
+            stream_pipeline_context_id=stream_pipeline_context_id,
+        ),
     )
 
 
@@ -49,6 +60,17 @@ def get_adapter_mapped_kwargs(future: Any) -> dict:
     if not isinstance(context, AdapterFutureContext):
         return {}
     return context.mapped_kwargs
+
+
+def get_adapter_stream_pipeline_context_id(future: Any) -> Optional[str]:
+    """Return the stream-pipeline context id stored on a model future."""
+    context = getattr(future, _ADAPTER_CONTEXT_ATTR, None)
+    if not isinstance(context, AdapterFutureContext):
+        return None
+    context_id = context.stream_pipeline_context_id
+    if isinstance(context_id, str):
+        return context_id
+    return None
 
 
 def adapter_gpu_work_submitted(future: Any) -> bool:

--- a/inference_models/inference_models/models/base/async_handoff.py
+++ b/inference_models/inference_models/models/base/async_handoff.py
@@ -12,6 +12,7 @@ from typing import Any, Callable, Optional
 
 _ADAPTER_CONTEXT_ATTR = "_inference_adapter_future_context"
 _ASYNC_RESPONSE_FUTURE_ATTR = "_async_response_future"
+_ASYNC_RESPONSE_CONTEXT_ID_ATTR = "_async_response_context_id"
 _DEFERRED_POSTPROCESS_ATTR = "_inference_deferred_postprocess_handoff"
 
 
@@ -80,14 +81,28 @@ def get_adapter_gpu_submit_generation(future: Any) -> Optional[int]:
     return context.gpu_submit_generation
 
 
-def attach_async_response_future(response: Any, response_future: Any) -> None:
+def attach_async_response_future(
+    response: Any,
+    response_future: Any,
+    context_id: Optional[str] = None,
+) -> None:
     """Attach a CPU response future to a placeholder workflow response."""
     setattr(response, _ASYNC_RESPONSE_FUTURE_ATTR, response_future)
+    if context_id is not None:
+        setattr(response, _ASYNC_RESPONSE_CONTEXT_ID_ATTR, context_id)
 
 
 def get_async_response_future(response: Any) -> Any:
     """Return the CPU response future attached to a workflow response."""
     return getattr(response, _ASYNC_RESPONSE_FUTURE_ATTR, None)
+
+
+def get_async_response_context_id(response: Any) -> Optional[str]:
+    """Return the stream context id attached to a placeholder response."""
+    context_id = getattr(response, _ASYNC_RESPONSE_CONTEXT_ID_ATTR, None)
+    if isinstance(context_id, str):
+        return context_id
+    return None
 
 
 def attach_deferred_postprocess_handoff(

--- a/tests/inference/unit_tests/core/entities/test_inference_response_dc.py
+++ b/tests/inference/unit_tests/core/entities/test_inference_response_dc.py
@@ -12,6 +12,11 @@ from inference.core.entities.responses.inference import (
     _is_pred_dc_to_dict,
     _is_response_dc_to_dict,
 )
+from inference_models.models.base.async_handoff import (
+    attach_async_response_future,
+    get_async_response_context_id,
+    get_async_response_future,
+)
 
 
 def _pydantic_prediction(
@@ -157,3 +162,20 @@ def test_workflow_dc_path_emits_mask_format_in_prediction_dicts() -> None:
         prediction["mask_format"] == "polygon"
         for prediction in dumped["predictions"]
     )
+
+
+def test_instance_segmentation_dc_can_carry_async_response_context() -> None:
+    response = InstanceSegmentationInferenceResponseDC(
+        predictions=[],
+        image=InferenceResponseImageDC(width=640, height=480),
+    )
+    response_future = object()
+
+    attach_async_response_future(
+        response=response,
+        response_future=response_future,
+        context_id="context-1",
+    )
+
+    assert get_async_response_future(response) is response_future
+    assert get_async_response_context_id(response) == "context-1"

--- a/tests/inference/unit_tests/core/interfaces/stream/test_workflows.py
+++ b/tests/inference/unit_tests/core/interfaces/stream/test_workflows.py
@@ -1,8 +1,10 @@
 from concurrent.futures import Future
 from datetime import datetime
 from types import SimpleNamespace
+from typing import Optional
 
 import numpy as np
+import pytest
 
 from inference.core.interfaces.camera.entities import VideoFrame
 from inference.core.interfaces.stream.model_handlers.workflows import (
@@ -14,6 +16,7 @@ from inference.core.workflows.core_steps.common.entities import StepExecutionMod
 from inference.core.workflows.core_steps.models.roboflow.instance_segmentation.v3 import (
     RoboflowInstanceSegmentationModelBlockV3,
 )
+from inference.core.workflows.execution_engine.entities.base import Batch, VideoMetadata
 from inference_models.models.base.async_handoff import attach_async_response_future
 
 
@@ -200,25 +203,60 @@ class _ImmediateExecutor:
 
 
 class _FakeWorkflowImage:
-    def __init__(self, tag: str) -> None:
+    def __init__(
+        self,
+        tag: str,
+        width: int = 8,
+        height: int = 8,
+        frame_number: Optional[int] = None,
+    ) -> None:
         self.tag = tag
+        self._image = np.zeros((height, width, 3), dtype=np.uint8)
+        if frame_number is None and tag.rsplit("-", maxsplit=1)[-1].isdigit():
+            frame_number = int(tag.rsplit("-", maxsplit=1)[-1])
+        if frame_number is None:
+            frame_number = 1
+        self._video_metadata = VideoMetadata(
+            video_identifier=f"video-{tag}",
+            frame_number=frame_number,
+            frame_timestamp=datetime.now(),
+        )
+
+    @property
+    def video_metadata(self) -> VideoMetadata:
+        return self._video_metadata
+
+    @property
+    def numpy_image(self):
+        return self._image
 
     def to_inference_format(self, numpy_preferred: bool):
         assert numpy_preferred is True
         return {
             "type": "numpy_object",
-            "value": np.zeros((8, 8, 3), dtype=np.uint8),
+            "value": self._image,
         }
 
 
 class _FakeResponse:
-    def __init__(self, tag: str) -> None:
+    def __init__(
+        self,
+        tag: str,
+        width: int = 8,
+        height: int = 8,
+    ) -> None:
         self.tag = tag
+        self.width = width
+        self.height = height
 
     def model_dump(self, by_alias: bool, exclude_none: bool):
         assert by_alias is True
         assert exclude_none is True
-        return {"tag": self.tag}
+        return {
+            "tag": self.tag,
+            "image": {"width": self.width, "height": self.height},
+            "predictions": [],
+        }
 
 
 class _FakeStreamModel:
@@ -258,11 +296,61 @@ class _FakeModelManager:
         return self.model
 
 
-def _make_async_placeholder(response_tag: str) -> _FakeResponse:
+class _ContextAwareModelManager(_FakeModelManager):
+    def __init__(self, mode: str) -> None:
+        super().__init__(inference_results=[])
+        self.mode = mode
+        self.source_infos = []
+
+    def infer_from_request_sync(self, model_id: str, request):
+        self.infer_calls += 1
+        self.source_infos.append(request.source_info)
+        if self.infer_calls == 1:
+            return [_FakeResponse("priming", width=8, height=8)]
+        if self.mode == "previous":
+            return [
+                _make_async_placeholder(
+                    "first-final",
+                    context_id=self.source_infos[0],
+                    response_width=8,
+                    response_height=8,
+                )
+            ]
+        if self.mode == "current-with-old-size":
+            return [
+                _make_async_placeholder(
+                    "first-final",
+                    context_id=request.source_info,
+                    response_width=8,
+                    response_height=8,
+                )
+            ]
+        return [
+            _make_async_placeholder(
+                "first-final",
+                context_id="missing-context",
+                response_width=8,
+                response_height=8,
+            )
+        ]
+
+
+def _make_async_placeholder(
+    response_tag: str,
+    context_id: Optional[str] = None,
+    response_width: int = 8,
+    response_height: int = 8,
+) -> _FakeResponse:
     future = Future()
-    future.set_result([_FakeResponse(response_tag)])
+    future.set_result(
+        [_FakeResponse(response_tag, width=response_width, height=response_height)]
+    )
     response = _FakeResponse("placeholder")
-    attach_async_response_future(response=response, response_future=future)
+    attach_async_response_future(
+        response=response,
+        response_future=future,
+        context_id=context_id,
+    )
     return response
 
 
@@ -551,3 +639,174 @@ def test_instance_segmentation_stream_flush_drains_model_without_rerunning_workf
     assert manager.model.flush_calls == 1
     block.close_stream_pipeline()
     assert manager.model.shutdown_calls == 1
+
+
+def test_instance_segmentation_stream_pipeline_uses_response_context_id() -> None:
+    manager = _ContextAwareModelManager(mode="previous")
+    block = RoboflowInstanceSegmentationModelBlockV3(
+        model_manager=manager,
+        api_key="api-key",
+        step_execution_mode=StepExecutionMode.LOCAL,
+    )
+    block._get_stream_response_executor = lambda: _ImmediateExecutor()
+    block._post_process_result = lambda images, predictions, class_filter, model_id: [
+        {
+            "predictions": f"{images[0].tag}:{predictions[0]['tag']}",
+            "class_filter": class_filter,
+            "model_id": model_id,
+        }
+    ]
+
+    block.run_locally(
+        images=[_FakeWorkflowImage("frame-1", width=8, height=8)],
+        model_id="model",
+        class_agnostic_nms=None,
+        class_filter=["car"],
+        confidence=0.4,
+        iou_threshold=None,
+        max_detections=None,
+        max_candidates=None,
+        mask_decode_mode="accurate",
+        tradeoff_factor=None,
+        disable_active_learning=None,
+        active_learning_target_dataset=None,
+        enforce_dense_masks_in_inference_models=False,
+    )
+    second_result = block.run_locally(
+        images=[_FakeWorkflowImage("frame-2", width=4, height=4)],
+        model_id="model",
+        class_agnostic_nms=None,
+        class_filter=["car"],
+        confidence=0.4,
+        iou_threshold=None,
+        max_detections=None,
+        max_candidates=None,
+        mask_decode_mode="accurate",
+        tradeoff_factor=None,
+        disable_active_learning=None,
+        active_learning_target_dataset=None,
+        enforce_dense_masks_in_inference_models=False,
+    )
+
+    assert second_result[0]["predictions"].result() == "frame-1:first-final"
+    assert len(manager.source_infos) == 2
+    assert manager.source_infos[0] != manager.source_infos[1]
+
+
+def test_instance_segmentation_stream_pipeline_rejects_unknown_context_id() -> None:
+    manager = _ContextAwareModelManager(mode="missing")
+    block = RoboflowInstanceSegmentationModelBlockV3(
+        model_manager=manager,
+        api_key="api-key",
+        step_execution_mode=StepExecutionMode.LOCAL,
+    )
+    block._get_stream_response_executor = lambda: _ImmediateExecutor()
+    block._post_process_result = lambda images, predictions, class_filter, model_id: [
+        {
+            "predictions": f"{images[0].tag}:{predictions[0]['tag']}",
+            "class_filter": class_filter,
+            "model_id": model_id,
+        }
+    ]
+
+    block.run_locally(
+        images=[_FakeWorkflowImage("frame-1", width=8, height=8)],
+        model_id="model",
+        class_agnostic_nms=None,
+        class_filter=["car"],
+        confidence=0.4,
+        iou_threshold=None,
+        max_detections=None,
+        max_candidates=None,
+        mask_decode_mode="accurate",
+        tradeoff_factor=None,
+        disable_active_learning=None,
+        active_learning_target_dataset=None,
+        enforce_dense_masks_in_inference_models=False,
+    )
+
+    with pytest.raises(RuntimeError, match="context did not match"):
+        block.run_locally(
+            images=[_FakeWorkflowImage("frame-2", width=4, height=4)],
+            model_id="model",
+            class_agnostic_nms=None,
+            class_filter=["car"],
+            confidence=0.4,
+            iou_threshold=None,
+            max_detections=None,
+            max_candidates=None,
+            mask_decode_mode="accurate",
+            tradeoff_factor=None,
+            disable_active_learning=None,
+            active_learning_target_dataset=None,
+            enforce_dense_masks_in_inference_models=False,
+        )
+
+
+def test_instance_segmentation_stream_pipeline_rejects_image_metadata_mismatch() -> (
+    None
+):
+    manager = _ContextAwareModelManager(mode="current-with-old-size")
+    block = RoboflowInstanceSegmentationModelBlockV3(
+        model_manager=manager,
+        api_key="api-key",
+        step_execution_mode=StepExecutionMode.LOCAL,
+    )
+    block._get_stream_response_executor = lambda: _ImmediateExecutor()
+    block._post_process_result = lambda images, predictions, class_filter, model_id: [
+        {
+            "predictions": f"{images[0].tag}:{predictions[0]['tag']}",
+            "class_filter": class_filter,
+            "model_id": model_id,
+        }
+    ]
+
+    block.run_locally(
+        images=[_FakeWorkflowImage("frame-1", width=8, height=8)],
+        model_id="model",
+        class_agnostic_nms=None,
+        class_filter=["car"],
+        confidence=0.4,
+        iou_threshold=None,
+        max_detections=None,
+        max_candidates=None,
+        mask_decode_mode="accurate",
+        tradeoff_factor=None,
+        disable_active_learning=None,
+        active_learning_target_dataset=None,
+        enforce_dense_masks_in_inference_models=False,
+    )
+    second_result = block.run_locally(
+        images=[_FakeWorkflowImage("frame-2", width=4, height=4)],
+        model_id="model",
+        class_agnostic_nms=None,
+        class_filter=["car"],
+        confidence=0.4,
+        iou_threshold=None,
+        max_detections=None,
+        max_candidates=None,
+        mask_decode_mode="accurate",
+        tradeoff_factor=None,
+        disable_active_learning=None,
+        active_learning_target_dataset=None,
+        enforce_dense_masks_in_inference_models=False,
+    )
+
+    with pytest.raises(RuntimeError, match="image metadata"):
+        second_result[0]["predictions"].result()
+
+
+def test_instance_segmentation_stream_context_id_includes_frame_metadata() -> None:
+    block = RoboflowInstanceSegmentationModelBlockV3(
+        model_manager=SimpleNamespace(__contains__=lambda *_args, **_kwargs: False),
+        api_key="api-key",
+        step_execution_mode=StepExecutionMode.LOCAL,
+    )
+    image = _FakeWorkflowImage("frame-7", width=8, height=8, frame_number=7)
+
+    context_id = block._build_stream_context_id(
+        images=Batch.init(content=[image], indices=[(0,)]),
+    )
+
+    assert "video-frame-7" in context_id
+    assert ":7:" in context_id

--- a/tests/inference/unit_tests/core/interfaces/stream/test_workflows.py
+++ b/tests/inference/unit_tests/core/interfaces/stream/test_workflows.py
@@ -300,18 +300,19 @@ class _ContextAwareModelManager(_FakeModelManager):
     def __init__(self, mode: str) -> None:
         super().__init__(inference_results=[])
         self.mode = mode
-        self.source_infos = []
+        self.stream_pipeline_context_ids = []
 
     def infer_from_request_sync(self, model_id: str, request):
         self.infer_calls += 1
-        self.source_infos.append(request.source_info)
+        assert request.source_info is None
+        self.stream_pipeline_context_ids.append(request.stream_pipeline_context_id)
         if self.infer_calls == 1:
             return [_FakeResponse("priming", width=8, height=8)]
         if self.mode == "previous":
             return [
                 _make_async_placeholder(
                     "first-final",
-                    context_id=self.source_infos[0],
+                    context_id=self.stream_pipeline_context_ids[0],
                     response_width=8,
                     response_height=8,
                 )
@@ -320,7 +321,7 @@ class _ContextAwareModelManager(_FakeModelManager):
             return [
                 _make_async_placeholder(
                     "first-final",
-                    context_id=request.source_info,
+                    context_id=request.stream_pipeline_context_id,
                     response_width=8,
                     response_height=8,
                 )
@@ -689,8 +690,11 @@ def test_instance_segmentation_stream_pipeline_uses_response_context_id() -> Non
     )
 
     assert second_result[0]["predictions"].result() == "frame-1:first-final"
-    assert len(manager.source_infos) == 2
-    assert manager.source_infos[0] != manager.source_infos[1]
+    assert len(manager.stream_pipeline_context_ids) == 2
+    assert (
+        manager.stream_pipeline_context_ids[0]
+        != manager.stream_pipeline_context_ids[1]
+    )
 
 
 def test_instance_segmentation_stream_pipeline_rejects_unknown_context_id() -> None:

--- a/tests/inference/unit_tests/core/models/test_inference_models_adapters.py
+++ b/tests/inference/unit_tests/core/models/test_inference_models_adapters.py
@@ -414,3 +414,17 @@ def test_pipeline_depth_three_submits_oldest_pending_before_forward() -> None:
         "submit:f3",
         "result:f1",
     ]
+
+
+def test_pipeline_submit_response_build_stores_response_context_id() -> None:
+    ops: list[str] = []
+    future = _FakePipelineFuture(name="f1", ops=ops)
+    adapter = _make_pipeline_adapter(futures=[future], ops=ops, pipeline_depth=2)
+
+    adapter._submit_response_build(
+        future,
+        _make_meta("frame-1"),
+        {"source_info": "context-xyz"},
+    )
+
+    assert adapter._response_futures[-1][1] == "context-xyz"

--- a/tests/inference/unit_tests/core/models/test_inference_models_adapters.py
+++ b/tests/inference/unit_tests/core/models/test_inference_models_adapters.py
@@ -22,6 +22,7 @@ from inference_models import (
     InstanceDetections,
     MultiLabelClassificationPrediction,
 )
+from inference_models.models.base.async_handoff import attach_adapter_mapped_kwargs
 
 
 class _ImmediateExecutor:
@@ -421,10 +422,31 @@ def test_pipeline_submit_response_build_stores_response_context_id() -> None:
     future = _FakePipelineFuture(name="f1", ops=ops)
     adapter = _make_pipeline_adapter(futures=[future], ops=ops, pipeline_depth=2)
 
+    attach_adapter_mapped_kwargs(
+        future,
+        {},
+        stream_pipeline_context_id="context-xyz",
+    )
     adapter._submit_response_build(
         future,
         _make_meta("frame-1"),
-        {"source_info": "context-xyz"},
+        {},
     )
 
     assert adapter._response_futures[-1][1] == "context-xyz"
+
+
+def test_map_inference_kwargs_strips_stream_pipeline_context_id() -> None:
+    adapter = object.__new__(InferenceModelsInstanceSegmentationAdapter)
+    adapter._model = SimpleNamespace(supported_mask_formats={"rle"})
+
+    mapped = adapter.map_inference_kwargs(
+        {
+            "stream_pipeline_context_id": "context-xyz",
+            "disable_preproc_contrast": False,
+            "disable_preproc_grayscale": False,
+            "disable_preproc_static_crop": False,
+        }
+    )
+
+    assert "stream_pipeline_context_id" not in mapped


### PR DESCRIPTION
## What does this PR do?

Part of the RF-DETR stream-pipeline review follow-ups for `codeflash-rfdetr-seg-optimization` (review item 3 — async block context pairing).

With `RFDETR_PIPELINE_DEPTH=2`, RF-DETR defers CPU response finalization across frames. The v3 block must pair each async response with the **correct** `WorkflowImageData` when calling `_post_process_result` (parent coordinates, image dimensions, class filter). Previously this relied on blind FIFO deques in the block and adapter with no shared frame identity — mis-pairing could attach detections to the wrong frame context silently.

This PR introduces a **`context_id`** stamped at block submit, carried on the request via internal `stream_pipeline_context_id` (not `source_info`), stored on the adapter future and placeholder response, and used to pop the matching pending stream context by id (not FIFO). W/H validation raises `RuntimeError` when resolved response metadata does not match the paired frame.

**Not in scope:** workflow-output parent-coordinate conversion (fixed separately by PR #2475 at dispatch time). Runner `VideoFrame` FIFO timing is unchanged.

### Context-id pairing flow

```mermaid
sequenceDiagram
    participant Block as v3 block
    participant Deque as pending contexts deque
    participant Request as InferenceRequest
    participant Adapter as InstanceSeg adapter
    participant Placeholder as Placeholder DC
    participant Future as response_future
    participant Executor as block executor

    Note over Block: Frame N-1 submitted earlier
    Block->>Block: _build_stream_context_id()<br/>video_id:frame_number:gen
    Block->>Deque: append context(N-1)
    Block->>Request: stream_pipeline_context_id = context_id(N-1)

    Note over Block,Adapter: Frame N submitted (current)
    Request->>Adapter: forward / postprocess
    Adapter->>Future: build response (frame N-1 detections)
    Adapter->>Adapter: store (future, context_id on AdapterFutureContext)
    Adapter->>Placeholder: attach_async_response_future<br/>(future, context_id)
    Adapter-->>Block: placeholder DC (current frame W/H)

    Block->>Block: extract context_id from placeholder
    Block->>Deque: pop by context_id (not FIFO)
    alt context_id matches pending context
        Deque-->>Block: context(N-1)
        Block->>Executor: finalize future → _post_process_result<br/>(images = frame N-1)
        Executor->>Executor: validate response W/H vs frame N-1
    else unknown context_id
        Block-->>Block: RuntimeError
    else W/H mismatch after resolve
        Executor-->>Executor: RuntimeError
    end
```

**Main elements:**
- `inference/core/entities/requests/inference.py` — `stream_pipeline_context_id` (excluded from public serialization)
- `inference/core/models/base.py` — inject internal id into infer kwargs only
- `inference/core/workflows/core_steps/models/roboflow/instance_segmentation/v3.py` — context id generation, pop-by-id, W/H validation
- `inference/core/models/inference_models_adapters.py` — `(future, context_id)` queue, attach id to placeholder
- `inference_models/inference_models/models/base/async_handoff.py` — `get_async_response_context_id` / extended `attach_async_response_future`
- `inference/core/entities/responses/inference.py` — `_async_response_context_id` on response DC

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other:

## Testing

### Unit tests

- `test_instance_segmentation_stream_pipeline_uses_response_context_id` — async response on frame 2 pairs with frame 1 context via `stream_pipeline_context_id`
- `test_instance_segmentation_stream_pipeline_rejects_unknown_context_id` — bad id → `RuntimeError`
- `test_instance_segmentation_stream_pipeline_rejects_image_metadata_mismatch` — correct id but wrong W/H → `RuntimeError` on `.result()`
- `test_instance_segmentation_stream_context_id_includes_frame_metadata` — id encodes `video_identifier` and `frame_number`
- `test_instance_segmentation_dc_can_carry_async_response_context` — async handoff roundtrip on response DC
- `test_pipeline_submit_response_build_stores_response_context_id` — adapter stores context id from `AdapterFutureContext`
- `test_map_inference_kwargs_strips_stream_pipeline_context_id` — internal id is not forwarded to inference_models
- Existing stream workflow tests updated for `video_metadata` on fake images

### Integration tests

- None for this PR.

### Other

```bash
PYTHONPATH="inference_models:${PYTHONPATH}" uv run pytest \
  tests/inference/unit_tests/core/interfaces/stream/test_workflows.py \
  tests/inference/unit_tests/core/entities/test_inference_response_dc.py::test_instance_segmentation_dc_can_carry_async_response_context \
  tests/inference/unit_tests/core/models/test_inference_models_adapters.py::test_pipeline_submit_response_build_stores_response_context_id \
  -q
# 13 passed
```

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where necessary, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have updated the documentation accordingly (if applicable)

## Additional Context

- **Base branch:** `codeflash-rfdetr-seg-optimization`
- **Branch:** `fix/stream-pipeline-context-id`
- **Related:** PR #2475 fixes workflow-output parent-coordinate conversion at dispatch; this PR fixes block-internal async context pairing — separate failure modes.
- **Known limit:** `PipelinedWorkflowRunner` still uses FIFO for `VideoFrame` emit timing; single-image stream pipelines only for depth > 1.
