### PR TITLE
[WIP] Guard size measurement object loop against None dimensions

### DIFF
--- a/inference/core/workflows/core_steps/classical_cv/size_measurement/v1.py
+++ b/inference/core/workflows/core_steps/classical_cv/size_measurement/v1.py
@@ -291,7 +291,7 @@ class SizeMeasurementBlockV1(WorkflowBlock):
         dimensions = []
         for i in range(len(object_predictions)):
             obj_w_pixels, obj_h_pixels = get_detection_dimensions(object_predictions, i)
-            if obj_w_pixels > 0 and obj_h_pixels > 0:
+            if obj_w_pixels and obj_h_pixels and obj_w_pixels > 0 and obj_h_pixels > 0:
                 obj_w_actual = obj_w_pixels * width_scale
                 obj_h_actual = obj_h_pixels * height_scale
                 dimensions.append(


### PR DESCRIPTION
## 🚧 Work in progress — not ready for review

Draft PR from a batch addressing findings from an in-depth engineering review. Fixes **review finding 37** (Medium, Error-handling).

## The bug
`SizeMeasurementBlockV1.run` crashes with `TypeError: '>' not supported between instances of 'NoneType' and 'int'` when `object_predictions` is instance segmentation and any detection has a degenerate mask. The object loop at `inference/core/workflows/core_steps/classical_cv/size_measurement/v1.py:294` evaluates `obj_w_pixels > 0 and obj_h_pixels > 0` without guarding against `None`.

## Root cause
`get_detection_dimensions` (lines 209-223) returns `(None, None)` when `detection.mask` is set but the mask yields no contour, or its largest contour has area `<= 0` (e.g. an all-zero mask, or a thin single-row / colinear sliver whose `cv.contourArea` is `0.0`). The object loop then compares `None > 0` and aborts the whole block. The reference-object path (line 285) already guards with `if not ref_width_pixels or not ref_height_pixels`, so the two paths were inconsistent.

## Fix
`inference/core/workflows/core_steps/classical_cv/size_measurement/v1.py` — change the object-loop guard from `if obj_w_pixels > 0 and obj_h_pixels > 0:` to `if obj_w_pixels and obj_h_pixels and obj_w_pixels > 0 and obj_h_pixels > 0:`. When either dimension is `None`, the guard is now falsy and the loop appends `None` for that object via the existing `else` branch, matching the reference path's tolerance for degenerate geometry.

## Verification
Standalone check in `roboflow-inference`: a thin single-row mask produces one contour with `cv.contourArea == 0.0`, so `get_detection_dimensions` returns `(None, None)`. Before: `None > 0` raises `TypeError: '>' not supported between instances of 'NoneType' and 'int'`. After: the new guard evaluates to a falsy `None` (object appended as `None`), while real dimensions (`5.0, 3.0`) still evaluate truthy and are measured.

## Scope
Focused change; one of a coordinated batch (one PR per finding).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
