### PR TITLE
[WIP] Guard SIFT comparison against None descriptors

### DIFF
--- a/inference/core/workflows/core_steps/classical_cv/sift_comparison/v1.py
+++ b/inference/core/workflows/core_steps/classical_cv/sift_comparison/v1.py
@@ -134,7 +134,12 @@ class SIFTComparisonBlockV1(WorkflowBlock):
         ratio_threshold: float = 0.7,
     ) -> BlockResult:
         # Check if both descriptor arrays have at least 2 descriptors
-        if len(descriptor_1) < 2 or len(descriptor_2) < 2:
+        if (
+            descriptor_1 is None
+            or descriptor_2 is None
+            or len(descriptor_1) < 2
+            or len(descriptor_2) < 2
+        ):
             return {
                 "good_matches_count": 0,
                 "images_match": False,

--- a/inference/core/workflows/core_steps/classical_cv/sift_comparison/v2.py
+++ b/inference/core/workflows/core_steps/classical_cv/sift_comparison/v2.py
@@ -228,7 +228,12 @@ class SIFTComparisonBlockV2(WorkflowBlock):
             visualization_2 = None
 
         # Check if both descriptor arrays have at least 2 descriptors
-        if len(descriptors_1) < 2 or len(descriptors_2) < 2:
+        if (
+            descriptors_1 is None
+            or descriptors_2 is None
+            or len(descriptors_1) < 2
+            or len(descriptors_2) < 2
+        ):
             return {
                 "good_matches_count": 0,
                 "images_match": False,


### PR DESCRIPTION
## 🚧 Work in progress — not ready for review

Draft PR from a batch addressing findings from an in-depth engineering review. Fixes **review finding 27** (Medium, Error-handling).

## The bug
When a low-texture, uniform, or blank image is fed to the SIFT Comparison block, `cv2.SIFT.detectAndCompute` finds 0 keypoints and returns `des=None`. `apply_sift` propagates that `None` as `descriptors_1`/`descriptors_2`, and the guard at `inference/core/workflows/core_steps/classical_cv/sift_comparison/v2.py:231` calls `len(None)`, raising `TypeError: object of type 'NoneType' has no len()` and aborting the workflow instead of reporting no match. The same latent path exists in `sift_comparison/v1.py:137`, where a `None` `descriptors` output from a SIFT feature-detection step reaches the same `len()` guard.

## Root cause
The "at least 2 descriptors" guard assumes the descriptor arrays are always array-like, but SIFT legitimately returns `None` when no features are detected. `len(None)` throws before the graceful `images_match=False` path can be reached.

## Fix
- `v2.py`: extend the guard to `descriptors_1 is None or descriptors_2 is None or len(...) < 2 or len(...) < 2`, so a `None` descriptor short-circuits to the existing graceful `images_match=False` return.
- `v1.py`: apply the identical null-check to the `descriptor_1`/`descriptor_2` guard.

Minimal change; no behavior change for the normal (non-`None`, ≥2 descriptor) path.

## Verification
Standalone repro in the `roboflow-inference` env on a 100x100 blank image:
- Before: `len(descriptors_1)` → `TypeError: object of type 'NoneType' has no len()`.
- After: the extended guard short-circuits to `images_match=False` gracefully.

Both files parse cleanly (`ast.parse`).

## Scope
Focused change; one of a coordinated batch (one PR per finding).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
