### PR TITLE
[WIP] Prevent path traversal via file_name_prefix in local file sink

### DIFF
--- a/inference/core/workflows/core_steps/sinks/local_file/v1.py
+++ b/inference/core/workflows/core_steps/sinks/local_file/v1.py
@@ -286,6 +286,7 @@ class LocalFileSinkBlockV1(WorkflowBlock):
             file_name_prefix=file_name_prefix,
             file_type=file_type,
         )
+        self._verify_write_access_to_directory(target_directory=target_path)
         return handle_content_saving(
             target_path=target_path,
             file_operation_mode="w",
@@ -356,6 +357,7 @@ class LocalFileSinkBlockV1(WorkflowBlock):
             file_name_prefix=file_name_prefix,
             file_type=extension,
         )
+        self._verify_write_access_to_directory(target_directory=file_path)
         parent_dir = os.path.dirname(file_path)
         os.makedirs(parent_dir, exist_ok=True)
         return open(file_path, "w")

--- a/tests/workflows/unit_tests/core_steps/sinks/test_local_file.py
+++ b/tests/workflows/unit_tests/core_steps/sinks/test_local_file.py
@@ -177,6 +177,62 @@ def test_saving_files_when_allowed_write_directory_does_not_match(
         )
 
 
+def test_saving_separate_file_when_file_name_prefix_attempts_path_traversal(
+    empty_directory: str,
+) -> None:
+    # given
+    sandbox = os.path.join(empty_directory, "sandbox")
+    os.makedirs(sandbox, exist_ok=True)
+    escaped_target = os.path.join(empty_directory, "escaped.txt")
+    block = LocalFileSinkBlockV1(
+        allow_access_to_file_system=True, allowed_write_directory=sandbox
+    )
+
+    # when
+    with pytest.raises(ValueError):
+        _ = block.run(
+            content="content-1",
+            file_type="txt",
+            output_mode="separate_files",
+            target_directory=sandbox,
+            file_name_prefix="../escaped",
+            max_entries_per_file=100,
+        )
+
+    # then
+    assert not glob(
+        os.path.join(empty_directory, "escaped_*.txt")
+    ), "Traversal via file_name_prefix must not write outside the allowed directory"
+    assert not os.path.exists(escaped_target)
+
+
+def test_saving_append_log_when_file_name_prefix_attempts_path_traversal(
+    empty_directory: str,
+) -> None:
+    # given
+    sandbox = os.path.join(empty_directory, "sandbox")
+    os.makedirs(sandbox, exist_ok=True)
+    block = LocalFileSinkBlockV1(
+        allow_access_to_file_system=True, allowed_write_directory=sandbox
+    )
+
+    # when
+    result = block.run(
+        content="content-1",
+        file_type="txt",
+        output_mode="append_log",
+        target_directory=sandbox,
+        file_name_prefix="../escaped",
+        max_entries_per_file=100,
+    )
+
+    # then
+    assert result["error_status"] is True
+    assert not glob(
+        os.path.join(empty_directory, "escaped_*.txt")
+    ), "Traversal via file_name_prefix must not write outside the allowed directory"
+
+
 def test_saving_json_into_separate_files(empty_directory: str) -> None:
     # given
     block = LocalFileSinkBlockV1(


### PR DESCRIPTION
## 🚧 Work in progress — not ready for review

Draft PR from a batch addressing findings from an in-depth engineering review. Fixes **review finding 17** (High, Security).

## The bug
The Local File Sink block enforces the `WORKFLOW_BLOCKS_WRITE_DIRECTORY` sandbox by validating only `target_directory` (`inference/core/workflows/core_steps/sinks/local_file/v1.py:248`, check at `:264-275`). The actual write path is built in `generate_new_file_path` (`v1.py:368-373`) by concatenating the user-supplied `file_name_prefix` and then `os.path.abspath`-normalizing. `file_name_prefix` is never validated, so `..` segments in it resolve outside the sandbox and reach `save_to_file`/`_open_new_append_log_file`, which `os.makedirs(...)` + `open(path, "w")`.

## Root cause
The security check runs against `target_directory` before the final filename is composed. Because `os.path.abspath` collapses `..` in the concatenated `f"{file_name_prefix}_{ts}.{file_type}"`, a prefix like `../../../../../../tmp/pwned` produces a resolved path outside the validated directory — an arbitrary filesystem write that defeats the sandbox.

## Fix
`inference/core/workflows/core_steps/sinks/local_file/v1.py` — re-validate the fully resolved write path against the allowed directory (reusing `_verify_write_access_to_directory`) immediately after `generate_new_file_path`, in **both** write paths: `_save_to_separate_file` and `_open_new_append_log_file`. A traversal-crafted `file_name_prefix` now raises `ValueError` (separate_files) / returns `error_status=True` (append_log) and no file is written outside the sandbox. Legitimate prefixes are unaffected.

Added regression tests in `tests/workflows/unit_tests/core_steps/sinks/test_local_file.py` for both modes, asserting the traversal is blocked and nothing lands outside the allowed directory.

## Verification
Ran the real `run()` end-to-end against the fixed module:
- separate_files, prefix `../escaped` → `ValueError` raised, no `escaped_*.txt` written outside sandbox.
- append_log, prefix `../escaped` → `error_status=True`, no file written outside sandbox.
- legit prefix `my_file` → `Data saved successfully`, file written inside sandbox.
Against the unfixed code the same separate_files scenario silently wrote `escaped_<ts>.txt` outside the sandbox, confirming the tests catch the bug.

## Scope
Focused change; one of a coordinated batch (one PR per finding).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
