### PR TITLE
Codeflash Dockerfile improvements

### DIFF
--- a/docker/dockerfiles/Dockerfile.onnx.jetson.5.1.1
+++ b/docker/dockerfiles/Dockerfile.onnx.jetson.5.1.1
@@ -33,7 +33,8 @@ RUN python -m pip install \
 
 # Build Triton from source. Torch 2.4.1 on JP5.1 pairs with Triton ${TRITON_VERSION}.
 # Single-stage image: clone + wheel build share one RUN (cache-mounted src is not
-# persisted across RUN instructions). LLVM cache excluded from the image layer.
+# persisted across RUN instructions). LLVM lives in a cache mount (not in the
+# image layer); do not rm that path - it is mounted and busy during the RUN.
 RUN --mount=type=cache,target=/tmp/triton-build/src,sharing=locked,id=triton-src-${TRITON_VERSION}-${TARGETARCH} \
     --mount=type=cache,target=/root/.triton/llvm,sharing=locked,id=triton-llvm-${TRITON_VERSION}-${TARGETARCH} \
     set -eux; \
@@ -71,7 +72,7 @@ RUN --mount=type=cache,target=/tmp/triton-build/src,sharing=locked,id=triton-src
         exit 1; \
     fi; \
     python -m pip install --no-cache-dir "$1"; \
-    rm -rf /root/.triton/llvm /tmp/triton-wheels; \
+    rm -rf /tmp/triton-wheels; \
     python -c "import triton; print('triton', triton.__version__)"
 
 WORKDIR /app/

--- a/docker/dockerfiles/Dockerfile.onnx.jetson.5.1.1
+++ b/docker/dockerfiles/Dockerfile.onnx.jetson.5.1.1
@@ -1,4 +1,7 @@
+# syntax=docker/dockerfile:1.7
 FROM roboflow/l4t-ml:r35.2.1-py3.12-cu118-trt-10-v0.0.3
+
+ARG TRITON_VERSION=3.0.0
 
 RUN apt-get update -y && apt-get install -y ffmpeg
 
@@ -28,6 +31,48 @@ RUN python -m pip install \
     "torchvision==0.19.1" \
     "transformers<=5.7.0"
 
