### PR TITLE
[WIP] Fix Dynamic Zones polygon metadata to match scaled mask and zones

### DIFF
--- a/inference/core/workflows/core_steps/transformations/dynamic_zones/v1.py
+++ b/inference/core/workflows/core_steps/transformations/dynamic_zones/v1.py
@@ -361,12 +361,12 @@ class DynamicZonesBlockV1(WorkflowBlock):
                     simplified_polygon = simplified_polygon[
                         :required_number_of_vertices
                     ]
-                updated_detection[POLYGON_KEY_IN_SV_DETECTIONS] = np.array(
-                    [simplified_polygon]
-                )
                 simplified_polygon = scale_polygon(
                     polygon=simplified_polygon,
                     scale=scale_ratio,
+                )
+                updated_detection[POLYGON_KEY_IN_SV_DETECTIONS] = np.array(
+                    [simplified_polygon]
                 )
                 simplified_polygons.append(simplified_polygon.tolist())
                 mask_bool = sv.polygon_to_mask(


### PR DESCRIPTION
## 🚧 Work in progress — not ready for review

Draft PR from a batch addressing findings from an in-depth engineering review. Fixes **review finding 60** (Medium, API-contract).

## The bug
In the Dynamic Zones transformation (`inference/core/workflows/core_steps/transformations/dynamic_zones/v1.py:364`), each detection's polygon metadata key `POLYGON_KEY_IN_SV_DETECTIONS` was assigned the **pre-scale** simplified polygon, and only afterwards was the polygon scaled by `scale_ratio`. The scaled polygon was then used for both the `zones` output and the regenerated `detection.mask`. When `scale_ratio != 1`, a single detection reported two different geometries: its polygon metadata was original-size while its mask and the emitted zones were scaled.

## Root cause
The metadata assignment (`updated_detection[POLYGON_KEY_IN_SV_DETECTIONS] = np.array([simplified_polygon])`) executed **before** the `scale_polygon(...)` call, so it captured the unscaled quadrilateral. Mask regeneration and `simplified_polygons.append(...)` ran after scaling and captured the scaled quadrilateral.

## Fix
Reorder the two operations so scaling happens first: `scale_polygon(...)` is now applied, and the resulting scaled polygon is stored in `POLYGON_KEY_IN_SV_DETECTIONS`. The polygon metadata, the regenerated mask, and the `zones` output now all describe the same geometry. When `scale_ratio == 1`, `scale_polygon` returns the polygon unchanged, so behavior is unaffected. Single file changed; 3 lines reordered.

## Verification
Standalone check reproducing the reordered logic with the block's own `scale_polygon` helper (`scale_ratio=1.5`, base quad `[[50,50],[50,149],[149,149],[149,50]]`):

- Before: metadata polygon `[[50,50],[50,149],[149,149],[149,50]]` (unscaled) vs zones `[[25,25],[25,173],[173,173],[173,25]]` (scaled) — disagree.
- After: metadata polygon `[[25,25],[25,173],[173,173],[173,25]]` == zones `[[25,25],[25,173],[173,173],[173,25]]` — agree, and both match the mask regenerated from the same scaled polygon.

## Scope
Focused change; one of a coordinated batch (one PR per finding).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
