### PR TITLE
[WIP] Add visited-set to _downstream_step_selectors BFS

### DIFF
--- a/inference/core/workflows/execution_engine/v1/executor/core.py
+++ b/inference/core/workflows/execution_engine/v1/executor/core.py
@@ -299,13 +299,16 @@ def _downstream_step_selectors(
         construct_step_selector(step_name=step_name) for step_name in workflow.steps
     }
     result = set()
+    visited = set(step_selectors)
     nodes_to_visit = list(step_selectors)
     while nodes_to_visit:
         node = nodes_to_visit.pop(0)
         for successor in workflow.execution_graph.successors(node):
             if successor in step_selector_set and successor not in result:
                 result.add(successor)
-            nodes_to_visit.append(successor)
+            if successor not in visited:
+                visited.add(successor)
+                nodes_to_visit.append(successor)
     return result
 
 


### PR DESCRIPTION
## 🚧 Work in progress — not ready for review

Draft PR from a batch addressing findings from an in-depth engineering review. Fixes **review finding 49** (Medium, Performance).

## The bug
`_downstream_step_selectors` in `inference/core/workflows/execution_engine/v1/executor/core.py:302-308` does a BFS over the execution graph but appends every successor to `nodes_to_visit` unconditionally, with no visited-set. The `successor not in result` guard only prevents duplicate insertion into `result`, not re-traversal, so each node is re-popped and re-expanded once per distinct path that reaches it.

## Root cause
On a DAG with convergent (diamond / fan-in) step branches, the number of pops is exponential in graph depth. A layered width-2 diamond DAG doubles the pop count per layer (`pops = 2*(2^k - 1)`), so a ~50-step graph yields billions of iterations — spinning CPU and effectively hanging the stream-flush path (`flush_stream_pipeline_workflow` -> `_downstream_step_selectors`).

## Fix
`executor/core.py`: maintain a `visited` set (seeded with the start selectors) and only enqueue a successor when it has not already been visited. Traversal now touches each node once — O(V+E) — and produces the identical `result` set.

## Verification
Ran the exact loop body on layered fully-connected width-2 diamond DAGs, before vs after:

```
L=4:  OLD pops=30   result=6  | NEW pops=8   result=6  | same_result=True
L=6:  OLD pops=126  result=10 | NEW pops=12  result=10 | same_result=True
L=8:  OLD pops=510  result=14 | NEW pops=16  result=14 | same_result=True
L=10: OLD pops=2046 result=18 | NEW pops=20  result=18 | same_result=True
L=12: OLD pops=8190 result=22 | NEW pops=24  result=22 | same_result=True
```

OLD pop counts reproduce the review's numbers (30/126/510/2046/8190) and collapse to linear (= node count) after the fix, with the result set unchanged.

## Scope
Focused change; one of a coordinated batch (one PR per finding).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
