### PR TITLE
[WIP] Fix execute_termination indexing ManagedInferencePipeline as a tuple

### DIFF
--- a/inference/core/interfaces/stream_manager/manager_app/app.py
+++ b/inference/core/interfaces/stream_manager/manager_app/app.py
@@ -308,16 +308,16 @@ def get_response_ignoring_thrash(
 def execute_termination(
     signal_number: int,
     frame: FrameType,
-    processes_table: Dict[str, Tuple[Process, Queue, Queue, Lock]],
+    processes_table: Dict[str, ManagedInferencePipeline],
 ) -> None:
     with PROCESSES_TABLE_LOCK:
         pipeline_ids = list(processes_table.keys())
         for pipeline_id in pipeline_ids:
             logger.info(f"Terminating pipeline: {pipeline_id}")
-            processes_table[pipeline_id][0].terminate()
+            processes_table[pipeline_id].pipeline_manager.terminate()
             logger.info(f"Pipeline: {pipeline_id} terminated.")
             logger.info(f"Joining pipeline: {pipeline_id}")
-            processes_table[pipeline_id][0].join()
+            processes_table[pipeline_id].pipeline_manager.join()
             logger.info(f"Pipeline: {pipeline_id} joined.")
         logger.info(f"Termination handler completed.")
         sys.exit(0)


### PR DESCRIPTION
## 🚧 Work in progress — not ready for review

Draft PR from a batch addressing findings from an in-depth engineering review. Fixes **review finding 7** (High, Correctness).

## The bug
`execute_termination` — the registered SIGINT/SIGTERM handler in `inference/core/interfaces/stream_manager/manager_app/app.py:308-323` — indexes each table entry as a tuple: `processes_table[pipeline_id][0].terminate()` (line 317) and `[0].join()` (line 320). `PROCESSES_TABLE` stores `ManagedInferencePipeline` dataclass instances (defined at `app.py:60-73`, populated at `app.py:530`), which are not subscriptable.

## Root cause
The processes table was migrated from `(Process, Queue, Queue, Lock)` tuples to the `ManagedInferencePipeline` dataclass, but `execute_termination` was never updated — including its stale parameter type hint `Dict[str, Tuple[Process, Queue, Queue, Lock]]` (line 311). On SIGTERM/SIGINT with ≥1 active pipeline, the first loop iteration raises `TypeError: 'ManagedInferencePipeline' object is not subscriptable`, so child `InferencePipeline` processes are never terminated/joined and `sys.exit(0)` is never reached — orphaning worker processes and failing graceful shutdown. Sibling functions (`join_inference_pipeline`, `check_process_health`) already use the correct `.pipeline_manager` attribute.

## Fix
In `app.py`, within `execute_termination`:
- Replace `processes_table[pipeline_id][0].terminate()` → `processes_table[pipeline_id].pipeline_manager.terminate()`
- Replace `processes_table[pipeline_id][0].join()` → `processes_table[pipeline_id].pipeline_manager.join()`
- Correct the stale parameter type hint to `Dict[str, ManagedInferencePipeline]`

Three-line change; no behavior change beyond making the handler actually terminate and join pipelines.

## Verification
Standalone repro of the access pattern: a `@dataclass` instance raises `TypeError: 'M' object is not subscriptable` on `[0]` (the original code path), while `.pipeline_manager.terminate()` / `.join()` dispatch correctly (the fixed path). `py_compile` on the edited module passes.

## Scope
Focused change; one of a coordinated batch (one PR per finding).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
