### PR TITLE
[WIP] Fix RecursionError in Path Deviation over long-lived tracks

### DIFF
--- a/inference/core/workflows/core_steps/analytics/path_deviation/v1.py
+++ b/inference/core/workflows/core_steps/analytics/path_deviation/v1.py
@@ -30,6 +30,7 @@ from inference.core.workflows.prototypes.block import (
 )
 
 OUTPUT_KEY: str = "path_deviation_detections"
+MAX_TRACK_HISTORY: int = 1000
 SHORT_DESCRIPTION = "Calculate Fréchet distance of object from the reference path."
 LONG_DESCRIPTION = """
 Measure how closely tracked objects follow a reference path by calculating the Fréchet distance between the object's actual trajectory and the expected reference path, enabling path compliance monitoring, route deviation detection, quality control in automated systems, and behavioral analysis workflows.
@@ -194,6 +195,9 @@ class PathDeviationAnalyticsBlockV1(WorkflowBlock):
             if tracker_id not in self._object_paths[video_id]:
                 self._object_paths[video_id][tracker_id] = []
             self._object_paths[video_id][tracker_id].append(anchor_point)
+            self._object_paths[video_id][tracker_id] = self._bound_path_length(
+                self._object_paths[video_id][tracker_id]
+            )
 
             object_path = np.array(self._object_paths[video_id][tracker_id])
             ref_path = np.array(reference_path)
@@ -206,48 +210,38 @@ class PathDeviationAnalyticsBlockV1(WorkflowBlock):
 
         return {OUTPUT_KEY: sv.Detections.merge(result_detections)}
 
+    def _bound_path_length(
+        self, path: List[Tuple[float, float]]
+    ) -> List[Tuple[float, float]]:
+        if len(path) <= MAX_TRACK_HISTORY:
+            return path
+        indices = np.linspace(0, len(path) - 1, num=MAX_TRACK_HISTORY).astype(int)
+        return [path[index] for index in indices]
+
     def _calculate_frechet_distance(
         self, path1: np.ndarray, path2: np.ndarray
     ) -> float:
-        dist_matrix = np.ones((len(path1), len(path2))) * -1
-        return self._compute_distance(
-            dist_matrix, len(path1) - 1, len(path2) - 1, path1, path2
-        )
-
-    def _compute_distance(
-        self,
-        dist_matrix: np.ndarray,
-        i: int,
-        j: int,
-        path1: np.ndarray,
-        path2: np.ndarray,
-    ) -> float:
-        if dist_matrix[i, j] > -1:
-            return dist_matrix[i, j]
-        elif i == 0 and j == 0:
-            dist_matrix[i, j] = self._euclidean_distance(path1[0], path2[0])
-        elif i > 0 and j == 0:
-            dist_matrix[i, j] = max(
-                self._compute_distance(dist_matrix, i - 1, 0, path1, path2),
-                self._euclidean_distance(path1[i], path2[0]),
-            )
-        elif i == 0 and j > 0:
-            dist_matrix[i, j] = max(
-                self._compute_distance(dist_matrix, 0, j - 1, path1, path2),
-                self._euclidean_distance(path1[0], path2[j]),
-            )
-        elif i > 0 and j > 0:
-            dist_matrix[i, j] = max(
-                min(
-                    self._compute_distance(dist_matrix, i - 1, j, path1, path2),
-                    self._compute_distance(dist_matrix, i - 1, j - 1, path1, path2),
-                    self._compute_distance(dist_matrix, i, j - 1, path1, path2),
-                ),
-                self._euclidean_distance(path1[i], path2[j]),
-            )
-        else:
-            dist_matrix[i, j] = float("inf")
-        return dist_matrix[i, j]
+        n, m = len(path1), len(path2)
+        dist_matrix = np.zeros((n, m))
+        for i in range(n):
+            for j in range(m):
+                euclidean = self._euclidean_distance(path1[i], path2[j])
+                if i == 0 and j == 0:
+                    dist_matrix[i, j] = euclidean
+                elif i > 0 and j == 0:
+                    dist_matrix[i, j] = max(dist_matrix[i - 1, 0], euclidean)
+                elif i == 0 and j > 0:
+                    dist_matrix[i, j] = max(dist_matrix[0, j - 1], euclidean)
+                else:
+                    dist_matrix[i, j] = max(
+                        min(
+                            dist_matrix[i - 1, j],
+                            dist_matrix[i - 1, j - 1],
+                            dist_matrix[i, j - 1],
+                        ),
+                        euclidean,
+                    )
+        return dist_matrix[n - 1, m - 1]
 
     def _euclidean_distance(self, point1: np.ndarray, point2: np.ndarray) -> float:
         return np.sqrt(np.sum((point1 - point2) ** 2))

--- a/inference/core/workflows/core_steps/analytics/path_deviation/v2.py
+++ b/inference/core/workflows/core_steps/analytics/path_deviation/v2.py
@@ -30,6 +30,7 @@ from inference.core.workflows.prototypes.block import (
 )
 
 OUTPUT_KEY: str = "path_deviation_detections"
+MAX_TRACK_HISTORY: int = 1000
 SHORT_DESCRIPTION = "Calculate Fréchet distance of object from the reference path."
 LONG_DESCRIPTION = """
 Measure how closely tracked objects follow a reference path by calculating the Fréchet distance between the object's actual trajectory and the expected reference path, enabling path compliance monitoring, route deviation detection, quality control in automated systems, and behavioral analysis workflows.
@@ -206,6 +207,9 @@ class PathDeviationAnalyticsBlockV2(WorkflowBlock):
             if tracker_id not in self._object_paths[video_id]:
                 self._object_paths[video_id][tracker_id] = []
             self._object_paths[video_id][tracker_id].append(anchor_point)
