### PR TITLE
Make Rate Limiter cooldown_seconds visible without expanding additional properties

### DIFF
--- a/inference/core/workflows/core_steps/flow_control/rate_limiter/v1.py
+++ b/inference/core/workflows/core_steps/flow_control/rate_limiter/v1.py
@@ -93,6 +93,9 @@ class RateLimiterManifest(WorkflowBlockManifest):
         examples=[1.0],
         default=1.0,
         ge=0.0,
+        json_schema_extra={
+            "always_visible": True,
+        },
     )
     depends_on: Selector() = Field(
         description="Reference to the workflow step that immediately precedes this rate limiter block. This establishes the dependency relationship - the rate limiter monitors when this step completes to determine if the cooldown period has elapsed since the last execution. The depends_on step can be any workflow block whose output triggers the rate-limited downstream processing.",


### PR DESCRIPTION
## Summary

The Rate Limiter flow-control block (`roboflow_core/rate_limiter@v1`) has a single user-configurable input — `cooldown_seconds` — but because the field has a default value, the Workflows UI tucked it away under the **additional properties** section. Users had to click into "additional properties" just to set the block's only meaningful setting.

This PR adds the `"always_visible": True` flag to the field's `json_schema_extra`, which surfaces `cooldown_seconds` directly in the block configuration panel (the same mechanism already used by blocks like ByteTrack, BotSort, and Data Aggregator).

## Changes

- `inference/core/workflows/core_steps/flow_control/rate_limiter/v1.py`: mark `cooldown_seconds` as `always_visible`.

## Notes

No behavioral change to the block's execution — this only affects how the field is presented in the UI.

Slack thread: https://roboflow.slack.com/archives/C09A50AQE7N/p1782087223541429

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013mLsHq5NBjgFD4DTcNq1bn)_