### PR TITLE
Add TwelveLabs Pegasus video understanding workflow block

### DIFF
--- a/inference/core/workflows/core_steps/loader.py
+++ b/inference/core/workflows/core_steps/loader.py
@@ -369,6 +369,9 @@ from inference.core.workflows.core_steps.models.foundation.stability_ai.inpainti
 from inference.core.workflows.core_steps.models.foundation.stability_ai.outpainting.v1 import (
     StabilityAIOutpaintingBlockV1,
 )
+from inference.core.workflows.core_steps.models.foundation.twelvelabs.v1 import (
+    TwelveLabsPegasusBlockV1,
+)
 from inference.core.workflows.core_steps.models.foundation.yolo_world.v1 import (
     YoloWorldModelBlockV1,
 )
@@ -942,6 +945,7 @@ def load_blocks() -> List[Type[WorkflowBlock]]:
         TimeInZoneBlockV3,
         TrackClassLockBlockV1,
         TriangleVisualizationBlockV1,
+        TwelveLabsPegasusBlockV1,
         TextDisplayVisualizationBlockV1,
         VLMAsClassifierBlockV1,
         VLMAsDetectorBlockV1,

--- a/inference/core/workflows/core_steps/models/foundation/twelvelabs/v1.py
+++ b/inference/core/workflows/core_steps/models/foundation/twelvelabs/v1.py
@@ -1,0 +1,176 @@
+from typing import List, Literal, Optional, Type, Union
+
+from pydantic import ConfigDict, Field
+
+from inference.core.workflows.execution_engine.entities.base import OutputDefinition
+from inference.core.workflows.execution_engine.entities.types import (
+    FLOAT_KIND,
+    LANGUAGE_MODEL_OUTPUT_KIND,
+    SECRET_KIND,
+    STRING_KIND,
+    Selector,
+)
+from inference.core.workflows.prototypes.block import (
+    AirGappedAvailability,
+    BlockResult,
+    WorkflowBlock,
+    WorkflowBlockManifest,
+)
+
+LONG_DESCRIPTION = """
+Analyze a whole video with [TwelveLabs](https://twelvelabs.io) Pegasus, a video-language
+model that understands what happens across an entire clip - not just a single frame.
+
+Unlike image-based VLM blocks, this block reasons over the temporal content of a video. Pass a
+publicly accessible video URL together with a natural-language prompt and the model returns a free-form
+text answer. Typical uses include summarising footage, answering questions about events in a video,
+generating chapter descriptions, or extracting structured information from recordings.
+
+You need a TwelveLabs API key to use this block. You can grab a free API key at
+[twelvelabs.io](https://twelvelabs.io) - there is a generous free tier.
+
+**WARNING!**
+
+The video referenced by `video_url` is fetched and processed by TwelveLabs' servers, so the URL must be
+publicly reachable. The model has resolution and duration requirements (resolution between 360p and 2160p);
+very short or low-resolution clips may be rejected by the API.
+"""
+
+
+class BlockManifest(WorkflowBlockManifest):
+    model_config = ConfigDict(
+        json_schema_extra={
+            "name": "TwelveLabs Pegasus",
+            "version": "v1",
+            "short_description": "Understand and answer questions about a whole video with TwelveLabs Pegasus.",
+            "long_description": LONG_DESCRIPTION,
+            "license": "Apache-2.0",
+            "block_type": "model",
+            "search_keywords": [
+                "LMM",
+                "VLM",
+                "video",
+                "TwelveLabs",
+                "Pegasus",
+                "video understanding",
+            ],
+            "beta": True,
+            "is_vlm_block": True,
+            "ui_manifest": {
+                "section": "model",
+                "icon": "fa-solid fa-film",
+                "blockPriority": 6,
+            },
+        },
+        protected_namespaces=(),
+    )
+    type: Literal["roboflow_core/twelvelabs_pegasus@v1"]
+    video_url: Union[Selector(kind=[STRING_KIND]), str] = Field(
+        description="Publicly accessible URL of the video to analyze.",
+        examples=["https://example.com/video.mp4", "$inputs.video_url"],
+    )
+    prompt: Union[Selector(kind=[STRING_KIND]), str] = Field(
+        description="Natural-language prompt describing what TwelveLabs Pegasus should do with the video.",
+        examples=["Summarize what happens in this video.", "$inputs.prompt"],
+        json_schema_extra={"multiline": True},
+    )
+    api_key: Union[Selector(kind=[STRING_KIND, SECRET_KIND]), str] = Field(
+        description="Your TwelveLabs API key.",
+        examples=["xxx-xxx", "$inputs.twelvelabs_api_key"],
+        private=True,
+    )
+    model_version: Union[
+        Selector(kind=[STRING_KIND]),
+        Literal["pegasus1.5", "pegasus1.2"],
+    ] = Field(
+        default="pegasus1.5",
+        description="TwelveLabs Pegasus model to be used.",
+        examples=["pegasus1.5", "$inputs.twelvelabs_model"],
+    )
+    max_tokens: int = Field(
+        default=2048,
+        ge=512,
+        description="Maximum number of tokens the model can generate in its response. "
+        "TwelveLabs requires this to be at least 512 for Pegasus.",
+    )
+    temperature: Optional[Union[float, Selector(kind=[FLOAT_KIND])]] = Field(
+        default=None,
+        description="Temperature to sample from the model - value in range 0.0-1.0, the higher - the more "
+        'random / "creative" the generations are.',
+        ge=0.0,
+        le=1.0,
+    )
+
+    @classmethod
+    def get_air_gapped_availability(cls) -> AirGappedAvailability:
+        return AirGappedAvailability(available=False, reason="requires_internet")
+
+    @classmethod
+    def describe_outputs(cls) -> List[OutputDefinition]:
+        return [
+            OutputDefinition(
+                name="output", kind=[STRING_KIND, LANGUAGE_MODEL_OUTPUT_KIND]
+            ),
+        ]
+
+    @classmethod
+    def get_execution_engine_compatibility(cls) -> Optional[str]:
+        return ">=1.3.0,<2.0.0"
+
+
+class TwelveLabsPegasusBlockV1(WorkflowBlock):
+
+    @classmethod
+    def get_manifest(cls) -> Type[WorkflowBlockManifest]:
+        return BlockManifest
+
+    @classmethod
+    def get_execution_engine_compatibility(cls) -> Optional[str]:
+        return ">=1.3.0,<2.0.0"
+
+    def run(
+        self,
+        video_url: str,
+        prompt: str,
+        api_key: str,
+        model_version: str,
+        max_tokens: int,
+        temperature: Optional[float],
+    ) -> BlockResult:
+        output = analyze_video_with_pegasus(
+            video_url=video_url,
+            prompt=prompt,
+            api_key=api_key,
+            model_version=model_version,
+            max_tokens=max_tokens,
+            temperature=temperature,
+        )
+        return {"output": output}
+
+
+def analyze_video_with_pegasus(
+    video_url: str,
+    prompt: str,
+    api_key: str,
+    model_version: str,
+    max_tokens: int,
+    temperature: Optional[float],
+) -> str:
+    # `twelvelabs` is an optional dependency - import lazily so this module can always be loaded.
+    try:
+        from twelvelabs import TwelveLabs
+        from twelvelabs.types.video_context import VideoContext_Url
+    except ImportError as error:
+        raise ImportError(
+            "The `twelvelabs` package is required to use the TwelveLabs Pegasus block. "
+            "Install it with `pip install twelvelabs`."
+        ) from error
+    client = TwelveLabs(api_key=api_key)
+    response = client.analyze(
+        model_name=model_version,
+        video=VideoContext_Url(url=video_url),
+        prompt=prompt,
+        max_tokens=max_tokens,
+        temperature=temperature,
+    )
+    return response.data or ""

