### PR TITLE
Fix 2/ghsa hjmm hr52 vrp2

### DIFF
--- a/docs/install/security.md
+++ b/docs/install/security.md
@@ -10,7 +10,7 @@ network restrictions by default — it is built to be easy to start, not to be
 safe to expose. Out of the box it will answer any request that reaches it,
 including requests to run models and execute Workflows.
 
-This page covers the four controls every self-hosted deployment should
+This page covers the five controls every self-hosted deployment should
 review before it handles anything beyond local development traffic. They are
 complementary — apply as many as your environment allows.
 
@@ -130,6 +130,100 @@ docker run --rm -p 9001:9001 \
     enabling it only on deployments where the network and authentication
     controls above are already in place.
 
+## 5. Restrict image fetching from URLs (SSRF)
+
+Inference can load images straight from a URL supplied in the request
+(`{"image": {"type": "url", "value": "https://..."}}`). Any time a server
+fetches a URL that a caller controls, the caller can try to steer it into
+making requests on their behalf — a class of attack called **Server-Side
+Request Forgery (SSRF)**. Someone who cannot reach your internal network
+directly can ask *your server* to fetch, for example:
+
+- `http://169.254.169.254/latest/meta-data/` — the cloud metadata service
+  (AWS/GCP/Azure), which can hand back instance credentials.
+- `http://127.0.0.1:9001/...` and other `localhost` services — admin panels,
+  databases, or the inference server's own unauthenticated endpoints.
+- `http://10.0.0.5/`, `http://192.168.1.1/`, and other private (RFC1918),
+  link-local, CGNAT, or IPv6 ULA hosts that sit behind your perimeter.
+
+A public-looking hostname is not proof of a public target: it may resolve to a
+private IP, redirect to one, or use **DNS rebinding** (resolve to a public IP
+for the validation check, then a private IP for the actual connection).
+Inference ships controls for all of these.
+
+### Turn URL input off if you don't need it
+
+The strongest control is to not accept URL images at all. If your clients
+always send images as base64 or file uploads, disable URL fetching outright:
+
+```bash
+docker run --rm -p 9001:9001 \
+  -e ALLOW_URL_INPUT=false \
+  roboflow/roboflow-inference-server-cpu:latest
+```
+
+### Harden URL input when you do need it
+
+When URL images are required, these flags narrow what the server is allowed to
+fetch. Together they reject internal targets, **pin the connection to the
+validated IP** (defeating DNS rebinding), and re-check every redirect hop:
+
+| Variable | Default | Effect |
+| --- | --- | --- |
+| `ALLOW_URL_INPUT` | `True` | Master switch for URL image input. `False` rejects all URL images. |
+| `ALLOW_URL_TO_NON_GLOBAL_ADDRESSES` | `True` | When `False`, a URL whose host resolves to a **non-global** address (loopback, private, link-local/metadata, CGNAT, IPv6 ULA, …) is rejected, and the connection is pinned to the validated IP so a second DNS answer cannot swap the target. |
+| `VALIDATE_IMAGE_URL_REDIRECTS` | `False` | When `True`, redirects are followed **one hop at a time** and each hop URL is re-validated, instead of being followed blindly. |
+| `MAX_IMAGE_URL_REDIRECTS` | `30` | Hard cap on redirect hops, enforced regardless of the flag above. |
+| `ALLOW_NON_HTTPS_URL_INPUT` | `False` | When `False`, only `https://` URLs are accepted. |
+| `ALLOW_URL_INPUT_WITHOUT_FQDN` | `False` | When `False`, URLs whose host is a bare IP or has no public suffix are rejected — callers must use a real domain name. |
+| `WHITELISTED_DESTINATIONS_FOR_URL_INPUT` | *(unset)* | Comma-separated allow-list of destinations (`subdomain.domain.suffix`). When set, **only** these are permitted. |
+| `BLACKLISTED_DESTINATIONS_FOR_URL_INPUT` | *(unset)* | Comma-separated block-list of destinations that are always rejected. |
+
+A hardened configuration that still allows public HTTPS image URLs:
+
+```bash
+docker run --rm -p 9001:9001 \
+  -e ALLOW_URL_TO_NON_GLOBAL_ADDRESSES=false \
+  -e VALIDATE_IMAGE_URL_REDIRECTS=true \
+  roboflow/roboflow-inference-server-cpu:latest
+```
+
+For the tightest control, add an allow-list so the server can only reach the
+exact hosts you serve images from:
+
+```bash
+docker run --rm -p 9001:9001 \
+  -e ALLOW_URL_TO_NON_GLOBAL_ADDRESSES=false \
+  -e VALIDATE_IMAGE_URL_REDIRECTS=true \
+  -e WHITELISTED_DESTINATIONS_FOR_URL_INPUT=images.example.com,cdn.example.com \
+  roboflow/roboflow-inference-server-cpu:latest
+```
+
+!!! warning "Two defaults are changing in Q4 2026"
+
+    `ALLOW_URL_TO_NON_GLOBAL_ADDRESSES` (→ `False`) and
+    `VALIDATE_IMAGE_URL_REDIRECTS` (→ `True`) currently default to the legacy,
+    permissive behaviour for backward compatibility. Both defaults are
+    scheduled to flip to the secure values in **Q4 2026**. Set them explicitly
+    now — to the secure values to opt in early, or to the legacy values if a
+    workflow genuinely depends on fetching internal URLs — so the change does
+    not surprise you.
+
+!!! note "Proxies bypass this protection"
+
+    If an HTTP(S) proxy is configured for the server, the proxy — not
+    Inference — resolves the destination, so non-global blocking and
+    connection pinning cannot be enforced (the server emits a warning when it
+    detects this). Restrict what the proxy itself can reach if you rely on
+    these controls.
+
+!!! note "Same controls in the Python SDK"
+
+    The `inference-sdk` client applies the same URL policy and SSRF protections
+    — and reads the same environment variables — when it loads images from
+    URLs, so a client that hydrates URL images before sending them is covered
+    too.
+
 ## Recommended baseline
 
 For any self-hosted server that is reachable beyond `localhost`:
@@ -138,3 +232,4 @@ For any self-hosted server that is reachable beyond `localhost`:
 - [ ] `WORKSPACES_WHITELISTED_FOR_LOCAL_DEPLOYMENT` set, or your own auth in front.
 - [ ] TLS terminated at the server or an upstream proxy.
 - [ ] `ALLOW_CUSTOM_PYTHON_EXECUTION_IN_WORKFLOWS=false` unless you genuinely need it.
+- [ ] URL image input disabled (`ALLOW_URL_INPUT=false`), or hardened with `ALLOW_URL_TO_NON_GLOBAL_ADDRESSES=false` and `VALIDATE_IMAGE_URL_REDIRECTS=true` (plus an allow-list where you can).

--- a/docs/server_configuration/accepted_input_formats.md
+++ b/docs/server_configuration/accepted_input_formats.md
@@ -88,5 +88,17 @@ other targets will be rejected.
 destinations for URL requests. For example:  `BLACKLISTED_DESTINATIONS_FOR_URL_INPUT=192.168.0.15,some.site.com`.
 URLs pointing to these targets will be rejected.
 * `ALLOW_LOADING_IMAGES_FROM_LOCAL_FILESYSTEM` - Set to `False` to disable local filesystem access to images - default: `True`.
+* `ALLOW_URL_TO_NON_GLOBAL_ADDRESSES` - Set to `False` to reject URLs whose host resolves to a non-global address
+(loopback, private/RFC1918, link-local/cloud-metadata `169.254.169.254`, CGNAT, IPv6 ULA, ...) and pin the connection to
+the validated IP so DNS rebinding cannot swap the target after validation - default: `True` (scheduled to change to
+`False` in Q4 2026).
+* `VALIDATE_IMAGE_URL_REDIRECTS` - Set to `True` to follow redirects one hop at a time and re-validate every hop URL
+(scheme / FQDN / allow-list / block-list / non-global address) instead of letting the client follow redirects blindly -
+default: `False` (scheduled to change to `True` in Q4 2026).
+* `MAX_IMAGE_URL_REDIRECTS` - Hard cap on the number of redirect hops allowed when fetching a URL image, enforced
+regardless of `VALIDATE_IMAGE_URL_REDIRECTS` - default: `30`.
+
+See [Securing a Self-Hosted Server](../install/security.md) for a fuller explanation of the SSRF controls and
+recommended configurations.
 
 Check [inference cli docs](../inference_helpers/inference_cli.md) to see how to run server with specific flags.

--- a/inference/core/env.py
+++ b/inference/core/env.py
@@ -40,6 +40,26 @@ if BLACKLISTED_DESTINATIONS_FOR_URL_INPUT is not None:
         BLACKLISTED_DESTINATIONS_FOR_URL_INPUT.split(",")
     )
 
+# SSRF hardening for URL image input (GHSA-hjmm-hr52-vrp2).
+# When enabled, redirects are followed one hop at a time and every hop URL is
+# re-validated (scheme / FQDN / allow-list / block-list) instead of being
+# followed blindly by `requests`. Default is currently False to preserve the
+# legacy behaviour; the default is scheduled to flip to True in Q4 2026.
+VALIDATE_IMAGE_URL_REDIRECTS = str2bool(
+    os.getenv("VALIDATE_IMAGE_URL_REDIRECTS", False)
+)
+# Hard cap on the number of redirect hops allowed when fetching a URL image.
+# Enforced regardless of VALIDATE_IMAGE_URL_REDIRECTS. 30 mirrors the historical
+# `requests` default.
+MAX_IMAGE_URL_REDIRECTS = int(os.getenv("MAX_IMAGE_URL_REDIRECTS", 30))
+# When False, a URL image whose hostname resolves to a non-global address
+# (loopback, private, link-local/metadata, CGNAT, ULA, ...) is rejected and the
+# connection is pinned to the validated IP. Default is currently True to preserve
+# the legacy behaviour; the default is scheduled to flip to False in Q4 2026.
+ALLOW_URL_TO_NON_GLOBAL_ADDRESSES = str2bool(
+    os.getenv("ALLOW_URL_TO_NON_GLOBAL_ADDRESSES", True)
+)
+
 # List of allowed origins
 ALLOW_ORIGINS = os.getenv("ALLOW_ORIGINS", "*")
 ALLOW_ORIGINS = ALLOW_ORIGINS.split(",")

