### PR TITLE
[codex] support SAM3 visual box-to-mask prompts

### DIFF
--- a/inference/core/entities/requests/sam2.py
+++ b/inference/core/entities/requests/sam2.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from pydantic import BaseModel, Field, root_validator, validator
 
@@ -61,6 +61,180 @@ class Box(BaseModel):
     y: float
     width: float
     height: float
+    class_name: Optional[str] = Field(default=None)
+    class_id: Optional[Union[int, str]] = Field(default=None)
+    detection_id: Optional[str] = Field(default=None)
+    parent_id: Optional[str] = Field(default=None)
+    confidence: Optional[float] = Field(default=None)
+
+    @root_validator(pre=True)
+    def _coerce_class_alias(cls, values):
+        if (
+            isinstance(values, dict)
+            and "class" in values
+            and "class_name" not in values
+        ):
+            values = values.copy()
+            values["class_name"] = values["class"]
+        return values
+
+    def to_xyxy(self) -> List[float]:
+        return [
+            self.x - self.width / 2,
+            self.y - self.height / 2,
+            self.x + self.width / 2,
+            self.y + self.height / 2,
+        ]
+
+    def prediction_metadata(self) -> Dict[str, Any]:
+        return _box_prediction_metadata(self)
+
+
+class BoxXYXY(BaseModel):
+    x1: float
+    y1: float
+    x2: float
+    y2: float
+    class_name: Optional[str] = Field(default=None)
+    class_id: Optional[Union[int, str]] = Field(default=None)
+    detection_id: Optional[str] = Field(default=None)
+    parent_id: Optional[str] = Field(default=None)
+    confidence: Optional[float] = Field(default=None)
+
+    @root_validator(pre=True)
+    def _coerce_box_aliases(cls, values):
+        if not isinstance(values, dict):
+            return values
+        values = values.copy()
+        if "class" in values and "class_name" not in values:
+            values["class_name"] = values["class"]
+        if {"x0", "y0", "x1", "y1"} <= set(values.keys()) and not {
+            "x2",
+            "y2",
+        } <= set(values.keys()):
+            values["x2"] = values["x1"]
+            values["y2"] = values["y1"]
+            values["x1"] = values["x0"]
+            values["y1"] = values["y0"]
+        return values
+
+    def to_xyxy(self) -> List[float]:
+        return [self.x1, self.y1, self.x2, self.y2]
+
+    def prediction_metadata(self) -> Dict[str, Any]:
+        return _box_prediction_metadata(self)
+
+
+BoxPrompt = Union[Box, BoxXYXY]
+
+
+def _box_prediction_metadata(box: BoxPrompt) -> Dict[str, Any]:
+    metadata: Dict[str, Any] = {}
+    if box.class_name is not None:
+        metadata["class_name"] = box.class_name
+    if box.class_id is not None:
+        metadata["class_id"] = box.class_id
+    if box.detection_id is not None:
+        metadata["detection_id"] = box.detection_id
+    if box.parent_id is not None:
+        metadata["parent_id"] = box.parent_id
+    elif box.detection_id is not None:
+        metadata["parent_id"] = box.detection_id
+    if box.confidence is not None:
+        metadata["detection_confidence"] = box.confidence
+    return metadata
+
+
+def _normalize_box_payload(value: Any) -> Any:
+    if isinstance(value, (Box, BoxXYXY)):
+        return value
+    if _is_flat_box(value):
+        return BoxXYXY(x1=value[0], y1=value[1], x2=value[2], y2=value[3])
+    if not isinstance(value, dict):
+        return value
+
+    value = value.copy()
+    if "class" in value and "class_name" not in value:
+        value["class_name"] = value["class"]
+
+    nested = None
+    if "box" in value:
+        nested = value["box"]
+    elif "bbox" in value:
+        nested = value["bbox"]
+    if nested is not None:
+        nested = _normalize_box_payload(nested)
+        if isinstance(nested, (Box, BoxXYXY)):
+            nested = nested.dict()
+        if isinstance(nested, dict):
+            nested = nested.copy()
+            for key in (
+                "class",
+                "class_name",
+                "class_id",
+                "detection_id",
+                "parent_id",
+                "confidence",
+            ):
+                if key in value and nested.get(key) is None:
+                    nested[key] = value[key]
+        return nested
+
+    return value
+
+
+def _box_payload_to_prompts(box_payload: Any) -> List[Dict[str, Any]]:
+    if box_payload is None:
+        return []
+    if isinstance(box_payload, dict):
+        if "predictions" in box_payload:
+            box_payload = box_payload["predictions"]
+        elif "detections" in box_payload:
+            box_payload = box_payload["detections"]
+        elif "boxes" in box_payload:
+            box_payload = box_payload["boxes"]
+        else:
+            box_payload = [box_payload]
+    elif _is_flat_box(box_payload):
+        box_payload = [box_payload]
+
+    if not isinstance(box_payload, list):
+        raise ValueError(
+            "boxes/detections must be a list, a single box, or a dict containing predictions/detections"
+        )
+    return [{"box": _normalize_box_payload(item)} for item in box_payload]
+
+
+def _append_box_prompts(
+    existing_prompts: Any, box_prompts: List[Dict[str, Any]]
+) -> Any:
+    if existing_prompts is None:
+        return {"prompts": box_prompts}
+    if isinstance(existing_prompts, Sam2PromptSet):
+        prompts = [
+            prompt.dict(exclude_none=True) for prompt in existing_prompts.prompts or []
+        ]
+    elif isinstance(existing_prompts, dict):
+        if "prompts" in existing_prompts:
+            prompts = existing_prompts.get("prompts") or []
+        else:
+            prompts = [existing_prompts]
+    elif isinstance(existing_prompts, list):
+        prompts = existing_prompts
+    else:
+        return existing_prompts
+    return {"prompts": [*prompts, *box_prompts]}
+
+
+def _is_flat_box(value: Any) -> bool:
+    if not isinstance(value, (list, tuple)) or len(value) != 4:
+        return False
+    try:
+        for element in value:
+            float(element)
+    except (TypeError, ValueError):
+        return False
+    return True
 
 
 class Point(BaseModel):
