### PR TITLE
[WIP] Fix ACTOR_KEYS usage accounting mutating raw JSON instead of decoded dict

### DIFF
--- a/inference/core/usage.py
+++ b/inference/core/usage.py
@@ -52,11 +52,11 @@ def trackUsage(endpoint, actor, n=1):
                 memcache_client.add("ACTOR_KEYS", json.dumps(ak))
             else:
                 decoded = json.loads(actor_keys)
-                if actor in actor_keys:
-                    actor_keys[actor] += n
+                if actor in decoded:
+                    decoded[actor] += n
                 else:
-                    actor_keys[actor] = n
-                memcache_client.set("ACTOR_KEYS", json.dumps(actor_keys))
+                    decoded[actor] = n
+                memcache_client.set("ACTOR_KEYS", json.dumps(decoded))
 
     except Exception as e:
         logger.debug("WARNING: there was an error in counting this inference")


### PR DESCRIPTION
## 🚧 Work in progress — not ready for review

Draft PR from a batch addressing findings from an in-depth engineering review. Fixes **review finding 32** (Medium, Correctness).

## The bug
In `trackUsage`, the ACTOR_KEYS else-branch (`inference/core/usage.py:54-59`) decodes the stored value into `decoded = json.loads(actor_keys)` but then never uses `decoded`. It does `if actor in actor_keys` (substring test on the raw JSON string/bytes), `actor_keys[actor] += n` / `actor_keys[actor] = n` (item-assignment on a `str`/`bytes`), and `json.dumps(actor_keys)`. Per-actor usage accounting is silently broken.

## Root cause
Copy-paste slip. The JOB_KEYS branch just above (lines 43-46) correctly operates on `decoded`, but the ACTOR_KEYS branch kept mutating the raw `actor_keys` value returned from memcache. When a new job key appears for an already-recorded actor, `incr` returns `None` so this block runs with a non-None ACTOR_KEYS, and `actor_keys[actor] = n` raises `TypeError: 'str' object does not support item assignment` (or a bytes/str `in` TypeError). The broad `except Exception` at line 61 swallows it at debug level, so per-actor totals never accumulate beyond the first insert.

## Fix
`inference/core/usage.py`: operate on `decoded` in the ACTOR_KEYS else-branch — `if actor in decoded`, `decoded[actor] += n` / `decoded[actor] = n`, and `json.dumps(decoded)` — mirroring the correct JOB_KEYS handling. Four-line change, no behavior change beyond making accumulation actually work.

## Verification
Standalone before/after on the exact expression:
- BUGGY, str input `{"A": 1}` -> RAISED `TypeError: string indices must be integers`
- BUGGY, bytes input `b'{"A": 1}'` -> RAISED `TypeError: a bytes-like object is required, not 'str'`
- FIXED, str input -> `{"A": 2}`
- FIXED, bytes input -> `{"A": 2}`

Both prior errors were caught by the `except Exception` and only logged at debug level.

## Scope
Focused change; one of a coordinated batch (one PR per finding).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
