### PR TITLE
Default RF-DETR stream pipeline to disabled for v1, v2, v4

### DIFF
--- a/inference/core/entities/requests/inference.py
+++ b/inference/core/entities/requests/inference.py
@@ -261,6 +261,10 @@ class InstanceSegmentationInferenceRequest(ObjectDetectionInferenceRequest):
         "RLE but consume more memory which may be unstable in some cases. This flag cannot be tweaked "
         "when used on Roboflow serverless platform.",
     )
+    disable_stream_pipeline: Optional[bool] = Field(
+        default=True,
+        description="Internal workflow flag forcing RF-DETR stream pipelining off for requests whose downstream graph needs same-frame context.",
+    )
 
 
 class SemanticSegmentationInferenceRequest(CVInferenceRequest):

--- a/inference/core/models/inference_models_adapters.py
+++ b/inference/core/models/inference_models_adapters.py
@@ -451,7 +451,7 @@ class InferenceModelsInstanceSegmentationAdapter(Model):
 
     def predict(self, img_in, **kwargs):
         mapped_kwargs = self.map_inference_kwargs(kwargs)
-        if self._pipeline_depth <= 1:
+        if self._pipeline_depth <= 1 or kwargs.get("disable_stream_pipeline", True):
             # Original path: forward on current frame, postprocess on
             # current frame, all synchronous.
             return self._model.forward(img_in, **mapped_kwargs)
@@ -597,7 +597,11 @@ class InferenceModelsInstanceSegmentationAdapter(Model):
         preprocess_return_metadata: PreprocessingMetadata,
         **kwargs,
     ) -> List[InstanceSegmentationInferenceResponse]:
-        if self._pipeline_depth <= 1 or not isinstance(predictions, InferenceFuture):
+        if (
+            self._pipeline_depth <= 1
+            or kwargs.get("disable_stream_pipeline", True)
+            or not isinstance(predictions, InferenceFuture)
+        ):
             return self._postprocess_sync(
                 predictions, preprocess_return_metadata, **kwargs
             )
@@ -706,13 +710,14 @@ class InferenceModelsInstanceSegmentationAdapter(Model):
         **kwargs,
     ) -> List[InstanceSegmentationInferenceResponse]:
         return_in_rle = kwargs.get("response_mask_format") == "rle"
-        # Workflow callers consume a plain dict via `_is_response_dc_to_dict`;
-        # dataclasses avoid pydantic validation + `model_dump` overhead per
-        # frame. Keep the pydantic path for RLE responses and for non-workflow
-        # callers that rely on the response model type.
+        # Stream-pipelined workflow callers consume a plain dict via
+        # `_is_response_dc_to_dict`; dataclasses avoid pydantic validation +
+        # `model_dump` overhead per frame. Keep the pydantic path for disabled,
+        # RLE, and non-workflow callers that rely on the response model type.
         use_dc = (
             kwargs.get("source") == "workflow-execution"
             and not return_in_rle
+            and not kwargs.get("disable_stream_pipeline", True)
             and getattr(self, "_pipeline_depth", 1) > 1
         )
 

--- a/inference/core/workflows/core_steps/models/roboflow/instance_segmentation/v3.py
+++ b/inference/core/workflows/core_steps/models/roboflow/instance_segmentation/v3.py
@@ -261,6 +261,7 @@ class RoboflowInstanceSegmentationModelBlockV3(WorkflowBlock):
             deque()
         )
         self._stream_context_generation = 0
+        self._last_request_used_stream_pipeline = False
 
     @classmethod
     def get_init_parameters(cls) -> List[str]:
@@ -348,13 +349,18 @@ class RoboflowInstanceSegmentationModelBlockV3(WorkflowBlock):
             model_id=model_id,
             api_key=self._api_key,
         )
+        stream_pipeline_disabled = len(images) != 1
+        model_stream_pipeline_depth = self._model_stream_pipeline_depth()
+        self._last_request_used_stream_pipeline = (
+            not stream_pipeline_disabled and model_stream_pipeline_depth > 0
+        )
         stream_context = _StreamPredictionContext(
             images=images,
             class_filter=class_filter,
             model_id=model_id,
             context_id=self._build_stream_context_id(images=images),
         )
