### PR TITLE
[WIP] Guard bounding_rect against empty/degenerate masks

### DIFF
--- a/inference/core/workflows/core_steps/transformations/bounding_rect/v1.py
+++ b/inference/core/workflows/core_steps/transformations/bounding_rect/v1.py
@@ -112,8 +112,10 @@ class BoundingRectManifest(WorkflowBlockManifest):
 
 def calculate_minimum_bounding_rectangle(
     mask: np.ndarray,
-) -> Tuple[np.array, float, float, float]:
+) -> Optional[Tuple[np.array, float, float, float]]:
     contours = sv.mask_to_polygons(mask)
+    if not contours:
+        return None
     largest_contour = max(contours, key=len)
 
     rect = cv.minAreaRect(largest_contour)
@@ -143,9 +145,12 @@ class BoundingRectBlockV1(WorkflowBlock):
             # copy
             det = predictions[i]
 
-            rect, width, height, angle = calculate_minimum_bounding_rectangle(
-                det.mask[0]
-            )
+            bounding_rectangle = calculate_minimum_bounding_rectangle(det.mask[0])
+            if bounding_rectangle is None:
+                # Mask has no extractable contour (e.g. empty or degenerate
+                # mask); skip this detection instead of aborting the batch.
+                continue
+            rect, width, height, angle = bounding_rectangle
 
             det.mask = np.array(
                 [


### PR DESCRIPTION
## 🚧 Work in progress — not ready for review

Draft PR from a batch addressing findings from an in-depth engineering review. Fixes **review finding 51** (Medium, Error-handling).

## The bug
`calculate_minimum_bounding_rectangle` calls `max(contours, key=len)` on the result of `sv.mask_to_polygons(mask)` at `inference/core/workflows/core_steps/transformations/bounding_rect/v1.py:116-117`. For an all-zero mask `mask_to_polygons` returns `[]`, so `max()` raises `ValueError('max() arg is an empty sequence')` and the entire Workflow batch fails instead of that single detection being skipped.

## Root cause
No empty-check before `max()`. This is triggered not only by all-zero masks but also by degenerate masks whose contours have fewer than 3 points — supervision's `mask_to_polygons` filters those out (`MIN_POLYGON_POINT_COUNT`), so a single-pixel / thin mask also yields `[]`.

## Fix
Single file, `inference/core/workflows/core_steps/transformations/bounding_rect/v1.py`:
- `calculate_minimum_bounding_rectangle` now returns `Optional[...]`, returning `None` when `sv.mask_to_polygons` yields no contours.
- `BoundingRectBlockV1.run` skips (`continue`) a detection whose mask has no extractable contour instead of aborting the batch. Skipping (rather than passing the raw detection through) keeps the merged detections' `data` keys consistent for `sv.Detections.merge`.

## Verification
Standalone repro against the corrected logic (supervision 0.29.0):
- Before: `max([], key=len)` → `ValueError: max() arg is an empty sequence`.
- After: empty mask → `None`; single-pixel/degenerate mask → `None`; real mask → valid `(box, w, h, angle)`. Simulated the `run` skip loop over `[empty, real, tiny]` → 1 detection kept, no crash; `sv.Detections.merge([])` also confirmed to return an empty `Detections`.

## Scope
Focused change; one of a coordinated batch (one PR per finding).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
