### PR TITLE
Add bounded timeouts for RF-DETR stream pipeline future resolution

### DIFF
--- a/inference/core/env.py
+++ b/inference/core/env.py
@@ -863,6 +863,12 @@ HOT_MODELS_QUEUE_LOCK_ACQUIRE_TIMEOUT = float(
 # 2048 -> ~22G
 RFDETR_ONNX_MAX_RESOLUTION = int(os.getenv("RFDETR_ONNX_MAX_RESOLUTION", "1600"))
 
+# Timeout in seconds for resolving asynchronous workflow / RF-DETR stream
+# pipeline futures on the main execution path.
+WORKFLOWS_ASYNC_FUTURE_RESULT_TIMEOUT = float(
+    os.getenv("WORKFLOWS_ASYNC_FUTURE_RESULT_TIMEOUT", "60.0")
+)
+
 # Confidence lower bound to prevent OOM when inferring on instance segmentation models
 CONFIDENCE_LOWER_BOUND_OOM_PREVENTION = float(
     os.getenv("CONFIDENCE_LOWER_BOUND_OOM_PREVENTION", "0.01")

--- a/inference/core/interfaces/stream/inference_pipeline.py
+++ b/inference/core/interfaces/stream/inference_pipeline.py
@@ -1,5 +1,5 @@
 import os
-from concurrent.futures import Future, ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from enum import Enum
 from functools import partial
@@ -67,6 +67,7 @@ from inference.core.workflows.execution_engine.profiling.core import (
     BaseWorkflowsProfiler,
     NullWorkflowsProfiler,
 )
+from inference.core.workflows.execution_engine.v1.executor.utils import resolve_futures
 from inference.models.aliases import resolve_roboflow_model_alias
 from inference.models.utils import ROBOFLOW_MODEL_TYPES, get_model
 
@@ -1219,17 +1220,10 @@ def send_inference_pipeline_status_update(
 
 
 def _resolve_prediction_futures(value: Any) -> Any:
-    if isinstance(value, Future):
-        return _resolve_prediction_futures(value.result())
-    if isinstance(value, list):
-        return [_resolve_prediction_futures(element) for element in value]
-    if isinstance(value, tuple):
-        return tuple(_resolve_prediction_futures(element) for element in value)
-    if isinstance(value, dict):
-        return {
-            key: _resolve_prediction_futures(element) for key, element in value.items()
-        }
-    return value
+    return resolve_futures(
+        value=value,
+        context="inference_pipeline | prediction_dispatch",
+    )
 
 
 def _workflow_parent_coordinate_output_names(

--- a/inference/core/models/inference_models_adapters.py
+++ b/inference/core/models/inference_models_adapters.py
@@ -487,7 +487,7 @@ class InferenceModelsInstanceSegmentationAdapter(Model):
         self._submit_all_pending_responses()
         responses: List[InstanceSegmentationInferenceResponse] = []
         while self._response_futures:
-            response_future = self._response_futures.popleft()
+            response_future, _ = self._response_futures.popleft()
             responses.extend(
                 _resolve_response_future(
                     future=response_future,

--- a/inference/core/models/inference_models_adapters.py
+++ b/inference/core/models/inference_models_adapters.py
@@ -1,7 +1,7 @@
 import base64
 import io
 from collections import OrderedDict, deque
-from concurrent.futures import Future, ThreadPoolExecutor
+from concurrent.futures import Future, ThreadPoolExecutor, TimeoutError
 from io import BytesIO
 from threading import local
 from time import perf_counter
@@ -45,6 +45,7 @@ from inference.core.env import (
     GCP_SERVERLESS,
     RFDETR_ONNX_MAX_RESOLUTION,
     VALID_INFERENCE_MODELS_BACKENDS,
+    WORKFLOWS_ASYNC_FUTURE_RESULT_TIMEOUT,
 )
 from inference.core.exceptions import PostProcessingError
 from inference.core.models.base import Model
@@ -143,6 +144,16 @@ def get_pinned_buffer(name: str, shape, dtype: torch.dtype) -> torch.Tensor:
     while len(cache) > _PINNED_HOST_BUFFER_CACHE_SIZE:
         cache.popitem(last=False)
     return buf
+
+
+def _resolve_response_future(
+    future: Future,
+    context: str,
+):
+    try:
+        return future.result(timeout=WORKFLOWS_ASYNC_FUTURE_RESULT_TIMEOUT)
+    except TimeoutError as error:
+        raise RuntimeError(f"Timed out while waiting for {context}.") from error
 
 
 class _PipelinePrimingSentinel:
@@ -476,8 +487,18 @@ class InferenceModelsInstanceSegmentationAdapter(Model):
         self._submit_all_pending_responses()
         responses: List[InstanceSegmentationInferenceResponse] = []
         while self._response_futures:
+<<<<<<< HEAD
             response_future, _ = self._response_futures.popleft()
             responses.extend(response_future.result())
+=======
+            response_future = self._response_futures.popleft()
+            responses.extend(
+                _resolve_response_future(
+                    future=response_future,
+                    context="RF-DETR stream pipeline flush",
+                )
+            )
+>>>>>>> a7390e23b (Enhance asynchronous future resolution in inference pipeline and models)
         return responses
 
     def shutdown_pipeline(self) -> None:
@@ -599,7 +620,10 @@ class InferenceModelsInstanceSegmentationAdapter(Model):
                     context_id=context_id,
                 )
             return responses
-        return response_future.result()
+        return _resolve_response_future(
+            future=response_future,
+            context="RF-DETR stream pipeline response finalization",
+        )
 
     def _empty_responses_for_metadata(
         self,

--- a/inference/core/models/inference_models_adapters.py
+++ b/inference/core/models/inference_models_adapters.py
@@ -487,10 +487,6 @@ class InferenceModelsInstanceSegmentationAdapter(Model):
         self._submit_all_pending_responses()
         responses: List[InstanceSegmentationInferenceResponse] = []
         while self._response_futures:
-<<<<<<< HEAD
-            response_future, _ = self._response_futures.popleft()
-            responses.extend(response_future.result())
-=======
             response_future = self._response_futures.popleft()
             responses.extend(
                 _resolve_response_future(
@@ -498,7 +494,6 @@ class InferenceModelsInstanceSegmentationAdapter(Model):
                     context="RF-DETR stream pipeline flush",
                 )
             )
->>>>>>> a7390e23b (Enhance asynchronous future resolution in inference pipeline and models)
         return responses
 
     def shutdown_pipeline(self) -> None:

--- a/inference/core/workflows/core_steps/models/roboflow/instance_segmentation/v3.py
+++ b/inference/core/workflows/core_steps/models/roboflow/instance_segmentation/v3.py
@@ -1,5 +1,5 @@
 from collections import deque
-from concurrent.futures import Future, ThreadPoolExecutor
+from concurrent.futures import Future, ThreadPoolExecutor, TimeoutError
 from dataclasses import dataclass
 from typing import Deque, List, Literal, Optional, Tuple, Type, Union
 
@@ -15,6 +15,7 @@ from inference.core.entities.responses.inference import (
 from inference.core.env import (
     HOSTED_INSTANCE_SEGMENTATION_URL,
     LOCAL_INFERENCE_API_URL,
+    WORKFLOWS_ASYNC_FUTURE_RESULT_TIMEOUT,
     WORKFLOWS_REMOTE_API_TARGET,
     WORKFLOWS_REMOTE_EXECUTION_MAX_STEP_BATCH_SIZE,
     WORKFLOWS_REMOTE_EXECUTION_MAX_STEP_CONCURRENT_REQUESTS,
@@ -459,7 +460,10 @@ class RoboflowInstanceSegmentationModelBlockV3(WorkflowBlock):
         predictions_future: Future,
         stream_context: _StreamPredictionContext,
     ) -> BlockResult:
-        predictions = predictions_future.result()
+        predictions = _resolve_stream_future(
+            future=predictions_future,
+            context="RF-DETR async prediction finalization",
+        )
         if not isinstance(predictions, list):
             predictions = [predictions]
         return self._finalize_prediction_responses(
@@ -523,7 +527,10 @@ class RoboflowInstanceSegmentationModelBlockV3(WorkflowBlock):
         result_future: Future,
         image_index: int,
     ):
-        result = result_future.result()
+        result = _resolve_stream_future(
+            future=result_future,
+            context="RF-DETR async prediction selection",
+        )
         if image_index >= len(result):
             return []
         return result[image_index]["predictions"]
@@ -716,6 +723,16 @@ class RoboflowInstanceSegmentationModelBlockV3(WorkflowBlock):
             }
             for inference_id, prediction in zip(inference_ids, predictions)
         ]
+
+
+def _resolve_stream_future(
+    future: Future,
+    context: str,
+):
+    try:
+        return future.result(timeout=WORKFLOWS_ASYNC_FUTURE_RESULT_TIMEOUT)
+    except TimeoutError as error:
+        raise RuntimeError(f"Timed out while waiting for {context}.") from error
 
 
 def _stream_context_indices(images: Batch[WorkflowImageData]) -> List[Tuple[int, ...]]:

--- a/inference/core/workflows/execution_engine/v1/executor/utils.py
+++ b/inference/core/workflows/execution_engine/v1/executor/utils.py
@@ -1,6 +1,8 @@
-from concurrent.futures import Future, ThreadPoolExecutor
+from concurrent.futures import Future, ThreadPoolExecutor, TimeoutError
 from typing import Any, Callable, Generator, Iterable, List, Optional, TypeVar
 
+from inference.core.env import WORKFLOWS_ASYNC_FUTURE_RESULT_TIMEOUT
+from inference.core.workflows.errors import ExecutionEngineRuntimeError
 from inference.core.workflows.execution_engine.entities.base import Batch
 
 T = TypeVar("T")
@@ -39,24 +41,56 @@ def _run(fun: Callable[[], T]) -> T:
     return fun()
 
 
+def resolve_future_result(
+    future: Future,
+    *,
+    context: str,
+    timeout: float = WORKFLOWS_ASYNC_FUTURE_RESULT_TIMEOUT,
+) -> Any:
+    try:
+        return future.result(timeout=timeout)
+    except TimeoutError as error:
+        raise ExecutionEngineRuntimeError(
+            public_message=(
+                "Timed out while resolving an asynchronous workflow future."
+            ),
+            context=context,
+            inner_error=error,
+        ) from error
+
+
 def resolve_futures(
     value: Any,
+    timeout: float = WORKFLOWS_ASYNC_FUTURE_RESULT_TIMEOUT,
     context: str = "workflow_execution | future_resolution",
 ) -> Any:
     if isinstance(value, Future):
-        return resolve_futures(value.result(), context=context)
+        return resolve_futures(
+            resolve_future_result(value, context=context, timeout=timeout),
+            timeout=timeout,
+            context=context,
+        )
     if isinstance(value, Batch):
         return Batch.init(
-            content=[resolve_futures(element, context=context) for element in value],
+            content=[
+                resolve_futures(element, timeout=timeout, context=context)
+                for element in value
+            ],
             indices=value.indices,
         )
     if isinstance(value, list):
-        return [resolve_futures(element, context=context) for element in value]
+        return [
+            resolve_futures(element, timeout=timeout, context=context)
+            for element in value
+        ]
     if isinstance(value, tuple):
-        return tuple(resolve_futures(element, context=context) for element in value)
+        return tuple(
+            resolve_futures(element, timeout=timeout, context=context)
+            for element in value
+        )
     if isinstance(value, dict):
         return {
-            key: resolve_futures(element, context=context)
+            key: resolve_futures(element, timeout=timeout, context=context)
             for key, element in value.items()
         }
     return value
@@ -76,8 +110,9 @@ def contains_future(value: Any) -> bool:
 
 def maybe_resolve_futures(
     value: Any,
+    timeout: float = WORKFLOWS_ASYNC_FUTURE_RESULT_TIMEOUT,
     context: str = "workflow_execution | future_resolution",
 ) -> Any:
     if not contains_future(value):
         return value
-    return resolve_futures(value=value, context=context)
+    return resolve_futures(value=value, timeout=timeout, context=context)

--- a/tests/inference/unit_tests/core/interfaces/stream/test_interface_pipeline.py
+++ b/tests/inference/unit_tests/core/interfaces/stream/test_interface_pipeline.py
@@ -36,6 +36,7 @@ from inference.core.interfaces.stream.entities import (
 )
 from inference.core.interfaces.stream.inference_pipeline import (
     InferencePipeline,
+    SinkMode,
     _apply_workflow_parent_coordinate_conversion,
     _resolve_prediction_futures,
     _workflow_parent_coordinate_output_names,
@@ -295,7 +296,7 @@ def test_dispatch_inference_results_applies_deferred_parent_coordinate_conversio
 ) -> None:
     detections = _detections_with_root_shift()
     prediction_future = Future()
-    prediction_future.set_result({"predictions": detections})
+    prediction_future.set_result(detections)
     frame = VideoFrame(
         image=np.zeros((8, 8, 3), dtype=np.uint8),
         frame_id=1,
@@ -310,6 +311,8 @@ def test_dispatch_inference_results_applies_deferred_parent_coordinate_conversio
     pipeline = object.__new__(InferencePipeline)
     pipeline._predictions_queue = Queue()
     pipeline._on_prediction = on_prediction
+    pipeline._sink_mode = SinkMode.SEQUENTIAL
+    pipeline._video_sources = []
     pipeline._workflow_parent_coordinate_outputs = frozenset({"predictions"})
     pipeline._workflow_defer_output_coordinate_conversion = True
     pipeline._handle_predictions_dispatching = InferencePipeline._handle_predictions_dispatching.__get__(

--- a/tests/inference/unit_tests/core/models/test_inference_models_adapters.py
+++ b/tests/inference/unit_tests/core/models/test_inference_models_adapters.py
@@ -417,41 +417,6 @@ def test_pipeline_depth_three_submits_oldest_pending_before_forward() -> None:
     ]
 
 
-<<<<<<< HEAD
-def test_pipeline_submit_response_build_stores_response_context_id() -> None:
-    ops: list[str] = []
-    future = _FakePipelineFuture(name="f1", ops=ops)
-    adapter = _make_pipeline_adapter(futures=[future], ops=ops, pipeline_depth=2)
-
-    attach_adapter_mapped_kwargs(
-        future,
-        {},
-        stream_pipeline_context_id="context-xyz",
-    )
-    adapter._submit_response_build(
-        future,
-        _make_meta("frame-1"),
-        {},
-    )
-
-    assert adapter._response_futures[-1][1] == "context-xyz"
-
-
-def test_map_inference_kwargs_strips_stream_pipeline_context_id() -> None:
-    adapter = object.__new__(InferenceModelsInstanceSegmentationAdapter)
-    adapter._model = SimpleNamespace(supported_mask_formats={"rle"})
-
-    mapped = adapter.map_inference_kwargs(
-        {
-            "stream_pipeline_context_id": "context-xyz",
-            "disable_preproc_contrast": False,
-            "disable_preproc_grayscale": False,
-            "disable_preproc_static_crop": False,
-        }
-    )
-
-    assert "stream_pipeline_context_id" not in mapped
-=======
 def test_pipeline_flush_raises_on_response_future_timeout(monkeypatch) -> None:
     monkeypatch.setattr(
         "inference.core.models.inference_models_adapters.WORKFLOWS_ASYNC_FUTURE_RESULT_TIMEOUT",
@@ -464,4 +429,3 @@ def test_pipeline_flush_raises_on_response_future_timeout(monkeypatch) -> None:
 
     with pytest.raises(RuntimeError, match="Timed out while waiting for"):
         adapter.flush()
->>>>>>> a7390e23b (Enhance asynchronous future resolution in inference pipeline and models)

--- a/tests/inference/unit_tests/core/models/test_inference_models_adapters.py
+++ b/tests/inference/unit_tests/core/models/test_inference_models_adapters.py
@@ -417,6 +417,7 @@ def test_pipeline_depth_three_submits_oldest_pending_before_forward() -> None:
     ]
 
 
+<<<<<<< HEAD
 def test_pipeline_submit_response_build_stores_response_context_id() -> None:
     ops: list[str] = []
     future = _FakePipelineFuture(name="f1", ops=ops)
@@ -450,3 +451,17 @@ def test_map_inference_kwargs_strips_stream_pipeline_context_id() -> None:
     )
 
     assert "stream_pipeline_context_id" not in mapped
+=======
+def test_pipeline_flush_raises_on_response_future_timeout(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "inference.core.models.inference_models_adapters.WORKFLOWS_ASYNC_FUTURE_RESULT_TIMEOUT",
+        0.001,
+    )
+    ops: list[str] = []
+    adapter = _make_pipeline_adapter(futures=[], ops=ops, pipeline_depth=2)
+    hung_future = Future()
+    adapter._response_futures.append(hung_future)
+
+    with pytest.raises(RuntimeError, match="Timed out while waiting for"):
+        adapter.flush()
+>>>>>>> a7390e23b (Enhance asynchronous future resolution in inference pipeline and models)

--- a/tests/inference/unit_tests/core/models/test_inference_models_adapters.py
+++ b/tests/inference/unit_tests/core/models/test_inference_models_adapters.py
@@ -425,7 +425,7 @@ def test_pipeline_flush_raises_on_response_future_timeout(monkeypatch) -> None:
     ops: list[str] = []
     adapter = _make_pipeline_adapter(futures=[], ops=ops, pipeline_depth=2)
     hung_future = Future()
-    adapter._response_futures.append(hung_future)
+    adapter._response_futures.append((hung_future, None))
 
     with pytest.raises(RuntimeError, match="Timed out while waiting for"):
         adapter.flush()

--- a/tests/workflows/unit_tests/execution_engine/executor/test_future_resolution_utils.py
+++ b/tests/workflows/unit_tests/execution_engine/executor/test_future_resolution_utils.py
@@ -2,10 +2,12 @@ from concurrent.futures import Future
 
 import pytest
 
+from inference.core.workflows.errors import ExecutionEngineRuntimeError
 from inference.core.workflows.execution_engine.entities.base import Batch
 from inference.core.workflows.execution_engine.v1.executor.utils import (
     contains_future,
     maybe_resolve_futures,
+    resolve_future_result,
     resolve_futures,
 )
 
@@ -79,3 +81,22 @@ def test_resolve_futures_propagates_future_exception() -> None:
         resolve_futures(batch)
 
     assert error_info.value is resolution_error
+
+
+def test_resolve_future_result_raises_on_timeout() -> None:
+    future = Future()
+
+    with pytest.raises(ExecutionEngineRuntimeError, match="Timed out"):
+        resolve_future_result(
+            future,
+            context="test | future_resolution",
+            timeout=0.001,
+        )
+
+
+def test_resolve_futures_raises_on_timeout() -> None:
+    future = Future()
+    batch = Batch.init(content=[future], indices=[(0,)])
+
+    with pytest.raises(ExecutionEngineRuntimeError, match="Timed out"):
+        resolve_futures(batch, timeout=0.001)


### PR DESCRIPTION
## What does this PR do?

Part of the RF-DETR stream-pipeline review follow-ups (review item 4 — `.result()` timeouts). Stacks on #2488 (`fix/stream-pipeline-context-id`).

With `RFDETR_PIPELINE_DEPTH>=2`, several code paths block on `concurrent.futures.Future.result()` with no timeout. If GPU work stalls (kernel JIT failure mid-stream, CUDA error, dead worker), workflow output construction, stream dispatch, adapter `flush()`, or block async finalization can hang indefinitely — including pipeline shutdown.

This PR adds a shared bounded wait via `WORKFLOWS_ASYNC_FUTURE_RESULT_TIMEOUT` (default **60s**, env-configurable). Workflow executor paths raise `ExecutionEngineRuntimeError` with a clear message; adapter and v3 block paths raise `RuntimeError` naming the stalled stage. `inference_pipeline` prediction dispatch now delegates to the shared `resolve_futures` helper so stream sinks get the same timeout behavior.

**Main elements:**
- `inference/core/env.py` — `WORKFLOWS_ASYNC_FUTURE_RESULT_TIMEOUT`
- `inference/core/workflows/execution_engine/v1/executor/utils.py` — `resolve_future_result()`, timeout-aware `resolve_futures` / `maybe_resolve_futures`
- `inference/core/models/inference_models_adapters.py` — `_resolve_response_future()` on `flush()` and sync `postprocess()` return path
- `inference/core/workflows/core_steps/models/roboflow/instance_segmentation/v3.py` — `_resolve_stream_future()` on async finalize/selector paths
- `inference/core/interfaces/stream/inference_pipeline.py` — dispatch uses shared `resolve_futures`

**Known limit:** `_finalize_future` still calls `fut.result()` without a direct timeout on the worker thread; a GPU future stall there is surfaced when the outer `response_future` times out on `flush()` or workflow output resolution.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other:

## Testing

### Unit tests

- `test_resolve_future_result_raises_on_timeout` — hung future → `ExecutionEngineRuntimeError`
- `test_resolve_futures_raises_on_timeout` — `Batch`-wrapped hung future → `ExecutionEngineRuntimeError`
- `test_pipeline_flush_raises_on_response_future_timeout` — adapter `flush()` → `RuntimeError` with context message

### Integration tests

- None for this PR.

### Other

```bash
PYTHONPATH="inference_models:${PYTHONPATH}" uv run pytest \
  tests/workflows/unit_tests/execution_engine/executor/test_future_resolution_utils.py \
  tests/inference/unit_tests/core/models/test_inference_models_adapters.py::test_pipeline_flush_raises_on_response_future_timeout \
  -q
# 9 passed
```

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where necessary, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have updated the documentation accordingly (if applicable)

## Additional Context

- **Base branch:** `fix/stream-pipeline-context-id` (PR #2488)
- **Branch:** `fix/future-result-timeouts`
- **Env:** `WORKFLOWS_ASYNC_FUTURE_RESULT_TIMEOUT=60.0` (seconds)

Made with [Cursor](https://cursor.com)