-        if self.stream_pipeline_depth() > 0 and len(images) == 1:
+        if self._last_request_used_stream_pipeline:
             self._pending_stream_prediction_contexts.append(stream_context)
         request = InstanceSegmentationInferenceRequest(
             api_key=self._api_key,
@@ -373,6 +379,7 @@ class RoboflowInstanceSegmentationModelBlockV3(WorkflowBlock):
             source="workflow-execution",
             stream_pipeline_context_id=stream_context.context_id,
             enforce_dense_masks_in_inference_models=enforce_dense_masks_in_inference_models,
+            disable_stream_pipeline=stream_pipeline_disabled,
         )
         predictions = self._model_manager.infer_from_request_sync(
             model_id=model_id, request=request
@@ -542,19 +549,21 @@ class RoboflowInstanceSegmentationModelBlockV3(WorkflowBlock):
             return []
         return result[image_index]["predictions"]
 
-    def is_stream_pipelined(self) -> bool:
+    def _model_stream_pipeline_depth(self) -> int:
         if self._step_execution_mode is not StepExecutionMode.LOCAL:
-            return False
+            return 0
         if (
             self._last_model_id is None
             or self._last_model_id not in self._model_manager
         ):
-            return False
+            return 0
         model = self._model_manager[self._last_model_id]
-        return (
-            callable(getattr(model, "flush", None))
-            and getattr(model, "_pipeline_depth", 1) > 1
-        )
+        if not callable(getattr(model, "flush", None)):
+            return 0
+        return max(0, int(getattr(model, "_pipeline_depth", 1)) - 1)
+
+    def is_stream_pipelined(self) -> bool:
+        return self._model_stream_pipeline_depth() > 0
 
     def can_activate_stream_pipeline(self) -> bool:
         return (
@@ -563,14 +572,16 @@ class RoboflowInstanceSegmentationModelBlockV3(WorkflowBlock):
         )
 
     def stream_pipeline_depth(self) -> int:
-        if not self.is_stream_pipelined():
+        if not self._last_request_used_stream_pipeline:
             return 0
-        model = self._model_manager[self._last_model_id]
-        return max(0, int(getattr(model, "_pipeline_depth", 1)) - 1)
+        return self._model_stream_pipeline_depth()
 
     def flush_stream_pipeline_outputs(
         self,
     ) -> List[Tuple[List[Tuple[int, ...]], BlockResult]]:
+        if not self._last_request_used_stream_pipeline:
+            self._pending_stream_prediction_contexts.clear()
+            return []
         if (
             self._last_model_id is None
             or self._last_model_id not in self._model_manager

--- a/tests/inference/unit_tests/core/interfaces/stream/test_workflows.py
+++ b/tests/inference/unit_tests/core/interfaces/stream/test_workflows.py
@@ -279,6 +279,7 @@ class _FakeModelManager:
         self._inference_results = list(inference_results)
         self.model = _FakeStreamModel()
         self.add_model_calls = []
+        self.requests = []
         self.infer_calls = 0
 
     def add_model(self, model_id: str, api_key: str) -> None:
@@ -286,6 +287,7 @@ class _FakeModelManager:
 
     def infer_from_request_sync(self, model_id: str, request):
         self.infer_calls += 1
+        self.requests.append(request)
         return self._inference_results.pop(0)
 
     def __contains__(self, model_id: str) -> bool:
@@ -564,6 +566,51 @@ def test_instance_segmentation_stream_pipeline_activation_requires_depth_above_o
     assert block.can_activate_stream_pipeline() is True
 
 
+def test_instance_segmentation_stream_pipeline_is_disabled_for_generated_batches() -> (
+    None
+):
+    manager = _FakeModelManager(
+        inference_results=[
+            [_FakeResponse("frame-1-a"), _FakeResponse("frame-1-b")],
+        ]
+    )
+    block = RoboflowInstanceSegmentationModelBlockV3(
+        model_manager=manager,
+        api_key="api-key",
+        step_execution_mode=StepExecutionMode.LOCAL,
+    )
+    block._post_process_result = lambda images, predictions, class_filter, model_id: [
+        {
+            "predictions": f"{image.tag}:{prediction['tag']}",
+            "model_id": model_id,
+        }
+        for image, prediction in zip(images, predictions)
+    ]
+
+    result = block.run_locally(
+        images=[_FakeWorkflowImage("slice-1"), _FakeWorkflowImage("slice-2")],
+        model_id="model",
+        class_agnostic_nms=None,
+        class_filter=None,
+        confidence=0.4,
+        iou_threshold=None,
+        max_detections=None,
+        max_candidates=None,
+        mask_decode_mode="accurate",
+        tradeoff_factor=None,
+        disable_active_learning=None,
+        active_learning_target_dataset=None,
+        enforce_dense_masks_in_inference_models=False,
+    )
+
+    assert manager.requests[0].disable_stream_pipeline is True
+    assert block.stream_pipeline_depth() == 0
+    assert result == [
+        {"predictions": "slice-1:frame-1-a", "model_id": "model"},
+        {"predictions": "slice-2:frame-1-b", "model_id": "model"},
+    ]
+
+
 def test_instance_segmentation_stream_flush_drains_model_without_rerunning_workflow() -> (
     None
 ):
@@ -627,6 +674,8 @@ def test_instance_segmentation_stream_flush_drains_model_without_rerunning_workf
         }
     ]
     assert second_result[0]["predictions"].result() == "frame-1:first-final"