--- a/requirements/_requirements.txt
+++ b/requirements/_requirements.txt
@@ -36,6 +36,7 @@ shapely>=2.0.4,<2.1.0
 tldextract~=5.1.2
 packaging~=24.0
 anthropic~=0.49.0
+twelvelabs>=1.2.8,<2.0.0
 pandas>=2.2.3,<3.0.0
 paho-mqtt~=1.6.1
 pytest>=9.0.3,<10.0.0  # this is not a joke, sam2 requires this as the fork we are using is dependent on that, yet

--- a/tests/workflows/unit_tests/core_steps/models/foundation/test_twelvelabs.py
+++ b/tests/workflows/unit_tests/core_steps/models/foundation/test_twelvelabs.py
@@ -1,0 +1,220 @@
+import sys
+from typing import Any
+from unittest.mock import MagicMock, Mock
+
+import pytest
+from pydantic import ValidationError
+
+from inference.core.workflows.core_steps.models.foundation.twelvelabs.v1 import (
+    BlockManifest,
+    TwelveLabsPegasusBlockV1,
+    analyze_video_with_pegasus,
+)
+
+
+def test_twelvelabs_step_validation_when_input_is_valid() -> None:
+    # given
+    specification = {
+        "type": "roboflow_core/twelvelabs_pegasus@v1",
+        "name": "step_1",
+        "video_url": "$inputs.video_url",
+        "prompt": "$inputs.prompt",
+        "api_key": "$inputs.twelvelabs_api_key",
+    }
+
+    # when
+    result = BlockManifest.model_validate(specification)
+
+    # then
+    assert result.type == "roboflow_core/twelvelabs_pegasus@v1"
+    assert result.name == "step_1"
+    assert result.video_url == "$inputs.video_url"
+    assert result.prompt == "$inputs.prompt"
+    assert result.api_key == "$inputs.twelvelabs_api_key"
+    # defaults
+    assert result.model_version == "pegasus1.5"
+    assert result.max_tokens == 2048
+    assert result.temperature is None
+
+
+def test_twelvelabs_step_validation_when_inputs_given_directly() -> None:
+    # given
+    specification = {
+        "type": "roboflow_core/twelvelabs_pegasus@v1",
+        "name": "step_1",
+        "video_url": "https://example.com/video.mp4",
+        "prompt": "Summarize this video.",
+        "api_key": "my-secret-key",
+        "model_version": "pegasus1.2",
+        "max_tokens": 1024,
+        "temperature": 0.5,
+    }
+
+    # when
+    result = BlockManifest.model_validate(specification)
+
+    # then
+    assert result.video_url == "https://example.com/video.mp4"
+    assert result.prompt == "Summarize this video."
+    assert result.model_version == "pegasus1.2"
+    assert result.max_tokens == 1024
+    assert result.temperature == 0.5
+
+
+@pytest.mark.parametrize("value", [None, 1, True, [1, 2, 3]])
+def test_twelvelabs_step_validation_when_prompt_is_invalid(value: Any) -> None:
+    # given
+    specification = {
+        "type": "roboflow_core/twelvelabs_pegasus@v1",
+        "name": "step_1",
+        "video_url": "$inputs.video_url",
+        "prompt": value,
+        "api_key": "$inputs.twelvelabs_api_key",
+    }
+
+    # when
+    with pytest.raises(ValidationError):
+        _ = BlockManifest.model_validate(specification)
+
+
+@pytest.mark.parametrize("value", [256, 0, -1])
+def test_twelvelabs_step_validation_when_max_tokens_below_minimum(value: int) -> None:
+    # given - TwelveLabs requires max_tokens >= 512 for Pegasus
+    specification = {
+        "type": "roboflow_core/twelvelabs_pegasus@v1",
+        "name": "step_1",
+        "video_url": "$inputs.video_url",
+        "prompt": "$inputs.prompt",
+        "api_key": "$inputs.twelvelabs_api_key",
+        "max_tokens": value,
+    }
+
+    # when
+    with pytest.raises(ValidationError):
+        _ = BlockManifest.model_validate(specification)
+
+
+@pytest.mark.parametrize("value", [-0.1, 1.1, 2.0])
+def test_twelvelabs_step_validation_when_temperature_out_of_range(value: float) -> None:
+    # given
+    specification = {
+        "type": "roboflow_core/twelvelabs_pegasus@v1",
+        "name": "step_1",
+        "video_url": "$inputs.video_url",
+        "prompt": "$inputs.prompt",
+        "api_key": "$inputs.twelvelabs_api_key",
+        "temperature": value,
+    }
+
+    # when
+    with pytest.raises(ValidationError):
+        _ = BlockManifest.model_validate(specification)
+
+
+def test_twelvelabs_block_is_not_air_gapped() -> None:
+    # when
+    availability = BlockManifest.get_air_gapped_availability()
+
+    # then
+    assert availability.available is False
+
+
+def _install_fake_twelvelabs_sdk(
+    monkeypatch, captured: dict, response_data: str
+) -> Mock:
+    """Inject a fake `twelvelabs` SDK so the block can be exercised without the real package."""
+    fake_client = MagicMock()
+
+    def _analyze(**kwargs):
+        captured.update(kwargs)
+        result = Mock()
+        result.data = response_data
+        return result
+
+    fake_client.analyze.side_effect = _analyze
+
+    twelvelabs_module = MagicMock()
+    twelvelabs_module.TwelveLabs.return_value = fake_client
+
+    video_context_module = MagicMock()
+
+    class _FakeVideoContextUrl:
+        def __init__(self, url: str) -> None:
+            self.url = url
+
+    video_context_module.VideoContext_Url = _FakeVideoContextUrl
+
+    monkeypatch.setitem(sys.modules, "twelvelabs", twelvelabs_module)
+    monkeypatch.setitem(sys.modules, "twelvelabs.types", MagicMock())
+    monkeypatch.setitem(
+        sys.modules, "twelvelabs.types.video_context", video_context_module
+    )
+    return twelvelabs_module.TwelveLabs
+
+
+def test_analyze_video_with_pegasus_wires_request_correctly(monkeypatch) -> None:
+    # given
+    captured: dict = {}
+    twelvelabs_ctor = _install_fake_twelvelabs_sdk(
+        monkeypatch, captured, response_data="A dog runs across a field."
+    )
+
+    # when
+    output = analyze_video_with_pegasus(
+        video_url="https://example.com/video.mp4",
+        prompt="What happens in this video?",
+        api_key="secret-key",
+        model_version="pegasus1.5",
+        max_tokens=1024,
+        temperature=0.3,
+    )
+
+    # then
+    assert output == "A dog runs across a field."
+    twelvelabs_ctor.assert_called_once_with(api_key="secret-key")
+    assert captured["model_name"] == "pegasus1.5"
+    assert captured["prompt"] == "What happens in this video?"
+    assert captured["max_tokens"] == 1024
+    assert captured["temperature"] == 0.3
+    assert captured["video"].url == "https://example.com/video.mp4"
+
+
+def test_twelvelabs_block_run_returns_output(monkeypatch) -> None:
+    # given
+    captured: dict = {}
+    _install_fake_twelvelabs_sdk(
+        monkeypatch, captured, response_data="A summary of the clip."
+    )
+    block = TwelveLabsPegasusBlockV1()
+
+    # when
+    result = block.run(
+        video_url="https://example.com/video.mp4",
+        prompt="Summarize this video.",
+        api_key="secret-key",
+        model_version="pegasus1.5",
+        max_tokens=2048,
+        temperature=None,
+    )
+
+    # then
+    assert result == {"output": "A summary of the clip."}
+
+
+def test_analyze_video_with_pegasus_handles_empty_response(monkeypatch) -> None:
+    # given - the SDK may return `data=None`; the block must coerce to a string
+    captured: dict = {}
+    _install_fake_twelvelabs_sdk(monkeypatch, captured, response_data=None)
+
+    # when
+    output = analyze_video_with_pegasus(
+        video_url="https://example.com/video.mp4",
+        prompt="Describe this.",
+        api_key="secret-key",
+        model_version="pegasus1.5",
+        max_tokens=512,
+        temperature=None,
+    )
+
+    # then
+    assert output == ""


