### PR TITLE
perf(inference_models): batch instance-seg RLE mask encoding

### DIFF
--- a/inference_models/inference_models/models/common/rle_utils.py
+++ b/inference_models/inference_models/models/common/rle_utils.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import List, Optional
 
 import numpy as np
 import torch
@@ -12,15 +12,36 @@ def torch_mask_to_coco_rle(mask: torch.Tensor) -> dict:
     # coco tools expect fortran order (column-wise)
     mask_flat = mask.permute(1, 0).reshape(-1)
     values, lengths = torch.unique_consecutive(mask_flat, return_counts=True)
-    counts = lengths.cpu().tolist()
+    counts = lengths.cpu().tolist()  # <-- device->host sync, once per detection
 
-    if values[0] == 1:
+    if values[0] == 1:  # <-- second per-detection sync (reads a GPU scalar)
         counts.insert(0, 0)
 
     h, w = mask.shape
     # compress
     rle = mask_utils.frPyObjects({"counts": counts, "size": [h, w]}, h, w)
     return rle
+
+
+def torch_masks_to_coco_rle_batch(masks: torch.Tensor) -> List[dict]:
+    """Batch equivalent of ``torch_mask_to_coco_rle`` for an ``[N, H, W]`` stack.
+
+    Encodes every mask to compressed COCO RLE with a SINGLE device->host
+    transfer followed by one vectorized ``pycocotools.mask.encode`` call,
+    instead of one ``torch_mask_to_coco_rle`` call per detection. Each per-mask
+    call does its own ``.cpu()`` sync; on Jetson those per-detection syncs
+    serialize the GPU N times per frame and dominate instance-segmentation
+    post-processing. The encoded output is identical to encoding each mask
+    individually (pycocotools encodes in Fortran/column-major order, matching
+    ``torch_mask_to_coco_rle``).
+    """
+    n = masks.shape[0]
+    if n == 0:
+        return []
+    # pycocotools expects a Fortran-ordered [H, W, N] uint8 array. The single
+    # .cpu() here replaces the 2*N per-detection syncs in torch_mask_to_coco_rle.
+    masks_hwn = masks.to(torch.uint8).permute(1, 2, 0).contiguous().cpu().numpy()
+    return mask_utils.encode(np.asfortranarray(masks_hwn))
 
 
 def coco_rle_masks_to_numpy_mask(instances_masks: InstancesRLEMasks) -> np.ndarray:

--- a/inference_models/inference_models/models/rfdetr/common.py
+++ b/inference_models/inference_models/models/rfdetr/common.py
@@ -14,10 +14,10 @@ from inference_models.configuration import (
 )
 from inference_models.entities import ImageDimensions
 from inference_models.errors import CorruptedModelPackageError
+from inference_models.models.common.rle_utils import torch_masks_to_coco_rle_batch
 from inference_models.models.common.roboflow.model_packages import PreProcessingMetadata
 from inference_models.models.common.roboflow.post_processing import (
     align_instance_segmentation_results,
-    align_instance_segmentation_results_to_rle_masks,
     rescale_image_detections,
 )
 from inference_models.models.rfdetr.class_remapping import ClassesReMapping
@@ -366,8 +366,12 @@ def _post_process_single_instance_segmentation_result_to_rle_masks(
         image_meta.pad_bottom,
     )
     selected_boxes_xyxy = selected_boxes_xyxy_pct * denorm_size_whwh