+    assert manager.requests[0].disable_stream_pipeline is False
+    assert manager.requests[1].disable_stream_pipeline is False
     assert flushed_results == [
         [
             {
@@ -692,8 +741,7 @@ def test_instance_segmentation_stream_pipeline_uses_response_context_id() -> Non
     assert second_result[0]["predictions"].result() == "frame-1:first-final"
     assert len(manager.stream_pipeline_context_ids) == 2
     assert (
-        manager.stream_pipeline_context_ids[0]
-        != manager.stream_pipeline_context_ids[1]
+        manager.stream_pipeline_context_ids[0] != manager.stream_pipeline_context_ids[1]
     )
 
 

--- a/tests/inference/unit_tests/core/models/test_inference_models_adapters.py
+++ b/tests/inference/unit_tests/core/models/test_inference_models_adapters.py
@@ -206,6 +206,24 @@ def test_pipeline_uses_sync_forward_for_batched_requests() -> None:
     assert len(adapter._model.forward_calls) == 1
 
 
+def test_pipeline_uses_sync_forward_when_stream_pipeline_not_explicitly_enabled() -> (
+    None
+):
+    ops: list[str] = []
+    future = _FakePipelineFuture(name="f1", ops=ops)
+    adapter = _make_pipeline_adapter(
+        futures=[future],
+        ops=ops,
+        pipeline_depth=2,
+    )
+
+    result = adapter.predict("frame-1", response_mask_format="dense")
+
+    assert result == "sync-raw"
+    assert ops == []
+    assert len(adapter._model.forward_calls) == 1
+
+
 def test_pipeline_postprocess_uses_sync_path_for_non_future_predictions() -> None:
     ops: list[str] = []
     adapter = _make_pipeline_adapter(
@@ -243,6 +261,7 @@ def test_workflow_response_fast_dataclass_path_is_disabled_at_depth_one() -> Non
         detections,
         metadata,
         source="workflow-execution",
+        disable_stream_pipeline=False,
     )
 
     assert isinstance(responses[0], InstanceSegmentationInferenceResponse)
@@ -266,9 +285,34 @@ def test_workflow_response_fast_dataclass_path_is_enabled_above_depth_one() -> N
         detections,
         metadata,
         source="workflow-execution",
+        disable_stream_pipeline=False,
     )
 
     assert isinstance(responses[0], InstanceSegmentationInferenceResponseDC)
+
+
+def test_workflow_response_uses_pydantic_when_stream_pipeline_is_disabled() -> None:
+    adapter = object.__new__(InferenceModelsInstanceSegmentationAdapter)
+    adapter._pipeline_depth = 2
+    adapter.class_names = ["car"]
+    metadata = [SimpleNamespace(original_size=SimpleNamespace(width=4, height=4))]
+    detections = [
+        InstanceDetections(
+            xyxy=torch.tensor([[1, 1, 3, 3]], dtype=torch.int32),
+            confidence=torch.tensor([0.9], dtype=torch.float32),
+            class_id=torch.tensor([0], dtype=torch.int32),
+            mask=torch.zeros((1, 4, 4), dtype=torch.uint8),
+        )
+    ]
+
+    responses = adapter._build_responses_from_detections(
+        detections,
+        metadata,
+        source="workflow-execution",
+        disable_stream_pipeline=True,
+    )
+
+    assert isinstance(responses[0], InstanceSegmentationInferenceResponse)
 
 
 def test_prepare_multi_label_response_uses_class_ids_for_predicted_classes() -> None:
@@ -356,17 +400,26 @@ def test_pipeline_submits_previous_future_before_next_forward() -> None:
     )
 
     meta_1 = _make_meta("meta-1")
-    prediction_1 = adapter.predict("frame-1", response_mask_format="dense")
+    prediction_1 = adapter.predict(
+        "frame-1",
+        response_mask_format="dense",
+        disable_stream_pipeline=False,
+    )
     priming = adapter.postprocess(
         prediction_1,
         meta_1,
         response_mask_format="dense",
+        disable_stream_pipeline=False,
     )
 
     assert len(priming) == 1
     assert future_1.submitted_meta == []
 
-    adapter.predict("frame-2", response_mask_format="dense")
+    adapter.predict(
+        "frame-2",
+        response_mask_format="dense",
+        disable_stream_pipeline=False,
+    )
 
     assert future_1.submitted_meta == [meta_1]
     assert ops == ["forward:f1", "submit:f1", "forward:f2"]
@@ -384,14 +437,28 @@ def test_pipeline_returns_previous_frame_response_using_previous_metadata() -> N
 
     meta_1 = _make_meta("meta-1")
     meta_2 = _make_meta("meta-2")
-    prediction_1 = adapter.predict("frame-1", response_mask_format="dense")
-    adapter.postprocess(prediction_1, meta_1, response_mask_format="dense")
+    prediction_1 = adapter.predict(
+        "frame-1",
+        response_mask_format="dense",
+        disable_stream_pipeline=False,
+    )
+    adapter.postprocess(
+        prediction_1,
+        meta_1,
+        response_mask_format="dense",
+        disable_stream_pipeline=False,
+    )
 
-    prediction_2 = adapter.predict("frame-2", response_mask_format="dense")
+    prediction_2 = adapter.predict(
+        "frame-2",
+        response_mask_format="dense",
+        disable_stream_pipeline=False,
+    )
     responses = adapter.postprocess(
         prediction_2,
         meta_2,
         response_mask_format="dense",
+        disable_stream_pipeline=False,
     )
 
     assert responses == ["meta-1"]
@@ -416,8 +483,17 @@ def test_pipeline_flush_submits_remaining_gpu_work_before_finalizing() -> None:
     )
 
     meta_1 = _make_meta("meta-1")
