### PR TITLE
Modify the rules of agentic review to push contributors to answer on doubts

### DIFF
--- a/.github/prompts/claude-pr-review.md
+++ b/.github/prompts/claude-pr-review.md
@@ -91,14 +91,14 @@ avoid an empty review.
 Do not spend review space on broad summaries, implementation walkthroughs, or
 style feedback unless they are necessary to explain a concrete risk.
 
-Escalate only for genuinely difficult cases, unclear ownership or product
+Escalate to code-owners only for genuinely difficult cases, unclear ownership or product
 intent, security-sensitive decisions, or when the contributor repeatedly does
-not address requested fixes. When escalation is needed, mention
+not address requested fixes. When such escalation is needed, mention
 @PawelPeczek-Roboflow, @grzegorz-roboflow, and @dkosowski87 in the top-level
 PR comment with a plain-language escalation summary that helps a human reviewer
 get up to speed quickly.
 
-For escalations, include:
+For code-owners escalations, include:
 
 - What the problem is.
 - Why it matters and who/what can hit it.
@@ -106,6 +106,19 @@ For escalations, include:
 - The recommended solution or decision needed.
 - A small Mermaid.js diagram, flowchart, or step-by-step flow when it helps
   explain the situation faster than prose.
+
+For non-blocking issues which requires clarification of shortcuts and decisions made, 
+tag contributor with action item which should include:
+
+- List of all doubts and questions to be clarified, enumerated, without duplicates 
+including references to submitted code / broader context to explore by contributor.
+- Clear call to action and warning that unanswered questions may stop the PR from being 
+included in release
+
+When all concerns are addressed and PR is ready for final check - submit comment with 
+the following content.
+
+😎PR passes the vibe-check and trust-me-bro verification.
 
 ## Finding And Severity Rules
 

--- a/.github/prompts/claude-pr-review.md
+++ b/.github/prompts/claude-pr-review.md
@@ -118,7 +118,7 @@ included in release
 When all concerns are addressed and PR is ready for final check - submit comment with 
 the following content.
 
-😎PR passes the vibe-check and trust-me-bro verification.
+😎 PR passes the vibe-check and trust-me-bro verification.
 
 ## Finding And Severity Rules
 

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -163,6 +163,5 @@ jobs:
           prompt: ${{ steps.review-prompt.outputs.prompt }}
           claude_args: |
             --model claude-opus-4-8
-            --max-turns 20
-            --effort max
+            --max-turns 40
             --allowedTools "Read,Glob,Grep,mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(python:*),Bash(python3:*),Bash(pytest:*)"

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -163,5 +163,5 @@ jobs:
           prompt: ${{ steps.review-prompt.outputs.prompt }}
           claude_args: |
             --model claude-opus-4-8
-            --max-turns 10
+            --max-turns 20
             --allowedTools "Read,Glob,Grep,mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(python:*),Bash(python3:*),Bash(pytest:*)"

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -164,4 +164,5 @@ jobs:
           claude_args: |
             --model claude-opus-4-8
             --max-turns 20
+            --effort max
             --allowedTools "Read,Glob,Grep,mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(python:*),Bash(python3:*),Bash(pytest:*)"


### PR DESCRIPTION
## What does this PR do?

Change to agentic review to enforce marking doubts explicitly.

## Type of Change

<!-- Please select one and delete the others, or describe if Other -->

- New feature (non-breaking change that adds functionality)


## Testing

<!-- Describe how you tested your changes -->
-vibe checking agsinst internal PRs
- [ ] I have tested this change locally
- [ ] I have added/updated tests for this change

**Test details:**
<!-- Describe what tests were added/updated and what they cover -->

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)

## Additional Context

<!-- Add any other context, screenshots, or notes about the PR here -->
