### PR TITLE
[WIP] Fix semantic-seg center-crop border labeled as foreground

### DIFF
--- a/inference_models/inference_models/models/common/roboflow/post_processing.py
+++ b/inference_models/inference_models/models/common/roboflow/post_processing.py
@@ -771,22 +771,35 @@ def post_process_semantic_segmentation_logits(
             round(mask_w_scale * image_metadata.pad_right),
         )
         _, mh, mw = image_results.shape
+        border_mask: Optional[torch.Tensor] = None
         if (
             mask_pad_top < 0
             or mask_pad_bottom < 0
             or mask_pad_left < 0
             or mask_pad_right < 0
         ):
+            negative_padding = (
+                abs(min(mask_pad_left, 0)),
+                abs(min(mask_pad_right, 0)),
+                abs(min(mask_pad_top, 0)),
+                abs(min(mask_pad_bottom, 0)),
+            )
+            # A negative pad means the input was CENTER_CROP-ed, so the border the
+            # crop removed has no prediction and must resolve to background. Track it
+            # in `border_mask` and force it to background after argmax; padding the
+            # logits themselves with a class id (as opposed to tracking the region)
+            # makes argmax select a foreground channel over the re-added border.
+            border_mask = torch.nn.functional.pad(
+                torch.zeros((mh, mw), dtype=torch.bool, device=device),
+                negative_padding,
+                "constant",
+                True,
+            )
             image_results = torch.nn.functional.pad(
                 image_results,
-                (
-                    abs(min(mask_pad_left, 0)),
-                    abs(min(mask_pad_right, 0)),
-                    abs(min(mask_pad_top, 0)),
-                    abs(min(mask_pad_bottom, 0)),
-                ),
+                negative_padding,
                 "constant",
-                background_class_id,
+                0,
             )
             padded_mask_offset_top = max(mask_pad_top, 0)
             padded_mask_offset_bottom = max(mask_pad_bottom, 0)
@@ -797,6 +810,12 @@ def post_process_semantic_segmentation_logits(
                 padded_mask_offset_top : image_results.shape[1]
                 - padded_mask_offset_bottom,
                 padded_mask_offset_left : image_results.shape[2]
+                - padded_mask_offset_right,
+            ]
+            border_mask = border_mask[
+                padded_mask_offset_top : border_mask.shape[0]
+                - padded_mask_offset_bottom,
+                padded_mask_offset_left : border_mask.shape[1]
                 - padded_mask_offset_right,
             ]
         else:
@@ -817,6 +836,19 @@ def post_process_semantic_segmentation_logits(
                 ],
                 interpolation=functional.InterpolationMode.BILINEAR,
             )
+            if border_mask is not None:
+                border_mask = (
+                    functional.resize(
+                        border_mask.unsqueeze(0).to(dtype=torch.uint8),
+                        [
+                            image_metadata.size_after_pre_processing.height,
+                            image_metadata.size_after_pre_processing.width,
+                        ],
+                        interpolation=functional.InterpolationMode.NEAREST,
+                    )
+                    .squeeze(0)
+                    .to(dtype=torch.bool)
+                )
         if image_results.shape[0] == 1:
             image_confidence = image_results[0].sigmoid()
             image_class_ids = insert_background_class(
@@ -833,6 +865,11 @@ def post_process_semantic_segmentation_logits(
                     background_class_id=background_class_id,
                     num_classes=len(class_names),
                 )
+        if border_mask is not None:
+            image_class_ids = image_class_ids.clone()
+            image_confidence = image_confidence.clone()
+            image_class_ids[border_mask] = background_class_id
+            image_confidence[border_mask] = 0.0
         if (
             image_metadata.static_crop_offset.offset_x > 0
             or image_metadata.static_crop_offset.offset_y > 0


### PR DESCRIPTION
## 🚧 Work in progress — not ready for review

Draft PR from a batch addressing findings from an in-depth engineering review. Fixes **review finding 47** (Medium, Correctness).

## The bug
In `post_process_semantic_segmentation_logits`, the negative-padding branch (reached on CENTER_CROP, when the input image is larger than the network input) re-adds the cropped-away border via `torch.nn.functional.pad(image_results, ..., "constant", background_class_id)` at `inference_models/inference_models/models/common/roboflow/post_processing.py:789`. But `image_results` are class **logits**, not class ids. Filling every logit channel with the scalar `background_class_id` yields a uniform logit vector over the border, so argmax/sigmoid mislabels it: for 1 foreground class, `sigmoid(0)=0.5`; for 2 classes, `softmax([0,0])=0.5` at channel 0, which `insert_background_class` maps to the first foreground class. Both survive the default `0.4` confidence threshold, so the outer border ring of the original image is segmented as foreground instead of background.

## Root cause
The re-added border is a region with **no prediction**, but it was expressed as a fill value in logit space. Background is not a logit channel here — it is produced only by the post-argmax threshold collapse — so no logit fill value can make argmax choose background (softmax is shift-invariant, so a uniform fill always yields `1/K` at some foreground channel). Contrast the instance-seg analog, which correctly fills masks with `0` (`post_processing.py:438-448`).

## Fix
`inference_models/inference_models/models/common/roboflow/post_processing.py`, single function, minimal:
- Pad the logits with a neutral `0` (value now irrelevant to the border pixels) and separately track the re-added border in a boolean `border_mask`, padded/cropped/resized in lockstep with the logits (nearest interpolation across the existing resize step).
- After sigmoid/softmax + argmax, force `border_mask` pixels to `background_class_id` and confidence `0.0`, before the static-crop canvas placement — mirroring the static-crop canvas handling and the threshold-collapse semantics.

## Verification
Standalone simulation of the exact code path (pad → crop → resize → sigmoid/softmax → argmax → border correction → threshold), K in {1,2,3,5}:
- Before: corner border pixel labeled foreground class 1 at conf 0.500 for K=1 and K=2 (bug); background for K>=3.
- After: 0 foreground pixels across the entire re-added border for all K (231/231 border pixels background, confidence 0).

## Scope
Focused change; one of a coordinated batch (one PR per finding).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
