### PR TITLE
[WIP] Fix email sink dropping CC/BCC recipients in SMTP path

### DIFF
--- a/inference/core/workflows/core_steps/sinks/email_notification/v1.py
+++ b/inference/core/workflows/core_steps/sinks/email_notification/v1.py
@@ -486,12 +486,17 @@ def _send_email_using_smtp_server(
             f"attachment; filename= {attachment_name}",
         )
         e_mail_message.attach(part)
+    del e_mail_message["Bcc"]
     to_sent = e_mail_message.as_string()
     with establish_smtp_connection(
         smtp_server=smtp_server, smtp_port=smtp_port
     ) as server:
         server.login(sender_email, sender_email_password)
-        server.sendmail(sender_email, receiver_email, to_sent)
+        server.sendmail(
+            sender_email,
+            receiver_email + (cc_receiver_email or []) + (bcc_receiver_email or []),
+            to_sent,
+        )
 
 
 @contextmanager

--- a/inference/core/workflows/core_steps/sinks/email_notification/v2.py
+++ b/inference/core/workflows/core_steps/sinks/email_notification/v2.py
@@ -1054,6 +1054,7 @@ def _send_email_using_smtp_server_v2(
         )
         e_mail_message.attach(part)
 
+    del e_mail_message["Bcc"]
     to_sent = e_mail_message.as_string()
 
     # Establish SMTP connection
@@ -1069,4 +1070,8 @@ def _send_email_using_smtp_server_v2(
         smtp_server=smtp_server, smtp_port=smtp_port
     ) as server:
         server.login(sender_email, sender_email_password)
-        server.sendmail(sender_email, receiver_email, to_sent)
+        server.sendmail(
+            sender_email,
+            receiver_email + (cc_receiver_email or []) + (bcc_receiver_email or []),
+            to_sent,
+        )


### PR DESCRIPTION
## 🚧 Work in progress — not ready for review

Draft PR from a batch addressing findings from an in-depth engineering review. Fixes **review finding 25** (Medium, Correctness).

## The bug
The email notification sink's direct-SMTP path builds Cc/Bcc as MIME headers but delivers only to the To addresses. In `inference/core/workflows/core_steps/sinks/email_notification/v1.py:494` the call is `server.sendmail(sender_email, receiver_email, to_sent)` — the envelope recipient list is just `receiver_email`. The same defect is at `v2.py:1072`. Because SMTP delivery is driven by the envelope RCPT-TO addresses (not the Cc/Bcc message headers), `cc_receiver_email` and `bcc_receiver_email` recipients silently receive nothing, even though the block schema and LONG_DESCRIPTION advertise CC/BCC delivery.

## Root cause
`smtplib.SMTP.sendmail(from_addr, to_addrs, msg)` issues one `RCPT TO` per address in `to_addrs`; message headers are informational only. Passing just `receiver_email` as `to_addrs` means Cc/Bcc addresses are never added to the envelope, so the MTA is never told to deliver to them.

## Fix
Per file, minimal:
- `v1.py` / `v2.py`: pass the union `receiver_email + (cc_receiver_email or []) + (bcc_receiver_email or [])` as the envelope recipient list to `server.sendmail`, so CC and BCC addresses are actually delivered to. The `or []` guards keep the `Optional[List[str]]` None case safe.
- `v1.py` / `v2.py`: `del e_mail_message["Bcc"]` before `as_string()` so the Bcc header is not serialized into the outgoing message and BCC recipients stay hidden from all recipients. The Cc header is intentionally preserved. Only the direct-SMTP path is touched; v2's Roboflow-proxy path already forwards cc/bcc in its JSON payload.

## Verification
Standalone repro of the MIME serialization + envelope logic (conda env `roboflow-inference`):
- Before: envelope RCPT-TO = `['a@x.com']` (cc/bcc dropped); Bcc header present in serialized message.
- After: envelope RCPT-TO = `['a@x.com', 'b@x.com', 'c@x.com']`; Bcc header absent from serialized output and the bcc address does not appear anywhere in the message body; Cc header preserved; the `cc=None`/`bcc=None` case yields `['a@x.com']` with no TypeError.

## Scope
Focused change; one of a coordinated batch (one PR per finding).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
