### PR TITLE
Document pinned-buffer view lifetime in RF-DETR response finalization

### DIFF
--- a/inference/core/models/inference_models_adapters.py
+++ b/inference/core/models/inference_models_adapters.py
@@ -128,6 +128,13 @@ def get_pinned_buffer(name: str, shape, dtype: torch.dtype) -> torch.Tensor:
     submits later GPU work. Keeping this cache thread-local avoids two workers
     writing into the same scratch tensor. The small LRU cap prevents retaining a
     new pinned allocation for every transient shape.
+
+    The cache is keyed by ``(name, dtype)`` only. When a cached buffer is large
+    enough, this returns a **view** into that entry, not a fresh allocation.
+    ``.numpy()`` and any slices alias the scratch memory until the next
+    ``copy_`` into the same cache slot. Values that outlive the current
+    finalization must be copied or reduced to scalars / fresh polygon arrays
+    before returning.
     """
     cache = getattr(_PINNED_HOST_BUFFER_CONTEXT, "cache", None)
     if cache is None:
@@ -729,6 +736,8 @@ class InferenceModelsInstanceSegmentationAdapter(Model):
                     and isinstance(combined_gpu, torch.Tensor)
                     and combined_gpu.is_cuda
                 ):
+                    # combined_np / class_column / combined_slice are scratch views;
+                    # use only for survivor counting and in-loop scalar extraction.
                     combined_host = get_pinned_buffer(
                         "combined_full",
                         tuple(combined_gpu.shape),
@@ -852,6 +861,10 @@ class InferenceModelsInstanceSegmentationAdapter(Model):
                         polys_or_rles = rle_masks2poly(det.mask)
                 class_ids = det.class_id.detach().cpu().numpy()
 
+            # Some branches above intentionally keep numpy views into
+            # thread-local pinned scratch buffers. Only scalar values and
+            # polygon/RLE lists may be stored on responses below; do not return
+            # those arrays or any view derived from them.
             predictions: List[
                 Union[InstanceSegmentationPrediction, InstanceSegmentationRLEPrediction]
             ] = []


### PR DESCRIPTION
## What does this PR do?

Part of the RF-DETR stream-pipeline review follow-ups (review item 5 — pinned-buffer view hazard).

`get_pinned_buffer()` reuses thread-local pinned CPU scratch tensors keyed by `(name, dtype)`. When a cached buffer is large enough, callers receive a **view** into that entry; `.numpy()` and column slices in `_build_responses_from_detections` alias the same memory until the next frame's DtoH `copy_`. That is safe today because the prediction loop only materializes Python scalars and fresh polygon point lists before returning — but the contract is easy to break with a small refactor.

This PR adds documentation-only comments at the three high-risk sites: the `get_pinned_buffer` docstring, the deferred `combined_full` survivor-count path, and immediately before response assembly. No logic or performance changes.

**Main elements:**
- `inference/core/models/inference_models_adapters.py` — docstring + two inline invariants in `_build_responses_from_detections`

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other:

## Testing

### Unit tests

- None — comments only; existing adapter/stream tests unchanged.

### Integration tests

- None for this PR.

### Other

- No test commands required (documentation-only diff).

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where necessary, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have updated the documentation accordingly (if applicable)

## Additional Context

- **Base branch:** `codeflash-rfdetr-seg-optimization`
- **Branch:** `fix/pinned-buffer-view-docs`
- **Review item:** #5 from PR #2464 audit — documents the scratch-buffer lifetime contract; defensive `.copy()` at DtoH intentionally deferred to avoid per-frame alloc cost.

Made with [Cursor](https://cursor.com)