### PR TITLE
Restrict RF-DETR Triton preprocess resize mode

### DIFF
--- a/inference_models/inference_models/models/rfdetr/triton_preprocess_runtime.py
+++ b/inference_models/inference_models/models/rfdetr/triton_preprocess_runtime.py
@@ -415,12 +415,7 @@ class FastPreprocessRuntime:
             return "only scaling_factor None or 255 is supported"
         if network_input.normalization is None:
             return "normalization is required"
-        if network_input.resize_mode not in (
-            ResizeMode.STRETCH_TO,
-            ResizeMode.LETTERBOX,
-            ResizeMode.CENTER_CROP,
-            ResizeMode.LETTERBOX_REFLECT_EDGES,
-        ):
+        if network_input.resize_mode is not ResizeMode.STRETCH_TO:
             return f"resize mode {network_input.resize_mode!r} is unsupported"
 
         if isinstance(images, list):

--- a/inference_models/tests/unit_tests/models/rfdetr/test_trt_preprocess_fast_path.py
+++ b/inference_models/tests/unit_tests/models/rfdetr/test_trt_preprocess_fast_path.py
@@ -247,6 +247,25 @@ def test_trt_fast_preprocess_warns_for_unavailable_runtime(
         ),
         (
             torch.device("cuda"),
+            {"network_input": _network_input(resize_mode=ResizeMode.LETTERBOX)},
+            "resize mode",
+        ),
+        (
+            torch.device("cuda"),
+            {"network_input": _network_input(resize_mode=ResizeMode.CENTER_CROP)},
+            "resize mode",
+        ),
+        (
+            torch.device("cuda"),
+            {
+                "network_input": _network_input(
+                    resize_mode=ResizeMode.LETTERBOX_REFLECT_EDGES
+                )
+            },
+            "resize mode",
+        ),
+        (
+            torch.device("cuda"),
             {"network_input": _network_input(resize_mode=ResizeMode.FIT_LONGER_EDGE)},
             "resize mode",
         ),


### PR DESCRIPTION
## Summary
- restrict the RF-DETR Triton preprocessing fast path to `ResizeMode.STRETCH_TO`
- force letterbox, center-crop, and reflected-edge resize modes through the reference preprocessing path until Triton implements those pixel/metadata semantics
- add unit coverage for the unsupported resize modes

## Tests
- `source /home/ubuntu/inference/.venv/bin/activate && PYTHONPATH=/tmp/inference-triton-preproc-resize-mode:/tmp/inference-triton-preproc-resize-mode/inference_models pytest inference_models/tests/unit_tests/models/rfdetr/test_trt_preprocess_fast_path.py -q`
  - `21 passed`
- `source /home/ubuntu/inference/.venv/bin/activate && PYTHONPATH=/tmp/inference-triton-preproc-resize-mode:/tmp/inference-triton-preproc-resize-mode/inference_models pytest inference_models/tests/unit_tests/models/rfdetr/test_trt_preprocess_fast_path.py inference_models/tests/unit_tests/models/rfdetr/test_triton_preprocess.py inference_models/tests/unit_tests/models/rfdetr/test_pre_processing.py -q`
  - `43 passed`