### PR TITLE
webexec deploy: add EU target (Modal env eu, region eu = EEA group) to the deploy matrix

### DIFF
--- a/.github/workflows/modal.custom_python_block.deploy.yml
+++ b/.github/workflows/modal.custom_python_block.deploy.yml
@@ -11,12 +11,47 @@ on:
         type: string
         description: "Optional inference version to deploy (e.g., 0.64.5)"
         default: ""
+      targets:
+        type: choice
+        description: "Region target(s) for the webexec app (fans out to each)"
+        options:
+          - us,eu
+          - us
+          - eu
+        default: us,eu
 
 jobs:
-  deploy:
+  # Build the deploy matrix from the chosen targets. Both regions live in the SAME
+  # Modal workspace ($MODAL_WORKSPACE_NAME); they differ only by Modal environment +
+  # region knobs, so one deploy credential covers both.
+  #   us -> env `main` (workspace default), aws/us-east-1  (unchanged from prior behavior)
+  #   eu -> env `eu`, gcp + region eu, routed eu-west       -> roboflow-eu--...eu-west.modal.run
+  setup:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    outputs:
+      matrix: ${{ steps.gen.outputs.matrix }}
+    steps:
+      - id: gen
+        env:
+          TARGETS: ${{ github.event.inputs.targets || 'us,eu' }}
+        run: |
+          inc='[]'
+          IFS=',' read -ra TS <<< "$TARGETS"
+          for t in "${TS[@]}"; do
+            case "$t" in
+              us) inc=$(jq -c '. + [{"target":"us","environment":"main","cloud":"aws","region":"us-east-1","routing_region":""}]' <<< "$inc") ;;
+              eu) inc=$(jq -c '. + [{"target":"eu","environment":"eu","cloud":"gcp","region":"eu","routing_region":"eu-west"}]' <<< "$inc") ;;
+            esac
+          done
+          echo "matrix={\"include\":$inc}" >> "$GITHUB_OUTPUT"
+
+  deploy:
+    needs: setup
+    runs-on: ubuntu-latest
     timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.setup.outputs.matrix) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -26,11 +61,15 @@ jobs:
           python-version: '3.12'
       - name: Install dependencies
         run: python3 -m pip install modal
-      - name: Deploy Modal App
+      - name: Deploy webexec (${{ matrix.target }} -> Modal env ${{ matrix.environment }})
         env:
           MODAL_WORKSPACE_NAME: ${{ secrets.MODAL_WORKSPACE_NAME }}
           MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID_FOR_DEPLOYMENT }}
           MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET_FOR_DEPLOYMENT }}
-          INFERENCE_VERSION: ${{ github.event.inputs.inference_version }} 
+          INFERENCE_VERSION: ${{ github.event.inputs.inference_version }}
+          MODAL_ENVIRONMENT: ${{ matrix.environment }}
+          WEBEXEC_MODAL_CLOUD: ${{ matrix.cloud }}
+          WEBEXEC_MODAL_REGION: ${{ matrix.region }}
+          WEBEXEC_MODAL_ROUTING_REGION: ${{ matrix.routing_region }}
         working-directory: modal
         run: python3 deploy_modal_app.py


### PR DESCRIPTION
## Problem
The EU custom-Python webexec (Modal env `eu` → `roboflow-eu--webexec-executor-execute-block.eu-west.modal.run`) was **hand-deployed** — this workflow only deployed the US default env. So on any inference version bump the EU webexec goes stale until someone manually re-runs `deploy_modal_app.py`.

## Change
Fan the deploy over a `targets` input (`us,eu` default). Every Modal knob is set **explicitly per target** in the matrix — nothing rides on an ambient deploy-profile default at deploy time:

| target | Modal env | cloud | region | routing_region |
|---|---|---|---|---|
| **us** | `main` | `aws` | `us-east-1` | — |
| **eu** | `eu` | `gcp` | `eu` | `eu-west` |

`modal_app.py` reads `WEBEXEC_MODAL_CLOUD` / `WEBEXEC_MODAL_REGION` / `WEBEXEC_MODAL_ROUTING_REGION` (already on `main`) and applies them to the `Executor` decorator, so these matrix values are what the deployed app runs with.

**US is byte-for-byte unchanged.** The US row's values are exactly `modal_app.py`'s built-in defaults (`aws` / `us-east-1`) and the env the US webexec already lives in. Verified live: the `roboflow` workspace has envs `main` / `eu-staging` / `eu-prod` / `eu` (there is **no** env named `default`), and the production `webexec` app runs in **`main`** — the same env the previous (no-`MODAL_ENVIRONMENT`) job resolved to via the credential's default. Pinning it explicitly **removes the reliance on that ambient default; it does not re-target anything.** Setting all knobs explicitly is deliberate — it's what makes the US/EU behavior unambiguous from the workflow alone.

Both regions live in the **same `roboflow` workspace**, so the existing deploy credential (`secrets.MODAL_*_FOR_DEPLOYMENT`) covers both — **no new / EU-specific deploy creds needed**.

### Why region `eu` (EEA region group), not a pinned `europe-west1`
`region: eu` selects Modal's **EU region group** rather than a single datacenter. Every datacenter in that group is **EEA-resident**, so GDPR data-residency holds either way — but the group gives Modal scheduling latitude across EEA regions, which means **better capacity / availability and failover** than pinning one region (a single region can hit capacity or zonal pressure). We deliberately trade a fixed single placement for EEA-wide-but-still-compliant placement. Our E2E run landed in `europe-west1`; any placement stays within the EEA. (If a future compliance requirement calls for a single named-region placement contract, pin `region: europe-west1` and re-validate — but `eu` is both compliant and more resilient today.)

## Validation
- YAML parses; matrix jq logic verified for `us,eu` / `us` / `eu`.
- The EU webexec was deployed with **exactly these knobs** (`env eu`, `cloud gcp`, `region eu`, `routing eu-west`) and E2E-validated end-to-end: a custom-Python block executed through the EU endpoint and reported **`region: europe-west1`** (EEA-resident). **CI deploys the same knob values that were validated** — `region` is `eu` in both the manual validation and this matrix; `europe-west1` was the observed placement, not a different config.
- US env verified live: production `webexec` is in env `main`; the US leg targets that same env (US path unchanged).
