### PR TITLE
[WIP] Fix Detection Offset percentage mode never activating

### DIFF
--- a/inference/core/workflows/core_steps/transformations/detection_offset/v1.py
+++ b/inference/core/workflows/core_steps/transformations/detection_offset/v1.py
@@ -155,7 +155,7 @@ class DetectionOffsetBlockV1(WorkflowBlock):
         offset_height: int,
         units: str = "Pixels",
     ) -> BlockResult:
-        use_percentage = units == "Percent (%) - of bounding box width / height"
+        use_percentage = units == "Percent (%)"
         return [
             {
                 "predictions": offset_detections(

--- a/tests/workflows/unit_tests/core_steps/transformations/test_detection_offset.py
+++ b/tests/workflows/unit_tests/core_steps/transformations/test_detection_offset.py
@@ -7,8 +7,10 @@ from pydantic import ValidationError
 
 from inference.core.workflows.core_steps.transformations.detection_offset.v1 import (
     BlockManifest,
+    DetectionOffsetBlockV1,
     offset_detections,
 )
+from inference.core.workflows.execution_engine.entities.base import Batch
 
 
 @pytest.mark.parametrize(
@@ -181,6 +183,41 @@ def test_offset_detection_with_percentage() -> None:
 
     # then
     x1, y1, x2, y2 = result.xyxy[0]
+    assert x1 == 85, "Left corner should be moved by 5% of detection width to the left"
+    assert y1 == 180, "Top corner should be moved by 5% of detection height to the top"
+    assert (
+        x2 == 415
+    ), "Right corner should be moved by 5% of detection width to the right"
+    assert (
+        y2 == 620
+    ), "Bottom corner should be moved by 5% of detection height to the bottom"
+
+
+def test_run_offsets_by_percentage_when_percent_units_selected() -> None:
+    # given
+    detections = sv.Detections(
+        xyxy=np.array([[100, 200, 400, 600]], dtype=np.float64),
+        class_id=np.array([1]),
+        confidence=np.array([0.5], dtype=np.float64),
+        data={
+            "detection_id": np.array(["three"]),
+            "class_name": np.array(["truck"]),
+            "parent_id": np.array(["p3"]),
+            "image_dimensions": np.array([[640, 640]]),
+        },
+    )
+    block = DetectionOffsetBlockV1()
+
+    # when
+    result = block.run(
+        predictions=Batch(content=[detections], indices=[(0,)]),
+        offset_width=10,
+        offset_height=10,
+        units="Percent (%)",
+    )
+
+    # then
+    x1, y1, x2, y2 = result[0]["predictions"].xyxy[0]
     assert x1 == 85, "Left corner should be moved by 5% of detection width to the left"
     assert y1 == 180, "Top corner should be moved by 5% of detection height to the top"
     assert (


### PR DESCRIPTION
## 🚧 Work in progress — not ready for review

Draft PR from a batch addressing findings from an in-depth engineering review. Fixes **review finding 2** (High, Correctness).

## The bug
In `inference/core/workflows/core_steps/transformations/detection_offset/v1.py:158`, `run()` computes `use_percentage = (units == "Percent (%) - of bounding box width / height")`. The manifest constrains `units` to `Literal["Percent (%)", "Pixels"]` (line 115), so the compared string can never be a possible value. `use_percentage` is therefore always `False`, and selecting the **Percent (%)** unit silently applies the fixed-pixel branch instead of percentage-of-box offsets.

## Root cause
A stale/never-produced sentinel string was used in the equality check. It occurs nowhere else in the repo (verified by grep — only at v1.py:158), so the percentage branch is dead code.

## Fix
- `detection_offset/v1.py`: compare against the actual literal — `use_percentage = units == "Percent (%)"` — so the percentage branch activates when the user selects it. One-line change; the offset math itself was already correct.
- `test_detection_offset.py`: add `test_run_offsets_by_percentage_when_percent_units_selected`, which drives `DetectionOffsetBlockV1().run(..., units="Percent (%)")` end to end (the existing percentage test only called the `offset_detections` helper directly, bypassing the units→`use_percentage` mapping and hiding the bug). It asserts percentage-scaled boxes.

## Verification
Standalone repro in the `roboflow-inference` env on box `[100,200,400,600]`, `offset_width=offset_height=10`, image `640x640`:
- `TypeAdapter(Literal["Percent (%)","Pixels"]).validate_python("Percent (%)")` → `"Percent (%)"`.
- OLD comparison → `use_percentage=False` → pixel branch → `(95, 195, 405, 605)` (wrong 5px padding).
- NEW comparison → `use_percentage=True` → percentage branch → `(85, 180, 415, 620)` (correct 5%-of-box padding), matching the added test's assertions.

## Scope
Focused change; one of a coordinated batch (one PR per finding).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
