### PR TITLE
[WIP] Fix dominant color returning wrong color when a K-means cluster is empty

### DIFF
--- a/inference/core/workflows/core_steps/classical_cv/dominant_color/v1.py
+++ b/inference/core/workflows/core_steps/classical_cv/dominant_color/v1.py
@@ -184,10 +184,10 @@ class DominantColorBlockV1(WorkflowBlock):
 
         # Get the colors and their counts
         colors = centroids
-        _, counts = np.unique(labels, return_counts=True)
+        uniq, counts = np.unique(labels, return_counts=True)
 
         # Find the most dominant color
-        dominant_color = colors[np.argmax(counts)]
+        dominant_color = colors[uniq[np.argmax(counts)]]
         rgb_color = tuple(
             int(np.clip(round(x), 0, 255)) for x in reversed(dominant_color)
         )


### PR DESCRIPTION
## 🚧 Work in progress — not ready for review

Draft PR from a batch addressing findings from an in-depth engineering review. Fixes **review finding 36** (Medium, Correctness).

## The bug
The dominant-color block can return a non-dominant (often the minority) color. In `inference/core/workflows/core_steps/classical_cv/dominant_color/v1.py:187-190`, `colors` (the K-means centroids) is indexed by cluster label `0..k-1`, but `np.unique(labels, return_counts=True)` returns counts aligned to the sorted *unique labels present* in `labels`. When a cluster ends up with zero assigned pixels, `np.unique` yields fewer than `k` entries, so `np.argmax(counts)` is a *position* within the unique array, not the actual cluster label. `colors[np.argmax(counts)]` then indexes a centroid by the wrong index.

## Root cause
Off-by-index between two label spaces: `counts` is indexed by position in `uniq`, while `colors` is indexed by cluster label. These coincide only when every cluster is non-empty. With fewer distinct color groups than `color_clusters` (very common: 2-3 color logos, product on a plain background, default `color_clusters=4`) at least one cluster is empty, breaking the alignment.

## Fix
Single-file change in `dominant_color/v1.py`: capture the unique labels as `uniq` and select the dominant centroid via `colors[uniq[np.argmax(counts)]]` instead of `colors[np.argmax(counts)]`. Two-line change, no behavior change when all clusters are populated.

## Verification
Reproduced the exact block algorithm on a 40x40 image (80% `[10,10,200]` / 20% `[200,10,10]` BGR), `color_clusters=3`, `max_iterations=100`, `np.random.seed(260)`:
- `uniq=[0,2]`, `counts=[320,1280]`; centroids `[[200,10,10],[200,10,10],[10,10,200]]`.
- Most-populous label is `2` → majority centroid `[10,10,200]`.
- BEFORE (`colors[np.argmax(counts)]` → `colors[1]`): returns `[200,10,10]` (minority) — WRONG.
- AFTER (`colors[uniq[np.argmax(counts)]]` → `colors[2]`): returns `[10,10,200]` (majority) — CORRECT.

## Scope
Focused change; one of a coordinated batch (one PR per finding).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