### PR DESCRIPTION
Hi! I'm Mohit, I work at TwelveLabs (@mohit-twelvelabs).

## What this adds

A new opt-in workflow block, **TwelveLabs Pegasus** (`roboflow_core/twelvelabs_pegasus@v1`), under `core_steps/models/foundation/twelvelabs/`. Unlike the existing image-based VLM blocks, this block reasons over the *temporal* content of an entire video: you pass a publicly-accessible video URL plus a natural-language prompt, and [TwelveLabs Pegasus](https://twelvelabs.io) returns a free-form text answer. Typical uses: summarizing footage, answering questions about events across a clip, generating chapter descriptions, or extracting structured info from recordings.

It is registered in `core_steps/loader.py` like the other foundation-model blocks (Anthropic Claude, Google Gemini, Stability AI), exposes a single `output` (`STRING`/`LANGUAGE_MODEL_OUTPUT`), and is marked `beta` + `is_vlm_block`. The API key field is `private=True`, matching the convention used by the other third-party model blocks.

## Why it helps this project

Inference workflows already support image VLMs but have no native way to ask questions about a whole video without first sampling frames. Pegasus fills that gap, giving workflow authors true video understanding as a drop-in block.

## Opt-in / non-breaking

- No existing block, default, or behavior is changed.
- The `twelvelabs` SDK is imported **lazily** inside the run function, so the module always loads even if the SDK isn't installed (it raises a clear, actionable `ImportError` only when the block is actually executed). The dependency is added to `requirements/_requirements.txt` pinned to `twelvelabs>=1.2.8,<2.0.0`.
- The block reports `AirGappedAvailability(available=False, ...)` since it calls a hosted API.

## How it was tested

- **Unit tests** (`tests/workflows/unit_tests/core_steps/models/foundation/test_twelvelabs.py`, 16 cases, all passing, no network): manifest validation (valid spec, direct values, invalid prompt types, `max_tokens >= 512` floor, `temperature` range), `get_air_gapped_availability`, plus request-wiring and `run()` tests against a fake injected SDK (asserting `model_name`/`prompt`/`max_tokens`/`temperature`/`video.url` are forwarded correctly and an empty response coerces to `""`).
- **SDK contract verified** against the installed `twelvelabs` package: `client.analyze(model_name=, video=VideoContext_Url(url=), prompt=, max_tokens=, temperature=)` returning a `NonStreamAnalyzeResponse` with a `.data` field — the exact call the block makes.
- Ran `black` and `isort --profile black` on the changed files.

You can grab a free API key at https://twelvelabs.io — there's a generous free tier.
