### PR TITLE
feat(jetson): add JetPack 7.2.0 multi-arch inference image (Thor + Orin)

### DIFF
--- a/.github/workflows/docker.jetson.7.2.0.yml
+++ b/.github/workflows/docker.jetson.7.2.0.yml
@@ -1,0 +1,61 @@
+name: Build and Push Jetson 7.2.0 Container
+permissions:
+  contents: read
+on:
+  release:
+    types: [created]
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      force_push:
+        type: boolean
+        description: "Do you want to push image after build?"
+        default: false
+      custom_tag:
+        type: string
+        description: "Custom tag to use for the image (overrides VERSION)"
+        default: ""
+
+env:
+  VERSION: "0.0.0" # Default version, will be overwritten
+  BASE_IMAGE: "roboflow/roboflow-inference-server-jetson-7.2.0"
+
+jobs:
+  docker:
+    runs-on:
+      labels: depot-ubuntu-24.04-4
+      group: public-depot
+    timeout-minutes: 360
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Login to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: 🛎️ Checkout
+        uses: actions/checkout@v6
+      - name: Read version from file
+        run: echo "VERSION=$(DISABLE_VERSION_CHECK=true python ./inference/core/version.py)" >> $GITHUB_ENV
+      - name: Determine Image Tags
+        id: tags
+        uses: ./.github/actions/determine-tags
+        with:
+          custom_tag: ${{ github.event.inputs.custom_tag }}
+          version: ${{ env.VERSION }}
+          base_image: ${{ env.BASE_IMAGE }}
+          force_push: ${{ github.event.inputs.force_push }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Depot CLI
+        uses: depot/setup-action@v1
+      - name: Build and Push
+        uses: depot/build-push-action@v1
+        with:
+          push: ${{ github.event_name == 'release' || (github.event.inputs.force_push == 'true')}}
+          project: v1xzfwkc4b
+          tags: ${{ steps.tags.outputs.image_tags }}
+          platforms: linux/arm64
+          file: ./docker/dockerfiles/Dockerfile.onnx.jetson.7.2.0

--- a/docker/dockerfiles/Dockerfile.onnx.jetson.7.2.0
+++ b/docker/dockerfiles/Dockerfile.onnx.jetson.7.2.0
@@ -1,0 +1,472 @@
+# syntax=docker/dockerfile:1.7
+# Jetson 7.2.0 (JetPack 7.2 / L4T r39.2): PyTorch/torchvision/ONNX Runtime compiled
+# from source for CUDA 13.2 + cuDNN 9.20 + TensorRT 10.16, numpy 2.x.
+# MULTI-ARCH: JetPack 7.2 spans both Thor (sm_110, Blackwell) and the Orin family
+# (sm_87, Ampere — AGX Orin / Orin Nano got JP7.2 support). AOT CUDA kernels are built
+# for BOTH archs (8.7;11.0) so one JP7.2 image runs across the whole fleet. (Triton JITs
+# per-device and TensorRT builds engines on-device, so those are arch-portable already.)
+# Stage 1: Builder - Compile everything from source
+FROM ubuntu:24.04 AS builder
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG CMAKE_VERSION=4.2.0
+ARG PYTORCH_VERSION=2.10.0
+ARG TORCHVISION_VERSION=0.25.0
+ARG OPENCV_VERSION=4.10.0
+ARG ONNXRUNTIME_VERSION=1.24.2
+ARG TRITON_VERSION=3.6.0
+# Build parallelism. Defaults are tuned for the ~32 GB Depot arm builder used in CI;
+# override (e.g. --build-arg PYTORCH_MAX_JOBS=14) on a larger native builder.
+ARG PYTORCH_MAX_JOBS=12
+ARG ORT_BUILD_PARALLEL=8
+ARG FLASH_ATTN_MAX_JOBS=2
+ENV LANG=en_US.UTF-8
+
+WORKDIR /build
+
+# Add NVIDIA Jetson repositories for r39.2.
+# Disable docker-clean and keep downloaded .debs; cache mounts on /var/cache/apt
+# and /var/lib/apt persist across Depot builds.
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=apt-cache-jp72-builder-${TARGETARCH} \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked,id=apt-lib-jp72-builder-${TARGETARCH} \
+    rm -f /etc/apt/apt.conf.d/docker-clean && \
+    echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache && \
+    apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+    ca-certificates \
+    gnupg \
+    wget \
+    && wget -qO - https://repo.download.nvidia.com/jetson/jetson-ota-public.asc | gpg --dearmor -o /usr/share/keyrings/nvidia-jetson.gpg \
+    && echo "deb [signed-by=/usr/share/keyrings/nvidia-jetson.gpg] https://repo.download.nvidia.com/jetson/common r39.2 main" > /etc/apt/sources.list.d/nvidia-jetson.list \
+    && echo "deb [signed-by=/usr/share/keyrings/nvidia-jetson.gpg] https://repo.download.nvidia.com/jetson/som r39.2 main" >> /etc/apt/sources.list.d/nvidia-jetson.list \
+    && apt-get update -y
+
+# Install NVIDIA JetPack components and build dependencies
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=apt-cache-jp72-builder-${TARGETARCH} \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked,id=apt-lib-jp72-builder-${TARGETARCH} \
+    apt-get install -y --no-install-recommends \
+    cuda-toolkit-13-2 \
+    libcudnn9-cuda-13 \
+    libcudnn9-dev-cuda-13 \
+    tensorrt \
+    python3-libnvinfer \
+    python3-libnvinfer-dev \
+    python3-libnvinfer-dispatch \
+    python3-libnvinfer-lean \
+    build-essential \
+    cmake \
+    ninja-build \
+    git \
+    curl \
+    python3-dev \
+    python3-pip \
+    python3-venv \
+    libopenblas-dev \
+    libproj-dev \
+    libsqlite3-dev \
+    libtiff-dev \
+    libcurl4-openssl-dev \
+    libssl-dev \
+    zlib1g-dev \
+    libxext6 \
+    libvips-dev \
+    pkg-config \
+    libjpeg-dev \
+    libpng-dev \
+    libavcodec-dev \
+    libavformat-dev \
+    libswscale-dev \
+    libv4l-dev \
+    libatlas-base-dev \
+    liblapack-dev \
+    gfortran \
+    libhdf5-dev \
+    libgflags-dev \
+    libgoogle-glog-dev \
+    liblmdb-dev \
+    libleveldb-dev \
+    libsnappy-dev \
+    libprotobuf-dev \
+    protobuf-compiler \
+    libxml2-dev
+
+# Install CMake
+RUN wget -q https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-aarch64.sh && \
+    chmod +x cmake-${CMAKE_VERSION}-linux-aarch64.sh && \
+    ./cmake-${CMAKE_VERSION}-linux-aarch64.sh --prefix=/usr/local --skip-license && \
+    rm cmake-${CMAKE_VERSION}-linux-aarch64.sh
+
+# Install pip and numpy 2.x FIRST (use --ignore-installed to avoid conflicts with system packages)
+RUN python3 -m pip install --break-system-packages --ignore-installed pip setuptools wheel && \
+    python3 -m pip install --break-system-packages "numpy>=2.0.0,<2.4.0"
+
+# Install uv
+RUN curl -LsSf https://astral.sh/uv/install.sh | env INSTALLER_NO_MODIFY_PATH=1 sh && \
+    ln -s /root/.local/bin/uv /usr/local/bin/uv
+
+# Compile GDAL from source
+WORKDIR /build/gdal
+RUN wget https://github.com/OSGeo/gdal/releases/download/v3.11.5/gdal-3.11.5.tar.gz && \
+    tar -xzf gdal-3.11.5.tar.gz && \
+    cd gdal-3.11.5 && mkdir build && cd build && \
+    cmake .. -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local -DBUILD_PYTHON_BINDINGS=OFF && \
+    ninja && ninja install && ldconfig && \
+    cd ../.. && rm -rf gdal-3.11.5*
+
+# Set CUDA environment variables
+ENV CUDA_HOME=/usr/local/cuda \
+    PATH=/usr/local/cuda/bin:$PATH \
+    LD_LIBRARY_PATH=/usr/local/cuda/lib64:$LD_LIBRARY_PATH
+
+# Compile PyTorch from source with Jetson Thor optimizations.
+# Clone in its own RUN so the build/ cache mount overlays cleanly (mount would
+# otherwise auto-create the parent and break git clone).
+WORKDIR /build/pytorch
+RUN git clone --recursive --branch v${PYTORCH_VERSION} https://github.com/pytorch/pytorch
+# build/ is cache-mounted (Thor = sm 11.0); cache id includes version + arch + CUDA line.
+RUN --mount=type=cache,target=/build/pytorch/pytorch/build,sharing=locked,id=pytorch-build-${PYTORCH_VERSION}-${TARGETARCH}-sm87110-cu132 \
+    --mount=type=cache,target=/root/.cache/pip,sharing=locked,id=pip-cache-jp72-${TARGETARCH} \
+    cd pytorch && \
+    python3 -m pip install --break-system-packages -r requirements.txt && \
+    export USE_CUDA=1 USE_CUDNN=1 CUDA_HOME=/usr/local/cuda && \
+    export CUDNN_LIB_DIR=/usr/lib/aarch64-linux-gnu CUDNN_INCLUDE_DIR=/usr/include && \
+    export TORCH_CUDA_ARCH_LIST="8.7;11.0" && \
+    export USE_MKLDNN=0 USE_OPENMP=0 && \
+    export USE_DISTRIBUTED=0 USE_GLOO=0 USE_MPI=0 USE_TENSORPIPE=0 USE_NCCL=0 && \
+    export BUILD_TEST=0 && \
+    export USE_QNNPACK=0 USE_PYTORCH_QNNPACK=0 USE_XNNPACK=0 USE_NNPACK=0 && \
+    export USE_FBGEMM=0 USE_KINETO=0 USE_CUPTI_SO=0 && \
+    export USE_FLASH_ATTENTION=1 USE_MEM_EFF_ATTENTION=1 && \
+    export USE_MPS=0 USE_ROCM=0 && \
+    export PYTORCH_BUILD_VERSION=${PYTORCH_VERSION} PYTORCH_BUILD_NUMBER=1 && \
+    export CMAKE_BUILD_TYPE=Release BUILD_SHARED_LIBS=ON USE_PRIORITIZED_TEXT_FOR_LD=1 && \
+    export MAX_JOBS=${PYTORCH_MAX_JOBS} && \
+    export CMAKE_POLICY_VERSION_MINIMUM=3.5 && \
+    python3 setup.py bdist_wheel && \
+    python3 -m pip install --break-system-packages dist/torch-*.whl
+
+# Compile torchvision from source (with retry for transient GitHub issues).
+# Clone in its own RUN so build/ cache mount overlays cleanly.
+WORKDIR /build/torchvision
+RUN for i in 1 2 3; do \
+        git clone --branch v${TORCHVISION_VERSION} https://github.com/pytorch/vision && break || sleep 60; \
+    done
+RUN --mount=type=cache,target=/build/torchvision/vision/build,sharing=locked,id=torchvision-build-${TORCHVISION_VERSION}-${TARGETARCH}-sm87110-cu132 \
+    --mount=type=cache,target=/root/.cache/pip,sharing=locked,id=pip-cache-jp72-${TARGETARCH} \
+    cd vision && \
+    export BUILD_VERSION=${TORCHVISION_VERSION} TORCH_CUDA_ARCH_LIST="8.7;11.0" && \
+    export FORCE_CUDA=1 CMAKE_BUILD_TYPE=Release USE_PRIORITIZED_TEXT_FOR_LD=1 && \
+    python3 setup.py bdist_wheel && \
+    python3 -m pip install --break-system-packages dist/torchvision-*.whl
+
+# Build ONNX Runtime GPU from source with CUDA 13.2 and TensorRT 10.16 support.
+# Pinned to v1.24.2 (proven on the 7.1.0 image): includes the CUDA 13 fix (PR #26153) and a
+# TensorRT-EP whose cmake handles the TRT 10.11+ version-macro scheme, so it auto-detects the
+# installed TensorRT 10.16.
+# NOTE: v1.25.0+ (incl. 1.26.0) do NOT build against JetPack 7.2's CUDA 13.2 CCCL headers.
+# ORT 1.25.0 added a <cub/cub.cuh> umbrella include (cu_inc/cub.cuh -> common.cuh) that pulls
+# cub/device/device_transform.cuh, where CUDA 13.2's bundled CCCL emits ill-formed C++
+# ("struct ::cuda::proclaims_copyable_arguments<...> : ::cuda::std::true_type" -> gcc 13/14:
+# "global qualification of class name is invalid before ':' token"). Upstream: NVIDIA/cccl
+# #8833, microsoft/onnxruntime #28023; fixed by NVIDIA/cccl PR #8771 but not yet in a shipped
+# CUDA toolkit. v1.24.2 predates that include and compiles clean. To move back to 1.26.0 once
+# CUDA ships the CCCL fix (or by sed-patching the header in this stage), see ORT #28023.
+# No prebuilt ARM64 CUDA 13 packages available - must build from source.
+# ORT_BUILD_PARALLEL (default 8) limits parallel jobs to prevent OOM during CUDA kernel
+# compilation on the 32 GB Depot arm builder.
+WORKDIR /build/onnxruntime
+RUN git clone --recursive --branch v${ONNXRUNTIME_VERSION} https://github.com/microsoft/onnxruntime.git
+RUN --mount=type=cache,target=/build/onnxruntime/onnxruntime/build/Linux,sharing=locked,id=ort-build-${ONNXRUNTIME_VERSION}-${TARGETARCH}-sm87110-cu132 \
+    --mount=type=cache,target=/root/.cache/pip,sharing=locked,id=pip-cache-jp72-${TARGETARCH} \
+    cd onnxruntime && \
+    python3 -m pip install --break-system-packages -r requirements-dev.txt && \
+    ./build.sh --config Release --update --build --parallel ${ORT_BUILD_PARALLEL} \
+        --build_wheel \
+        --allow_running_as_root \
+        --compile_no_warning_as_error \
+        --use_cuda \
+        --cuda_home /usr/local/cuda \
+        --cudnn_home /usr \
+        --use_tensorrt \
+        --tensorrt_home /usr \
+        --skip_tests \
+        --cmake_extra_defines \
+            CMAKE_POLICY_VERSION_MINIMUM=3.5 \
+            CMAKE_CUDA_ARCHITECTURES="87-real;110-real;110-virtual" \
+            onnxruntime_BUILD_UNIT_TESTS=OFF && \
+    python3 -m pip install --break-system-packages build/Linux/Release/dist/onnxruntime_gpu*.whl
+
+# Install flash-attn (requires CUDA-enabled PyTorch already installed).
+# FLASH_ATTN_MAX_JOBS=2: middle ground between the historical MAX_JOBS=4 that starved the Depot
+# BuildKit gRPC connection (#2068) and the safe-but-slow MAX_JOBS=1. flash-attn nvcc instances
+# peak ~3-4 GB each against PyTorch 2.10 headers, so 2 fits comfortably on a 32 GB Depot arm
+# builder; override higher on a larger native builder.
+# Built from a pinned main commit (FLASH_ATTN_REF). Its setup.py recognizes archs
+# 80/90/100/110/120 (main added the CUDA-13 "Thor rename" compute_110f/sm_110) but SILENTLY
+# IGNORES 87 — so JP7.2 Orin (sm_87, Ampere) would get no flash-attn kernel. We request "80;110"
+# (the "80" only exists to trigger the arch-80 branch) and sed-REPLACE its compute_80 gencode with
+# compute_87 -> the image builds sm_87 (Orin) + sm_110 (Thor) only, NOT sm_80 (no A100 in a Jetson
+# fleet — building it just doubled the slow Ampere kernels below). Tagged releases (<=2.8.3.post1)
+# lack sm_110 entirely.
+# Declared here (not at the top) so changing it doesn't invalidate the torch/ORT build cache.
+# TWO more patches, both flash-attn's own commented-out options, essential for the Ampere build:
+#  (a) --ptxas-options=-O1 : the Ampere (sm_87) flash_fwd_split_hdim128 kernels make ptxas's default
+#      -O3 register allocator blow up under CUDA 13.2 (a single kernel ran >4 h on this Thor; -O2
+#      still ~50 min; -O1 makes it tractable — sm_110 alone never hits this). Negligible runtime cost
+#      for these (VLM-only) kernels. (b) -DFLASHATTENTION_DISABLE_BACKWARD: inference never needs the
+#      backward pass; skipping ~24 bwd kernels roughly halves the build.
+ARG FLASH_ATTN_REF=d16e381f6f8041422bd36f27adaf61fbf8ca872a
+RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked,id=pip-cache-jp72-${TARGETARCH} \
+    export MAX_JOBS=${FLASH_ATTN_MAX_JOBS} FLASH_ATTN_CUDA_ARCHS="80;110" && \
+    git clone https://github.com/Dao-AILab/flash-attention.git /tmp/flash-attention && \
+    cd /tmp/flash-attention && git checkout ${FLASH_ATTN_REF} && \
+    sed -i 's#"arch=compute_80,code=sm_80"#"arch=compute_87,code=sm_87"#' setup.py && \
+    sed -i 's|# "--ptxas-options=-O2"|"--ptxas-options=-O1"|' setup.py && \
+    sed -i 's|# "-DFLASHATTENTION_DISABLE_BACKWARD"|"-DFLASHATTENTION_DISABLE_BACKWARD"|' setup.py && \
+    grep -q "compute_87,code=sm_87" setup.py \
+      && grep -qE '^\s*"--ptxas-options=-O1"' setup.py \
+      && grep -qE '^\s*"-DFLASHATTENTION_DISABLE_BACKWARD"' setup.py \
+      || { echo "flash-attn sm_87 / ptxas-O2 / disable-backward patch failed to apply" >&2; exit 1; } && \
+    git submodule update --init --recursive && \
+    python3 -m pip install --break-system-packages --no-build-isolation . && \
+    cd / && rm -rf /tmp/flash-attention
+
+# Build Triton from source. Torch 2.10.0 on JP7.2 pairs with Triton ${TRITON_VERSION}.
+# Triton powers the RF-DETR Triton fast-path kernels (GPU pre/post-processing) used by the
+# instance-segmentation TensorRT pipeline; without it those kernels fall back to the slow
+# CPU path. Done in the main builder (not runtime) to reuse build deps. Clone + wheel build
+# share one RUN: cache-mounted src is not persisted across RUN instructions.
+# Triton 3.6 wheels from the repo root (not python/ subdir).
+WORKDIR /build/triton
+RUN --mount=type=cache,target=/build/triton/src,sharing=locked,id=triton-src-${TRITON_VERSION}-${TARGETARCH} \
+    --mount=type=cache,target=/root/.triton/llvm,sharing=locked,id=triton-llvm-${TRITON_VERSION}-${TARGETARCH} \
+    --mount=type=cache,target=/root/.cache/pip,sharing=locked,id=pip-cache-jp72-${TARGETARCH} \
+    set -eux; \
+    if [ ! -d src/.git ]; then \
+        git clone --depth 1 --branch v${TRITON_VERSION} https://github.com/triton-lang/triton.git src; \
+    else \
+        git -C src fetch --depth 1 origin tag v${TRITON_VERSION} && \
+        git -C src checkout v${TRITON_VERSION}; \
+    fi; \
+    git -C src submodule update --init --recursive; \
+    mkdir -p /tmp/triton-wheels; \
+    python3 -m pip install --break-system-packages --no-cache-dir \
+        -r /build/triton/src/python/requirements.txt; \
+    MAX_JOBS=4 python3 -m pip wheel --no-cache-dir \
+        --no-build-isolation \
+        --no-deps \
+        /build/triton/src \
+        --wheel-dir /tmp/triton-wheels; \
+    set -- /tmp/triton-wheels/triton-${TRITON_VERSION}*.whl; \
+    if [ ! -e "$1" ]; then \
+        echo "Expected source-built Triton wheel for ${TRITON_VERSION} was not found" >&2; \
+        exit 1; \
+    fi; \
+    python3 -m pip install --break-system-packages --no-cache-dir "$1"; \
+    rm -rf /tmp/triton-wheels; \
+    python3 -c "import triton; print('triton', triton.__version__)"
+
+# Copy requirements files (done after compilation to improve cache efficiency)
+WORKDIR /build/reqs
+COPY requirements/_requirements.txt \
+     requirements/requirements.http.txt \
+     requirements/requirements.clip.txt \
+     requirements/requirements.transformers.txt \
+     requirements/requirements.sam.txt \
+     requirements/requirements.groundingdino.txt \
+     requirements/requirements.yolo_world.txt \
+     requirements/requirements.doctr.txt \
+     requirements/requirements.sdk.http.txt \
+     requirements/requirements.easyocr.txt \
+     requirements/requirements.jetson.txt \
+     ./
+
+# Install Python dependencies
+# IMPORTANT: Use --override to protect our source-compiled torch/torchvision from being replaced
+RUN echo "torch==${PYTORCH_VERSION}" > /tmp/overrides.txt && \
+    echo "torchvision==${TORCHVISION_VERSION}" >> /tmp/overrides.txt && \
+    uv pip install --system --break-system-packages --index-strategy unsafe-best-match \
+    --override /tmp/overrides.txt \
+    -r _requirements.txt \
+    -r requirements.http.txt \
+    -r requirements.clip.txt \
+    -r requirements.transformers.txt \
+    -r requirements.sam.txt \
+    -r requirements.groundingdino.txt \
+    -r requirements.yolo_world.txt \
+    -r requirements.doctr.txt \
+    -r requirements.sdk.http.txt \
+    -r requirements.easyocr.txt \
+    -r requirements.jetson.txt \
+    "pycuda>=2025.0.0,<2026.0.0" \
+    "setuptools<=75.5.0" \
+    "transformers>=4.57.3,<5.9.0" \
+    packaging \
+    && rm -rf ~/.cache/uv /tmp/overrides.txt
+
+# Build inference packages
+WORKDIR /build/inference
+COPY . .
+RUN ln -sf /usr/bin/python3 /usr/bin/python && \
+    python -m pip install --break-system-packages wheel twine requests && \
+    rm -f dist/* && \
+    python .release/pypi/inference.core.setup.py bdist_wheel && \
+    python .release/pypi/inference.gpu.setup.py bdist_wheel && \
+    python .release/pypi/inference.cli.setup.py bdist_wheel && \
+    python .release/pypi/inference.sdk.setup.py bdist_wheel && \
+    python -m pip install --break-system-packages --no-deps dist/inference_gpu*.whl && \
+    python -m pip install --break-system-packages \
+        dist/inference_core*.whl \
+        dist/inference_cli*.whl \
+        dist/inference_sdk*.whl \
+        "setuptools<=75.5.0"
+
+# Remove test directories, development tools, and unnecessary packages to reduce image size
+# This happens AFTER all package installations to ensure everything gets cleaned
+# Note: Keep numpy/torch test dirs (public APIs depend on them), keep .pyi files (lazy_loader needs them)
+RUN cd /usr/local/lib/python3.12/dist-packages && \
+    find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true && \
+    rm -rf debugpy* jupyterlab* jupyter_* notebook* ipython* ipykernel* || true && \
+    rm -rf onnx/backend/test onnx/test || true && \
+    rm -rf scipy/*/tests pandas/tests || true && \
+    rm -rf */examples */benchmarks */docs || true && \
+    rm -rf skimage/data || true
+
+# Stage 2: Runtime
+FROM ubuntu:24.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+ENV LANG=en_US.UTF-8
+
+WORKDIR /app
+
+# Add NVIDIA Jetson repositories for r39.2 (runtime stage cache id differs from builder).
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=apt-cache-jp72-runtime-${TARGETARCH} \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked,id=apt-lib-jp72-runtime-${TARGETARCH} \
+    rm -f /etc/apt/apt.conf.d/docker-clean && \
+    echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache && \
+    apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+    ca-certificates \
+    gnupg \
+    wget \
+    && wget -qO - https://repo.download.nvidia.com/jetson/jetson-ota-public.asc | gpg --dearmor -o /usr/share/keyrings/nvidia-jetson.gpg \
+    && echo "deb [signed-by=/usr/share/keyrings/nvidia-jetson.gpg] https://repo.download.nvidia.com/jetson/common r39.2 main" > /etc/apt/sources.list.d/nvidia-jetson.list \
+    && echo "deb [signed-by=/usr/share/keyrings/nvidia-jetson.gpg] https://repo.download.nvidia.com/jetson/som r39.2 main" >> /etc/apt/sources.list.d/nvidia-jetson.list \
+    && apt-get update -y
+
+RUN ln -sf /usr/bin/python3 /usr/bin/python
+
+# Install runtime dependencies including NVIDIA packages
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=apt-cache-jp72-runtime-${TARGETARCH} \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked,id=apt-lib-jp72-runtime-${TARGETARCH} \
+    apt-get install -y --no-install-recommends \
+    cuda-cudart-13-2 \
+    cuda-libraries-13-2 \
+    cuda-nvcc-13-2 \
+    # ptxas for sm_110a; Triton bundled ptxas-blackwell is CUDA 12.9
+    libcudnn9-cuda-13 \
+    tensorrt-libs \
+    python3-libnvinfer \
+    python3-libnvinfer-dispatch \
+    python3-libnvinfer-lean \
+    file \
+    libopenblas0 \
+    libproj25 \
+    libsqlite3-0 \
+    libtiff6 \
+    libcurl4t64 \
+    libssl3t64 \
+    zlib1g \
+    libgomp1 \
+    python3 \
+    python3-pip \
+    libxext6 \
+    libvips42 \
+    libglib2.0-0 \
+    libsm6 \
+    libjpeg-turbo8 \
+    libpng16-16t64 \
+    libexpat1 \
+    curl \
+    libv4l-0 \
+    libavcodec60 \
+    libavformat60 \
+    libswscale7 \
+    ffmpeg \
+    libatlas3-base \
+    libgl1 \
+    libglib2.0-0 \
+    libatomic1 \
+    build-essential \
+    python3-dev \
+    zlib1g-dev \
+    libxml2-dev
+
+# Copy GDAL (skip headers - not needed in runtime)
+COPY --from=builder /usr/local/bin/gdal* /usr/local/bin/
+COPY --from=builder /usr/local/bin/ogr* /usr/local/bin/
+COPY --from=builder /usr/local/bin/gnm* /usr/local/bin/
+COPY --from=builder /usr/local/lib/libgdal* /usr/local/lib/
+COPY --from=builder /usr/local/share/gdal /usr/local/share/gdal
+
+ENV GDAL_DATA=/usr/local/share/gdal
+ENV LD_LIBRARY_PATH=/usr/local/lib:/usr/local/cuda/lib64:$LD_LIBRARY_PATH
+
+RUN ldconfig
+
+# build-essential/python3-dev/zlib1g-dev/libxml2-dev: required for Triton JIT kernel
+# compilation at runtime. Triton python pkg ships in dist-packages below.
+
+# Copy Python packages from builder
+COPY --from=builder /usr/local/lib/python3.12/dist-packages /usr/local/lib/python3.12/dist-packages
+COPY --from=builder /root/.triton/nvidia /root/.triton/nvidia
+COPY --from=builder /root/.triton/json /root/.triton/json
+
+# Copy TensorRT Python bindings (installed via apt in runtime stage, but ensure paths are correct)
+# Note: python3-libnvinfer packages install to /usr/lib/python3.12/dist-packages
+ENV PYTHONPATH=/usr/local/lib/python3.12/dist-packages:/usr/lib/python3.12/dist-packages:$PYTHONPATH
+
+COPY --from=builder /usr/local/bin/inference /usr/local/bin/inference
+
+# Copy application code
+COPY inference inference
+COPY inference_cli inference_cli
+COPY inference_sdk inference_sdk
+COPY docker/config/gpu_http.py gpu_http.py
+COPY docker/entrypoint/run_uvicorn.sh /usr/local/bin/run_uvicorn.sh
+RUN chmod +x /usr/local/bin/run_uvicorn.sh
+
+RUN python -m pip install --break-system-packages --force-reinstall "boto3>=1.40.0,<=1.41.5" "botocore>=1.40.0,<=1.41.5"
+
+# Environment variables
+ENV CUDA_HOME=/usr/local/cuda \
+    PATH=/usr/local/cuda/bin:$PATH \
+    TRITON_PTXAS_BLACKWELL_PATH=/usr/local/cuda/bin/ptxas \
+    NVIDIA_VISIBLE_DEVICES=all \
+    VERSION_CHECK_MODE=once \
+    CORE_MODEL_SAM2_ENABLED=True \
+    NUM_WORKERS=1 \
+    HOST=0.0.0.0 \
+    PORT=9001 \
+    ORT_TENSORRT_FP16_ENABLE=1 \
+    ORT_TENSORRT_ENGINE_CACHE_ENABLE=1 \
+    ORT_TENSORRT_ENGINE_CACHE_PATH=/tmp/ort_cache \
+    ORT_TENSORRT_MAX_WORKSPACE_SIZE=4294967296 \
+    ORT_TENSORRT_BUILDER_OPTIMIZATION_LEVEL=5 \
+    OPENBLAS_CORETYPE=ARMV8 \
+    LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libgomp.so.1 \
+    WORKFLOWS_STEP_EXECUTION_MODE=local \
+    WORKFLOWS_MAX_CONCURRENT_STEPS=4 \
+    API_LOGGING_ENABLED=True \
+    DISABLE_WORKFLOW_ENDPOINTS=false \
+    ALLOW_INFERENCE_EXP_UNTRUSTED_MODELS=True \
+    USE_INFERENCE_EXP_MODELS=False \
+    RUNNING_ON_JETSON=True \
+    L4T_VERSION=39.2.0
+
+LABEL org.opencontainers.image.description="Inference Server - Jetson 7.2.0 (PyTorch from source, numpy 2.x)"
+
+EXPOSE 9001
+
+ENTRYPOINT ["/usr/local/bin/run_uvicorn.sh", "gpu_http:app"]

--- a/inference_cli/lib/container_adapter.py
+++ b/inference_cli/lib/container_adapter.py
@@ -98,6 +98,9 @@ class _JetsonImage(NamedTuple):
 # Ordered by (l4t_major DESC, l4t_minor_min DESC).  First match wins.
 # See https://developer.nvidia.com/embedded/jetpack-archive for the full mapping.
 _JETSON_IMAGES: List[_JetsonImage] = [
+    _JetsonImage(
+        39, 0, "7.2", "roboflow/roboflow-inference-server-jetson-7.2.0:latest"
+    ),
     _JetsonImage(38, 0, "7", "roboflow/roboflow-inference-server-jetson-7.1.0:latest"),
     _JetsonImage(
         36, 4, "6.2", "roboflow/roboflow-inference-server-jetson-6.2.0:latest"

--- a/tests/inference_cli/unit_tests/lib/test_container_adapter.py
+++ b/tests/inference_cli/unit_tests/lib/test_container_adapter.py
@@ -287,6 +287,7 @@ JETSON_511 = "roboflow/roboflow-inference-server-jetson-5.1.1:latest"
 JETSON_600 = "roboflow/roboflow-inference-server-jetson-6.0.0:latest"
 JETSON_620 = "roboflow/roboflow-inference-server-jetson-6.2.0:latest"
 JETSON_710 = "roboflow/roboflow-inference-server-jetson-7.1.0:latest"
+JETSON_720 = "roboflow/roboflow-inference-server-jetson-7.2.0:latest"
 
 
 class TestParseTegraRelease:
@@ -332,6 +333,8 @@ class TestImageForL4t:
             (36, 5, JETSON_620),
             (38, 0, JETSON_710),
             (38, 4, JETSON_710),
+            (39, 0, JETSON_720),
+            (39, 2, JETSON_720),
         ],
     )
     def test_l4t_to_image(self, l4t_major: int, l4t_minor: int, expected: str) -> None:
@@ -358,6 +361,9 @@ class TestGetJetpackImage:
             ("6.2.0", JETSON_620),
             ("7.1", JETSON_710),
             ("7.1.0", JETSON_710),
+            ("7.2", JETSON_720),
+            ("7.2.0", JETSON_720),
+            ("7.2-b187", JETSON_720),
         ],
     )
     def test_returns_correct_image(self, version: str, expected_image: str) -> None:


### PR DESCRIPTION
## What & why

Adds a **multi-arch JetPack 7.2.0** inference-server image that runs across Roboflow's whole JP7.2 Jetson fleet — **Thor** (Blackwell, `sm_110`) **and** the **Orin** family (Ampere, `sm_87`: AGX Orin, Orin Nano Super) — derived from the **current** 7.1.0 image. JetPack 7.2 ships a newer BSP than 7.1.0 targets, and is the first release to bring both GPU architectures onto the same L4T/CUDA stack, so one image can serve them all.

> The branch was **rebased onto `main` (inference 1.3.3)** and the 7.2.0 Dockerfile **re-derived from the current 7.1.0** — which now builds **Triton from source**. This matters: without Triton the image cannot run the merged RF-DETR instance-segmentation fast path (#2464), and would ship already behind `main`. See Tier 3 below.

Component stack (confirmed by reading a Thor device flashed with JetPack 7.2):

| | JetPack 7.1.0 | **JetPack 7.2.0 (this PR)** |
|---|---|---|
| NVIDIA Jetson apt repo | `r38.4` | **`r39.2`** |
| L4T | 38.4.0 | **39.2.0** |
| CUDA | 13.0 (`cuda-toolkit-13-0`) | **13.2 (`cuda-toolkit-13-2`)** |
| cuDNN | 9.x | **9.20.0.46** |
| TensorRT | 10.13 | **10.16.2.10** |
| target GPU arch | Thor `sm_110` | **Thor `sm_110` + Orin `sm_87`** |
| PyTorch / torchvision | 2.10.0 / 0.25.0 (source) | 2.10.0 / 0.25.0 (source) |
| ONNX Runtime | 1.24.2 (source) | 1.24.2 (source) |
| Triton | 3.6.0 (source) | 3.6.0 (source) |
| flash-attn | 2.8.3 | **main @ `d16e381` (sm_87 + sm_110)** |

## Multi-arch: one image for the whole JetPack 7.2 fleet

JetPack 7.2 is the first release to span **both** GPU architectures we target on Jetson:

| device | GPU | arch | compute cap |
|---|---|---|---|
| Jetson AGX **Thor** | Blackwell | `sm_110` | 11.0 |
| Jetson **AGX Orin** | Ampere | `sm_87` | 8.7 |
| Jetson **Orin Nano** Super | Ampere | `sm_87` | 8.7 |

Rather than ship two images, this one compiles ahead-of-time (AOT) CUDA kernels for **both** archs. CUDA PTX is only *forward*-compatible — a `compute_110` PTX blob can't JIT down to an Orin's `sm_87` — so each arch needs its own AOT SASS baked in:

- **PyTorch / torchvision** — `TORCH_CUDA_ARCH_LIST="8.7;11.0"`
- **ONNX Runtime** — `CMAKE_CUDA_ARCHITECTURES="87-real;110-real;110-virtual"` (real SASS for both, plus PTX for Thor)
- **flash-attn** — `sm_87` + `sm_110` SASS (source surgery below)
- **Triton** JITs per-device and **TensorRT** builds engines on-device, so both are already arch-portable — no change needed.

**flash-attn needed source surgery for `sm_87`.** Built from a pinned `main` commit (`d16e381`); its `setup.py` recognizes archs 80/90/100/110/120 (main added the CUDA-13 "Thor rename" `compute_110f/sm_110`) but **silently ignores 87** — so an Orin would get no flash-attn kernel and fail at runtime with `no kernel image is available for execution on the device`. The build requests `FLASH_ATTN_CUDA_ARCHS="80;110"` and sed-**replaces** the `compute_80,sm_80` gencode with `compute_87,sm_87` → it emits sm_87 (Orin) + sm_110 (Thor) only, not sm_80 (there's no A100 in a Jetson fleet — building it would just double the slow Ampere kernels). Two of flash-attn's own commented-out options are also enabled, both essential for the Ampere build under CUDA 13.2:
- **`--ptxas-options=-O1`** — the Ampere `flash_fwd_split_hdim128` kernels blow up ptxas's default `-O3` register allocator under CUDA 13.2: a single kernel ran **>4 h** on the Thor builder (`-O2` ≈50 min; `-O1` makes it tractable). sm_110 alone never triggers this. Negligible runtime cost for these (VLM-only) kernels.
- **`-DFLASHATTENTION_DISABLE_BACKWARD`** — inference never runs the backward pass; skipping ~24 bwd kernels roughly halves the build.

All three patches are grep-verified in the build step (it fails fast if flash-attn's source layout shifts). flash-attn is only used by the VLM blocks (PaliGemma / Qwen-VL / SmolVLM / Gemma / GLM-OCR); RF-DETR and YOLO don't touch it.

## Approach: compile from source (not prebuilt wheels)

7.1.0 compiles PyTorch / torchvision / ONNX Runtime / Triton / flash-attn from source because no prebuilt CUDA-13 aarch64 wheels existed. Prebuilt wheels exist now, but I evaluated both on the Thor device and **kept the source build**, with evidence:

- **jetson-ai-lab `sbsa/cu130`** torch wheels need undeclared system libs (NVPL `libnvpl_lapack…`, cuDSS `libcudss.so.0`) absent from JetPack's apt repo. Satisfying them via pip drags in `cuda-toolkit 13.3` + `nvidia-cublas 13.5`, which **skew against the system CUDA 13.2** that TensorRT and our source-built ONNX Runtime link → fragile.
- **`download.pytorch.org/whl/cu132`** torch 2.12 bundles pip `nvidia-cudnn-cu13 9.20.0.48` (skew vs system 9.20.0.46), Thor-broken Triton, and ~3 GB of bloat.
- The source build links apt **OpenBLAS** (`USE_MKLDNN=0 USE_OPENMP=0`) + system CUDA → exactly one clean CUDA stack in the image. It's also what lets us target both archs from one toolchain (above).

## ONNX Runtime pin (1.24.2, not 1.26.0)

ONNX Runtime stays at **1.24.2**. 1.26.0 (and any ≥1.25.0) fails to compile against JetPack 7.2's CUDA 13.2: ORT 1.25.0 added a `<cub/cub.cuh>` umbrella include (`cu_inc/cub.cuh` → `common.cuh`) that pulls `cub/device/device_transform.cuh`, where CUDA 13.2's bundled CCCL emits ill-formed C++ (`struct ::cuda::proclaims_copyable_arguments<…> : ::cuda::std::true_type` → gcc 13/14: *"global qualification of class name is invalid before ':' token"*). Tracked upstream: [NVIDIA/cccl#8833](https://github.com/NVIDIA/cccl/issues/8833), [onnxruntime#28023](https://github.com/microsoft/onnxruntime/issues/28023); fixed by [cccl#8771](https://github.com/NVIDIA/cccl/pull/8771) but not yet in a shipped CUDA toolkit. 1.24.2 predates the include and builds clean (it's also what 7.1.0 ships; its TensorRT-EP still auto-detects TRT 10.16).

## Changes

- **`docker/dockerfiles/Dockerfile.onnx.jetson.7.2.0`** — new; re-derived from the current 7.1.0. r39.2 repo, CUDA 13.2 (builder + runtime), `L4T_VERSION=39.2.0`, **multi-arch compile flags** (torch/ORT arch lists + flash-attn sm_87 surgery above), the ORT pin, **Triton 3.6.0 built from source** (+ `cuda-nvcc-13-2` and the runtime ptxas/`build-essential` deps it needs for on-device JIT). Build parallelism exposed as args (`PYTORCH_MAX_JOBS`/`ORT_BUILD_PARALLEL`/`FLASH_ATTN_MAX_JOBS`, Depot-safe defaults); BuildKit cache ids version+arch-scoped (`jp72`/`cu132`/`sm87110`).
- **`.github/workflows/docker.jetson.7.2.0.yml`** — new; mirrors the 7.1.0 Depot `linux/arm64` build. (Multi-arch here means CUDA compute archs baked into the compile flags — it's still a single `linux/arm64` Docker platform.)
- **`inference_cli/lib/container_adapter.py`** — auto-detect L4T 39 / JetPack 7.2 → the 7.2.0 image (sorted-descending `_JetsonImage` entry; `"7.2"` matched before the `"7"` catch-all). Resolves for both Thor and Orin on JP7.2.
- **`tests/inference_cli/unit_tests/lib/test_container_adapter.py`** — cases for L4T 39 → 7.2.0 and jetpack `7.2` / `7.2.0` / `7.2-b187` → 7.2.0 (61 tests pass).

## Validation

### Multi-arch — every GPU kernel path, on real hardware of both arches

Built natively on the **Thor**, then the same 19.4 GB image was loaded onto a freshly-flashed **AGX Orin** and **Orin Nano Super** and an identical key-free suite was run on each. Every GPU code path — the AOT-compiled ones (torch, torchvision, flash-attn) *and* the on-device ones (ORT CUDA/TRT EPs, Triton JIT) — executes on both architectures. Each check runs a real kernel, so a missing-SASS mismatch surfaces as `no kernel image available`, not a silent pass:

| check (exercises a real GPU kernel) | Thor `sm_110` | AGX Orin `sm_87` | Orin Nano `sm_87` |
|---|:---:|:---:|:---:|
| PyTorch 2.10.0 CUDA matmul | ✅ | ✅ | ✅ |
| torchvision 0.25.0 NMS (CUDA) | ✅ | ✅ | ✅ |
| flash-attn 2.8.4 fwd kernel | ✅ | ✅ | ✅ |
| ONNX Runtime 1.24.2 CUDA EP | ✅ | ✅ | ✅ |
| ONNX Runtime 1.24.2 TensorRT EP | ✅ | ✅ | ✅ |
| Triton 3.6.0 JIT | ✅ | ✅ | ✅ |
| | **6/6** | **6/6** | **6/6** |

torch reports `cc=(11,0)` on Thor and `cc=(8,7)` on both Orins — confirming the correct per-device SASS is selected. The whole RF-DETR graph runs on the TRT EP as a single subgraph (no CPU fallback); **YOLOv8n** (640²) runs via ORT TensorRT EP (fp16). The Thor benchmark tiers follow; the **same harness re-run on both Orins** is in the *Orin benchmarks* section after.

### Benchmarks (Thor, JetPack 7.2)

Key-free (public COCO weights), batch-1, single-stream. RF-DETR is reported in tiers, because the model forward is a small slice of wall-clock and CPU preprocessing dominates.

> **⚠️ Measurement prerequisite — MAXN + `jetson_clocks`.** The Thor ships in the **120 W** power mode with the GPU on the dynamic governor, which idles at its **315 MHz minimum**. Inference is bursty (a short GPU forward between ~15 ms of CPU preprocessing), so the governor never sees sustained GPU load and never ramps — the whole pipeline runs at **~20 % of GPU clock**, making a Thor look *slower than an Orin Nano*. Every number below is measured after:
> ```
> sudo nvpmodel -m 0     # MAXN
> sudo jetson_clocks     # lock GPU 1575MHz / CPU 2601MHz / EMC 4266MHz
> ```
> This alone is worth **~1.6–1.7×** end-to-end (e.g. seg-nano native-res fast path 62 → **99 FPS**). `nvpmodel` persists across reboot; `jetson_clocks` does **not** — deployments should re-apply it at boot or the numbers silently regress.

#### Tier 1 — model-forward throughput (what the Thor GPU delivers)
ORT TensorRT EP (fp16), synthetic fixed input, forward only:

| OD model | input | TRT-EP | CUDA-EP | | IS model | input | TRT-EP | CUDA-EP |
|---|---|---|---|---|---|---|---|---|
| nano | 384² | **700** | 189 | | seg-nano | 312² | **513** | 106 |
| small | 512² | **490** | 107 | | seg-small | 384² | **403** | 83 |
| medium | 576² | **376** | 79 | | seg-medium | 432² | **305** | 58 |
| base | 560² | **410** | 78 | | seg-large | 504² | **244** | 42 |
| large | 704² | **283** | 50 | | seg-xlarge | 624² | **150** | 20 |
| xlarge | 700² | **205** | 28 | | seg-2xlarge | 768² | **83** | 12 |
| 2xlarge | 880² | **129** | 23 | | | | | |

#### Tier 2 — deployed single-model end-to-end (`inference_models`, real 1080p input)
Full `pre_process → forward → post_process` on a 1920×1080 frame, deployed ONNX backend. **TensorRT EP is the faster execution provider end-to-end for every model**; CUDA EP remains the shipped default (matches 7.1.0), and TRT EP is opt-in via `ONNXRUNTIME_EXECUTION_PROVIDERS`:

| OD model | e2e TRT-EP | e2e CUDA-EP | | IS model | e2e TRT-EP | e2e CUDA-EP |
|---|---|---|---|---|---|---|
| nano | **59** | 48 | | seg-nano | **52** | 38 |
| small | **52** | 38 | | seg-small | **51** | 34 |
| medium | **50** | 33 | | seg-medium | **48** | 29 |
| base | **50** | 33 | | seg-large | **46** | 24 |
| large | **45** | 25 | | seg-xlarge | **38** | 14 |
| xlarge | **43** | 19 | | seg-2xlarge | **30** | 9 |
| 2xlarge | **36** | 16 | | | | |

Even so, e2e (nano 59) is far below the forward (700) — the ~15 ms CPU resize/normalize of a full 1080p frame dominates. That preprocessing wall is what the fast path and native-resolution input remove (below).

#### Tier 3 — RF-DETR instance-segmentation fast path (Triton + CUDA graphs + pipelining)
The merged CodeFlash optimization (#2464, inference ≥1.3.2): fused **Triton** GPU pre/post-processing + TensorRT **CUDA graphs** + **depth-2** CPU/GPU pipeline scheduling, for the `trt` backend via `InferencePipeline`. **This is why the rebase + Triton addition are in this PR.** Measured on Thor across **all six instance-segmentation sizes** (TRT backend, `@v3` block, `enforce_dense_masks_in_inference_models: False`, through `InferencePipeline`; 875-frame clips), baseline vs fast path on a 1080p stream and on each model's native-resolution stream:

| seg model | native | baseline 1080p | **fast path 1080p** | **fast path native-res** |
|---|---|---|---|---|
| seg-nano | 312² | 12.8 | **31.1** | **99.9** |
| seg-small | 384² | 12.3 | **28.5** | **83.1** |
| seg-medium | 432² | 11.5 | **27.8** | **77.1** |
| seg-large | 504² | 10.9 | **25.2** | **68.9** |
| seg-xlarge | 624² | 9.0 | **21.2** | **47.9** |
| seg-2xlarge | 768² | 8.5 | **19.4** | **35.9** |

The fast path is a consistent **~2.3–2.4×** over baseline across the whole range. seg-nano's **99.9 FPS at native resolution matches the CodeFlash team's ~105 FPS on an Orin Nano** — i.e. the Thor now performs as it should, and even seg-2xlarge stays real-time-capable. Enabled with:
```
INFERENCE_MODELS_RFDETR_TRITON_PREPROC_ENABLED=true \
INFERENCE_MODELS_RFDETR_TRITON_POSTPROC_ENABLED=true \
RFDETR_PIPELINE_DEPTH=2 \
ENABLE_AUTO_CUDA_GRAPHS_FOR_TRT_BACKEND=true   # see note
```
(Constraints, per the optimization's authors: `trt` backend, `@v3` seg block with non-dense masks, static batch 1, `STRETCH_TO` resize, via `InferencePipeline`.)

**Note on CUDA graphs:** the numbers above are *without* `ENABLE_AUTO_CUDA_GRAPHS_FOR_TRT_BACKEND`. With it, the TRT engine I built locally for this validation (a plain `OnnxParser` FP16 build) fails CUDA-graph capture (`cudaErrorStreamCaptureInvalidated`) — it isn't graph-capturable. Platform-served TRT packages (built by `inference_models`' own compile path, which the authors validated with CUDA graphs) support it for additional gain on top.

#### Where the rest of the time goes — input resolution & stream decode
Feeding each model an input already at its **exact size** (no 1080p→model resize) collapses preprocessing, and the TRT-EP forward advantage carries straight through:

| OD model | 1080p | **exact-size** | | IS model | 1080p | **exact-size** |
|---|---|---|---|---|---|---|
| nano | 59 | **243** | | seg-nano | 52 | **230** |
| small | 52 | **184** | | seg-small | 51 | **190** |
| medium | 50 | **145** | | seg-medium | 48 | **164** |
| base | 50 | **153** | | seg-large | 46 | **132** |
| large | 45 | **109** | | seg-xlarge | 38 | **85** |
| xlarge | 43 | **95** | | seg-2xlarge | 30 | **52** |
| 2xlarge | 36 | **63** | | | | |

Full **stream** end-to-end through `InferencePipeline` over real RTSP — the live **geary** SF-cam (30 fps) and a local **120 fps** source (so configs above 30 fps aren't capped), seg-nano:

| source | resolution | fast path |
|---|---|---|
| geary live SF cam (30 fps) | 1080p | ~28 FPS |
| local 120 fps RTSP | 1080p | 31 FPS |
| local 120 fps RTSP | 312² (native) | **99 FPS** |

**Takeaway:** the 7.2 image's compute is not the limiter — forward is 83–700 FPS and native-resolution e2e is 30–243 FPS. Deployed FPS at 1080p is spent on whole-frame resize (removed by the Triton fast path this image enables) and stream decode + the synchronous execution engine (a separate platform-wide pipelining effort). The one thing that must not be forgotten: **set MAXN + `jetson_clocks`**, without which the device runs at ~20 %.

### Orin benchmarks (AGX Orin + Orin Nano Super, both `sm_87`, JetPack 7.2)

The **same `deployed_bench` harness** and conditions as the Thor above — public COCO weights, batch-1, real 1080p input — re-run on both Ampere devices at **MAXN + `jetson_clocks`** (AGX `nvpmodel -m 0`; Nano `-m 2` = "MAXN SUPER" — the throttling caveat applies identically). Columns are forward-only throughput (what the GPU delivers) and deployed 1080p end-to-end, per EP.

**Both EPs are run across the full 13-model set on each device.** (TensorRT engine builds for RF-DETR's deformable-attention graph are slow on Ampere — the `myelin` fusion pass is largely CPU-bound, ~2–3 min/model; sm_110 is much faster — but every engine built cleanly: **0 failures across ~120 builds**, including xlarge/2xlarge on the Nano's 8 GB.) TRT-EP is opt-in via `ONNXRUNTIME_EXECUTION_PROVIDERS`; CUDA-EP is the shipped default (matches 7.1.0).

**AGX Orin Developer Kit** — Ampere, 8 TPC @ 1.30 GHz, 64 GB (FPS):

| model | input | fwd **TRT** | fwd CUDA | e2e-1080p **TRT** | e2e-1080p CUDA |
|---|---|---|---|---|---|
| nano | 384² | **283** | 72 | **35.0** | 25.5 |
| small | 512² | **182** | 41 | **30.5** | 19.3 |
| medium | 576² | **148** | 31 | **28.8** | 16.5 |
| base | 560² | **143** | 33 | **28.8** | 17.3 |
| large | 704² | **109** | 22 | **25.3** | 13.3 |
| xlarge | 700² | **65** | 13 | **21.8** | 9.2 |
| 2xlarge | 880² | **45** | 11 | **18.1** | 7.9 |
| seg-nano | 312² | **180** | 41 | **30.6** | 19.6 |
| seg-small | 384² | **143** | 34 | **28.8** | 17.4 |
| seg-medium | 432² | **110** | 24 | **26.5** | 14.3 |
| seg-large | 504² | **87** | 19 | **24.6** | 12.4 |
| seg-xlarge | 624² | **53** | 11 | **19.6** | 7.9 |
| seg-2xlarge | 768² | **35** | 6 | **15.7** | 5.1 |

**Orin Nano Super Developer Kit** — Ampere, 4 TPC @ 1.02 GHz, 8 GB (FPS):

| model | input | fwd **TRT** | fwd CUDA | e2e-1080p **TRT** | e2e-1080p CUDA |
|---|---|---|---|---|---|
| nano | 384² | **145** | 32 | **25.8** | 15.8 |
| small | 512² | **87** | 18 | **21.8** | 11.1 |
| medium | 576² | **69** | 14 | **20.2** | 9.3 |
| base | 560² | **66** | 14 | **19.9** | 9.6 |
| large | 704² | **45** | 10 | **16.6** | 7.2 |
| xlarge | 700² | **25** | 5 | **12.6** | 4.4 |
| 2xlarge | 880² | **17** | 4 | **9.7** | 3.6 |
| seg-nano | 312² | **96** | 20 | **21.6** | 11.7 |
| seg-small | 384² | **71** | 15 | **19.4** | 9.8 |
| seg-medium | 432² | **53** | 11 | **17.6** | 7.8 |
| seg-large | 504² | **40** | 8 | **15.7** | 6.3 |
| seg-xlarge | 624² | **24** | 5 | **11.6** | 4.1 |
| seg-2xlarge | 768² | **15** | 3 | **8.7** | 2.5 |

Same story as Thor: **TRT-EP forward is ~3–4× CUDA-EP**, but deployed 1080p e2e stays far below the forward rate because CPU preprocessing (~23–30 ms/frame here) dominates — the Triton fast path (Tier 3) is what closes that gap. Device ordering is as expected across the fleet — **Thor `sm_110` > AGX Orin `sm_87` > Orin Nano `sm_87`** — e.g. nano forward TRT-EP: **700 / 283 / 145 FPS**; seg-nano: **513 / 180 / 96 FPS**. All three run the *same multi-arch image*.

**Native-resolution (exact-size input).** Feeding each model an input already at its input size — no 1080p→model resize, the same "compute ceiling" measurement as the Thor's exact-size table above, and where a correctly-sized capture or the Triton fast path lands. **Both EPs across all 13 on both devices.** End-to-end FPS:

| model | input | AGX **TRT** | AGX CUDA | Nano **TRT** | Nano CUDA |
|---|---|---|---|---|---|
| nano | 384² | **116** | 52 | **74** | 26 |
| small | 512² | **78** | 32 | **49** | 16 |
| medium | 576² | **67** | 24 | **41** | 12 |
| base | 560² | **68** | 26 | **39** | 13 |
| large | 704² | **52** | 18 | **29** | 9 |
| xlarge | 700² | **39** | 11 | **19** | 5 |
| 2xlarge | 880² | **28** | 9 | **13** | 4 |
| seg-nano | 312² | **101** | 35 | **63** | 18 |
| seg-small | 384² | **79** | 28 | **45** | 14 |
| seg-medium | 432² | **64** | 21 | **36** | 10 |
| seg-large | 504² | **51** | 17 | **28** | 8 |
| seg-xlarge | 624² | **35** | 10 | **18** | 5 |
| seg-2xlarge | 768² | **24** | 6 | **12** | 3 |

Removing the 1080p resize lifts small-model e2e **2–3×** (AGX nano CUDA 25.5→**52**, TRT 35→**116**; Nano nano CUDA 15.8→**26**, TRT 26→**74**) — that gap is exactly the CPU preprocessing wall the Triton fast path removes. TRT-EP holds a **~2–3× lead over CUDA-EP across the whole size range** at native res (AGX 2xlarge **28 vs 9**, seg-2xlarge **24 vs 6**; even the Nano's 2xlarge is **13 vs 4**); for the biggest models the forward dominates so the *native-vs-1080p* delta shrinks (AGX 2xlarge TRT 18→28), but TRT's advantage over CUDA persists. Every engine built cleanly on both devices — the RAM-limited **Orin Nano ran the full 13-model range at native res on 8 GB** (down to seg-2xlarge at 768², no OOM). AGX nano at native res (**116 FPS TRT**) is ~½ the Thor's 243 and seg-nano (**101**) ~0.44× the Thor's 230 — a consistent sm_110-vs-sm_87 gap on the same image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)