### PR TITLE
webexec deploy: install modal_app import-time deps (fixes 'No module named requests')

### DIFF
--- a/.github/workflows/modal.custom_python_block.deploy.yml
+++ b/.github/workflows/modal.custom_python_block.deploy.yml
@@ -60,7 +60,7 @@ jobs:
         with:
           python-version: '3.12'
       - name: Install dependencies
-        run: python3 -m pip install modal
+        run: python3 -m pip install modal requests packaging pydantic structlog python-dotenv rich
       - name: Deploy webexec (${{ matrix.target }} -> Modal env ${{ matrix.environment }})
         env:
           MODAL_WORKSPACE_NAME: ${{ secrets.MODAL_WORKSPACE_NAME }}


### PR DESCRIPTION
## Problem
The webexec deploy workflow (`modal.custom_python_block.deploy.yml`) installs only `modal`, then runs `deploy_modal_app.py`. That script imports `modal_app.py`, which at module load imports the inference source:

```
modal/modal_app.py:18  from inference.core.workflows…dynamic_blocks.error_utils import …
                       → inference.core.workflows.errors → pydantic
                       → inference.core.logger → rich   (logger.py:9)
```

So the deploy step fails before any deploy happens:

```
Error: Could not import modal_app: No module named 'requests'
```

Latent — it only surfaces once credentials are present and the script actually runs (previous runs failed earlier, at the credential step).

## Fix
Install `modal_app`'s import-time dependencies in the install step:

```
python3 -m pip install modal requests packaging pydantic structlog python-dotenv rich
```

Matches the dependency set used for manual webexec deploys, which import the same module. `rich` is currently vendored transitively by `modal` (its CLI is rich-based), but is listed explicitly so the deploy import doesn't rely on that. Deliberately **not** `pip install inference` — that pulls heavy *runtime* deps (torch/opencv/…) that belong in the Modal container image (via `.pip_install`), not on the deploy runner.

## How it was found
Surfaced by the first end-to-end dispatch of the EU deploy leg (added in the merged webexec-EU-matrix PR): with deploy creds in place, the run got past auth and hit this import error. Fix applies to both the `us` and `eu` legs (shared step).

## Validation (verified pre-merge, on this branch)
`workflow_dispatch` runs the workflow file as it exists on the target branch, so this was proven without merging by dispatching on `fix/webexec-deploy-deps` (`targets: eu`, `inference_version: 1.3.3`):

- **Reproduces the bug** without the fix (main, `pip install modal` only): [run 28679374038](https://github.com/roboflow/inference/actions/runs/28679374038) → `deploy (eu)` fails `No module named 'requests'`.
- **Green with the fix**: [run 28680147041](https://github.com/roboflow/inference/actions/runs/28680147041) (HEAD `28a7bc5b3`, `rich` explicit) → `setup` ✅ + `deploy (eu, eu, gcp, eu, eu-west)` ✅ → `✓ App deployed`, endpoint `roboflow-eu--webexec-executor-execute-block.eu-west.modal.run`.
- **Deployed webexec executes in-region (EEA)**: proxy-authed POST to the freshly-deployed endpoint ran a `cv2` + `numpy` + `supervision` block → `HTTP 200 success:true`, `MODAL_REGION=europe-west1`, `CLOUD_PROVIDER_GCP`.

Full attestation with logs in the PR comments. `fail-fast: false` isolates the EU leg from US.

## Follow-up (out of scope here — future fix)
This install-step change is a tactical unblock. The list still hand-mirrors inference's import-time dependency tree, which drifts as inference's internals change — that's why this broke twice (`requests`, then `rich`). Structural improvements to do separately:

- **Declare the deploy-runner deps in a versioned file** (e.g. `requirements/requirements.modal-deploy.txt`) and `pip install -r` it, instead of an inline list in the YAML — a single reviewed source of truth, ideally *derived* from an inference extra / requirements file rather than a hand-picked subset.
- **Pin / lock** what the runner installs (hashes or a lockfile) so an upstream release (e.g. a new `rich`/`pydantic` major) can't silently change or break a deploy.

_(Ideal root fix, a separate change to `modal_app.py`: defer its single top-level `inference` import into the container via `image.imports()` so the deploy runner needs only `modal` — eliminating this class of failure entirely.)_
