### PR TITLE
[WIP] Group OCR line detections by mutual gap, not absolute pixel buckets

### DIFF
--- a/inference/core/workflows/core_steps/transformations/stitch_ocr_detections/v1.py
+++ b/inference/core/workflows/core_steps/transformations/stitch_ocr_detections/v1.py
@@ -307,21 +307,34 @@ def group_detections_by_line(
     reading_direction: str,
     tolerance: int,
 ) -> Dict[float, Dict[str, List]]:
-    """Group detections into lines based on primary coordinate."""
+    """Group detections into lines based on primary coordinate.
+
+    Detections are grouped by mutual distance: after sorting by the primary
+    coordinate, a new line is started only when the gap to the previous
+    detection exceeds ``tolerance``. This keeps detections that lie within
+    ``tolerance`` of each other on the same line even when they straddle an
+    absolute pixel-grid boundary.
+    """
     # After prepare_coordinates swap, we always group by y ([:, 1])
     primary_coord = xyxy[:, 1]  # This is y for horizontal, swapped x for vertical
 
-    # Round primary coordinate to group into lines
-    rounded_primary = np.round(primary_coord / tolerance) * tolerance
+    # Sort by primary coordinate so lines can be grouped by mutual gap
+    order = np.argsort(primary_coord)
 
     boxes_by_line = {}
+    line_key = None
+    prev_coord = None
     # Group bounding boxes and associated indices by line
-    for i, (bbox, line_pos) in enumerate(zip(xyxy, rounded_primary)):
-        if line_pos not in boxes_by_line:
-            boxes_by_line[line_pos] = {"xyxy": [bbox], "idx": [i]}
+    for i in order:
+        coord = primary_coord[i]
+        # Start a new line when the gap to the previous detection exceeds tolerance
+        if prev_coord is None or coord - prev_coord > tolerance:
+            line_key = float(coord)
+            boxes_by_line[line_key] = {"xyxy": [xyxy[i]], "idx": [i]}
         else:
-            boxes_by_line[line_pos]["xyxy"].append(bbox)
-            boxes_by_line[line_pos]["idx"].append(i)
+            boxes_by_line[line_key]["xyxy"].append(xyxy[i])
+            boxes_by_line[line_key]["idx"].append(i)
+        prev_coord = coord
 
     return boxes_by_line
 

--- a/inference/core/workflows/core_steps/transformations/stitch_ocr_detections/v2.py
+++ b/inference/core/workflows/core_steps/transformations/stitch_ocr_detections/v2.py
@@ -392,21 +392,34 @@ def group_detections_by_line(
     reading_direction: str,
     tolerance: int,
 ) -> Dict[float, Dict[str, List]]:
-    """Group detections into lines based on primary coordinate."""
+    """Group detections into lines based on primary coordinate.
+
+    Detections are grouped by mutual distance: after sorting by the primary
+    coordinate, a new line is started only when the gap to the previous
+    detection exceeds ``tolerance``. This keeps detections that lie within
+    ``tolerance`` of each other on the same line even when they straddle an
+    absolute pixel-grid boundary.
+    """
     # After prepare_coordinates swap, we always group by y ([:, 1])
     primary_coord = xyxy[:, 1]  # This is y for horizontal, swapped x for vertical
 
-    # Round primary coordinate to group into lines
-    rounded_primary = np.round(primary_coord / tolerance) * tolerance
+    # Sort by primary coordinate so lines can be grouped by mutual gap
+    order = np.argsort(primary_coord)
 
     boxes_by_line = {}
+    line_key = None
+    prev_coord = None
     # Group bounding boxes and associated indices by line
-    for i, (bbox, line_pos) in enumerate(zip(xyxy, rounded_primary)):
-        if line_pos not in boxes_by_line:
-            boxes_by_line[line_pos] = {"xyxy": [bbox], "idx": [i]}
+    for i in order:
+        coord = primary_coord[i]
+        # Start a new line when the gap to the previous detection exceeds tolerance
+        if prev_coord is None or coord - prev_coord > tolerance:
+            line_key = float(coord)
+            boxes_by_line[line_key] = {"xyxy": [xyxy[i]], "idx": [i]}
         else:
-            boxes_by_line[line_pos]["xyxy"].append(bbox)
-            boxes_by_line[line_pos]["idx"].append(i)
+            boxes_by_line[line_key]["xyxy"].append(xyxy[i])
+            boxes_by_line[line_key]["idx"].append(i)
+        prev_coord = coord
 
     return boxes_by_line
 


### PR DESCRIPTION
## 🚧 Work in progress — not ready for review

Draft PR from a batch addressing findings from an in-depth engineering review. Fixes **review finding 26** (Medium, Correctness).

## The bug
`group_detections_by_line` in `stitch_ocr_detections/v1.py:315` (and the byte-identical `v2.py:400`) assigns each OCR detection to a line via `np.round(y1 / tolerance) * tolerance`, snapping the top-y coordinate to the nearest absolute multiple of `tolerance`. Two boxes on the same physical text line whose `y1` values straddle a bucket boundary land on different lines even though they are far closer than `tolerance` — directly contradicting the documented contract "Detections within this tolerance distance are grouped into the same line."

## Root cause
Grouping was done by fixed pixel-grid bucket membership, not by mutual distance. With `tolerance=10`, `y1=14 -> round(1.4)*10 = 10` and `y1=16 -> round(1.6)*10 = 20`, so two boxes 2px apart are placed on separate lines and the output becomes `A\nB` instead of `AB`.

## Fix
Rewrote `group_detections_by_line` in both `v1.py` and `v2.py` to group by mutual gap (the same greedy approach `v2.adaptive_word_grouping` already uses for lines): sort detections by the primary coordinate, then start a new line only when the gap to the previous detection exceeds `tolerance`. Each line is keyed by its first detection's primary coordinate, so the caller's `sorted(boxes_by_line.keys(), reverse=...)` top-to-bottom / bottom-to-top ordering is preserved unchanged. Both blocks' `tolerance` stitching mode are affected (v2's default `stitching_algorithm="tolerance"` routes to the same function).

## Verification
Standalone before/after on the review's exact repro (Box A `xyxy=[0,14,10,30]` 'A', Box B `xyxy=[20,16,30,32]` 'B', left_to_right, tolerance=10):
- straddle-boundary y1=14/16: OLD `'A\nB'` -> NEW `'AB'` (fixed)
- genuine two lines y1=14/40: NEW `'A\nB'` (still splits correctly)
- same-bucket y1=11/13: OLD `'AB'` == NEW `'AB'` (unchanged)
- within-line ordering (A right of B, left_to_right): NEW `'BA'` (correct)

## Scope
Focused change; one of a coordinated batch (one PR per finding).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