+            self._object_paths[video_id][tracker_id] = self._bound_path_length(
+                self._object_paths[video_id][tracker_id]
+            )
 
             object_path = np.array(self._object_paths[video_id][tracker_id])
             ref_path = np.array(reference_path)
@@ -218,48 +222,38 @@ class PathDeviationAnalyticsBlockV2(WorkflowBlock):
 
         return {OUTPUT_KEY: sv.Detections.merge(result_detections)}
 
+    def _bound_path_length(
+        self, path: List[Tuple[float, float]]
+    ) -> List[Tuple[float, float]]:
+        if len(path) <= MAX_TRACK_HISTORY:
+            return path
+        indices = np.linspace(0, len(path) - 1, num=MAX_TRACK_HISTORY).astype(int)
+        return [path[index] for index in indices]
+
     def _calculate_frechet_distance(
         self, path1: np.ndarray, path2: np.ndarray
     ) -> float:
-        dist_matrix = np.ones((len(path1), len(path2))) * -1
-        return self._compute_distance(
-            dist_matrix, len(path1) - 1, len(path2) - 1, path1, path2
-        )
-
-    def _compute_distance(
-        self,
-        dist_matrix: np.ndarray,
-        i: int,
-        j: int,
-        path1: np.ndarray,
-        path2: np.ndarray,
-    ) -> float:
-        if dist_matrix[i, j] > -1:
-            return dist_matrix[i, j]
-        elif i == 0 and j == 0:
-            dist_matrix[i, j] = self._euclidean_distance(path1[0], path2[0])
-        elif i > 0 and j == 0:
-            dist_matrix[i, j] = max(
-                self._compute_distance(dist_matrix, i - 1, 0, path1, path2),
-                self._euclidean_distance(path1[i], path2[0]),
-            )
-        elif i == 0 and j > 0:
-            dist_matrix[i, j] = max(
-                self._compute_distance(dist_matrix, 0, j - 1, path1, path2),
-                self._euclidean_distance(path1[0], path2[j]),
-            )
-        elif i > 0 and j > 0:
-            dist_matrix[i, j] = max(
-                min(
-                    self._compute_distance(dist_matrix, i - 1, j, path1, path2),
-                    self._compute_distance(dist_matrix, i - 1, j - 1, path1, path2),
-                    self._compute_distance(dist_matrix, i, j - 1, path1, path2),
-                ),
-                self._euclidean_distance(path1[i], path2[j]),
-            )
-        else:
-            dist_matrix[i, j] = float("inf")
-        return dist_matrix[i, j]
+        n, m = len(path1), len(path2)
+        dist_matrix = np.zeros((n, m))
+        for i in range(n):
+            for j in range(m):
+                euclidean = self._euclidean_distance(path1[i], path2[j])
+                if i == 0 and j == 0:
+                    dist_matrix[i, j] = euclidean
+                elif i > 0 and j == 0:
+                    dist_matrix[i, j] = max(dist_matrix[i - 1, 0], euclidean)
+                elif i == 0 and j > 0:
+                    dist_matrix[i, j] = max(dist_matrix[0, j - 1], euclidean)
+                else:
+                    dist_matrix[i, j] = max(
+                        min(
+                            dist_matrix[i - 1, j],
+                            dist_matrix[i - 1, j - 1],
+                            dist_matrix[i, j - 1],
+                        ),
+                        euclidean,
+                    )
+        return dist_matrix[n - 1, m - 1]
 
     def _euclidean_distance(self, point1: np.ndarray, point2: np.ndarray) -> float:
         return np.sqrt(np.sum((point1 - point2) ** 2))


### PR DESCRIPTION
## 🚧 Work in progress — not ready for review

Draft PR from a batch addressing findings from an in-depth engineering review. Fixes **review finding 14** (High, Correctness).

## The bug
The Path Deviation analytics block accumulates each tracked object's anchor point into an ever-growing per-track path (`v1.py:196`, `v2.py:208`) and, every frame, recomputes the Fréchet distance over the full path with the top-down recursive memoized DP `_compute_distance` (`v1.py:217`, `v2.py:229`). The recursion descends one `(i, j)` cell at a time, so its Python call depth grows to ~`len(path1) + len(path2)`. Once a track has been present for roughly 1000 frames, the depth exceeds Python's default recursion limit (1000) and the block raises `RecursionError`, aborting the workflow. Below that threshold it is still cumulative O(N²·M) work and unbounded memory per track.

## Root cause
Two coupled issues: (1) the Fréchet distance is computed with unbounded top-down recursion whose depth scales with path length, and (2) the stored per-track path is never trimmed, so both call depth and memory grow without limit for long-lived tracks.

## Fix
Applied identically to `v1.py` and `v2.py`:
- Replace the recursive `_compute_distance` with an iterative bottom-up fill of the `len(path1)×len(path2)` matrix in nested loops. Row-major order guarantees the three dependencies (`[i-1,j]`, `[i-1,j-1]`, `[i,j-1]`) are already computed, so results are identical — no recursion, no stack growth.
- Add `_bound_path_length` and a `MAX_TRACK_HISTORY = 1000` cap: when a stored track path exceeds the cap it is uniformly downsampled (preserving endpoints and ordering), bounding per-frame cost and memory while keeping the whole-trajectory shape.

## Verification
Standalone check in `roboflow-inference` (recursionlimit=1000): a faithful copy of the recursive impl vs the new iterative impl over 300 random path pairs gives max abs diff = 0.0 (exact parity). The recursive version raises `RecursionError` at n=1500; the iterative version returns a value with no error. The bound helper reduces a 5000-point path to 1000 points with first/last points preserved.

## Scope
Focused change; one of a coordinated batch (one PR per finding).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