-    prediction_1 = adapter.predict("frame-1", response_mask_format="dense")
-    adapter.postprocess(prediction_1, meta_1, response_mask_format="dense")
+    prediction_1 = adapter.predict(
+        "frame-1",
+        response_mask_format="dense",
+        disable_stream_pipeline=False,
+    )
+    adapter.postprocess(
+        prediction_1,
+        meta_1,
+        response_mask_format="dense",
+        disable_stream_pipeline=False,
+    )
 
     responses = adapter.flush()
 
@@ -441,17 +517,40 @@ def test_pipeline_depth_three_submits_oldest_pending_before_forward() -> None:
     meta_2 = _make_meta("meta-2")
     meta_3 = _make_meta("meta-3")
 
-    prediction_1 = adapter.predict("frame-1", response_mask_format="dense")
-    adapter.postprocess(prediction_1, meta_1, response_mask_format="dense")
+    prediction_1 = adapter.predict(
+        "frame-1",
+        response_mask_format="dense",
+        disable_stream_pipeline=False,
+    )
+    adapter.postprocess(
+        prediction_1,
+        meta_1,
+        response_mask_format="dense",
+        disable_stream_pipeline=False,
+    )
 
-    prediction_2 = adapter.predict("frame-2", response_mask_format="dense")
-    priming = adapter.postprocess(prediction_2, meta_2, response_mask_format="dense")
+    prediction_2 = adapter.predict(
+        "frame-2",
+        response_mask_format="dense",
+        disable_stream_pipeline=False,
+    )
+    priming = adapter.postprocess(
+        prediction_2,
+        meta_2,
+        response_mask_format="dense",
+        disable_stream_pipeline=False,
+    )
 
-    prediction_3 = adapter.predict("frame-3", response_mask_format="dense")
+    prediction_3 = adapter.predict(
+        "frame-3",
+        response_mask_format="dense",
+        disable_stream_pipeline=False,
+    )
     responses = adapter.postprocess(
         prediction_3,
         meta_3,
         response_mask_format="dense",
+        disable_stream_pipeline=False,
     )
 
     assert len(priming) == 1

