### PR TITLE
[WIP] Fix PerspectiveCorrection stale transformation-matrix cache

### DIFF
--- a/inference/core/workflows/core_steps/transformations/perspective_correction/v1.py
+++ b/inference/core/workflows/core_steps/transformations/perspective_correction/v1.py
@@ -746,9 +746,18 @@ def correct_detections(
     return sv.Detections.merge(corrected_detections)
 
 
+def _to_hashable(value):
+    if isinstance(value, np.ndarray):
+        return _to_hashable(value.tolist())
+    if isinstance(value, (list, tuple)):
+        return tuple(_to_hashable(element) for element in value)
+    return value
+
+
 class PerspectiveCorrectionBlockV1(WorkflowBlock):
     def __init__(self):
         self.perspective_transformers: List[Tuple[np.ndarray, float, float]] = []
+        self.perspective_transformers_cache_key: Optional[tuple] = None
 
     @classmethod
     def get_manifest(cls) -> Type[WorkflowBlockManifest]:
@@ -787,10 +796,21 @@ class PerspectiveCorrectionBlockV1(WorkflowBlock):
         if isinstance(transformed_rect_width, int):
             transformed_rect_width = [transformed_rect_width] * batch_size
 
+        perspective_transformers_cache_key = (
+            _to_hashable(perspective_polygons),
+            _to_hashable(transformed_rect_width),
+            _to_hashable(transformed_rect_height),
+            str(extend_perspective_polygon_by_detections_anchor),
+        )
         if (
             not self.perspective_transformers
             or extend_perspective_polygon_by_detections_anchor
+            or self.perspective_transformers_cache_key
+            != perspective_transformers_cache_key
         ):
+            self.perspective_transformers_cache_key = (
+                perspective_transformers_cache_key
+            )
             self.perspective_transformers = []
             largest_perspective_polygons = pick_largest_perspective_polygons(
                 perspective_polygons


### PR DESCRIPTION
## 🚧 Work in progress — not ready for review

Draft PR from a batch addressing findings from an in-depth engineering review. Fixes **review finding 62** (Medium, Correctness).

## The bug
`PerspectiveCorrectionBlockV1.run()` caches the computed perspective-transformation matrices in `self.perspective_transformers` and, in the default configuration (no detections-anchor extension), only recomputes them when the cache is empty (`inference/core/workflows/core_steps/transformations/perspective_correction/v1.py:790`). When a workflow feeds per-frame `perspective_polygons` (a supported, batch-accepted input, e.g. `$steps.perspective_wrap.zones`), frames 2..N reuse the frame-1 homography, warping every later frame/detection with the wrong matrix.

## Root cause
The recompute guard was `if not self.perspective_transformers or extend_perspective_polygon_by_detections_anchor:` — it never depended on the identity of `perspective_polygons` / `transformed_rect_width` / `transformed_rect_height`, so changed polygons on subsequent calls were ignored and the stale cached matrix was reused.

## Fix
`inference/core/workflows/core_steps/transformations/perspective_correction/v1.py`:
- Added a small `_to_hashable` helper that canonicalizes nested lists / numpy arrays into hashable tuples.
- Store `self.perspective_transformers_cache_key` and derive a cache key each call from the polygons, transformed rect width/height, and the anchor.
- Recompute the transformers when the cache is empty, when a detections anchor is set (unchanged behavior), or when the cache key differs from the previous call. This preserves the optimization for static polygons while producing correct matrices when polygons change per frame.

## Verification
Standalone reproduction of the guard logic (matrix computation stubbed):
- Frame 1 (polygon A): recompute = True
- Frame 2 (polygon B, different): recompute = True  ← previously False (stale cache)
- Frame 3 (polygon B again): recompute = False (optimization preserved)
- Keys are stable and hashable; numpy-array and list polygon inputs produce equal keys.

Full runtime verification via the `inference` package import is deferred (WIP); the guard/key logic follows the review's proven remediation.

## Scope
Focused change; one of a coordinated batch (one PR per finding).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
