### PR TITLE
[WIP] Fix inference server unreachable on non-default --port

### DIFF
--- a/inference_cli/lib/container_adapter.py
+++ b/inference_cli/lib/container_adapter.py
@@ -250,7 +250,7 @@ def start_inference_container(
     )
     pull_image(image, use_local_images=use_local_images)
     print(f"Starting inference server container...")
-    ports = {"9001": port}
+    ports = {str(port): port}
     if development:
         ports["9002"] = 9002
     docker_client = docker.from_env()


### PR DESCRIPTION
## 🚧 Work in progress — not ready for review

Draft PR from a batch addressing findings from an in-depth engineering review. Fixes **review finding 11** (High, Correctness).

## The bug
`inference server start --port <non-9001>` yields an unreachable server. `start_inference_container` publishes the container with `ports = {"9001": port}` at `inference_cli/lib/container_adapter.py:253` (docker-py semantics: `{container_port: host_port}`), so only container port 9001 is forwarded to the host. But `prepare_container_environment` sets `environment["PORT"] = str(port)` (`:304`) and the image entrypoint (`docker/entrypoint/run_uvicorn.sh`) binds uvicorn to `--port $PORT`. For any `--port` other than 9001, uvicorn binds container:`<port>` while Docker only publishes container:9001, where nothing listens — so `curl http://localhost:<port>` is refused. Default 9001 works only by coincidence.

## Root cause
The container's internal bind port (driven by the `PORT` env var → uvicorn) was decoupled from the published container port in the port map. The map key was hard-coded to `9001` regardless of the user-selected port, so the published host port pointed at a dead container port whenever `--port != 9001`.

## Fix
- `inference_cli/lib/container_adapter.py`: change `ports = {"9001": port}` → `ports = {str(port): port}`, so the published container port matches the port uvicorn actually binds (per the `PORT` env). This also keeps `ask_user_to_kill_container` (reads `PORT` env) and `check_inference_server_status` (reads `ExposedPorts`) consistent with the real port. One-line change; default port 9001 behavior is unchanged.

## Verification
Confirmed docker-py `ports` dict semantics (`{container_port: host_port}`) from `ContainerCollection.run` docstring, then simulated the mapping vs. the `PORT`-driven bind port:
- Before: `--port 8080` → `ports={'9001': 8080}`, uvicorn binds container:8080 → reachable=**False** (bug reproduced).
- After: `--port 8080` → `ports={'8080': 8080}`, uvicorn binds container:8080 → reachable=**True**.
- Default `--port 9001` → `ports={'9001': 9001}` → reachable=True (unchanged).

No live Docker daemon available in-env, so this is a logic-level repro of the mapping vs. bind-port relationship.

## Scope
Focused change; one of a coordinated batch (one PR per finding).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
