### PR TITLE
[WIP] Preserve detections with absent classification when fallback is set

### DIFF
--- a/inference/core/workflows/core_steps/fusion/detections_classes_replacement/v1.py
+++ b/inference/core/workflows/core_steps/fusion/detections_classes_replacement/v1.py
@@ -309,12 +309,12 @@ class DetectionsClassesReplacementBlockV1(WorkflowBlock):
 
             return {"predictions": selected_object_detection_predictions}
 
-        if all(
+        if not fallback_class_name and all(
             p is None or "top" in p and not p["top"] or "predictions" not in p
             for p in classification_predictions
         ):
             return {"predictions": sv.Detections.empty()}
-        detection_id_by_class: Dict[str, Optional[Tuple[str, int]]] = {
+        detection_id_by_class: Dict[str, Optional[Tuple[str, int, float]]] = {
             prediction[PARENT_ID_KEY]: extract_leading_class_from_prediction(
                 prediction=prediction,
                 fallback_class_name=fallback_class_name,
@@ -323,6 +323,21 @@ class DetectionsClassesReplacementBlockV1(WorkflowBlock):
             for prediction in classification_predictions
             if prediction is not None
         }
+        if fallback_class_name:
+            # A None entry in the batch carries no parent_id, so detections whose
+            # classification is entirely absent never enter detection_id_by_class.
+            # Route them through the fallback instead of dropping them, matching
+            # the string path and the documented fallback behavior.
+            try:
+                resolved_fallback_id = int(fallback_class_id)
+            except (ValueError, TypeError):
+                resolved_fallback_id = None
+            if resolved_fallback_id is None or resolved_fallback_id < 0:
+                resolved_fallback_id = sys.maxsize
+            fallback_class = (fallback_class_name, resolved_fallback_id, 0.0)
+            for detection_id in object_detection_predictions.data[DETECTION_ID_KEY]:
+                if detection_id_by_class.get(detection_id) is None:
+                    detection_id_by_class[detection_id] = fallback_class
         detections_to_remain_mask = [
             detection_id_by_class.get(detection_id) is not None
             for detection_id in object_detection_predictions.data[DETECTION_ID_KEY]

--- a/tests/workflows/unit_tests/core_steps/fusion/test_detections_classes_replacement.py
+++ b/tests/workflows/unit_tests/core_steps/fusion/test_detections_classes_replacement.py
@@ -397,6 +397,112 @@ def test_classes_replacement_when_empty_classification_predictions_fallback_clas
     ), "class name expected to be set to value passed with fallback_class_name parameter"
 
 
+def test_classes_replacement_when_dict_prediction_is_none_fallback_class_provided():
+    # given
+    step = DetectionsClassesReplacementBlockV1()
+    detections = sv.Detections(
+        xyxy=np.array(
+            [
+                [10, 20, 30, 40],
+                [11, 21, 31, 41],
+            ]
+        ),
+        class_id=np.array([7, 7]),
+        confidence=np.array([0.36, 0.91]),
+        data={
+            "class_name": np.array(["animal", "animal"]),
+            "detection_id": np.array(["zero", "one"]),
+        },
+    )
+    cls_prediction = ClassificationInferenceResponse(
+        image=InferenceResponseImage(width=128, height=256),
+        predictions=[
+            ClassificationPrediction(
+                **{"class": "cat", "class_id": 0, "confidence": 0.6}
+            ),
+            ClassificationPrediction(
+                **{"class": "dog", "class_id": 1, "confidence": 0.4}
+            ),
+        ],
+        top="cat",
+        confidence=0.6,
+        parent_id="some",
+    ).dict(by_alias=True, exclude_none=True)
+    cls_prediction["parent_id"] = "one"
+    classification_predictions = Batch(
+        content=[
+            cls_prediction,
+            None,
+        ],
+        indices=[(0, 0), (0, 1)],
+    )
+
+    # when
+    result = step.run(
+        object_detection_predictions=detections,
+        classification_predictions=classification_predictions,
+        fallback_class_name="unknown",
+        fallback_class_id=123,
+    )
+
+    # then
+    assert (
+        len(result["predictions"]) == 2
+    ), "Expected both detections preserved: the matched one classified, the unmatched one via fallback"
+    predictions = result["predictions"]
+    # detection "one" is classified as cat; detection "zero" has no classification -> fallback
+    assert predictions.data["class_name"].tolist() == [
+        "unknown",
+        "cat",
+    ], "Detection whose classification is None must receive the fallback class name"
+    assert predictions.class_id.tolist() == [
+        123,
+        0,
+    ], "Fallback class id expected for the detection without classification"
+    assert (
+        predictions.confidence[0] == 0.0
+    ), "Fallback class confidence expected to be set to 0"
+
+
+def test_classes_replacement_when_all_dict_predictions_none_fallback_class_provided():
+    # given
+    step = DetectionsClassesReplacementBlockV1()
+    detections = sv.Detections(
+        xyxy=np.array(
+            [
+                [10, 20, 30, 40],
+                [11, 21, 31, 41],
+            ]
+        ),
+        class_id=np.array([7, 7]),
+        confidence=np.array([0.36, 0.91]),
+        data={
+            "class_name": np.array(["animal", "animal"]),
+            "detection_id": np.array(["zero", "one"]),
+        },
+    )
+    classification_predictions = Batch(
+        content=[None, None],
+        indices=[(0, 0), (0, 1)],
+    )
+
+    # when
+    result = step.run(
+        object_detection_predictions=detections,
+        classification_predictions=classification_predictions,
+        fallback_class_name="unknown",
+        fallback_class_id=123,
+    )
+
+    # then
+    assert (
+        len(result["predictions"]) == 2
+    ), "Fallback must preserve detections even when every classification is absent"
+    predictions = result["predictions"]
+    assert predictions.data["class_name"].tolist() == ["unknown", "unknown"]
+    assert predictions.class_id.tolist() == [123, 123]
+
+
 def test_extract_leading_class_from_prediction_when_prediction_is_multi_label() -> None:
     # given
     prediction = ClassificationInferenceResponse(


### PR DESCRIPTION
## 🚧 Work in progress — not ready for review

Draft PR from a batch addressing findings from an in-depth engineering review. Fixes **review finding 50** (Medium, API-contract).

## The bug
In `inference/core/workflows/core_steps/fusion/detections_classes_replacement/v1.py`, the classification (dict) path builds `detection_id_by_class` from predictions keyed by `PARENT_ID_KEY`, skipping `None` entries (`v1.py:317-325`). A detection whose classification is entirely absent (a `None` entry in the batch — valid input since `accepts_empty_values()` returns `True`, e.g. a zero-area crop from `dynamic_crop`) never gets a `detection_id_by_class` entry, so it fails the `detection_id_by_class.get(detection_id) is not None` mask and is silently dropped — even when `fallback_class_name` is configured. The string path (`v1.py:261-272`) routes `None` predictions through the fallback, so the two paths behave inconsistently, and the docstring promises the fallback preserves detections "when classification fails or is unavailable."

## Root cause
`None` batch entries carry no `parent_id`, so they cannot be matched to a detection and the corresponding detection is absent from `detection_id_by_class`. Fallback resolution only happened inside `extract_leading_class_from_prediction` (present-but-empty prediction dicts), never for detections whose classification entry is `None`. Additionally, the all-empty early return returned `sv.Detections.empty()` unconditionally, discarding everything even when a fallback was set.

## Fix
`v1.py` (classification/dict path only):
- After building `detection_id_by_class`, when `fallback_class_name` is set, assign the resolved fallback tuple to every detection whose id maps to `None`/is absent, so unmatched detections are preserved with the fallback class instead of being dropped. Fallback-id resolution mirrors the existing dict-path logic (`int()`, `None`/negative → `sys.maxsize`).
- Guard the all-empty early return with `not fallback_class_name` so an all-`None`/empty batch still preserves detections via the fallback (matching the string path).
- Corrected the `detection_id_by_class` annotation to the actual 3-tuple `Tuple[str, int, float]`.

Tests (`tests/workflows/unit_tests/core_steps/fusion/test_detections_classes_replacement.py`): added `test_classes_replacement_when_dict_prediction_is_none_fallback_class_provided` (one valid dict + one `None`, fallback set → both preserved, unmatched gets fallback) and `test_classes_replacement_when_all_dict_predictions_none_fallback_class_provided` (all `None` + fallback → all preserved).

## Verification
Standalone before/after of the exact dict-path mask logic (conda env `roboflow-inference`):
`dets=[det_one, det_two]`, `class_preds=[{parent_id:det_two, top:labrador, ...}, None]`, `fallback_class_name=unknown`, `fallback_class_id=123`.
- Before: `OLD kept: 1 -> ['det_two']` (det_one silently dropped).
- After: `NEW kept: 2 -> ['det_one', 'det_two']`; classes `det_one -> ('unknown', 123, 0.0)`, `det_two -> ('labrador', 5, 0.8)`.
Full pytest suite for the block could not run inside the sparse worktree (partial package tree); the added unit tests drive the real `run()` code path and full runtime verification is deferred (WIP).

## Scope
Focused change; one of a coordinated batch (one PR per finding).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
