### PR TITLE
[WIP] Fix async retry give-up handler KeyError on 429/503/504

### DIFF
--- a/inference_sdk/http/utils/executors.py
+++ b/inference_sdk/http/utils/executors.py
@@ -430,7 +430,11 @@ def raise_client_error(details: dict) -> None:
         details: The details of the error.
     """
     status_code = details["value"][0]
-    request_data = details["kwargs"]["request_data"]
+    request_data = (
+        details["args"][0]
+        if details.get("args")
+        else details["kwargs"].get("request_data")
+    )
     raise ClientResponseError(
         request_info=RequestInfo(
             url=request_data.url,

--- a/tests/inference_sdk/unit_tests/http/utils/test_executors.py
+++ b/tests/inference_sdk/unit_tests/http/utils/test_executors.py
@@ -599,6 +599,40 @@ async def test_make_request_async_when_retryable_error_occurs_and_does_not_recov
 
 @pytest.mark.asyncio
 @pytest.mark.slow
+async def test_make_request_async_when_retryable_error_occurs_and_does_not_recover_with_positional_request_data() -> (
+    None
+):
+    # given
+    request_data = RequestData(
+        url="https://some.com",
+        request_elements=1,
+        headers=None,
+        data="some",
+        parameters=None,
+        payload=None,
+        image_scaling_factors=[None],
+    )
+
+    with aioresponses() as m:
+        async with aiohttp.ClientSession() as session:
+            m.get("https://some.com", status=503)
+            m.get("https://some.com", status=503)
+            m.get("https://some.com", status=503)
+
+            # when - request_data is passed positionally, mirroring how
+            # make_parallel_requests_async invokes make_request_async. This
+            # makes backoff record it in details["args"][0] rather than
+            # details["kwargs"], so the give-up handler must not assume kwargs.
+            with pytest.raises(ClientResponseError):
+                _ = await make_request_async(
+                    request_data,
+                    request_method=RequestMethod.GET,
+                    session=session,
+                )
+
+
+@pytest.mark.asyncio
+@pytest.mark.slow
 async def test_make_request_async_when_retryable_error_occurs_and_does_recover() -> (
     None
 ):


### PR DESCRIPTION
## 🚧 Work in progress — not ready for review

Draft PR from a batch addressing findings from an in-depth engineering review. Fixes **review finding 8** (High, Error-handling).

## The bug
`raise_client_error()` (`inference_sdk/http/utils/executors.py:433`) is the `on_giveup` handler for the retry-decorated `make_request_async`. It reads the failed request via `details["kwargs"]["request_data"]`, but `make_parallel_requests_async` invokes the coroutine positionally — `make_request_closure(data)` → `make_request_async(data, request_method=..., session=...)`. `backoff` therefore records `request_data` in `details["args"][0]`, leaving `details["kwargs"] = {request_method, session}`. When all 3 attempts return a retryable status (429/503/504), the give-up handler hits `details["kwargs"]["request_data"]` and raises `KeyError('request_data')` instead of the intended `ClientResponseError`.

## Root cause
The give-up handler assumed `request_data` is always a keyword argument, but the production async path passes it positionally. `backoff` mirrors the actual call site, so the value lands in `details["args"]`, not `details["kwargs"]`. The raised `KeyError` is not caught by `wrap_errors_async` (which only handles `ClientResponseError`/`ClientConnectionError`, `client.py:158-173`), so it surfaces to the caller — exactly during server throttling/overload.

## Fix
- `inference_sdk/http/utils/executors.py`: read the request positionally with a keyword fallback — `details["args"][0] if details.get("args") else details["kwargs"].get("request_data")` — so both the production positional path and any keyword invocation build a proper `ClientResponseError`.
- `tests/inference_sdk/unit_tests/http/utils/test_executors.py`: add `test_make_request_async_when_retryable_error_occurs_and_does_not_recover_with_positional_request_data`, which drives 3× 503 through `make_request_async` with `request_data` passed **positionally** (mirroring `make_parallel_requests_async`) and asserts a `ClientResponseError` is raised. The existing retryable test passes `request_data` by keyword, so it did not exercise this path.

## Verification
Imported the real `raise_client_error` and drove the actual give-up code path (aioresponses-based tests could not run in this env — a pre-existing `aioresponses`↔`aiohttp` `stream_writer` version skew fails all async tests in this module identically, unrelated to this change):
- Positional details `{'value':(503,b'body'),'args':(rd,),'kwargs':{'request_method','session'}}` → before: `KeyError('request_data')` (review-proven); after: `ClientResponseError status = 503`.
- Keyword details (`kwargs['request_data']=rd`) → after: `ClientResponseError status = 503` (still works).

## Scope
Focused change; one of a coordinated batch (one PR per finding).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
