### PR TITLE
fix: reuse sync HTTP sessions for inference SDK requests

### DIFF
--- a/development/benchmark_scripts/benchmark_remote_http_session_reuse.py
+++ b/development/benchmark_scripts/benchmark_remote_http_session_reuse.py
@@ -13,8 +13,10 @@ import argparse
 import json
 import math
 import os
+import platform
 import statistics
 import time
+from datetime import datetime, timezone
 from io import BytesIO
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -24,6 +26,7 @@ import requests
 from PIL import Image
 
 from inference_sdk import InferenceConfiguration, InferenceHTTPClient
+from inference_sdk import __version__ as inference_sdk_version
 from inference_sdk.http.utils import executors
 
 DEFAULT_API_URL = "https://serverless.roboflow.com"
@@ -63,6 +66,12 @@ def parse_args() -> argparse.Namespace:
         type=int,
         default=5,
         help="Untimed warmup requests per pass.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Optional path to write the benchmark JSON.",
     )
     return parser.parse_args()
 
@@ -112,6 +121,36 @@ def summarize(durations: List[float]) -> Dict[str, Any]:
         "max_ms": max(durations) * 1000 if durations else None,
         "p90_ms": percentile(durations, 90) * 1000 if durations else None,
         "p95_ms": percentile(durations, 95) * 1000 if durations else None,
+    }
+
+
+def compare_modes(
+    fresh_session: Dict[str, Any],
+    reused_session: Dict[str, Any],
+) -> Dict[str, Optional[float]]:
+    fresh_avg_ms = fresh_session["avg_ms"]
+    reused_avg_ms = reused_session["avg_ms"]
+    fresh_fps = fresh_session["fps"]
+    reused_fps = reused_session["fps"]
+    return {
+        "avg_ms_delta": (
+            fresh_avg_ms - reused_avg_ms
+            if fresh_avg_ms is not None and reused_avg_ms is not None
+            else None
+        ),
+        "avg_ms_reduction_percent": (
+            ((fresh_avg_ms - reused_avg_ms) / fresh_avg_ms) * 100
+            if fresh_avg_ms
+            else None
+        ),
+        "fps_delta": (
+            reused_fps - fresh_fps
+            if reused_fps is not None and fresh_fps is not None
+            else None
+        ),
+        "fps_increase_percent": (
+            ((reused_fps - fresh_fps) / fresh_fps) * 100 if fresh_fps else None
+        ),
     }
 
 
@@ -176,6 +215,12 @@ def main() -> None:
 
     result = {
         "api_url": args.api_url,
+        "benchmark_started_at": datetime.now(timezone.utc).isoformat(),
+        "environment": {
+            "inference_sdk_version": inference_sdk_version,
+            "python": platform.python_version(),
+            "system": platform.platform(),
+        },
         "model_id": args.model_id,
         "image": {
             "source": redact_source(args.image),
@@ -188,8 +233,16 @@ def main() -> None:
             "fresh_session_per_request": fresh_session,
             "thread_local_session_reuse": reused_session,
         },
+        "comparison": compare_modes(
+            fresh_session=fresh_session,
+            reused_session=reused_session,
+        ),
     }
-    print(json.dumps(result, indent=2, sort_keys=True))
+    result_json = json.dumps(result, indent=2, sort_keys=True)
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(result_json + "\n", encoding="utf-8")
+    print(result_json)
 
 
 if __name__ == "__main__":