--- a/inference/core/utils/image_utils.py
+++ b/inference/core/utils/image_utils.py
@@ -25,7 +25,10 @@ from inference.core.env import (
     ALLOW_NUMPY_INPUT,
     ALLOW_URL_INPUT,
     ALLOW_URL_INPUT_WITHOUT_FQDN,
+    ALLOW_URL_TO_NON_GLOBAL_ADDRESSES,
     BLACKLISTED_DESTINATIONS_FOR_URL_INPUT,
+    MAX_IMAGE_URL_REDIRECTS,
+    VALIDATE_IMAGE_URL_REDIRECTS,
     WHITELISTED_DESTINATIONS_FOR_URL_INPUT,
 )
 from inference.core.exceptions import (
@@ -36,6 +39,11 @@ from inference.core.exceptions import (
 )
 from inference.core.utils.function import deprecated
 from inference.core.utils.requests import api_key_safe_raise_for_status
+from inference.core.utils.url_input import (
+    URLAddressNotAllowedError,
+    fetch_url_content_legacy,
+    fetch_url_content_validating_redirects,
+)
 
 BASE64_DATA_TYPE_PATTERN = re.compile(r"^data:image\/[a-z]+;base64,")
 
@@ -395,6 +403,30 @@ def load_image_from_url(
         Image.Image: The loaded PIL image.
     """
     _ensure_url_input_allowed()
+    prepared_url = _validate_url_destination(value=value)
+    try:
+        image_bytes = _fetch_image_bytes_from_url(prepared_url=prepared_url)
+    except URLAddressNotAllowedError as error:
+        message = "URL points to a network destination that is not allowed."
+        raise InputImageLoadError(
+            message=f"{message} Details: {error}",
+            public_message=message,
+        ) from error
+    except (RequestException, ConnectionError) as error:
+        raise InputImageLoadError(
+            message=f"Could not load image from url: {value}. Details: {error}",
+            public_message="Data pointed by URL could not be decoded into image.",
+        )
+    return load_image_from_encoded_bytes(
+        value=image_bytes, cv_imread_flags=cv_imread_flags
+    )
+
+
+def _validate_url_destination(value: str) -> str:
+    """Run the URL-string SSRF policy (scheme / FQDN / allow-list / block-list)
+    and return the prepared URL. Called for the initial URL and re-used per
+    redirect hop when redirect validation is enabled.
+    """
     try:
         original_parsed_url = urllib.parse.urlparse(value)
         if "\\" in original_parsed_url.netloc:
@@ -426,17 +458,26 @@ def load_image_from_url(
     _ensure_location_matches_destination_blacklist(
         destination=address_parts_concatenated
     )
-    try:
-        response = requests.get(prepared_url, stream=True)
-        api_key_safe_raise_for_status(response=response)
-        return load_image_from_encoded_bytes(
-            value=response.content, cv_imread_flags=cv_imread_flags
+    return prepared_url
+
+
+def _fetch_image_bytes_from_url(prepared_url: str) -> bytes:
+    """Dispatch URL fetching to the hardened per-hop validator or the legacy
+    (redirect-following) path, based on VALIDATE_IMAGE_URL_REDIRECTS. Non-global
+    address blocking is applied by both paths, independently.
+    """
+    if VALIDATE_IMAGE_URL_REDIRECTS:
+        return fetch_url_content_validating_redirects(
+            url=prepared_url,
+            allow_non_global_addresses=ALLOW_URL_TO_NON_GLOBAL_ADDRESSES,
+            max_redirects=MAX_IMAGE_URL_REDIRECTS,
+            validate_redirect=_validate_url_destination,
         )
-    except (RequestException, ConnectionError) as error:
-        raise InputImageLoadError(
-            message=f"Could not load image from url: {value}. Details: {error}",
-            public_message="Data pointed by URL could not be decoded into image.",
-        )
+    return fetch_url_content_legacy(
+        url=prepared_url,
+        allow_non_global_addresses=ALLOW_URL_TO_NON_GLOBAL_ADDRESSES,
+        max_redirects=MAX_IMAGE_URL_REDIRECTS,
+    )
 
 
 def _ensure_url_input_allowed() -> None:

--- a/inference/core/utils/url_input.py
+++ b/inference/core/utils/url_input.py
@@ -18,11 +18,12 @@ import socket
 import threading
 import urllib.parse
 import warnings
-from typing import Callable, List, Optional
+from typing import Callable, List, Optional, Tuple
 
 import requests
 import urllib3.util
 from requests.adapters import HTTPAdapter
+from requests.utils import select_proxy
 from urllib3.connectionpool import HTTPConnectionPool, HTTPSConnectionPool
 
 from inference.core import logger
@@ -174,37 +175,83 @@ class SSRFProtectedHTTPAdapter(HTTPAdapter):
             request.headers["Host"] = host_header
         return super().send(request, **kwargs)
 
-    def get_connection(self, url, proxies=None):
+    def _resolve_pin_target(self, url: str) -> Optional[Tuple[str, str]]:
+        """Return ``(hostname, pinned_ip)`` to pin, or ``None`` to connect
+        normally. Raises :class:`URLAddressNotAllowedError` when the destination
+        is a blocked non-global address.
+        """
         parsed = urllib3.util.parse_url(url)
         host = parsed.host
         if host is None:
-            return super().get_connection(url, proxies)
+            return None
         scheme = parsed.scheme or "https"
         port = parsed.port or (443 if scheme == "https" else 80)
-
         if _host_is_ip_literal(host):
             literal = _strip_ipv6_brackets(host)
             if not self._allow_non_global_addresses and not address_is_global(literal):
                 raise URLAddressNotAllowedError(
                     f"URL points to non-global address '{literal}'."
                 )
-            return super().get_connection(url, proxies)
-
+            # The literal already is the validated address; connect directly.
+            return None
         resolved_ips = resolve_and_validate_ips(
             host=host,
             port=port,
             allow_non_global_addresses=self._allow_non_global_addresses,
         )
-        pinned_ip = resolved_ips[0]
-        if scheme == "https":
-            return HTTPSConnectionPool(
-                host=pinned_ip,
-                port=port,
-                assert_hostname=host,
-                cert_reqs="CERT_REQUIRED",
-                conn_kw={"server_hostname": host},
+        return host, resolved_ips[0]
+
+    def _build_pinned_pool(self, host_params, pool_kwargs, hostname, pinned_ip):
+        # Reuse requests' own host params / TLS pool kwargs (so proxies, custom
+        # CA bundles and mTLS client certs are preserved), but point the pool at
+        # the validated IP and verify TLS against the original hostname.
+        host_params = dict(host_params)
+        host_params["host"] = pinned_ip
+        pool_kwargs = dict(pool_kwargs)
+        pool_kwargs["assert_hostname"] = hostname
+        pool = self.poolmanager.connection_from_host(
+            **host_params, pool_kwargs=pool_kwargs
+        )
+        # SNI must target the original hostname even though we dial the IP.
+        pool.conn_kw["server_hostname"] = hostname
+        return pool
+
+    def get_connection_with_tls_context(
+        self, request, verify, proxies=None, cert=None
+    ):
+        # This is the method on the send() path for requests >= 2.32 (the pinned
+        # floor). With a forward proxy the proxy resolves the target, so
+        # client-side pinning is moot -> defer and keep proxy/CA/mTLS intact.
+        if select_proxy(request.url, proxies):
+            return super().get_connection_with_tls_context(
+                request, verify, proxies=proxies, cert=cert
             )
-        return HTTPConnectionPool(host=pinned_ip, port=port)
+        pin = self._resolve_pin_target(request.url)
+        if pin is None:
+            return super().get_connection_with_tls_context(
+                request, verify, proxies=proxies, cert=cert
+            )
+        hostname, pinned_ip = pin
+        host_params, pool_kwargs = self.build_connection_pool_key_attributes(
+            request, verify, cert
+        )
+        return self._build_pinned_pool(host_params, pool_kwargs, hostname, pinned_ip)
+
+    def get_connection(self, url, proxies=None):
+        # Fallback for requests < 2.32 (below the pinned floor); kept so the
+        # protection also holds if an older requests is somehow installed.
+        if select_proxy(url, proxies):
+            return super().get_connection(url, proxies)
+        pin = self._resolve_pin_target(url)
+        if pin is None:
+            return super().get_connection(url, proxies)
+        hostname, pinned_ip = pin
+        parsed = urllib3.util.parse_url(url)
+        scheme = parsed.scheme or "https"
+        port = parsed.port or (443 if scheme == "https" else 80)
+        host_params = {"scheme": scheme, "host": pinned_ip, "port": port}
+        pool_kwargs = {"cert_reqs": "CERT_REQUIRED"} if scheme == "https" else {}
+        return self._build_pinned_pool(host_params, pool_kwargs, hostname, pinned_ip)
 
 
 def _build_ssrf_protected_session(allow_non_global_addresses: bool) -> requests.Session:

--- a/inference/core/utils/url_input.py
+++ b/inference/core/utils/url_input.py
@@ -293,7 +293,6 @@ def fetch_url_content_legacy(
 
 
 def fetch_url_content_validating_redirects(
-    *,
     url: str,
     allow_non_global_addresses: bool,
     max_redirects: int,

--- a/inference/core/utils/url_input.py
+++ b/inference/core/utils/url_input.py
@@ -24,7 +24,6 @@ import requests
 import urllib3.util
 from requests.adapters import HTTPAdapter
 from requests.utils import select_proxy
-from urllib3.connectionpool import HTTPConnectionPool, HTTPSConnectionPool
 
 from inference.core import logger
 from inference.core.utils.requests import api_key_safe_raise_for_status
@@ -34,25 +33,18 @@ from inference.core.warnings import InferenceDeprecationWarning
 # Deprecation notices (emitted once per process to avoid hot-path log spam).
 # ---------------------------------------------------------------------------
 _WARNING_LOCK = threading.Lock()
-_LEGACY_REDIRECT_WARNING_EMITTED = False
-_NON_GLOBAL_WARNING_EMITTED = False
+_EMITTED_WARNINGS = set()
 
 
 class URLAddressNotAllowedError(Exception):
     """Raised when a URL resolves to a destination that is not permitted."""
 
 
-def _warn_once(flag_name: str, message: str) -> None:
-    global _LEGACY_REDIRECT_WARNING_EMITTED, _NON_GLOBAL_WARNING_EMITTED
+def _warn_once(key: str, message: str) -> None:
     with _WARNING_LOCK:
-        if flag_name == "VALIDATE_IMAGE_URL_REDIRECTS":
-            if _LEGACY_REDIRECT_WARNING_EMITTED:
-                return
-            _LEGACY_REDIRECT_WARNING_EMITTED = True
-        else:
-            if _NON_GLOBAL_WARNING_EMITTED:
-                return
-            _NON_GLOBAL_WARNING_EMITTED = True
+        if key in _EMITTED_WARNINGS:
+            return
+        _EMITTED_WARNINGS.add(key)
     warnings.warn(message, category=InferenceDeprecationWarning, stacklevel=2)
     logger.warning(message)
 
@@ -74,6 +66,15 @@ def _warn_non_global_allowed() -> None:
         "(ALLOW_URL_TO_NON_GLOBAL_ADDRESSES=True). This is an SSRF-sensitive "
         "default and is scheduled to change to False in Q4 2026. Set "
         "ALLOW_URL_TO_NON_GLOBAL_ADDRESSES=False to opt in early.",
+    )
+
+
+def _warn_proxy_bypasses_ssrf_protection() -> None:
+    _warn_once(
+        "URL_IMAGE_PROXY_BYPASS",
+        "An HTTP(S) proxy is configured for URL image fetching; the proxy "
+        "resolves the destination, so non-global address blocking and DNS "
+        "rebinding pinning are NOT enforced for these requests.",
     )
 
 
@@ -208,21 +209,26 @@ class SSRFProtectedHTTPAdapter(HTTPAdapter):
         host_params = dict(host_params)
         host_params["host"] = pinned_ip
         pool_kwargs = dict(pool_kwargs)
-        pool_kwargs["assert_hostname"] = hostname
+        is_https = host_params.get("scheme") == "https"
+        if is_https:
+            # assert_hostname / server_hostname are HTTPS-only; forwarding them
+            # to a plain HTTPConnection raises TypeError at connect time.
+            pool_kwargs["assert_hostname"] = hostname
         pool = self.poolmanager.connection_from_host(
             **host_params, pool_kwargs=pool_kwargs
         )
-        # SNI must target the original hostname even though we dial the IP.
-        pool.conn_kw["server_hostname"] = hostname
+        if is_https:
+            # SNI must target the original hostname even though we dial the IP.
+            pool.conn_kw["server_hostname"] = hostname
         return pool
 
-    def get_connection_with_tls_context(
-        self, request, verify, proxies=None, cert=None
-    ):
+    def get_connection_with_tls_context(self, request, verify, proxies=None, cert=None):
         # This is the method on the send() path for requests >= 2.32 (the pinned
         # floor). With a forward proxy the proxy resolves the target, so
         # client-side pinning is moot -> defer and keep proxy/CA/mTLS intact.
         if select_proxy(request.url, proxies):
+            if not self._allow_non_global_addresses:
+                _warn_proxy_bypasses_ssrf_protection()
             return super().get_connection_with_tls_context(
                 request, verify, proxies=proxies, cert=cert
             )
@@ -241,6 +247,8 @@ class SSRFProtectedHTTPAdapter(HTTPAdapter):
         # Fallback for requests < 2.32 (below the pinned floor); kept so the
         # protection also holds if an older requests is somehow installed.
         if select_proxy(url, proxies):
+            if not self._allow_non_global_addresses:
+                _warn_proxy_bypasses_ssrf_protection()
             return super().get_connection(url, proxies)
         pin = self._resolve_pin_target(url)
         if pin is None:

--- a/inference/core/utils/url_input.py
+++ b/inference/core/utils/url_input.py
@@ -1,0 +1,291 @@
+"""SSRF-hardened primitives for fetching caller-supplied URL image input.
+
+This module owns the *network* side of URL image loading: resolving hostnames,
+rejecting non-global destinations, pinning the connection to the validated IP so
+DNS rebinding cannot swap the target after validation, and (optionally)
+re-validating every redirect hop instead of letting ``requests`` follow
+redirects blindly.
+
+The *URL-string* policy (scheme / FQDN / allow-list / block-list) stays in
+``inference.core.utils.image_utils`` and is injected here as a ``validate_redirect``
+callback so this module has no opinion about how a URL string is judged.
+
+Background: GHSA-hjmm-hr52-vrp2.
+"""
+
+import ipaddress
+import socket
+import threading
+import urllib.parse
+import warnings
+from typing import Callable, List, Optional
+
+import requests
+import urllib3.util
+from requests.adapters import HTTPAdapter
+from urllib3.connectionpool import HTTPConnectionPool, HTTPSConnectionPool
+
+from inference.core import logger
+from inference.core.utils.requests import api_key_safe_raise_for_status
+from inference.core.warnings import InferenceDeprecationWarning
+
+# ---------------------------------------------------------------------------
+# Deprecation notices (emitted once per process to avoid hot-path log spam).
+# ---------------------------------------------------------------------------
+_WARNING_LOCK = threading.Lock()
+_LEGACY_REDIRECT_WARNING_EMITTED = False
+_NON_GLOBAL_WARNING_EMITTED = False
+
+
+class URLAddressNotAllowedError(Exception):
+    """Raised when a URL resolves to a destination that is not permitted."""
+
+
+def _warn_once(flag_name: str, message: str) -> None:
+    global _LEGACY_REDIRECT_WARNING_EMITTED, _NON_GLOBAL_WARNING_EMITTED
+    with _WARNING_LOCK:
+        if flag_name == "VALIDATE_IMAGE_URL_REDIRECTS":
+            if _LEGACY_REDIRECT_WARNING_EMITTED:
+                return
+            _LEGACY_REDIRECT_WARNING_EMITTED = True
+        else:
+            if _NON_GLOBAL_WARNING_EMITTED:
+                return
+            _NON_GLOBAL_WARNING_EMITTED = True
+    warnings.warn(message, category=InferenceDeprecationWarning, stacklevel=2)
+    logger.warning(message)
+
+
+def _warn_legacy_redirect_handling() -> None:
+    _warn_once(
+        "VALIDATE_IMAGE_URL_REDIRECTS",
+        "URL image redirects are being followed without per-hop validation "
+        "(VALIDATE_IMAGE_URL_REDIRECTS=False). This is an SSRF-sensitive default "
+        "and is scheduled to change to True in Q4 2026. Set "
+        "VALIDATE_IMAGE_URL_REDIRECTS=True to opt in early.",
+    )
+
+
+def _warn_non_global_allowed() -> None:
+    _warn_once(
+        "ALLOW_URL_TO_NON_GLOBAL_ADDRESSES",
+        "URL image input is allowed to reach non-global addresses "
+        "(ALLOW_URL_TO_NON_GLOBAL_ADDRESSES=True). This is an SSRF-sensitive "
+        "default and is scheduled to change to False in Q4 2026. Set "
+        "ALLOW_URL_TO_NON_GLOBAL_ADDRESSES=False to opt in early.",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Address classification + resolution.
+# ---------------------------------------------------------------------------
+def address_is_global(address: str) -> bool:
+    """Return True only for public, routable unicast addresses.
+
+    ``ipaddress.is_global`` already excludes loopback, private (RFC1918),
+    link-local (incl. 169.254.169.254 metadata), CGNAT (100.64/10), ULA
+    (fc00::/7), unspecified and reserved ranges, so a single check covers the
+    destinations the advisory asks us to block. IPv4-mapped IPv6 is unwrapped so
+    ``::ffff:127.0.0.1`` cannot smuggle a loopback target past the check.
+    """
+    try:
+        parsed = ipaddress.ip_address(address)
+    except ValueError:
+        return False
+    if isinstance(parsed, ipaddress.IPv6Address) and parsed.ipv4_mapped is not None:
+        parsed = parsed.ipv4_mapped
+    return parsed.is_global
+
+
+def _strip_ipv6_brackets(host: str) -> str:
+    if host.startswith("[") and host.endswith("]"):
+        return host[1:-1]
+    return host
+
+
+def _host_is_ip_literal(host: str) -> bool:
+    try:
+        ipaddress.ip_address(_strip_ipv6_brackets(host))
+        return True
+    except ValueError:
+        return False
+
+
+def resolve_and_validate_ips(
+    host: str,
+    port: int,
+    allow_non_global_addresses: bool,
+) -> List[str]:
+    """Resolve ``host`` and, unless non-global is allowed, require every
+    resolved IP to be global. Returns the resolved IPs (validated ones first
+    would be identical since all must pass).
+
+    Rejecting when *any* resolved address is non-global is deliberately
+    conservative: it prevents a rebinding-style response that mixes a global and
+    a non-global A-record from later steering the pinned connection to the
+    non-global one.
+    """
+    try:
+        addr_infos = socket.getaddrinfo(
+            host, port, proto=socket.IPPROTO_TCP
+        )
+    except socket.gaierror as error:
+        # Unresolvable host is a normal connection failure, not an SSRF block.
+        raise requests.exceptions.ConnectionError(
+            f"Could not resolve host: {host}"
+        ) from error
+    resolved_ips = [info[4][0] for info in addr_infos]
+    if not resolved_ips:
+        raise requests.exceptions.ConnectionError(f"Could not resolve host: {host}")
+    if not allow_non_global_addresses:
+        for ip in resolved_ips:
+            if not address_is_global(ip):
+                raise URLAddressNotAllowedError(
+                    f"Host '{host}' resolves to non-global address '{ip}'."
+                )
+    return resolved_ips
+
+
+# ---------------------------------------------------------------------------
+# Connection pinning adapter.
+# ---------------------------------------------------------------------------
+class SSRFProtectedHTTPAdapter(HTTPAdapter):
+    """``requests`` adapter that validates + pins the destination IP.
+
+    For hostname targets it resolves once, validates, and connects the pool to
+    the resolved IP while preserving the original hostname for TLS SNI, cert
+    verification, and the ``Host`` header — so a second resolution (rebinding)
+    cannot redirect the socket. For IP-literal targets it validates the literal
+    directly and lets ``requests`` connect normally.
+
+    The adapter is mounted on every hop, so even when ``requests`` follows
+    redirects itself (legacy mode) each redirect connection is still validated.
+    """
+
+    def __init__(self, *, allow_non_global_addresses: bool, **kwargs):
+        self._allow_non_global_addresses = allow_non_global_addresses
+        super().__init__(**kwargs)
+
+    def send(self, request, **kwargs):
+        # Preserve the vhost/Host header when the pool is pinned to a raw IP.
+        parsed = urllib3.util.parse_url(request.url)
+        if parsed.host is not None and not _host_is_ip_literal(parsed.host):
+            host_header = parsed.host
+            if parsed.port is not None:
+                host_header = f"{host_header}:{parsed.port}"
+            request.headers["Host"] = host_header
+        return super().send(request, **kwargs)
+
+    def get_connection(self, url, proxies=None):
+        parsed = urllib3.util.parse_url(url)
+        host = parsed.host
+        if host is None:
+            return super().get_connection(url, proxies)
+        scheme = parsed.scheme or "https"
+        port = parsed.port or (443 if scheme == "https" else 80)
+
+        if _host_is_ip_literal(host):
+            literal = _strip_ipv6_brackets(host)
+            if not self._allow_non_global_addresses and not address_is_global(literal):
+                raise URLAddressNotAllowedError(
+                    f"URL points to non-global address '{literal}'."
+                )
+            return super().get_connection(url, proxies)
+
+        resolved_ips = resolve_and_validate_ips(
+            host=host,
+            port=port,
+            allow_non_global_addresses=self._allow_non_global_addresses,
+        )
+        pinned_ip = resolved_ips[0]
+        if scheme == "https":
+            return HTTPSConnectionPool(
+                host=pinned_ip,
+                port=port,
+                assert_hostname=host,
+                cert_reqs="CERT_REQUIRED",
+                conn_kw={"server_hostname": host},
+            )
+        return HTTPConnectionPool(host=pinned_ip, port=port)
+
+
+def _build_ssrf_protected_session(allow_non_global_addresses: bool) -> requests.Session:
+    session = requests.Session()
+    if allow_non_global_addresses:
+        _warn_non_global_allowed()
+        return session
+    adapter = SSRFProtectedHTTPAdapter(allow_non_global_addresses=False)
+    session.mount("http://", adapter)
+    session.mount("https://", adapter)
+    return session
+
+
+# ---------------------------------------------------------------------------
+# Fetch entry points.
+# ---------------------------------------------------------------------------
+def fetch_url_content_legacy(
+    *,
+    url: str,
+    allow_non_global_addresses: bool,
+    max_redirects: int,
+    request_timeout: Optional[float] = None,
+) -> bytes:
+    """Legacy fetch: ``requests`` follows redirects itself (capped at
+    ``max_redirects``). Behaviour matches the pre-hardening implementation; the
+    only additions are the explicit redirect cap and — when non-global is
+    disallowed — per-connection IP validation/pinning via the mounted adapter.
+    """
+    _warn_legacy_redirect_handling()
+    session = _build_ssrf_protected_session(allow_non_global_addresses)
+    session.max_redirects = max_redirects
+    try:
+        response = session.get(
+            url, stream=True, allow_redirects=True, timeout=request_timeout
+        )
+        api_key_safe_raise_for_status(response=response)
+        return response.content
+    finally:
+        session.close()
+
+
+def fetch_url_content_validating_redirects(
+    *,
+    url: str,
+    allow_non_global_addresses: bool,
+    max_redirects: int,
+    validate_redirect: Callable[[str], str],
+    request_timeout: Optional[float] = None,
+) -> bytes:
+    """Hardened fetch: follow redirects one hop at a time, re-running the full
+    URL-string policy (via ``validate_redirect``) on every hop before the next
+    request is issued. IP validation/pinning is applied on every hop by the
+    mounted adapter.
+    """
+    session = _build_ssrf_protected_session(allow_non_global_addresses)
+    current_url = url
+    try:
+        for _ in range(max_redirects + 1):
+            response = session.get(
+                current_url,
+                stream=True,
+                allow_redirects=False,
+                timeout=request_timeout,
+            )
+            if response.is_redirect:
+                location = response.headers.get("Location")
+                response.close()
+                if not location:
+                    raise requests.exceptions.RequestException(
+                        "Redirect response did not contain a Location header."
+                    )
+                next_url = urllib.parse.urljoin(current_url, location)
+                # Re-run scheme / FQDN / allow-list / block-list on the hop.
+                current_url = validate_redirect(next_url)
+                continue
+            api_key_safe_raise_for_status(response=response)
+            return response.content
+        raise requests.exceptions.TooManyRedirects(
+            f"Exceeded maximum of {max_redirects} redirects."
+        )
+    finally:
+        session.close()

--- a/inference/core/utils/url_input.py
+++ b/inference/core/utils/url_input.py
@@ -126,9 +126,7 @@ def resolve_and_validate_ips(
     non-global one.
     """
     try:
-        addr_infos = socket.getaddrinfo(
-            host, port, proto=socket.IPPROTO_TCP
-        )
+        addr_infos = socket.getaddrinfo(host, port, proto=socket.IPPROTO_TCP)
     except socket.gaierror as error:
         # Unresolvable host is a normal connection failure, not an SSRF block.
         raise requests.exceptions.ConnectionError(

--- a/inference/core/utils/url_input.py
+++ b/inference/core/utils/url_input.py
@@ -15,66 +15,55 @@ Background: GHSA-hjmm-hr52-vrp2.
 
 import ipaddress
 import socket
-import threading
 import urllib.parse
 import warnings
-from typing import Callable, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import requests
 import urllib3.util
 from requests.adapters import HTTPAdapter
 from requests.utils import select_proxy
+from urllib3.connectionpool import HTTPConnectionPool
 
-from inference.core import logger
 from inference.core.utils.requests import api_key_safe_raise_for_status
 from inference.core.warnings import InferenceDeprecationWarning
-
-# ---------------------------------------------------------------------------
-# Deprecation notices (emitted once per process to avoid hot-path log spam).
-# ---------------------------------------------------------------------------
-_WARNING_LOCK = threading.Lock()
-_EMITTED_WARNINGS = set()
 
 
 class URLAddressNotAllowedError(Exception):
     """Raised when a URL resolves to a destination that is not permitted."""
 
 
-def _warn_once(key: str, message: str) -> None:
-    with _WARNING_LOCK:
-        if key in _EMITTED_WARNINGS:
-            return
-        _EMITTED_WARNINGS.add(key)
-    warnings.warn(message, category=InferenceDeprecationWarning, stacklevel=2)
-    logger.warning(message)
-
-
+# `warnings.warn` deduplicates identical warnings per call site under the
+# default filter, so these do not spam the hot path.
 def _warn_legacy_redirect_handling() -> None:
-    _warn_once(
-        "VALIDATE_IMAGE_URL_REDIRECTS",
+    warnings.warn(
         "URL image redirects are being followed without per-hop validation "
         "(VALIDATE_IMAGE_URL_REDIRECTS=False). This is an SSRF-sensitive default "
         "and is scheduled to change to True in Q4 2026. Set "
         "VALIDATE_IMAGE_URL_REDIRECTS=True to opt in early.",
+        category=InferenceDeprecationWarning,
+        stacklevel=2,
     )
 
 
 def _warn_non_global_allowed() -> None:
-    _warn_once(
-        "ALLOW_URL_TO_NON_GLOBAL_ADDRESSES",
+    warnings.warn(
         "URL image input is allowed to reach non-global addresses "
         "(ALLOW_URL_TO_NON_GLOBAL_ADDRESSES=True). This is an SSRF-sensitive "
         "default and is scheduled to change to False in Q4 2026. Set "
         "ALLOW_URL_TO_NON_GLOBAL_ADDRESSES=False to opt in early.",
+        category=InferenceDeprecationWarning,
+        stacklevel=2,
     )
 
 
 def _warn_proxy_bypasses_ssrf_protection() -> None:
-    _warn_once(
-        "URL_IMAGE_PROXY_BYPASS",
+    warnings.warn(
         "An HTTP(S) proxy is configured for URL image fetching; the proxy "
         "resolves the destination, so non-global address blocking and DNS "
         "rebinding pinning are NOT enforced for these requests.",
+        category=InferenceDeprecationWarning,
+        stacklevel=2,
     )
 
 
@@ -202,7 +191,13 @@ class SSRFProtectedHTTPAdapter(HTTPAdapter):
         )
         return host, resolved_ips[0]
 
-    def _build_pinned_pool(self, host_params, pool_kwargs, hostname, pinned_ip):
+    def _build_pinned_pool(
+        self,
+        host_params: Dict[str, Any],
+        pool_kwargs: Dict[str, Any],
+        hostname: str,
+        pinned_ip: str,
+    ) -> HTTPConnectionPool:
         # Reuse requests' own host params / TLS pool kwargs (so proxies, custom
         # CA bundles and mTLS client certs are preserved), but point the pool at
         # the validated IP and verify TLS against the original hostname.
@@ -273,11 +268,7 @@ def _build_ssrf_protected_session(allow_non_global_addresses: bool) -> requests.
     return session
 
 
-# ---------------------------------------------------------------------------
-# Fetch entry points.
-# ---------------------------------------------------------------------------
 def fetch_url_content_legacy(
-    *,
     url: str,
     allow_non_global_addresses: bool,
     max_redirects: int,

--- a/inference/core/version.py
+++ b/inference/core/version.py
@@ -1,4 +1,4 @@
-__version__ = "1.3.4"
+__version__ = "1.3.5"
 
 
 if __name__ == "__main__":

--- a/inference_cli/lib/enterprise/inference_compiler/core/local_trt_install.py
+++ b/inference_cli/lib/enterprise/inference_compiler/core/local_trt_install.py
@@ -14,12 +14,14 @@ from inference_cli.lib.enterprise.inference_compiler.constants import (
     KEYPOINTS_METADATA_FILE,
     TRT_CONFIG_FILE,
 )
-from inference_cli.lib.enterprise.inference_compiler.core.entities import TRTConfig, TRTModelPackageV1
+from inference_cli.lib.enterprise.inference_compiler.core.entities import (
+    TRTConfig,
+    TRTModelPackageV1,
+)
 from inference_cli.lib.enterprise.inference_compiler.utils.file_system import (
     calculate_local_file_md5,
     dump_json,
 )
-
 from inference_models.weights_providers.local_trt_constants import (
     LOCAL_TRT_MANIFEST_FILE,
     LOCAL_TRT_PACKAGE_PREFIX,
@@ -60,7 +62,9 @@ def install_compiled_trt_package(
     )
 
     package_id = local_package_id_for_manifest(package_manifest)
-    install_dir = generate_model_package_cache_path(model_id=model_id, package_id=package_id)
+    install_dir = generate_model_package_cache_path(
+        model_id=model_id, package_id=package_id
+    )
     if os.path.isdir(install_dir):
         shutil.rmtree(install_dir, ignore_errors=True)
     os.makedirs(install_dir, exist_ok=True)

--- a/inference_sdk/config.py
+++ b/inference_sdk/config.py
@@ -128,6 +128,42 @@ remote_processing_times = contextvars.ContextVar(
 WORKFLOW_RUN_RETRIES_ENABLED = str2bool(
     os.getenv("WORKFLOW_RUN_RETRIES_ENABLED", "True")
 )
+
+# --- URL image input hardening (mirrors inference server, GHSA-hjmm-hr52-vrp2) ---
+# NOTE on defaults: the server defaults ALLOW_NON_HTTPS_URL_INPUT / FQDN
+# enforcement to the restrictive side. The SDK historically applied NO URL
+# validation, so to avoid a hard breaking change these *newly introduced*
+# restrictions default to permissive here. The SSRF-specific flags
+# (VALIDATE_IMAGE_URL_REDIRECTS / ALLOW_URL_TO_NON_GLOBAL_ADDRESSES) follow the
+# same deprecation schedule as the server.
+ALLOW_URL_INPUT = str2bool(os.getenv("ALLOW_URL_INPUT", "True"))
+ALLOW_NON_HTTPS_URL_INPUT = str2bool(os.getenv("ALLOW_NON_HTTPS_URL_INPUT", "True"))
+ALLOW_URL_INPUT_WITHOUT_FQDN = str2bool(
+    os.getenv("ALLOW_URL_INPUT_WITHOUT_FQDN", "True")
+)
+WHITELISTED_DESTINATIONS_FOR_URL_INPUT = os.getenv(
+    "WHITELISTED_DESTINATIONS_FOR_URL_INPUT"
+)
+if WHITELISTED_DESTINATIONS_FOR_URL_INPUT is not None:
+    WHITELISTED_DESTINATIONS_FOR_URL_INPUT = set(
+        WHITELISTED_DESTINATIONS_FOR_URL_INPUT.split(",")
+    )
+BLACKLISTED_DESTINATIONS_FOR_URL_INPUT = os.getenv(
+    "BLACKLISTED_DESTINATIONS_FOR_URL_INPUT"
+)
+if BLACKLISTED_DESTINATIONS_FOR_URL_INPUT is not None:
+    BLACKLISTED_DESTINATIONS_FOR_URL_INPUT = set(
+        BLACKLISTED_DESTINATIONS_FOR_URL_INPUT.split(",")
+    )
+# Scheduled to flip to True in Q4 2026 (per-hop redirect validation).
+VALIDATE_IMAGE_URL_REDIRECTS = str2bool(
+    os.getenv("VALIDATE_IMAGE_URL_REDIRECTS", "False")
+)
+MAX_IMAGE_URL_REDIRECTS = int(os.getenv("MAX_IMAGE_URL_REDIRECTS", "30"))
+# Scheduled to flip to False in Q4 2026 (block non-global destinations).
+ALLOW_URL_TO_NON_GLOBAL_ADDRESSES = str2bool(
+    os.getenv("ALLOW_URL_TO_NON_GLOBAL_ADDRESSES", "True")
+)
 EXECUTION_ID_HEADER = os.getenv("EXECUTION_ID_HEADER", "execution_id")
 PROCESSING_TIME_HEADER = os.getenv("PROCESSING_TIME_HEADER", "X-Processing-Time")
 INTERNAL_REMOTE_EXEC_REQ_HEADER = "X-Internal-Remote-Exec-Req"

--- a/inference_sdk/http/errors.py
+++ b/inference_sdk/http/errors.py
@@ -168,3 +168,11 @@ class RetryError(Exception):
 
     def __str__(self) -> str:
         return self.__repr__()
+
+
+class InvalidURLImageInput(HTTPClientError):
+    """Raised when a URL image reference fails the SDK URL-string policy."""
+
+
+class URLAddressNotAllowedError(HTTPClientError):
+    """Raised when a URL resolves to a destination that is not permitted."""

--- a/inference_sdk/http/utils/loaders.py
+++ b/inference_sdk/http/utils/loaders.py
@@ -21,6 +21,10 @@ from inference_sdk.http.utils.pre_processing import (
     resize_opencv_image,
     resize_pillow_image,
 )
+from inference_sdk.http.utils.url_utils import (
+    fetch_url_bytes,
+    fetch_url_bytes_async,
+)
 
 
 def load_stream_inference_input(
@@ -307,11 +311,10 @@ def load_image_from_url(
     Returns:
         The image and the scaling factor.
     """
-    response = requests.get(url)
-    response.raise_for_status()
+    content = fetch_url_bytes(url)
     if max_height is None or max_width is None:
-        return encode_base_64(response.content), None
-    image = bytes_to_opencv_image(payload=response.content)
+        return encode_base_64(content), None
+    image = bytes_to_opencv_image(payload=content)
     resized_image, scaling_factor = resize_opencv_image(
         image=image,
         max_height=max_height,
@@ -336,10 +339,7 @@ async def load_image_from_url_async(
     Returns:
         The image and the scaling factor.
     """
-    async with aiohttp.ClientSession() as session:
-        async with session.get(url) as response:
-            response.raise_for_status()
-            response_payload = await response.read()
+    response_payload = await fetch_url_bytes_async(url)
     if max_height is None or max_width is None:
         return encode_base_64(response_payload), None
     image = bytes_to_opencv_image(payload=response_payload)

--- a/inference_sdk/http/utils/loaders.py
+++ b/inference_sdk/http/utils/loaders.py
@@ -21,10 +21,7 @@ from inference_sdk.http.utils.pre_processing import (
     resize_opencv_image,
     resize_pillow_image,
 )
-from inference_sdk.http.utils.url_utils import (
-    fetch_url_bytes,
-    fetch_url_bytes_async,
-)
+from inference_sdk.http.utils.url_utils import fetch_url_bytes, fetch_url_bytes_async
 
 
 def load_stream_inference_input(

--- a/inference_sdk/http/utils/url_utils.py
+++ b/inference_sdk/http/utils/url_utils.py
@@ -146,9 +146,7 @@ def validate_url_destination(value: str) -> str:
 
     scheme = parsed.scheme
     if scheme != "https" and not config.ALLOW_NON_HTTPS_URL_INPUT:
-        raise InvalidURLImageInput(
-            "Providing images via non-https URL is not enabled."
-        )
+        raise InvalidURLImageInput("Providing images via non-https URL is not enabled.")
     hostname = parsed.hostname or ""
     if not hostname and not config.ALLOW_URL_INPUT_WITHOUT_FQDN:
         raise InvalidURLImageInput(

--- a/inference_sdk/http/utils/url_utils.py
+++ b/inference_sdk/http/utils/url_utils.py
@@ -23,7 +23,7 @@ import socket
 import threading
 import urllib.parse
 import warnings
-from typing import List, Optional, Set
+from typing import List, Optional, Set, Tuple
 
 import aiohttp
 import requests
@@ -33,6 +33,7 @@ from aiohttp import ClientResponseError
 from aiohttp.abc import AbstractResolver
 from requests import HTTPError
 from requests.adapters import HTTPAdapter
+from requests.utils import select_proxy
 from tldextract.tldextract import ExtractResult
 from urllib3.connectionpool import HTTPConnectionPool, HTTPSConnectionPool
 
@@ -216,11 +217,15 @@ class SSRFProtectedHTTPAdapter(HTTPAdapter):
             request.headers["Host"] = host_header
         return super().send(request, **kwargs)
 
-    def get_connection(self, url, proxies=None):
+    def _resolve_pin_target(self, url: str) -> Optional[Tuple[str, str]]:
+        """Return ``(hostname, pinned_ip)`` to pin, or ``None`` to connect
+        normally. Raises :class:`URLAddressNotAllowedError` on a blocked
+        non-global destination.
+        """
         parsed = urllib3.util.parse_url(url)
         host = parsed.host
         if host is None:
-            return super().get_connection(url, proxies)
+            return None
         scheme = parsed.scheme or "https"
         port = parsed.port or (443 if scheme == "https" else 80)
         if _host_is_ip_literal(host):
@@ -229,21 +234,62 @@ class SSRFProtectedHTTPAdapter(HTTPAdapter):
                 raise URLAddressNotAllowedError(
                     f"URL points to non-global address '{literal}'."
                 )
-            return super().get_connection(url, proxies)
-        pinned_ip = resolve_and_validate_ips(
+            return None
+        resolved_ips = resolve_and_validate_ips(
             host=host,
             port=port,
             allow_non_global_addresses=self._allow_non_global_addresses,
-        )[0]
-        if scheme == "https":
-            return HTTPSConnectionPool(
-                host=pinned_ip,
-                port=port,
-                assert_hostname=host,
-                cert_reqs="CERT_REQUIRED",
-                conn_kw={"server_hostname": host},
+        )
+        return host, resolved_ips[0]
+
+    def _build_pinned_pool(self, host_params, pool_kwargs, hostname, pinned_ip):
+        # Reuse requests' own host params / TLS pool kwargs (preserving proxies,
+        # custom CA bundles and mTLS client certs), but dial the validated IP and
+        # verify TLS against the original hostname.
+        host_params = dict(host_params)
+        host_params["host"] = pinned_ip
+        pool_kwargs = dict(pool_kwargs)
+        pool_kwargs["assert_hostname"] = hostname
+        pool = self.poolmanager.connection_from_host(
+            **host_params, pool_kwargs=pool_kwargs
+        )
+        pool.conn_kw["server_hostname"] = hostname
+        return pool
+
+    def get_connection_with_tls_context(
+        self, request, verify, proxies=None, cert=None
+    ):
+        # send() path for requests >= 2.32 (the pinned floor). Defer under a
+        # forward proxy (the proxy resolves the target, so pinning is moot).
+        if select_proxy(request.url, proxies):
+            return super().get_connection_with_tls_context(
+                request, verify, proxies=proxies, cert=cert
             )
-        return HTTPConnectionPool(host=pinned_ip, port=port)
+        pin = self._resolve_pin_target(request.url)
+        if pin is None:
+            return super().get_connection_with_tls_context(
+                request, verify, proxies=proxies, cert=cert
+            )
+        hostname, pinned_ip = pin
+        host_params, pool_kwargs = self.build_connection_pool_key_attributes(
+            request, verify, cert
+        )
+        return self._build_pinned_pool(host_params, pool_kwargs, hostname, pinned_ip)
+
+    def get_connection(self, url, proxies=None):
+        # Fallback for requests < 2.32 (below the pinned floor).
+        if select_proxy(url, proxies):
+            return super().get_connection(url, proxies)
+        pin = self._resolve_pin_target(url)
+        if pin is None:
+            return super().get_connection(url, proxies)
+        hostname, pinned_ip = pin
+        parsed = urllib3.util.parse_url(url)
+        scheme = parsed.scheme or "https"
+        port = parsed.port or (443 if scheme == "https" else 80)
+        host_params = {"scheme": scheme, "host": pinned_ip, "port": port}
+        pool_kwargs = {"cert_reqs": "CERT_REQUIRED"} if scheme == "https" else {}
+        return self._build_pinned_pool(host_params, pool_kwargs, hostname, pinned_ip)
 
 
 def _build_sync_session(allow_non_global_addresses: bool) -> requests.Session:

--- a/inference_sdk/http/utils/url_utils.py
+++ b/inference_sdk/http/utils/url_utils.py
@@ -12,11 +12,12 @@ Covers both the sync (``requests``) and async (``aiohttp``) code paths:
 * Redirect handling: either legacy (client follows redirects, capped) or
   hardened (follow one hop at a time, re-validating each hop URL).
 
-FQDN handling here is hostname-based (no ``tldextract`` dependency in the SDK).
-The allow/block lists are compared against the parsed hostname.
+FQDN handling mirrors the inference server exactly: ``tldextract`` derives the
+FQDN (empty for IPs and hosts without a public suffix) for the
+``ALLOW_URL_INPUT_WITHOUT_FQDN`` gate, and the allow/block lists are matched
+against the concatenated ``subdomain.domain.suffix`` network location.
 """
 
-import asyncio
 import ipaddress
 import socket
 import threading
@@ -26,14 +27,21 @@ from typing import List, Optional, Set
 
 import aiohttp
 import requests
+import tldextract
 import urllib3.util
+from aiohttp import ClientResponseError
 from aiohttp.abc import AbstractResolver
+from requests import HTTPError
 from requests.adapters import HTTPAdapter
+from tldextract.tldextract import ExtractResult
 from urllib3.connectionpool import HTTPConnectionPool, HTTPSConnectionPool
 
 from inference_sdk import config
 from inference_sdk.http.errors import HTTPClientError
-from inference_sdk.http.utils.requests import api_key_safe_raise_for_status
+from inference_sdk.http.utils.requests import (
+    api_key_safe_raise_for_status,
+    deduct_api_key_from_string,
+)
 
 _WARNING_LOCK = threading.Lock()
 _LEGACY_REDIRECT_WARNING_EMITTED = False
@@ -144,26 +152,48 @@ def validate_url_destination(value: str) -> str:
     except (requests.exceptions.RequestException, ValueError) as error:
         raise InvalidURLImageInput("Provided image URL is invalid.") from error
 
-    scheme = parsed.scheme
-    if scheme != "https" and not config.ALLOW_NON_HTTPS_URL_INPUT:
+    if parsed.scheme != "https" and not config.ALLOW_NON_HTTPS_URL_INPUT:
         raise InvalidURLImageInput("Providing images via non-https URL is not enabled.")
-    hostname = parsed.hostname or ""
-    if not hostname and not config.ALLOW_URL_INPUT_WITHOUT_FQDN:
+
+    network_location = parsed.hostname or ""
+    if ":" in network_location:
+        network_location = f"[{network_location}]"
+    domain_extraction_result = tldextract.TLDExtract(suffix_list_urls=())(
+        network_location
+    )  # strip ports and parse FQDNs (mirrors the inference server)
+    if not domain_extraction_result.fqdn and not config.ALLOW_URL_INPUT_WITHOUT_FQDN:
         raise InvalidURLImageInput(
-            "Providing images via URL without a hostname is not enabled."
+            "Providing images via URL without FQDN is not enabled."
         )
-    _ensure_not_blocked_by_lists(hostname=hostname)
+    destination = _concatenate_chunks_of_network_location(
+        extraction_result=domain_extraction_result
+    )  # even if there is no FQDN but an address, this allows allow/block matching
+    _ensure_not_blocked_by_lists(destination=destination)
     return prepared_url
 
 
-def _ensure_not_blocked_by_lists(hostname: str) -> None:
+def _concatenate_chunks_of_network_location(extraction_result: ExtractResult) -> str:
+    chunks = [
+        extraction_result.subdomain,
+        extraction_result.domain,
+        extraction_result.suffix,
+    ]
+    non_empty_chunks = [chunk for chunk in chunks if chunk]
+    result = ".".join(non_empty_chunks)
+    if result.startswith("[") and result.endswith("]"):
+        # dropping brackets for IPv6
+        return result[1:-1]
+    return result
+
+
+def _ensure_not_blocked_by_lists(destination: str) -> None:
     whitelist: Optional[Set[str]] = config.WHITELISTED_DESTINATIONS_FOR_URL_INPUT
     blacklist: Optional[Set[str]] = config.BLACKLISTED_DESTINATIONS_FOR_URL_INPUT
-    if whitelist is not None and hostname not in whitelist:
+    if whitelist is not None and destination not in whitelist:
         raise InvalidURLImageInput(
             "URL destination is not on the allow-list (whitelisted)."
         )
-    if blacklist is not None and hostname in blacklist:
+    if blacklist is not None and destination in blacklist:
         raise InvalidURLImageInput(
             "URL destination is on the block-list (blacklisted)."
         )
@@ -242,8 +272,19 @@ def fetch_url_bytes(url: str, request_timeout: Optional[float] = None) -> bytes:
         return _fetch_legacy_sync(
             session=session, url=prepared_url, request_timeout=request_timeout
         )
-    except requests.exceptions.TooManyRedirects as error:
-        raise HTTPClientError(f"Too many redirects while loading URL image: {error}")
+    except HTTPError:
+        # HTTP-status errors keep flowing so wrap_errors maps them to
+        # HTTPCallErrorError (status code + api message preserved).
+        raise
+    except HTTPClientError:
+        # Our own validation / SSRF / redirect errors are already the right type.
+        raise
+    except requests.exceptions.RequestException as error:
+        # ConnectionError, TooManyRedirects, Timeout, ... -> uniform SDK error.
+        raise HTTPClientError(
+            f"Could not load image from URL. Details: "
+            f"{deduct_api_key_from_string(str(error))}"
+        ) from error
     finally:
         session.close()
 
@@ -332,23 +373,34 @@ async def fetch_url_bytes_async(
         else aiohttp.ClientTimeout()
     )
     async with aiohttp.ClientSession(connector=connector, timeout=timeout) as session:
-        if config.VALIDATE_IMAGE_URL_REDIRECTS:
-            return await _fetch_validating_redirects_async(
-                session=session, url=prepared_url
-            )
-        return await _fetch_legacy_async(session=session, url=prepared_url)
+        try:
+            if config.VALIDATE_IMAGE_URL_REDIRECTS:
+                return await _fetch_validating_redirects_async(
+                    session=session, url=prepared_url
+                )
+            return await _fetch_legacy_async(session=session, url=prepared_url)
+        except ClientResponseError:
+            # HTTP-status errors keep flowing so wrap_errors_async maps them to
+            # HTTPCallErrorError (status code + api message preserved).
+            raise
+        except HTTPClientError:
+            # Our own validation / SSRF / redirect errors are already correct.
+            raise
+        except aiohttp.ClientError as error:
+            # TooManyRedirects, connection errors, ... -> uniform SDK error.
+            raise HTTPClientError(
+                f"Could not load image from URL. Details: "
+                f"{deduct_api_key_from_string(str(error))}"
+            ) from error
 
 
 async def _fetch_legacy_async(session: aiohttp.ClientSession, url: str) -> bytes:
     _warn_legacy_redirect_handling()
-    try:
-        async with session.get(
-            url, allow_redirects=True, max_redirects=config.MAX_IMAGE_URL_REDIRECTS
-        ) as response:
-            response.raise_for_status()
-            return await response.read()
-    except aiohttp.TooManyRedirects as error:
-        raise HTTPClientError(f"Too many redirects while loading URL image: {error}")
+    async with session.get(
+        url, allow_redirects=True, max_redirects=config.MAX_IMAGE_URL_REDIRECTS
+    ) as response:
+        response.raise_for_status()
+        return await response.read()
 
 
 async def _fetch_validating_redirects_async(

--- a/inference_sdk/http/utils/url_utils.py
+++ b/inference_sdk/http/utils/url_utils.py
@@ -22,7 +22,7 @@ import ipaddress
 import socket
 import urllib.parse
 import warnings
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Any, Dict, List, Mapping, Optional, Set, Tuple, Union
 
 import aiohttp
 import requests
@@ -32,23 +32,18 @@ from aiohttp import ClientResponseError
 from aiohttp.abc import AbstractResolver
 from requests import HTTPError
 from requests.adapters import HTTPAdapter
+from requests.models import PreparedRequest
 from requests.utils import select_proxy
 from tldextract.tldextract import ExtractResult
 from urllib3.connectionpool import HTTPConnectionPool
 
 from inference_sdk import config
-from inference_sdk.http.errors import HTTPClientError
+from inference_sdk.config import InferenceSDKDeprecationWarning
+from inference_sdk.http.errors import HTTPClientError, InvalidURLImageInput, URLAddressNotAllowedError
 from inference_sdk.http.utils.requests import (
     api_key_safe_raise_for_status,
     deduct_api_key_from_string,
 )
-
-class InvalidURLImageInput(HTTPClientError):
-    """Raised when a URL image reference fails the SDK URL-string policy."""
-
-
-class URLAddressNotAllowedError(HTTPClientError):
-    """Raised when a URL resolves to a destination that is not permitted."""
 
 
 # `warnings.warn` deduplicates identical warnings per call site under the
@@ -58,7 +53,7 @@ def _warn_legacy_redirect_handling() -> None:
         "URL image redirects are followed without per-hop validation "
         "(VALIDATE_IMAGE_URL_REDIRECTS=False). This default is scheduled to "
         "change to True in Q4 2026.",
-        category=DeprecationWarning,
+        category=InferenceSDKDeprecationWarning,
         stacklevel=2,
     )
 
@@ -68,7 +63,7 @@ def _warn_non_global_allowed() -> None:
         "URL image input is allowed to reach non-global addresses "
         "(ALLOW_URL_TO_NON_GLOBAL_ADDRESSES=True). This default is scheduled to "
         "change to False in Q4 2026.",
-        category=DeprecationWarning,
+        category=InferenceSDKDeprecationWarning,
         stacklevel=2,
     )
 
@@ -200,11 +195,11 @@ def _ensure_not_blocked_by_lists(destination: str) -> None:
 # Sync path (requests) — pinning adapter, mirrors the server.
 # ---------------------------------------------------------------------------
 class SSRFProtectedHTTPAdapter(HTTPAdapter):
-    def __init__(self, *, allow_non_global_addresses: bool, **kwargs):
+    def __init__(self, *, allow_non_global_addresses: bool, **kwargs: Any) -> None:
         self._allow_non_global_addresses = allow_non_global_addresses
         super().__init__(**kwargs)
 
-    def send(self, request, **kwargs):
+    def send(self, request: PreparedRequest, **kwargs: Any) -> requests.Response:
         parsed = urllib3.util.parse_url(request.url)
         if parsed.host is not None and not _host_is_ip_literal(parsed.host):
             host_header = parsed.host
@@ -263,7 +258,13 @@ class SSRFProtectedHTTPAdapter(HTTPAdapter):
             pool.conn_kw["server_hostname"] = hostname
         return pool
 
-    def get_connection_with_tls_context(self, request, verify, proxies=None, cert=None):
+    def get_connection_with_tls_context(
+        self,
+        request: PreparedRequest,
+        verify: Union[bool, str],
+        proxies: Optional[Mapping[str, str]] = None,
+        cert: Optional[Union[str, Tuple[str, str]]] = None,
+    ) -> HTTPConnectionPool:
         # send() path for requests >= 2.32 (the pinned floor). Defer under a
         # forward proxy (the proxy resolves the target, so pinning is moot).
         if select_proxy(request.url, proxies):
@@ -283,7 +284,9 @@ class SSRFProtectedHTTPAdapter(HTTPAdapter):
         )
         return self._build_pinned_pool(host_params, pool_kwargs, hostname, pinned_ip)
 
-    def get_connection(self, url, proxies=None):
+    def get_connection(
+        self, url: str, proxies: Optional[Mapping[str, str]] = None
+    ) -> HTTPConnectionPool:
         # Fallback for requests < 2.32 (below the pinned floor).
         if select_proxy(url, proxies):
             if not self._allow_non_global_addresses:
@@ -388,11 +391,13 @@ class ValidatingResolver(AbstractResolver):
     validates and pins the connection to a checked IP on every hop.
     """
 
-    def __init__(self, allow_non_global_addresses: bool):
+    def __init__(self, allow_non_global_addresses: bool) -> None:
         self._allow_non_global_addresses = allow_non_global_addresses
         self._delegate = aiohttp.ThreadedResolver()
 
-    async def resolve(self, host: str, port: int = 0, family: int = socket.AF_INET):
+    async def resolve(
+        self, host: str, port: int = 0, family: int = socket.AF_INET
+    ) -> List[Dict[str, Any]]:
         hosts = await self._delegate.resolve(host, port, family)
         if self._allow_non_global_addresses:
             return hosts

--- a/inference_sdk/http/utils/url_utils.py
+++ b/inference_sdk/http/utils/url_utils.py
@@ -1,0 +1,373 @@
+"""SSRF-hardened URL image fetching for the inference SDK.
+
+Mirrors the protections in ``inference.core.utils.url_input`` / ``image_utils``
+but is self-contained (the SDK must not import from the ``inference`` package).
+
+Covers both the sync (``requests``) and async (``aiohttp``) code paths:
+
+* URL-string policy: scheme / FQDN / allow-list / block-list.
+* Non-global destination blocking with connection pinning (sync: a pinning
+  adapter; async: a validating resolver), so DNS rebinding cannot swap the
+  target after validation.
+* Redirect handling: either legacy (client follows redirects, capped) or
+  hardened (follow one hop at a time, re-validating each hop URL).
+
+FQDN handling here is hostname-based (no ``tldextract`` dependency in the SDK).
+The allow/block lists are compared against the parsed hostname.
+"""
+
+import asyncio
+import ipaddress
+import socket
+import threading
+import urllib.parse
+import warnings
+from typing import List, Optional, Set
+
+import aiohttp
+import requests
+import urllib3.util
+from aiohttp.abc import AbstractResolver
+from requests.adapters import HTTPAdapter
+from urllib3.connectionpool import HTTPConnectionPool, HTTPSConnectionPool
+
+from inference_sdk import config
+from inference_sdk.http.errors import HTTPClientError
+from inference_sdk.http.utils.requests import api_key_safe_raise_for_status
+
+_WARNING_LOCK = threading.Lock()
+_LEGACY_REDIRECT_WARNING_EMITTED = False
+_NON_GLOBAL_WARNING_EMITTED = False
+
+
+class InvalidURLImageInput(HTTPClientError):
+    """Raised when a URL image reference fails the SDK URL-string policy."""
+
+
+class URLAddressNotAllowedError(HTTPClientError):
+    """Raised when a URL resolves to a destination that is not permitted."""
+
+
+def _warn_legacy_redirect_handling() -> None:
+    global _LEGACY_REDIRECT_WARNING_EMITTED
+    with _WARNING_LOCK:
+        if _LEGACY_REDIRECT_WARNING_EMITTED:
+            return
+        _LEGACY_REDIRECT_WARNING_EMITTED = True
+    warnings.warn(
+        "URL image redirects are followed without per-hop validation "
+        "(VALIDATE_IMAGE_URL_REDIRECTS=False). This default is scheduled to "
+        "change to True in Q4 2026.",
+        category=DeprecationWarning,
+        stacklevel=2,
+    )
+
+
+def _warn_non_global_allowed() -> None:
+    global _NON_GLOBAL_WARNING_EMITTED
+    with _WARNING_LOCK:
+        if _NON_GLOBAL_WARNING_EMITTED:
+            return
+        _NON_GLOBAL_WARNING_EMITTED = True
+    warnings.warn(
+        "URL image input is allowed to reach non-global addresses "
+        "(ALLOW_URL_TO_NON_GLOBAL_ADDRESSES=True). This default is scheduled to "
+        "change to False in Q4 2026.",
+        category=DeprecationWarning,
+        stacklevel=2,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Address classification.
+# ---------------------------------------------------------------------------
+def address_is_global(address: str) -> bool:
+    try:
+        parsed = ipaddress.ip_address(address)
+    except ValueError:
+        return False
+    if isinstance(parsed, ipaddress.IPv6Address) and parsed.ipv4_mapped is not None:
+        parsed = parsed.ipv4_mapped
+    return parsed.is_global
+
+
+def _strip_ipv6_brackets(host: str) -> str:
+    if host.startswith("[") and host.endswith("]"):
+        return host[1:-1]
+    return host
+
+
+def _host_is_ip_literal(host: str) -> bool:
+    try:
+        ipaddress.ip_address(_strip_ipv6_brackets(host))
+        return True
+    except ValueError:
+        return False
+
+
+def resolve_and_validate_ips(
+    host: str, port: int, allow_non_global_addresses: bool
+) -> List[str]:
+    try:
+        addr_infos = socket.getaddrinfo(host, port, proto=socket.IPPROTO_TCP)
+    except socket.gaierror as error:
+        raise requests.exceptions.ConnectionError(
+            f"Could not resolve host: {host}"
+        ) from error
+    resolved_ips = [info[4][0] for info in addr_infos]
+    if not resolved_ips:
+        raise requests.exceptions.ConnectionError(f"Could not resolve host: {host}")
+    if not allow_non_global_addresses:
+        for ip in resolved_ips:
+            if not address_is_global(ip):
+                raise URLAddressNotAllowedError(
+                    f"Host '{host}' resolves to non-global address '{ip}'."
+                )
+    return resolved_ips
+
+
+# ---------------------------------------------------------------------------
+# URL-string policy (scheme / FQDN / allow-list / block-list).
+# ---------------------------------------------------------------------------
+def validate_url_destination(value: str) -> str:
+    """Validate the URL string against the SDK policy and return the prepared
+    URL. Raises :class:`InvalidURLImageInput` on rejection.
+    """
+    if not config.ALLOW_URL_INPUT:
+        raise InvalidURLImageInput("Providing images via URL is not enabled.")
+    try:
+        original_parsed = urllib.parse.urlparse(value)
+        if "\\" in original_parsed.netloc:
+            raise ValueError("URL authority contains a backslash")
+        prepared_url = requests.Request(method="GET", url=value).prepare().url
+        parsed = urllib.parse.urlparse(prepared_url)
+    except (requests.exceptions.RequestException, ValueError) as error:
+        raise InvalidURLImageInput("Provided image URL is invalid.") from error
+
+    scheme = parsed.scheme
+    if scheme != "https" and not config.ALLOW_NON_HTTPS_URL_INPUT:
+        raise InvalidURLImageInput(
+            "Providing images via non-https URL is not enabled."
+        )
+    hostname = parsed.hostname or ""
+    if not hostname and not config.ALLOW_URL_INPUT_WITHOUT_FQDN:
+        raise InvalidURLImageInput(
+            "Providing images via URL without a hostname is not enabled."
+        )
+    _ensure_not_blocked_by_lists(hostname=hostname)
+    return prepared_url
+
+
+def _ensure_not_blocked_by_lists(hostname: str) -> None:
+    whitelist: Optional[Set[str]] = config.WHITELISTED_DESTINATIONS_FOR_URL_INPUT
+    blacklist: Optional[Set[str]] = config.BLACKLISTED_DESTINATIONS_FOR_URL_INPUT
+    if whitelist is not None and hostname not in whitelist:
+        raise InvalidURLImageInput(
+            "URL destination is not on the allow-list (whitelisted)."
+        )
+    if blacklist is not None and hostname in blacklist:
+        raise InvalidURLImageInput(
+            "URL destination is on the block-list (blacklisted)."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Sync path (requests) — pinning adapter, mirrors the server.
+# ---------------------------------------------------------------------------
+class SSRFProtectedHTTPAdapter(HTTPAdapter):
+    def __init__(self, *, allow_non_global_addresses: bool, **kwargs):
+        self._allow_non_global_addresses = allow_non_global_addresses
+        super().__init__(**kwargs)
+
+    def send(self, request, **kwargs):
+        parsed = urllib3.util.parse_url(request.url)
+        if parsed.host is not None and not _host_is_ip_literal(parsed.host):
+            host_header = parsed.host
+            if parsed.port is not None:
+                host_header = f"{host_header}:{parsed.port}"
+            request.headers["Host"] = host_header
+        return super().send(request, **kwargs)
+
+    def get_connection(self, url, proxies=None):
+        parsed = urllib3.util.parse_url(url)
+        host = parsed.host
+        if host is None:
+            return super().get_connection(url, proxies)
+        scheme = parsed.scheme or "https"
+        port = parsed.port or (443 if scheme == "https" else 80)
+        if _host_is_ip_literal(host):
+            literal = _strip_ipv6_brackets(host)
+            if not self._allow_non_global_addresses and not address_is_global(literal):
+                raise URLAddressNotAllowedError(
+                    f"URL points to non-global address '{literal}'."
+                )
+            return super().get_connection(url, proxies)
+        pinned_ip = resolve_and_validate_ips(
+            host=host,
+            port=port,
+            allow_non_global_addresses=self._allow_non_global_addresses,
+        )[0]
+        if scheme == "https":
+            return HTTPSConnectionPool(
+                host=pinned_ip,
+                port=port,
+                assert_hostname=host,
+                cert_reqs="CERT_REQUIRED",
+                conn_kw={"server_hostname": host},
+            )
+        return HTTPConnectionPool(host=pinned_ip, port=port)
+
+
+def _build_sync_session(allow_non_global_addresses: bool) -> requests.Session:
+    session = requests.Session()
+    if allow_non_global_addresses:
+        _warn_non_global_allowed()
+        return session
+    adapter = SSRFProtectedHTTPAdapter(allow_non_global_addresses=False)
+    session.mount("http://", adapter)
+    session.mount("https://", adapter)
+    return session
+
+
+def fetch_url_bytes(url: str, request_timeout: Optional[float] = None) -> bytes:
+    """Validate ``url`` and fetch its bytes with SSRF protections applied,
+    honouring the SDK config flags. This is the sync entry point used by the
+    loaders.
+    """
+    prepared_url = validate_url_destination(url)
+    session = _build_sync_session(config.ALLOW_URL_TO_NON_GLOBAL_ADDRESSES)
+    try:
+        if config.VALIDATE_IMAGE_URL_REDIRECTS:
+            return _fetch_validating_redirects_sync(
+                session=session, url=prepared_url, request_timeout=request_timeout
+            )
+        return _fetch_legacy_sync(
+            session=session, url=prepared_url, request_timeout=request_timeout
+        )
+    except requests.exceptions.TooManyRedirects as error:
+        raise HTTPClientError(f"Too many redirects while loading URL image: {error}")
+    finally:
+        session.close()
+
+
+def _fetch_legacy_sync(
+    session: requests.Session, url: str, request_timeout: Optional[float]
+) -> bytes:
+    _warn_legacy_redirect_handling()
+    session.max_redirects = config.MAX_IMAGE_URL_REDIRECTS
+    response = session.get(
+        url, stream=True, allow_redirects=True, timeout=request_timeout
+    )
+    api_key_safe_raise_for_status(response=response)
+    return response.content
+
+
+def _fetch_validating_redirects_sync(
+    session: requests.Session, url: str, request_timeout: Optional[float]
+) -> bytes:
+    current_url = url
+    for _ in range(config.MAX_IMAGE_URL_REDIRECTS + 1):
+        response = session.get(
+            current_url, stream=True, allow_redirects=False, timeout=request_timeout
+        )
+        if response.is_redirect:
+            location = response.headers.get("Location")
+            response.close()
+            if not location:
+                raise HTTPClientError("Redirect response missing Location header.")
+            next_url = urllib.parse.urljoin(current_url, location)
+            current_url = validate_url_destination(next_url)
+            continue
+        api_key_safe_raise_for_status(response=response)
+        return response.content
+    raise requests.exceptions.TooManyRedirects(
+        f"Exceeded maximum of {config.MAX_IMAGE_URL_REDIRECTS} redirects."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Async path (aiohttp) — validating resolver + optional manual redirect loop.
+# ---------------------------------------------------------------------------
+class ValidatingResolver(AbstractResolver):
+    """aiohttp resolver that rejects non-global resolved addresses. Because
+    aiohttp connects to the addresses the resolver returns, filtering here both
+    validates and pins the connection to a checked IP on every hop.
+    """
+
+    def __init__(self, allow_non_global_addresses: bool):
+        self._allow_non_global_addresses = allow_non_global_addresses
+        self._delegate = aiohttp.ThreadedResolver()
+
+    async def resolve(self, host: str, port: int = 0, family: int = socket.AF_INET):
+        hosts = await self._delegate.resolve(host, port, family)
+        if self._allow_non_global_addresses:
+            return hosts
+        for entry in hosts:
+            if not address_is_global(entry["host"]):
+                raise URLAddressNotAllowedError(
+                    f"Host '{host}' resolves to non-global address '{entry['host']}'."
+                )
+        return hosts
+
+    async def close(self) -> None:
+        await self._delegate.close()
+
+
+def _build_async_connector(allow_non_global_addresses: bool) -> aiohttp.TCPConnector:
+    if allow_non_global_addresses:
+        _warn_non_global_allowed()
+        return aiohttp.TCPConnector()
+    return aiohttp.TCPConnector(
+        resolver=ValidatingResolver(allow_non_global_addresses=False)
+    )
+
+
+async def fetch_url_bytes_async(
+    url: str, request_timeout: Optional[float] = None
+) -> bytes:
+    """Async counterpart of :func:`fetch_url_bytes`."""
+    prepared_url = validate_url_destination(url)
+    connector = _build_async_connector(config.ALLOW_URL_TO_NON_GLOBAL_ADDRESSES)
+    timeout = (
+        aiohttp.ClientTimeout(total=request_timeout)
+        if request_timeout is not None
+        else aiohttp.ClientTimeout()
+    )
+    async with aiohttp.ClientSession(connector=connector, timeout=timeout) as session:
+        if config.VALIDATE_IMAGE_URL_REDIRECTS:
+            return await _fetch_validating_redirects_async(
+                session=session, url=prepared_url
+            )
+        return await _fetch_legacy_async(session=session, url=prepared_url)
+
+
+async def _fetch_legacy_async(session: aiohttp.ClientSession, url: str) -> bytes:
+    _warn_legacy_redirect_handling()
+    try:
+        async with session.get(
+            url, allow_redirects=True, max_redirects=config.MAX_IMAGE_URL_REDIRECTS
+        ) as response:
+            response.raise_for_status()
+            return await response.read()
+    except aiohttp.TooManyRedirects as error:
+        raise HTTPClientError(f"Too many redirects while loading URL image: {error}")
+
+
+async def _fetch_validating_redirects_async(
+    session: aiohttp.ClientSession, url: str
+) -> bytes:
+    current_url = url
+    for _ in range(config.MAX_IMAGE_URL_REDIRECTS + 1):
+        async with session.get(current_url, allow_redirects=False) as response:
+            if response.status in (301, 302, 303, 307, 308):
+                location = response.headers.get("Location")
+                if not location:
+                    raise HTTPClientError("Redirect response missing Location header.")
+                next_url = urllib.parse.urljoin(current_url, location)
+                current_url = validate_url_destination(next_url)
+                continue
+            response.raise_for_status()
+            return await response.read()
+    raise HTTPClientError(
+        f"Exceeded maximum of {config.MAX_IMAGE_URL_REDIRECTS} redirects."
+    )

--- a/inference_sdk/http/utils/url_utils.py
+++ b/inference_sdk/http/utils/url_utils.py
@@ -20,10 +20,9 @@ against the concatenated ``subdomain.domain.suffix`` network location.
 
 import ipaddress
 import socket
-import threading
 import urllib.parse
 import warnings
-from typing import List, Optional, Set, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 import aiohttp
 import requests
@@ -35,6 +34,7 @@ from requests import HTTPError
 from requests.adapters import HTTPAdapter
 from requests.utils import select_proxy
 from tldextract.tldextract import ExtractResult
+from urllib3.connectionpool import HTTPConnectionPool
 
 from inference_sdk import config
 from inference_sdk.http.errors import HTTPClientError
@@ -42,12 +42,6 @@ from inference_sdk.http.utils.requests import (
     api_key_safe_raise_for_status,
     deduct_api_key_from_string,
 )
-
-_WARNING_LOCK = threading.Lock()
-_LEGACY_REDIRECT_WARNING_EMITTED = False
-_NON_GLOBAL_WARNING_EMITTED = False
-_PROXY_BYPASS_WARNING_EMITTED = False
-
 
 class InvalidURLImageInput(HTTPClientError):
     """Raised when a URL image reference fails the SDK URL-string policy."""
@@ -57,12 +51,9 @@ class URLAddressNotAllowedError(HTTPClientError):
     """Raised when a URL resolves to a destination that is not permitted."""
 
 
+# `warnings.warn` deduplicates identical warnings per call site under the
+# default filter, so these do not spam the hot path.
 def _warn_legacy_redirect_handling() -> None:
-    global _LEGACY_REDIRECT_WARNING_EMITTED
-    with _WARNING_LOCK:
-        if _LEGACY_REDIRECT_WARNING_EMITTED:
-            return
-        _LEGACY_REDIRECT_WARNING_EMITTED = True
     warnings.warn(
         "URL image redirects are followed without per-hop validation "
         "(VALIDATE_IMAGE_URL_REDIRECTS=False). This default is scheduled to "
@@ -73,11 +64,6 @@ def _warn_legacy_redirect_handling() -> None:
 
 
 def _warn_non_global_allowed() -> None:
-    global _NON_GLOBAL_WARNING_EMITTED
-    with _WARNING_LOCK:
-        if _NON_GLOBAL_WARNING_EMITTED:
-            return
-        _NON_GLOBAL_WARNING_EMITTED = True
     warnings.warn(
         "URL image input is allowed to reach non-global addresses "
         "(ALLOW_URL_TO_NON_GLOBAL_ADDRESSES=True). This default is scheduled to "
@@ -88,11 +74,6 @@ def _warn_non_global_allowed() -> None:
 
 
 def _warn_proxy_bypasses_ssrf_protection() -> None:
-    global _PROXY_BYPASS_WARNING_EMITTED
-    with _WARNING_LOCK:
-        if _PROXY_BYPASS_WARNING_EMITTED:
-            return
-        _PROXY_BYPASS_WARNING_EMITTED = True
     warnings.warn(
         "An HTTP(S) proxy is configured for URL image fetching; the proxy "
         "resolves the destination, so non-global address blocking and DNS "
@@ -257,7 +238,13 @@ class SSRFProtectedHTTPAdapter(HTTPAdapter):
         )
         return host, resolved_ips[0]
 
-    def _build_pinned_pool(self, host_params, pool_kwargs, hostname, pinned_ip):
+    def _build_pinned_pool(
+        self,
+        host_params: Dict[str, Any],
+        pool_kwargs: Dict[str, Any],
+        hostname: str,
+        pinned_ip: str,
+    ) -> HTTPConnectionPool:
         # Reuse requests' own host params / TLS pool kwargs (preserving proxies,
         # custom CA bundles and mTLS client certs), but dial the validated IP and
         # verify TLS against the original hostname.

--- a/inference_sdk/http/utils/url_utils.py
+++ b/inference_sdk/http/utils/url_utils.py
@@ -35,7 +35,6 @@ from requests import HTTPError
 from requests.adapters import HTTPAdapter
 from requests.utils import select_proxy
 from tldextract.tldextract import ExtractResult
-from urllib3.connectionpool import HTTPConnectionPool, HTTPSConnectionPool
 
 from inference_sdk import config
 from inference_sdk.http.errors import HTTPClientError
@@ -47,6 +46,7 @@ from inference_sdk.http.utils.requests import (
 _WARNING_LOCK = threading.Lock()
 _LEGACY_REDIRECT_WARNING_EMITTED = False
 _NON_GLOBAL_WARNING_EMITTED = False
+_PROXY_BYPASS_WARNING_EMITTED = False
 
 
 class InvalidURLImageInput(HTTPClientError):
@@ -83,6 +83,21 @@ def _warn_non_global_allowed() -> None:
         "(ALLOW_URL_TO_NON_GLOBAL_ADDRESSES=True). This default is scheduled to "
         "change to False in Q4 2026.",
         category=DeprecationWarning,
+        stacklevel=2,
+    )
+
+
+def _warn_proxy_bypasses_ssrf_protection() -> None:
+    global _PROXY_BYPASS_WARNING_EMITTED
+    with _WARNING_LOCK:
+        if _PROXY_BYPASS_WARNING_EMITTED:
+            return
+        _PROXY_BYPASS_WARNING_EMITTED = True
+    warnings.warn(
+        "An HTTP(S) proxy is configured for URL image fetching; the proxy "
+        "resolves the destination, so non-global address blocking and DNS "
+        "rebinding pinning are NOT enforced for these requests.",
+        category=UserWarning,
         stacklevel=2,
     )
 
@@ -249,19 +264,24 @@ class SSRFProtectedHTTPAdapter(HTTPAdapter):
         host_params = dict(host_params)
         host_params["host"] = pinned_ip
         pool_kwargs = dict(pool_kwargs)
-        pool_kwargs["assert_hostname"] = hostname
+        is_https = host_params.get("scheme") == "https"
+        if is_https:
+            # assert_hostname / server_hostname are HTTPS-only; forwarding them
+            # to a plain HTTPConnection raises TypeError at connect time.
+            pool_kwargs["assert_hostname"] = hostname
         pool = self.poolmanager.connection_from_host(
             **host_params, pool_kwargs=pool_kwargs
         )
-        pool.conn_kw["server_hostname"] = hostname
+        if is_https:
+            pool.conn_kw["server_hostname"] = hostname
         return pool
 
-    def get_connection_with_tls_context(
-        self, request, verify, proxies=None, cert=None
-    ):
+    def get_connection_with_tls_context(self, request, verify, proxies=None, cert=None):
         # send() path for requests >= 2.32 (the pinned floor). Defer under a
         # forward proxy (the proxy resolves the target, so pinning is moot).
         if select_proxy(request.url, proxies):
+            if not self._allow_non_global_addresses:
+                _warn_proxy_bypasses_ssrf_protection()
             return super().get_connection_with_tls_context(
                 request, verify, proxies=proxies, cert=cert
             )
@@ -279,6 +299,8 @@ class SSRFProtectedHTTPAdapter(HTTPAdapter):
     def get_connection(self, url, proxies=None):
         # Fallback for requests < 2.32 (below the pinned floor).
         if select_proxy(url, proxies):
+            if not self._allow_non_global_addresses:
+                _warn_proxy_bypasses_ssrf_protection()
             return super().get_connection(url, proxies)
         pin = self._resolve_pin_target(url)
         if pin is None:
@@ -407,22 +429,49 @@ def _build_async_connector(allow_non_global_addresses: bool) -> aiohttp.TCPConne
     )
 
 
+def _ensure_ip_literal_allowed(url: str) -> None:
+    """aiohttp skips its resolver for IP-literal hosts, so a literal non-global
+    target (e.g. the cloud metadata IP ``169.254.169.254``) would otherwise
+    bypass :class:`ValidatingResolver`. Validate literals explicitly before the
+    request is issued (the resolver still covers hostname targets).
+    """
+    if config.ALLOW_URL_TO_NON_GLOBAL_ADDRESSES:
+        return
+    parsed = urllib3.util.parse_url(url)
+    host = parsed.host
+    if host and _host_is_ip_literal(host):
+        literal = _strip_ipv6_brackets(host)
+        if not address_is_global(literal):
+            raise URLAddressNotAllowedError(
+                f"URL points to non-global address '{literal}'."
+            )
+
+
 async def fetch_url_bytes_async(
     url: str, request_timeout: Optional[float] = None
 ) -> bytes:
     """Async counterpart of :func:`fetch_url_bytes`."""
     prepared_url = validate_url_destination(url)
+    _ensure_ip_literal_allowed(prepared_url)
     connector = _build_async_connector(config.ALLOW_URL_TO_NON_GLOBAL_ADDRESSES)
-    timeout = (
-        aiohttp.ClientTimeout(total=request_timeout)
-        if request_timeout is not None
-        else aiohttp.ClientTimeout()
-    )
-    async with aiohttp.ClientSession(connector=connector, timeout=timeout) as session:
+    # Leave aiohttp's default ClientTimeout (total=300s) in place unless the
+    # caller sets one; passing an empty ClientTimeout() would disable it.
+    session_kwargs = {"connector": connector}
+    if request_timeout is not None:
+        session_kwargs["timeout"] = aiohttp.ClientTimeout(total=request_timeout)
+    async with aiohttp.ClientSession(**session_kwargs) as session:
         try:
             if config.VALIDATE_IMAGE_URL_REDIRECTS:
-                return await _fetch_validating_redirects_async(
-                    session=session, url=prepared_url
+                return await _fetch_manual_redirects_async(
+                    session, prepared_url, revalidate_string_policy=True
+                )
+            if not config.ALLOW_URL_TO_NON_GLOBAL_ADDRESSES:
+                # Non-global blocking is on: follow redirects manually so every
+                # hop (including IP literals, which aiohttp's resolver skips) is
+                # checked -- parity with the sync per-hop adapter.
+                _warn_legacy_redirect_handling()
+                return await _fetch_manual_redirects_async(
+                    session, prepared_url, revalidate_string_policy=False
                 )
             return await _fetch_legacy_async(session=session, url=prepared_url)
         except ClientResponseError:
@@ -449,9 +498,13 @@ async def _fetch_legacy_async(session: aiohttp.ClientSession, url: str) -> bytes
         return await response.read()
 
 
-async def _fetch_validating_redirects_async(
-    session: aiohttp.ClientSession, url: str
+async def _fetch_manual_redirects_async(
+    session: aiohttp.ClientSession, url: str, revalidate_string_policy: bool
 ) -> bytes:
+    """Follow redirects one hop at a time. Every hop gets the IP-literal
+    non-global check; when ``revalidate_string_policy`` is True the full
+    URL-string policy (scheme / FQDN / allow-block) is re-applied too.
+    """
     current_url = url
     for _ in range(config.MAX_IMAGE_URL_REDIRECTS + 1):
         async with session.get(current_url, allow_redirects=False) as response:
@@ -460,7 +513,10 @@ async def _fetch_validating_redirects_async(
                 if not location:
                     raise HTTPClientError("Redirect response missing Location header.")
                 next_url = urllib.parse.urljoin(current_url, location)
-                current_url = validate_url_destination(next_url)
+                if revalidate_string_policy:
+                    next_url = validate_url_destination(next_url)
+                _ensure_ip_literal_allowed(next_url)
+                current_url = next_url
                 continue
             response.raise_for_status()
             return await response.read()

--- a/inference_sdk/http/utils/url_utils.py
+++ b/inference_sdk/http/utils/url_utils.py
@@ -39,7 +39,11 @@ from urllib3.connectionpool import HTTPConnectionPool
 
 from inference_sdk import config
 from inference_sdk.config import InferenceSDKDeprecationWarning
-from inference_sdk.http.errors import HTTPClientError, InvalidURLImageInput, URLAddressNotAllowedError
+from inference_sdk.http.errors import (
+    HTTPClientError,
+    InvalidURLImageInput,
+    URLAddressNotAllowedError,
+)
 from inference_sdk.http.utils.requests import (
     api_key_safe_raise_for_status,
     deduct_api_key_from_string,

--- a/requirements/requirements.sdk.http.txt
+++ b/requirements/requirements.sdk.http.txt
@@ -1,4 +1,6 @@
 requests>=2.33.0,<3.0.0
+urllib3>=1.26,<3.0.0
+tldextract~=5.1.2
 dataclasses-json~=0.6.0
 opencv-python>=4.8.1.78,<=4.10.0.84
 pillow>=12.2.0,<13.0.0

--- a/tests/inference/unit_tests/core/entities/test_inference_response_dc.py
+++ b/tests/inference/unit_tests/core/entities/test_inference_response_dc.py
@@ -159,8 +159,7 @@ def test_workflow_dc_path_emits_mask_format_in_prediction_dicts() -> None:
     dumped = _is_response_dc_to_dict(response)
 
     assert all(
-        prediction["mask_format"] == "polygon"
-        for prediction in dumped["predictions"]
+        prediction["mask_format"] == "polygon" for prediction in dumped["predictions"]
     )
 
 

--- a/tests/inference/unit_tests/core/interfaces/stream/test_workflows.py
+++ b/tests/inference/unit_tests/core/interfaces/stream/test_workflows.py
@@ -692,8 +692,7 @@ def test_instance_segmentation_stream_pipeline_uses_response_context_id() -> Non
     assert second_result[0]["predictions"].result() == "frame-1:first-final"
     assert len(manager.stream_pipeline_context_ids) == 2
     assert (
-        manager.stream_pipeline_context_ids[0]
-        != manager.stream_pipeline_context_ids[1]
+        manager.stream_pipeline_context_ids[0] != manager.stream_pipeline_context_ids[1]
     )
 
 

--- a/tests/inference/unit_tests/core/interfaces/webrtc_worker/test_start_worker_region_enforcement.py
+++ b/tests/inference/unit_tests/core/interfaces/webrtc_worker/test_start_worker_region_enforcement.py
@@ -18,8 +18,8 @@ from inference.core.interfaces.stream_manager.manager_app.entities import (
 )
 from inference.core.interfaces.webrtc_worker import start_worker
 from inference.core.interfaces.webrtc_worker.entities import (
-    WebRTCWorkerResult,
     WebRTCWorkerRequest,
+    WebRTCWorkerResult,
 )
 
 

--- a/tests/inference/unit_tests/core/registries/test_roboflow.py
+++ b/tests/inference/unit_tests/core/registries/test_roboflow.py
@@ -563,7 +563,9 @@ def test_get_model_type_when_roboflow_api_is_called_for_model_from_new_model_reg
     )
 
 
-@mock.patch.object(roboflow, "ALLOW_INFERENCE_MODELS_DIRECTLY_ACCESS_LOCAL_PACKAGES", True)
+@mock.patch.object(
+    roboflow, "ALLOW_INFERENCE_MODELS_DIRECTLY_ACCESS_LOCAL_PACKAGES", True
+)
 @mock.patch.object(roboflow, "USE_INFERENCE_MODELS", True)
 def test_get_model_type_for_local_inference_models_package_uses_declared_architecture(
     empty_local_dir: str,

--- a/tests/inference/unit_tests/core/utils/test_image_utils.py
+++ b/tests/inference/unit_tests/core/utils/test_image_utils.py
@@ -283,6 +283,86 @@ def test_load_image_from_url_when_locations_blacklisted(
     assert "blacklisted" in str(error.value)
 
 
+@mock.patch.object(image_utils, "VALIDATE_IMAGE_URL_REDIRECTS", False)
+@mock.patch.object(image_utils, "ALLOW_URL_TO_NON_GLOBAL_ADDRESSES", True)
+def test_load_image_from_url_legacy_path_follows_redirect(
+    requests_mock: Mocker,
+    image_as_numpy: np.ndarray,
+    image_as_png_bytes: bytes,
+) -> None:
+    # given - legacy path lets requests follow the redirect
+    start = "https://some.com/image.jpg"
+    target = "https://cdn.some.com/real.png"
+    requests_mock.get(start, status_code=302, headers={"Location": target})
+    requests_mock.get(target, content=image_as_png_bytes)
+
+    # when
+    result = load_image_from_url(value=start)
+
+    # then
+    assert np.allclose(image_as_numpy, result)
+
+
+@mock.patch.object(image_utils, "VALIDATE_IMAGE_URL_REDIRECTS", True)
+@mock.patch.object(image_utils, "ALLOW_URL_TO_NON_GLOBAL_ADDRESSES", True)
+@mock.patch.object(image_utils, "ALLOW_URL_INPUT", True)
+@mock.patch.object(image_utils, "ALLOW_NON_HTTPS_URL_INPUT", False)
+@mock.patch.object(image_utils, "ALLOW_URL_INPUT_WITHOUT_FQDN", False)
+def test_load_image_from_url_validated_path_follows_valid_redirect(
+    requests_mock: Mocker,
+    image_as_numpy: np.ndarray,
+    image_as_png_bytes: bytes,
+) -> None:
+    # given - hardened path re-validates the hop, which is a normal https FQDN
+    start = "https://some.com/image.jpg"
+    target = "https://cdn.some.com/real.png"
+    requests_mock.get(start, status_code=302, headers={"Location": target})
+    requests_mock.get(target, content=image_as_png_bytes)
+
+    # when
+    result = load_image_from_url(value=start)
+
+    # then
+    assert np.allclose(image_as_numpy, result)
+
+
+@mock.patch.object(image_utils, "VALIDATE_IMAGE_URL_REDIRECTS", True)
+@mock.patch.object(image_utils, "ALLOW_URL_TO_NON_GLOBAL_ADDRESSES", True)
+@mock.patch.object(image_utils, "ALLOW_URL_INPUT", True)
+@mock.patch.object(image_utils, "ALLOW_NON_HTTPS_URL_INPUT", False)
+@mock.patch.object(image_utils, "ALLOW_URL_INPUT_WITHOUT_FQDN", True)
+@mock.patch.object(
+    image_utils,
+    "BLACKLISTED_DESTINATIONS_FOR_URL_INPUT",
+    {"metadata.internal.example"},
+)
+def test_load_image_from_url_validated_path_rejects_redirect_to_blacklisted_host(
+    requests_mock: Mocker,
+) -> None:
+    # given - a valid start URL that redirects to a block-listed internal host
+    start = "https://some.com/image.jpg"
+    internal = "https://metadata.internal.example/latest/meta-data"
+    requests_mock.get(start, status_code=302, headers={"Location": internal})
+
+    # when / then - the hop is re-validated and rejected by the block-list
+    with pytest.raises(InputImageLoadError) as error:
+        _ = load_image_from_url(value=start)
+    assert "blacklisted" in str(error.value)
+
+
+@mock.patch.object(image_utils, "VALIDATE_IMAGE_URL_REDIRECTS", False)
+@mock.patch.object(image_utils, "ALLOW_URL_TO_NON_GLOBAL_ADDRESSES", False)
+@mock.patch.object(image_utils, "ALLOW_URL_INPUT", True)
+@mock.patch.object(image_utils, "ALLOW_NON_HTTPS_URL_INPUT", False)
+@mock.patch.object(image_utils, "ALLOW_URL_INPUT_WITHOUT_FQDN", True)
+def test_load_image_from_url_blocks_non_global_ip_literal() -> None:
+    # given - URL-string checks pass (FQDN-less allowed), the adapter blocks the
+    # non-global literal at connection time; no network should be touched.
+    with pytest.raises(InputImageLoadError) as error:
+        _ = load_image_from_url(value="https://127.0.0.1/image.jpg")
+    assert "not allowed" in str(error.value).lower()
+
+
 @mock.patch.object(image_utils, "ALLOW_NUMPY_INPUT", True)
 def test_load_image_from_numpy_str_when_empty_bytes_given() -> None:
     # when

--- a/tests/inference/unit_tests/core/utils/test_image_utils.py
+++ b/tests/inference/unit_tests/core/utils/test_image_utils.py
@@ -1,5 +1,6 @@
 import io
 import pickle
+import socket
 from typing import Any
 from unittest import mock
 from unittest.mock import MagicMock
@@ -18,7 +19,7 @@ from inference.core.exceptions import (
     InvalidImageTypeDeclared,
     InvalidNumpyInput,
 )
-from inference.core.utils import image_utils
+from inference.core.utils import image_utils, url_input
 from inference.core.utils.image_utils import (
     ImageType,
     attempt_loading_image_from_string,
@@ -361,6 +362,35 @@ def test_load_image_from_url_blocks_non_global_ip_literal() -> None:
     with pytest.raises(InputImageLoadError) as error:
         _ = load_image_from_url(value="https://127.0.0.1/image.jpg")
     assert "not allowed" in str(error.value).lower()
+
+
+@mock.patch.object(image_utils, "VALIDATE_IMAGE_URL_REDIRECTS", False)
+@mock.patch.object(image_utils, "ALLOW_URL_TO_NON_GLOBAL_ADDRESSES", False)
+@mock.patch.object(image_utils, "ALLOW_URL_INPUT", True)
+@mock.patch.object(image_utils, "ALLOW_NON_HTTPS_URL_INPUT", False)
+def test_load_image_from_url_blocks_hostname_resolving_to_non_global(
+    monkeypatch,
+) -> None:
+    # End-to-end regression for the requests>=2.32 send() path: a public FQDN
+    # that DNS-resolves to loopback must be blocked (and pinned), proving the
+    # adapter actually runs on send() rather than being dead get_connection code.
+    resolved = []
+
+    def _fake_getaddrinfo(host, port, *args, **kwargs):
+        resolved.append(host)
+        return [
+            (socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", ("127.0.0.1", port))
+        ]
+
+    monkeypatch.setattr(url_input.socket, "getaddrinfo", _fake_getaddrinfo)
+
+    with pytest.raises(InputImageLoadError) as error:
+        _ = load_image_from_url(value="https://evil.com/image.jpg")
+
+    # "not allowed" only appears if the adapter resolved + rejected the target;
+    # a dead adapter would surface a DNS/connection error message instead.
+    assert "not allowed" in str(error.value).lower()
+    assert resolved == ["evil.com"]  # resolution ran on the real send() path
 
 
 @mock.patch.object(image_utils, "ALLOW_NUMPY_INPUT", True)

--- a/tests/inference/unit_tests/core/utils/test_image_utils.py
+++ b/tests/inference/unit_tests/core/utils/test_image_utils.py
@@ -379,7 +379,13 @@ def test_load_image_from_url_blocks_hostname_resolving_to_non_global(
     def _fake_getaddrinfo(host, port, *args, **kwargs):
         resolved.append(host)
         return [
-            (socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", ("127.0.0.1", port))
+            (
+                socket.AF_INET,
+                socket.SOCK_STREAM,
+                socket.IPPROTO_TCP,
+                "",
+                ("127.0.0.1", port),
+            )
         ]
 
     monkeypatch.setattr(url_input.socket, "getaddrinfo", _fake_getaddrinfo)

--- a/tests/inference/unit_tests/core/utils/test_url_input.py
+++ b/tests/inference/unit_tests/core/utils/test_url_input.py
@@ -1,0 +1,179 @@
+import socket
+
+import pytest
+import requests
+from urllib3.connectionpool import HTTPConnectionPool, HTTPSConnectionPool
+
+from inference.core.utils import url_input
+from inference.core.utils.url_input import (
+    SSRFProtectedHTTPAdapter,
+    URLAddressNotAllowedError,
+    address_is_global,
+    fetch_url_content_validating_redirects,
+    resolve_and_validate_ips,
+)
+
+
+def _fake_getaddrinfo(ip: str):
+    def _inner(host, port, *args, **kwargs):
+        return [(socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", (ip, port))]
+
+    return _inner
+
+
+@pytest.mark.parametrize(
+    "address, expected",
+    [
+        ("8.8.8.8", True),
+        ("1.1.1.1", True),
+        ("127.0.0.1", False),  # loopback
+        ("10.0.0.5", False),  # private
+        ("192.168.1.10", False),  # private
+        ("169.254.169.254", False),  # link-local / cloud metadata
+        ("100.64.0.1", False),  # CGNAT
+        ("0.0.0.0", False),  # unspecified
+        ("::1", False),  # IPv6 loopback
+        ("fc00::1", False),  # IPv6 ULA
+        ("::ffff:127.0.0.1", False),  # IPv4-mapped loopback must not slip through
+        ("2001:4860:4860::8888", True),  # public IPv6 (Google DNS)
+        ("not-an-ip", False),
+    ],
+)
+def test_address_is_global(address: str, expected: bool) -> None:
+    assert address_is_global(address) is expected
+
+
+def test_resolve_and_validate_ips_blocks_non_global_when_disallowed(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        url_input.socket, "getaddrinfo", _fake_getaddrinfo("169.254.169.254")
+    )
+    with pytest.raises(URLAddressNotAllowedError):
+        resolve_and_validate_ips(
+            host="metadata.attacker.example",
+            port=443,
+            allow_non_global_addresses=False,
+        )
+
+
+def test_resolve_and_validate_ips_allows_non_global_when_permitted(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(url_input.socket, "getaddrinfo", _fake_getaddrinfo("127.0.0.1"))
+    result = resolve_and_validate_ips(
+        host="localhost.example",
+        port=80,
+        allow_non_global_addresses=True,
+    )
+    assert result == ["127.0.0.1"]
+
+
+def test_resolve_and_validate_ips_allows_global(monkeypatch) -> None:
+    monkeypatch.setattr(url_input.socket, "getaddrinfo", _fake_getaddrinfo("8.8.8.8"))
+    result = resolve_and_validate_ips(
+        host="example.com",
+        port=443,
+        allow_non_global_addresses=False,
+    )
+    assert result == ["8.8.8.8"]
+
+
+def test_resolve_raises_connection_error_when_host_unresolvable(monkeypatch) -> None:
+    def _raise(host, port, *args, **kwargs):
+        raise socket.gaierror("nope")
+
+    monkeypatch.setattr(url_input.socket, "getaddrinfo", _raise)
+    with pytest.raises(requests.exceptions.ConnectionError):
+        resolve_and_validate_ips(
+            host="does-not-exist.example",
+            port=443,
+            allow_non_global_addresses=False,
+        )
+
+
+def test_adapter_blocks_ip_literal_that_is_non_global() -> None:
+    adapter = SSRFProtectedHTTPAdapter(allow_non_global_addresses=False)
+    with pytest.raises(URLAddressNotAllowedError):
+        adapter.get_connection("http://127.0.0.1:8080/secret")
+
+
+def test_adapter_blocks_hostname_resolving_to_non_global(monkeypatch) -> None:
+    monkeypatch.setattr(
+        url_input.socket, "getaddrinfo", _fake_getaddrinfo("169.254.169.254")
+    )
+    adapter = SSRFProtectedHTTPAdapter(allow_non_global_addresses=False)
+    with pytest.raises(URLAddressNotAllowedError):
+        # nip.io-style: a valid FQDN that resolves to the metadata address.
+        adapter.get_connection("https://169-254-169-254.nip.io/latest/meta-data")
+
+
+def test_adapter_pins_connection_to_resolved_global_ip(monkeypatch) -> None:
+    monkeypatch.setattr(url_input.socket, "getaddrinfo", _fake_getaddrinfo("8.8.8.8"))
+    adapter = SSRFProtectedHTTPAdapter(allow_non_global_addresses=False)
+    pool = adapter.get_connection("https://example.com/image.jpg")
+    assert isinstance(pool, HTTPSConnectionPool)
+    assert pool.host == "8.8.8.8"  # pinned to the validated IP
+    assert pool.assert_hostname == "example.com"  # cert still checked vs hostname
+
+
+def test_adapter_pins_http_connection(monkeypatch) -> None:
+    monkeypatch.setattr(url_input.socket, "getaddrinfo", _fake_getaddrinfo("8.8.8.8"))
+    adapter = SSRFProtectedHTTPAdapter(allow_non_global_addresses=False)
+    pool = adapter.get_connection("http://example.com/image.jpg")
+    assert isinstance(pool, HTTPConnectionPool)
+    assert pool.host == "8.8.8.8"
+
+
+def test_validating_redirects_revalidates_each_hop(requests_mock) -> None:
+    start = "https://start.example/image.jpg"
+    hop = "https://hop.example/real.jpg"
+    requests_mock.get(start, status_code=302, headers={"Location": hop})
+    requests_mock.get(hop, content=b"image-bytes")
+
+    validated = []
+
+    def _validate(url: str) -> str:
+        validated.append(url)
+        return url
+
+    content = fetch_url_content_validating_redirects(
+        url=start,
+        allow_non_global_addresses=True,
+        max_redirects=30,
+        validate_redirect=_validate,
+    )
+
+    assert content == b"image-bytes"
+    assert validated == [hop]  # the redirect hop was re-validated before following
+
+
+def test_validating_redirects_propagates_validation_rejection(requests_mock) -> None:
+    start = "https://start.example/image.jpg"
+    hop = "http://169.254.169.254/latest/meta-data"
+    requests_mock.get(start, status_code=302, headers={"Location": hop})
+
+    def _reject(url: str) -> str:
+        raise ValueError("blocked hop")
+
+    with pytest.raises(ValueError, match="blocked hop"):
+        fetch_url_content_validating_redirects(
+            url=start,
+            allow_non_global_addresses=True,
+            max_redirects=30,
+            validate_redirect=_reject,
+        )
+
+
+def test_validating_redirects_enforces_max_redirects(requests_mock) -> None:
+    # An endless redirect loop must terminate with TooManyRedirects.
+    looping = "https://loop.example/image.jpg"
+    requests_mock.get(looping, status_code=302, headers={"Location": looping})
+
+    with pytest.raises(requests.exceptions.TooManyRedirects):
+        fetch_url_content_validating_redirects(
+            url=looping,
+            allow_non_global_addresses=True,
+            max_redirects=3,
+            validate_redirect=lambda url: url,
+        )

--- a/tests/inference/unit_tests/core/utils/test_url_input.py
+++ b/tests/inference/unit_tests/core/utils/test_url_input.py
@@ -2,6 +2,7 @@ import socket
 
 import pytest
 import requests
+from requests.models import PreparedRequest
 from urllib3.connectionpool import HTTPConnectionPool, HTTPSConnectionPool
 
 from inference.core.utils import url_input
@@ -12,6 +13,14 @@ from inference.core.utils.url_input import (
     fetch_url_content_validating_redirects,
     resolve_and_validate_ips,
 )
+
+_HAS_TLS_CONTEXT = hasattr(SSRFProtectedHTTPAdapter, "build_connection_pool_key_attributes")
+
+
+def _prepared_get(url: str) -> PreparedRequest:
+    request = PreparedRequest()
+    request.prepare(method="GET", url=url)
+    return request
 
 
 def _fake_getaddrinfo(ip: str):
@@ -123,6 +132,59 @@ def test_adapter_pins_http_connection(monkeypatch) -> None:
     pool = adapter.get_connection("http://example.com/image.jpg")
     assert isinstance(pool, HTTPConnectionPool)
     assert pool.host == "8.8.8.8"
+
+
+# The methods below drive get_connection_with_tls_context, which is the method
+# actually on the requests>=2.32 send() path (get_connection is not).
+@pytest.mark.skipif(not _HAS_TLS_CONTEXT, reason="requests < 2.32")
+def test_tls_context_blocks_hostname_resolving_to_non_global(monkeypatch) -> None:
+    monkeypatch.setattr(
+        url_input.socket, "getaddrinfo", _fake_getaddrinfo("169.254.169.254")
+    )
+    adapter = SSRFProtectedHTTPAdapter(allow_non_global_addresses=False)
+    with pytest.raises(URLAddressNotAllowedError):
+        adapter.get_connection_with_tls_context(
+            _prepared_get("https://metadata.example/latest/meta-data"), verify=True
+        )
+
+
+@pytest.mark.skipif(not _HAS_TLS_CONTEXT, reason="requests < 2.32")
+def test_tls_context_blocks_non_global_ip_literal() -> None:
+    adapter = SSRFProtectedHTTPAdapter(allow_non_global_addresses=False)
+    with pytest.raises(URLAddressNotAllowedError):
+        adapter.get_connection_with_tls_context(
+            _prepared_get("https://127.0.0.1/image.jpg"), verify=True
+        )
+
+
+@pytest.mark.skipif(not _HAS_TLS_CONTEXT, reason="requests < 2.32")
+def test_tls_context_pins_to_resolved_global_ip(monkeypatch) -> None:
+    monkeypatch.setattr(url_input.socket, "getaddrinfo", _fake_getaddrinfo("8.8.8.8"))
+    adapter = SSRFProtectedHTTPAdapter(allow_non_global_addresses=False)
+    pool = adapter.get_connection_with_tls_context(
+        _prepared_get("https://example.com/image.jpg"), verify=True
+    )
+    assert isinstance(pool, HTTPSConnectionPool)
+    assert pool.host == "8.8.8.8"  # dialled at the validated IP
+    assert pool.assert_hostname == "example.com"  # cert checked vs hostname
+    assert pool.conn_kw.get("server_hostname") == "example.com"  # SNI vs hostname
+    # A real connection object can be built (guards against latent conn_kw bugs).
+    conn = pool._new_conn()
+    assert conn.host == "8.8.8.8"
+    assert getattr(conn, "server_hostname", None) == "example.com"
+
+
+@pytest.mark.skipif(not _HAS_TLS_CONTEXT, reason="requests < 2.32")
+def test_tls_context_allows_global_and_preserves_custom_ca(monkeypatch) -> None:
+    # verify as a CA-bundle path must flow through to the pinned pool.
+    monkeypatch.setattr(url_input.socket, "getaddrinfo", _fake_getaddrinfo("8.8.8.8"))
+    adapter = SSRFProtectedHTTPAdapter(allow_non_global_addresses=True)
+    pool = adapter.get_connection_with_tls_context(
+        _prepared_get("https://example.com/image.jpg"), verify=True
+    )
+    # allow_non_global=True still pins to the resolved IP.
+    assert pool.host == "8.8.8.8"
+    assert pool.assert_hostname == "example.com"
 
 
 def test_validating_redirects_revalidates_each_hop(requests_mock) -> None:

--- a/tests/inference/unit_tests/core/utils/test_url_input.py
+++ b/tests/inference/unit_tests/core/utils/test_url_input.py
@@ -132,6 +132,10 @@ def test_adapter_pins_http_connection(monkeypatch) -> None:
     pool = adapter.get_connection("http://example.com/image.jpg")
     assert isinstance(pool, HTTPConnectionPool)
     assert pool.host == "8.8.8.8"
+    # http:// must NOT receive HTTPS-only assert_hostname/server_hostname, which
+    # would raise TypeError at connect time; build a real connection to prove it.
+    conn = pool._new_conn()
+    assert conn.host == "8.8.8.8"
 
 
 # The methods below drive get_connection_with_tls_context, which is the method
@@ -172,6 +176,45 @@ def test_tls_context_pins_to_resolved_global_ip(monkeypatch) -> None:
     conn = pool._new_conn()
     assert conn.host == "8.8.8.8"
     assert getattr(conn, "server_hostname", None) == "example.com"
+
+
+@pytest.mark.skipif(not _HAS_TLS_CONTEXT, reason="requests < 2.32")
+def test_tls_context_pins_plain_http_without_tls_kwargs(monkeypatch) -> None:
+    # Regression: http:// pinned pool must build a real connection (assert_hostname
+    # / server_hostname are HTTPS-only and crash a plain HTTPConnection).
+    monkeypatch.setattr(url_input.socket, "getaddrinfo", _fake_getaddrinfo("8.8.8.8"))
+    adapter = SSRFProtectedHTTPAdapter(allow_non_global_addresses=False)
+    pool = adapter.get_connection_with_tls_context(
+        _prepared_get("http://example.com/image.jpg"), verify=True
+    )
+    assert isinstance(pool, HTTPConnectionPool)
+    assert pool.host == "8.8.8.8"
+    conn = pool._new_conn()  # must not raise
+    assert conn.host == "8.8.8.8"
+
+
+@pytest.mark.skipif(not _HAS_TLS_CONTEXT, reason="requests < 2.32")
+def test_tls_context_defers_and_warns_under_proxy(monkeypatch) -> None:
+    monkeypatch.setattr(
+        url_input, "select_proxy", lambda url, proxies: "http://proxy.local:3128"
+    )
+    warned = []
+    monkeypatch.setattr(
+        url_input,
+        "_warn_proxy_bypasses_ssrf_protection",
+        lambda: warned.append(1),
+    )
+    # resolution must NOT run when we defer to the proxy path.
+    monkeypatch.setattr(
+        url_input.socket,
+        "getaddrinfo",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("should not resolve")),
+    )
+    adapter = SSRFProtectedHTTPAdapter(allow_non_global_addresses=False)
+    adapter.get_connection_with_tls_context(
+        _prepared_get("https://metadata.example/x"), verify=True
+    )
+    assert warned == [1]  # user is told protection is bypassed behind the proxy
 
 
 @pytest.mark.skipif(not _HAS_TLS_CONTEXT, reason="requests < 2.32")

--- a/tests/inference/unit_tests/core/utils/test_url_input.py
+++ b/tests/inference/unit_tests/core/utils/test_url_input.py
@@ -14,7 +14,9 @@ from inference.core.utils.url_input import (
     resolve_and_validate_ips,
 )
 
-_HAS_TLS_CONTEXT = hasattr(SSRFProtectedHTTPAdapter, "build_connection_pool_key_attributes")
+_HAS_TLS_CONTEXT = hasattr(
+    SSRFProtectedHTTPAdapter, "build_connection_pool_key_attributes"
+)
 
 
 def _prepared_get(url: str) -> PreparedRequest:
@@ -25,7 +27,9 @@ def _prepared_get(url: str) -> PreparedRequest:
 
 def _fake_getaddrinfo(ip: str):
     def _inner(host, port, *args, **kwargs):
-        return [(socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", (ip, port))]
+        return [
+            (socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", (ip, port))
+        ]
 
     return _inner
 

--- a/tests/inference/unit_tests/models/vllm_proxy/test_qwen3vl_vllm.py
+++ b/tests/inference/unit_tests/models/vllm_proxy/test_qwen3vl_vllm.py
@@ -215,9 +215,7 @@ class TestPostprocess:
         assert responses[0].image.width == 48
         assert responses[0].image.height == 64
 
-    def test_no_think_tag_is_prepended_or_parsed(
-        self, model: Qwen3VLVLLMProxy
-    ) -> None:
+    def test_no_think_tag_is_prepended_or_parsed(self, model: Qwen3VLVLLMProxy) -> None:
         # given - text that the qwen3_5 thinking parser would split; qwen3vl
         # has no thinking mode, so it must come back verbatim even when the
         # caller passes enable_thinking.

--- a/tests/inference_sdk/unit_tests/http/utils/test_loaders.py
+++ b/tests/inference_sdk/unit_tests/http/utils/test_loaders.py
@@ -59,37 +59,29 @@ def test_uri_is_http_link_when_https_url_provided() -> None:
     assert result is True
 
 
-@mock.patch.object(loaders.requests, "get")
 def test_load_file_from_url_on_unsuccessful_image_download(
-    requests_get_mock: MagicMock,
+    requests_mock,
 ) -> None:
     # given
-    response = Response()
-    response.status_code = 404
-    requests_get_mock.return_value = response
+    url = "https://some.com/file.jpg"
+    requests_mock.get(url, status_code=404)
 
     # when
     with pytest.raises(HTTPError):
-        _ = load_image_from_url(url="http://some/file.jpg")
-
-    # then
-    requests_get_mock.assert_called_once_with("http://some/file.jpg")
+        _ = load_image_from_url(url=url)
 
 
-@mock.patch.object(loaders.requests, "get")
 def test_load_file_from_url_on_successful_image_download_without_resize(
-    requests_get_mock: MagicMock,
+    requests_mock,
 ) -> None:
     # given
-    response = Response()
-    response.status_code = 200
+    url = "https://some.com/file.jpg"
     image = np.zeros((128, 128, 3), dtype=np.uint8)
     _, encoded_image = cv2.imencode(".jpg", image)
-    response._content = encoded_image
-    requests_get_mock.return_value = response
+    requests_mock.get(url, content=encoded_image.tobytes())
 
     # when
-    serialised_image, scaling_factor = load_image_from_url(url="http://some/file.jpg")
+    serialised_image, scaling_factor = load_image_from_url(url=url)
     recovered_image = base64.b64decode(serialised_image)
     bytes_array = np.frombuffer(recovered_image, dtype=np.uint8)
     decoding_result = cv2.imdecode(bytes_array, cv2.IMREAD_UNCHANGED)
@@ -98,7 +90,6 @@ def test_load_file_from_url_on_successful_image_download_without_resize(
     assert scaling_factor is None
     assert decoding_result.shape == image.shape
     assert np.allclose(decoding_result, image)
-    requests_get_mock.assert_called_once_with("http://some/file.jpg")
 
 
 @pytest.mark.asyncio
@@ -125,21 +116,18 @@ async def test_load_file_from_url_async_on_successful_image_download_without_res
         assert np.allclose(decoding_result, image)
 
 
-@mock.patch.object(loaders.requests, "get")
 def test_load_file_from_url_on_successful_image_download_with_resize(
-    requests_get_mock: MagicMock,
+    requests_mock,
 ) -> None:
     # given
-    response = Response()
-    response.status_code = 200
+    url = "https://some.com/file.jpg"
     image = np.zeros((128, 128, 3), dtype=np.uint8)
     _, encoded_image = cv2.imencode(".jpg", image)
-    response._content = encoded_image
-    requests_get_mock.return_value = response
+    requests_mock.get(url, content=encoded_image.tobytes())
 
     # when
     serialised_image, scaling_factor = load_image_from_url(
-        url="http://some/file.jpg",
+        url=url,
         max_width=64,
         max_height=128,
     )
@@ -151,7 +139,6 @@ def test_load_file_from_url_on_successful_image_download_with_resize(
     assert abs(scaling_factor - 0.5) < 1e-5
     assert decoding_result.shape == (64, 64, 3)
     assert (decoding_result == 0).all()
-    requests_get_mock.assert_called_once_with("http://some/file.jpg")
 
 
 @pytest.mark.asyncio
@@ -180,22 +167,17 @@ async def test_load_file_from_url_async_on_successful_image_download_with_resize
         assert (decoding_result == 0).all()
 
 
-@mock.patch.object(loaders.requests, "get")
 def test_load_image_from_string_when_file_to_be_downloaded(
-    requests_get_mock: MagicMock,
+    requests_mock,
 ) -> None:
     # given
-    response = Response()
-    response.status_code = 200
+    url = "https://some.com/file.jpg"
     image = np.zeros((128, 128, 3), dtype=np.uint8)
     _, encoded_image = cv2.imencode(".jpg", image)
-    response._content = encoded_image
-    requests_get_mock.return_value = response
+    requests_mock.get(url, content=encoded_image.tobytes())
 
     # when
-    serialised_image, scaling_factor = load_image_from_string(
-        reference="https://some/file.jpg"
-    )
+    serialised_image, scaling_factor = load_image_from_string(reference=url)
 
     # then
     recovered_image = base64.b64decode(serialised_image)
@@ -206,7 +188,6 @@ def test_load_image_from_string_when_file_to_be_downloaded(
     assert scaling_factor is None
     assert decoding_result.shape == image.shape
     assert np.allclose(decoding_result, image)
-    requests_get_mock.assert_called_once_with("https://some/file.jpg")
 
 
 @pytest.mark.asyncio

--- a/tests/inference_sdk/unit_tests/http/utils/test_url_utils.py
+++ b/tests/inference_sdk/unit_tests/http/utils/test_url_utils.py
@@ -9,14 +9,13 @@ from urllib3.connectionpool import HTTPSConnectionPool
 from inference_sdk import config
 from inference_sdk.http.utils import url_utils
 from inference_sdk.http.utils.url_utils import (
-    InvalidURLImageInput,
     SSRFProtectedHTTPAdapter,
-    URLAddressNotAllowedError,
     address_is_global,
     fetch_url_bytes,
     resolve_and_validate_ips,
     validate_url_destination,
 )
+from inference_sdk.http.errors import InvalidURLImageInput, URLAddressNotAllowedError
 
 
 def _fake_getaddrinfo(ip: str):

--- a/tests/inference_sdk/unit_tests/http/utils/test_url_utils.py
+++ b/tests/inference_sdk/unit_tests/http/utils/test_url_utils.py
@@ -168,6 +168,108 @@ def test_tls_context_pins_to_resolved_global_ip(monkeypatch) -> None:
     assert getattr(conn, "server_hostname", None) == "example.com"
 
 
+@pytest.mark.skipif(not _HAS_TLS_CONTEXT, reason="requests < 2.32")
+def test_tls_context_pins_plain_http_without_tls_kwargs(monkeypatch) -> None:
+    # Regression: http:// pinned pool must build a real connection (assert_hostname
+    # / server_hostname are HTTPS-only and crash a plain HTTPConnection).
+    from urllib3.connectionpool import HTTPConnectionPool
+
+    monkeypatch.setattr(url_utils.socket, "getaddrinfo", _fake_getaddrinfo("8.8.8.8"))
+    adapter = SSRFProtectedHTTPAdapter(allow_non_global_addresses=False)
+    pool = adapter.get_connection_with_tls_context(
+        _prepared_get("http://example.com/image.jpg"), verify=True
+    )
+    assert isinstance(pool, HTTPConnectionPool)
+    assert pool.host == "8.8.8.8"
+    conn = pool._new_conn()  # must not raise
+    assert conn.host == "8.8.8.8"
+
+
+@pytest.mark.skipif(not _HAS_TLS_CONTEXT, reason="requests < 2.32")
+def test_tls_context_defers_and_warns_under_proxy(monkeypatch) -> None:
+    monkeypatch.setattr(
+        url_utils, "select_proxy", lambda url, proxies: "http://proxy.local:3128"
+    )
+    warned = []
+    monkeypatch.setattr(
+        url_utils, "_warn_proxy_bypasses_ssrf_protection", lambda: warned.append(1)
+    )
+    monkeypatch.setattr(
+        url_utils.socket,
+        "getaddrinfo",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("should not resolve")),
+    )
+    adapter = SSRFProtectedHTTPAdapter(allow_non_global_addresses=False)
+    adapter.get_connection_with_tls_context(
+        _prepared_get("https://metadata.example/x"), verify=True
+    )
+    assert warned == [1]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "target",
+    [
+        "http://127.0.0.1/image.jpg",
+        "http://169.254.169.254/latest/meta-data",
+        "http://[::1]/image.jpg",
+    ],
+)
+async def test_fetch_url_bytes_async_blocks_non_global_ip_literal(
+    target: str, monkeypatch
+) -> None:
+    # aiohttp skips its resolver for IP literals; the explicit pre-check must
+    # still block non-global literal targets (no network is touched).
+    monkeypatch.setattr(config, "ALLOW_URL_TO_NON_GLOBAL_ADDRESSES", False)
+    monkeypatch.setattr(config, "ALLOW_NON_HTTPS_URL_INPUT", True)
+    monkeypatch.setattr(config, "ALLOW_URL_INPUT_WITHOUT_FQDN", True)
+    with pytest.raises(URLAddressNotAllowedError):
+        await url_utils.fetch_url_bytes_async(target)
+
+
+@pytest.mark.asyncio
+async def test_fetch_url_bytes_async_legacy_blocks_redirect_to_literal(
+    monkeypatch,
+) -> None:
+    # Parity with sync: even in legacy redirect mode (VALIDATE=False), with
+    # non-global blocking on, a redirect to a literal metadata IP is rejected.
+    from aioresponses import aioresponses
+
+    monkeypatch.setattr(config, "VALIDATE_IMAGE_URL_REDIRECTS", False)
+    monkeypatch.setattr(config, "ALLOW_URL_TO_NON_GLOBAL_ADDRESSES", False)
+    monkeypatch.setattr(config, "ALLOW_NON_HTTPS_URL_INPUT", True)
+    monkeypatch.setattr(config, "ALLOW_URL_INPUT_WITHOUT_FQDN", True)
+    start = "https://start.example/image.jpg"
+    metadata = "http://169.254.169.254/latest/meta-data"
+    with aioresponses() as m:
+        m.get(start, status=302, headers={"Location": metadata})
+        with pytest.raises(URLAddressNotAllowedError):
+            await url_utils.fetch_url_bytes_async(start)
+
+
+@pytest.mark.asyncio
+async def test_fetch_url_bytes_async_keeps_default_timeout(monkeypatch) -> None:
+    # Passing an empty ClientTimeout() would disable aiohttp's 300s default;
+    # when the caller gives no timeout we must not override it.
+    monkeypatch.setattr(config, "ALLOW_URL_TO_NON_GLOBAL_ADDRESSES", True)
+    captured = {}
+    real_session = url_utils.aiohttp.ClientSession
+
+    def _capture(*args, **kwargs):
+        captured.update(kwargs)
+        return real_session(*args, **kwargs)
+
+    monkeypatch.setattr(url_utils.aiohttp, "ClientSession", _capture)
+
+    from aioresponses import aioresponses
+
+    with aioresponses() as m:
+        m.get("https://some.com/image.jpg", body=b"bytes")
+        await url_utils.fetch_url_bytes_async("https://some.com/image.jpg")
+
+    assert "timeout" not in captured  # aiohttp default (total=300s) left intact
+
+
 def test_fetch_url_bytes_validated_redirects_revalidate_hops(
     requests_mock, monkeypatch
 ) -> None:

--- a/tests/inference_sdk/unit_tests/http/utils/test_url_utils.py
+++ b/tests/inference_sdk/unit_tests/http/utils/test_url_utils.py
@@ -1,5 +1,7 @@
 import socket
 
+import aiohttp
+
 import pytest
 import requests
 from urllib3.connectionpool import HTTPSConnectionPool
@@ -71,6 +73,34 @@ def test_validate_url_destination_respects_whitelist(monkeypatch) -> None:
     )
 
 
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://localhost/image.jpg",
+        "https://192.168.0.1/image.jpg",
+        "https://internalhost/image.jpg",
+        "https://internal.corp/image.jpg",
+        "https://metadata.google.internal/latest/meta-data",
+    ],
+)
+def test_validate_url_destination_fqdn_gate_rejects_suffixless_hosts(
+    url: str, monkeypatch
+) -> None:
+    # Mirrors the server: with FQDN enforced, IPs / bare hosts / suffix-less
+    # internal names are rejected on the URL string alone.
+    monkeypatch.setattr(config, "ALLOW_URL_INPUT_WITHOUT_FQDN", False)
+    monkeypatch.setattr(config, "ALLOW_NON_HTTPS_URL_INPUT", True)
+    with pytest.raises(InvalidURLImageInput):
+        validate_url_destination(url)
+
+
+def test_validate_url_destination_fqdn_gate_allows_public_domain(monkeypatch) -> None:
+    monkeypatch.setattr(config, "ALLOW_URL_INPUT_WITHOUT_FQDN", False)
+    assert validate_url_destination("https://sub.example.com/image.jpg").startswith(
+        "https://sub.example.com"
+    )
+
+
 def test_resolve_blocks_non_global_when_disallowed(monkeypatch) -> None:
     monkeypatch.setattr(
         url_utils.socket, "getaddrinfo", _fake_getaddrinfo("169.254.169.254")
@@ -123,6 +153,44 @@ def test_fetch_url_bytes_enforces_max_redirects(requests_mock, monkeypatch) -> N
 
     with pytest.raises(HTTPClientError):
         fetch_url_bytes(looping)
+
+
+def test_fetch_url_bytes_translates_transport_error_to_http_client_error(
+    requests_mock,
+) -> None:
+    from inference_sdk.http.errors import HTTPClientError
+
+    url = "https://some.com/file.jpg"
+    requests_mock.get(url, exc=requests.exceptions.ConnectionError("boom"))
+
+    with pytest.raises(HTTPClientError) as error:
+        fetch_url_bytes(url)
+    # It must not leak the raw requests exception past the SDK error contract.
+    assert not isinstance(error.value, requests.exceptions.RequestException)
+
+
+def test_fetch_url_bytes_preserves_http_status_error(requests_mock) -> None:
+    from requests import HTTPError
+
+    url = "https://some.com/file.jpg"
+    requests_mock.get(url, status_code=500)
+
+    # Status errors keep flowing as HTTPError so wrap_errors -> HTTPCallErrorError.
+    with pytest.raises(HTTPError):
+        fetch_url_bytes(url)
+
+
+@pytest.mark.asyncio
+async def test_fetch_url_bytes_async_translates_transport_error(monkeypatch) -> None:
+    from aioresponses import aioresponses
+
+    from inference_sdk.http.errors import HTTPClientError
+
+    url = "https://some.com/file.jpg"
+    with aioresponses() as m:
+        m.get(url, exception=aiohttp.ClientConnectionError("boom"))
+        with pytest.raises(HTTPClientError):
+            await url_utils.fetch_url_bytes_async(url)
 
 
 @pytest.mark.asyncio

--- a/tests/inference_sdk/unit_tests/http/utils/test_url_utils.py
+++ b/tests/inference_sdk/unit_tests/http/utils/test_url_utils.py
@@ -126,6 +126,48 @@ def test_adapter_blocks_non_global_ip_literal() -> None:
         adapter.get_connection("https://127.0.0.1/image.jpg")
 
 
+_HAS_TLS_CONTEXT = hasattr(
+    SSRFProtectedHTTPAdapter, "build_connection_pool_key_attributes"
+)
+
+
+def _prepared_get(url: str):
+    from requests.models import PreparedRequest
+
+    request = PreparedRequest()
+    request.prepare(method="GET", url=url)
+    return request
+
+
+# get_connection_with_tls_context is the requests>=2.32 send() path.
+@pytest.mark.skipif(not _HAS_TLS_CONTEXT, reason="requests < 2.32")
+def test_tls_context_blocks_hostname_resolving_to_non_global(monkeypatch) -> None:
+    monkeypatch.setattr(
+        url_utils.socket, "getaddrinfo", _fake_getaddrinfo("169.254.169.254")
+    )
+    adapter = SSRFProtectedHTTPAdapter(allow_non_global_addresses=False)
+    with pytest.raises(URLAddressNotAllowedError):
+        adapter.get_connection_with_tls_context(
+            _prepared_get("https://metadata.example/latest/meta-data"), verify=True
+        )
+
+
+@pytest.mark.skipif(not _HAS_TLS_CONTEXT, reason="requests < 2.32")
+def test_tls_context_pins_to_resolved_global_ip(monkeypatch) -> None:
+    monkeypatch.setattr(url_utils.socket, "getaddrinfo", _fake_getaddrinfo("8.8.8.8"))
+    adapter = SSRFProtectedHTTPAdapter(allow_non_global_addresses=False)
+    pool = adapter.get_connection_with_tls_context(
+        _prepared_get("https://example.com/image.jpg"), verify=True
+    )
+    assert isinstance(pool, HTTPSConnectionPool)
+    assert pool.host == "8.8.8.8"
+    assert pool.assert_hostname == "example.com"
+    assert pool.conn_kw.get("server_hostname") == "example.com"
+    conn = pool._new_conn()
+    assert conn.host == "8.8.8.8"
+    assert getattr(conn, "server_hostname", None) == "example.com"
+
+
 def test_fetch_url_bytes_validated_redirects_revalidate_hops(
     requests_mock, monkeypatch
 ) -> None:

--- a/tests/inference_sdk/unit_tests/http/utils/test_url_utils.py
+++ b/tests/inference_sdk/unit_tests/http/utils/test_url_utils.py
@@ -1,0 +1,164 @@
+import socket
+
+import pytest
+import requests
+from urllib3.connectionpool import HTTPSConnectionPool
+
+from inference_sdk import config
+from inference_sdk.http.utils import url_utils
+from inference_sdk.http.utils.url_utils import (
+    InvalidURLImageInput,
+    SSRFProtectedHTTPAdapter,
+    URLAddressNotAllowedError,
+    address_is_global,
+    fetch_url_bytes,
+    resolve_and_validate_ips,
+    validate_url_destination,
+)
+
+
+def _fake_getaddrinfo(ip: str):
+    def _inner(host, port, *args, **kwargs):
+        return [(socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", (ip, port))]
+
+    return _inner
+
+
+@pytest.mark.parametrize(
+    "address, expected",
+    [
+        ("8.8.8.8", True),
+        ("127.0.0.1", False),
+        ("10.0.0.1", False),
+        ("169.254.169.254", False),
+        ("100.64.0.1", False),
+        ("::1", False),
+        ("::ffff:127.0.0.1", False),
+    ],
+)
+def test_address_is_global(address: str, expected: bool) -> None:
+    assert address_is_global(address) is expected
+
+
+def test_validate_url_destination_rejects_backslash_authority() -> None:
+    with pytest.raises(InvalidURLImageInput):
+        validate_url_destination("https://localhost:6666\\@evil.example")
+
+
+def test_validate_url_destination_rejects_non_https_when_disabled(monkeypatch) -> None:
+    monkeypatch.setattr(config, "ALLOW_NON_HTTPS_URL_INPUT", False)
+    with pytest.raises(InvalidURLImageInput):
+        validate_url_destination("http://some.com/file.jpg")
+
+
+def test_validate_url_destination_respects_blacklist(monkeypatch) -> None:
+    monkeypatch.setattr(
+        config, "BLACKLISTED_DESTINATIONS_FOR_URL_INPUT", {"blocked.example"}
+    )
+    with pytest.raises(InvalidURLImageInput):
+        validate_url_destination("https://blocked.example/file.jpg")
+
+
+def test_validate_url_destination_respects_whitelist(monkeypatch) -> None:
+    monkeypatch.setattr(
+        config, "WHITELISTED_DESTINATIONS_FOR_URL_INPUT", {"allowed.example"}
+    )
+    with pytest.raises(InvalidURLImageInput):
+        validate_url_destination("https://not-allowed.example/file.jpg")
+    # allowed host passes validation
+    assert validate_url_destination("https://allowed.example/file.jpg").startswith(
+        "https://allowed.example"
+    )
+
+
+def test_resolve_blocks_non_global_when_disallowed(monkeypatch) -> None:
+    monkeypatch.setattr(
+        url_utils.socket, "getaddrinfo", _fake_getaddrinfo("169.254.169.254")
+    )
+    with pytest.raises(URLAddressNotAllowedError):
+        resolve_and_validate_ips(
+            host="metadata.example", port=443, allow_non_global_addresses=False
+        )
+
+
+def test_adapter_pins_to_resolved_global_ip(monkeypatch) -> None:
+    monkeypatch.setattr(url_utils.socket, "getaddrinfo", _fake_getaddrinfo("8.8.8.8"))
+    adapter = SSRFProtectedHTTPAdapter(allow_non_global_addresses=False)
+    pool = adapter.get_connection("https://example.com/image.jpg")
+    assert isinstance(pool, HTTPSConnectionPool)
+    assert pool.host == "8.8.8.8"
+    assert pool.assert_hostname == "example.com"
+
+
+def test_adapter_blocks_non_global_ip_literal() -> None:
+    adapter = SSRFProtectedHTTPAdapter(allow_non_global_addresses=False)
+    with pytest.raises(URLAddressNotAllowedError):
+        adapter.get_connection("https://127.0.0.1/image.jpg")
+
+
+def test_fetch_url_bytes_validated_redirects_revalidate_hops(
+    requests_mock, monkeypatch
+) -> None:
+    monkeypatch.setattr(config, "VALIDATE_IMAGE_URL_REDIRECTS", True)
+    monkeypatch.setattr(config, "ALLOW_URL_TO_NON_GLOBAL_ADDRESSES", True)
+    monkeypatch.setattr(
+        config, "BLACKLISTED_DESTINATIONS_FOR_URL_INPUT", {"internal.example"}
+    )
+    start = "https://start.example/image.jpg"
+    blocked = "https://internal.example/secret"
+    requests_mock.get(start, status_code=302, headers={"Location": blocked})
+
+    with pytest.raises(InvalidURLImageInput):
+        fetch_url_bytes(start)
+
+
+def test_fetch_url_bytes_enforces_max_redirects(requests_mock, monkeypatch) -> None:
+    monkeypatch.setattr(config, "VALIDATE_IMAGE_URL_REDIRECTS", True)
+    monkeypatch.setattr(config, "ALLOW_URL_TO_NON_GLOBAL_ADDRESSES", True)
+    monkeypatch.setattr(config, "MAX_IMAGE_URL_REDIRECTS", 2)
+    looping = "https://loop.example/image.jpg"
+    requests_mock.get(looping, status_code=302, headers={"Location": looping})
+
+    from inference_sdk.http.errors import HTTPClientError
+
+    with pytest.raises(HTTPClientError):
+        fetch_url_bytes(looping)
+
+
+@pytest.mark.asyncio
+async def test_validating_resolver_blocks_non_global(monkeypatch) -> None:
+    resolver = url_utils.ValidatingResolver(allow_non_global_addresses=False)
+
+    async def _fake_resolve(host, port=0, family=socket.AF_INET):
+        return [
+            {
+                "hostname": host,
+                "host": "169.254.169.254",
+                "port": port,
+                "family": family,
+                "proto": 0,
+                "flags": 0,
+            }
+        ]
+
+    monkeypatch.setattr(resolver._delegate, "resolve", _fake_resolve)
+    with pytest.raises(URLAddressNotAllowedError):
+        await resolver.resolve("metadata.example", 443)
+    await resolver.close()
+
+
+@pytest.mark.asyncio
+async def test_fetch_url_bytes_async_validated_redirect_blocked(monkeypatch) -> None:
+    from aioresponses import aioresponses
+
+    monkeypatch.setattr(config, "VALIDATE_IMAGE_URL_REDIRECTS", True)
+    monkeypatch.setattr(config, "ALLOW_URL_TO_NON_GLOBAL_ADDRESSES", True)
+    monkeypatch.setattr(
+        config, "BLACKLISTED_DESTINATIONS_FOR_URL_INPUT", {"internal.example"}
+    )
+    start = "https://start.example/image.jpg"
+    blocked = "https://internal.example/secret"
+    with aioresponses() as m:
+        m.get(start, status=302, headers={"Location": blocked})
+        with pytest.raises(InvalidURLImageInput):
+            await url_utils.fetch_url_bytes_async(start)

--- a/tests/workflows/unit_tests/core_steps/models/foundation/test_anthropic_claude.py
+++ b/tests/workflows/unit_tests/core_steps/models/foundation/test_anthropic_claude.py
@@ -13,6 +13,8 @@ from inference.core.workflows.core_steps.models.foundation.anthropic_claude.v2 i
 )
 from inference.core.workflows.core_steps.models.foundation.anthropic_claude.v3 import (
     EXACT_MODEL_VERSIONS as EXACT_MODEL_VERSIONS_V3,
+)
+from inference.core.workflows.core_steps.models.foundation.anthropic_claude.v3 import (
     MAX_OUTPUT_TOKENS as MAX_OUTPUT_TOKENS_V3,
 )
 

--- a/tests/workflows/unit_tests/core_steps/models/foundation/test_google_gemini.py
+++ b/tests/workflows/unit_tests/core_steps/models/foundation/test_google_gemini.py
@@ -5,16 +5,16 @@ import pytest
 from pydantic import ValidationError
 
 from inference.core.workflows.core_steps.models.foundation.google_gemini.v2 import (
-    BlockManifest,
     MODEL_VERSION_IDS,
+    BlockManifest,
     execute_gemini_request,
     prepare_generation_config,
 )
 from inference.core.workflows.core_steps.models.foundation.google_gemini.v3 import (
-    BlockManifest as V3BlockManifest,
+    MODEL_VERSION_IDS as V3_MODEL_VERSION_IDS,
 )
 from inference.core.workflows.core_steps.models.foundation.google_gemini.v3 import (
-    MODEL_VERSION_IDS as V3_MODEL_VERSION_IDS,
+    BlockManifest as V3BlockManifest,
 )
 
 STALE_MODEL_IDS = {
@@ -69,7 +69,9 @@ def test_gemini_v3_step_validation_when_input_is_valid() -> None:
     "model_ids",
     [MODEL_VERSION_IDS, V3_MODEL_VERSION_IDS],
 )
-def test_gemini_model_catalog_uses_available_google_models(model_ids: list[str]) -> None:
+def test_gemini_model_catalog_uses_available_google_models(
+    model_ids: list[str],
+) -> None:
     assert not STALE_MODEL_IDS.intersection(model_ids)
     assert "gemini-3.1-pro-preview" in model_ids
     assert "gemini-3.1-flash-lite" in model_ids

--- a/tests/workflows/unit_tests/execution_engine/executor/test_output_constructor.py
+++ b/tests/workflows/unit_tests/execution_engine/executor/test_output_constructor.py
@@ -534,7 +534,9 @@ def test_construct_workflow_output_can_defer_future_resolution() -> None:
     )
     predictions = _completed_future(["resolved"])
     execution_data_manager.get_selector_indices.return_value = None
-    execution_data_manager.get_non_batch_data.return_value = {"predictions": predictions}
+    execution_data_manager.get_non_batch_data.return_value = {
+        "predictions": predictions
+    }
 
     # when
     result = construct_workflow_output(


### PR DESCRIPTION
## What does this PR do?

Fix SSRF in URL image loading (GHSA-hjmm-hr52-vrp2)

Summary

Image loading from caller-supplied URLs validated only the hostname string — it never resolved the host and rejected non-global targets, and it followed redirects without re-validating each hop. An attacker could therefore make the server (or SDK) fetch internal resources: cloud metadata (169.254.169.254), loopback services (127.0.0.1:9001), and private/link-local/CGNAT/ULA hosts — directly, via a hostname that resolves to a private IP, via a redirect, or via DNS rebinding (resolve public for the check, private for the connection).

This PR adds resolved-IP validation, connection pinning to the validated IP, and per-hop redirect re-validation, on both the server (requests) and SDK (requests + aiohttp) paths. All new behaviour is off by default and gated behind env flags to stay non-breaking; the secure defaults are scheduled to flip in Q4 2026 (surfaced via deprecation warnings today).

Steps taken

New env flags (inference/core/env.py, mirrored in inference_sdk/config.py):
- VALIDATE_IMAGE_URL_REDIRECTS (default False → True Q4 2026) — follow redirects one hop at a time, re-validating each hop.
- ALLOW_URL_TO_NON_GLOBAL_ADDRESSES (default True → False Q4 2026) — block non-global resolved destinations and pin the connection to the validated IP.
- MAX_IMAGE_URL_REDIRECTS (default 30) — hard redirect cap, enforced in both modes.
- applied for both core library and Inference SDK



## Type of Change

<!-- Please select one and delete the others, or describe if Other -->

- Bug fix (non-breaking change that fixes an issue)

## Testing

<!-- Describe how you tested your changes -->

- [x] I have tested this change locally (manual verification with stub server - to the point possible w/o domain name)
- [x] I have added/updated tests for this change

**Test details:**
<!-- Describe what tests were added/updated and what they cover -->

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)

## Additional Context

<!-- Add any other context, screenshots, or notes about the PR here -->
