### PR TITLE
[WIP] Fix OCR delimiter corrupting multi-line stitched text

### DIFF
--- a/inference/core/workflows/core_steps/transformations/stitch_ocr_detections/v1.py
+++ b/inference/core/workflows/core_steps/transformations/stitch_ocr_detections/v1.py
@@ -272,8 +272,8 @@ def stitch_ocr_detections(
     )
 
     # Build final text
-    ordered_class_names = []
-    for i, key in enumerate(lines):
+    line_strings = []
+    for key in lines:
         line_data = boxes_by_line[key]
         line_xyxy = np.array(line_data["xyxy"])
         line_idx = np.array(line_data["idx"])
@@ -281,14 +281,11 @@ def stitch_ocr_detections(
         # Sort detections within line
         sort_idx = sort_line_detections(line_xyxy, reading_direction)
 
-        # Add sorted class names for this line
-        ordered_class_names.extend(class_names[line_idx[sort_idx]])
+        # Join sorted class names within this line using the delimiter
+        line_strings.append(delimiter.join(class_names[line_idx[sort_idx]]))
 
-        # Add line separator if not last line
-        if i < len(lines) - 1:
-            ordered_class_names.append(get_line_separator(reading_direction))
-
-    return {"ocr_text": delimiter.join(ordered_class_names)}
+    # Join lines with the reading-direction line separator
+    return {"ocr_text": get_line_separator(reading_direction).join(line_strings)}
 
 
 def prepare_coordinates(

--- a/inference/core/workflows/core_steps/transformations/stitch_ocr_detections/v2.py
+++ b/inference/core/workflows/core_steps/transformations/stitch_ocr_detections/v2.py
@@ -357,8 +357,8 @@ def stitch_ocr_detections(
     )
 
     # Build final text
-    ordered_class_names = []
-    for i, key in enumerate(lines):
+    line_strings = []
+    for key in lines:
         line_data = boxes_by_line[key]
         line_xyxy = np.array(line_data["xyxy"])
         line_idx = np.array(line_data["idx"])
@@ -366,14 +366,11 @@ def stitch_ocr_detections(
         # Sort detections within line
         sort_idx = sort_line_detections(line_xyxy, reading_direction)
 
-        # Add sorted class names for this line
-        ordered_class_names.extend(class_names[line_idx[sort_idx]])
+        # Join sorted class names within this line using the delimiter
+        line_strings.append(delimiter.join(class_names[line_idx[sort_idx]]))
 
-        # Add line separator if not last line
-        if i < len(lines) - 1:
-            ordered_class_names.append(get_line_separator(reading_direction))
-
-    return {"ocr_text": delimiter.join(ordered_class_names)}
+    # Join lines with the reading-direction line separator
+    return {"ocr_text": get_line_separator(reading_direction).join(line_strings)}
 
 
 def prepare_coordinates(


### PR DESCRIPTION
## 🚧 Work in progress — not ready for review

Draft PR from a batch addressing findings from an in-depth engineering review. Fixes **review finding 69** (Low, Correctness).

## The bug
In `stitch_ocr_detections`, line separators (`'\n'` for horizontal reading, `' '` for vertical) are appended into `ordered_class_names` as if they were text tokens, then the whole list is joined with `delimiter.join(...)` (`inference/core/workflows/core_steps/transformations/stitch_ocr_detections/v1.py:291`; identical at `v2.py:376`). With a non-empty delimiter the separator token gets the delimiter inserted on both sides, corrupting multi-line output.

## Root cause
The line separator was a list element passed through the same `delimiter.join(...)` used for text tokens, so `delimiter` was placed around the separator instead of only between text tokens. Example: `delimiter=' '` over two lines `['H','I']` and `['B']` produced `'H I \n B'` (space before and after the newline) instead of `'H I\nB'`. Similarly `delimiter=','` produced `'H,I,\n,B'`.

## Fix
Per file (`v1.py`, `v2.py`), the "Build final text" block now builds one string per line with `delimiter.join(line_tokens)` and joins the lines with `get_line_separator(reading_direction)`. The delimiter is therefore only inserted between text tokens within a line, and the line separator cleanly separates lines. The empty-delimiter path is unchanged.

## Verification
Standalone check of the fixed join logic over lines `[['H','I'],['B']]`, `left_to_right`:
- before: `''` -> `'HI\nB'`, `' '` -> `'H I \n B'`, `','` -> `'H,I,\n,B'`
- after: `''` -> `'HI\nB'`, `' '` -> `'H I\nB'`, `','` -> `'H,I\nB'`

Empty-delimiter output is identical (no regression); non-empty delimiters now produce clean line breaks.

## Scope
Focused change; one of a coordinated batch (one PR per finding).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