--- a/development/benchmark_scripts/benchmark_remote_http_session_reuse.py
+++ b/development/benchmark_scripts/benchmark_remote_http_session_reuse.py
@@ -1,0 +1,194 @@
+"""Benchmark sync HTTP session reuse for hosted inference requests.
+
+This script compares the old effective behavior, where each timed request uses
+a fresh HTTP session, against the SDK executor's thread-local session reuse.
+
+Example:
+    ROBOFLOW_API_KEY=... python development/benchmark_scripts/benchmark_remote_http_session_reuse.py \
+        --model-id coco/3 \
+        --iterations 100
+"""
+
+import argparse
+import json
+import math
+import os
+import statistics
+import time
+from io import BytesIO
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+from urllib.parse import urlsplit, urlunsplit
+
+import requests
+from PIL import Image
+
+from inference_sdk import InferenceConfiguration, InferenceHTTPClient
+from inference_sdk.http.utils import executors
+
+DEFAULT_API_URL = "https://serverless.roboflow.com"
+DEFAULT_IMAGE_URL = "https://media.roboflow.com/inference/seawithdock.jpeg"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Compare fresh HTTP sessions with thread-local session reuse for "
+            "sync inference_sdk requests."
+        )
+    )
+    parser.add_argument(
+        "--api-url",
+        default=os.getenv("ROBOFLOW_API_URL", DEFAULT_API_URL),
+        help=f"Inference API URL. Defaults to {DEFAULT_API_URL}.",
+    )
+    parser.add_argument(
+        "--model-id",
+        default=os.getenv("ROBOFLOW_MODEL_ID", "coco/3"),
+        help="Model id to benchmark. Defaults to ROBOFLOW_MODEL_ID or coco/3.",
+    )
+    parser.add_argument(
+        "--image",
+        default=os.getenv("ROBOFLOW_BENCHMARK_IMAGE", DEFAULT_IMAGE_URL),
+        help="Image path or URL. URL inputs are downloaded once before timing.",
+    )
+    parser.add_argument(
+        "--iterations",
+        type=int,
+        default=50,
+        help="Timed requests per pass.",
+    )
+    parser.add_argument(
+        "--warmup",
+        type=int,
+        default=5,
+        help="Untimed warmup requests per pass.",
+    )
+    return parser.parse_args()
+
+
+def load_image(image_reference: str) -> Image.Image:
+    if image_reference.startswith(("http://", "https://")):
+        response = requests.get(image_reference, timeout=30)
+        response.raise_for_status()
+        return Image.open(BytesIO(response.content)).convert("RGB")
+    return Image.open(Path(image_reference)).convert("RGB")
+
+
+def build_client(api_url: str, api_key: str) -> InferenceHTTPClient:
+    client = InferenceHTTPClient(api_url=api_url.rstrip("/"), api_key=api_key)
+    if "roboflow.com" in api_url:
+        client.select_api_v0()
+    return client.configure(
+        inference_configuration=InferenceConfiguration(
+            disable_active_learning=True,
+            max_batch_size=1,
+            max_concurrent_requests=1,
+            source="remote-http-session-reuse-benchmark",
+        )
+    )
+
+
+def percentile(values: List[float], p: float) -> Optional[float]:
+    if not values:
+        return None
+    sorted_values = sorted(values)
+    index = math.ceil((p / 100) * len(sorted_values)) - 1
+    index = min(max(index, 0), len(sorted_values) - 1)
+    return sorted_values[index]
+
+
+def summarize(durations: List[float]) -> Dict[str, Any]:
+    total = sum(durations)
+    return {
+        "requests": len(durations),
+        "total_s": total,
+        "fps": len(durations) / total if total else None,
+        "avg_ms": statistics.fmean(durations) * 1000 if durations else None,
+        "median_ms": statistics.median(durations) * 1000 if durations else None,
+        "min_ms": min(durations) * 1000 if durations else None,
+        "max_ms": max(durations) * 1000 if durations else None,
+        "p90_ms": percentile(durations, 90) * 1000 if durations else None,
+        "p95_ms": percentile(durations, 95) * 1000 if durations else None,
+    }
+
+
+def run_pass(
+    *,
+    client: InferenceHTTPClient,
+    image: Image.Image,
+    model_id: str,
+    iterations: int,
+    warmup: int,
+    reset_session_each_request: bool,
+) -> Dict[str, Any]:
+    for _ in range(warmup):
+        if reset_session_each_request:
+            executors._reset_thread_local_requests_session()
+        client.infer(inference_input=image, model_id=model_id)
+
+    durations = []
+    for _ in range(iterations):
+        if reset_session_each_request:
+            executors._reset_thread_local_requests_session()
+        start = time.perf_counter()
+        client.infer(inference_input=image, model_id=model_id)
+        durations.append(time.perf_counter() - start)
+
+    executors._reset_thread_local_requests_session()
+    return summarize(durations=durations)
+
+
+def redact_source(value: str) -> str:
+    if not value.startswith(("http://", "https://")):
+        return value
+    parts = urlsplit(value)
+    return urlunsplit((parts.scheme, parts.netloc, parts.path, "", ""))
+
+
+def main() -> None:
+    args = parse_args()
+    api_key = os.getenv("ROBOFLOW_API_KEY")
+    if not api_key:
+        raise SystemExit("ROBOFLOW_API_KEY must be set.")
+
+    image = load_image(image_reference=args.image)
+    client = build_client(api_url=args.api_url, api_key=api_key)
+
+    fresh_session = run_pass(
+        client=client,
+        image=image,
+        model_id=args.model_id,
+        iterations=args.iterations,
+        warmup=args.warmup,
+        reset_session_each_request=True,
+    )
+    reused_session = run_pass(
+        client=client,
+        image=image,
+        model_id=args.model_id,
+        iterations=args.iterations,
+        warmup=args.warmup,
+        reset_session_each_request=False,
+    )
+
+    result = {
+        "api_url": args.api_url,
+        "model_id": args.model_id,
+        "image": {
+            "source": redact_source(args.image),
+            "width": image.width,
+            "height": image.height,
+        },
+        "iterations": args.iterations,
+        "warmup": args.warmup,
+        "modes": {
+            "fresh_session_per_request": fresh_session,
+            "thread_local_session_reuse": reused_session,
+        },
+    }
+    print(json.dumps(result, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/development/benchmark_scripts/benchmark_remote_http_session_reuse.py
+++ b/development/benchmark_scripts/benchmark_remote_http_session_reuse.py
@@ -77,7 +77,9 @@ def load_image(image_reference: str) -> Image.Image:
 
 def build_client(api_url: str, api_key: str) -> InferenceHTTPClient:
     client = InferenceHTTPClient(api_url=api_url.rstrip("/"), api_key=api_key)
-    if "roboflow.com" in api_url:
+    parsed_url = urlsplit(api_url if "://" in api_url else f"//{api_url}")
+    hostname = parsed_url.hostname or ""
+    if hostname == "roboflow.com" or hostname.endswith(".roboflow.com"):
         client.select_api_v0()
     return client.configure(
         inference_configuration=InferenceConfiguration(

--- a/inference_sdk/http/utils/executors.py
+++ b/inference_sdk/http/utils/executors.py
@@ -2,6 +2,7 @@ import asyncio
 import contextvars
 import json
 import logging
+import threading
 from concurrent.futures import ThreadPoolExecutor
 from enum import Enum
 from functools import partial
@@ -36,6 +37,7 @@ MODEL_COLD_START_COUNT_HEADER = "X-Model-Cold-Start-Count"
 MODEL_LOAD_TIME_HEADER = "X-Model-Load-Time"
 MODEL_LOAD_DETAILS_HEADER = "X-Model-Load-Details"
 MODEL_ID_HEADER = "X-Model-Id"
+_REQUESTS_SESSION_LOCAL = threading.local()
 
 
 class RequestMethod(Enum):
@@ -273,6 +275,14 @@ def make_parallel_requests(
     Returns:
         The list of responses.
     """
+    if len(requests_data) == 1:
+        return [
+            make_request(
+                request_data=requests_data[0],
+                request_method=request_method,
+            )
+        ]
+
     # Capture the current contextvars snapshot so OTel trace context
     # propagates into the thread pool workers. Must capture here (caller
     # thread) not inside the worker — workers run in fresh threads that
@@ -296,6 +306,22 @@ def make_parallel_requests(
 
     with ThreadPoolExecutor(max_workers=workers) as executor:
         return list(executor.map(_run_in_parent_context, requests_data))
+
+
+def _get_thread_local_requests_session() -> requests.Session:
+    session = getattr(_REQUESTS_SESSION_LOCAL, "session", None)
+    if session is None:
+        session = requests.Session()
+        _REQUESTS_SESSION_LOCAL.session = session
+    return session
+
+
+def _reset_thread_local_requests_session() -> None:
+    session = getattr(_REQUESTS_SESSION_LOCAL, "session", None)
+    if session is None:
+        return
+    session.close()
+    del _REQUESTS_SESSION_LOCAL.session
 
 
 @backoff.on_predicate(
@@ -324,7 +350,8 @@ def make_request(request_data: RequestData, request_method: RequestMethod) -> Re
     Returns:
         The response from the API.
     """
-    method = requests.get if request_method is RequestMethod.GET else requests.post
+    session = _get_thread_local_requests_session()
+    method = session.get if request_method is RequestMethod.GET else session.post
     return method(
         request_data.url,
         headers=request_data.headers,

--- a/inference_sdk/http/utils/executors.py
+++ b/inference_sdk/http/utils/executors.py
@@ -301,8 +301,11 @@ def make_parallel_requests(
         try:
             return make_request_closure(rd)
         finally:
-            for var, tok in tokens:
-                var.reset(tok)
+            try:
+                _reset_thread_local_requests_session()
+            finally:
+                for var, tok in tokens:
+                    var.reset(tok)
 
     with ThreadPoolExecutor(max_workers=workers) as executor:
         return list(executor.map(_run_in_parent_context, requests_data))

--- a/inference_sdk/http/utils/executors.py
+++ b/inference_sdk/http/utils/executors.py
@@ -355,13 +355,19 @@ def make_request(request_data: RequestData, request_method: RequestMethod) -> Re
     """
     session = _get_thread_local_requests_session()
     method = session.get if request_method is RequestMethod.GET else session.post
-    return method(
-        request_data.url,
-        headers=request_data.headers,
-        params=request_data.parameters,
-        data=request_data.data,
-        json=request_data.payload,
-    )
+    # Preserve the old requests.get/post cookie behavior while still reusing
+    # the session's connection pool.
+    session.cookies.clear()
+    try:
+        return method(
+            request_data.url,
+            headers=request_data.headers,
+            params=request_data.parameters,
+            data=request_data.data,
+            json=request_data.payload,
+        )
+    finally:
+        session.cookies.clear()
 
 
 async def execute_requests_packages_async(

--- a/tests/inference_sdk/unit_tests/http/utils/test_executors.py
+++ b/tests/inference_sdk/unit_tests/http/utils/test_executors.py
@@ -277,6 +277,61 @@ def test_make_request_reuses_thread_local_session() -> None:
     )
 
 
+def test_make_request_does_not_reuse_cookies_between_calls() -> None:
+    # given
+    expected_response = Response()
+    expected_response.status_code = 200
+    request_data = RequestData(
+        url="https://some.com",
+        request_elements=1,
+        headers={"some": "header"},
+        data=None,
+        parameters={"a": "1"},
+        payload={"some": "value"},
+        image_scaling_factors=[None],
+    )
+
+    class FakeCookies:
+        def __init__(self) -> None:
+            self.value = "preexisting-cookie"
+            self.clear_calls = 0
+
+        def clear(self) -> None:
+            self.value = None
+            self.clear_calls += 1
+
+    class FakeSession:
+        def __init__(self) -> None:
+            self.cookies = FakeCookies()
+            self.cookie_values_seen_by_requests = []
+
+        def post(self, *args: object, **kwargs: object) -> Response:
+            self.cookie_values_seen_by_requests.append(self.cookies.value)
+            self.cookies.value = "server-set-cookie"
+            return expected_response
+
+        def close(self) -> None:
+            pass
+
+    session = FakeSession()
+
+    # when
+    with mock.patch.object(executors.requests, "Session", return_value=session):
+        first = make_request(
+            request_data=request_data, request_method=RequestMethod.POST
+        )
+        second = make_request(
+            request_data=request_data, request_method=RequestMethod.POST
+        )
+
+    # then
+    assert first is expected_response
+    assert second is expected_response
+    assert session.cookie_values_seen_by_requests == [None, None]
+    assert session.cookies.value is None
+    assert session.cookies.clear_calls == 4
+
+
 @mock.patch.object(executors, "make_request")
 def test_make_parallel_requests(
     make_request_mock: MagicMock,

--- a/tests/inference_sdk/unit_tests/http/utils/test_executors.py
+++ b/tests/inference_sdk/unit_tests/http/utils/test_executors.py
@@ -1,4 +1,5 @@
 import threading
+from typing import Generator
 from unittest import mock
 from unittest.mock import MagicMock, call
 
@@ -24,7 +25,7 @@ from inference_sdk.http.utils.request_building import RequestData
 
 
 @pytest.fixture(autouse=True)
-def reset_thread_local_requests_session() -> None:
+def reset_thread_local_requests_session() -> Generator[None, None, None]:
     executors._reset_thread_local_requests_session()
     yield
     executors._reset_thread_local_requests_session()
@@ -340,6 +341,40 @@ def test_make_parallel_requests_with_single_request_runs_on_current_thread(
     # then
     assert result == [response]
     assert seen_threads == [parent_thread]
+
+
+def test_make_parallel_requests_closes_worker_thread_sessions() -> None:
+    # given
+    created_sessions = []
+    request_data = RequestData(
+        url="https://some.com",
+        request_elements=1,
+        headers={"some": "header"},
+        data=None,
+        parameters={"a": "1"},
+        payload={"some": "value"},
+        image_scaling_factors=[None],
+    )
+
+    def session_factory() -> MagicMock:
+        response = Response()
+        response.status_code = 200
+        session = MagicMock()
+        session.post.return_value = response
+        created_sessions.append(session)
+        return session
+
+    # when
+    with mock.patch.object(executors.requests, "Session", side_effect=session_factory):
+        result = make_parallel_requests(
+            requests_data=[request_data, request_data],
+            request_method=RequestMethod.POST,
+        )
+
+    # then
+    assert len(result) == 2
+    assert len(created_sessions) == 2
+    assert all(session.close.called for session in created_sessions)
 
 
 def test_execute_requests_packages_when_api_call_error_occurs(

--- a/tests/inference_sdk/unit_tests/http/utils/test_executors.py
+++ b/tests/inference_sdk/unit_tests/http/utils/test_executors.py
@@ -1,3 +1,4 @@
+import threading
 from unittest import mock
 from unittest.mock import MagicMock, call
 
@@ -22,13 +23,20 @@ from inference_sdk.http.utils.executors import (
 from inference_sdk.http.utils.request_building import RequestData
 
 
+@pytest.fixture(autouse=True)
+def reset_thread_local_requests_session() -> None:
+    executors._reset_thread_local_requests_session()
+    yield
+    executors._reset_thread_local_requests_session()
+
+
 @pytest.mark.slow
 @mock.patch.object(executors, "requests")
 def test_make_request_when_connection_error_occurs_and_does_not_recover(
     requests_mock: MagicMock,
 ) -> None:
     # given
-    requests_mock.get.side_effect = [
+    requests_mock.Session.return_value.get.side_effect = [
         ConnectionError(),
         ConnectionError(),
         ConnectionError("Third"),
@@ -60,7 +68,10 @@ def test_make_request_when_connection_error_occurs_and_recovers(
 ) -> None:
     # given
     expected_response = Response()
-    requests_mock.get.side_effect = [ConnectionError(), expected_response]
+    requests_mock.Session.return_value.get.side_effect = [
+        ConnectionError(),
+        expected_response,
+    ]
     request_data = RequestData(
         url="https://some.com",
         request_elements=1,
@@ -219,6 +230,52 @@ def test_make_request_when_successful_response_is_expected(
     ), "Parameters must be posted according to request specification"
 
 
+def test_make_request_reuses_thread_local_session() -> None:
+    # given
+    expected_response = Response()
+    expected_response.status_code = 200
+    session = MagicMock()
+    session.post.return_value = expected_response
+    request_data = RequestData(
+        url="https://some.com",
+        request_elements=1,
+        headers={"some": "header"},
+        data=None,
+        parameters={"a": "1"},
+        payload={"some": "value"},
+        image_scaling_factors=[None],
+    )
+
+    # when
+    with mock.patch.object(
+        executors.requests, "Session", return_value=session
+    ) as session_factory:
+        first = make_request(
+            request_data=request_data, request_method=RequestMethod.POST
+        )
+        second = make_request(
+            request_data=request_data, request_method=RequestMethod.POST
+        )
+
+    # then
+    assert first is expected_response
+    assert second is expected_response
+    session_factory.assert_called_once()
+    assert session.post.call_count == 2
+    session.post.assert_has_calls(
+        [
+            call(
+                "https://some.com",
+                headers={"some": "header"},
+                params={"a": "1"},
+                data=None,
+                json={"some": "value"},
+            )
+        ]
+        * 2
+    )
+
+
 @mock.patch.object(executors, "make_request")
 def test_make_parallel_requests(
     make_request_mock: MagicMock,
@@ -245,6 +302,44 @@ def test_make_parallel_requests(
     make_request_mock.assert_has_calls(
         [call(request_data, request_method=RequestMethod.GET)] * 4, any_order=True
     ), "Mock of request method must be invoked 4 times with proper parameters"
+
+
+def test_make_parallel_requests_with_single_request_runs_on_current_thread(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # given
+    parent_thread = threading.get_ident()
+    seen_threads = []
+    response = Response()
+    response.status_code = 200
+    request_data = RequestData(
+        url="https://some.com",
+        request_elements=1,
+        headers={"some": "header"},
+        data=None,
+        parameters={"a": "1"},
+        payload={"some": "value"},
+        image_scaling_factors=[None],
+    )
+
+    def fake_make_request(
+        request_data: RequestData,
+        request_method: RequestMethod,
+    ) -> Response:
+        seen_threads.append(threading.get_ident())
+        return response
+
+    monkeypatch.setattr(executors, "make_request", fake_make_request)
+
+    # when
+    result = make_parallel_requests(
+        requests_data=[request_data],
+        request_method=RequestMethod.POST,
+    )
+
+    # then
+    assert result == [response]
+    assert seen_threads == [parent_thread]
 
 
 def test_execute_requests_packages_when_api_call_error_occurs(


### PR DESCRIPTION
# Description

This fixes the HTTP setup overhead we saw while benchmarking remote Workflow execution against `serverless.roboflow.com` from a CPU worker in GCP `us-central1-a`.

The sync SDK executor now:

- uses a per-thread `requests.Session` so repeated inference calls can reuse TCP/TLS connections
- runs single-request packages on the caller thread instead of creating a one-off `ThreadPoolExecutor`, which lets sequential workflow frames reuse the same session
- keeps parallel requests isolated per worker thread instead of sharing one `Session` across threads
- adds a manual benchmark script at `development/benchmark_scripts/benchmark_remote_http_session_reuse.py`

Benchmark context from the remote Workflow run:

- Workflow: 640x360 video frames, 1,275 frames / 42.54s at 29.97 FPS -> RF-DETR nano remote model step on `serverless.roboflow.com` -> ByteTrack -> bounding-box visualization
- Worker: GCP `us-central1-a`, about 11 ms ping to serverless
- Before: 5.28 FPS sequential, avg frame ~189 ms, HTTP wall ~180 ms, server processing ~30 ms, non-server request path ~150 ms
- After session reuse: 9.02 FPS sequential, HTTP wall ~103 ms, server processing ~34 ms, non-server request path ~69 ms
- Improvement: request-path overhead down by about 81 ms/frame, sequential FPS up about 71%

## Type of change

- [x] Bug fix / performance improvement
- [ ] New feature
- [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

- `.venv/bin/python -m black inference_sdk/http/utils/executors.py tests/inference_sdk/unit_tests/http/utils/test_executors.py development/benchmark_scripts/benchmark_remote_http_session_reuse.py`
- `.venv/bin/python -m pytest tests/inference_sdk/unit_tests/http/utils/test_executors.py -q` -> 24 passed
- `.venv/bin/python -m py_compile development/benchmark_scripts/benchmark_remote_http_session_reuse.py inference_sdk/http/utils/executors.py`
- `.venv/bin/python development/benchmark_scripts/benchmark_remote_http_session_reuse.py --help`

## Any specific deployment considerations

This changes the sync SDK HTTP request path. It intentionally uses per-thread sessions because `requests.Session` is not safe to share across threads. The change does not cache mutable `InferenceHTTPClient` instances or workflow block clients.

The benchmark script requires `ROBOFLOW_API_KEY` and can be run against serverless like:

```bash
ROBOFLOW_API_KEY=... python development/benchmark_scripts/benchmark_remote_http_session_reuse.py --model-id coco/3 --iterations 100
```

Repro command used locally on 2026-07-01:

```bash
ROBOFLOW_API_KEY=... .venv/bin/python development/benchmark_scripts/benchmark_remote_http_session_reuse.py \
  --api-url https://serverless.roboflow.com \
  --model-id coco/3 \
  --iterations 20 \
  --warmup 3 \
  --output /tmp/remote_http_session_reuse_benchmark.json
```

Local output summary: fresh-session path 3.73 FPS / 268.44 ms avg; reused-session path 5.06 FPS / 197.55 ms avg; +35.9% FPS and -70.9 ms avg request time.

## Docs

- [ ] Docs updated? What were the changes: not applicable; added a focused benchmark script for validation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core sync HTTP path used by `InferenceHTTPClient`; session reuse and cookie clearing are intentional but any subtle behavior change could affect all remote inference calls.
> 
> **Overview**
> **Sync inference HTTP calls** now go through a **per-thread `requests.Session`** so repeated `infer` calls can reuse TCP/TLS connections instead of paying setup cost on every request. **`make_request`** uses that session for GET/POST and **clears cookies before and after each call** so behavior stays aligned with the old `requests.get`/`post` path while still pooling connections.
> 
> **`make_parallel_requests`** skips a one-off **`ThreadPoolExecutor`** when there is only one request (runs on the caller thread so sequential workflow frames can reuse the same session), and **closes thread-local sessions** when pool workers finish so sessions are not left open across threads.
> 
> Adds **`development/benchmark_scripts/benchmark_remote_http_session_reuse.py`** to compare fresh-session vs thread-local reuse against hosted inference, plus **unit tests** for session reuse, cookie isolation, single-request threading, and worker session cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f94f5adba7d4a34eda1c358c67ed90fc0f648ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->




