### PR TITLE
[WIP] Fix Slack sink firing spurious empty files_upload_v2 on text-only notifications

### DIFF
--- a/inference/core/workflows/core_steps/sinks/slack/notification/v1.py
+++ b/inference/core/workflows/core_steps/sinks/slack/notification/v1.py
@@ -399,6 +399,7 @@ def _send_slack_notification(
             channel=channel,
             text=message,
         )
+        return
     file_uploads = [
         {
             "title": name,

--- a/tests/workflows/unit_tests/core_steps/sinks/test_slack_notification.py
+++ b/tests/workflows/unit_tests/core_steps/sinks/test_slack_notification.py
@@ -222,6 +222,7 @@ def test_send_slack_notification_when_operation_succeeds_without_attachments() -
         channel="some",
         text="msg",
     )
+    client.files_upload_v2.assert_not_called()
     assert result[0] is False
 
 
@@ -238,7 +239,7 @@ def test_send_slack_notification_when_operation_succeeds_with_attachments() -> N
     )
 
     # then
-    client.chat_postMessage.files_upload_v2(
+    client.files_upload_v2.assert_called_once_with(
         channel="some",
         initial_comment="msg",
         file_uploads=[{"title": "some", "content": b"data"}],


### PR DESCRIPTION
## 🚧 Work in progress — not ready for review

Draft PR from a batch addressing findings from an in-depth engineering review. Fixes **review finding 16** (High, Correctness).

## The bug
In the Slack Notification sink, `_send_slack_notification` (`inference/core/workflows/core_steps/sinks/slack/notification/v1.py:397-413`) posts a text-only message via `client.chat_postMessage(...)` inside the `if not attachments:` branch, but that branch has no `return`. Execution falls through and unconditionally calls `client.files_upload_v2(channel=..., initial_comment=message, file_uploads=[])`. The common, default text-only path therefore performs a second, spurious Slack API call.

## Root cause
`files_upload_v2([])` does not hit slack_sdk's `file_uploads is None` guard (`[]` is not `None`); it skips the per-file upload loops and calls `files_completeUploadExternal(files=[], initial_comment=message, ...)`. Slack rejects this with `invalid_arguments` → `SlackApiError`. In synchronous mode `send_slack_notification` catches it and returns `error_status=True`, so a notification that was actually delivered is reported as FAILED; in fire-and-forget mode an error is logged on every text-only send (or, if Slack accepts the empty upload, the message is posted a second time).

## Fix
- `inference/core/workflows/core_steps/sinks/slack/notification/v1.py`: add `return` after `chat_postMessage(...)` in the no-attachments branch, so the text-only path no longer falls through to `files_upload_v2`.
- `tests/workflows/unit_tests/core_steps/sinks/test_slack_notification.py` (folds in finding 64): the no-attachments test now asserts `client.files_upload_v2.assert_not_called()`; the with-attachments test's tautological `client.chat_postMessage.files_upload_v2(...)` (a no-op mock-attribute call) is replaced with a real `client.files_upload_v2.assert_called_once_with(channel='some', initial_comment='msg', file_uploads=[{'title':'some','content':b'data'}])`.

## Verification
Standalone reproduction of the fixed function body with a `MagicMock` client:
- Before: with `attachments={}` both `chat_postMessage` and `files_upload_v2` were invoked.
- After: with `attachments={}` → `chat_postMessage` called once, `files_upload_v2` NOT called; with `attachments={"some": b"data"}` → `files_upload_v2` called once with the expected file_uploads, `chat_postMessage` NOT called. Both branches asserted green. (Full package import is not available from the sparse worktree; the standalone check exercises the exact corrected branching.)

## Scope
Focused change; one of a coordinated batch (one PR per finding).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
