### PR TITLE
Add weakref finalizers for RF-DETR stream pipeline executors

### DIFF
--- a/inference/core/models/inference_models_adapters.py
+++ b/inference/core/models/inference_models_adapters.py
@@ -6,6 +6,7 @@ from io import BytesIO
 from threading import local
 from time import perf_counter
 from typing import Any, Deque, List, Optional, Tuple, Union
+from weakref import finalize
 
 import numpy as np
 import torch
@@ -376,6 +377,7 @@ class InferenceModelsInstanceSegmentationAdapter(Model):
         ] = deque()
         self._gpu_submit_generation = 0
         self._response_executor: Optional[ThreadPoolExecutor] = None
+        self._response_executor_finalizer = None
         self._response_futures: Deque[
             Tuple[
                 Future[List[InstanceSegmentationInferenceResponse]],
@@ -506,12 +508,21 @@ class InferenceModelsInstanceSegmentationAdapter(Model):
     def shutdown_pipeline(self) -> None:
         if self._response_executor is None:
             return None
+        finalizer = self._response_executor_finalizer
+        if finalizer is not None and finalizer.alive:
+            finalizer.detach()
         self._response_executor.shutdown(wait=False)
         self._response_executor = None
+        self._response_executor_finalizer = None
 
     def _get_response_executor(self) -> ThreadPoolExecutor:
         if self._response_executor is None:
             self._response_executor = ThreadPoolExecutor(max_workers=1)
+            self._response_executor_finalizer = finalize(
+                self,
+                self._response_executor.shutdown,
+                wait=False,
+            )
         return self._response_executor
 
     def _submit_future_gpu_work(

--- a/inference/core/workflows/core_steps/models/roboflow/instance_segmentation/v3.py
+++ b/inference/core/workflows/core_steps/models/roboflow/instance_segmentation/v3.py
@@ -2,6 +2,7 @@ from collections import deque
 from concurrent.futures import Future, ThreadPoolExecutor, TimeoutError
 from dataclasses import dataclass
 from typing import Deque, List, Literal, Optional, Tuple, Type, Union
+from weakref import finalize
 
 from pydantic import ConfigDict, Field, PositiveInt, model_validator
 
@@ -255,6 +256,7 @@ class RoboflowInstanceSegmentationModelBlockV3(WorkflowBlock):
         self._step_execution_mode = step_execution_mode
         self._last_model_id: Optional[str] = None
         self._stream_response_executor: Optional[ThreadPoolExecutor] = None
+        self._stream_response_executor_finalizer = None
         self._pending_stream_prediction_contexts: Deque[_StreamPredictionContext] = (
             deque()
         )
@@ -420,6 +422,11 @@ class RoboflowInstanceSegmentationModelBlockV3(WorkflowBlock):
     def _get_stream_response_executor(self) -> ThreadPoolExecutor:
         if self._stream_response_executor is None:
             self._stream_response_executor = ThreadPoolExecutor(max_workers=1)
+            self._stream_response_executor_finalizer = finalize(
+                self,
+                self._stream_response_executor.shutdown,
+                wait=False,
+            )
         return self._stream_response_executor
 
     def _submit_async_post_process_result(
@@ -610,8 +617,12 @@ class RoboflowInstanceSegmentationModelBlockV3(WorkflowBlock):
 
     def close_stream_pipeline(self) -> None:
         if self._stream_response_executor is not None:
+            finalizer = self._stream_response_executor_finalizer
+            if finalizer is not None and finalizer.alive:
+                finalizer.detach()
             self._stream_response_executor.shutdown(wait=False)
             self._stream_response_executor = None
+            self._stream_response_executor_finalizer = None
         if (
             self._last_model_id is None
             or self._last_model_id not in self._model_manager

--- a/tests/inference/unit_tests/core/interfaces/stream/test_workflows.py
+++ b/tests/inference/unit_tests/core/interfaces/stream/test_workflows.py
@@ -814,3 +814,21 @@ def test_instance_segmentation_stream_context_id_includes_frame_metadata() -> No
 
     assert "video-frame-7" in context_id
     assert ":7:" in context_id
+
+
+def test_close_stream_pipeline_detaches_response_executor_finalizer() -> None:
+    block = RoboflowInstanceSegmentationModelBlockV3(
+        model_manager=SimpleNamespace(__contains__=lambda *_args, **_kwargs: False),
+        api_key="api-key",
+        step_execution_mode=StepExecutionMode.LOCAL,
+    )
+    executor = block._get_stream_response_executor()
+
+    assert block._stream_response_executor_finalizer is not None
+    assert block._stream_response_executor_finalizer.alive
+
+    block.close_stream_pipeline()
+
+    assert block._stream_response_executor is None
+    assert block._stream_response_executor_finalizer is None
+    assert executor._shutdown

--- a/tests/inference/unit_tests/core/models/test_inference_models_adapters.py
+++ b/tests/inference/unit_tests/core/models/test_inference_models_adapters.py
@@ -99,6 +99,7 @@ def _make_pipeline_adapter(
     adapter._pending_futures = deque()
     adapter._response_futures = deque()
     adapter._response_executor = None
+    adapter._response_executor_finalizer = None
     adapter._model = _FakePipelineModel(futures=futures, ops=ops)
     adapter.class_names = []
     adapter.map_inference_kwargs = lambda kwargs: dict(kwargs)
@@ -110,6 +111,58 @@ def _make_pipeline_adapter(
     )
 
     return adapter
+
+
+def _make_live_pipeline_adapter(
+    pipeline_depth: int = 2,
+) -> InferenceModelsInstanceSegmentationAdapter:
+    adapter = object.__new__(InferenceModelsInstanceSegmentationAdapter)
+    adapter._pipeline_depth = pipeline_depth
+    adapter._response_delay = max(1, pipeline_depth - 1)
+    adapter._pending_gpu_submissions = deque()
+    adapter._pending_futures = deque()
+    adapter._response_futures = deque()
+    adapter._response_executor = None
+    adapter._response_executor_finalizer = None
+    adapter._gpu_submit_generation = 0
+    adapter._model = _FakePipelineModel(futures=[], ops=[])
+    adapter.class_names = []
+    return adapter
+
+
+def test_get_response_executor_registers_shutdown_finalizer() -> None:
+    adapter = _make_live_pipeline_adapter()
+    executor = InferenceModelsInstanceSegmentationAdapter._get_response_executor(
+        adapter
+    )
+
+    assert adapter._response_executor is executor
+    assert adapter._response_executor_finalizer is not None
+    assert adapter._response_executor_finalizer.alive
+
+    adapter.shutdown_pipeline()
+
+    assert adapter._response_executor is None
+    assert adapter._response_executor_finalizer is None
+    assert executor._shutdown
+
+
+def test_response_executor_finalizer_shuts_down_when_adapter_is_collected() -> None:
+    import gc
+    import weakref
+
+    adapter = _make_live_pipeline_adapter()
+    executor = InferenceModelsInstanceSegmentationAdapter._get_response_executor(
+        adapter
+    )
+    assert not executor._shutdown
+
+    adapter_ref = weakref.ref(adapter)
+    del adapter
+    gc.collect()
+
+    assert adapter_ref() is None
+    assert executor._shutdown
 
 
 def test_pipeline_depth_falls_back_to_one_for_unsupported_models(monkeypatch) -> None:


### PR DESCRIPTION
## What does this PR do?

Part of the RF-DETR stream-pipeline review follow-ups (review item 6 — executor leak on abnormal teardown).

The RF-DETR stream pipeline lazily creates `ThreadPoolExecutor(max_workers=1)` pools in the instance-segmentation adapter (`_get_response_executor`) and v3 block (`_get_stream_response_executor`). Today they are torn down only via explicit `shutdown_pipeline()` / `close_stream_pipeline()`, which run through `PipelinedWorkflowRunner.close()` and the inference pipeline's `_close_inference_handler()` finally block. If teardown skips that path (exception during pipeline build, GC of the block/adapter without `close()`), the worker thread can leak.

This PR registers a `weakref.finalize` safety net when each executor is first created. On explicit close/shutdown, the finalizer is detached before `shutdown(wait=False)` so normal teardown does not double-shutdown. If the owning object is collected without close, the finalizer still shuts down the executor.

**Main elements:**
- `inference/core/models/inference_models_adapters.py` — `_response_executor_finalizer` on lazy create; detach in `shutdown_pipeline()`
- `inference/core/workflows/core_steps/models/roboflow/instance_segmentation/v3.py` — `_stream_response_executor_finalizer` on lazy create; detach in `close_stream_pipeline()`

**Known limit:** The GC finalizer is best-effort (`shutdown(wait=False)`); long-lived servers should still route through explicit `close()`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other:

## Testing

### Unit tests

- `test_get_response_executor_registers_shutdown_finalizer` — explicit `shutdown_pipeline()` detaches finalizer and shuts down executor
- `test_response_executor_finalizer_shuts_down_when_adapter_is_collected` — GC of adapter triggers executor shutdown via finalizer
- `test_close_stream_pipeline_detaches_response_executor_finalizer` — block `close_stream_pipeline()` detaches finalizer and shuts down executor

### Integration tests

- None for this PR.

### Other

```bash
PYTHONPATH="inference_models:${PYTHONPATH}" uv run pytest \
  tests/inference/unit_tests/core/models/test_inference_models_adapters.py::test_get_response_executor_registers_shutdown_finalizer \
  tests/inference/unit_tests/core/models/test_inference_models_adapters.py::test_response_executor_finalizer_shuts_down_when_adapter_is_collected \
  tests/inference/unit_tests/core/interfaces/stream/test_workflows.py::test_close_stream_pipeline_detaches_response_executor_finalizer \
  -q
# 3 passed
```

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where necessary, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have updated the documentation accordingly (if applicable)

## Additional Context

- **Base branch:** `codeflash-rfdetr-seg-optimization`
- **Branch:** `fix/stream-pipeline-executor-teardown`
- **Review item:** #6 from PR #2464 audit — complements existing explicit close paths in `PipelinedWorkflowRunner` and `InferencePipeline` finally blocks.

Made with [Cursor](https://cursor.com)