### PR TITLE
Restore deferred workflow coordinate conversion

### DIFF
--- a/inference/core/interfaces/stream/inference_pipeline.py
+++ b/inference/core/interfaces/stream/inference_pipeline.py
@@ -62,7 +62,6 @@ from inference.core.managers.decorators.fixed_size_cache import WithFixedSizeCac
 from inference.core.registries.roboflow import RoboflowModelRegistry
 from inference.core.utils.function import experimental
 from inference.core.workflows.core_steps.common.entities import StepExecutionMode
-from inference.core.workflows.execution_engine.entities.base import CoordinatesSystem
 from inference.core.workflows.execution_engine.profiling.core import (
     BaseWorkflowsProfiler,
     NullWorkflowsProfiler,
@@ -572,9 +571,6 @@ class InferencePipeline:
                 newest version for the request. Only applies for Workflows definitions saved on Roboflow platform.
             serialize_results (bool): Boolean flag to decide if ExecutionEngine run should serialize workflow
                 results for each frame. If that is set true, sinks will receive serialized workflow responses.
-                When False, output futures are resolved in the dispatch thread and detections in workflow
-                outputs declared with `coordinates_system: parent` are converted to root coordinates at
-                dispatch time instead of in the execution engine.
             predictions_queue_size int: Size of buffer for predictions that are ready for dispatching
                 default value is taken from INFERENCE_PIPELINE_PREDICTIONS_QUEUE_SIZE env variable
             decoding_buffer_size (int): size of video source decoding buffer
@@ -611,8 +607,6 @@ class InferencePipeline:
             raise ValueError(
                 "Either (`workspace_name`, `workflow_id`) or `workflow_specification` must be provided."
             )
-        workflow_parent_coordinate_outputs = frozenset()
-        workflow_defer_output_coordinate_conversion = False
         try:
             from inference.core.interfaces.stream.model_handlers.workflows import (
                 WorkflowRunner,
@@ -677,12 +671,6 @@ class InferencePipeline:
                 workflow_runner=workflow_runner,
                 execution_engine=execution_engine,
             )
-            workflow_parent_coordinate_outputs = (
-                _workflow_parent_coordinate_output_names(
-                    workflow_specification=workflow_specification,
-                )
-            )
-            workflow_defer_output_coordinate_conversion = not serialize_results
         except ImportError as error:
             raise CannotInitialiseModelError(
                 f"Could not initialise workflow processing due to lack of dependencies required. "
@@ -710,10 +698,6 @@ class InferencePipeline:
             batch_collection_timeout=batch_collection_timeout,
             predictions_queue_size=predictions_queue_size,
             decoding_buffer_size=decoding_buffer_size,
-            workflow_parent_coordinate_outputs=workflow_parent_coordinate_outputs,
-            workflow_defer_output_coordinate_conversion=(
-                workflow_defer_output_coordinate_conversion
-            ),
         )
 
     @classmethod
@@ -734,8 +718,6 @@ class InferencePipeline:
         sink_mode: SinkMode = SinkMode.ADAPTIVE,
         predictions_queue_size: int = PREDICTIONS_QUEUE_SIZE,
         decoding_buffer_size: int = DEFAULT_BUFFER_SIZE,
-        workflow_parent_coordinate_outputs: Optional[frozenset[str]] = None,
-        workflow_defer_output_coordinate_conversion: bool = False,
     ) -> "InferencePipeline":
         """
         This class creates the abstraction for making inferences from given workflow against video stream.
@@ -806,15 +788,6 @@ class InferencePipeline:
                 default value is taken from INFERENCE_PIPELINE_PREDICTIONS_QUEUE_SIZE env variable
             decoding_buffer_size (int): size of video source decoding buffer
                 default value is taken from VIDEO_SOURCE_BUFFER_SIZE env variable
-            workflow_parent_coordinate_outputs (Optional[frozenset[str]]): Names of workflow outputs whose
-                `coordinates_system` is `parent`. Used by the dispatch thread to convert `sv.Detections`
-                to root coordinates when coordinate conversion is deferred. Populated automatically by
-                `init_with_workflow(...)`; only needed when constructing the pipeline via
-                `init_with_custom_logic(...)` with a workflow-backed handler.
-            workflow_defer_output_coordinate_conversion (bool): When True, parent-coordinate conversion
-                for workflow detections is applied in `_dispatch_inference_results(...)` after futures
-                are resolved, rather than in the execution engine output constructor. Set automatically
-                to `not serialize_results` by `init_with_workflow(...)`.
 
         Other ENV variables involved in low-level configuration:
         * INFERENCE_PIPELINE_PREDICTIONS_QUEUE_SIZE - size of buffer for predictions that are ready for dispatching
@@ -869,10 +842,6 @@ class InferencePipeline:
             on_pipeline_end=on_pipeline_end,
             batch_collection_timeout=batch_collection_timeout,
             sink_mode=sink_mode,
-            workflow_parent_coordinate_outputs=workflow_parent_coordinate_outputs,
-            workflow_defer_output_coordinate_conversion=(
-                workflow_defer_output_coordinate_conversion
-            ),
         )
 
     def __init__(
@@ -888,8 +857,6 @@ class InferencePipeline:
         max_fps: Optional[float] = None,
         batch_collection_timeout: Optional[float] = None,
         sink_mode: SinkMode = SinkMode.ADAPTIVE,
-        workflow_parent_coordinate_outputs: Optional[frozenset[str]] = None,
-        workflow_defer_output_coordinate_conversion: bool = False,
     ):
         self._on_video_frame = on_video_frame
         self._video_sources = video_sources
@@ -907,12 +874,6 @@ class InferencePipeline:
         self._on_pipeline_end = on_pipeline_end
         self._batch_collection_timeout = batch_collection_timeout
         self._sink_mode = sink_mode
-        self._workflow_parent_coordinate_outputs = (
-            workflow_parent_coordinate_outputs or frozenset()
-        )
-        self._workflow_defer_output_coordinate_conversion = (
-            workflow_defer_output_coordinate_conversion
-        )
 
     def start(self, use_main_thread: bool = True) -> None:
         self._stop = False
@@ -1029,11 +990,6 @@ class InferencePipeline:
             predictions, video_frames = inference_results
             if _rfdetr_stream_pipeline_enabled():
                 predictions = _resolve_prediction_futures(predictions)
-                if self._workflow_defer_output_coordinate_conversion:
-                    predictions = _apply_workflow_parent_coordinate_conversion(
-                        predictions=predictions,
-                        parent_output_names=self._workflow_parent_coordinate_outputs,
-                    )
             if self._on_prediction is not None:
                 self._handle_predictions_dispatching(
                     predictions=predictions,
@@ -1224,55 +1180,6 @@ def _resolve_prediction_futures(value: Any) -> Any:
         value=value,
         context="inference_pipeline | prediction_dispatch",
     )
-
-
-def _workflow_parent_coordinate_output_names(
-    workflow_specification: Optional[dict],
-) -> frozenset[str]:
-    if workflow_specification is None:
-        return frozenset()
-    parent_output_names = set()
-    for output in workflow_specification.get("outputs", []):
-        coordinates_system = output.get(
-            "coordinates_system",
-            CoordinatesSystem.PARENT.value,
-        )
-        if coordinates_system in (
-            CoordinatesSystem.PARENT,
-            CoordinatesSystem.PARENT.value,
-        ):
-            parent_output_names.add(output["name"])
-    return frozenset(parent_output_names)
-
-
-def _apply_workflow_parent_coordinate_conversion(
-    predictions: Any,
-    parent_output_names: frozenset[str],
-) -> Any:
-    if not parent_output_names:
-        return predictions
-    from inference.core.workflows.execution_engine.v1.executor.output_constructor import (
-        convert_sv_detections_coordinates,
-    )
-
-    if isinstance(predictions, list):
-        return [
-            _apply_workflow_parent_coordinate_conversion(
-                predictions=item,
-                parent_output_names=parent_output_names,
-            )
-            for item in predictions
-        ]
-    if isinstance(predictions, dict):
-        converted = dict(predictions)
-        for output_name in parent_output_names:
-            if output_name not in converted:
-                continue
-            converted[output_name] = convert_sv_detections_coordinates(
-                data=converted[output_name]
-            )
-        return converted
-    return predictions
 
 
 def _rfdetr_stream_pipeline_enabled() -> bool:

--- a/inference/core/workflows/execution_engine/v1/executor/output_constructor.py
+++ b/inference/core/workflows/execution_engine/v1/executor/output_constructor.py
@@ -1,5 +1,7 @@
 import traceback
 from collections import defaultdict
+from concurrent.futures import Future
+from threading import Lock
 from typing import Any, Callable, Dict, List, Optional, Set, Union
 
 import numpy as np
@@ -12,6 +14,10 @@ from inference.core.workflows.core_steps.common.utils import (
 )
 from inference.core.workflows.errors import AssumptionError, ExecutionEngineRuntimeError
 from inference.core.workflows.execution_engine.constants import (
+    IMAGE_DIMENSIONS_KEY,
+    ROOT_PARENT_COORDINATES_KEY,
+    ROOT_PARENT_DIMENSIONS_KEY,
+    SCALING_RELATIVE_TO_ROOT_PARENT_KEY,
     TOP_LEVEL_LINEAGES_KEY,
     WORKFLOW_INPUT_BATCH_LINEAGE_ID,
 )
@@ -180,13 +186,13 @@ def create_outputs_for_input_induced_lineages(
             indices=indices,
         )
         for index, data_piece in zip(indices, data):
-            if resolve_output_futures:
-                data_piece = _maybe_resolve_output_futures(data_piece)
-            if (
-                name in outputs_requested_in_parent_coordinates
-                and data_contains_sv_detections(data=data_piece)
-            ):
-                data_piece = convert_sv_detections_coordinates(data=data_piece)
+            data_piece = _prepare_data_piece_for_output(
+                data_piece=data_piece,
+                resolve_output_futures=resolve_output_futures,
+                convert_to_parent_coordinates=(
+                    name in outputs_requested_in_parent_coordinates
+                ),
+            )
             if serialize_results:
                 output_kind = kinds_of_output_nodes[name]
                 data_piece = serialize_data_piece(
@@ -277,13 +283,13 @@ def create_outputs_for_generated_lineage_outputs(
             indices=indices,
         )
         for index, data_piece in zip(indices, data):
-            if resolve_output_futures:
-                data_piece = _maybe_resolve_output_futures(data_piece)
-            if (
-                name in outputs_requested_in_parent_coordinates
-                and data_contains_sv_detections(data=data_piece)
-            ):
-                data_piece = convert_sv_detections_coordinates(data=data_piece)
+            data_piece = _prepare_data_piece_for_output(
+                data_piece=data_piece,
+                resolve_output_futures=resolve_output_futures,
+                convert_to_parent_coordinates=(
+                    name in outputs_requested_in_parent_coordinates
+                ),
+            )
             if serialize_results:
                 output_kind = kinds_of_output_nodes[name]
                 data_piece = serialize_data_piece(
@@ -326,6 +332,85 @@ def create_outputs_for_generated_lineage_outputs(
                 element = array[i]
             results[name].append(element)
     return results
+
+
+class _DeferredResolvedOutput(Future):
+    def __init__(
+        self,
+        value: Any,
+        transform: Callable[[Any], Any],
+    ) -> None:
+        super().__init__()
+        self._value = value
+        self._transform = transform
+        self._resolution_lock = Lock()
+
+    def result(self, timeout: Optional[float] = None) -> Any:
+        if not self.done():
+            with self._resolution_lock:
+                if not self.done():
+                    try:
+                        resolved_value = _resolve_output_futures(value=self._value)
+                        self.set_result(self._transform(resolved_value))
+                    except BaseException as error:
+                        self.set_exception(error)
+        return super().result(timeout=timeout)
+
+
+def _prepare_data_piece_for_output(
+    data_piece: Any,
+    resolve_output_futures: bool,
+    convert_to_parent_coordinates: bool,
+) -> Any:
+    if resolve_output_futures:
+        data_piece = _maybe_resolve_output_futures(value=data_piece)
+    elif convert_to_parent_coordinates and _output_contains_future(value=data_piece):
+        return _DeferredResolvedOutput(
+            value=data_piece,
+            transform=_convert_sv_detections_coordinates_if_present,
+        )
+    if convert_to_parent_coordinates:
+        return _convert_sv_detections_coordinates_if_present(data=data_piece)
+    return data_piece
+
+
+def _convert_sv_detections_coordinates_if_present(data: Any) -> Any:
+    if data_needs_sv_detections_coordinate_conversion(data=data):
+        return convert_sv_detections_coordinates(data=data)
+    return data
+
+
+def data_needs_sv_detections_coordinate_conversion(data: Any) -> bool:
+    if isinstance(data, sv.Detections):
+        return _sv_detections_need_root_coordinate_conversion(detections=data)
+    if isinstance(data, (list, tuple)):
+        return any(data_needs_sv_detections_coordinate_conversion(data=e) for e in data)
+    if isinstance(data, dict):
+        return any(
+            data_needs_sv_detections_coordinate_conversion(data=e)
+            for e in data.values()
+        )
+    return False
+
+
+def _sv_detections_need_root_coordinate_conversion(detections: sv.Detections) -> bool:
+    if len(detections) == 0:
+        return False
+    root_coordinates = detections.data.get(ROOT_PARENT_COORDINATES_KEY)
+    if root_coordinates is None:
+        return False
+    if np.any(np.asarray(root_coordinates) != 0):
+        return True
+    root_dimensions = detections.data.get(ROOT_PARENT_DIMENSIONS_KEY)
+    image_dimensions = detections.data.get(IMAGE_DIMENSIONS_KEY)
+    if (
+        root_dimensions is not None
+        and image_dimensions is not None
+        and not np.array_equal(root_dimensions, image_dimensions)
+    ):
+        return True
+    root_scale = detections.data.get(SCALING_RELATIVE_TO_ROOT_PARENT_KEY)
+    return root_scale is not None and not np.allclose(root_scale, 1.0)
 
 
 def _resolve_output_futures(value: Any) -> Any:

--- a/tests/inference/unit_tests/core/interfaces/stream/test_interface_pipeline.py
+++ b/tests/inference/unit_tests/core/interfaces/stream/test_interface_pipeline.py
@@ -9,7 +9,6 @@ from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
-import supervision as sv
 
 from inference.core.active_learning.middlewares import ThreadingActiveLearningMiddleware
 from inference.core.cache import MemoryCache
@@ -36,10 +35,7 @@ from inference.core.interfaces.stream.entities import (
 )
 from inference.core.interfaces.stream.inference_pipeline import (
     InferencePipeline,
-    SinkMode,
-    _apply_workflow_parent_coordinate_conversion,
     _resolve_prediction_futures,
-    _workflow_parent_coordinate_output_names,
 )
 from inference.core.interfaces.stream.model_handlers.roboflow_models import (
     default_process_frame,
@@ -216,121 +212,6 @@ def test_resolve_prediction_futures_recursively_resolves_nested_values() -> None
     assert _resolve_prediction_futures((outer, {"raw": inner})) == (
         {"detections": ["resolved"]},
         {"raw": "resolved"},
-    )
-
-
-def test_resolve_prediction_futures_recursively_resolves_nested_values() -> None:
-    inner = Future()
-    inner.set_result("resolved")
-    outer = Future()
-    outer.set_result({"detections": [inner]})
-
-    assert _resolve_prediction_futures((outer, {"raw": inner})) == (
-        {"detections": ["resolved"]},
-        {"raw": "resolved"},
-    )
-
-
-def test_workflow_parent_coordinate_output_names_defaults_to_parent_outputs() -> None:
-    workflow_specification = {
-        "outputs": [
-            {"name": "predictions", "selector": "$steps.model.predictions"},
-            {
-                "name": "crop_predictions",
-                "selector": "$steps.crop.predictions",
-                "coordinates_system": "own",
-            },
-            {"name": "visualization", "selector": "$steps.viz.image"},
-        ]
-    }
-
-    assert _workflow_parent_coordinate_output_names(
-        workflow_specification=workflow_specification
-    ) == frozenset({"predictions", "visualization"})
-
-
-def _detections_with_root_shift() -> sv.Detections:
-    return sv.Detections(
-        xyxy=np.array([[25.0, 50.0, 75.0, 150.0]]),
-        data={
-            "parent_coordinates": np.array([[10.0, 20.0]]),
-            "root_parent_coordinates": np.array([[50.0, 100.0]]),
-            "root_parent_dimensions": np.array([[512.0, 1024.0]]),
-            "root_parent_id": np.array(["root"]),
-        },
-    )
-
-
-def test_apply_workflow_parent_coordinate_conversion_shifts_parent_outputs() -> None:
-    detections = _detections_with_root_shift()
-    predictions = {
-        "predictions": detections,
-        "crop_predictions": sv.Detections(
-            xyxy=np.array([[5.0, 10.0, 15.0, 20.0]]),
-            data={
-                "parent_coordinates": np.array([[10.0, 20.0]]),
-                "root_parent_coordinates": np.array([[50.0, 100.0]]),
-                "root_parent_dimensions": np.array([[512.0, 1024.0]]),
-                "root_parent_id": np.array(["root"]),
-            },
-        ),
-    }
-
-    converted = _apply_workflow_parent_coordinate_conversion(
-        predictions=predictions,
-        parent_output_names=frozenset({"predictions"}),
-    )
-
-    assert np.allclose(
-        converted["predictions"].xyxy,
-        np.array([[75.0, 150.0, 125.0, 250.0]]),
-    )
-    assert np.allclose(
-        converted["crop_predictions"].xyxy,
-        np.array([[5.0, 10.0, 15.0, 20.0]]),
-    )
-
-
-def test_dispatch_inference_results_applies_deferred_parent_coordinate_conversion(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    detections = _detections_with_root_shift()
-    prediction_future = Future()
-    prediction_future.set_result(detections)
-    frame = VideoFrame(
-        image=np.zeros((8, 8, 3), dtype=np.uint8),
-        frame_id=1,
-        frame_timestamp=datetime.now(),
-        source_id=0,
-    )
-    dispatched = []
-
-    def on_prediction(prediction: dict, video_frame: VideoFrame) -> None:
-        dispatched.append((prediction, video_frame))
-
-    pipeline = object.__new__(InferencePipeline)
-    pipeline._predictions_queue = Queue()
-    pipeline._on_prediction = on_prediction
-    pipeline._sink_mode = SinkMode.SEQUENTIAL
-    pipeline._video_sources = []
-    pipeline._workflow_parent_coordinate_outputs = frozenset({"predictions"})
-    pipeline._workflow_defer_output_coordinate_conversion = True
-    pipeline._handle_predictions_dispatching = InferencePipeline._handle_predictions_dispatching.__get__(
-        pipeline, InferencePipeline
-    )
-    monkeypatch.setattr(
-        "inference.core.interfaces.stream.inference_pipeline._rfdetr_stream_pipeline_enabled",
-        lambda: True,
-    )
-
-    pipeline._predictions_queue.put(([{"predictions": prediction_future}], [frame]))
-    pipeline._predictions_queue.put(None)
-    pipeline._dispatch_inference_results()
-
-    assert len(dispatched) == 1
-    assert np.allclose(
-        dispatched[0][0]["predictions"].xyxy,
-        np.array([[75.0, 150.0, 125.0, 250.0]]),
     )
 
 

--- a/tests/workflows/unit_tests/execution_engine/executor/test_output_constructor.py
+++ b/tests/workflows/unit_tests/execution_engine/executor/test_output_constructor.py
@@ -589,6 +589,51 @@ def test_construct_workflow_output_defers_batch_wrapped_futures() -> None:
     assert contains_future(result[0]["a"]) is True
 
 
+def test_construct_workflow_output_defers_coordinate_conversion_with_future_output() -> (
+    None
+):
+    # given
+    execution_data_manager = MagicMock()
+    workflow_outputs = [
+        JsonField(type="JsonField", name="a", selector="$steps.some.a"),
+    ]
+    execution_graph = DiGraph()
+    execution_graph.add_node(
+        "$outputs.a",
+        node_compilation_output=OutputNode(
+            node_category=NodeCategory.OUTPUT_NODE,
+            name=workflow_outputs[0].name,
+            selector=workflow_outputs[0].selector,
+            data_lineage=["<workflow_input>"],
+            output_manifest=workflow_outputs[0],
+        ),
+    )
+    execution_graph.graph[TOP_LEVEL_LINEAGES_KEY] = WORKFLOW_INPUT_BATCH_LINEAGE_ID
+    execution_data_manager.get_selector_indices.return_value = [(0,)]
+    execution_data_manager.get_batch_data.return_value = [
+        {"predictions": _completed_future(assembly_sv_detections())}
+    ]
+    execution_data_manager.get_lineage_indices.return_value = [(0,)]
+
+    # when
+    result = construct_workflow_output(
+        workflow_outputs=workflow_outputs,
+        execution_graph=execution_graph,
+        execution_data_manager=execution_data_manager,
+        serialize_results=False,
+        kinds_serializers=KINDS_SERIALIZERS,
+        resolve_output_futures=False,
+    )
+
+    # then
+    deferred_output = result[0]["a"]
+    assert isinstance(deferred_output, Future)
+    resolved_output = deferred_output.result()
+    assert_transformed_detections_matches_expectation(
+        result=resolved_output["predictions"]
+    )
+
+
 def test_construct_workflow_output_when_batch_outputs_present() -> None:
     # given
     execution_data_manager = MagicMock()


### PR DESCRIPTION
## What
- Cherry-pick `422ac8f` only onto `roboflow:codeflash-rfdetr-seg-optimization`.
- Restores deferred workflow output coordinate conversion so Future-backed `sv.Detections` are converted after resolution.
- Removes the older stream-pipeline coordinate conversion path/tests that this supersedes.

## Performance check
Sequential benchmark on `london_1920_1080_30fps.mp4` with `rfdetr-seg-small`, local TRT package, multistep workflow:

`relative_statoic_crop@v1 -> roboflow_instance_segmentation_model@v3 -> per_class_confidence_filter@v1`

422-only branch:
- baseline: 704 frames, 116.08s, 6.06 fps
- optimized: 704 frames, 39.60s, 17.78 fps
- speedup: 2.93x

For comparison, plain `roboflow/codeflash-rfdetr-seg-optimization` on the same workflow/input/model was:
- baseline: 704 frames, 115.80s, 6.08 fps
- optimized: 704 frames, 160.52s, 4.39 fps
- speedup: 0.72x

This confirms `422ac8f` alone recovers the optimized FPS for the crop-based coordinate-transform workflow and does not require `959548789`.

## Tests
- `pytest -q tests/workflows/unit_tests/execution_engine/executor/test_output_constructor.py` - 30 passed
- Sequential performance benchmark above
