### PR TITLE
[WIP] Fix inverted StringMatches query-language operation

### DIFF
--- a/inference/core/workflows/core_steps/common/query_language/operations/strings/base.py
+++ b/inference/core/workflows/core_steps/common/query_language/operations/strings/base.py
@@ -62,4 +62,4 @@ def string_matches(value: Any, regex: str, execution_context: str, **kwargs) -> 
             f"got value which of type {type(value)}: {value_as_str}",
             context=f"step_execution | roboflow_query_language_evaluation | {execution_context}",
         )
-    return not re.match(pattern=regex, string=value)
+    return bool(re.search(pattern=regex, string=value))

--- a/tests/workflows/unit_tests/core_steps/common/query_language/operations/test_strings_operations.py
+++ b/tests/workflows/unit_tests/core_steps/common/query_language/operations/test_strings_operations.py
@@ -1,0 +1,34 @@
+import pytest
+
+from inference.core.workflows.core_steps.common.query_language.errors import (
+    InvalidInputTypeError,
+)
+from inference.core.workflows.core_steps.common.query_language.operations.core import (
+    execute_operations,
+)
+
+
+@pytest.mark.parametrize(
+    "value, regex, expected",
+    [
+        ("hello", "hello", True),
+        ("hello world", "hello", True),
+        ("say hello", "hello", True),
+        ("hello", "^hello$", True),
+        ("hello", "world", False),
+        ("world", "hello", False),
+        ("hell", "hello", False),
+    ],
+)
+def test_string_matches_operation(value: str, regex: str, expected: bool) -> None:
+    """StringMatches returns True when the string matches the regex and False otherwise."""
+    operations = [{"type": "StringMatches", "regex": regex}]
+    result = execute_operations(value=value, operations=operations)
+    assert result is expected
+
+
+def test_string_matches_operation_invalid_input_raises() -> None:
+    """StringMatches raises InvalidInputTypeError for non-string input."""
+    operations = [{"type": "StringMatches", "regex": "hello"}]
+    with pytest.raises(InvalidInputTypeError):
+        execute_operations(value=123, operations=operations)


### PR DESCRIPTION
## 🚧 Work in progress — not ready for review

Draft PR from a batch addressing findings from an in-depth engineering review. Fixes **review finding 1** (High, Correctness).

## The bug
The `StringMatches` query-language operation returns the exact opposite of its documented meaning. In `inference/core/workflows/core_steps/common/query_language/operations/strings/base.py:65` the body was `return not re.match(pattern=regex, string=value)`. Since `re.match` returns a truthy `Match` on a match and `None` otherwise, the leading `not` inverts the boolean: a string that DOES match yields `False` and one that does NOT match yields `True`. The operation is documented (entities/operations.py:458, `StringMatches`, `BOOLEAN_KIND`) as "Checks if string matches regex". Any Filter/branch driven by `StringMatches` takes the opposite path.

## Root cause
A stray `not` in front of the regex call inverts the returned truthiness. A secondary defect: `re.match` only anchors at the start of the string, so a pattern occurring mid-string was also treated as a non-match, diverging further from "matches regex".

## Fix
- `strings/base.py`: replace `return not re.match(pattern=regex, string=value)` with `return bool(re.search(pattern=regex, string=value))` — drops the inverting `not` and uses `re.search` so a match anywhere in the string is reported, returning the documented truthiness.
- Adds `tests/workflows/unit_tests/core_steps/common/query_language/operations/test_strings_operations.py` driving the real `execute_operations` path: asserts `True` on matches (including mid-string), `False` on non-matches, and `InvalidInputTypeError` on non-string input. The operation was previously uncovered by any test.

## Verification
Standalone before/after of the exact expression (conda env `roboflow-inference`):

| input | regex | old (`not re.match`) | new (`bool(re.search)`) |
|---|---|---|---|
| `'hello'` | `'hello'` | `False` | `True` |
| `'hello'` | `'world'` | `True` | `False` |
| `'hello world'` | `'hello'` | `False` | `True` |
| `'world'` | `'hello'` | `True` | `False` |

The old column is the inverted (buggy) behavior; the new column is correct. Full-package pytest was not run from the sparse review worktree; every added test-case expectation was validated against `re.search` semantics.

## Scope
Focused change; one of a coordinated batch (one PR per finding).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
