### PR TITLE
Fix RF-DETR stream pipeline correctness

### DIFF
--- a/inference/core/entities/requests/inference.py
+++ b/inference/core/entities/requests/inference.py
@@ -261,6 +261,10 @@ class InstanceSegmentationInferenceRequest(ObjectDetectionInferenceRequest):
         "RLE but consume more memory which may be unstable in some cases. This flag cannot be tweaked "
         "when used on Roboflow serverless platform.",
     )
+    disable_stream_pipeline: Optional[bool] = Field(
+        default=False,
+        description="Internal workflow flag forcing RF-DETR stream pipelining off for requests whose downstream graph needs same-frame context.",
+    )
 
 
 class SemanticSegmentationInferenceRequest(CVInferenceRequest):

--- a/inference/core/interfaces/stream/inference_pipeline.py
+++ b/inference/core/interfaces/stream/inference_pipeline.py
@@ -62,7 +62,6 @@ from inference.core.managers.decorators.fixed_size_cache import WithFixedSizeCac
 from inference.core.registries.roboflow import RoboflowModelRegistry
 from inference.core.utils.function import experimental
 from inference.core.workflows.core_steps.common.entities import StepExecutionMode
-from inference.core.workflows.execution_engine.entities.base import CoordinatesSystem
 from inference.core.workflows.execution_engine.profiling.core import (
     BaseWorkflowsProfiler,
     NullWorkflowsProfiler,
@@ -572,9 +571,6 @@ class InferencePipeline:
                 newest version for the request. Only applies for Workflows definitions saved on Roboflow platform.
             serialize_results (bool): Boolean flag to decide if ExecutionEngine run should serialize workflow
                 results for each frame. If that is set true, sinks will receive serialized workflow responses.
-                When False, output futures are resolved in the dispatch thread and detections in workflow
-                outputs declared with `coordinates_system: parent` are converted to root coordinates at
-                dispatch time instead of in the execution engine.
             predictions_queue_size int: Size of buffer for predictions that are ready for dispatching
                 default value is taken from INFERENCE_PIPELINE_PREDICTIONS_QUEUE_SIZE env variable
             decoding_buffer_size (int): size of video source decoding buffer
@@ -611,8 +607,6 @@ class InferencePipeline:
             raise ValueError(
                 "Either (`workspace_name`, `workflow_id`) or `workflow_specification` must be provided."
             )
-        workflow_parent_coordinate_outputs = frozenset()
-        workflow_defer_output_coordinate_conversion = False
         try:
             from inference.core.interfaces.stream.model_handlers.workflows import (
                 WorkflowRunner,
@@ -677,12 +671,6 @@ class InferencePipeline:
                 workflow_runner=workflow_runner,
                 execution_engine=execution_engine,
             )
-            workflow_parent_coordinate_outputs = (
-                _workflow_parent_coordinate_output_names(
-                    workflow_specification=workflow_specification,
-                )
-            )
-            workflow_defer_output_coordinate_conversion = not serialize_results
         except ImportError as error:
             raise CannotInitialiseModelError(
                 f"Could not initialise workflow processing due to lack of dependencies required. "
@@ -710,10 +698,6 @@ class InferencePipeline:
             batch_collection_timeout=batch_collection_timeout,
             predictions_queue_size=predictions_queue_size,
             decoding_buffer_size=decoding_buffer_size,
-            workflow_parent_coordinate_outputs=workflow_parent_coordinate_outputs,
-            workflow_defer_output_coordinate_conversion=(
-                workflow_defer_output_coordinate_conversion
-            ),
         )
 
     @classmethod
@@ -734,8 +718,6 @@ class InferencePipeline:
         sink_mode: SinkMode = SinkMode.ADAPTIVE,
         predictions_queue_size: int = PREDICTIONS_QUEUE_SIZE,
         decoding_buffer_size: int = DEFAULT_BUFFER_SIZE,
-        workflow_parent_coordinate_outputs: Optional[frozenset[str]] = None,
-        workflow_defer_output_coordinate_conversion: bool = False,
     ) -> "InferencePipeline":
         """
         This class creates the abstraction for making inferences from given workflow against video stream.
@@ -806,15 +788,6 @@ class InferencePipeline:
                 default value is taken from INFERENCE_PIPELINE_PREDICTIONS_QUEUE_SIZE env variable
             decoding_buffer_size (int): size of video source decoding buffer
                 default value is taken from VIDEO_SOURCE_BUFFER_SIZE env variable
-            workflow_parent_coordinate_outputs (Optional[frozenset[str]]): Names of workflow outputs whose
-                `coordinates_system` is `parent`. Used by the dispatch thread to convert `sv.Detections`
-                to root coordinates when coordinate conversion is deferred. Populated automatically by
-                `init_with_workflow(...)`; only needed when constructing the pipeline via
-                `init_with_custom_logic(...)` with a workflow-backed handler.
-            workflow_defer_output_coordinate_conversion (bool): When True, parent-coordinate conversion
-                for workflow detections is applied in `_dispatch_inference_results(...)` after futures
-                are resolved, rather than in the execution engine output constructor. Set automatically
-                to `not serialize_results` by `init_with_workflow(...)`.
 
         Other ENV variables involved in low-level configuration:
         * INFERENCE_PIPELINE_PREDICTIONS_QUEUE_SIZE - size of buffer for predictions that are ready for dispatching
@@ -869,10 +842,6 @@ class InferencePipeline:
             on_pipeline_end=on_pipeline_end,
             batch_collection_timeout=batch_collection_timeout,
             sink_mode=sink_mode,
-            workflow_parent_coordinate_outputs=workflow_parent_coordinate_outputs,
-            workflow_defer_output_coordinate_conversion=(
-                workflow_defer_output_coordinate_conversion
-            ),
         )
 
     def __init__(
@@ -888,8 +857,6 @@ class InferencePipeline:
         max_fps: Optional[float] = None,
         batch_collection_timeout: Optional[float] = None,
         sink_mode: SinkMode = SinkMode.ADAPTIVE,
-        workflow_parent_coordinate_outputs: Optional[frozenset[str]] = None,
-        workflow_defer_output_coordinate_conversion: bool = False,
     ):
         self._on_video_frame = on_video_frame
         self._video_sources = video_sources
@@ -907,12 +874,6 @@ class InferencePipeline:
         self._on_pipeline_end = on_pipeline_end
         self._batch_collection_timeout = batch_collection_timeout
         self._sink_mode = sink_mode
-        self._workflow_parent_coordinate_outputs = (
-            workflow_parent_coordinate_outputs or frozenset()
-        )
-        self._workflow_defer_output_coordinate_conversion = (
-            workflow_defer_output_coordinate_conversion
-        )
 
     def start(self, use_main_thread: bool = True) -> None:
         self._stop = False
@@ -1029,11 +990,6 @@ class InferencePipeline:
             predictions, video_frames = inference_results
             if _rfdetr_stream_pipeline_enabled():
                 predictions = _resolve_prediction_futures(predictions)
-                if self._workflow_defer_output_coordinate_conversion:
-                    predictions = _apply_workflow_parent_coordinate_conversion(
-                        predictions=predictions,
-                        parent_output_names=self._workflow_parent_coordinate_outputs,
-                    )
             if self._on_prediction is not None:
                 self._handle_predictions_dispatching(
                     predictions=predictions,
@@ -1224,55 +1180,6 @@ def _resolve_prediction_futures(value: Any) -> Any:
         value=value,
         context="inference_pipeline | prediction_dispatch",
     )
-
-
-def _workflow_parent_coordinate_output_names(
-    workflow_specification: Optional[dict],
-) -> frozenset[str]:
-    if workflow_specification is None:
-        return frozenset()
-    parent_output_names = set()
-    for output in workflow_specification.get("outputs", []):
-        coordinates_system = output.get(
-            "coordinates_system",
-            CoordinatesSystem.PARENT.value,
-        )
-        if coordinates_system in (
-            CoordinatesSystem.PARENT,
-            CoordinatesSystem.PARENT.value,
-        ):
-            parent_output_names.add(output["name"])
-    return frozenset(parent_output_names)
-
-
-def _apply_workflow_parent_coordinate_conversion(
-    predictions: Any,
-    parent_output_names: frozenset[str],
-) -> Any:
-    if not parent_output_names:
-        return predictions
-    from inference.core.workflows.execution_engine.v1.executor.output_constructor import (
-        convert_sv_detections_coordinates,
-    )
-
-    if isinstance(predictions, list):
-        return [
-            _apply_workflow_parent_coordinate_conversion(
-                predictions=item,
-                parent_output_names=parent_output_names,
-            )
-            for item in predictions
-        ]
-    if isinstance(predictions, dict):
-        converted = dict(predictions)
-        for output_name in parent_output_names:
-            if output_name not in converted:
-                continue
-            converted[output_name] = convert_sv_detections_coordinates(
-                data=converted[output_name]
-            )
-        return converted
-    return predictions
 
 
 def _rfdetr_stream_pipeline_enabled() -> bool:

--- a/inference/core/interfaces/stream/model_handlers/workflows.py
+++ b/inference/core/interfaces/stream/model_handlers/workflows.py
@@ -1,14 +1,29 @@
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
+import networkx as nx
+
 from inference.core.interfaces.camera.entities import VideoFrame
 from inference.core.interfaces.stream.entities import InferenceHandlerResult
+from inference.core.workflows.execution_engine.constants import (
+    NODE_COMPILATION_OUTPUT_PROPERTY,
+)
 from inference.core.workflows.execution_engine.core import ExecutionEngine
 from inference.core.workflows.execution_engine.entities.base import VideoMetadata
+from inference.core.workflows.execution_engine.v1.compiler.entities import (
+    DynamicStepInputDefinition,
+    NodeCategory,
+    StepInputDefinition,
+    StepNode,
+)
+from inference.core.workflows.execution_engine.v1.compiler.utils import (
+    get_step_selector_from_its_output,
+)
 
 
 @dataclass(frozen=True)
 class _StreamPipelineStep:
+    selector: str
     step: Any
 
 
@@ -184,6 +199,12 @@ def wrap_workflow_runner_for_stream_pipeline(
     stream_steps = _stream_pipeline_steps(execution_engine=execution_engine)
     if not stream_steps:
         return workflow_runner
+    if _workflow_requires_synchronous_stream_steps(
+        execution_engine=execution_engine,
+        stream_steps=stream_steps,
+    ):
+        _disable_stream_pipeline_steps(stream_steps=stream_steps)
+        return workflow_runner
     return PipelinedWorkflowRunner(
         workflow_runner=workflow_runner,
         stream_steps=stream_steps,
@@ -197,10 +218,15 @@ def _stream_pipeline_steps(
     compiled_workflow = getattr(engine, "_compiled_workflow", None)
     steps = getattr(compiled_workflow, "steps", {})
     stream_steps = []
-    for initialised_step in steps.values():
+    for step_name, initialised_step in steps.items():
         step_instance = getattr(initialised_step, "step", None)
         if _is_stream_pipeline_step(step_instance=step_instance):
-            stream_steps.append(_StreamPipelineStep(step=step_instance))
+            stream_steps.append(
+                _StreamPipelineStep(
+                    selector=f"$steps.{step_name}",
+                    step=step_instance,
+                )
+            )
     return stream_steps
 
 
@@ -217,3 +243,92 @@ def _stream_step_depth(stream_step: _StreamPipelineStep) -> int:
     if not callable(get_depth):
         return 0
     return max(0, int(get_depth()))
+
+
+def _workflow_requires_synchronous_stream_steps(
+    execution_engine: ExecutionEngine,
+    stream_steps: List[_StreamPipelineStep],
+) -> bool:
+    engine = getattr(execution_engine, "_engine", None)
+    compiled_workflow = getattr(engine, "_compiled_workflow", None)
+    execution_graph = getattr(compiled_workflow, "execution_graph", None)
+    if execution_graph is None:
+        return False
+    stream_step_selectors = {stream_step.selector for stream_step in stream_steps}
+    safe_step_selectors = set(stream_step_selectors)
+    downstream_step_selectors = set()
+    for stream_step_selector in stream_step_selectors:
+        if stream_step_selector not in execution_graph:
+            continue
+        downstream_step_selectors.update(
+            node
+            for node in nx.descendants(execution_graph, stream_step_selector)
+            if _is_step_node(execution_graph=execution_graph, node=node)
+        )
+    for node in nx.topological_sort(execution_graph):
+        if node not in downstream_step_selectors:
+            continue
+        step_node = _get_step_node(execution_graph=execution_graph, node=node)
+        if step_node is None:
+            continue
+        if _step_has_unsafe_stream_dependency(
+            step_node=step_node,
+            safe_step_selectors=safe_step_selectors,
+        ):
+            return True
+        safe_step_selectors.add(node)
+    return False
+
+
+def _disable_stream_pipeline_steps(stream_steps: List[_StreamPipelineStep]) -> None:
+    for stream_step in stream_steps:
+        disable_fn = getattr(
+            stream_step.step,
+            "disable_stream_pipeline_for_workflow",
+            None,
+        )
+        if callable(disable_fn):
+            disable_fn()
+
+
+def _step_has_unsafe_stream_dependency(
+    step_node: StepNode,
+    safe_step_selectors: set[str],
+) -> bool:
+    for input_definition in step_node.input_data.values():
+        for leaf_definition in _iter_step_input_definitions(input_definition):
+            if leaf_definition.is_static_value():
+                continue
+            if leaf_definition.points_to_input():
+                return True
+            if not isinstance(leaf_definition, DynamicStepInputDefinition):
+                continue
+            producer_step_selector = get_step_selector_from_its_output(
+                step_output_selector=leaf_definition.selector,
+            )
+            if producer_step_selector not in safe_step_selectors:
+                return True
+    return False
+
+
+def _iter_step_input_definitions(input_definition: Any):
+    iterate_definitions = getattr(input_definition, "iterate_through_definitions", None)
+    if callable(iterate_definitions):
+        yield from iterate_definitions()
+        return
+    if isinstance(input_definition, StepInputDefinition):
+        yield input_definition
+
+
+def _is_step_node(execution_graph: Any, node: str) -> bool:
+    step_node = _get_step_node(execution_graph=execution_graph, node=node)
+    return step_node is not None
+
+
+def _get_step_node(execution_graph: Any, node: str) -> Optional[StepNode]:
+    node_data = execution_graph.nodes[node].get(NODE_COMPILATION_OUTPUT_PROPERTY)
+    if getattr(node_data, "node_category", None) is not NodeCategory.STEP_NODE:
+        return None
+    if not isinstance(node_data, StepNode):
+        return None
+    return node_data

--- a/inference/core/models/inference_models_adapters.py
+++ b/inference/core/models/inference_models_adapters.py
@@ -119,6 +119,7 @@ DEFAULT_COLOR_PALETTE = [
 
 _PINNED_HOST_BUFFER_CACHE_SIZE = 16
 _PINNED_HOST_BUFFER_CONTEXT = local()
+_RFDETR_SPARSE_RLE_POSTPROCESS_ATTR = "_rfdetr_sparse_rle_postprocess"
 
 
 def get_pinned_buffer(name: str, shape, dtype: torch.dtype) -> torch.Tensor:
@@ -448,11 +449,13 @@ class InferenceModelsInstanceSegmentationAdapter(Model):
 
     def predict(self, img_in, **kwargs):
         mapped_kwargs = self.map_inference_kwargs(kwargs)
-        if self._pipeline_depth <= 1:
+        if (
+            self._pipeline_depth <= 1
+            or kwargs.get("disable_stream_pipeline")
+            or self._request_batch_size(img_in) > 1
+        ):
             # Original path: forward on current frame, postprocess on
             # current frame, all synchronous.
-            return self._model.forward(img_in, **mapped_kwargs)
-        if self._request_batch_size(img_in) > 1:
             return self._model.forward(img_in, **mapped_kwargs)
 
         mapped_kwargs["defer_count_to_adapter"] = (
@@ -585,7 +588,11 @@ class InferenceModelsInstanceSegmentationAdapter(Model):
         preprocess_return_metadata: PreprocessingMetadata,
         **kwargs,
     ) -> List[InstanceSegmentationInferenceResponse]:
-        if self._pipeline_depth <= 1 or not isinstance(predictions, InferenceFuture):
+        if (
+            self._pipeline_depth <= 1
+            or kwargs.get("disable_stream_pipeline")
+            or not isinstance(predictions, InferenceFuture)
+        ):
             return self._postprocess_sync(
                 predictions, preprocess_return_metadata, **kwargs
             )
@@ -680,6 +687,8 @@ class InferenceModelsInstanceSegmentationAdapter(Model):
         return_in_rle = kwargs.get("response_mask_format") == "rle"
         mapped_kwargs = self.map_inference_kwargs(kwargs)
         mapped_kwargs["defer_count_to_adapter"] = not return_in_rle
+        if len(preprocess_return_metadata) > 1:
+            mapped_kwargs["use_triton_postprocess"] = False
         detections_list = self._model.post_process(
             predictions, preprocess_return_metadata, **mapped_kwargs
         )
@@ -709,6 +718,9 @@ class InferenceModelsInstanceSegmentationAdapter(Model):
             finalize_pending = get_deferred_postprocess_finalizer(det)
             if callable(finalize_pending):
                 det = finalize_pending()
+            sparse_rle_postprocess = return_in_rle and bool(
+                getattr(det, _RFDETR_SPARSE_RLE_POSTPROCESS_ATTR, False)
+            )
             H = preproc_metadata.original_size.height
             W = preproc_metadata.original_size.width
 
@@ -939,19 +951,22 @@ class InferenceModelsInstanceSegmentationAdapter(Model):
                         )
 
             if use_dc:
-                responses.append(
-                    InstanceSegmentationInferenceResponseDC(
-                        predictions=predictions,
-                        image=InferenceResponseImageDC(width=W, height=H),
-                    )
+                response = InstanceSegmentationInferenceResponseDC(
+                    predictions=predictions,
+                    image=InferenceResponseImageDC(width=W, height=H),
                 )
             else:
-                responses.append(
-                    InstanceSegmentationInferenceResponse(
-                        predictions=predictions,
-                        image=InferenceResponseImage(width=W, height=H),
-                    )
+                response = InstanceSegmentationInferenceResponse(
+                    predictions=predictions,
+                    image=InferenceResponseImage(width=W, height=H),
                 )
+            if sparse_rle_postprocess:
+                object.__setattr__(
+                    response,
+                    _RFDETR_SPARSE_RLE_POSTPROCESS_ATTR,
+                    True,
+                )
+            responses.append(response)
         return responses
 
     def clear_cache(self, delete_from_disk: bool = True) -> None:

--- a/inference/core/workflows/core_steps/common/utils.py
+++ b/inference/core/workflows/core_steps/common/utils.py
@@ -66,6 +66,7 @@ from inference.core.workflows.execution_engine.entities.base import (
 from inference.core.workflows.prototypes.block import BlockResult
 
 T = TypeVar("T")
+_RFDETR_SPARSE_RLE_POSTPROCESS_ATTR = "_rfdetr_sparse_rle_postprocess"
 
 
 def load_core_model(
@@ -281,6 +282,8 @@ def convert_inference_detections_batch_to_sv_detections(
                 raw_predictions = filter_out_invalid_polygons(
                     predictions=raw_predictions
                 )
+            if _has_sparse_rle_postprocess_marker(prediction=p):
+                detections.data.pop(POLYGON_KEY_IN_SV_DETECTIONS, None)
         else:
             detections, raw_predictions = fast_result
 
@@ -304,6 +307,16 @@ def convert_inference_detections_batch_to_sv_detections(
             )
         batch_of_detections.append(detections)
     return batch_of_detections
+
+
+def _has_sparse_rle_postprocess_marker(prediction: Dict[str, Any]) -> bool:
+    if not prediction.get(_RFDETR_SPARSE_RLE_POSTPROCESS_ATTR):
+        return False
+    return any(
+        d.get(RLE_MASK_KEY_IN_INFERENCE_RESPONSE) is not None
+        or d.get("rle") is not None
+        for d in prediction.get("predictions", [])
+    )
 
 
 def add_inference_keypoints_to_sv_detections(

--- a/inference/core/workflows/core_steps/fusion/detections_stitch/v1.py
+++ b/inference/core/workflows/core_steps/fusion/detections_stitch/v1.py
@@ -6,6 +6,7 @@ import supervision as sv
 from pydantic import ConfigDict, Field
 from supervision import OverlapFilter, move_boxes, move_masks
 from supervision.config import ORIENTED_BOX_COORDINATES
+from supervision.detection.compact_mask import CompactMask
 
 from inference.core.workflows.core_steps.common.utils import (
     attach_parents_coordinates_to_sv_detections,
@@ -286,9 +287,16 @@ def move_detections(
             raise ValueError(
                 "To move non-empty detections with segmentation mask, resolution_wh is needed, but not given."
             )
-        detections.mask = move_masks(
-            masks=detections.mask, offset=offset, resolution_wh=resolution_wh
-        )
+        if isinstance(detections.mask, CompactMask):
+            detections.mask = detections.mask.with_offset(
+                dx=int(offset[0]),
+                dy=int(offset[1]),
+                new_image_shape=(resolution_wh[1], resolution_wh[0]),
+            )
+        else:
+            detections.mask = move_masks(
+                masks=detections.mask, offset=offset, resolution_wh=resolution_wh
+            )
     return detections
 
 

--- a/inference/core/workflows/core_steps/models/roboflow/instance_segmentation/v3.py
+++ b/inference/core/workflows/core_steps/models/roboflow/instance_segmentation/v3.py
@@ -73,6 +73,8 @@ block. To learn more about setting your Roboflow API key, [refer to the Inferenc
 documentation](https://inference.roboflow.com/quickstart/configure_api_key/).
 """
 
