### PR TITLE
[WIP] Delete cloud-deploy temp YAML holding the Roboflow API key

### DIFF
--- a/inference_cli/lib/cloud_adapter.py
+++ b/inference_cli/lib/cloud_adapter.py
@@ -1,4 +1,6 @@
+import os
 import random
+import shlex
 import string
 import tempfile
 
@@ -196,7 +198,7 @@ def cloud_deploy(provider, compute_type, dry_run, custom, help, roboflow_api_key
         return
 
     placeholder_string = (
-        f" --env ROBOFLOW_API_KEY={roboflow_api_key} "
+        f" --env ROBOFLOW_API_KEY={shlex.quote(roboflow_api_key)} "
         if roboflow_api_key is not None
         else ""
     )
@@ -208,11 +210,14 @@ def cloud_deploy(provider, compute_type, dry_run, custom, help, roboflow_api_key
 
     yaml_string = yaml_string.replace("PLACEHOLDER", placeholder_string)
 
-    with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
-        file_path = f.name
-        f.write(yaml_string)
-        f.close()
+    tmp_file = tempfile.NamedTemporaryFile(mode="w", delete=False)
+    file_path = tmp_file.name
+    try:
+        tmp_file.write(yaml_string)
+        tmp_file.close()
         task = sky.Task.from_yaml(file_path)
+    finally:
+        os.unlink(file_path)
 
     cluster_name = f"roboflow-inference-{provider}-{compute_type}-{_random_char(5)}"
 


### PR DESCRIPTION
## 🚧 Work in progress — not ready for review

Draft PR from a batch addressing findings from an in-depth engineering review. Fixes **review finding 43** (Medium, Security).

## The bug
`cloud_deploy` in `inference_cli/lib/cloud_adapter.py:211` writes the sky task YAML — whose `run:` line contains `--env ROBOFLOW_API_KEY=<key>` in plaintext — to a `tempfile.NamedTemporaryFile(delete=False)` and never removes it. After `inference cloud deploy` exits, a temp file (e.g. `/tmp/tmpXXXX`, mode 0600) holding the plaintext Roboflow API key survives on disk indefinitely. The key is also interpolated unquoted into the shell command, so a key containing a space or shell metacharacter would break or alter the generated `docker run`.

## Root cause
The temp file is created with `delete=False` and there is no `os.unlink`/cleanup anywhere in the function, so the file that only needs to exist for the duration of `sky.Task.from_yaml(file_path)` outlives the process. Separately, the API key is embedded directly (`f" --env ROBOFLOW_API_KEY={roboflow_api_key} "`) without shell quoting.

## Fix
`inference_cli/lib/cloud_adapter.py`:
- Wrap the temp-file write + `sky.Task.from_yaml(file_path)` in a `try` and `os.unlink(file_path)` in a `finally`, so the file is always removed once sky has parsed it (even if `from_yaml` raises). Adds `import os`.
- Shell-quote the key with `shlex.quote(roboflow_api_key)` so keys with spaces/metacharacters can't break the generated `docker run`. Adds `import shlex`.

## Verification
Standalone repro of the fixed logic (with `sky.Task.from_yaml` stubbed to read the file while it exists):
- Before: temp file created `delete=False` persists after the block (`exists = True`), plaintext key on disk.
- After: for keys `plain_key_123`, `key with spaces`, and `weird$;key&`, the stub reads the file successfully, then `os.unlink` runs in `finally` and `os.path.exists(file_path)` is `False` in every case; keys with spaces/metachars are emitted as `--env ROBOFLOW_API_KEY='key with spaces'` / `'weird$;key&'`. `py_compile` passes.

## Scope
Focused change; one of a coordinated batch (one PR per finding).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
