### PR TITLE
[WIP] Guard serverless auth-denial logger when API logging disabled

### DIFF
--- a/inference/core/interfaces/http/http_api.py
+++ b/inference/core/interfaces/http/http_api.py
@@ -509,6 +509,8 @@ def _log_serverless_authorization_denial(
     workspace_id: Optional[str],
     cache_hit: bool,
 ) -> None:
+    if not API_LOGGING_ENABLED:
+        return
     log_fields = {
         "method": request.method,
         "path": request.url.path,


### PR DESCRIPTION
## 🚧 Work in progress — not ready for review

Draft PR from a batch addressing findings from an in-depth engineering review. Fixes **review finding 54** (Medium, Error-handling).

## The bug
`_log_serverless_authorization_denial` (`inference/core/interfaces/http/http_api.py:524`) unconditionally calls `logger.info("Serverless authorization denied", **log_fields)` with structured kwargs (`method`, `path`, `status_code`, ...). Those kwargs are only valid for the structlog `BoundLogger`, which is selected only when `API_LOGGING_ENABLED=True`. When `API_LOGGING_ENABLED=False` (the default) the module logger is a plain `logging.Logger`, and `Logger.info(**kwargs)` raises `TypeError: Logger._log() got an unexpected keyword argument 'method'` once INFO is an effective level.

## Root cause
With `GCP_SERVERLESS=True`, `API_LOGGING_ENABLED=False`, and `LOG_LEVEL=INFO`/`DEBUG`, an unauthorized request routes through `_authorization_error_response -> _log_serverless_authorization_denial`, where the stdlib logger rejects the structured kwargs. The `TypeError` propagates out of the middleware (re-raised in `http_api.py`), so the client receives a generic 500 instead of the intended 401/402, and the denial is never logged. The sibling `_log_serverless_request_received` already guards with `if not API_LOGGING_ENABLED: return`; the denial logger omitted the same guard.

## Fix
`inference/core/interfaces/http/http_api.py`: add `if not API_LOGGING_ENABLED: return` at the top of `_log_serverless_authorization_denial`, mirroring `_log_serverless_request_received`. Two-line change; no other behavior touched.

## Verification
Standalone reproduction (conda env `roboflow-inference`) of the stdlib logging path:
- Before (no guard, stdlib logger at INFO): `logger.info("...", method="GET", status_code=401, ...)` → `TypeError: Logger._log() got an unexpected keyword argument 'method'`.
- After (guard, `API_LOGGING_ENABLED=False`): returns cleanly, no crash.

## Scope
Focused change; one of a coordinated batch (one PR per finding).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
