### PR TITLE
[WIP] Fix collect_tags mutating global ACTIVE_LEARNING_TAGS in place

### DIFF
--- a/inference/core/active_learning/core.py
+++ b/inference/core/active_learning/core.py
@@ -162,7 +162,7 @@ def register_datapoint_at_roboflow(
 def collect_tags(
     configuration: ActiveLearningConfiguration, sampling_strategy: str
 ) -> List[str]:
-    tags = ACTIVE_LEARNING_TAGS if ACTIVE_LEARNING_TAGS is not None else []
+    tags = list(ACTIVE_LEARNING_TAGS) if ACTIVE_LEARNING_TAGS is not None else []
     tags.extend(configuration.tags)
     tags.extend(configuration.strategies_tags[sampling_strategy])
     if configuration.persist_predictions:


### PR DESCRIPTION
## 🚧 Work in progress — not ready for review

Draft PR from a batch addressing findings from an in-depth engineering review. Fixes **review finding 10** (High, Correctness).

## The bug
`collect_tags` in `inference/core/active_learning/core.py:165` binds `tags` directly to the module-global `ACTIVE_LEARNING_TAGS` list (imported at line 24) when it is not `None`, then mutates it in place via `extend`/`append`. Each active-learning registration therefore appends its config tags, per-strategy tags, and model id onto the shared global, so the list grows unbounded and images get progressively wrong/duplicated tags across calls and strategies.

## Root cause
`ACTIVE_LEARNING_TAGS` is a list produced by `safe_split_value` (env.py:612). The `tags = ACTIVE_LEARNING_TAGS if ... else []` expression aliases that object rather than copying it, so `tags.extend(...)` / `tags.append(...)` write straight into the process-wide global.

## Fix
`inference/core/active_learning/core.py`: copy before mutating — `tags = list(ACTIVE_LEARNING_TAGS) if ACTIVE_LEARNING_TAGS is not None else []`. Single-line change; each call now builds its own fresh list.

## Verification
Standalone repro of the exact logic. Before (alias): call1 `['env_tag','a','s1t','ws-m-1']`, call2 `['env_tag','a','s1t','ws-m-1','a','s2t','ws-m-1']`, global polluted, `t1 is global` -> True. After (`list(...)`): call1 `['env_tag','a','s1t','ws-m-1']`, call2 `['env_tag','a','s2t','ws-m-1']`, global stays `['env_tag']`, `t1 is global` -> False.

## Scope
Focused change; one of a coordinated batch (one PR per finding).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
