### PR TITLE
Fix HTTPS gateway request handling for secure edge deployments

### DIFF
--- a/inference_models/inference_models/weights_providers/roboflow.py
+++ b/inference_models/inference_models/weights_providers/roboflow.py
@@ -205,9 +205,11 @@ def roboflow_secure_gateway_proxy_url_builder(
         url = _add_query_params_to_url(url=url, query=query)
     if not SECURE_GATEWAY:
         return url
-    return f"http://{SECURE_GATEWAY}/proxy?url=" + urllib.parse.quote(
-        url, safe="~()*!'"
+    parts = urllib.parse.urlsplit(
+        SECURE_GATEWAY if "://" in SECURE_GATEWAY else f"http://{SECURE_GATEWAY}"
     )
+    gateway_base = f"{parts.scheme}://{parts.netloc}"
+    return f"{gateway_base}/proxy?url=" + urllib.parse.quote(url, safe="~()*!'")
 
 
 def get_model_metadata(

--- a/inference_models/tests/unit_tests/weights_providers/test_roboflow.py
+++ b/inference_models/tests/unit_tests/weights_providers/test_roboflow.py
@@ -1895,6 +1895,34 @@ def test_proxy_uses_http_not_https():
     assert outer.scheme == "http"
 
 
+@patch.object(roboflow_module, "SECURE_GATEWAY", "https://gateway.local")
+def test_scheme_qualified_gateway_is_used_verbatim():
+    result = roboflow_secure_gateway_proxy_url_builder(
+        url="https://api.roboflow.com/models/v1/weights",
+        query=None,
+    )
+    outer = _parse_proxy_result(result)
+    assert outer.scheme == "https"
+    assert outer.netloc == "gateway.local"
+    assert outer.path == "/proxy"
+
+    inner = urllib.parse.urlparse(_extract_proxied_url(result))
+    assert inner.netloc == "api.roboflow.com"
+    assert inner.path == "/models/v1/weights"
+
+
+@patch.object(roboflow_module, "SECURE_GATEWAY", "https://gateway.local:8443/")
+def test_scheme_qualified_gateway_keeps_port_and_strips_trailing_slash():
+    result = roboflow_secure_gateway_proxy_url_builder(
+        url="https://api.roboflow.com/weights",
+        query=None,
+    )
+    outer = _parse_proxy_result(result)
+    assert outer.scheme == "https"
+    assert outer.netloc == "gateway.local:8443"
+    assert outer.path == "/proxy"
+
+
 @patch.object(roboflow_module, "SECURE_GATEWAY", "proxy.internal")
 def test_roundtrip_preserves_query_with_special_characters():
     result = roboflow_secure_gateway_proxy_url_builder(


### PR DESCRIPTION
## What does this PR do?

Currently, our URL handling for requests through the secure gateway for edge deployments are forced through a HTTP URL, when we should respect the scheme if supplied by the `SECURE_GATEWAY` environment variable.

## Type of Change

- Bug fix (non-breaking change that fixes an issue)

## Testing

Observed requests before/after based on the value supplied for the  `SECURE_GATEWAY` environment variable

- [x] I have tested this change locally
- [x] I have added/updated tests for this change

**Test details:**

The tests are a simple check of the new URL format to verify the scheme is preserved.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)

## Additional Context

N/A