### PR TITLE
[WIP] Fix Identify Outliers crash when window_size=None

### DIFF
--- a/inference/core/workflows/core_steps/sampling/identify_outliers/v1.py
+++ b/inference/core/workflows/core_steps/sampling/identify_outliers/v1.py
@@ -204,7 +204,7 @@ class IdentifyOutliersBlockV1(WorkflowBlock):
         embedding: List[float],
         threshold_percentile: float,
         warmup: int,
-        window_size: int,
+        window_size: Optional[int],
     ) -> BlockResult:
         # Convert to np array
         embedding = np.array(embedding, dtype=float)
@@ -221,7 +221,7 @@ class IdentifyOutliersBlockV1(WorkflowBlock):
 
         # Store normalized embedding for vMF:
         self.all_embeddings.append(embedding_normed)
-        if len(self.all_embeddings) > window_size:
+        if window_size is not None and len(self.all_embeddings) > window_size:
             # Remove oldest embedding
             self.all_embeddings.pop(0)
 


### PR DESCRIPTION
## 🚧 Work in progress — not ready for review

Draft PR from a batch addressing findings from an in-depth engineering review. Fixes **review finding 3** (High, Error-handling).

## The bug
The Identify Outliers block's `window_size` field is `Optional[int]` and its description explicitly says "Set to None for unlimited window (uses all historical data)", with `None` listed among the examples. But `run()` does `if len(self.all_embeddings) > window_size:` with no `None` handling (`inference/core/workflows/core_steps/sampling/identify_outliers/v1.py:224`). In Python 3, `int > None` raises `TypeError`, so any user who follows the documented usage and sets `window_size=None` crashes the block on its very first call.

## Root cause
The FIFO window-eviction check compares `len(...)` against `window_size` unconditionally. The manifest accepts `None` (validated fine), but the run path never guards for it — and no `model_validator` rejects it either. The result: the documented "unlimited window" behavior is unreachable and always throws.

## Fix
`inference/core/workflows/core_steps/sampling/identify_outliers/v1.py`:
- Guard the eviction check: `if window_size is not None and len(self.all_embeddings) > window_size:` — `None` now correctly means "unlimited" (no oldest-embedding eviction), matching the field docs.
- Correct the `run()` signature annotation from `window_size: int` to `window_size: Optional[int]` to reflect the actual manifest type.

## Verification
Standalone repro of the exact comparison:
- Before: `len([1,2,3,4]) > None` → `TypeError: '>' not supported between instances of 'int' and 'NoneType'`.
- After: `window_size=None` → no eviction (unlimited, correct); `window_size=32` → no eviction; `window_size=3` over a length-4 buffer → evicts oldest (FIFO preserved).

`python -m py_compile` passes on the modified file.

## Scope
Focused change; one of a coordinated batch (one PR per finding).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