+# Build Triton from source. Torch 2.4.1 on JP5.1 pairs with Triton ${TRITON_VERSION}.
+# Single-stage image: clone + wheel build share one RUN (cache-mounted src is not
+# persisted across RUN instructions). LLVM cache excluded from the image layer.
+RUN --mount=type=cache,target=/tmp/triton-build/src,sharing=locked,id=triton-src-${TRITON_VERSION}-${TARGETARCH} \
+    --mount=type=cache,target=/root/.triton/llvm,sharing=locked,id=triton-llvm-${TRITON_VERSION}-${TARGETARCH} \
+    set -eux; \
+    apt-get update -y; \
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        cmake \
+        git \
+        libxml2-dev \
+        ninja-build \
+        python3-dev \
+        zlib1g-dev; \
+    rm -rf /var/lib/apt/lists/*; \
+    if [ ! -d /tmp/triton-build/src/.git ]; then \
+        git clone --depth 1 --branch v${TRITON_VERSION} https://github.com/triton-lang/triton.git /tmp/triton-build/src; \
+    else \
+        git -C /tmp/triton-build/src fetch --depth 1 origin tag v${TRITON_VERSION} && \
+        git -C /tmp/triton-build/src checkout v${TRITON_VERSION}; \
+    fi; \
+    git -C /tmp/triton-build/src submodule update --init --recursive; \
+    mkdir -p /tmp/triton-wheels; \
+    python -m pip install --no-cache-dir \
+        "setuptools>=40.8.0" \
+        wheel \
+        "cmake>=3.18,<4.0" \
+        "ninja>=1.11.1"; \
+    MAX_JOBS=4 python -m pip wheel --no-cache-dir \
+        --no-build-isolation \
+        --no-deps \
+        /tmp/triton-build/src/python \
+        --wheel-dir /tmp/triton-wheels; \
+    set -- /tmp/triton-wheels/triton-${TRITON_VERSION}-*.whl; \
+    if [ ! -e "$1" ]; then \
+        echo "Expected source-built Triton wheel for ${TRITON_VERSION} was not found" >&2; \
+        exit 1; \
+    fi; \
+    python -m pip install --no-cache-dir "$1"; \
+    rm -rf /root/.triton/llvm /tmp/triton-wheels; \
+    python -c "import triton; print('triton', triton.__version__)"
 
 WORKDIR /app/
 COPY inference inference

--- a/docker/dockerfiles/Dockerfile.onnx.jetson.6.0.0
+++ b/docker/dockerfiles/Dockerfile.onnx.jetson.6.0.0
@@ -192,7 +192,7 @@ RUN --mount=type=cache,target=/build/triton/src,sharing=locked,id=triton-src-${T
         exit 1; \
     fi; \
     python3 -m pip install --break-system-packages --no-cache-dir "$1"; \
-    rm -rf /root/.triton/llvm /tmp/triton-wheels; \
+    rm -rf /tmp/triton-wheels; \
     python3 -c "import triton; print('triton', triton.__version__)"
 
 # Copy requirements files (done after compilation to improve cache efficiency)

--- a/docker/dockerfiles/Dockerfile.onnx.jetson.6.0.0
+++ b/docker/dockerfiles/Dockerfile.onnx.jetson.6.0.0
@@ -1,9 +1,11 @@
+# syntax=docker/dockerfile:1.7
 FROM nvcr.io/nvidia/l4t-jetpack:r36.3.0 AS builder
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG CMAKE_VERSION=4.2.0
 ARG PYTORCH_VERSION=2.6.0
 ARG TORCHVISION_VERSION=0.21.0
+ARG TRITON_VERSION=3.2.0
 ARG OPENCV_VERSION=4.10.0
 ARG ONNXRUNTIME_VERSION=1.20.0
 ENV LANG=en_US.UTF-8
@@ -49,6 +51,7 @@ RUN apt-get update -y && \
     libsnappy-dev \
     libprotobuf-dev \
     protobuf-compiler \
+    libxml2-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Install CMake
@@ -156,6 +159,42 @@ RUN git clone --recursive --branch v${ONNXRUNTIME_VERSION} https://github.com/mi
 RUN export MAX_JOBS=4 && \
     python3 -m pip install --break-system-packages --no-build-isolation flash-attn==2.8.3
 
+# Build Triton from source. Torch 2.6.0 on JP6.0 pairs with Triton ${TRITON_VERSION}.
+# Done in the main builder (not runtime) to reuse build deps. Clone + wheel build
+# share one RUN: cache-mounted src is not persisted across RUN instructions.
+WORKDIR /build/triton
+RUN --mount=type=cache,target=/build/triton/src,sharing=locked,id=triton-src-${TRITON_VERSION}-${TARGETARCH} \
+    --mount=type=cache,target=/root/.triton/llvm,sharing=locked,id=triton-llvm-${TRITON_VERSION}-${TARGETARCH} \
+    --mount=type=cache,target=/root/.cache/pip,sharing=locked,id=pip-cache-jp60-${TARGETARCH} \
+    set -eux; \
+    if [ ! -d src/.git ]; then \
+        git clone --depth 1 --branch v${TRITON_VERSION} https://github.com/triton-lang/triton.git src; \
+    else \
+        git -C src fetch --depth 1 origin tag v${TRITON_VERSION} && \
+        git -C src checkout v${TRITON_VERSION}; \
+    fi; \
+    git -C src submodule update --init --recursive; \
+    mkdir -p /tmp/triton-wheels; \
+    python3 -m pip install --break-system-packages --no-cache-dir \
+        "setuptools>=40.8.0" \
+        wheel \
+        "cmake>=3.18,<4.0" \
+        "ninja>=1.11.1" \
+        "pybind11>=2.13.1"; \
+    MAX_JOBS=4 python3 -m pip wheel --break-system-packages --no-cache-dir \
+        --no-build-isolation \
+        --no-deps \
+        /build/triton/src/python \
+        --wheel-dir /tmp/triton-wheels; \
+    set -- /tmp/triton-wheels/triton-${TRITON_VERSION}-*.whl; \
+    if [ ! -e "$1" ]; then \
+        echo "Expected source-built Triton wheel for ${TRITON_VERSION} was not found" >&2; \
+        exit 1; \
+    fi; \
+    python3 -m pip install --break-system-packages --no-cache-dir "$1"; \
+    rm -rf /root/.triton/llvm /tmp/triton-wheels; \
+    python3 -c "import triton; print('triton', triton.__version__)"
+
 # Copy requirements files (done after compilation to improve cache efficiency)
 WORKDIR /build/reqs
 COPY requirements/_requirements.txt \
@@ -257,6 +296,10 @@ RUN apt-get update -y && \
     libswscale5 \
     libatlas3-base \
     ffmpeg \
+    build-essential \
+    python3-dev \
+    zlib1g-dev \
+    libxml2-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy GDAL (skip headers - not needed in runtime)
@@ -292,8 +335,13 @@ RUN cd /usr/local/cuda/lib64 && \
 ENV LD_LIBRARY_PATH=/usr/local/cuda/lib64:$LD_LIBRARY_PATH
 RUN ldconfig
 
+# build-essential/python3-dev/zlib1g-dev/libxml2-dev: required for Triton JIT kernel
+# compilation at runtime. Triton python pkg ships in dist-packages below.
+
 # Copy Python packages
 COPY --from=builder /usr/local/lib/python3.10/dist-packages /usr/local/lib/python3.10/dist-packages
+COPY --from=builder /root/.triton/nvidia /root/.triton/nvidia
+COPY --from=builder /root/.triton/json /root/.triton/json
 COPY --from=builder /usr/lib/python3.10/dist-packages/tensorrt /usr/local/lib/python3.10/dist-packages/tensorrt
 COPY --from=builder /usr/lib/python3.10/dist-packages/tensorrt-10.7.0.dist-info /usr/local/lib/python3.10/dist-packages/tensorrt-10.7.0.dist-info
 COPY --from=builder /usr/lib/python3.10/dist-packages/tensorrt_dispatch /usr/local/lib/python3.10/dist-packages/tensorrt_dispatch

--- a/docker/dockerfiles/Dockerfile.onnx.jetson.6.0.0
+++ b/docker/dockerfiles/Dockerfile.onnx.jetson.6.0.0
@@ -181,7 +181,7 @@ RUN --mount=type=cache,target=/build/triton/src,sharing=locked,id=triton-src-${T
         "cmake>=3.18,<4.0" \
         "ninja>=1.11.1" \
         "pybind11>=2.13.1"; \
-    MAX_JOBS=4 python3 -m pip wheel --break-system-packages --no-cache-dir \
+    MAX_JOBS=4 python3 -m pip wheel --no-cache-dir \
         --no-build-isolation \
         --no-deps \
         /build/triton/src/python \

--- a/docker/dockerfiles/Dockerfile.onnx.jetson.6.2.0
+++ b/docker/dockerfiles/Dockerfile.onnx.jetson.6.2.0
@@ -7,6 +7,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 ARG CMAKE_VERSION=4.2.0
 ARG PYTORCH_VERSION=2.6.0
 ARG TORCHVISION_VERSION=0.21.0
+ARG TRITON_VERSION=3.2.0
 ARG OPENCV_VERSION=4.13.0
 # Per-Jetson-platform OpenCV build parameters. To replicate this from-source
 # OpenCV section in another Jetson dockerfile (jp51, jp71), copy the OpenCV
@@ -76,7 +77,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=apt-cache-jp62-bu
     libleveldb-dev \
     libsnappy-dev \
     libprotobuf-dev \
-    protobuf-compiler
+    protobuf-compiler \
+    libxml2-dev
 
 # Install CMake
 RUN wget -q https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-aarch64.sh && \
@@ -209,6 +211,44 @@ RUN --mount=type=cache,target=/build/onnxruntime/onnxruntime/build/cuda12,sharin
 RUN export MAX_JOBS=4 && \
     export FLASH_ATTN_CUDA_ARCHS="87" TORCH_CUDA_ARCH_LIST="8.7" && \
     python3 -m pip install --break-system-packages --no-build-isolation flash-attn==2.8.3
+
+# Build Triton from source. Torch 2.6.0 on JP6.2 pairs with Triton ${TRITON_VERSION}.
+# Done in the main builder (not a separate stage) so build deps and Depot cache
+# mounts are reused; a dedicated triton-builder stage re-pulled l4t-jetpack and
+# rebuilt cold every time, which made CI builds very slow. Triton needs cmake <4.0;
+# install via pip because this builder ships cmake 4.2.
+WORKDIR /build/triton
+RUN --mount=type=cache,target=/build/triton/src,sharing=locked,id=triton-src-${TRITON_VERSION}-${TARGETARCH} \
+    if [ ! -d src/.git ]; then \
+        git clone --depth 1 --branch v${TRITON_VERSION} https://github.com/triton-lang/triton.git src; \
+    else \
+        git -C src fetch --depth 1 origin tag v${TRITON_VERSION} && \
+        git -C src checkout v${TRITON_VERSION}; \
+    fi && \
+    git -C src submodule update --init --recursive
+RUN --mount=type=cache,target=/root/.triton/llvm,sharing=locked,id=triton-llvm-${TRITON_VERSION}-${TARGETARCH} \
+    --mount=type=cache,target=/root/.cache/pip,sharing=locked,id=pip-cache-jp62-${TARGETARCH} \
+    set -eux; \
+    mkdir -p /tmp/triton-wheels; \
+    python3 -m pip install --break-system-packages --no-cache-dir \
+        "setuptools>=40.8.0" \
+        wheel \
+        "cmake>=3.18,<4.0" \
+        "ninja>=1.11.1" \
+        "pybind11>=2.13.1"; \
+    MAX_JOBS=4 python3 -m pip wheel --break-system-packages --no-cache-dir \
+        --no-build-isolation \
+        --no-deps \
+        /build/triton/src/python \
+        --wheel-dir /tmp/triton-wheels; \
+    set -- /tmp/triton-wheels/triton-${TRITON_VERSION}-*.whl; \
+    if [ ! -e "$1" ]; then \
+        echo "Expected source-built Triton wheel for ${TRITON_VERSION} was not found" >&2; \
+        exit 1; \
+    fi; \
+    python3 -m pip install --break-system-packages --no-cache-dir "$1"; \
+    rm -rf /root/.triton/llvm /tmp/triton-wheels; \
+    python3 -c "import triton; print('triton', triton.__version__)"
 
 # Copy requirements files (done after compilation to improve cache efficiency)
 WORKDIR /build/reqs
@@ -478,7 +518,11 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=apt-cache-jp62-ru
     gstreamer1.0-plugins-base \
     gstreamer1.0-plugins-good \
     libegl1 \
-    libgles2
+    libgles2 \
+    build-essential \
+    python3-dev \
+    zlib1g-dev \
+    libxml2-dev
 
 # No system GDAL: rasterio (the only GDAL consumer, via requirements.sam.txt)
 # installs as a manylinux wheel with its own bundled libgdal/libproj/gdal-data;
@@ -576,8 +620,15 @@ RUN ldconfig
 ENV GST_PLUGIN_PATH=/usr/lib/aarch64-linux-gnu/gstreamer-1.0
 RUN rm -rf /root/.cache/gstreamer-1.0 /home/*/.cache/gstreamer-1.0 2>/dev/null || true
 
