### PR TITLE
[WIP] Guard vlm_as_classifier against bare JSON scalar output

### DIFF
--- a/inference/core/workflows/core_steps/formatters/vlm_as_classifier/v1.py
+++ b/inference/core/workflows/core_steps/formatters/vlm_as_classifier/v1.py
@@ -222,7 +222,14 @@ def string2json(
 
 def try_parse_json(content: str) -> Tuple[bool, dict]:
     try:
-        return False, json.loads(content)
+        parsed = json.loads(content)
+        if isinstance(parsed, dict):
+            return False, parsed
+        logging.warning(
+            "Could not parse JSON to dict in `roboflow_core/vlm_as_classifier@v1` block. "
+            f"Unexpected JSON root type: {type(parsed).__name__}."
+        )
+        return True, {}
     except Exception as error:
         logging.warning(
             f"Could not parse JSON to dict in `roboflow_core/vlm_as_classifier@v1` block. "

--- a/inference/core/workflows/core_steps/formatters/vlm_as_classifier/v2.py
+++ b/inference/core/workflows/core_steps/formatters/vlm_as_classifier/v2.py
@@ -228,7 +228,14 @@ def string2json(
 
 def try_parse_json(content: str) -> Tuple[bool, dict]:
     try:
-        return False, json.loads(content)
+        parsed = json.loads(content)
+        if isinstance(parsed, dict):
+            return False, parsed
+        logging.warning(
+            "Could not parse JSON to dict in `roboflow_core/vlm_as_classifier@v1` block. "
+            f"Unexpected JSON root type: {type(parsed).__name__}."
+        )
+        return True, {}
     except Exception as error:
         logging.warning(
             f"Could not parse JSON to dict in `roboflow_core/vlm_as_classifier@v1` block. "


### PR DESCRIPTION
## 🚧 Work in progress — not ready for review

Draft PR from a batch addressing findings from an in-depth engineering review. Fixes **review finding 22** (Medium, Error-handling).

## The bug
`vlm_as_classifier` crashes with an uncaught `TypeError` when the VLM returns a valid-but-non-object JSON body (a bare scalar like `5`, `3.14`, `true`, or `null`). `try_parse_json` (`inference/core/workflows/core_steps/formatters/vlm_as_classifier/v1.py:223`; identical at `v2.py:229`) returns `json.loads(content)` without checking the root type, so `parsed_data` can be a scalar. `run()` then executes `"class_name" in parsed_data` (`v1.py:192`) with no guard; membership testing on a non-iterable raises `TypeError: argument of type 'int' is not iterable`, which propagates out and fails the workflow step instead of returning the documented graceful `error_status=True` / `predictions=None`.

## Root cause
`try_parse_json` lacks the JSON-root-type check that the sibling `vlm_as_detector.try_parse_json` already has (`isinstance(parsed, (dict, list))`). A scalar JSON root is accepted as `error_status=False` and handed to the membership dispatch, which assumes an iterable.

## Fix
In `try_parse_json`, after `json.loads`, verify `isinstance(parsed, dict)` (the classifier only handles dict-shaped results); on any other root type, log a warning and return `(True, {})` so the block reports a graceful error. Applied identically to `v1.py` and `v2.py`. No behavior change for valid dict payloads.

## Verification
Standalone repro of the corrected `try_parse_json` over `'5'`, `'3.14'`, `'true'`, `'null'`, and ```` ```json\n5\n``` ````: each now returns `err=True` / `parsed={}` (so `run()` takes the graceful `error_status=True` path and the membership test never executes), while `{"class_name":"a","confidence":0.9}` still returns `err=False` with the parsed dict. Before the fix, `'class_name' in json.loads('5')` raised `TypeError`.

## Scope
Focused change; one of a coordinated batch (one PR per finding).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