--- a/tests/workflows/unit_tests/core_steps/models/roboflow/instance_segmentation/test_stream_pipeline_compatibility.py
+++ b/tests/workflows/unit_tests/core_steps/models/roboflow/instance_segmentation/test_stream_pipeline_compatibility.py
@@ -1,0 +1,94 @@
+import numpy as np
+import pytest
+
+from inference.core.entities.responses.inference import (
+    InferenceResponseImage,
+    InstanceSegmentationInferenceResponse,
+)
+from inference.core.workflows.core_steps.common.entities import StepExecutionMode
+from inference.core.workflows.core_steps.models.roboflow.instance_segmentation.v1 import (
+    RoboflowInstanceSegmentationModelBlockV1,
+)
+from inference.core.workflows.core_steps.models.roboflow.instance_segmentation.v2 import (
+    RoboflowInstanceSegmentationModelBlockV2,
+)
+from inference.core.workflows.core_steps.models.roboflow.instance_segmentation.v4 import (
+    RoboflowInstanceSegmentationModelBlockV4,
+)
+from inference.core.workflows.execution_engine.entities.base import (
+    ImageParentMetadata,
+    WorkflowImageData,
+)
+
+
+class _FakeModelManager:
+    def __init__(self) -> None:
+        self.requests = []
+
+    def add_model(self, **kwargs) -> None:
+        pass
+
+    def infer_from_request_sync(self, model_id, request):
+        self.requests.append(request)
+        return [
+            InstanceSegmentationInferenceResponse(
+                predictions=[],
+                image=InferenceResponseImage(width=10, height=10),
+            )
+        ]
+
+
+def _workflow_image() -> WorkflowImageData:
+    return WorkflowImageData(
+        parent_metadata=ImageParentMetadata(parent_id="root"),
+        numpy_image=np.zeros((10, 10, 3), dtype=np.uint8),
+    )
+
+
+@pytest.mark.parametrize(
+    "block_class, extra_kwargs",
+    [
+        (
+            RoboflowInstanceSegmentationModelBlockV1,
+            {
+                "confidence": 0.4,
+                "enforce_dense_masks_in_inference_models": False,
+            },
+        ),
+        (
+            RoboflowInstanceSegmentationModelBlockV2,
+            {
+                "confidence": 0.4,
+                "enforce_dense_masks_in_inference_models": False,
+            },
+        ),
+        (RoboflowInstanceSegmentationModelBlockV4, {"confidence": 0.4}),
+    ],
+)
+def test_non_deferred_instance_segmentation_blocks_disable_stream_pipeline(
+    block_class,
+    extra_kwargs,
+) -> None:
+    manager = _FakeModelManager()
+    block = block_class(
+        model_manager=manager,
+        api_key=None,
+        step_execution_mode=StepExecutionMode.LOCAL,
+    )
+
+    block.run_locally(
+        images=[_workflow_image()],
+        model_id="model/1",
+        class_agnostic_nms=None,
+        class_filter=None,
+        iou_threshold=None,
+        max_detections=None,
+        max_candidates=None,
+        mask_decode_mode="accurate",
+        tradeoff_factor=None,
+        disable_active_learning=None,
+        active_learning_target_dataset=None,
+        **extra_kwargs,
+    )
+
+    assert manager.requests[0].disable_stream_pipeline is True


### PR DESCRIPTION
## Summary
- Default instance segmentation requests to disable RF-DETR stream pipelining unless a workflow explicitly opts in.
- Preserve synchronous/pydantic behavior for direct callers and non-v3 workflow blocks.
- Let V3 enable the stream pipeline only for single-image local requests; generated batches stay synchronous.

## Tests
- `PYTHONPATH=/tmp/inference-rfdetr-stream-opt-in-pr:/tmp/inference-rfdetr-stream-opt-in-pr/inference_models pytest tests/inference/unit_tests/core/entities/test_inference_response_dc.py tests/inference/unit_tests/core/models/test_inference_models_adapters.py tests/inference/unit_tests/core/interfaces/stream/test_workflows.py tests/inference/unit_tests/core/interfaces/stream/test_interface_pipeline.py tests/workflows/unit_tests/execution_engine/executor/test_output_constructor.py tests/workflows/unit_tests/execution_engine/executor/execution_data_manager/test_step_output_future_resolution.py tests/workflows/unit_tests/execution_engine/executor/test_stream_pipeline_flush.py tests/workflows/unit_tests/core_steps/fusion/test_detections_stitch.py tests/workflows/unit_tests/core_steps/models/roboflow/instance_segmentation/test_v1.py tests/workflows/unit_tests/core_steps/models/roboflow/instance_segmentation/test_v2.py tests/workflows/unit_tests/core_steps/models/roboflow/instance_segmentation/test_v3.py tests/workflows/unit_tests/core_steps/models/roboflow/instance_segmentation/test_v4.py tests/workflows/unit_tests/core_steps/models/roboflow/instance_segmentation/test_stream_pipeline_compatibility.py -q` (194 passed, 8538 warnings)
- `python -m black --check` on touched files
- `git diff --check`

Note: `tests/workflows/unit_tests/execution_engine/executor/test_sparse_rle_workflow_coordinates.py` does not exist on this target branch.