@@ -73,11 +247,22 @@ class Point(BaseModel):
 
 
 class Sam2Prompt(BaseModel):
-    box: Optional[Box] = Field(default=None)
+    box: Optional[BoxPrompt] = Field(default=None)
     points: Optional[List[Point]] = Field(default=None)
+
+    @validator("box", pre=True)
+    def _coerce_box(cls, value):
+        if value is None or isinstance(value, (Box, BoxXYXY)):
+            return value
+        return _normalize_box_payload(value)
 
     def num_points(self) -> int:
         return len(self.points or [])
+
+    def prediction_metadata(self) -> Dict[str, Any]:
+        if self.box is None:
+            return {}
+        return self.box.prediction_metadata()
 
 
 class Sam2PromptSet(BaseModel):
@@ -91,17 +276,19 @@ class Sam2PromptSet(BaseModel):
             return 0
         return sum(prompt.num_points() for prompt in self.prompts)
 
+    def has_boxes(self) -> bool:
+        return any(prompt.box is not None for prompt in self.prompts or [])
+
+    def prediction_metadata(self) -> List[Dict[str, Any]]:
+        return [prompt.prediction_metadata() for prompt in self.prompts or []]
+
     def to_sam2_inputs(self):
         if self.prompts is None:
             return {"point_coords": None, "point_labels": None, "box": None}
         return_dict = {"point_coords": [], "point_labels": [], "box": []}
         for prompt in self.prompts:
             if prompt.box is not None:
-                x1 = prompt.box.x - prompt.box.width / 2
-                y1 = prompt.box.y - prompt.box.height / 2
-                x2 = prompt.box.x + prompt.box.width / 2
-                y2 = prompt.box.y + prompt.box.height / 2
-                return_dict["box"].append([x1, y1, x2, y2])
+                return_dict["box"].append(prompt.box.to_xyxy())
             if prompt.points is not None:
                 return_dict["point_coords"].append(
                     list([point.x, point.y] for point in prompt.points)
@@ -162,6 +349,37 @@ class Sam2SegmentationRequest(Sam2InferenceRequest):
         "to select the best mask. For non-ambiguous prompts, such as multiple "
         "input prompts, multimask_output=False can give better results.",
     )
