### PR TITLE
[WIP] Preserve HTTPException status/detail in route decorators

### DIFF
--- a/inference/core/interfaces/http/error_handlers.py
+++ b/inference/core/interfaces/http/error_handlers.py
@@ -1,5 +1,6 @@
 from functools import wraps
 
+from fastapi import HTTPException
 from starlette.responses import JSONResponse
 
 from inference.core import logger
@@ -597,6 +598,8 @@ def with_route_exceptions(route):
                     **error.get_structured_public_error_details(),
                 },
             )
+        except HTTPException:
+            raise
         except Exception as error:
             logger.exception("%s: %s", type(error).__name__, error)
             resp = JSONResponse(status_code=500, content={"message": "Internal error."})
@@ -1069,6 +1072,8 @@ def with_route_exceptions_async(route):
                     **error.get_structured_public_error_details(),
                 },
             )
+        except HTTPException:
+            raise
         except Exception as error:
             logger.exception("%s: %s", type(error).__name__, error)
             resp = JSONResponse(status_code=500, content={"message": "Internal error."})


### PR DESCRIPTION
## 🚧 Work in progress — not ready for review

Draft PR from a batch addressing findings from an in-depth engineering review. Fixes **review finding 6** (High, API-contract).

## The bug
Many HTTP routes raise `fastapi.HTTPException` to signal specific errors (e.g. `/infer/lmm/{model_id}` model-id mismatch 400, `/webrtc/session/heartbeat` 401/404, `/sam3/*` 501/500). These routes are wrapped by `@with_route_exceptions` / `@with_route_exceptions_async`, whose final `except Exception` clause (`inference/core/interfaces/http/error_handlers.py:600` and `:1072`) catches the `HTTPException` (an `Exception` subclass) and returns `JSONResponse(status_code=500, content={"message": "Internal error."})`. The intended status code and detail are discarded, so callers cannot distinguish auth/validation failures from real server errors.

## Root cause
The decorator handles the exception *inside* the route callable, so `HTTPException` never propagates to FastAPI's built-in `HTTPException` handler. It matches no earlier `except` clause and falls through to the generic catch-all, which rewrites every error as a 500.

## Fix
In `inference/core/interfaces/http/error_handlers.py`, add an early `except HTTPException: raise` immediately before the generic `except Exception` in both `with_route_exceptions` and `with_route_exceptions_async`, and import `HTTPException` from `fastapi`. Re-raising lets FastAPI's built-in handler emit the intended `status_code`/`detail`. Five lines total; no route call sites touched.

## Verification
Standalone reproduction of the decorator's nested-try control flow (full package import is not possible from the sparse worktree):
- OLD: `raise HTTPException(400, "Model ID mismatch…")` → `JSONResponse 500 {"message":"Internal error."}`
- NEW: same raise → `HTTPException` propagates with `status=400 detail='Model ID mismatch…'`, so FastAPI produces the correct 400 response.

`python -m py_compile` passes on the edited module.

## Scope
Focused change; one of a coordinated batch (one PR per finding).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
