### PR TITLE
[WIP] Copy status_update_handlers before appending watchdog handler

### DIFF
--- a/inference/core/interfaces/stream/inference_pipeline.py
+++ b/inference/core/interfaces/stream/inference_pipeline.py
@@ -801,8 +801,7 @@ class InferencePipeline:
         """
         if watchdog is None:
             watchdog = NullPipelineWatchdog()
-        if status_update_handlers is None:
-            status_update_handlers = []
+        status_update_handlers = list(status_update_handlers or [])
         status_update_handlers.append(watchdog.on_status_update)
         desired_source_fps = None
         if ENABLE_FRAME_DROP_ON_VIDEO_FILE_RATE_LIMITING:


### PR DESCRIPTION
## 🚧 Work in progress — not ready for review

Draft PR from a batch addressing findings from an in-depth engineering review. Fixes **review finding 65** (Low, API-contract).

## The bug
`InferencePipeline.init_with_custom_logic` mutates the caller-provided `status_update_handlers` list in place. At `inference/core/interfaces/stream/inference_pipeline.py:806`, `status_update_handlers.append(watchdog.on_status_update)` grows the exact list object the caller passed (a fresh `[]` is only created when the arg is `None`). That same mutated list is then handed to `prepare_video_sources` and attached to every `VideoSource`, making it shared state across the caller, the watchdog wiring, and all sources.

## Root cause
No copy is made before appending. When a caller reuses one `handlers` list across two `init` calls, the first appends `wd1.on_status_update` and the second appends `wd2.on_status_update` to the *same* list — so both pipelines' `VideoSource`s carry both watchdogs' handlers. Pipeline-1 frames then drive pipeline-2's watchdog and vice-versa, corrupting latency/throughput reports; even a single call silently grows the caller's own list.

## Fix
`inference/core/interfaces/stream/inference_pipeline.py`: replace the `None`-check + in-place `append` with a defensive copy — `status_update_handlers = list(status_update_handlers or [])` before appending the watchdog handler. This handles the `None` default and gives each pipeline an isolated handler list without changing the appended behavior.

## Verification
Standalone before/after of the exact logic:
- OLD: `caller after: ['my', 'wd1', 'wd2'] | p1 is p2: True | wd2 in p1: True`
- NEW: `caller after: ['my'] | p1 is p2: False | wd2 in p1: False` (p1 = `['my','wd1']`, p2 = `['my','wd2']`)

Confirms the caller list is no longer mutated and handler lists are isolated per pipeline. Follows the review's proven remediation; full runtime verification deferred (WIP).

## Scope
Focused change; one of a coordinated batch (one PR per finding).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
