### PR TITLE
[WIP] Clip absolute static crop to image bounds instead of numpy wrap-around

### DIFF
--- a/inference/core/workflows/core_steps/transformations/absolute_static_crop/v1.py
+++ b/inference/core/workflows/core_steps/transformations/absolute_static_crop/v1.py
@@ -151,6 +151,13 @@ def take_static_crop(
     y_min = round(y_center - height / 2)
     x_max = round(x_min + width)
     y_max = round(y_min + height)
+    image_height, image_width = image.numpy_image.shape[:2]
+    x_min = max(0, x_min)
+    y_min = max(0, y_min)
+    x_max = min(image_width, x_max)
+    y_max = min(image_height, y_max)
+    if x_max <= x_min or y_max <= y_min:
+        return None
     cropped_image = image.numpy_image[y_min:y_max, x_min:x_max]
     if not cropped_image.size:
         return None


### PR DESCRIPTION
## 🚧 Work in progress — not ready for review

Draft PR from a batch addressing findings from an in-depth engineering review. Fixes **review finding 45** (Medium, Correctness).

## The bug
`take_static_crop` in `inference/core/workflows/core_steps/transformations/absolute_static_crop/v1.py:154` slices `image.numpy_image[y_min:y_max, x_min:x_max]` with coordinates derived from `round(x_center - width / 2)`, which can be negative. numpy treats a negative slice start as an offset from the far edge (`W + x_min`) — a wrap-around — rather than clamping to 0. The block's docstrings promise the crop is "clipped to image boundaries", but off-image or oversized crops instead return a silently-wrong region.

## Root cause
The crop boundaries are never clamped to the image dimensions before slicing. A negative `x_min`/`y_min` wraps in from the right/bottom edge, and an `x_max`/`y_max` beyond the image simply saturates at the array end — so the returned crop misrepresents the requested region with no error.

## Fix
In `absolute_static_crop/v1.py`, before slicing: clamp `x_min`/`y_min` to `max(0, ...)`, clamp `x_max`/`y_max` to the image `width`/`height`, and return `None` when the clamped box is empty (`x_max <= x_min` or `y_max <= y_min`). `offset_x`/`offset_y` now carry the clamped origin, so the crop's recorded position matches the pixels actually returned. In-bounds crops are unchanged.

## Verification
Standalone numpy repro on a 100×100 image whose pixel value equals its column index, `x_center=10, width=200` (`x_min=-90, x_max=110`):
- Before: shape `(100, 90)`, first column value `10` (= `W + x_min` wrap), left 10 columns missing.
- After: shape `(100, 100)`, first column value `0` — full-width clipped crop as documented.
- Fully off-image (`x_center=500, width=50`): both return `None` (new guard).
- Normal in-bounds (`x_center=50, width=40`): identical before and after.

## Scope
Focused change; one of a coordinated batch (one PR per finding). The finding notes the same slicing pattern exists in `relative_static_crop/v1.py`; that file is out of scope for this PR and left to its own finding.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
