### PR TITLE
[WIP] Catch requests ConnectionError in SDK sync infer path (fixes API key leak)

### DIFF
--- a/inference_sdk/http/client.py
+++ b/inference_sdk/http/client.py
@@ -147,7 +147,7 @@ def wrap_errors(function: callable) -> callable:
                 status_code=error.response.status_code,
                 api_message=api_message,
             ) from error
-        except ConnectionError as error:
+        except (ConnectionError, requests.exceptions.ConnectionError) as error:
             raise HTTPClientError(
                 f"Error with server connection: {deduct_api_key_from_string(str(error))}"
             ) from error

--- a/inference_sdk/http/utils/executors.py
+++ b/inference_sdk/http/utils/executors.py
@@ -337,7 +337,7 @@ def _reset_thread_local_requests_session() -> None:
 )
 @backoff.on_exception(
     backoff.constant,
-    exception=ConnectionError,
+    exception=(ConnectionError, requests.exceptions.ConnectionError),
     max_tries=3,
     interval=1,
     backoff_log_level=logging.DEBUG,


### PR DESCRIPTION
## 🚧 Work in progress — not ready for review

Draft PR from a batch addressing findings from an in-depth engineering review. Fixes **review finding 12** (High, Security).

## The bug
`requests.exceptions.ConnectionError` is **not** a subclass of the builtin `ConnectionError` — it derives from `OSError` via `requests`' own hierarchy. The SDK's sync inference path only ever references the builtin: `make_request`'s `@backoff.on_exception(exception=ConnectionError)` (`inference_sdk/http/utils/executors.py:340`) and `wrap_errors`' `except ConnectionError` (`inference_sdk/http/client.py:150`). So on a real connection failure neither catches the exception `requests` actually raises: the failure is never retried, and the raw exception escapes unwrapped and unredacted. For V0 the `api_key` is passed in the query string (`infer_from_api_v0`, `client.py:576-591`), so the exception message contains `api_key=<secret>` in cleartext (e.g. `Max retries exceeded with url: /proj/1?api_key=SECRETKEY12345`), exposing the key to the caller and any error tracker.

## Root cause
`except ConnectionError` / `exception=ConnectionError` reference the builtin, but the requests library raises `requests.exceptions.ConnectionError`, which is not a subclass of the builtin. The existing redaction in `wrap_errors` (`deduct_api_key_from_string`) was correct but simply never ran, because the handler never matched.

## Fix
Two one-line changes, matching the pattern already used at `executors.py:541` (`send_post_request`):
- `inference_sdk/http/client.py:150` — broaden `wrap_errors`' handler to `except (ConnectionError, requests.exceptions.ConnectionError)`. The message already flows through `deduct_api_key_from_string`, so the key is now redacted before surfacing.
- `inference_sdk/http/utils/executors.py:340` — broaden `make_request`'s backoff to `exception=(ConnectionError, requests.exceptions.ConnectionError)` so connection failures in the sync/parallel infer path are retried.

Left the V0 `api_key`-in-query behavior unchanged (server contract); redaction now fully covers the leak.

## Verification
Standalone run (`conda run -n roboflow-inference`):
- `issubclass(requests.exceptions.ConnectionError, ConnectionError)` → `False` (the bug).
- Real failing `session.post('http://127.0.0.1:9/proj/1', params={'api_key':'SECRETKEY12345'})`: builtin-only `except` does **not** catch it; the fixed tuple `except (ConnectionError, requests.exceptions.ConnectionError)` **does**.
- After redaction, `'SECRETKEY12345' in message` → `False` (message now shows `api_key=SE***`).
- `backoff.on_exception(exception=(ConnectionError, requests.exceptions.ConnectionError), max_tries=2)` retries a raised `requests.exceptions.ConnectionError` (2 attempts), confirming the tuple form works with backoff.

## Scope
Focused change; one of a coordinated batch (one PR per finding).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
