### PR TITLE
Forward weight provider headers from SAM video blocks

### DIFF
--- a/inference/core/workflows/core_steps/models/foundation/segment_anything2_video/v1.py
+++ b/inference/core/workflows/core_steps/models/foundation/segment_anything2_video/v1.py
@@ -27,6 +27,7 @@ import supervision as sv
 from pydantic import ConfigDict, Field
 
 from inference.core.managers.base import ModelManager
+from inference.core.roboflow_api import get_extra_weights_provider_headers
 from inference.core.workflows.core_steps.common.entities import StepExecutionMode
 from inference.core.workflows.core_steps.common.utils import (
     attach_parents_coordinates_to_batch_of_sv_detections,
@@ -258,9 +259,11 @@ class SegmentAnything2VideoBlockV1(WorkflowBlock):
         if self._model is None or self._current_model_id != model_id:
             from inference_models import AutoModel
 
+            extra_weights_provider_headers = get_extra_weights_provider_headers()
             self._model = AutoModel.from_pretrained(
                 model_id_or_path=model_id,
                 api_key=self._api_key,
+                weights_provider_extra_headers=extra_weights_provider_headers,
             )
             self._current_model_id = model_id
             # Switching model invalidates every session we held.

--- a/inference/core/workflows/core_steps/models/foundation/segment_anything3_video/v1.py
+++ b/inference/core/workflows/core_steps/models/foundation/segment_anything3_video/v1.py
@@ -23,6 +23,7 @@ import supervision as sv
 from pydantic import ConfigDict, Field
 
 from inference.core.managers.base import ModelManager
+from inference.core.roboflow_api import get_extra_weights_provider_headers
 from inference.core.workflows.core_steps.common.entities import StepExecutionMode
 from inference.core.workflows.core_steps.common.utils import (
     attach_parents_coordinates_to_batch_of_sv_detections,
@@ -238,9 +239,11 @@ class SegmentAnything3VideoBlockV1(WorkflowBlock):
         if self._model is None or self._current_model_id != model_id:
             from inference_models import AutoModel
 
+            extra_weights_provider_headers = get_extra_weights_provider_headers()
             self._model = AutoModel.from_pretrained(
                 model_id_or_path=model_id,
                 api_key=self._api_key,
+                weights_provider_extra_headers=extra_weights_provider_headers,
             )
             self._current_model_id = model_id
             # Switching model invalidates every session we held.

--- a/tests/workflows/unit_tests/core_steps/models/foundation/test_segment_anything2_video.py
+++ b/tests/workflows/unit_tests/core_steps/models/foundation/test_segment_anything2_video.py
@@ -5,7 +5,9 @@ we inject a fake model on the instance so tests don't touch
 ``inference_models`` or the real SAM2 weights.
 """
 
+import sys
 from datetime import datetime
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import numpy as np
@@ -13,6 +15,9 @@ import pytest
 import supervision as sv
 
 from inference.core.workflows.core_steps.common.entities import StepExecutionMode
+from inference.core.workflows.core_steps.models.foundation.segment_anything2_video import (
+    v1 as sam2_video_module,
+)
 from inference.core.workflows.core_steps.models.foundation.segment_anything2_video.v1 import (
     BlockManifest,
     SegmentAnything2VideoBlockV1,
@@ -192,6 +197,39 @@ def test_block_rejects_remote_execution_mode_at_runtime():
             prompt_interval=30,
             threshold=0.0,
         )
+
+
+# ---------------------------------------------------------------------------
+# Model loading
+# ---------------------------------------------------------------------------
+
+
+def test_model_loader_forwards_extra_weight_provider_headers(monkeypatch):
+    from_pretrained = MagicMock(return_value=object())
+    headers = {"x-temporary-auth-token": "token"}
+    monkeypatch.setitem(
+        sys.modules,
+        "inference_models",
+        SimpleNamespace(AutoModel=SimpleNamespace(from_pretrained=from_pretrained)),
+    )
+    monkeypatch.setattr(
+        sam2_video_module,
+        "get_extra_weights_provider_headers",
+        MagicMock(return_value=headers),
+    )
+    block = SegmentAnything2VideoBlockV1(
+        model_manager=MagicMock(),
+        api_key="rf-test",
+        step_execution_mode=StepExecutionMode.LOCAL,
+    )
+
+    block._get_model(model_id="sam2video/small")
+
+    from_pretrained.assert_called_once_with(
+        model_id_or_path="sam2video/small",
+        api_key="rf-test",
+        weights_provider_extra_headers=headers,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/workflows/unit_tests/core_steps/models/foundation/test_segment_anything3_video.py
+++ b/tests/workflows/unit_tests/core_steps/models/foundation/test_segment_anything3_video.py
@@ -9,8 +9,10 @@ with detection scores and the prompt→object-ids mapping (which may grow
 mid-stream as new matching objects enter the scene).
 """
 
+import sys
 from dataclasses import dataclass, field
 from datetime import datetime
+from types import SimpleNamespace
 from typing import Dict, List
 from unittest.mock import MagicMock
 
@@ -18,6 +20,9 @@ import numpy as np
 import pytest
 
 from inference.core.workflows.core_steps.common.entities import StepExecutionMode
+from inference.core.workflows.core_steps.models.foundation.segment_anything3_video import (
+    v1 as sam3_video_module,
+)
 from inference.core.workflows.core_steps.models.foundation.segment_anything3_video.v1 import (
     BlockManifest,
     SegmentAnything3VideoBlockV1,
@@ -195,6 +200,39 @@ def test_block_rejects_remote_execution_mode_at_runtime():
             model_id="sam3video",
             threshold=0.5,
         )
+
+
+# ---------------------------------------------------------------------------
+# Model loading
+# ---------------------------------------------------------------------------
+
+
+def test_model_loader_forwards_extra_weight_provider_headers(monkeypatch):
+    from_pretrained = MagicMock(return_value=object())
+    headers = {"x-temporary-auth-token": "token"}
+    monkeypatch.setitem(
+        sys.modules,
+        "inference_models",
+        SimpleNamespace(AutoModel=SimpleNamespace(from_pretrained=from_pretrained)),
+    )
+    monkeypatch.setattr(
+        sam3_video_module,
+        "get_extra_weights_provider_headers",
+        MagicMock(return_value=headers),
+    )
+    block = SegmentAnything3VideoBlockV1(
+        model_manager=MagicMock(),
+        api_key="rf-test",
+        step_execution_mode=StepExecutionMode.LOCAL,
+    )
+
+    block._get_model(model_id="sam3video")
+
+    from_pretrained.assert_called_once_with(
+        model_id_or_path="sam3video",
+        api_key="rf-test",
+        weights_provider_extra_headers=headers,
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- forward Roboflow weight-provider headers when SAM2 video and SAM3 video workflow blocks lazily load inference-models models
- add unit coverage that verifies both blocks pass the extra headers into `AutoModel.from_pretrained`

## Context

Batch jobs route Roboflow API calls through the assume-identity proxy using `ROBOFLOW_API_EXTRA_HEADERS`. The non-video SAM adapters already pass those headers into the inference-models weights provider, but the SAM2/SAM3 video workflow blocks called `AutoModel.from_pretrained` directly without `weights_provider_extra_headers`. That dropped `x-temporary-auth-token` on `/models/v1/external/weights` requests and caused proxy auth failures before the Roboflow API middleware could run.

## Testing

- `/Users/hansent/code/inference/.venv/bin/pytest tests/workflows/unit_tests/core_steps/models/foundation/test_segment_anything2_video.py tests/workflows/unit_tests/core_steps/models/foundation/test_segment_anything3_video.py`
- `git diff --check`