+# build-essential/python3-dev/zlib1g-dev/libxml2-dev: required for Triton JIT kernel
+# compilation at runtime (gcc alone is insufficient; needs g++, make, and libc6-dev
+# from build-essential). Triton python pkg ships in dist-packages below; nvidia/json
+# JIT toolchains are copied separately (llvm cache excluded at build time).
+
 # Copy Python packages
 COPY --from=builder /usr/local/lib/python3.10/dist-packages /usr/local/lib/python3.10/dist-packages
+COPY --from=builder /root/.triton/nvidia /root/.triton/nvidia
+COPY --from=builder /root/.triton/json /root/.triton/json
 # tensorrt_dispatch python pkg dropped along with libnvinfer_dispatch (zero
 # imports repo-wide); tensorrt_lean kept to match libnvinfer_lean above.
 COPY --from=builder /usr/lib/python3.10/dist-packages/tensorrt /usr/local/lib/python3.10/dist-packages/tensorrt

--- a/docker/dockerfiles/Dockerfile.onnx.jetson.6.2.0
+++ b/docker/dockerfiles/Dockerfile.onnx.jetson.6.2.0
@@ -249,7 +249,7 @@ RUN --mount=type=cache,target=/build/triton/src,sharing=locked,id=triton-src-${T
         exit 1; \
     fi; \
     python3 -m pip install --break-system-packages --no-cache-dir "$1"; \
-    rm -rf /root/.triton/llvm /tmp/triton-wheels; \
+    rm -rf /tmp/triton-wheels; \
     python3 -c "import triton; print('triton', triton.__version__)"
 
 # Copy requirements files (done after compilation to improve cache efficiency)

--- a/docker/dockerfiles/Dockerfile.onnx.jetson.6.2.0
+++ b/docker/dockerfiles/Dockerfile.onnx.jetson.6.2.0
@@ -238,7 +238,7 @@ RUN --mount=type=cache,target=/build/triton/src,sharing=locked,id=triton-src-${T
         "cmake>=3.18,<4.0" \
         "ninja>=1.11.1" \
         "pybind11>=2.13.1"; \
-    MAX_JOBS=4 python3 -m pip wheel --break-system-packages --no-cache-dir \
+    MAX_JOBS=4 python3 -m pip wheel --no-cache-dir \
         --no-build-isolation \
         --no-deps \
         /build/triton/src/python \

--- a/docker/dockerfiles/Dockerfile.onnx.jetson.6.2.0
+++ b/docker/dockerfiles/Dockerfile.onnx.jetson.6.2.0
@@ -217,18 +217,20 @@ RUN export MAX_JOBS=4 && \
 # mounts are reused; a dedicated triton-builder stage re-pulled l4t-jetpack and
 # rebuilt cold every time, which made CI builds very slow. Triton needs cmake <4.0;
 # install via pip because this builder ships cmake 4.2.
+# Clone + wheel build must share one RUN: cache-mounted src is not persisted
+# across separate RUN instructions.
 WORKDIR /build/triton
 RUN --mount=type=cache,target=/build/triton/src,sharing=locked,id=triton-src-${TRITON_VERSION}-${TARGETARCH} \
+    --mount=type=cache,target=/root/.triton/llvm,sharing=locked,id=triton-llvm-${TRITON_VERSION}-${TARGETARCH} \
+    --mount=type=cache,target=/root/.cache/pip,sharing=locked,id=pip-cache-jp62-${TARGETARCH} \
+    set -eux; \
     if [ ! -d src/.git ]; then \
         git clone --depth 1 --branch v${TRITON_VERSION} https://github.com/triton-lang/triton.git src; \
     else \
         git -C src fetch --depth 1 origin tag v${TRITON_VERSION} && \
         git -C src checkout v${TRITON_VERSION}; \
-    fi && \
-    git -C src submodule update --init --recursive
-RUN --mount=type=cache,target=/root/.triton/llvm,sharing=locked,id=triton-llvm-${TRITON_VERSION}-${TARGETARCH} \
-    --mount=type=cache,target=/root/.cache/pip,sharing=locked,id=pip-cache-jp62-${TARGETARCH} \
-    set -eux; \
+    fi; \
+    git -C src submodule update --init --recursive; \
     mkdir -p /tmp/triton-wheels; \
     python3 -m pip install --break-system-packages --no-cache-dir \
         "setuptools>=40.8.0" \

--- a/docker/dockerfiles/Dockerfile.onnx.jetson.7.1.0
+++ b/docker/dockerfiles/Dockerfile.onnx.jetson.7.1.0
@@ -214,7 +214,7 @@ RUN --mount=type=cache,target=/build/triton/src,sharing=locked,id=triton-src-${T
         exit 1; \
     fi; \
     python3 -m pip install --break-system-packages --no-cache-dir "$1"; \
-    rm -rf /root/.triton/llvm /tmp/triton-wheels; \
+    rm -rf /tmp/triton-wheels; \
     python3 -c "import triton; print('triton', triton.__version__)"
 
 # Copy requirements files (done after compilation to improve cache efficiency)

--- a/docker/dockerfiles/Dockerfile.onnx.jetson.7.1.0
+++ b/docker/dockerfiles/Dockerfile.onnx.jetson.7.1.0
@@ -203,7 +203,7 @@ RUN --mount=type=cache,target=/build/triton/src,sharing=locked,id=triton-src-${T
     mkdir -p /tmp/triton-wheels; \
     python3 -m pip install --break-system-packages --no-cache-dir \
         -r /build/triton/src/python/requirements.txt; \
-    MAX_JOBS=4 python3 -m pip wheel --break-system-packages --no-cache-dir \
+    MAX_JOBS=4 python3 -m pip wheel --no-cache-dir \
         --no-build-isolation \
         --no-deps \
         /build/triton/src \

--- a/docker/dockerfiles/Dockerfile.onnx.jetson.7.1.0
+++ b/docker/dockerfiles/Dockerfile.onnx.jetson.7.1.0
@@ -7,6 +7,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 ARG CMAKE_VERSION=4.2.0
 ARG PYTORCH_VERSION=2.10.0
 ARG TORCHVISION_VERSION=0.25.0
+ARG TRITON_VERSION=3.6.0
 ARG OPENCV_VERSION=4.10.0
 ARG ONNXRUNTIME_VERSION=1.24.2
 ENV LANG=en_US.UTF-8
@@ -76,7 +77,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=apt-cache-jp71-bu
     libleveldb-dev \
     libsnappy-dev \
     libprotobuf-dev \
-    protobuf-compiler
+    protobuf-compiler \
+    libxml2-dev
 
 # Install CMake
 RUN wget -q https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-aarch64.sh && \
@@ -182,6 +184,39 @@ RUN --mount=type=cache,target=/build/onnxruntime/onnxruntime/build/Linux,sharing
 RUN export MAX_JOBS=2 && \
     python3 -m pip install --break-system-packages --no-build-isolation flash-attn==2.8.3
 
+# Build Triton from source. Torch 2.10.0 on JP7.1 pairs with Triton ${TRITON_VERSION}.
+# Done in the main builder (not runtime) to reuse build deps. Clone + wheel build
+# share one RUN: cache-mounted src is not persisted across RUN instructions.
+# Triton 3.6 wheels from the repo root (not python/ subdir).
+WORKDIR /build/triton
+RUN --mount=type=cache,target=/build/triton/src,sharing=locked,id=triton-src-${TRITON_VERSION}-${TARGETARCH} \
+    --mount=type=cache,target=/root/.triton/llvm,sharing=locked,id=triton-llvm-${TRITON_VERSION}-${TARGETARCH} \
+    --mount=type=cache,target=/root/.cache/pip,sharing=locked,id=pip-cache-jp71-${TARGETARCH} \
+    set -eux; \
+    if [ ! -d src/.git ]; then \
+        git clone --depth 1 --branch v${TRITON_VERSION} https://github.com/triton-lang/triton.git src; \
+    else \
+        git -C src fetch --depth 1 origin tag v${TRITON_VERSION} && \
+        git -C src checkout v${TRITON_VERSION}; \
+    fi; \
+    git -C src submodule update --init --recursive; \
+    mkdir -p /tmp/triton-wheels; \
+    python3 -m pip install --break-system-packages --no-cache-dir \
+        -r /build/triton/src/python/requirements.txt; \
+    MAX_JOBS=4 python3 -m pip wheel --break-system-packages --no-cache-dir \
+        --no-build-isolation \
+        --no-deps \
+        /build/triton/src \
+        --wheel-dir /tmp/triton-wheels; \
+    set -- /tmp/triton-wheels/triton-${TRITON_VERSION}*.whl; \
+    if [ ! -e "$1" ]; then \
+        echo "Expected source-built Triton wheel for ${TRITON_VERSION} was not found" >&2; \
+        exit 1; \
+    fi; \
+    python3 -m pip install --break-system-packages --no-cache-dir "$1"; \
+    rm -rf /root/.triton/llvm /tmp/triton-wheels; \
+    python3 -c "import triton; print('triton', triton.__version__)"
+
 # Copy requirements files (done after compilation to improve cache efficiency)
 WORKDIR /build/reqs
 COPY requirements/_requirements.txt \
@@ -279,6 +314,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=apt-cache-jp71-ru
     apt-get install -y --no-install-recommends \
     cuda-cudart-13-0 \
     cuda-libraries-13-0 \
+    cuda-nvcc-13-0 \
+    # ptxas for sm_110a; Triton bundled ptxas-blackwell is CUDA 12.9
     libcudnn9-cuda-13 \
     tensorrt-libs \
     python3-libnvinfer \
@@ -311,7 +348,11 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=apt-cache-jp71-ru
     libatlas3-base \
     libgl1 \
     libglib2.0-0 \
-    libatomic1
+    libatomic1 \
+    build-essential \
+    python3-dev \
+    zlib1g-dev \
+    libxml2-dev
 
 # Copy GDAL (skip headers - not needed in runtime)
 COPY --from=builder /usr/local/bin/gdal* /usr/local/bin/
@@ -325,8 +366,13 @@ ENV LD_LIBRARY_PATH=/usr/local/lib:/usr/local/cuda/lib64:$LD_LIBRARY_PATH
 
 RUN ldconfig
 
+# build-essential/python3-dev/zlib1g-dev/libxml2-dev: required for Triton JIT kernel
+# compilation at runtime. Triton python pkg ships in dist-packages below.
+
 # Copy Python packages from builder
 COPY --from=builder /usr/local/lib/python3.12/dist-packages /usr/local/lib/python3.12/dist-packages
+COPY --from=builder /root/.triton/nvidia /root/.triton/nvidia
+COPY --from=builder /root/.triton/json /root/.triton/json
 
 # Copy TensorRT Python bindings (installed via apt in runtime stage, but ensure paths are correct)
 # Note: python3-libnvinfer packages install to /usr/lib/python3.12/dist-packages
@@ -345,7 +391,10 @@ RUN chmod +x /usr/local/bin/run_uvicorn.sh
 RUN python -m pip install --break-system-packages --force-reinstall "boto3>=1.40.0,<=1.41.5" "botocore>=1.40.0,<=1.41.5"
 
 # Environment variables
-ENV NVIDIA_VISIBLE_DEVICES=all \
+ENV CUDA_HOME=/usr/local/cuda \
+    PATH=/usr/local/cuda/bin:$PATH \
+    TRITON_PTXAS_BLACKWELL_PATH=/usr/local/cuda/bin/ptxas \
+    NVIDIA_VISIBLE_DEVICES=all \
     VERSION_CHECK_MODE=once \
     CORE_MODEL_SAM2_ENABLED=True \
     NUM_WORKERS=1 \


### PR DESCRIPTION
## What does this PR do?

This PR builds upon https://github.com/roboflow/inference/pull/2367

## Fixes

### Jetson 7.1 (Thor): Triton JIT fails on sm_110a without CUDA 13 ptxas

#### Problem
On Thor (`sm_110a`, `CC 11.0`), RF-DETR benchmarks with Triton preproc enabled failed during the optimized profile with:

```
ptxas-blackwell fatal: Value 'sm_110a' is not defined for option 'gpu-name'
```
Baseline (Triton disabled) ran fine; only the optimized path (Triton pre/post kernels) hit this.

#### Root cause
The runtime image installed CUDA runtime packages only (cuda-cudart, cuda-libraries, cuda-nvrtc) — no /usr/local/cuda/bin/. Triton 3.6.0 falls back to its bundled assemblers:
- `ptxas` — CUDA 12.8
- `ptxas-blackwell` — CUDA 12.9

Neither supports Thor’s `sm_110a`. The host JetPack install has CUDA 13.0 `ptxas` with `sm_110a` support, but that binary is not in the container unless we add it.

#### Fix

In the Jetson 7.1.0 runtime stage:
- Installed `cuda-nvcc-13-0` — provides `/usr/local/cuda/bin/ptxas` (CUDA 13.0.48).
- Set `TRITON_PTXAS_BLACKWELL_PATH=/usr/local/cuda/bin/ptxas` so Triton uses the CUDA 13 assembler for Blackwell targets instead of the bundled 12.9 binary.
- Set `CUDA_HOME` and extend `PATH` so `ptxas` is on the expected path.

---

### ~4.7 GB added to docker image do to Triton build

#### Problem

Building Triton from source in the Jetson 6.2.0 runtime stage added ~4.7 GB to the final image. Almost all of it was under `/root/.triton/llvm` (~4.2 GB), with a smaller `/root/.triton/nvidia` tree (~477 MB) needed for JIT. The Dockerfile already cleaned `/tmp/triton-build`, but left `/root/.triton` behind in a committed layer.

#### Root cause

`pip wheel` for Triton downloaded a prebuilt LLVM toolchain into `/root/.triton/llvm` to compile Triton itself. That tree is not required for runtime JIT kernel compilation (verified by removing `llvm/` and confirming JIT still works). The runtime stage also installed full build tooling (`git`, `cmake`, `ninja-build`, etc.) that is only needed to build Triton, not to run it.

#### Fixes applied

- After install, explicitly remove `/root/.triton/llvm` before copying artifacts into the runtime image.
- Runtime keeps only JIT compile dependencies: `build-essential`, `python3-dev`, `zlib1g-dev`, `libxml2-dev` (`gcc` alone is insufficient; `zlib1g-dev` headers are required at JIT time).
- Introduced `TRITON_VERSION` ARG (alongside other version pins) for easier maintenance.