### PR TITLE
[WIP] Neutralize CSV formula injection in CSV Formatter block

### DIFF
--- a/inference/core/workflows/core_steps/formatters/csv/v1.py
+++ b/inference/core/workflows/core_steps/formatters/csv/v1.py
@@ -205,5 +205,18 @@ def unfold_parameters(
     return None
 
 
+CSV_INJECTION_PREFIXES = ("=", "+", "-", "@", "\t", "\r")
+
+
 def to_csv(data: List[Dict[str, Any]]) -> str:
-    return pd.DataFrame(data).to_csv(index=False)
+    sanitized_data = [
+        {key: neutralize_csv_injection(value) for key, value in row.items()}
+        for row in data
+    ]
+    return pd.DataFrame(sanitized_data).to_csv(index=False)
+
+
+def neutralize_csv_injection(value: Any) -> Any:
+    if isinstance(value, str) and value.startswith(CSV_INJECTION_PREFIXES):
+        return "'" + value
+    return value


### PR DESCRIPTION
## 🚧 Work in progress — not ready for review

Draft PR from a batch addressing findings from an in-depth engineering review. Fixes **review finding 52** (Medium, Security).

## The bug
`to_csv()` in `inference/core/workflows/core_steps/formatters/csv/v1.py:208-209` did `pd.DataFrame(data).to_csv(index=False)` with no neutralization of leading formula characters. Column values flow from untrusted workflow data (VLM/LLM class names and text, OCR output, model class names, workflow inputs). pandas only quotes cells containing delimiters/quotes/newlines — it does NOT escape cells beginning with `=`, `+`, `-`, `@`, or tab/CR. The resulting `csv_content` is commonly persisted via Local File Sink or sent through Email/Webhook sinks, where opening in Excel/Google Sheets executes the injected formula (data exfiltration / DDE command / misleading content).

## Root cause
No CSV-injection neutralization was applied to cell values before serialization; the raw string was written verbatim.

## Fix
In `formatters/csv/v1.py`, before building the DataFrame, `to_csv()` now sanitizes every cell: any string value starting with one of `= + - @` (or tab/CR) is prefixed with a single quote via a new `neutralize_csv_injection` helper (`CSV_INJECTION_PREFIXES` tuple), per OWASP CSV-injection guidance. Non-string values and safe strings are left untouched. Single-file, minimal change.

## Verification
Standalone before/after in the `roboflow-inference` env:

- BEFORE: `'class_name,note,link,tab,safe,num\n=SUM(1+1),+cmd|calc,"=HYPERLINK(""http://evil"",""click"")",\t=1+1,apple,42\n'`
- AFTER:  `'class_name,note,link,tab,safe,num\n\'=SUM(1+1),\'+cmd|calc,"\'=HYPERLINK(""http://evil"",""click"")",\'\t=1+1,apple,42\n'`

Dangerous-prefix cells (`=`, `+`, `=HYPERLINK`, tab) are neutralized with a leading `'`; safe values (`apple`, `42`) are unchanged.

## Scope
Focused change; one of a coordinated batch (one PR per finding).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
