### PR TITLE
[WIP] Move CLIP ONNX text tokens to model device in embed_text

### DIFF
--- a/inference_models/inference_models/models/clip/clip_onnx.py
+++ b/inference_models/inference_models/models/clip/clip_onnx.py
@@ -138,7 +138,7 @@ class ClipOnnx(TextImageEmbeddingModel):
     def embed_text(self, texts: Union[str, List[str]], **kwargs) -> torch.Tensor:
         if not isinstance(texts, list):
             texts = [texts]
-        tokenized_batch = clip.tokenize(texts)
+        tokenized_batch = clip.tokenize(texts).to(self._device)
         with self._textual_session_thread_lock:
             return run_onnx_session_with_batch_size_limit(
                 session=self._textual_onnx_session,


### PR DESCRIPTION
## 🚧 Work in progress — not ready for review

Draft PR from a batch addressing findings from an in-depth engineering review. Fixes **review finding 15** (High, Correctness).

## The bug
`ClipOnnx.embed_text` (`inference_models/inference_models/models/clip/clip_onnx.py:141`) tokenizes with `clip.tokenize(texts)`, which returns a CPU int32 tensor, and forwards it without moving it to `self._device`. `run_onnx_session_via_iobinding` resolves the execution device from the input tensor (CPU) and returns embeddings on CPU, while `embed_images` preprocesses onto `self._device` and returns embeddings on that device. On a GPU model the two embedding methods therefore return tensors on different devices, so `compare_embeddings`' final `x_embeddings_norm @ y_embeddings_norm.T` raises `RuntimeError: Expected all tensors to be on the same device`. Any zero-shot classification / image-text similarity on GPU fails.

## Root cause
`embed_text` omits the device transfer that its sibling `ClipTorch` performs (`clip_pytorch.py:87` does `.to(self._device)` on the tokens). The tokenizer always emits a CPU tensor, so the ONNX forward path resolves to CPU regardless of the model's configured device.

## Fix
`inference_models/inference_models/models/clip/clip_onnx.py`: move the tokenized batch to the model device before forward — `tokenized_batch = clip.tokenize(texts).to(self._device)` — mirroring `ClipTorch`. Single-line change; no other behavior touched.

## Verification
Standalone check in `roboflow-inference`: raw `clip.tokenize(['a photo of a cat'])` → `device=cpu, dtype=torch.int32, shape=(1, 77)` (the mismatch source); `.to(self._device)` correctly relocates the tensor (confirmed against a `meta` device stand-in since `torch.cuda.is_available()==False` on this box). Follows the review's proven remediation; the actual cross-device matmul on CUDA hardware could not be exercised here (WIP).

## Scope
Focused change; one of a coordinated batch (one PR per finding).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
