### PR TITLE
[WIP] Fix template matching detection_id length mismatch after NMS

### DIFF
--- a/inference/core/workflows/core_steps/classical_cv/template_matching/v1.py
+++ b/inference/core/workflows/core_steps/classical_cv/template_matching/v1.py
@@ -202,7 +202,7 @@ def apply_template_matching(
     w, h = template_gray.shape[::-1]
     res = cv2.matchTemplate(img_gray, template_gray, cv2.TM_CCOEFF_NORMED)
     loc = np.where(res >= matching_threshold)
-    xyxy, confidence, class_id, class_name, detections_id = [], [], [], [], []
+    xyxy, confidence, class_id, class_name = [], [], [], []
     for pt in zip(*loc[::-1]):
         top_left = pt
         bottom_right = (pt[0] + w, pt[1] + h)
@@ -210,7 +210,6 @@ def apply_template_matching(
         confidence.append(1.0)
         class_id.append(0)
         class_name.append("template_match")
-        detections_id.append(str(uuid4()))
     if len(xyxy) == 0:
         return sv.Detections.empty()
     detections = sv.Detections(
@@ -225,7 +224,9 @@ def apply_template_matching(
         [image.parent_metadata.parent_id] * len(detections)
     )
     detections[PREDICTION_TYPE_KEY] = np.array(["object-detection"] * len(detections))
-    detections[DETECTION_ID_KEY] = np.array(detections_id)
+    detections[DETECTION_ID_KEY] = np.array(
+        [str(uuid4()) for _ in range(len(detections))]
+    )
     image_height, image_width = image.numpy_image.shape[:2]
     detections[IMAGE_DIMENSIONS_KEY] = np.array(
         [[image_height, image_width]] * len(detections)


### PR DESCRIPTION
## 🚧 Work in progress — not ready for review

Draft PR from a batch addressing findings from an in-depth engineering review. Fixes **review finding 5** (High, Correctness).

## The bug
In `inference/core/workflows/core_steps/classical_cv/template_matching/v1.py`, `apply_template_matching` builds `detections_id` with one UUID per RAW match (length N). `with_nms()` (v1.py:223) reduces the `Detections` to M≤N rows, but the original code assigned `detections[DETECTION_ID_KEY] = np.array(detections_id)` (v1.py:228) using the stale length-N list. supervision's `Detections.__setitem__` performs no length check, so `detection_id` ends up longer than the row count (and holds the wrong IDs — the first N raw matches, not the survivors), while `parent_id`/`prediction_type`/`image_dimensions` are correctly sized to M.

## Root cause
The detection IDs were generated before NMS and applied after NMS, so their length was tied to the pre-NMS match count instead of the final row count.

## Fix
`v1.py` only: generate the `detection_id` array after `with_nms()`, sized to `len(detections)` via `[str(uuid4()) for _ in range(len(detections))]`. The now-unused pre-NMS `detections_id` list accumulation is removed. `uuid4` remains imported and used.

## Verification
Standalone repro with supervision 0.29.0.post0: 5 overlapping raw matches, `with_nms(threshold=0.5)` reduces to 2 rows. Before the fix a length-5 `detection_id` array was set and `det[det.confidence > 0.5]` raised `IndexError: boolean index did not match indexed array along axis 0; size of axis is 5 but size of corresponding boolean axis is 2`. After the fix `detection_id` length is 2 (matches row count) and the downstream boolean filter runs cleanly.

## Scope
Focused change; one of a coordinated batch (one PR per finding).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
