### PR TITLE
Stop shared CompactMask workflow conversion

### DIFF
--- a/inference/core/workflows/core_steps/fusion/detections_stitch/v1.py
+++ b/inference/core/workflows/core_steps/fusion/detections_stitch/v1.py
@@ -6,6 +6,7 @@ import supervision as sv
 from pydantic import ConfigDict, Field
 from supervision import OverlapFilter, move_boxes, move_masks
 from supervision.config import ORIENTED_BOX_COORDINATES
+from supervision.detection.compact_mask import CompactMask
 
 from inference.core.workflows.core_steps.common.utils import (
     attach_parents_coordinates_to_sv_detections,
@@ -286,10 +287,26 @@ def move_detections(
             raise ValueError(
                 "To move non-empty detections with segmentation mask, resolution_wh is needed, but not given."
             )
-        detections.mask = move_masks(
-            masks=detections.mask, offset=offset, resolution_wh=resolution_wh
+        detections.mask = move_detection_masks(
+            masks=detections.mask,
+            offset=offset,
+            resolution_wh=resolution_wh,
         )
     return detections
+
+
+def move_detection_masks(
+    masks: Union[np.ndarray, CompactMask],
+    offset: np.ndarray,
+    resolution_wh: Tuple[int, int],
+) -> Union[np.ndarray, CompactMask]:
+    if isinstance(masks, CompactMask):
+        return masks.with_offset(
+            dx=int(offset[0]),
+            dy=int(offset[1]),
+            new_image_shape=(resolution_wh[1], resolution_wh[0]),
+        )
+    return move_masks(masks=masks, offset=offset, resolution_wh=resolution_wh)
 
 
 def choose_overlap_filter_strategy(

--- a/inference/core/workflows/core_steps/transformations/dynamic_crop/v1.py
+++ b/inference/core/workflows/core_steps/transformations/dynamic_crop/v1.py
@@ -6,6 +6,7 @@ import numpy as np
 import supervision as sv
 from pydantic import AliasChoices, ConfigDict, Field
 from supervision.config import ORIENTED_BOX_COORDINATES
+from supervision.detection.compact_mask import CompactMask
 
 from inference.core.workflows.execution_engine.constants import (
     DETECTION_ID_KEY,
@@ -242,7 +243,13 @@ def crop_image(
             selected_detection,
             xyxy=sv.move_boxes(xyxy=selected_detection.xyxy, offset=(-x_min, -y_min)),
             mask=(
-                selected_detection.mask[:, y_min:y_max, x_min:x_max]
+                crop_selected_detection_mask(
+                    mask=selected_detection.mask,
+                    x_min=x_min,
+                    y_min=y_min,
+                    x_max=x_max,
+                    y_max=y_max,
+                )
                 if selected_detection.mask is not None
                 else None
             ),
@@ -274,6 +281,19 @@ def crop_image(
             }
         )
     return crops
+
+
+def crop_selected_detection_mask(
+    mask: Union[np.ndarray, CompactMask],
+    x_min: int,
+    y_min: int,
+    x_max: int,
+    y_max: int,
+) -> np.ndarray:
+    if isinstance(mask, CompactMask):
+        dense_mask = mask[0]
+        return dense_mask[np.newaxis, y_min:y_max, x_min:x_max]
+    return mask[:, y_min:y_max, x_min:x_max]
 
 
 def overlay_crop_with_mask(

--- a/tests/workflows/unit_tests/core_steps/fusion/test_detections_stitch.py
+++ b/tests/workflows/unit_tests/core_steps/fusion/test_detections_stitch.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 import supervision as sv
 from supervision.config import ORIENTED_BOX_COORDINATES
+from supervision.detection.compact_mask import CompactMask
 
 from inference.core.workflows.core_steps.fusion.detections_stitch.v1 import (
     BlockManifest,
@@ -197,6 +198,41 @@ def test_detections_stitch_with_masks() -> None:
     assert merged.mask is not None
     assert len(merged) == 1
     assert merged.mask.shape[1:] == (400, 500)
+
+
+def test_detections_stitch_with_compact_masks() -> None:
+    # given
+    block = DetectionsStitchBlockV1()
+    reference_image = make_test_image(width=500, height=400)
+    detections = make_test_detections(
+        boxes=np.array([[10, 10, 50, 50]]),
+        parent_offset=(50, 60),
+        parent_dims=(400, 500),
+        with_mask=True,
+        mask_shape=(100, 100),
+    )
+    detections.mask = CompactMask.from_dense(
+        detections.mask,
+        xyxy=detections.xyxy,
+        image_shape=(100, 100),
+    )
+
+    # when
+    result = block.run(
+        reference_image=reference_image,
+        predictions=[detections],
+        overlap_filtering_strategy="none",
+        iou_threshold=0.3,
+    )
+
+    # then
+    merged = result["predictions"]
+    assert merged.mask is not None
+    assert len(merged) == 1
+    dense_mask = merged.mask[0]
+    assert dense_mask.shape == (400, 500)
+    assert dense_mask[70:110, 60:100].all()
+    assert not dense_mask[:70].any()
 
 
 def test_detections_stitch_verify_mask_dimensions_match_reference() -> None:

--- a/tests/workflows/unit_tests/core_steps/transformations/test_crop.py
+++ b/tests/workflows/unit_tests/core_steps/transformations/test_crop.py
@@ -6,6 +6,7 @@ import pytest
 import supervision as sv
 from pydantic import ValidationError
 from supervision.config import ORIENTED_BOX_COORDINATES
+from supervision.detection.compact_mask import CompactMask
 
 from inference.core.workflows.core_steps.transformations.dynamic_crop.v1 import (
     BlockManifest,
@@ -451,6 +452,48 @@ def test_crop_image_when_background_removal_requested_and_mask_found() -> None:
     assert (
         result[2]["crops"].numpy_image == expected_third_crop
     ).all(), "Image must have expected size and color"
+
+
+def test_crop_image_when_compact_mask_found() -> None:
+    # given
+    np_image = np.zeros((100, 100, 3), dtype=np.uint8)
+    np_image[10:30, 20:50] = 39
+    mask = np.zeros((1, 100, 100), dtype=np.bool_)
+    mask[0, 12:24, 25:42] = True
+    image = WorkflowImageData(
+        parent_metadata=ImageParentMetadata(parent_id="origin_image"),
+        numpy_image=np_image,
+    )
+    boxes = np.array([[20, 10, 50, 30]], dtype=np.float64)
+    detections = sv.Detections(
+        xyxy=boxes,
+        class_id=np.array([1]),
+        mask=CompactMask.from_dense(mask, xyxy=boxes, image_shape=(100, 100)),
+        confidence=np.array([0.5], dtype=np.float64),
+        data={
+            "detection_id": np.array(["one"]),
+            "class_name": np.array(["cat"]),
+        },
+    )
+
+    # when
+    result = crop_image(
+        image=image,
+        detections=detections,
+        mask_opacity=1.0,
+        background_color=(127, 127, 127),
+    )
+
+    # then
+    assert len(result) == 1
+    expected_crop = np.ones((20, 30, 3), dtype=np.uint8) * 127
+    expected_crop[2:14, 5:22, :] = 39
+    assert (result[0]["crops"].numpy_image == expected_crop).all()
+    translated_mask = result[0]["predictions"].mask
+    assert isinstance(translated_mask, np.ndarray)
+    assert translated_mask.shape == (1, 20, 30)
+    assert translated_mask[0, 2:14, 5:22].all()
+    assert not translated_mask[0, :2].any()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- remove the shared workflow polygon-to-CompactMask fast path
- keep normal polygon segmentation outputs on the existing dense `np.ndarray` mask path
- add unit coverage that workflow polygon conversion returns dense masks

## Tests
- `python -m isort inference/core/workflows/core_steps/common/utils.py inference/core/workflows/core_steps/transformations/dynamic_crop/v1.py inference/core/workflows/core_steps/fusion/detections_stitch/v1.py tests/workflows/unit_tests/core_steps/common/test_utils.py tests/workflows/unit_tests/core_steps/transformations/test_crop.py tests/workflows/unit_tests/core_steps/fusion/test_detections_stitch.py`
- `python -m black inference/core/workflows/core_steps/common/utils.py inference/core/workflows/core_steps/transformations/dynamic_crop/v1.py inference/core/workflows/core_steps/fusion/detections_stitch/v1.py tests/workflows/unit_tests/core_steps/common/test_utils.py tests/workflows/unit_tests/core_steps/transformations/test_crop.py tests/workflows/unit_tests/core_steps/fusion/test_detections_stitch.py`
- `python -m pytest tests/workflows/unit_tests/core_steps/common/test_utils.py::test_convert_inference_detections_batch_to_sv_detections tests/workflows/unit_tests/core_steps/common/test_detections_mismatch.py::test_convert_inference_detections_batch_to_sv_detections_with_invalid_polygons tests/workflows/unit_tests/core_steps/transformations/test_crop.py tests/workflows/unit_tests/core_steps/fusion/test_detections_stitch.py -q`