+_RFDETR_SPARSE_RLE_POSTPROCESS_ATTR = "_rfdetr_sparse_rle_postprocess"
+
 
 @dataclass(frozen=True)
 class _StreamPredictionContext:
@@ -258,6 +260,8 @@ class RoboflowInstanceSegmentationModelBlockV3(WorkflowBlock):
         self._pending_stream_prediction_contexts: Deque[_StreamPredictionContext] = (
             deque()
         )
+        self._last_request_used_stream_pipeline = False
+        self._stream_pipeline_disabled_for_workflow = False
         self._stream_context_generation = 0
 
     @classmethod
@@ -346,13 +350,20 @@ class RoboflowInstanceSegmentationModelBlockV3(WorkflowBlock):
             model_id=model_id,
             api_key=self._api_key,
         )
+        stream_pipeline_disabled = (
+            self._stream_pipeline_disabled_for_workflow or len(images) != 1
+        )
+        model_stream_pipeline_depth = self._model_stream_pipeline_depth()
+        self._last_request_used_stream_pipeline = (
+            not stream_pipeline_disabled and model_stream_pipeline_depth > 0
+        )
         stream_context = _StreamPredictionContext(
             images=images,
             class_filter=class_filter,
             model_id=model_id,
             context_id=self._build_stream_context_id(images=images),
         )
