### PR TITLE
[codex] Fix SAM2 cache fast paths

### DIFF
--- a/inference/models/sam2/segment_anything2_inference_models.py
+++ b/inference/models/sam2/segment_anything2_inference_models.py
@@ -53,6 +53,7 @@ from inference.core.env import (
 from inference.core.models.base import Model
 from inference.core.utils.image_utils import load_image_bgr
 from inference.usage_tracking.collector import usage_collector
+from inference_models.errors import ModelInputError
 
 if DEVICE is None:
     DEVICE = "cuda:0" if torch.cuda.is_available() else "cpu"
@@ -275,7 +276,6 @@ class InferenceModelsSAM2Adapter(Model):
             load_logits_from_cache and not DISABLE_SAM2_LOGITS_CACHE
         )
         save_logits_to_cache = save_logits_to_cache and not DISABLE_SAM2_LOGITS_CACHE
-        loaded_image = self.preproc_image(image)
         if prompts is not None:
             if type(prompts) is dict:
                 prompts = Sam2PromptSet(**prompts)
@@ -293,9 +293,8 @@ class InferenceModelsSAM2Adapter(Model):
             args["box"] = np.array(args["box"])
         if mask_input is not None and isinstance(mask_input, list):
             mask_input = np.array(mask_input)
-        prediction = self._model.segment_images(
-            images=loaded_image,
-            image_hashes=image_id,
+
+        segment_kwargs = dict(
             point_coordinates=args["point_coords"],
             point_labels=args["point_labels"],
             boxes=args["box"],
@@ -306,7 +305,23 @@ class InferenceModelsSAM2Adapter(Model):
             save_to_mask_input_cache=save_logits_to_cache,
             use_embeddings_cache=True,
             return_logits=True,
-        )[0]
+        )
+
+        prediction = None
+        if image_id is not None:
+            try:
+                prediction = self._model.segment_images(
+                    images=None, image_hashes=image_id, **segment_kwargs
+                )[0]
+            except ModelInputError as error:
+                if "no embeddings were found in the cache" not in str(error):
+                    raise
+                prediction = None
+        if prediction is None:
+            loaded_image = self.preproc_image(image)
+            prediction = self._model.segment_images(
+                images=loaded_image, image_hashes=image_id, **segment_kwargs
+            )[0]
         return choose_most_confident_sam_prediction(
             masks=prediction.masks.cpu().numpy(),
             scores=prediction.scores.cpu().numpy(),

--- a/inference_models/inference_models/models/sam2/sam2_torch.py
+++ b/inference_models/inference_models/models/sam2/sam2_torch.py
@@ -374,7 +374,7 @@ class SAM2Torch:
                         f"invalid integration.",
                         help_url="https://inference-models.roboflow.com/errors/input-validation/#modelinputerror",
                     )
-                embeddings.append(cache_content)
+                embeddings.append(cache_content.to(device=self._device))
         else:
             embeddings = maybe_wrap_in_list(value=embeddings)
         image_hashes = [e.image_hash for e in embeddings]
@@ -914,7 +914,12 @@ def find_prior_prompt_in_cache(
 ) -> Optional[torch.Tensor]:
     maxed_size = 0
     best_match: Optional[SAM2MaskCacheEntry] = None
