### PR TITLE
[WIP] Catch TypeError for None fallback_class_id in detections classes replacement

### DIFF
--- a/inference/core/workflows/core_steps/fusion/detections_classes_replacement/v1.py
+++ b/inference/core/workflows/core_steps/fusion/detections_classes_replacement/v1.py
@@ -403,7 +403,7 @@ def extract_leading_class_from_prediction(
         elif not prediction.get("predictions") and fallback_class_name:
             try:
                 fallback_class_id = int(fallback_class_id)
-            except ValueError:
+            except (ValueError, TypeError):
                 fallback_class_id = None
             if fallback_class_id is None or fallback_class_id < 0:
                 fallback_class_id = sys.maxsize

--- a/tests/workflows/unit_tests/core_steps/fusion/test_detections_classes_replacement.py
+++ b/tests/workflows/unit_tests/core_steps/fusion/test_detections_classes_replacement.py
@@ -1,3 +1,5 @@
+import sys
+
 import numpy as np
 import pytest
 import supervision as sv
@@ -392,6 +394,78 @@ def test_classes_replacement_when_empty_classification_predictions_fallback_clas
     assert (
         detections.class_id[1] == 123
     ), "class id expected to be set to value passed with fallback_class_id parameter"
+    assert (
+        detections.data["class_name"][1] == "unknown"
+    ), "class name expected to be set to value passed with fallback_class_name parameter"
+
+
+def test_classes_replacement_when_empty_classification_predictions_fallback_class_provided_with_default_class_id():
+    # given
+    step = DetectionsClassesReplacementBlockV1()
+    detections = sv.Detections(
+        xyxy=np.array(
+            [
+                [10, 20, 30, 40],
+                [11, 21, 31, 41],
+            ]
+        ),
+        class_id=np.array([7, 7]),
+        confidence=np.array([0.36, 0.91]),
+        data={
+            "class_name": np.array(["animal", "animal"]),
+            "detection_id": np.array(["zero", "one"]),
+        },
+    )
+    first_cls_prediction = ClassificationInferenceResponse(
+        image=InferenceResponseImage(width=128, height=256),
+        predictions=[
+            ClassificationPrediction(
+                **{"class": "cat", "class_id": 0, "confidence": 0.6}
+            ),
+            ClassificationPrediction(
+                **{"class": "dog", "class_id": 1, "confidence": 0.4}
+            ),
+        ],
+        top="cat",
+        confidence=0.6,
+        parent_id="some",
+    ).dict(by_alias=True, exclude_none=True)
+    first_cls_prediction["parent_id"] = "zero"
+    second_cls_prediction = ClassificationInferenceResponse(
+        image=InferenceResponseImage(width=128, height=256),
+        predictions=[],
+        top="cat",
+        confidence=0.6,
+        parent_id="some",
+    ).dict(by_alias=True, exclude_none=True)
+    second_cls_prediction["parent_id"] = "one"
+    classification_predictions = Batch(
+        content=[
+            first_cls_prediction,
+            second_cls_prediction,
+        ],
+        indices=[(0, 0), (0, 1)],
+    )
+
+    # when
+    result = step.run(
+        object_detection_predictions=detections,
+        classification_predictions=classification_predictions,
+        fallback_class_name="unknown",
+        fallback_class_id=None,
+    )
+
+    # then
+    assert (
+        len(result["predictions"]) == 2
+    ), "Expected both detections to be preserved via fallback class"
+    detections = result["predictions"]
+    assert (
+        detections.confidence[1] == 0
+    ), "Fallback class confidence expected to be set to 0"
+    assert (
+        detections.class_id[1] == sys.maxsize
+    ), "class id expected to fall back to sys.maxsize when fallback_class_id left as None"
     assert (
         detections.data["class_name"][1] == "unknown"
     ), "class name expected to be set to value passed with fallback_class_name parameter"


### PR DESCRIPTION
## 🚧 Work in progress — not ready for review

Draft PR from a batch addressing findings from an in-depth engineering review. Fixes **review finding 4** (High, Error-handling).

## The bug
In `extract_leading_class_from_prediction`, the `top`-with-empty-predictions fallback branch (`inference/core/workflows/core_steps/fusion/detections_classes_replacement/v1.py:406`) coerces `fallback_class_id` via `int(fallback_class_id)` guarded by `except ValueError` only. The default (and documented most-common) value of `fallback_class_id` is `None`, and `int(None)` raises `TypeError`, which is not caught. When a detect→classify workflow enables the "preserve detections when classification fails" feature (`fallback_class_name='unknown'`) but leaves `fallback_class_id` at its `None` default, a crop that returns a non-empty `top` with empty `predictions` crashes the entire workflow step with `TypeError: int() argument must be ... not 'NoneType'`.

## Root cause
The `except` clause on line 406 lists only `ValueError`, so a `None` (or otherwise non-int) `fallback_class_id` escapes the guard and propagates a `TypeError`. The sibling empty-list branch at line 381 already catches `(ValueError, TypeError)`, confirming the intended behavior of falling back to `sys.maxsize`.

## Fix
- `v1.py`: change `except ValueError:` to `except (ValueError, TypeError):` on the classification fallback branch, matching the list-branch. A `None`/non-int `fallback_class_id` now resolves to `sys.maxsize` instead of crashing.
- `test_detections_classes_replacement.py`: add a unit test that drives `DetectionsClassesReplacementBlockV1().run()` with `fallback_class_name='unknown'` and `fallback_class_id=None` over a mixed batch (valid classification + `{top, predictions: []}`), asserting both detections are preserved and the fallback class id resolves to `sys.maxsize`.

## Verification
Standalone repro of the exact fixed branch logic under the roboflow-inference env:
- before (`except ValueError`): `int(None)` → uncaught `TypeError`.
- after (`except (ValueError, TypeError)`): `None → sys.maxsize` (9223372036854775807), `123 → 123`, `-5 → sys.maxsize`, `'x' → sys.maxsize`.

Full package-level pytest could not run from the sparse worktree (only the target files are materialized, so `inference.core.entities` is unavailable to import); the added test mirrors the existing passing test at line 328 with the `None` default and follows the review's proven remediation. Full runtime verification deferred (WIP).

## Scope
Focused change; one of a coordinated batch (one PR per finding).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
