### PR TITLE
[WIP] Guard None confidence/class_id in serialise_sv_detections

### DIFF
--- a/inference/core/workflows/core_steps/common/serializers.py
+++ b/inference/core/workflows/core_steps/common/serializers.py
@@ -85,8 +85,10 @@ def serialise_sv_detections(detections: sv.Detections) -> dict:
         detection_dict[X_KEY] = x1 + detection_dict[WIDTH_KEY] / 2
         detection_dict[Y_KEY] = y1 + detection_dict[HEIGHT_KEY] / 2
 
-        detection_dict[CONFIDENCE_KEY] = float(confidence)
-        detection_dict[CLASS_ID_KEY] = int(class_id)
+        detection_dict[CONFIDENCE_KEY] = (
+            float(confidence) if confidence is not None else 1.0
+        )
+        detection_dict[CLASS_ID_KEY] = int(class_id) if class_id is not None else 0
         if mask is not None:
             if (
                 POLYGON_KEY_IN_SV_DETECTIONS in data


### PR DESCRIPTION
## 🚧 Work in progress — not ready for review

Draft PR from a batch addressing findings from an in-depth engineering review. Fixes **review finding 59** (Medium, Error-handling).

## The bug
`serialise_sv_detections` in `inference/core/workflows/core_steps/common/serializers.py:88-89` calls `float(confidence)` and `int(class_id)` unconditionally while `tracker_id` and `mask` are None-guarded. When an `sv.Detections` legitimately carries `confidence=None` or `class_id=None`, iterating it yields `None` for that row, and `float(None)` / `int(None)` raise `TypeError`, failing the whole serialization.

## Root cause
`detections_merge/v1.py:165` builds a merged detection with `confidence=None` when its inputs have no confidence (and `mask_edge_snap/v1.py:573-574` similarly forwards possibly-None confidence/class_id). Both emit `OBJECT_DETECTION_PREDICTION_KIND` / segmentation kinds, whose registered serializer is `serialise_sv_detections`. The serializer had no guard for the None case.

## Fix
`serializers.py`: default `confidence` to `1.0` and `class_id` to `0` when the iterated value is `None`, keeping both keys always present. This avoids silently dropping the keys, which is required because the round-trip deserializer (`sv.Detections.from_inference` → `process_roboflow_result`) reads `prediction["confidence"]` / `prediction["class_id"]` via direct indexing and would `KeyError` if they were omitted.

## Verification
Standalone check against real `sv.Detections` iteration (conda env `roboflow-inference`, supervision 0.29.0):
- `confidence=None, class_id=3`: OLD raised `TypeError: float() argument must be a string or a real number, not 'NoneType'`; NEW → `{'c': 1.0, 'id': 3}`.
- `confidence=0.7, class_id=None`: OLD raised `TypeError: int() argument ... not 'NoneType'`; NEW → `{'c': 0.7, 'id': 0}`.
Present values are preserved unchanged.

## Scope
Focused change; one of a coordinated batch (one PR per finding).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