+    boxes: Optional[Any] = Field(
+        default=None,
+        description="Optional list of XYXY boxes or detection dictionaries to segment. "
+        "Each item is converted into an interactive box prompt.",
+    )
+    detections: Optional[Any] = Field(
+        default=None,
+        description="Optional detection payload to segment. Accepts a list of detections or a dict with a predictions/detections list.",
+    )
+    box_to_mask: bool = Field(
+        default=False,
+        description="If true, boxes/detections are treated as interactive box prompts.",
+    )
+    interactive_box: bool = Field(
+        default=False,
+        description="Alias for box_to_mask; boxes in this endpoint are interactive prompts.",
+    )
+
+    @root_validator(pre=True)
+    def _coerce_boxes_to_prompts(cls, values):
+        if not isinstance(values, dict):
+            return values
+        box_payload = values.get("boxes")
+        if box_payload is None:
+            box_payload = values.get("detections")
+        box_prompts = _box_payload_to_prompts(box_payload)
+        if not box_prompts:
+            return values
+        values = values.copy()
+        values["prompts"] = _append_box_prompts(values.get("prompts"), box_prompts)
+        return values
 
     # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.
     # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-validators for more information.

--- a/inference/core/entities/responses/sam2.py
+++ b/inference/core/entities/responses/sam2.py
@@ -33,6 +33,22 @@ class Sam2SegmentationPrediction(BaseModel):
     format: Optional[str] = Field(
         default="polygon", description="Format of the mask data: 'polygon' or 'rle'"
     )
+    class_name: Optional[str] = Field(
+        default=None, description="Class name from the source detection, if provided."
+    )
+    class_id: Optional[Union[int, str]] = Field(
+        default=None, description="Class id from the source detection, if provided."
+    )
+    detection_id: Optional[str] = Field(
+        default=None, description="Detection id from the source detection, if provided."
+    )
+    parent_id: Optional[str] = Field(
+        default=None, description="Parent id from the source detection, if provided."
+    )
+    detection_confidence: Optional[float] = Field(
+        default=None,
+        description="Confidence from the source detection, if provided.",
+    )
 
 
 class Sam2SegmentationResponse(BaseModel):

--- a/inference/models/sam3/visual_segmentation.py
+++ b/inference/models/sam3/visual_segmentation.py
@@ -203,8 +203,14 @@ class Sam3ForInteractiveImageSegmentation(RoboflowCoreModel):
             inference_time = perf_counter() - t1
             return Sam2EmbeddingResponse(time=inference_time, image_id=image_id)
         elif isinstance(request, Sam2SegmentationRequest):
+            prediction_metadata = request.prompts.prediction_metadata()
             masks, scores, low_resolution_logits = self.segment_image(**request.dict())
