### PR TITLE
[WIP] Evict stale tracker state in Velocity block to bound memory

### DIFF
--- a/inference/core/workflows/core_steps/analytics/velocity/v1.py
+++ b/inference/core/workflows/core_steps/analytics/velocity/v1.py
@@ -34,6 +34,11 @@ from inference.core.workflows.prototypes.block import (
 )
 
 OUTPUT_KEY: str = "velocity_detections"
+# Number of frames a tracker_id may be absent before its cached velocity state is
+# evicted. Set comfortably above typical tracker lost-track buffers so briefly
+# occluded objects keep their smoothing/velocity history, while preventing the
+# per-video state dictionaries from growing without bound on long-running streams.
+MAX_FRAMES_WITHOUT_DETECTION: int = 5 * 30
 SHORT_DESCRIPTION = "Calculate the velocity and speed of tracked objects with smoothing and unit conversion."
 LONG_DESCRIPTION = """
 Calculate the velocity and speed of tracked objects across video frames by measuring displacement of object centers over time, applying exponential moving average smoothing to reduce noise, and converting measurements from pixels per second to meters per second for traffic speed monitoring, movement analysis, behavior tracking, and performance measurement workflows.
@@ -183,6 +188,11 @@ class VelocityBlockV1(WorkflowBlock):
         ] = {}
         # Store smoothed velocities for each tracker_id
         self._smoothed_velocities: Dict[str, Dict[Union[int, str], np.ndarray]] = {}
+        # Track the most recent frame index each tracker_id was seen, per video,
+        # so state for tracks that disappear can be evicted (avoids unbounded
+        # growth of the per-video state dicts on long-running streams).
+        self._last_seen_frame: Dict[str, Dict[Union[int, str], int]] = {}
+        self._frame_counter: Dict[str, int] = {}
 
     @classmethod
     def get_manifest(cls) -> Type[WorkflowBlockManifest]:
@@ -214,6 +224,9 @@ class VelocityBlockV1(WorkflowBlock):
         video_id = image.video_metadata.video_identifier
         previous_positions = self._previous_positions.setdefault(video_id, {})
         smoothed_velocities = self._smoothed_velocities.setdefault(video_id, {})
+        last_seen_frame = self._last_seen_frame.setdefault(video_id, {})
+        frame_index = self._frame_counter.get(video_id, 0)
+        self._frame_counter[video_id] = frame_index + 1
 
         num_detections = len(detections)
 
@@ -268,6 +281,7 @@ class VelocityBlockV1(WorkflowBlock):
             # Store current position and timestamp for the next frame
             previous_positions[tracker_id] = (current_position, ts_current)
             smoothed_velocities[tracker_id] = smoothed_velocity
+            last_seen_frame[tracker_id] = frame_index
 
             # Convert velocities and speeds to meters per second if required
             velocity_m_s = velocity / pixels_per_meter
@@ -279,6 +293,18 @@ class VelocityBlockV1(WorkflowBlock):
             speeds[i] = speed_m_s
             smoothed_velocities_arr[i] = smoothed_velocity_m_s
             smoothed_speeds[i] = smoothed_speed_m_s
+
+        # Evict state for tracker_ids absent for longer than the retention window so
+        # the per-video state dictionaries stay bounded on long-running streams.
+        stale_tracker_ids = [
+            tid
+            for tid, last_frame in last_seen_frame.items()
+            if frame_index - last_frame > MAX_FRAMES_WITHOUT_DETECTION
+        ]
+        for tid in stale_tracker_ids:
+            previous_positions.pop(tid, None)
+            smoothed_velocities.pop(tid, None)
+            del last_seen_frame[tid]
 
         detections.data[VELOCITY_KEY_IN_SV_DETECTIONS] = np.array(velocities)
         detections.data[SPEED_KEY_IN_SV_DETECTIONS] = np.array(speeds)


### PR DESCRIPTION
## 🚧 Work in progress — not ready for review

Draft PR from a batch addressing findings from an in-depth engineering review. Fixes **review finding 38** (Medium, Concurrency).

## The bug
In the Velocity analytics block (`inference/core/workflows/core_steps/analytics/velocity/v1.py`), the per-video state dicts `self._previous_positions[video_id]` and `self._smoothed_velocities[video_id]` are written for every present `tracker_id` each frame (lines 282-283) but entries are never removed when a track disappears. Trackers (ByteTrack/SORT/etc.) assign monotonically increasing IDs, so on a long-running stream the number of distinct `tracker_id`s grows without bound and these dicts leak memory for the process lifetime — even though only a handful of objects are ever on screen at once.

## Root cause
Entries are only ever set, never deleted; the class had no eviction, TTL, or size bound anywhere (unlike `time_in_zone/v3.py`, which bounds its cache via `ZONE_CACHE_SIZE` + `OrderedDict.popitem`). A 24/7 stream accumulates one leaked entry per unique track ID indefinitely, steadily increasing RSS until OOM.

## Fix
`velocity/v1.py` only:
- Add per-video `self._last_seen_frame` and `self._frame_counter` state, plus a `MAX_FRAMES_WITHOUT_DETECTION` constant (150 frames, comfortably above typical tracker lost-track buffers).
- Record each `tracker_id`'s last-seen frame index as its state is stored.
- After processing a frame, prune `tracker_id`s absent for more than the retention window from all three per-video dicts. This keeps currently-visible and briefly-occluded tracks intact while bounding memory to O(on-screen + recent churn) instead of O(total distinct IDs).

## Verification
Standalone simulation mirroring the review's proven repro (100000 frames, 5 objects always on screen, one new monotonically-increasing ID churning in per frame, never reused):
- Before (review-confirmed): `previous_positions`/`smoothed_velocities` = **100004** entries (linear, unbounded).
- After this fix: **156** entries (= 5 stable + 150-frame window + 1), stable across the run; the 5 on-screen tracks are all retained.

## Scope
Focused change; one of a coordinated batch (one PR per finding).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