-        if self.stream_pipeline_depth() > 0 and len(images) == 1:
+        if self._last_request_used_stream_pipeline:
             self._pending_stream_prediction_contexts.append(stream_context)
         request = InstanceSegmentationInferenceRequest(
             api_key=self._api_key,
@@ -371,6 +382,7 @@ class RoboflowInstanceSegmentationModelBlockV3(WorkflowBlock):
             source="workflow-execution",
             stream_pipeline_context_id=stream_context.context_id,
             enforce_dense_masks_in_inference_models=enforce_dense_masks_in_inference_models,
+            disable_stream_pipeline=stream_pipeline_disabled,
         )
         predictions = self._model_manager.infer_from_request_sync(
             model_id=model_id, request=request
@@ -480,14 +492,7 @@ class RoboflowInstanceSegmentationModelBlockV3(WorkflowBlock):
         # (cheaper construct + dict-walk than pydantic). Any other response type
         # (e.g. if a non-rfdetr backend is bound to the same block) falls back
         # to `model_dump`.
-        predictions = [
-            (
-                _is_response_dc_to_dict(e)
-                if isinstance(e, InstanceSegmentationInferenceResponseDC)
-                else e.model_dump(by_alias=True, exclude_none=True)
-            )
-            for e in predictions
-        ]
+        predictions = [_prediction_response_to_dict(e) for e in predictions]
         _validate_stream_prediction_alignment(
             predictions=predictions,
             stream_context=stream_context,
@@ -536,34 +541,44 @@ class RoboflowInstanceSegmentationModelBlockV3(WorkflowBlock):
         return result[image_index]["predictions"]
 
     def is_stream_pipelined(self) -> bool:
+        return self.stream_pipeline_depth() > 0
+
+    def _model_stream_pipeline_depth(self) -> int:
         if self._step_execution_mode is not StepExecutionMode.LOCAL:
-            return False
+            return 0
         if (
             self._last_model_id is None
             or self._last_model_id not in self._model_manager
         ):
-            return False
+            return 0
         model = self._model_manager[self._last_model_id]
-        return (
-            callable(getattr(model, "flush", None))
-            and getattr(model, "_pipeline_depth", 1) > 1
-        )
+        if not callable(getattr(model, "flush", None)):
+            return 0
+        return max(0, int(getattr(model, "_pipeline_depth", 1)) - 1)
 
     def can_activate_stream_pipeline(self) -> bool:
         return (
             self._step_execution_mode is StepExecutionMode.LOCAL
             and get_rfdetr_pipeline_depth() > 1
+            and not self._stream_pipeline_disabled_for_workflow
         )
 
     def stream_pipeline_depth(self) -> int:
-        if not self.is_stream_pipelined():
+        if not self._last_request_used_stream_pipeline:
             return 0
-        model = self._model_manager[self._last_model_id]
-        return max(0, int(getattr(model, "_pipeline_depth", 1)) - 1)
+        return self._model_stream_pipeline_depth()
+
+    def disable_stream_pipeline_for_workflow(self) -> None:
+        self._stream_pipeline_disabled_for_workflow = True
+        self._last_request_used_stream_pipeline = False
+        self._pending_stream_prediction_contexts.clear()
 
     def flush_stream_pipeline_outputs(
         self,
     ) -> List[Tuple[List[Tuple[int, ...]], BlockResult]]:
+        if not self._last_request_used_stream_pipeline:
+            self._pending_stream_prediction_contexts.clear()
+            return []
         if (
             self._last_model_id is None
             or self._last_model_id not in self._model_manager
@@ -723,6 +738,16 @@ class RoboflowInstanceSegmentationModelBlockV3(WorkflowBlock):
             }
             for inference_id, prediction in zip(inference_ids, predictions)
         ]
+
+
+def _prediction_response_to_dict(response: object) -> dict:
+    if isinstance(response, InstanceSegmentationInferenceResponseDC):
+        result = _is_response_dc_to_dict(response)
+    else:
+        result = response.model_dump(by_alias=True, exclude_none=True)
+    if getattr(response, _RFDETR_SPARSE_RLE_POSTPROCESS_ATTR, False):
+        result[_RFDETR_SPARSE_RLE_POSTPROCESS_ATTR] = True
+    return result
 
 
 def _resolve_stream_future(

--- a/inference/core/workflows/core_steps/models/roboflow/instance_segmentation/v4.py
+++ b/inference/core/workflows/core_steps/models/roboflow/instance_segmentation/v4.py
@@ -65,6 +65,8 @@ This version of block introduces breaking change in behaviour of mask constructi
 shapes of any kind from remote server.
 """
 
+_RFDETR_SPARSE_RLE_POSTPROCESS_ATTR = "_rfdetr_sparse_rle_postprocess"
+
 
 class BlockManifest(WorkflowBlockManifest):
     model_config = ConfigDict(
@@ -336,9 +338,7 @@ class RoboflowInstanceSegmentationModelBlockV4(WorkflowBlock):
         )
         if not isinstance(predictions, list):
             predictions = [predictions]
-        predictions = [
-            e.model_dump(by_alias=True, exclude_none=True) for e in predictions
-        ]
+        predictions = [_prediction_response_to_dict(e) for e in predictions]
         return self._post_process_result(
             images=images,
             predictions=predictions,
@@ -432,3 +432,10 @@ class RoboflowInstanceSegmentationModelBlockV4(WorkflowBlock):
             }
             for inference_id, prediction in zip(inference_ids, predictions)
         ]
+
+
+def _prediction_response_to_dict(response: object) -> dict:
+    result = response.model_dump(by_alias=True, exclude_none=True)
+    if getattr(response, _RFDETR_SPARSE_RLE_POSTPROCESS_ATTR, False):
+        result[_RFDETR_SPARSE_RLE_POSTPROCESS_ATTR] = True
+    return result

--- a/inference/core/workflows/execution_engine/v1/executor/output_constructor.py
+++ b/inference/core/workflows/execution_engine/v1/executor/output_constructor.py
@@ -1,5 +1,7 @@
 import traceback
 from collections import defaultdict
+from concurrent.futures import Future
+from threading import Lock
 from typing import Any, Callable, Dict, List, Optional, Set, Union
 
 import numpy as np
@@ -12,6 +14,10 @@ from inference.core.workflows.core_steps.common.utils import (
 )
 from inference.core.workflows.errors import AssumptionError, ExecutionEngineRuntimeError
 from inference.core.workflows.execution_engine.constants import (
+    IMAGE_DIMENSIONS_KEY,
+    ROOT_PARENT_COORDINATES_KEY,
+    ROOT_PARENT_DIMENSIONS_KEY,
+    SCALING_RELATIVE_TO_ROOT_PARENT_KEY,
     TOP_LEVEL_LINEAGES_KEY,
     WORKFLOW_INPUT_BATCH_LINEAGE_ID,
 )
@@ -180,13 +186,13 @@ def create_outputs_for_input_induced_lineages(
             indices=indices,
         )
         for index, data_piece in zip(indices, data):
-            if resolve_output_futures:
-                data_piece = _maybe_resolve_output_futures(data_piece)
-            if (
-                name in outputs_requested_in_parent_coordinates
-                and data_contains_sv_detections(data=data_piece)
-            ):
-                data_piece = convert_sv_detections_coordinates(data=data_piece)
+            data_piece = _prepare_data_piece_for_output(
+                data_piece=data_piece,
+                resolve_output_futures=resolve_output_futures,
+                convert_to_parent_coordinates=(
+                    name in outputs_requested_in_parent_coordinates
+                ),
+            )
             if serialize_results:
                 output_kind = kinds_of_output_nodes[name]
                 data_piece = serialize_data_piece(
@@ -277,13 +283,13 @@ def create_outputs_for_generated_lineage_outputs(
             indices=indices,
         )
         for index, data_piece in zip(indices, data):
-            if resolve_output_futures:
-                data_piece = _maybe_resolve_output_futures(data_piece)
-            if (
-                name in outputs_requested_in_parent_coordinates
-                and data_contains_sv_detections(data=data_piece)
-            ):
-                data_piece = convert_sv_detections_coordinates(data=data_piece)
+            data_piece = _prepare_data_piece_for_output(
+                data_piece=data_piece,
+                resolve_output_futures=resolve_output_futures,
+                convert_to_parent_coordinates=(
+                    name in outputs_requested_in_parent_coordinates
+                ),
+            )
             if serialize_results:
                 output_kind = kinds_of_output_nodes[name]
                 data_piece = serialize_data_piece(
@@ -326,6 +332,85 @@ def create_outputs_for_generated_lineage_outputs(
                 element = array[i]
             results[name].append(element)
     return results
+
+
+class _DeferredResolvedOutput(Future):
+    def __init__(
+        self,
+        value: Any,
+        transform: Callable[[Any], Any],
+    ) -> None:
+        super().__init__()
+        self._value = value
+        self._transform = transform
+        self._resolution_lock = Lock()
+
+    def result(self, timeout: Optional[float] = None) -> Any:
+        if not self.done():
+            with self._resolution_lock:
+                if not self.done():
+                    try:
+                        resolved_value = _resolve_output_futures(value=self._value)
+                        self.set_result(self._transform(resolved_value))
+                    except BaseException as error:
+                        self.set_exception(error)
+        return super().result(timeout=timeout)
+
+
+def _prepare_data_piece_for_output(
+    data_piece: Any,
+    resolve_output_futures: bool,
+    convert_to_parent_coordinates: bool,
+) -> Any:
+    if resolve_output_futures:
+        data_piece = _maybe_resolve_output_futures(value=data_piece)
+    elif convert_to_parent_coordinates and _output_contains_future(value=data_piece):
+        return _DeferredResolvedOutput(
+            value=data_piece,
+            transform=_convert_sv_detections_coordinates_if_present,
+        )
+    if convert_to_parent_coordinates:
+        return _convert_sv_detections_coordinates_if_present(data=data_piece)
+    return data_piece
+
+
+def _convert_sv_detections_coordinates_if_present(data: Any) -> Any:
+    if data_needs_sv_detections_coordinate_conversion(data=data):
+        return convert_sv_detections_coordinates(data=data)
+    return data
+
+
+def data_needs_sv_detections_coordinate_conversion(data: Any) -> bool:
+    if isinstance(data, sv.Detections):
+        return _sv_detections_need_root_coordinate_conversion(detections=data)
+    if isinstance(data, (list, tuple)):
+        return any(data_needs_sv_detections_coordinate_conversion(data=e) for e in data)
+    if isinstance(data, dict):
+        return any(
+            data_needs_sv_detections_coordinate_conversion(data=e)
+            for e in data.values()
+        )
+    return False
+
+
+def _sv_detections_need_root_coordinate_conversion(detections: sv.Detections) -> bool:
+    if len(detections) == 0:
+        return False
+    root_coordinates = detections.data.get(ROOT_PARENT_COORDINATES_KEY)
+    if root_coordinates is None:
+        return False
+    if np.any(np.asarray(root_coordinates) != 0):
+        return True
+    root_dimensions = detections.data.get(ROOT_PARENT_DIMENSIONS_KEY)
+    image_dimensions = detections.data.get(IMAGE_DIMENSIONS_KEY)
+    if (
+        root_dimensions is not None
+        and image_dimensions is not None
+        and not np.array_equal(root_dimensions, image_dimensions)
+    ):
+        return True
+    root_scale = detections.data.get(SCALING_RELATIVE_TO_ROOT_PARENT_KEY)
+    return root_scale is not None and not np.allclose(root_scale, 1.0)
 
 
 def _resolve_output_futures(value: Any) -> Any:

--- a/inference_models/inference_models/models/rfdetr/common.py
+++ b/inference_models/inference_models/models/rfdetr/common.py
@@ -9,9 +9,7 @@ from inference_models.configuration import (
 )
 from inference_models.entities import ImageDimensions
 from inference_models.errors import CorruptedModelPackageError
-from inference_models.models.common.roboflow.model_packages import (
-    PreProcessingMetadata,
-)
+from inference_models.models.common.roboflow.model_packages import PreProcessingMetadata
 from inference_models.models.common.roboflow.post_processing import (
     align_instance_segmentation_results,
     align_instance_segmentation_results_to_rle_masks,
@@ -391,12 +389,18 @@ def post_process_instance_segmentation_results_to_rle_masks(
     num_classes: int,
     classes_re_mapping: Optional[ClassesReMapping],
     defer_postprocess_sync: bool = False,
+    use_triton_postprocess: Optional[bool] = None,
 ) -> List[InstanceDetections]:
     logits_sigmoid = torch.nn.functional.sigmoid(logits)
     device = bboxes.device
     if isinstance(threshold, torch.Tensor):
         threshold = threshold.to(device=device, dtype=logits_sigmoid.dtype)
-    if _TRITON_POSTPROC_ENABLED:
+    triton_postprocess_enabled = (
+        _TRITON_POSTPROC_ENABLED
+        if use_triton_postprocess is None
+        else use_triton_postprocess
+    )
+    if triton_postprocess_enabled:
         return [
             _post_process_single_instance_segmentation_result_to_rle_masks_with_triton(
                 image_bboxes=image_bboxes,

--- a/inference_models/inference_models/models/rfdetr/rfdetr_instance_segmentation_trt.py
+++ b/inference_models/inference_models/models/rfdetr/rfdetr_instance_segmentation_trt.py
@@ -99,6 +99,12 @@ except ImportError as import_error:
     ) from import_error
 
 
+def _supports_fast_preprocess_batch(
+    images: Union[torch.Tensor, List[torch.Tensor], np.ndarray, List[np.ndarray]],
+) -> bool:
+    return not isinstance(images, list) or len(images) == 1
+
+
 class RFDetrForInstanceSegmentationTRT(
     InstanceSegmentationModel[
         torch.Tensor,
@@ -263,7 +269,7 @@ class RFDetrForInstanceSegmentationTRT(
         **kwargs,
     ) -> Tuple[torch.Tensor, List[PreProcessingMetadata]]:
         fast = None
-        if self._fast_preprocess_enabled:
+        if self._fast_preprocess_enabled and _supports_fast_preprocess_batch(images):
             fast = self._fast_preprocess_runtime.try_preprocess(
                 images=images,
                 input_color_format=input_color_format,
@@ -469,6 +475,7 @@ class RFDetrForInstanceSegmentationTRT(
                     num_classes=len(self.class_names),
                     classes_re_mapping=self._classes_re_mapping,
                     defer_postprocess_sync=kwargs.get("defer_postprocess_sync", False),
+                    use_triton_postprocess=kwargs.get("use_triton_postprocess"),
                 )
             if graph_state is not None:
                 output_consumed_events = [

--- a/inference_models/inference_models/models/rfdetr/triton_postprocess.py
+++ b/inference_models/inference_models/models/rfdetr/triton_postprocess.py
@@ -78,6 +78,7 @@ _MAX_PINNED_HOST_POOL_BUFFERS = 8
 _PINNED_HOST_POOL = OrderedDict()
 _PINNED_HOST_POOL_LOCK = Lock()
 _PINNED_HOST_POOL_SIZE = 0
+_RFDETR_SPARSE_RLE_POSTPROCESS_ATTR = "_rfdetr_sparse_rle_postprocess"
 
 
 def _get_interpolation_weights(
@@ -214,6 +215,8 @@ def _release_pinned_host_buffer(buffer: torch.Tensor) -> None:
         buffers.append(buffer)
         _PINNED_HOST_POOL.move_to_end(key)
         _PINNED_HOST_POOL_SIZE += 1
+
+
 def post_process_single_instance_segmentation_result_to_rle_masks_triton(
     image_bboxes: torch.Tensor,
     image_scores: torch.Tensor,
@@ -607,14 +610,16 @@ def _instance_detections_from_sparse_records(
     """
     active_ranks = np.flatnonzero(metadata_host[:, 0] > 0.5)
     if active_ranks.size == 0:
-        return InstanceDetections(
-            xyxy=torch.empty((0, 4), dtype=torch.int32),
-            confidence=torch.empty((0,), dtype=torch.float32),
-            class_id=torch.empty((0,), dtype=torch.int32),
-            mask=InstancesRLEMasks.from_coco_rle_masks(
-                image_size=(height, width),
-                masks=[],
-            ),
+        return _mark_sparse_rle_postprocess(
+            InstanceDetections(
+                xyxy=torch.empty((0, 4), dtype=torch.int32),
+                confidence=torch.empty((0,), dtype=torch.float32),
+                class_id=torch.empty((0,), dtype=torch.int32),
+                mask=InstancesRLEMasks.from_coco_rle_masks(
+                    image_size=(height, width),
+                    masks=[],
+                ),
+            )
         )
     if np.any(metadata_host[active_ranks, 8] > 0.5):
         return None
@@ -673,11 +678,13 @@ def _instance_detections_from_sparse_records(
     # The pipeline RLE-to-polygon path consumes uncompressed counts directly, so
     # keep them beside the pycocotools-compressed masks instead of decoding later.
     _attach_uncompressed_counts(instances_masks, rle_counts)
-    return InstanceDetections(
-        xyxy=boxes,
-        confidence=confidence,
-        class_id=class_id,
-        mask=instances_masks,
+    return _mark_sparse_rle_postprocess(
+        InstanceDetections(
+            xyxy=boxes,
+            confidence=confidence,
+            class_id=class_id,
+            mask=instances_masks,
+        )
     )
 
 
@@ -698,14 +705,16 @@ def _instance_detections_from_sparse_query_records(
     """
     active_ranks = np.flatnonzero(class_metadata_host[:, 0] > 0.5)
     if active_ranks.size == 0:
-        return InstanceDetections(
-            xyxy=torch.empty((0, 4), dtype=torch.int32),
-            confidence=torch.empty((0,), dtype=torch.float32),
-            class_id=torch.empty((0,), dtype=torch.int32),
-            mask=InstancesRLEMasks.from_coco_rle_masks(
-                image_size=(height, width),
-                masks=[],
-            ),
+        return _mark_sparse_rle_postprocess(
+            InstanceDetections(
+                xyxy=torch.empty((0, 4), dtype=torch.int32),
+                confidence=torch.empty((0,), dtype=torch.float32),
+                class_id=torch.empty((0,), dtype=torch.int32),
+                mask=InstancesRLEMasks.from_coco_rle_masks(
+                    image_size=(height, width),
+                    masks=[],
+                ),
+            )
         )
     if np.any(class_metadata_host[active_ranks, 8] > 0.5):
         return None
@@ -777,12 +786,19 @@ def _instance_detections_from_sparse_query_records(
     # The pipeline RLE-to-polygon path consumes uncompressed counts directly, so
     # keep them beside the pycocotools-compressed masks instead of decoding later.
     _attach_uncompressed_counts(instances_masks, rle_counts)
-    return InstanceDetections(
-        xyxy=boxes,
-        confidence=confidence,
-        class_id=class_id,
-        mask=instances_masks,
+    return _mark_sparse_rle_postprocess(
+        InstanceDetections(
+            xyxy=boxes,
+            confidence=confidence,
+            class_id=class_id,
+            mask=instances_masks,
+        )
     )
+
+
+def _mark_sparse_rle_postprocess(detections: InstanceDetections) -> InstanceDetections:
+    setattr(detections, _RFDETR_SPARSE_RLE_POSTPROCESS_ATTR, True)
+    return detections
 
 
 def _sparse_query_records_failure_reason(
@@ -793,7 +809,9 @@ def _sparse_query_records_failure_reason(
     active_ranks = np.flatnonzero(class_metadata_host[:, 0] > 0.5)
     if active_ranks.size == 0:
         return "no_failure"
-    metadata_overflows = int(np.count_nonzero(class_metadata_host[active_ranks, 8] > 0.5))
+    metadata_overflows = int(
+        np.count_nonzero(class_metadata_host[active_ranks, 8] > 0.5)
+    )
     total_runs = int(records_host[0, 0])
     overflow_flag = int(records_host[0, 1])
     reasons = []
@@ -1730,9 +1748,7 @@ if triton is not None:
                     y_idx + y_base + 1,
                     mask=row_active,
                     other=0,
-                ).to(
-                    tl.int64
-                )
+                ).to(tl.int64)
                 y_weight0 = tl.load(y_weight + y_base, mask=row_active, other=0.0)
                 y_weight1 = tl.load(
                     y_weight + y_base + 1,
@@ -1780,7 +1796,9 @@ if triton is not None:
                 # current positive after previous background starts a run;
                 # previous positive followed by current background ends it.
                 previous_y = output_y - 1
-                previous_row_active = boundary_row_active & (row_y[:, None] > roi_y_start)
+                previous_row_active = boundary_row_active & (
+                    row_y[:, None] > roi_y_start
+                )
                 previous_active = previous_row_active & column_active[None, :]
                 previous_y_base = previous_y * 2
                 prev_source_y0 = tl.load(

--- a/tests/inference/unit_tests/core/interfaces/stream/test_interface_pipeline.py
+++ b/tests/inference/unit_tests/core/interfaces/stream/test_interface_pipeline.py
@@ -9,7 +9,6 @@ from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
-import supervision as sv
 
 from inference.core.active_learning.middlewares import ThreadingActiveLearningMiddleware
 from inference.core.cache import MemoryCache
@@ -36,10 +35,7 @@ from inference.core.interfaces.stream.entities import (
 )
 from inference.core.interfaces.stream.inference_pipeline import (
     InferencePipeline,
-    SinkMode,
-    _apply_workflow_parent_coordinate_conversion,
     _resolve_prediction_futures,
-    _workflow_parent_coordinate_output_names,
 )
 from inference.core.interfaces.stream.model_handlers.roboflow_models import (
     default_process_frame,
@@ -216,121 +212,6 @@ def test_resolve_prediction_futures_recursively_resolves_nested_values() -> None
     assert _resolve_prediction_futures((outer, {"raw": inner})) == (
         {"detections": ["resolved"]},
         {"raw": "resolved"},
-    )
-
-
-def test_resolve_prediction_futures_recursively_resolves_nested_values() -> None:
-    inner = Future()
-    inner.set_result("resolved")
-    outer = Future()
-    outer.set_result({"detections": [inner]})
-
-    assert _resolve_prediction_futures((outer, {"raw": inner})) == (
-        {"detections": ["resolved"]},
-        {"raw": "resolved"},
-    )
-
-
-def test_workflow_parent_coordinate_output_names_defaults_to_parent_outputs() -> None:
-    workflow_specification = {
-        "outputs": [
-            {"name": "predictions", "selector": "$steps.model.predictions"},
-            {
-                "name": "crop_predictions",
-                "selector": "$steps.crop.predictions",
-                "coordinates_system": "own",
-            },
-            {"name": "visualization", "selector": "$steps.viz.image"},
-        ]
-    }
-
-    assert _workflow_parent_coordinate_output_names(
-        workflow_specification=workflow_specification
-    ) == frozenset({"predictions", "visualization"})
-
-
-def _detections_with_root_shift() -> sv.Detections:
-    return sv.Detections(
-        xyxy=np.array([[25.0, 50.0, 75.0, 150.0]]),
-        data={
-            "parent_coordinates": np.array([[10.0, 20.0]]),
-            "root_parent_coordinates": np.array([[50.0, 100.0]]),
-            "root_parent_dimensions": np.array([[512.0, 1024.0]]),
-            "root_parent_id": np.array(["root"]),
-        },
-    )
-
-
-def test_apply_workflow_parent_coordinate_conversion_shifts_parent_outputs() -> None:
-    detections = _detections_with_root_shift()
-    predictions = {
-        "predictions": detections,
-        "crop_predictions": sv.Detections(
-            xyxy=np.array([[5.0, 10.0, 15.0, 20.0]]),
-            data={
-                "parent_coordinates": np.array([[10.0, 20.0]]),
-                "root_parent_coordinates": np.array([[50.0, 100.0]]),
-                "root_parent_dimensions": np.array([[512.0, 1024.0]]),
-                "root_parent_id": np.array(["root"]),
-            },
-        ),
-    }
-
-    converted = _apply_workflow_parent_coordinate_conversion(
-        predictions=predictions,
-        parent_output_names=frozenset({"predictions"}),
-    )
-
-    assert np.allclose(
-        converted["predictions"].xyxy,
-        np.array([[75.0, 150.0, 125.0, 250.0]]),
-    )
-    assert np.allclose(
-        converted["crop_predictions"].xyxy,
-        np.array([[5.0, 10.0, 15.0, 20.0]]),
-    )
-
-
-def test_dispatch_inference_results_applies_deferred_parent_coordinate_conversion(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    detections = _detections_with_root_shift()
-    prediction_future = Future()
-    prediction_future.set_result(detections)
-    frame = VideoFrame(
-        image=np.zeros((8, 8, 3), dtype=np.uint8),
-        frame_id=1,
-        frame_timestamp=datetime.now(),
-        source_id=0,
-    )
-    dispatched = []
-
-    def on_prediction(prediction: dict, video_frame: VideoFrame) -> None:
-        dispatched.append((prediction, video_frame))
-
-    pipeline = object.__new__(InferencePipeline)
-    pipeline._predictions_queue = Queue()
-    pipeline._on_prediction = on_prediction
-    pipeline._sink_mode = SinkMode.SEQUENTIAL
-    pipeline._video_sources = []
-    pipeline._workflow_parent_coordinate_outputs = frozenset({"predictions"})
-    pipeline._workflow_defer_output_coordinate_conversion = True
-    pipeline._handle_predictions_dispatching = InferencePipeline._handle_predictions_dispatching.__get__(
-        pipeline, InferencePipeline
-    )
-    monkeypatch.setattr(
-        "inference.core.interfaces.stream.inference_pipeline._rfdetr_stream_pipeline_enabled",
-        lambda: True,
-    )
-
-    pipeline._predictions_queue.put(([{"predictions": prediction_future}], [frame]))
-    pipeline._predictions_queue.put(None)
-    pipeline._dispatch_inference_results()
-
-    assert len(dispatched) == 1
-    assert np.allclose(
-        dispatched[0][0]["predictions"].xyxy,
-        np.array([[75.0, 150.0, 125.0, 250.0]]),
     )
 
 

--- a/tests/inference/unit_tests/core/interfaces/stream/test_workflows.py
+++ b/tests/inference/unit_tests/core/interfaces/stream/test_workflows.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from types import SimpleNamespace
 from typing import Optional
 
+import networkx as nx
 import numpy as np
 import pytest
 
@@ -17,6 +18,16 @@ from inference.core.workflows.core_steps.models.roboflow.instance_segmentation.v
     RoboflowInstanceSegmentationModelBlockV3,
 )
 from inference.core.workflows.execution_engine.entities.base import Batch, VideoMetadata
+from inference.core.workflows.execution_engine.constants import (
+    NODE_COMPILATION_OUTPUT_PROPERTY,
+)
+from inference.core.workflows.execution_engine.v1.compiler.entities import (
+    DynamicStepInputDefinition,
+    NodeCategory,
+    NodeInputCategory,
+    ParameterSpecification,
+    StepNode,
+)
 from inference_models.models.base.async_handoff import attach_async_response_future
 
 
@@ -38,6 +49,16 @@ class _FakePipelinedStep:
 
     def close_stream_pipeline(self) -> None:
         self.close_calls += 1
+
+
+class _DisableAwarePipelinedStep(_FakePipelinedStep):
+    def __init__(self, stream_buffer_depth: int) -> None:
+        super().__init__(stream_buffer_depth=stream_buffer_depth)
+        self.disable_calls = 0
+
+    def disable_stream_pipeline_for_workflow(self) -> None:
+        self.disable_calls += 1
+        self._stream_buffer_depth = 0
 
 
 class _FakeExecutionEngine:
@@ -82,6 +103,17 @@ class _FakeExecutionEngine:
         _is_preview,
     ):
         return self.step.flush_stream_pipeline()[0]
+
+
+class _GraphAwareExecutionEngine:
+    def __init__(self, execution_graph, step) -> None:
+        self.step = step
+        self._engine = SimpleNamespace(
+            _compiled_workflow=SimpleNamespace(
+                steps={"segmentation": SimpleNamespace(step=self.step)},
+                execution_graph=execution_graph,
+            )
+        )
 
 
 class _FakeLateActivatingStep:
@@ -192,6 +224,47 @@ class _FakeDownstreamPipelinedExecutionEngine:
         return [{"result": f"downstream-frame-{frame_number}"}]
 
 
+def _step_node(
+    name: str,
+    input_data: Optional[dict] = None,
+) -> StepNode:
+    return StepNode(
+        node_category=NodeCategory.STEP_NODE,
+        name=name,
+        selector=f"$steps.{name}",
+        data_lineage=[],
+        step_manifest=SimpleNamespace(type=f"test/{name}@v1"),
+        input_data=input_data or {},
+    )
+
+
+def _dynamic_input(
+    parameter_name: str,
+    selector: str,
+    category: NodeInputCategory = NodeInputCategory.BATCH_STEP_OUTPUT,
+) -> DynamicStepInputDefinition:
+    return DynamicStepInputDefinition(
+        parameter_specification=ParameterSpecification(
+            parameter_name=parameter_name,
+        ),
+        category=category,
+        data_lineage=[],
+        selector=selector,
+    )
+
+
+def _graph_with_nodes(nodes, edges):
+    graph = nx.DiGraph()
+    for node in nodes:
+        graph.add_node(
+            node.selector,
+            **{NODE_COMPILATION_OUTPUT_PROPERTY: node},
+        )
+    for source, target in edges:
+        graph.add_edge(source, target)
+    return graph
+
+
 class _ImmediateExecutor:
     def submit(self, fn, *args, **kwargs) -> Future:
         future = Future()
@@ -279,6 +352,7 @@ class _FakeModelManager:
         self._inference_results = list(inference_results)
         self.model = _FakeStreamModel()
         self.add_model_calls = []
+        self.requests = []
         self.infer_calls = 0
 
     def add_model(self, model_id: str, api_key: str) -> None:
@@ -286,6 +360,7 @@ class _FakeModelManager:
 
     def infer_from_request_sync(self, model_id: str, request):
         self.infer_calls += 1
+        self.requests.append(request)
         return self._inference_results.pop(0)
 
     def __contains__(self, model_id: str) -> bool:
@@ -410,6 +485,88 @@ def test_wrap_workflow_runner_leaves_non_pipelined_workflows_unchanged() -> None
         )
         is runner
     )
+
+
+def test_wrap_workflow_runner_keeps_stream_pipeline_for_prediction_only_downstream() -> (
+    None
+):
+    step = _DisableAwarePipelinedStep(stream_buffer_depth=1)
+    segmentation = _step_node("segmentation")
+    confidence_filter = _step_node(
+        "confidence_filter",
+        input_data={
+            "predictions": _dynamic_input(
+                parameter_name="predictions",
+                selector="$steps.segmentation.predictions",
+            )
+        },
+    )
+    engine = _GraphAwareExecutionEngine(
+        execution_graph=_graph_with_nodes(
+            nodes=[segmentation, confidence_filter],
+            edges=[("$steps.segmentation", "$steps.confidence_filter")],
+        ),
+        step=step,
+    )
+    runner = WorkflowRunner(
+        workflows_parameters=None,
+        execution_engine=engine,
+        image_input_name="image",
+        video_metadata_input_name="video_metadata",
+    )
+
+    wrapped = wrap_workflow_runner_for_stream_pipeline(
+        workflow_runner=runner,
+        execution_engine=engine,
+    )
+
+    assert isinstance(wrapped, PipelinedWorkflowRunner)
+    assert step.disable_calls == 0
+
+
+def test_wrap_workflow_runner_disables_stream_pipeline_for_downstream_image_inputs() -> (
+    None
+):
+    step = _DisableAwarePipelinedStep(stream_buffer_depth=1)
+    segmentation = _step_node("segmentation")
+    center_crop = _step_node("center_crop")
+    polygon_visualization = _step_node(
+        "polygon_visualization",
+        input_data={
+            "predictions": _dynamic_input(
+                parameter_name="predictions",
+                selector="$steps.segmentation.predictions",
+            ),
+            "image": _dynamic_input(
+                parameter_name="image",
+                selector="$steps.center_crop.crops",
+            ),
+        },
+    )
+    engine = _GraphAwareExecutionEngine(
+        execution_graph=_graph_with_nodes(
+            nodes=[segmentation, center_crop, polygon_visualization],
+            edges=[
+                ("$steps.center_crop", "$steps.polygon_visualization"),
+                ("$steps.segmentation", "$steps.polygon_visualization"),
+            ],
+        ),
+        step=step,
+    )
+    runner = WorkflowRunner(
+        workflows_parameters=None,
+        execution_engine=engine,
+        image_input_name="image",
+        video_metadata_input_name="video_metadata",
+    )
+
+    wrapped = wrap_workflow_runner_for_stream_pipeline(
+        workflow_runner=runner,
+        execution_engine=engine,
+    )
+
+    assert wrapped is runner
+    assert step.disable_calls == 1
 
 
 def test_workflow_runner_buffers_frames_until_delayed_prediction_arrives() -> None:
@@ -562,6 +719,51 @@ def test_instance_segmentation_stream_pipeline_activation_requires_depth_above_o
         lambda: 2,
     )
     assert block.can_activate_stream_pipeline() is True
+
+
+def test_instance_segmentation_stream_pipeline_is_disabled_for_generated_batches() -> (
+    None
+):
+    manager = _FakeModelManager(
+        inference_results=[
+            [_FakeResponse("frame-1-a"), _FakeResponse("frame-1-b")],
+        ]
+    )
+    block = RoboflowInstanceSegmentationModelBlockV3(
+        model_manager=manager,
+        api_key="api-key",
+        step_execution_mode=StepExecutionMode.LOCAL,
+    )
+    block._post_process_result = lambda images, predictions, class_filter, model_id: [
+        {
+            "predictions": f"{image.tag}:{prediction['tag']}",
+            "model_id": model_id,
+        }
+        for image, prediction in zip(images, predictions)
+    ]
+
+    result = block.run_locally(
+        images=[_FakeWorkflowImage("slice-1"), _FakeWorkflowImage("slice-2")],
+        model_id="model",
+        class_agnostic_nms=None,
+        class_filter=None,
+        confidence=0.4,
+        iou_threshold=None,
+        max_detections=None,
+        max_candidates=None,
+        mask_decode_mode="accurate",
+        tradeoff_factor=None,
+        disable_active_learning=None,
+        active_learning_target_dataset=None,
+        enforce_dense_masks_in_inference_models=False,
+    )
+
+    assert manager.requests[0].disable_stream_pipeline is True
+    assert block.stream_pipeline_depth() == 0
+    assert result == [
+        {"predictions": "slice-1:frame-1-a", "model_id": "model"},
+        {"predictions": "slice-2:frame-1-b", "model_id": "model"},
+    ]
 
 
 def test_instance_segmentation_stream_flush_drains_model_without_rerunning_workflow() -> (

--- a/tests/inference/unit_tests/core/models/test_inference_models_adapters.py
+++ b/tests/inference/unit_tests/core/models/test_inference_models_adapters.py
@@ -87,6 +87,16 @@ def _make_meta(tag: str):
     ]
 
 
+def _make_batch_meta(*tags: str):
+    return [
+        SimpleNamespace(
+            tag=tag,
+            original_size=SimpleNamespace(width=10, height=20),
+        )
+        for tag in tags
+    ]
+
+
 def _make_pipeline_adapter(
     futures: list[_FakePipelineFuture],
     ops: list[str],
@@ -170,6 +180,25 @@ def test_pipeline_postprocess_uses_sync_path_for_non_future_predictions() -> Non
     assert responses == ["meta-1"]
     assert len(adapter._model.post_process_calls) == 1
     assert adapter._model.post_process_calls[0][0] == "sync-raw"
+
+
+def test_sync_postprocess_disables_triton_postprocess_for_batches() -> None:
+    ops: list[str] = []
+    adapter = _make_pipeline_adapter(
+        futures=[],
+        ops=ops,
+        pipeline_depth=2,
+    )
+
+    adapter.postprocess(
+        "sync-raw",
+        _make_batch_meta("meta-1", "meta-2"),
+        response_mask_format="dense",
+    )
+
+    assert len(adapter._model.post_process_calls) == 1
+    kwargs = adapter._model.post_process_calls[0][2]
+    assert kwargs["use_triton_postprocess"] is False
 
 
 def test_workflow_response_fast_dataclass_path_is_disabled_at_depth_one() -> None:

--- a/tests/workflows/unit_tests/core_steps/fusion/test_detections_stitch.py
+++ b/tests/workflows/unit_tests/core_steps/fusion/test_detections_stitch.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 import supervision as sv
 from supervision.config import ORIENTED_BOX_COORDINATES
+from supervision.detection.compact_mask import CompactMask
 
 from inference.core.workflows.core_steps.fusion.detections_stitch.v1 import (
     BlockManifest,
@@ -197,6 +198,42 @@ def test_detections_stitch_with_masks() -> None:
     assert merged.mask is not None
     assert len(merged) == 1
     assert merged.mask.shape[1:] == (400, 500)
+
+
+def test_detections_stitch_moves_compact_masks_without_materializing_dense_masks() -> (
+    None
+):
+    # given
+    block = DetectionsStitchBlockV1()
+    reference_image = make_test_image(width=100, height=100)
+    dense_mask = np.zeros((1, 10, 10), dtype=np.bool_)
+    dense_mask[0, 2:5, 3:7] = True
+    boxes = np.array([[3, 2, 6, 4]], dtype=np.float32)
+    detections = make_test_detections(
+        boxes=boxes.copy(),
+        parent_offset=(20, 30),
+        parent_dims=(100, 100),
+    )
+    detections.mask = CompactMask.from_dense(
+        masks=dense_mask,
+        xyxy=boxes,
+        image_shape=(10, 10),
+    )
+
+    # when
+    result = block.run(
+        reference_image=reference_image,
+        predictions=[detections],
+        overlap_filtering_strategy="none",
+        iou_threshold=0.5,
+    )
+
+    # then
+    stitched = result["predictions"]
+    assert isinstance(stitched.mask, CompactMask)
+    np.testing.assert_array_equal(stitched.xyxy, np.array([[23, 32, 26, 34]]))
+    assert stitched.mask.offsets.tolist() == [[23, 32]]
+    assert stitched.mask.shape == (1, 100, 100)
 
 
 def test_detections_stitch_verify_mask_dimensions_match_reference() -> None:

--- a/tests/workflows/unit_tests/execution_engine/executor/test_output_constructor.py
+++ b/tests/workflows/unit_tests/execution_engine/executor/test_output_constructor.py
@@ -589,6 +589,51 @@ def test_construct_workflow_output_defers_batch_wrapped_futures() -> None:
     assert contains_future(result[0]["a"]) is True
 
 
+def test_construct_workflow_output_defers_coordinate_conversion_with_future_output() -> (
+    None
+):
+    # given
+    execution_data_manager = MagicMock()
+    workflow_outputs = [
+        JsonField(type="JsonField", name="a", selector="$steps.some.a"),
+    ]
+    execution_graph = DiGraph()
+    execution_graph.add_node(
+        "$outputs.a",
+        node_compilation_output=OutputNode(
+            node_category=NodeCategory.OUTPUT_NODE,
+            name=workflow_outputs[0].name,
+            selector=workflow_outputs[0].selector,
+            data_lineage=["<workflow_input>"],
+            output_manifest=workflow_outputs[0],
+        ),
+    )
+    execution_graph.graph[TOP_LEVEL_LINEAGES_KEY] = WORKFLOW_INPUT_BATCH_LINEAGE_ID
+    execution_data_manager.get_selector_indices.return_value = [(0,)]
+    execution_data_manager.get_batch_data.return_value = [
+        {"predictions": _completed_future(assembly_sv_detections())}
+    ]
+    execution_data_manager.get_lineage_indices.return_value = [(0,)]
+
+    # when
+    result = construct_workflow_output(
+        workflow_outputs=workflow_outputs,
+        execution_graph=execution_graph,
+        execution_data_manager=execution_data_manager,
+        serialize_results=False,
+        kinds_serializers=KINDS_SERIALIZERS,
+        resolve_output_futures=False,
+    )
+
+    # then
+    deferred_output = result[0]["a"]
+    assert isinstance(deferred_output, Future)
+    resolved_output = deferred_output.result()
+    assert_transformed_detections_matches_expectation(
+        result=resolved_output["predictions"]
+    )
+
+
 def test_construct_workflow_output_when_batch_outputs_present() -> None:
     # given
     execution_data_manager = MagicMock()

--- a/tests/workflows/unit_tests/execution_engine/executor/test_sparse_rle_workflow_coordinates.py
+++ b/tests/workflows/unit_tests/execution_engine/executor/test_sparse_rle_workflow_coordinates.py
@@ -1,0 +1,183 @@
+import numpy as np
+import supervision as sv
+
+from inference.core.workflows.core_steps.common.entities import StepExecutionMode
+from inference.core.workflows.execution_engine.constants import (
+    POLYGON_KEY_IN_SV_DETECTIONS,
+)
+from inference.core.workflows.execution_engine.core import ExecutionEngine
+
+WORKFLOW_WITH_CROP_SEGMENTATION_AND_FILTER = {
+    "version": "1.0",
+    "inputs": [{"type": "WorkflowImage", "name": "image"}],
+    "steps": [
+        {
+            "type": "RelativeStaticCrop",
+            "name": "crop",
+            "image": "$inputs.image",
+            "x_center": 0.4,
+            "y_center": 0.375,
+            "width": 0.4,
+            "height": 0.5,
+        },
+        {
+            "type": "roboflow_core/roboflow_instance_segmentation_model@v3",
+            "name": "segmentation",
+            "images": "$steps.crop.crops",
+            "model_id": "rfdetr-seg-nano/1",
+            "confidence_mode": "custom",
+            "custom_confidence": 0.4,
+        },
+        {
+            "type": "roboflow_core/detections_filter@v1",
+            "name": "only_cars",
+            "predictions": "$steps.segmentation.predictions",
+            "operations": [
+                {
+                    "type": "DetectionsFilter",
+                    "filter_operation": {
+                        "type": "StatementGroup",
+                        "operator": "and",
+                        "statements": [
+                            {
+                                "type": "BinaryStatement",
+                                "left_operand": {
+                                    "type": "DynamicOperand",
+                                    "operand_name": "_",
+                                    "operations": [
+                                        {
+                                            "type": "ExtractDetectionProperty",
+                                            "property_name": "class_name",
+                                        }
+                                    ],
+                                },
+                                "comparator": {"type": "in (Sequence)"},
+                                "right_operand": {
+                                    "type": "StaticOperand",
+                                    "value": ["car"],
+                                },
+                            }
+                        ],
+                    },
+                }
+            ],
+            "operations_parameters": {},
+        },
+    ],
+    "outputs": [
+        {
+            "type": "JsonField",
+            "name": "model_predictions",
+            "selector": "$steps.segmentation.predictions",
+        },
+        {
+            "type": "JsonField",
+            "name": "filtered_predictions",
+            "selector": "$steps.only_cars.predictions",
+        },
+    ],
+}
+
+
+class _FakeSparseRLEWorkflowResponse:
+    _rfdetr_sparse_rle_postprocess = True
+
+    def model_dump(self, by_alias: bool, exclude_none: bool) -> dict:
+        assert by_alias is True
+        assert exclude_none is True
+        return {
+            "image": {"width": 40, "height": 40},
+            "predictions": [
+                {
+                    "x": 10,
+                    "y": 10,
+                    "width": 10,
+                    "height": 10,
+                    "confidence": 0.9,
+                    "class": "car",
+                    "class_id": 0,
+                    # Forces the workflow converter through sv.Detections.from_inference,
+                    # which is where stale polygon metadata can enter this path.
+                    "rle": {"size": [40, 40], "counts": "unused-by-test"},
+                }
+            ],
+        }
+
+
+class _FakeModelManager:
+    def __init__(self) -> None:
+        self.add_model_calls = []
+        self.infer_calls = []
+
+    def add_model(self, model_id: str, api_key: str) -> None:
+        self.add_model_calls.append((model_id, api_key))
+
+    def infer_from_request_sync(self, model_id: str, request):
+        self.infer_calls.append((model_id, request))
+        return [_FakeSparseRLEWorkflowResponse()]
+
+    def __contains__(self, model_id: str) -> bool:
+        return False
+
+
+def test_sparse_rle_segmentation_after_relative_crop_serializes_direct_output_in_root_coordinates(
+    monkeypatch,
+) -> None:
+    # given
+    model_manager = _FakeModelManager()
+    image = np.zeros((80, 100, 3), dtype=np.uint8)
+
+    def fake_from_inference(payload: dict) -> sv.Detections:
+        assert payload["image"] == {"width": 40, "height": 40}
+        mask = np.zeros((1, 40, 40), dtype=np.bool_)
+        mask[0, 5:16, 5:16] = True
+        return sv.Detections(
+            xyxy=np.array([[5, 5, 15, 15]]),
+            mask=mask,
+            confidence=np.array([0.9]),
+            class_id=np.array([0]),
+            data={
+                "class_name": np.array(["car"]),
+                # Crop-local polygon metadata must not win over the shifted mask
+                # when the sparse RLE workflow output is serialized.
+                POLYGON_KEY_IN_SV_DETECTIONS: np.array(
+                    [[[5, 5], [5, 15], [15, 15], [15, 5]]]
+                ),
+            },
+        )
+
+    monkeypatch.setattr(sv.Detections, "from_inference", fake_from_inference)
+    execution_engine = ExecutionEngine.init(
+        workflow_definition=WORKFLOW_WITH_CROP_SEGMENTATION_AND_FILTER,
+        init_parameters={
+            "workflows_core.model_manager": model_manager,
+            "workflows_core.api_key": None,
+            "workflows_core.step_execution_mode": StepExecutionMode.LOCAL,
+        },
+        max_concurrent_steps=1,
+    )
+
+    # when
+    result = execution_engine.run(
+        runtime_parameters={"image": image},
+        serialize_results=True,
+    )
+
+    # then
+    assert len(result) == 1
+    model_prediction = result[0]["model_predictions"]["predictions"][0]
+    filtered_prediction = result[0]["filtered_predictions"]["predictions"][0]
+    assert model_prediction["x"] == 30
+    assert model_prediction["y"] == 20
+    assert model_prediction["width"] == 10
+    assert model_prediction["height"] == 10
+    assert _points_bounds(model_prediction["points"]) == (25, 15, 35, 25)
+    assert "polygon" not in model_prediction
+    assert _points_bounds(filtered_prediction["points"]) == (25, 15, 35, 25)
+    assert "polygon" not in filtered_prediction
+
+
+def _points_bounds(points: list[dict]) -> tuple[float, float, float, float]:
+    x_values = [point["x"] for point in points]
+    y_values = [point["y"] for point in points]
+    return min(x_values), min(y_values), max(x_values), max(y_values)


### PR DESCRIPTION
## Summary
- restore deferred workflow coordinate conversion for unresolved output futures
- apply RF-DETR stream-pipeline correctness fixes on top of `codeflash-rfdetr-seg-optimization`
- preserve stream pipelining for safe workflows while disabling it for unsafe downstream image/state dependencies
- handle generated batches synchronously and fix sparse-RLE/CompactMask coordinate serialization paths

## Commits
- `422ac8f8c` Restore deferred workflow coordinate conversion
- `959548789` Fix RF-DETR stream pipeline correctness

## Tests
- `source .venv/bin/activate && PYTHONPATH=/home/ubuntu/inference:/home/ubuntu/inference/inference_models pytest tests/inference/unit_tests/core/interfaces/stream/test_workflows.py tests/inference/unit_tests/core/interfaces/stream/test_interface_pipeline.py tests/inference/unit_tests/core/models/test_inference_models_adapters.py tests/workflows/unit_tests/execution_engine/executor/test_output_constructor.py tests/workflows/unit_tests/execution_engine/executor/execution_data_manager/test_step_output_future_resolution.py tests/workflows/unit_tests/execution_engine/executor/test_stream_pipeline_flush.py tests/workflows/unit_tests/core_steps/fusion/test_detections_stitch.py tests/workflows/unit_tests/execution_engine/executor/test_sparse_rle_workflow_coordinates.py -q`
  - `104 passed`