-    aligned_boxes, rle_masks = [], []
-    for bbox, mask in align_instance_segmentation_results_to_rle_masks(
+    # Align all masks in one batched call (the same routine the dense path uses)
+    # and RLE-encode them with a single device->host transfer. The previous
+    # per-detection generator (align_instance_segmentation_results_to_rle_masks)
+    # did a .cpu() sync per mask, serializing the GPU N times per frame on
+    # Jetson. Output is equivalent. This is the non-Triton fallback path.
+    aligned_boxes, aligned_masks = align_instance_segmentation_results(
         image_bboxes=selected_boxes_xyxy,
         masks=selected_masks,
         padding=padding,
@@ -377,24 +381,16 @@ def _post_process_single_instance_segmentation_result_to_rle_masks(
         size_after_pre_processing=image_meta.size_after_pre_processing,
         inference_size=denorm_size,
         static_crop_offset=image_meta.static_crop_offset,
-    ):
-        aligned_boxes.append(bbox)
-        rle_masks.append(mask)
+    )
     instances_masks = InstancesRLEMasks.from_coco_rle_masks(
         image_size=(
             image_meta.original_size.height,
             image_meta.original_size.width,
         ),
-        masks=rle_masks,
+        masks=torch_masks_to_coco_rle_batch(aligned_masks),
     )
-    if len(aligned_boxes) > 0:
-        aligned_boxes_tensor = torch.stack(aligned_boxes, dim=0)
-    else:
-        aligned_boxes_tensor = torch.empty(
-            (0, 4), dtype=torch.int32, device=image_bboxes.device
-        )
     return InstanceDetections(
-        xyxy=aligned_boxes_tensor.round().int(),
+        xyxy=aligned_boxes.round().int(),
         confidence=confidence,
         class_id=top_classes.int(),
         mask=instances_masks,

--- a/inference_models/inference_models/models/yolact/common.py
+++ b/inference_models/inference_models/models/yolact/common.py
@@ -3,10 +3,10 @@ from typing import List
 import torch
 
 from inference_models import InstanceDetections, InstancesRLEMasks
+from inference_models.models.common.rle_utils import torch_masks_to_coco_rle_batch
 from inference_models.models.common.roboflow.model_packages import PreProcessingMetadata
 from inference_models.models.common.roboflow.post_processing import (
     align_instance_segmentation_results,
-    align_instance_segmentation_results_to_rle_masks,
     crop_masks_to_boxes,
 )
 
@@ -72,8 +72,7 @@ def prepare_rle_masks(
             image_meta.pad_right,
             image_meta.pad_bottom,
         )
-        aligned_boxes, rle_masks = [], []
-        for bbox, mask in align_instance_segmentation_results_to_rle_masks(
+        aligned_boxes, aligned_masks = align_instance_segmentation_results(
             image_bboxes=image_bboxes,
             masks=cropped_masks,
             padding=padding,
@@ -84,37 +83,20 @@ def prepare_rle_masks(
             inference_size=image_meta.inference_size,
             static_crop_offset=image_meta.static_crop_offset,
             binarization_threshold=0.5,
-        ):
-            aligned_boxes.append(bbox)
-            rle_masks.append(mask)
+        )
         instances_masks = InstancesRLEMasks.from_coco_rle_masks(
             image_size=(
                 image_meta.original_size.height,
                 image_meta.original_size.width,
             ),
-            masks=rle_masks,
+            masks=torch_masks_to_coco_rle_batch(aligned_masks),
         )
-        if len(aligned_boxes) > 0:
-            aligned_boxes_tensor = torch.stack(aligned_boxes, dim=0)
-            final_results.append(
-                InstanceDetections(
-                    xyxy=aligned_boxes_tensor[:, :4].round().int(),
-                    class_id=aligned_boxes_tensor[:, 5].int(),
-                    confidence=aligned_boxes_tensor[:, 4],
-                    mask=instances_masks,
-                )
+        final_results.append(
+            InstanceDetections(
+                xyxy=aligned_boxes[:, :4].round().int(),
+                class_id=aligned_boxes[:, 5].int(),
+                confidence=aligned_boxes[:, 4],
+                mask=instances_masks,
             )
-        else:
-            final_results.append(
-                InstanceDetections(
-                    xyxy=torch.empty(
-                        (0, 4), dtype=torch.int32, device=image_bboxes.device
-                    ),
-                    class_id=torch.empty(
-                        (0,), dtype=torch.int32, device=image_bboxes.device
-                    ),
-                    confidence=torch.empty((0,), device=image_bboxes.device),
-                    mask=instances_masks,
-                )
-            )
+        )
     return final_results

--- a/inference_models/inference_models/models/yolo26/common.py
+++ b/inference_models/inference_models/models/yolo26/common.py
@@ -3,10 +3,10 @@ from typing import List
 import torch
 
 from inference_models import InstanceDetections, InstancesRLEMasks
+from inference_models.models.common.rle_utils import torch_masks_to_coco_rle_batch
 from inference_models.models.common.roboflow.model_packages import PreProcessingMetadata
 from inference_models.models.common.roboflow.post_processing import (
     align_instance_segmentation_results,
-    align_instance_segmentation_results_to_rle_masks,
     crop_masks_to_boxes,
     preprocess_segmentation_masks,
 )
@@ -74,8 +74,7 @@ def prepare_rle_masks(
             image_meta.pad_right,
             image_meta.pad_bottom,
         )
-        aligned_boxes, rle_masks = [], []
-        for bbox, mask in align_instance_segmentation_results_to_rle_masks(
+        aligned_boxes, aligned_masks = align_instance_segmentation_results(
             image_bboxes=image_bboxes,
             masks=cropped_masks,
             padding=padding,
@@ -85,37 +84,20 @@ def prepare_rle_masks(
             size_after_pre_processing=image_meta.size_after_pre_processing,
             inference_size=image_meta.inference_size,
             static_crop_offset=image_meta.static_crop_offset,
-        ):
-            aligned_boxes.append(bbox)
-            rle_masks.append(mask)
+        )
         instances_masks = InstancesRLEMasks.from_coco_rle_masks(
             image_size=(
                 image_meta.original_size.height,
                 image_meta.original_size.width,
             ),
-            masks=rle_masks,
+            masks=torch_masks_to_coco_rle_batch(aligned_masks),
         )
-        if len(aligned_boxes) > 0:
-            aligned_boxes_tensor = torch.stack(aligned_boxes, dim=0)
-            final_results.append(
-                InstanceDetections(
-                    xyxy=aligned_boxes_tensor[:, :4].round().int(),
-                    class_id=aligned_boxes_tensor[:, 5].int(),
-                    confidence=aligned_boxes_tensor[:, 4],
-                    mask=instances_masks,
-                )
+        final_results.append(
+            InstanceDetections(
+                xyxy=aligned_boxes[:, :4].round().int(),
+                class_id=aligned_boxes[:, 5].int(),
+                confidence=aligned_boxes[:, 4],
+                mask=instances_masks,
             )
-        else:
-            final_results.append(
-                InstanceDetections(
-                    xyxy=torch.empty(
-                        (0, 4), dtype=torch.int32, device=image_bboxes.device
-                    ),
-                    class_id=torch.empty(
-                        (0,), dtype=torch.int32, device=image_bboxes.device
-                    ),
-                    confidence=torch.empty((0,), device=image_bboxes.device),
-                    mask=instances_masks,
-                )
-            )
+        )
     return final_results

--- a/inference_models/inference_models/models/yolov5/common.py
+++ b/inference_models/inference_models/models/yolov5/common.py
@@ -3,10 +3,10 @@ from typing import List
 import torch
 
 from inference_models import InstanceDetections, InstancesRLEMasks
+from inference_models.models.common.rle_utils import torch_masks_to_coco_rle_batch
 from inference_models.models.common.roboflow.model_packages import PreProcessingMetadata
 from inference_models.models.common.roboflow.post_processing import (
     align_instance_segmentation_results,
-    align_instance_segmentation_results_to_rle_masks,
     crop_masks_to_boxes,
     preprocess_segmentation_masks,
 )
@@ -74,8 +74,7 @@ def prepare_rle_masks(
             image_meta.pad_right,
             image_meta.pad_bottom,
         )
-        aligned_boxes, rle_masks = [], []
-        for bbox, mask in align_instance_segmentation_results_to_rle_masks(
+        aligned_boxes, aligned_masks = align_instance_segmentation_results(
             image_bboxes=image_bboxes,
             masks=cropped_masks,
             padding=padding,
@@ -85,37 +84,20 @@ def prepare_rle_masks(
             size_after_pre_processing=image_meta.size_after_pre_processing,
             inference_size=image_meta.inference_size,
             static_crop_offset=image_meta.static_crop_offset,
-        ):
-            aligned_boxes.append(bbox)
-            rle_masks.append(mask)
+        )
         instances_masks = InstancesRLEMasks.from_coco_rle_masks(
             image_size=(
                 image_meta.original_size.height,
                 image_meta.original_size.width,
             ),
-            masks=rle_masks,
+            masks=torch_masks_to_coco_rle_batch(aligned_masks),
         )
-        if len(aligned_boxes) > 0:
-            aligned_boxes_tensor = torch.stack(aligned_boxes, dim=0)
-            final_results.append(
-                InstanceDetections(
-                    xyxy=aligned_boxes_tensor[:, :4].round().int(),
-                    class_id=aligned_boxes_tensor[:, 5].int(),
-                    confidence=aligned_boxes_tensor[:, 4],
-                    mask=instances_masks,
-                )
+        final_results.append(
+            InstanceDetections(
+                xyxy=aligned_boxes[:, :4].round().int(),
+                class_id=aligned_boxes[:, 5].int(),
+                confidence=aligned_boxes[:, 4],
+                mask=instances_masks,
             )
-        else:
-            final_results.append(
-                InstanceDetections(
-                    xyxy=torch.empty(
-                        (0, 4), dtype=torch.int32, device=image_bboxes.device
-                    ),
-                    class_id=torch.empty(
-                        (0,), dtype=torch.int32, device=image_bboxes.device
-                    ),
-                    confidence=torch.empty((0,), device=image_bboxes.device),
-                    mask=instances_masks,
-                )
-            )
+        )
     return final_results

--- a/inference_models/inference_models/models/yolov7/common.py
+++ b/inference_models/inference_models/models/yolov7/common.py
@@ -3,10 +3,10 @@ from typing import List
 import torch
 
 from inference_models import InstanceDetections, InstancesRLEMasks
+from inference_models.models.common.rle_utils import torch_masks_to_coco_rle_batch
 from inference_models.models.common.roboflow.model_packages import PreProcessingMetadata
 from inference_models.models.common.roboflow.post_processing import (
     align_instance_segmentation_results,
-    align_instance_segmentation_results_to_rle_masks,
     crop_masks_to_boxes,
     preprocess_segmentation_masks,
 )
@@ -74,8 +74,7 @@ def prepare_rle_masks(
             image_meta.pad_right,
             image_meta.pad_bottom,
         )
-        aligned_boxes, rle_masks = [], []
-        for bbox, mask in align_instance_segmentation_results_to_rle_masks(
+        aligned_boxes, aligned_masks = align_instance_segmentation_results(
             image_bboxes=image_bboxes,
             masks=cropped_masks,
             padding=padding,
@@ -85,37 +84,20 @@ def prepare_rle_masks(
             size_after_pre_processing=image_meta.size_after_pre_processing,
             inference_size=image_meta.inference_size,
             static_crop_offset=image_meta.static_crop_offset,
-        ):
-            aligned_boxes.append(bbox)
-            rle_masks.append(mask)
+        )
         instances_masks = InstancesRLEMasks.from_coco_rle_masks(
             image_size=(
                 image_meta.original_size.height,
                 image_meta.original_size.width,
             ),
-            masks=rle_masks,
+            masks=torch_masks_to_coco_rle_batch(aligned_masks),
         )
-        if len(aligned_boxes) > 0:
-            aligned_boxes_tensor = torch.stack(aligned_boxes, dim=0)
-            final_results.append(
-                InstanceDetections(
-                    xyxy=aligned_boxes_tensor[:, :4].round().int(),
-                    class_id=aligned_boxes_tensor[:, 5].int(),
-                    confidence=aligned_boxes_tensor[:, 4],
-                    mask=instances_masks,
-                )
+        final_results.append(
+            InstanceDetections(
+                xyxy=aligned_boxes[:, :4].round().int(),
+                class_id=aligned_boxes[:, 5].int(),
+                confidence=aligned_boxes[:, 4],
+                mask=instances_masks,
             )
-        else:
-            final_results.append(
-                InstanceDetections(
-                    xyxy=torch.empty(
-                        (0, 4), dtype=torch.int32, device=image_bboxes.device
-                    ),
-                    class_id=torch.empty(
-                        (0,), dtype=torch.int32, device=image_bboxes.device
-                    ),
-                    confidence=torch.empty((0,), device=image_bboxes.device),
-                    mask=instances_masks,
-                )
-            )
+        )
     return final_results

--- a/inference_models/inference_models/models/yolov8/common.py
+++ b/inference_models/inference_models/models/yolov8/common.py
@@ -3,10 +3,10 @@ from typing import List
 import torch
 
 from inference_models import InstanceDetections, InstancesRLEMasks
+from inference_models.models.common.rle_utils import torch_masks_to_coco_rle_batch
 from inference_models.models.common.roboflow.model_packages import PreProcessingMetadata
 from inference_models.models.common.roboflow.post_processing import (
     align_instance_segmentation_results,
-    align_instance_segmentation_results_to_rle_masks,
     crop_masks_to_boxes,
     preprocess_segmentation_masks,
 )
@@ -83,8 +83,7 @@ def prepare_rle_masks(
             image_meta.pad_right,
             image_meta.pad_bottom,
         )
-        aligned_boxes, rle_masks = [], []
-        for bbox, mask in align_instance_segmentation_results_to_rle_masks(
+        aligned_boxes, aligned_masks = align_instance_segmentation_results(
             image_bboxes=image_bboxes,
             masks=cropped_masks,
             padding=padding,
@@ -95,37 +94,20 @@ def prepare_rle_masks(
             inference_size=image_meta.inference_size,
             static_crop_offset=image_meta.static_crop_offset,
             binarization_threshold=masks_binarization_threshold,
-        ):
-            aligned_boxes.append(bbox)
-            rle_masks.append(mask)
+        )
         instances_masks = InstancesRLEMasks.from_coco_rle_masks(
             image_size=(
                 image_meta.original_size.height,
                 image_meta.original_size.width,
             ),
-            masks=rle_masks,
+            masks=torch_masks_to_coco_rle_batch(aligned_masks),
         )
-        if len(aligned_boxes) > 0:
-            aligned_boxes_tensor = torch.stack(aligned_boxes, dim=0)
-            final_results.append(
-                InstanceDetections(
-                    xyxy=aligned_boxes_tensor[:, :4].round().int(),
-                    class_id=aligned_boxes_tensor[:, 5].int(),
-                    confidence=aligned_boxes_tensor[:, 4],
-                    mask=instances_masks,
-                )
+        final_results.append(
+            InstanceDetections(
+                xyxy=aligned_boxes[:, :4].round().int(),
+                class_id=aligned_boxes[:, 5].int(),
+                confidence=aligned_boxes[:, 4],
+                mask=instances_masks,
             )
-        else:
-            final_results.append(
-                InstanceDetections(
-                    xyxy=torch.empty(
-                        (0, 4), dtype=torch.int32, device=image_bboxes.device
-                    ),
-                    class_id=torch.empty(
-                        (0,), dtype=torch.int32, device=image_bboxes.device
-                    ),
-                    confidence=torch.empty((0,), device=image_bboxes.device),
-                    mask=instances_masks,
-                )
-            )
+        )
     return final_results

--- a/inference_models/tests/unit_tests/models/common/test_rle_batch_encode.py
+++ b/inference_models/tests/unit_tests/models/common/test_rle_batch_encode.py
@@ -1,0 +1,182 @@
+"""Regression lock for the batched instance-segmentation RLE path.
+
+The instance-seg models (RF-DETR + YOLOv5/7/8/26 + YOLACT) used to encode masks
+one detection at a time via ``align_instance_segmentation_results_to_rle_masks``,
+which calls ``torch_mask_to_coco_rle`` per mask -- and that does a ``.cpu()``
+sync per detection. On Jetson those per-detection syncs serialize the GPU N times
+per frame and dominate seg post-processing.
+
+The replacement uses the batched ``align_instance_segmentation_results`` followed
+by ``torch_masks_to_coco_rle_batch`` (a single device->host transfer + one
+vectorized ``pycocotools.encode``). These tests lock that the new path is
+*output-identical* to the old one: same boxes, byte-identical RLE.
+"""
+
+import numpy as np
+import pytest
+import torch
+
+from inference_models.entities import ImageDimensions
+from inference_models.models.base.types import InstancesRLEMasks
+from inference_models.models.common.rle_utils import (
+    coco_rle_masks_to_numpy_mask,
+    torch_mask_to_coco_rle,
+    torch_masks_to_coco_rle_batch,
+)
+from inference_models.models.common.roboflow.model_packages import StaticCropOffset
+from inference_models.models.common.roboflow.post_processing import (
+    align_instance_segmentation_results,
+    align_instance_segmentation_results_to_rle_masks,
+)
+
+# ---------------------------------------------------------------------------
+# torch_masks_to_coco_rle_batch is a drop-in for per-mask torch_mask_to_coco_rle
+# ---------------------------------------------------------------------------
+
+
+def test_batch_encode_empty_returns_empty_list() -> None:
+    assert (
+        torch_masks_to_coco_rle_batch(torch.zeros((0, 16, 16), dtype=torch.bool)) == []
+    )
+
+
+@pytest.mark.parametrize("n,h,w", [(1, 32, 32), (3, 20, 40), (8, 17, 13), (32, 64, 48)])
+def test_batch_encode_byte_identical_to_per_mask(n: int, h: int, w: int) -> None:
+    rng = np.random.default_rng(seed=n * 100 + h)
+    masks = torch.from_numpy(rng.integers(0, 2, size=(n, h, w)).astype(bool))
+    batch = torch_masks_to_coco_rle_batch(masks)
+    per_mask = [torch_mask_to_coco_rle(m) for m in masks]
+    assert len(batch) == len(per_mask) == n
+    for got, want in zip(batch, per_mask):
+        assert got["counts"] == want["counts"]
+        assert list(got["size"]) == list(want["size"])
+
+
+@pytest.mark.parametrize(
+    "builder",
+    [
+        lambda: torch.zeros((3, 24, 24), dtype=torch.bool),  # all background
+        lambda: torch.ones((3, 24, 24), dtype=torch.bool),  # all foreground
+    ],
+)
+def test_batch_encode_degenerate_masks_match_per_mask(builder) -> None:
+    masks = builder()
+    for got, want in zip(
+        torch_masks_to_coco_rle_batch(masks),
+        [torch_mask_to_coco_rle(m) for m in masks],
+    ):
+        assert got["counts"] == want["counts"]
+
+
+def test_batch_encode_roundtrip_matches_input() -> None:
+    rng = np.random.default_rng(seed=2024)
+    n, h, w = 6, 50, 70
+    masks = torch.from_numpy(rng.integers(0, 2, size=(n, h, w)).astype(bool))
+    wrapped = InstancesRLEMasks.from_coco_rle_masks(
+        image_size=(h, w), masks=torch_masks_to_coco_rle_batch(masks)
+    )
+    decoded = coco_rle_masks_to_numpy_mask(wrapped)
+    assert decoded.shape == (n, h, w)
+    np.testing.assert_array_equal(decoded, masks.numpy())
+
+
+def test_batch_encode_does_not_mutate_input() -> None:
+    rng = np.random.default_rng(seed=5)
+    masks = torch.from_numpy(rng.integers(0, 2, size=(4, 20, 20)).astype(bool))
+    original = masks.clone()
+    _ = torch_masks_to_coco_rle_batch(masks)
+    assert torch.equal(masks, original)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_batch_encode_cuda_matches_cpu() -> None:
+    rng = np.random.default_rng(seed=11)
+    masks = torch.from_numpy(rng.integers(0, 2, size=(5, 40, 40)).astype(bool))
+    for cpu, cuda in zip(
+        torch_masks_to_coco_rle_batch(masks),
+        torch_masks_to_coco_rle_batch(masks.cuda()),
+    ):
+        assert cpu["counts"] == cuda["counts"]
+
+
+# ---------------------------------------------------------------------------
+# batched align + batch encode == per-detection generator (the model refactor)
+# ---------------------------------------------------------------------------
+
+
+def _boxes(n: int, w: int, h: int, seed: int) -> torch.Tensor:
+    g = torch.Generator().manual_seed(seed)
+    b = torch.zeros(n, 6)
+    b[:, 0] = torch.rand(n, generator=g) * w * 0.4
+    b[:, 1] = torch.rand(n, generator=g) * h * 0.4
+    b[:, 2] = b[:, 0] + torch.rand(n, generator=g) * w * 0.5 + 2
+    b[:, 3] = b[:, 1] + torch.rand(n, generator=g) * h * 0.5 + 2
+    b[:, 4] = torch.rand(n, generator=g)
+    b[:, 5] = torch.randint(0, 5, (n,), generator=g).float()
+    return b
+
+
+@pytest.mark.parametrize(
+    "n,mh,mw,ow,oh,sw,sh,iw,ih,pad,scl,cx,cy,seed",
+    [
+        (4, 64, 64, 100, 80, 100, 80, 64, 64, (4, 4, 4, 4), 1.0, 0, 0, 1),
+        (5, 64, 64, 120, 90, 120, 90, 64, 64, (6, 6, 6, 6), 1.25, 0, 0, 2),
+        (
+            3,
+            64,
+            64,
+            120,
+            100,
+            80,
+            64,
+            64,
+            64,
+            (4, 4, 4, 4),
+            1.0,
+            20,
+            18,
+            3,
+        ),  # static crop
+        (3, 48, 48, 99, 77, 99, 77, 48, 48, (5, 3, 5, 3), 1.0, 0, 0, 4),  # odd dims
+        (1, 32, 32, 64, 64, 64, 64, 32, 32, (2, 2, 2, 2), 1.0, 0, 0, 5),
+        (0, 64, 64, 100, 80, 100, 80, 64, 64, (4, 4, 4, 4), 1.0, 0, 0, 6),  # empty
+    ],
+)
+def test_batched_align_encode_matches_generator(
+    n, mh, mw, ow, oh, sw, sh, iw, ih, pad, scl, cx, cy, seed
+) -> None:
+    boxes = _boxes(n, ow, oh, seed)
+    masks = (
+        torch.rand(n, mh, mw, generator=torch.Generator().manual_seed(seed + 7)) - 0.5
+    )
+    kw = dict(
+        padding=pad,
+        scale_width=scl,
+        scale_height=scl,
+        original_size=ImageDimensions(width=ow, height=oh),
+        size_after_pre_processing=ImageDimensions(width=sw, height=sh),
+        inference_size=ImageDimensions(width=iw, height=ih),
+        static_crop_offset=StaticCropOffset(
+            offset_x=cx, offset_y=cy, crop_width=ow, crop_height=oh
+        ),
+    )
+
+    gen_boxes, gen_rles = [], []
+    for bb, mk in align_instance_segmentation_results_to_rle_masks(
+        image_bboxes=boxes.clone(), masks=masks.clone(), **kw
+    ):
+        gen_boxes.append(bb)
+        gen_rles.append(mk)
+    gen_boxes_t = torch.stack(gen_boxes) if gen_boxes else torch.empty((0, 6))
+
+    bat_boxes, bat_masks = align_instance_segmentation_results(
+        image_bboxes=boxes.clone(), masks=masks.clone(), **kw
+    )
+    bat_rles = torch_masks_to_coco_rle_batch(bat_masks)
+
+    assert gen_boxes_t.shape == bat_boxes.shape
+    assert torch.equal(gen_boxes_t, bat_boxes)
+    assert len(gen_rles) == len(bat_rles) == n
+    for got, want in zip(bat_rles, gen_rles):
+        assert got["counts"] == want["counts"]
+        assert list(got["size"]) == list(want["size"])


### PR DESCRIPTION
## What

Batch the instance-segmentation RLE mask encoding so post-processing does **one** device→host transfer per chunk of detections (`INFERENCE_MODELS_INSTANCE_SEG_MASK_PROCESSING_CHUNK_SIZE`, default 16) instead of **one per detection**.

## Why

Instance-seg post-processing encoded masks one detection at a time via `align_instance_segmentation_results_to_rle_masks`, whose `torch_mask_to_coco_rle` performs a `.cpu()` sync per mask (`lengths.cpu().tolist()` + a GPU scalar read). On Jetson those per-detection syncs serialize the GPU `~2·N` times per frame and dominate seg post-processing — a major contributor to the ~50% throughput drop seen running rf-detr-seg on a JetPack 6.2 device vs. detection.

## How

- New `torch_masks_to_coco_rle_batch(masks)` in `models/common/rle_utils.py`: a single `[N,H,W]→[H,W,N]` device→host transfer + one vectorized `pycocotools.mask.encode`.
- New `align_instance_segmentation_results_to_rle_masks_batched` in `post_processing.py`: runs the existing batched `align_instance_segmentation_results` (the same routine the dense path uses) plus the batched encode chunk by chunk, replacing the per-detection generator loop. Chunking keeps peak memory at `chunk × H × W` full-resolution masks rather than `N × H × W`; set the env var to 1 for the tightest memory bound.
- Applied to: **RF-DETR** (the non-Triton fallback path; the Triton fast path on `main` is unchanged) and **YOLOv5 / YOLOv7 / YOLOv8 / YOLO26 / YOLACT**.

## Behavior-preserving

Output is **byte-identical** — same boxes, same compressed RLE `counts`. Locked by a new test, `tests/unit_tests/models/common/test_rle_batch_encode.py`:

- `torch_masks_to_coco_rle_batch` == per-mask `torch_mask_to_coco_rle` (random / single / all-zero / all-one / empty).
- `align_instance_segmentation_results` + batch encode == the per-detection generator, for both boxes and RLE, across no-crop / scaled / static-crop / odd-dims / single / empty cases.
- The chunked helper == the generator for chunk sizes 1/2/3/16, and each align call sees at most `chunk` masks.
- Non-contiguous (strided/sliced/transposed) inputs and grad-tracking float inputs encode correctly.

## Test plan

- `pytest tests/unit_tests/models/common/test_rle_batch_encode.py tests/unit_tests/models/common/test_rle_utils.py` → green (CUDA cases skip on CPU).
- No accuracy change expected; this is a scheduling/transfer optimization only.

> Draft: opening for review of the approach + scope before marking ready.

