### PR TITLE
Cap RF-DETR pipeline depth at two

### DIFF
--- a/inference/core/models/inference_models_adapters.py
+++ b/inference/core/models/inference_models_adapters.py
@@ -72,6 +72,7 @@ from inference_models import (
 )
 from inference_models.configuration import (
     INFERENCE_MODELS_RFDETR_TRITON_POSTPROC_ENABLED,
+    MAX_RFDETR_PIPELINE_DEPTH,
     get_rfdetr_pipeline_depth,
 )
 from inference_models.models.base.async_handoff import (
@@ -384,7 +385,7 @@ class InferenceModelsInstanceSegmentationAdapter(Model):
         ] = deque()
 
     def _resolve_pipeline_depth(self) -> int:
-        requested_depth = get_rfdetr_pipeline_depth()
+        requested_depth = min(get_rfdetr_pipeline_depth(), MAX_RFDETR_PIPELINE_DEPTH)
         if requested_depth <= 1 or self._model_supports_stream_pipeline():
             return requested_depth
         return 1

--- a/inference_models/inference_models/configuration.py
+++ b/inference_models/inference_models/configuration.py
@@ -316,6 +316,7 @@ INFERENCE_MODELS_RFDETR_TRITON_PREPROC_ENABLED = get_boolean_from_env(
 RFDETR_PIPELINE_DEPTH_ENV_NAME = "RFDETR_PIPELINE_DEPTH"
 DEFAULT_RFDETR_PIPELINE_DEPTH = 1
 MIN_RFDETR_PIPELINE_DEPTH = 1
+MAX_RFDETR_PIPELINE_DEPTH = 2
 
 
 def parse_rfdetr_pipeline_depth(value: Optional[str]) -> int:
@@ -323,8 +324,9 @@ def parse_rfdetr_pipeline_depth(value: Optional[str]) -> int:
 
     Depth is the number of in-flight CPU/GPU stages the stream adapter may keep
     alive. ``1`` preserves the original synchronous behavior; values greater
-    than one enable delayed response finalization. Zero, negative, and
-    non-integer values are rejected instead of being silently clamped.
+    than one enable delayed response finalization. Values above the supported
+    maximum are normalized to ``2``. Zero, negative, and non-integer values are
+    rejected instead of being silently clamped.
     """
     if value is None:
         return DEFAULT_RFDETR_PIPELINE_DEPTH
@@ -346,7 +348,7 @@ def parse_rfdetr_pipeline_depth(value: Optional[str]) -> int:
             ),
             help_url="https://inference-models.roboflow.com/errors/runtime-environment/#invalidenvvariable",
         )
-    return parsed
+    return min(parsed, MAX_RFDETR_PIPELINE_DEPTH)
 
 
 def get_rfdetr_pipeline_depth() -> int:

--- a/inference_models/tests/unit_tests/test_configuration.py
+++ b/inference_models/tests/unit_tests/test_configuration.py
@@ -2,6 +2,7 @@ import pytest
 
 from inference_models.configuration import (
     DEFAULT_RFDETR_PIPELINE_DEPTH,
+    MAX_RFDETR_PIPELINE_DEPTH,
     get_rfdetr_pipeline_depth,
     parse_rfdetr_pipeline_depth,
 )
@@ -17,7 +18,8 @@ def test_parse_rfdetr_pipeline_depth_uses_default_when_env_missing() -> None:
     [
         ("1", 1),
         ("2", 2),
-        (" 3 ", 3),
+        (" 3 ", MAX_RFDETR_PIPELINE_DEPTH),
+        ("99", MAX_RFDETR_PIPELINE_DEPTH),
     ],
 )
 def test_parse_rfdetr_pipeline_depth_accepts_positive_integers(
@@ -34,8 +36,8 @@ def test_parse_rfdetr_pipeline_depth_rejects_invalid_values(value: str) -> None:
 
 
 def test_get_rfdetr_pipeline_depth_reads_environment(monkeypatch) -> None:
-    monkeypatch.setenv("RFDETR_PIPELINE_DEPTH", "2")
-    assert get_rfdetr_pipeline_depth() == 2
+    monkeypatch.setenv("RFDETR_PIPELINE_DEPTH", "3")
+    assert get_rfdetr_pipeline_depth() == MAX_RFDETR_PIPELINE_DEPTH
 
 
 @pytest.mark.parametrize("value", ["0", "-4", "invalid"])

--- a/tests/inference/unit_tests/core/models/test_inference_models_adapters.py
+++ b/tests/inference/unit_tests/core/models/test_inference_models_adapters.py
@@ -123,7 +123,7 @@ def test_pipeline_depth_falls_back_to_one_for_unsupported_models(monkeypatch) ->
     assert adapter._resolve_pipeline_depth() == 1
 
 
-def test_pipeline_depth_honors_requested_depth_for_supported_models(
+def test_pipeline_depth_caps_requested_depth_for_supported_models(
     monkeypatch,
 ) -> None:
     monkeypatch.setattr(
@@ -133,7 +133,7 @@ def test_pipeline_depth_honors_requested_depth_for_supported_models(
     adapter = object.__new__(InferenceModelsInstanceSegmentationAdapter)
     adapter._model = SimpleNamespace(supports_stream_pipeline=True)
 
-    assert adapter._resolve_pipeline_depth() == 3
+    assert adapter._resolve_pipeline_depth() == 2
 
 
 def test_pipeline_uses_sync_forward_for_batched_requests() -> None:


### PR DESCRIPTION
## Summary
- normalize `RFDETR_PIPELINE_DEPTH` values greater than or equal to 2 to effective depth 2
- expose `MAX_RFDETR_PIPELINE_DEPTH` and use it when resolving adapter pipeline depth
- update configuration and adapter tests for the capped behavior

## Tests
- `cd inference_models && source ../.venv/bin/activate && PYTHONPATH=/home/ubuntu/inference/inference_models pytest tests/unit_tests/test_configuration.py -q`
  - `14 passed`
- `source .venv/bin/activate && PYTHONPATH=/home/ubuntu/inference:/home/ubuntu/inference/inference_models pytest tests/inference/unit_tests/core/models/test_inference_models_adapters.py -q`
  - `14 passed`