-            predictions = _masks_to_predictions(masks, scores, request.format)
+            predictions = _masks_to_predictions(
+                masks,
+                scores,
+                request.format,
+                prediction_metadata=prediction_metadata,
+            )
             return Sam2SegmentationResponse(
                 time=perf_counter() - t1,
                 predictions=predictions,
@@ -294,6 +300,8 @@ class Sam3ForInteractiveImageSegmentation(RoboflowCoreModel):
                     args = prompts.to_sam2_inputs()
             else:
                 prompt_set = Sam2PromptSet()
+            if prompt_set.has_boxes():
+                multimask_output = False
 
             if mask_input is None and load_logits_from_cache:
                 mask_input = maybe_load_low_res_logits_from_cache(
@@ -319,11 +327,25 @@ class Sam3ForInteractiveImageSegmentation(RoboflowCoreModel):
                     normalize_coords=True,
                     **args,
                 )
-            masks, scores, low_resolution_logits = choose_most_confident_sam_prediction(
-                masks=masks,
-                scores=scores,
-                low_resolution_logits=low_resolution_logits,
-            )
+            masks = _to_numpy_array(masks)
+            scores = _to_numpy_array(scores).reshape(-1)
+            low_resolution_logits = _to_numpy_array(low_resolution_logits)
+            if multimask_output:
+                (
+                    masks,
+                    scores,
+                    low_resolution_logits,
+                ) = choose_most_confident_sam_prediction(
+                    masks=masks,
+                    scores=scores,
+                    low_resolution_logits=low_resolution_logits,
+                )
+            else:
+                masks, scores, low_resolution_logits = ensure_prompt_dimension(
+                    masks=masks,
+                    scores=scores,
+                    low_resolution_logits=low_resolution_logits,
+                )
 
             if save_logits_to_cache:
                 self.add_low_res_logits_to_cache(
@@ -562,6 +584,28 @@ def choose_most_confident_prompt_set_element_prediction(
     return selected_mask, selected_score, selected_low_resolution_logit
 
 
+def _to_numpy_array(value: Any) -> np.ndarray:
+    if hasattr(value, "detach"):
+        return value.detach().cpu().numpy()
+    return np.asarray(value)
+
+
+def ensure_prompt_dimension(
+    masks: np.ndarray,
+    scores: np.ndarray,
+    low_resolution_logits: np.ndarray,
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    if masks.ndim == 4 and masks.shape[1] == 1:
+        masks = masks[:, 0, ...]
+    if masks.ndim == 2:
+        masks = np.expand_dims(masks, axis=0)
+    if low_resolution_logits.ndim == 4 and low_resolution_logits.shape[1] == 1:
+        low_resolution_logits = low_resolution_logits[:, 0, ...]
+    if low_resolution_logits.ndim == 2:
+        low_resolution_logits = np.expand_dims(low_resolution_logits, axis=0)
+    return masks, scores.reshape(-1), low_resolution_logits
+
+
 def turn_segmentation_results_into_api_response(
     masks: np.ndarray,
     scores: np.ndarray,
@@ -608,7 +652,10 @@ def pad_points(args: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def _masks_to_predictions(
-    masks_np: np.ndarray, scores: List[float], fmt: str
+    masks_np: np.ndarray,
+    scores: List[float],
+    fmt: str,
+    prediction_metadata: Optional[List[Dict[str, Any]]] = None,
 ) -> List[Sam2SegmentationPrediction]:
     """Convert boolean masks (N,H,W) to API predictions in requested format.
 
@@ -629,25 +676,37 @@ def _masks_to_predictions(
 
     if fmt in ["polygon", "json"]:
         polygons = masks2multipoly((masks_np > 0).astype(np.uint8))
-        for poly, score in zip(polygons, scores[: len(polygons)]):
+        for idx, (poly, score) in enumerate(zip(polygons, scores[: len(polygons)])):
             preds.append(
                 Sam2SegmentationPrediction(
                     masks=[p.tolist() for p in poly],
                     confidence=float(score),
                     format="polygon",
+                    **_metadata_for_prediction(prediction_metadata, idx),
                 )
             )
     elif fmt == "rle":
-        for m, score in zip(masks_np, scores[: masks_np.shape[0]]):
+        for idx, (m, score) in enumerate(zip(masks_np, scores[: masks_np.shape[0]])):
             mb = (m > 0).astype(np.uint8)
             rle = mask_utils.encode(np.asfortranarray(mb))
             rle["counts"] = rle["counts"].decode("utf-8")
             preds.append(
                 Sam2SegmentationPrediction(
-                    masks=rle, confidence=float(score), format="rle"
+                    masks=rle,
+                    confidence=float(score),
+                    format="rle",
+                    **_metadata_for_prediction(prediction_metadata, idx),
                 )
             )
     return preds
+
+
+def _metadata_for_prediction(
+    prediction_metadata: Optional[List[Dict[str, Any]]], prediction_index: int
+) -> Dict[str, Any]:
+    if not prediction_metadata or prediction_index >= len(prediction_metadata):
+        return {}
+    return prediction_metadata[prediction_index]
 
 
 def safe_remove_from_list(values: List[T], element: T) -> None:

--- a/inference/models/sam3/visual_segmentation_inference_models.py
+++ b/inference/models/sam3/visual_segmentation_inference_models.py
@@ -110,18 +110,21 @@ class InferenceModelsSAM3InteractiveAdapter(Model):
             _, _, image_id = self.embed_image(**request.dict())
             return Sam2EmbeddingResponse(time=perf_counter() - t1, image_id=image_id)
         if isinstance(request, Sam2SegmentationRequest):
+            prediction_metadata = request.prompts.prediction_metadata()
             masks, scores, low_res_logits = self.segment_image(**request.dict())
             if request.format == "json" or request.format == "polygon":
                 return _build_polygon_response(
                     masks=masks,
                     scores=scores,
                     inference_start_timestamp=t1,
+                    prediction_metadata=prediction_metadata,
                 )
             if request.format == "rle":
                 return _build_rle_response(
                     masks=masks,
                     scores=scores,
                     inference_start_timestamp=t1,
+                    prediction_metadata=prediction_metadata,
                 )
             if request.format == "binary":
                 buf = BytesIO()
@@ -178,6 +181,8 @@ class InferenceModelsSAM3InteractiveAdapter(Model):
                 prompts = Sam2PromptSet(**prompts)
         else:
             prompts = Sam2PromptSet()
+        if prompts.has_boxes():
+            multimask_output = False
         args = prompts.to_sam2_inputs()
         args = _pad_points(args)
         if args["point_coords"] is not None:
@@ -252,15 +257,17 @@ def _build_polygon_response(
     masks: np.ndarray,
     scores: np.ndarray,
     inference_start_timestamp: float,
+    prediction_metadata: Optional[List[Dict[str, Any]]] = None,
 ) -> Sam2SegmentationResponse:
     predictions: List[Sam2SegmentationPrediction] = []
     polygons = masks2multipoly(masks >= MASK_THRESHOLD)
-    for poly, score in zip(polygons, scores):
+    for idx, (poly, score) in enumerate(zip(polygons, scores)):
         predictions.append(
             Sam2SegmentationPrediction(
                 masks=[m.tolist() for m in poly],
                 confidence=float(score),
                 format="polygon",
+                **_metadata_for_prediction(prediction_metadata, idx),
             )
         )
     return Sam2SegmentationResponse(
@@ -273,16 +280,30 @@ def _build_rle_response(
     masks: np.ndarray,
     scores: np.ndarray,
     inference_start_timestamp: float,
+    prediction_metadata: Optional[List[Dict[str, Any]]] = None,
 ) -> Sam2SegmentationResponse:
     predictions: List[Sam2SegmentationPrediction] = []
-    for mask, score in zip(masks, scores):
+    for idx, (mask, score) in enumerate(zip(masks, scores)):
         mb = (mask >= MASK_THRESHOLD).astype(np.uint8)
         rle = mask_utils.encode(np.asfortranarray(mb))
         rle["counts"] = rle["counts"].decode("utf-8")
         predictions.append(
-            Sam2SegmentationPrediction(masks=rle, confidence=float(score), format="rle")
+            Sam2SegmentationPrediction(
+                masks=rle,
+                confidence=float(score),
+                format="rle",
+                **_metadata_for_prediction(prediction_metadata, idx),
+            )
         )
     return Sam2SegmentationResponse(
         time=perf_counter() - inference_start_timestamp,
         predictions=predictions,
     )
+
+
+def _metadata_for_prediction(
+    prediction_metadata: Optional[List[Dict[str, Any]]], prediction_index: int
+) -> Dict[str, Any]:
+    if not prediction_metadata or prediction_index >= len(prediction_metadata):
+        return {}
+    return prediction_metadata[prediction_index]

--- a/tests/inference/unit_tests/models/test_sam3_visual_segmentation.py
+++ b/tests/inference/unit_tests/models/test_sam3_visual_segmentation.py
@@ -10,6 +10,9 @@ import numpy as np
 import pytest
 import torch
 
+from inference.core.entities.requests.inference import InferenceRequestImage
+from inference.core.entities.requests.sam2 import Sam2SegmentationRequest
+
 # Meta's `sam3` package is not installed in the unit-test environment, so the
 # adapter module (which imports it transitively via inference_models) cannot
 # be imported without stubbing it.
@@ -139,6 +142,121 @@ def test_segment_image_forwards_all_prompts_to_model(
     boxes = call_kwargs["boxes"]
     assert boxes.shape == (2, 4)
     np.testing.assert_allclose(boxes, [[8, 8, 12, 12], [26, 26, 34, 34]])
+
+
+def test_segment_image_accepts_xyxy_box_and_disables_multimask(
+    adapter_module: ModuleType,
+) -> None:
+    # given
+    prediction = SimpleNamespace(
+        masks=torch.rand(1, 8, 8),
+        scores=torch.tensor([0.9]),
+        logits=torch.rand(1, 16, 16),
+    )
+    adapter = _build_adapter(adapter_module, prediction)
+
+    # when
+    _ = adapter.segment_image(
+        image=None,
+        multimask_output=True,
+        prompts={"prompts": [{"box": [1, 2, 8, 9]}]},
+    )
+
+    # then
+    call_kwargs = adapter._model.segment_with_visual_prompts.call_args.kwargs
+    np.testing.assert_allclose(call_kwargs["boxes"], [[1, 2, 8, 9]])
+    assert call_kwargs["multi_mask_output"] is False
+
+
+def test_segmentation_request_converts_top_level_boxes_to_prompts() -> None:
+    # when
+    request = Sam2SegmentationRequest(
+        image=InferenceRequestImage(type="base64", value="abc"),
+        boxes=[
+            {
+                "x1": 1,
+                "y1": 2,
+                "x2": 8,
+                "y2": 9,
+                "class": "widget",
+                "class_id": 3,
+                "detection_id": "det-1",
+                "confidence": 0.87,
+            }
+        ],
+    )
+
+    # then
+    args = request.prompts.to_sam2_inputs()
+    np.testing.assert_allclose(args["box"], [[1, 2, 8, 9]])
+    assert request.prompts.prediction_metadata() == [
+        {
+            "class_name": "widget",
+            "class_id": 3,
+            "detection_id": "det-1",
+            "parent_id": "det-1",
+            "detection_confidence": 0.87,
+        }
+    ]
+
+    detection_request = Sam2SegmentationRequest(
+        image=InferenceRequestImage(type="base64", value="abc"),
+        detections={
+            "predictions": [
+                {
+                    "x": 10,
+                    "y": 10,
+                    "width": 4,
+                    "height": 4,
+                    "class": "widget",
+                }
+            ]
+        },
+    )
+    np.testing.assert_allclose(
+        detection_request.prompts.to_sam2_inputs()["box"],
+        [[8, 8, 12, 12]],
+    )
+    assert detection_request.prompts.prediction_metadata()[0]["class_name"] == "widget"
+
+
+def test_infer_from_request_preserves_box_metadata(
+    adapter_module: ModuleType,
+) -> None:
+    # given
+    mask = torch.zeros(1, 8, 8)
+    mask[:, 1:6, 1:6] = 1
+    prediction = SimpleNamespace(
+        masks=mask,
+        scores=torch.tensor([0.9]),
+        logits=torch.rand(1, 16, 16),
+    )
+    adapter = _build_adapter(adapter_module, prediction)
+    request = Sam2SegmentationRequest(
+        image=InferenceRequestImage(type="base64", value="abc"),
+        image_id="cached-image",
+        format="rle",
+        boxes=[
+            {
+                "bbox": [1, 2, 8, 9],
+                "class_name": "widget",
+                "class_id": 3,
+                "detection_id": "det-1",
+                "confidence": 0.87,
+            }
+        ],
+    )
+
+    # when
+    response = adapter.infer_from_request(request)
+
+    # then
+    prediction_response = response.predictions[0]
+    assert prediction_response.class_name == "widget"
+    assert prediction_response.class_id == 3
+    assert prediction_response.detection_id == "det-1"
+    assert prediction_response.parent_id == "det-1"
+    assert prediction_response.detection_confidence == 0.87
 
 
 def _single_prediction() -> SimpleNamespace:


### PR DESCRIPTION
## Summary

This PR adds box-to-mask support to the existing SAM3 visual segmentation endpoint, `/sam3/visual_segment`, without adding a new endpoint and without changing workflow blocks.

The goal is to make SAM3 behave like SAM/SAM2 for box prompts: given a box, segment the object indicated by that box. This is different from the SAM3 concept/semantic segmentation path, where a box can behave like a visual exemplar and the model may search for similar objects outside the box.

## Why this is needed

Today SAM3 has two relevant modes in Inference:

1. `/sam3/concept_segment`
   - open-vocabulary / semantic prompting
   - text and visual exemplar style prompting
   - boxes can be interpreted as examples of what to find
   - not the right behavior for detection-to-mask conversion

2. `/sam3/visual_segment`
   - SAM-style interactive segmentation
   - point and box prompting
   - backed by SAM3 interactive/PVS serving
   - already the correct endpoint for `segment this object indicated by this prompt`

For box-to-mask, we want mode 2. A detection box should be treated as a geometric prompt, not as a concept exemplar. This PR routes that behavior through the existing visual endpoint and keeps the current concept endpoint behavior unchanged.

## What changed

### Request schema

`Sam2SegmentationRequest` is used by `/sam3/visual_segment`, so the schema now accepts detection/box inputs directly:

```json
{
  "image": { "type": "url", "value": "..." },
  "boxes": [[10, 20, 100, 200]]
}
```

It also supports detection-style payloads:

```json
{
  "image": { "type": "url", "value": "..." },
  "detections": {
    "predictions": [
      {
        "x": 55,
        "y": 110,
        "width": 90,
        "height": 180,
        "class": "dog",
        "class_id": 1,
        "detection_id": "det-123",
        "confidence": 0.91
      }
    ]
  }
}
```

Accepted box formats now include:

- XYXY array: `[x1, y1, x2, y2]`
- XYXY dict: `{ "x1": ..., "y1": ..., "x2": ..., "y2": ... }`
- XYXY alias dict: `{ "x0": ..., "y0": ..., "x1": ..., "y1": ... }`
- existing center-based box: `{ "x": ..., "y": ..., "width": ..., "height": ... }`
- nested detection fields: `{ "bbox": [...] }` or `{ "box": ... }`

Top-level `boxes` / `detections` are normalized into the existing prompt structure, so the endpoint continues using the same internal visual segmentation path.

### SAM3 visual segmentation path

When a prompt contains boxes, the SAM3 visual segmentation wrappers now force:

```python
multimask_output = False
```

That matches the desired box-to-mask behavior: one best mask per input box.

This is implemented in both SAM3 visual paths:

- `inference/models/sam3/visual_segmentation_inference_models.py`
- `inference/models/sam3/visual_segmentation.py`

The current concept segmentation path is intentionally untouched.

### Response metadata

The output predictions now preserve source detection metadata when present:

- `class_name`
- `class_id`
- `detection_id`
- `parent_id`
- `detection_confidence`

Important detail: the mask prediction's `confidence` remains the SAM/SAM3 mask confidence. The original detection confidence is exposed separately as `detection_confidence`.

## What this does not do

- Does not add a new endpoint.
- Does not change workflow blocks.
- Does not crop images before SAM3.
- Does not pass boxes through the SAM3 concept/semantic prompt path.
- Does not change `/sam3/concept_segment` behavior.

## Why the implementation lives in the SAM2 request schema

`/sam3/visual_segment` already uses `Sam2SegmentationRequest` / `Sam2SegmentationResponse` because SAM3 interactive segmentation is exposed through the same SAM-style API shape as SAM2.

So the compatibility layer for `boxes` / `detections` belongs in that request model rather than in a new SAM3-only endpoint contract.

## Validation

Local checks run after rebasing on current `origin/main`:

```bash
PYENV_VERSION=inference python -m black --check \
  inference/core/entities/requests/sam2.py \
  inference/core/entities/responses/sam2.py \
  inference/models/sam3/visual_segmentation_inference_models.py \
  inference/models/sam3/visual_segmentation.py \
  tests/inference/unit_tests/models/test_sam3_visual_segmentation.py
```

```bash
PYENV_VERSION=inference PYTHONPATH=.:inference_models python -m pytest \
  tests/inference/unit_tests/models/test_sam2_inference_models.py \
  tests/inference/unit_tests/models/test_sam3.py \
  tests/inference/unit_tests/models/test_sam3_visual_segmentation.py \
  -q
```

Result:

```text
34 passed
```

## Test coverage added

Added unit coverage for:

- top-level `boxes` normalization into prompts
- top-level `detections.predictions` normalization into prompts
- XYXY list box forwarding as `[x1, y1, x2, y2]`
- forcing `multi_mask_output=False` when box prompts are present
- preserving detection metadata in RLE response predictions

## Existing integration test gap

There is an existing SAM3 integration test file:

- `tests/inference/integration_tests/test_sam3.py`

But it is skipped by default via `SKIP_SAM3_TESTS=True`, and its current `/sam3/visual_segment` test only calls the endpoint with an image, not with boxes or detections.

So this PR currently adds focused unit coverage for the new contract, but does not add a live SAM3 integration test for box-to-mask. That would require an environment where SAM3 integration tests are enabled and the model weights/runtime are available.

## Help needed / reviewer context

I would like Thomas's input on the serving/runtime side, specifically:

1. Confirm that `/sam3/visual_segment` is the correct public endpoint for detection-box-to-mask behavior.
2. Confirm that the deployed SAM3 PVS / interactive serving path accepts this request contract once `boxes` / `detections` are normalized into prompts.
3. Confirm whether we need an integration test variant that runs with `SKIP_SAM3_TESTS=False`, or whether unit coverage is enough for this change.
4. Confirm that preserving original detection metadata on `Sam2SegmentationPrediction` is acceptable for downstream consumers.

The key behavior to validate manually is: a supplied detection box should generate a mask for the object inside that box, and should not act as a visual exemplar that finds similar objects elsewhere in the image.