-    desired_size = len(serialized_prompt) - 1
+    num_points = (
+        0 if not serialized_prompt else len(serialized_prompt[0].get("points", []))
+    )
+    if num_points <= 1:
+        return None
+    desired_size = num_points - 1
     for cache_entry in matching_cache_entries[::-1]:
         is_viable = is_prompt_strict_subset(
             assumed_sub_set_prompt=(
@@ -927,13 +932,18 @@ def find_prior_prompt_in_cache(
             continue
 
         # short circuit search if we find prompt with one less point (most recent possible mask)
-        current_cache_entry_prompt_size = len(cache_entry.serialized_prompt)
+        cached_prompt = cache_entry.serialized_prompt
+        current_cache_entry_prompt_size = (
+            0 if not cached_prompt else len(cached_prompt[0].get("points", []))
+        )
         if current_cache_entry_prompt_size == desired_size:
             return cache_entry.mask.to(device=device)
         if current_cache_entry_prompt_size >= maxed_size:
             maxed_size = current_cache_entry_prompt_size
             best_match = cache_entry
-    return best_match.mask.to(device=device)
+    if best_match is not None:
+        return best_match.mask.to(device=device)
+    return None
 
 
 def is_prompt_strict_subset(

--- a/inference_models/tests/unit_tests/models/test_sam2_torch.py
+++ b/inference_models/tests/unit_tests/models/test_sam2_torch.py
@@ -1,0 +1,152 @@
+"""Unit tests for SAM2Torch cache handling."""
+
+import importlib
+import sys
+from contextlib import nullcontext
+from types import ModuleType, SimpleNamespace
+from typing import Generator
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+import torch
+
+SAM2_TORCH_MODULE = "inference_models.models.sam2.sam2_torch"
+
+
+def _build_sam2_stubs() -> dict:
+    sam2 = ModuleType("sam2")
+    sam2.__path__ = []
+    build_sam = ModuleType("sam2.build_sam")
+    build_sam.build_sam2 = MagicMock()
+
+    modeling = ModuleType("sam2.modeling")
+    modeling.__path__ = []
+    sam2_base = ModuleType("sam2.modeling.sam2_base")
+    sam2_base.SAM2Base = object
+
+    utils = ModuleType("sam2.utils")
+    utils.__path__ = []
+    transforms = ModuleType("sam2.utils.transforms")
+    transforms.SAM2Transforms = MagicMock()
+
+    sam2.build_sam = build_sam
+    sam2.modeling = modeling
+    sam2.utils = utils
+    modeling.sam2_base = sam2_base
+    utils.transforms = transforms
+
+    return {
+        "sam2": sam2,
+        "sam2.build_sam": build_sam,
+        "sam2.modeling": modeling,
+        "sam2.modeling.sam2_base": sam2_base,
+        "sam2.utils": utils,
+        "sam2.utils.transforms": transforms,
+    }
+
+
+@pytest.fixture(scope="module")
+def sam2_torch_module() -> Generator[ModuleType, None, None]:
+    with patch.dict(sys.modules, _build_sam2_stubs()):
+        sys.modules.pop(SAM2_TORCH_MODULE, None)
+        yield importlib.import_module(SAM2_TORCH_MODULE)
+
+
+def test_find_prior_prompt_in_cache_returns_none_when_no_prompt_matches(
+    sam2_torch_module: ModuleType,
+) -> None:
+    cached_mask = torch.ones(1, 4, 4)
+    cache_entry = sam2_torch_module.SAM2MaskCacheEntry(
+        prompt_hash="cached",
+        serialized_prompt=[
+            {"points": [{"x": 5, "y": 5, "positive": True}], "box": None}
+        ],
+        mask=cached_mask,
+    )
+
+    result = sam2_torch_module.find_prior_prompt_in_cache(
+        serialized_prompt_hash="current",
+        serialized_prompt=[
+            {"points": [{"x": 10, "y": 10, "positive": True}], "box": None}
+        ],
+        matching_cache_entries=[cache_entry],
+        device=torch.device("cpu"),
+    )
+
+    assert result is None
+
+
+def test_find_prior_prompt_in_cache_returns_nearest_matching_prior_prompt(
+    sam2_torch_module: ModuleType,
+) -> None:
+    cached_mask = torch.ones(1, 4, 4)
+    cache_entry = sam2_torch_module.SAM2MaskCacheEntry(
+        prompt_hash="cached",
+        serialized_prompt=[
+            {"points": [{"x": 5, "y": 5, "positive": True}], "box": None}
+        ],
+        mask=cached_mask,
+    )
+
+    result = sam2_torch_module.find_prior_prompt_in_cache(
+        serialized_prompt_hash="current",
+        serialized_prompt=[
+            {
+                "points": [
+                    {"x": 5, "y": 5, "positive": True},
+                    {"x": 10, "y": 10, "positive": False},
+                ],
+                "box": None,
+            }
+        ],
+        matching_cache_entries=[cache_entry],
+        device=torch.device("cpu"),
+    )
+
+    np.testing.assert_array_equal(result.numpy(), cached_mask.numpy())
+
+
+def test_segment_images_moves_cached_embedding_to_model_device(
+    sam2_torch_module: ModuleType,
+) -> None:
+    model = sam2_torch_module.SAM2Torch.__new__(sam2_torch_module.SAM2Torch)
+    model._device = torch.device("cpu")
+    model._lock = nullcontext()
+    model._model = object()
+    model._transform = object()
+    model._sam2_allow_client_generated_hash_ids = True
+    cached_embedding = MagicMock()
+    moved_embedding = SimpleNamespace(image_hash="abc", image_size_hw=(8, 8))
+    cached_embedding.to.return_value = moved_embedding
+    model._sam2_image_embeddings_cache = SimpleNamespace(
+        retrieve_embeddings=MagicMock(return_value=cached_embedding)
+    )
+
+    with patch.object(
+        sam2_torch_module,
+        "equalize_batch_size",
+        return_value=(None, None, None, None),
+    ), patch.object(
+        sam2_torch_module,
+        "pre_process_prompts",
+        return_value=(None, None, None, None),
+    ), patch.object(
+        sam2_torch_module,
+        "generate_model_inputs",
+        return_value=[
+            (moved_embedding, "abc", (8, 8), None, None, None, None),
+        ],
+    ), patch.object(
+        sam2_torch_module,
+        "predict_for_single_image",
+        return_value=(
+            torch.zeros(1, 8, 8),
+            torch.tensor([1.0]),
+            torch.zeros(1, 16, 16),
+        ),
+    ):
+        predictions = model.segment_images(images=None, image_hashes="abc")
+
+    cached_embedding.to.assert_called_once_with(device=torch.device("cpu"))
+    assert len(predictions) == 1

--- a/tests/inference/unit_tests/models/test_sam2_inference_models.py
+++ b/tests/inference/unit_tests/models/test_sam2_inference_models.py
@@ -22,6 +22,14 @@ if LOCAL_INFERENCE_MODELS_PATH not in sys.path:
     sys.path.insert(0, LOCAL_INFERENCE_MODELS_PATH)
 
 
+def _drop_inference_models_modules() -> None:
+    for module_name in list(sys.modules):
+        if module_name == "inference_models" or module_name.startswith(
+            "inference_models."
+        ):
+            sys.modules.pop(module_name, None)
+
+
 def _build_sam2_stubs() -> dict:
     sam2 = ModuleType("sam2")
     sam2.__path__ = []
@@ -64,15 +72,15 @@ def _build_sam2_stubs() -> dict:
 @pytest.fixture()
 def adapter_module() -> Generator[ModuleType, None, None]:
     with patch.dict(sys.modules, _build_sam2_stubs()):
+        _drop_inference_models_modules()
         sys.modules.pop(ADAPTER_MODULE, None)
-        sys.modules.pop(SAM2_TORCH_MODULE, None)
         yield importlib.import_module(ADAPTER_MODULE)
 
 
 @pytest.fixture()
 def sam2_torch_module() -> Generator[ModuleType, None, None]:
     with patch.dict(sys.modules, _build_sam2_stubs()):
-        sys.modules.pop(SAM2_TORCH_MODULE, None)
+        _drop_inference_models_modules()
         yield importlib.import_module(SAM2_TORCH_MODULE)
 
 

--- a/tests/inference/unit_tests/models/test_sam2_inference_models.py
+++ b/tests/inference/unit_tests/models/test_sam2_inference_models.py
@@ -1,0 +1,240 @@
+"""Unit tests for the inference_models-backed SAM2 adapter."""
+
+import importlib
+import sys
+from contextlib import nullcontext
+from types import ModuleType, SimpleNamespace
+from typing import Generator
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+import torch
+
+ADAPTER_MODULE = "inference.models.sam2.segment_anything2_inference_models"
+SAM2_TORCH_MODULE = "inference_models.models.sam2.sam2_torch"
+
+
+def _build_sam2_stubs() -> dict:
+    sam2 = ModuleType("sam2")
+    sam2.__path__ = []
+    build_sam = ModuleType("sam2.build_sam")
+    build_sam.build_sam2 = MagicMock()
+    sam2_image_predictor = ModuleType("sam2.sam2_image_predictor")
+    sam2_image_predictor.SAM2ImagePredictor = MagicMock()
+
+    modeling = ModuleType("sam2.modeling")
+    modeling.__path__ = []
+    sam2_base = ModuleType("sam2.modeling.sam2_base")
+    sam2_base.SAM2Base = object
+
+    utils = ModuleType("sam2.utils")
+    utils.__path__ = []
+    misc = ModuleType("sam2.utils.misc")
+    transforms = ModuleType("sam2.utils.transforms")
+    transforms.SAM2Transforms = MagicMock()
+
+    sam2.build_sam = build_sam
+    sam2.sam2_image_predictor = sam2_image_predictor
+    sam2.modeling = modeling
+    sam2.utils = utils
+    modeling.sam2_base = sam2_base
+    utils.misc = misc
+    utils.transforms = transforms
+
+    return {
+        "sam2": sam2,
+        "sam2.build_sam": build_sam,
+        "sam2.sam2_image_predictor": sam2_image_predictor,
+        "sam2.modeling": modeling,
+        "sam2.modeling.sam2_base": sam2_base,
+        "sam2.utils": utils,
+        "sam2.utils.misc": misc,
+        "sam2.utils.transforms": transforms,
+    }
+
+
+@pytest.fixture()
+def adapter_module() -> Generator[ModuleType, None, None]:
+    with patch.dict(sys.modules, _build_sam2_stubs()):
+        sys.modules.pop(ADAPTER_MODULE, None)
+        sys.modules.pop(SAM2_TORCH_MODULE, None)
+        yield importlib.import_module(ADAPTER_MODULE)
+
+
+@pytest.fixture()
+def sam2_torch_module() -> Generator[ModuleType, None, None]:
+    with patch.dict(sys.modules, _build_sam2_stubs()):
+        sys.modules.pop(SAM2_TORCH_MODULE, None)
+        yield importlib.import_module(SAM2_TORCH_MODULE)
+
+
+def _single_prediction() -> SimpleNamespace:
+    return SimpleNamespace(
+        masks=torch.rand(1, 8, 8),
+        scores=torch.tensor([0.7]),
+        logits=torch.rand(1, 16, 16),
+    )
+
+
+def _build_adapter(adapter_module: ModuleType, prediction):
+    adapter = adapter_module.InferenceModelsSAM2Adapter.__new__(
+        adapter_module.InferenceModelsSAM2Adapter
+    )
+    adapter._model = MagicMock()
+    adapter._model.segment_images.return_value = [prediction]
+    return adapter
+
+
+_CACHE_MISS_MESSAGE = (
+    "Attempted to use SAM model segment_images(...) method providing "
+    "`image_hashes` for which no embeddings were found in the cache."
+)
+
+
+def test_segment_image_with_cached_image_id_skips_preprocessing(
+    adapter_module: ModuleType,
+) -> None:
+    adapter = _build_adapter(adapter_module, _single_prediction())
+    adapter.preproc_image = MagicMock()
+
+    adapter.segment_image(image=object(), image_id="abc")
+
+    adapter.preproc_image.assert_not_called()
+    adapter._model.segment_images.assert_called_once()
+    call_kwargs = adapter._model.segment_images.call_args.kwargs
+    assert call_kwargs["images"] is None
+    assert call_kwargs["image_hashes"] == "abc"
+
+
+def test_segment_image_falls_back_to_preprocessing_on_cache_miss(
+    adapter_module: ModuleType,
+) -> None:
+    adapter = _build_adapter(adapter_module, _single_prediction())
+    adapter._model.segment_images.side_effect = [
+        adapter_module.ModelInputError(message=_CACHE_MISS_MESSAGE),
+        [_single_prediction()],
+    ]
+    loaded_image = object()
+    adapter.preproc_image = MagicMock(return_value=loaded_image)
+
+    adapter.segment_image(image=object(), image_id="abc")
+
+    adapter.preproc_image.assert_called_once()
+    assert adapter._model.segment_images.call_count == 2
+    call_kwargs = adapter._model.segment_images.call_args.kwargs
+    assert call_kwargs["images"] is loaded_image
+    assert call_kwargs["image_hashes"] == "abc"
+
+
+def test_segment_image_propagates_non_cache_miss_input_error(
+    adapter_module: ModuleType,
+) -> None:
+    adapter = _build_adapter(adapter_module, _single_prediction())
+    adapter._model.segment_images.side_effect = adapter_module.ModelInputError(
+        message="invalid point shape"
+    )
+    adapter.preproc_image = MagicMock()
+
+    with pytest.raises(adapter_module.ModelInputError):
+        adapter.segment_image(image=object(), image_id="abc")
+    adapter.preproc_image.assert_not_called()
+
+
+def test_find_prior_prompt_in_cache_returns_none_when_no_prompt_matches(
+    sam2_torch_module: ModuleType,
+) -> None:
+    cached_mask = torch.ones(1, 4, 4)
+    cache_entry = sam2_torch_module.SAM2MaskCacheEntry(
+        prompt_hash="cached",
+        serialized_prompt=[
+            {"points": [{"x": 5, "y": 5, "positive": True}], "box": None}
+        ],
+        mask=cached_mask,
+    )
+
+    result = sam2_torch_module.find_prior_prompt_in_cache(
+        serialized_prompt_hash="current",
+        serialized_prompt=[
+            {"points": [{"x": 10, "y": 10, "positive": True}], "box": None}
+        ],
+        matching_cache_entries=[cache_entry],
+        device=torch.device("cpu"),
+    )
+
+    assert result is None
+
+
+def test_find_prior_prompt_in_cache_returns_nearest_matching_prior_prompt(
+    sam2_torch_module: ModuleType,
+) -> None:
+    cached_mask = torch.ones(1, 4, 4)
+    cache_entry = sam2_torch_module.SAM2MaskCacheEntry(
+        prompt_hash="cached",
+        serialized_prompt=[
+            {"points": [{"x": 5, "y": 5, "positive": True}], "box": None}
+        ],
+        mask=cached_mask,
+    )
+
+    result = sam2_torch_module.find_prior_prompt_in_cache(
+        serialized_prompt_hash="current",
+        serialized_prompt=[
+            {
+                "points": [
+                    {"x": 5, "y": 5, "positive": True},
+                    {"x": 10, "y": 10, "positive": False},
+                ],
+                "box": None,
+            }
+        ],
+        matching_cache_entries=[cache_entry],
+        device=torch.device("cpu"),
+    )
+
+    np.testing.assert_array_equal(result.numpy(), cached_mask.numpy())
+
+
+def test_segment_images_moves_cached_embedding_to_model_device(
+    sam2_torch_module: ModuleType,
+) -> None:
+    model = sam2_torch_module.SAM2Torch.__new__(sam2_torch_module.SAM2Torch)
+    model._device = torch.device("cpu")
+    model._lock = nullcontext()
+    model._model = object()
+    model._transform = object()
+    model._sam2_allow_client_generated_hash_ids = True
+    cached_embedding = MagicMock()
+    moved_embedding = SimpleNamespace(image_hash="abc", image_size_hw=(8, 8))
+    cached_embedding.to.return_value = moved_embedding
+    model._sam2_image_embeddings_cache = SimpleNamespace(
+        retrieve_embeddings=MagicMock(return_value=cached_embedding)
+    )
+
+    with patch.object(
+        sam2_torch_module,
+        "equalize_batch_size",
+        return_value=(None, None, None, None),
+    ), patch.object(
+        sam2_torch_module,
+        "pre_process_prompts",
+        return_value=(None, None, None, None),
+    ), patch.object(
+        sam2_torch_module,
+        "generate_model_inputs",
+        return_value=[
+            (moved_embedding, "abc", (8, 8), None, None, None, None),
+        ],
+    ), patch.object(
+        sam2_torch_module,
+        "predict_for_single_image",
+        return_value=(
+            torch.zeros(1, 8, 8),
+            torch.tensor([1.0]),
+            torch.zeros(1, 16, 16),
+        ),
+    ):
+        predictions = model.segment_images(images=None, image_hashes="abc")
+
+    cached_embedding.to.assert_called_once_with(device=torch.device("cpu"))
+    assert len(predictions) == 1

--- a/tests/inference/unit_tests/models/test_sam2_inference_models.py
+++ b/tests/inference/unit_tests/models/test_sam2_inference_models.py
@@ -2,32 +2,14 @@
 
 import importlib
 import sys
-from contextlib import nullcontext
-from pathlib import Path
 from types import ModuleType, SimpleNamespace
 from typing import Generator
 from unittest.mock import MagicMock, patch
 
-import numpy as np
 import pytest
 import torch
 
 ADAPTER_MODULE = "inference.models.sam2.segment_anything2_inference_models"
-SAM2_TORCH_MODULE = "inference_models.models.sam2.sam2_torch"
-
-LOCAL_INFERENCE_MODELS_PATH = str(
-    Path(__file__).resolve().parents[4] / "inference_models"
-)
-if LOCAL_INFERENCE_MODELS_PATH not in sys.path:
-    sys.path.insert(0, LOCAL_INFERENCE_MODELS_PATH)
-
-
-def _drop_inference_models_modules() -> None:
-    for module_name in list(sys.modules):
-        if module_name == "inference_models" or module_name.startswith(
-            "inference_models."
-        ):
-            sys.modules.pop(module_name, None)
 
 
 def _build_sam2_stubs() -> dict:
@@ -72,16 +54,8 @@ def _build_sam2_stubs() -> dict:
 @pytest.fixture()
 def adapter_module() -> Generator[ModuleType, None, None]:
     with patch.dict(sys.modules, _build_sam2_stubs()):
-        _drop_inference_models_modules()
         sys.modules.pop(ADAPTER_MODULE, None)
         yield importlib.import_module(ADAPTER_MODULE)
-
-
-@pytest.fixture()
-def sam2_torch_module() -> Generator[ModuleType, None, None]:
-    with patch.dict(sys.modules, _build_sam2_stubs()):
-        _drop_inference_models_modules()
-        yield importlib.import_module(SAM2_TORCH_MODULE)
 
 
 def _single_prediction() -> SimpleNamespace:
@@ -154,102 +128,3 @@ def test_segment_image_propagates_non_cache_miss_input_error(
     with pytest.raises(adapter_module.ModelInputError):
         adapter.segment_image(image=object(), image_id="abc")
     adapter.preproc_image.assert_not_called()
-
-
-def test_find_prior_prompt_in_cache_returns_none_when_no_prompt_matches(
-    sam2_torch_module: ModuleType,
-) -> None:
-    cached_mask = torch.ones(1, 4, 4)
-    cache_entry = sam2_torch_module.SAM2MaskCacheEntry(
-        prompt_hash="cached",
-        serialized_prompt=[
-            {"points": [{"x": 5, "y": 5, "positive": True}], "box": None}
-        ],
-        mask=cached_mask,
-    )
-
-    result = sam2_torch_module.find_prior_prompt_in_cache(
-        serialized_prompt_hash="current",
-        serialized_prompt=[
-            {"points": [{"x": 10, "y": 10, "positive": True}], "box": None}
-        ],
-        matching_cache_entries=[cache_entry],
-        device=torch.device("cpu"),
-    )
-
-    assert result is None
-
-
-def test_find_prior_prompt_in_cache_returns_nearest_matching_prior_prompt(
-    sam2_torch_module: ModuleType,
-) -> None:
-    cached_mask = torch.ones(1, 4, 4)
-    cache_entry = sam2_torch_module.SAM2MaskCacheEntry(
-        prompt_hash="cached",
-        serialized_prompt=[
-            {"points": [{"x": 5, "y": 5, "positive": True}], "box": None}
-        ],
-        mask=cached_mask,
-    )
-
-    result = sam2_torch_module.find_prior_prompt_in_cache(
-        serialized_prompt_hash="current",
-        serialized_prompt=[
-            {
-                "points": [
-                    {"x": 5, "y": 5, "positive": True},
-                    {"x": 10, "y": 10, "positive": False},
-                ],
-                "box": None,
-            }
-        ],
-        matching_cache_entries=[cache_entry],
-        device=torch.device("cpu"),
-    )
-
-    np.testing.assert_array_equal(result.numpy(), cached_mask.numpy())
-
-
-def test_segment_images_moves_cached_embedding_to_model_device(
-    sam2_torch_module: ModuleType,
-) -> None:
-    model = sam2_torch_module.SAM2Torch.__new__(sam2_torch_module.SAM2Torch)
-    model._device = torch.device("cpu")
-    model._lock = nullcontext()
-    model._model = object()
-    model._transform = object()
-    model._sam2_allow_client_generated_hash_ids = True
-    cached_embedding = MagicMock()
-    moved_embedding = SimpleNamespace(image_hash="abc", image_size_hw=(8, 8))
-    cached_embedding.to.return_value = moved_embedding
-    model._sam2_image_embeddings_cache = SimpleNamespace(
-        retrieve_embeddings=MagicMock(return_value=cached_embedding)
-    )
-
-    with patch.object(
-        sam2_torch_module,
-        "equalize_batch_size",
-        return_value=(None, None, None, None),
-    ), patch.object(
-        sam2_torch_module,
-        "pre_process_prompts",
-        return_value=(None, None, None, None),
-    ), patch.object(
-        sam2_torch_module,
-        "generate_model_inputs",
-        return_value=[
-            (moved_embedding, "abc", (8, 8), None, None, None, None),
-        ],
-    ), patch.object(
-        sam2_torch_module,
-        "predict_for_single_image",
-        return_value=(
-            torch.zeros(1, 8, 8),
-            torch.tensor([1.0]),
-            torch.zeros(1, 16, 16),
-        ),
-    ):
-        predictions = model.segment_images(images=None, image_hashes="abc")
-
-    cached_embedding.to.assert_called_once_with(device=torch.device("cpu"))
-    assert len(predictions) == 1

--- a/tests/inference/unit_tests/models/test_sam2_inference_models.py
+++ b/tests/inference/unit_tests/models/test_sam2_inference_models.py
@@ -3,6 +3,7 @@
 import importlib
 import sys
 from contextlib import nullcontext
+from pathlib import Path
 from types import ModuleType, SimpleNamespace
 from typing import Generator
 from unittest.mock import MagicMock, patch
@@ -13,6 +14,12 @@ import torch
 
 ADAPTER_MODULE = "inference.models.sam2.segment_anything2_inference_models"
 SAM2_TORCH_MODULE = "inference_models.models.sam2.sam2_torch"
+
+LOCAL_INFERENCE_MODELS_PATH = str(
+    Path(__file__).resolve().parents[4] / "inference_models"
+)
+if LOCAL_INFERENCE_MODELS_PATH not in sys.path:
+    sys.path.insert(0, LOCAL_INFERENCE_MODELS_PATH)
 
 
 def _build_sam2_stubs() -> dict:


### PR DESCRIPTION
## What changed

This backports the SAM3 interactive-cache behavior to the inference_models-backed SAM2 path:

- SAM2 `/segment_image` now tries the `image_id` embedding-cache fast path before decoding/preprocessing the image, then falls back to the provided image only when the embedding cache misses.
- SAM2 cached embeddings loaded by `image_hashes` are moved back to the model device before prediction.
- SAM2 low-res logits cache lookup now treats "no prior prompt matches" as a cache miss instead of dereferencing `None`.
- Added SAM2 unit coverage for embedding-cache hit, embedding-cache miss fallback, non-cache-miss error propagation, logits-cache miss, logits-cache prior prompt match, and cached embedding device placement.

## Why

We saw SmartPoly SAM2 500s where inference raised:

```text
AttributeError: 'NoneType' object has no attribute 'mask'
```

The failing path had low-res logits cached for the image, but none of the cached prompt entries were a valid prior prompt for the current request. That should be a normal cache miss and continue with regular segmentation.

This is the same area touched recently for SAM3 in #2480. SAM3 already tries cached embeddings before image decode/preprocess and safely returns `None` when the prompt-logits cache cannot provide a prior prompt. SAM2 had the older behavior.

## Validation

```bash
/Users/hansent/code/inference/.venv/bin/black inference/models/sam2/segment_anything2_inference_models.py inference_models/inference_models/models/sam2/sam2_torch.py tests/inference/unit_tests/models/test_sam2_inference_models.py

PYTHONPATH=/private/tmp/inference-sam2-cache-fast-path:/private/tmp/inference-sam2-cache-fast-path/inference_models \
  /Users/hansent/code/inference/.venv/bin/pytest \
  tests/inference/unit_tests/models/test_sam2_inference_models.py \
  tests/inference/unit_tests/models/test_sam3_visual_segmentation.py
```

Result: `14 passed`.
