### PR TITLE
[WIP] Remap negative fallback_class_id to sys.maxsize in string-input None branch

### DIFF
--- a/inference/core/workflows/core_steps/fusion/detections_classes_replacement/v1.py
+++ b/inference/core/workflows/core_steps/fusion/detections_classes_replacement/v1.py
@@ -261,9 +261,9 @@ class DetectionsClassesReplacementBlockV1(WorkflowBlock):
                 if prediction is None:
                     if fallback_class_name:
                         resolved_fallback_id = (
-                            fallback_class_id
-                            if fallback_class_id is not None
-                            else sys.maxsize
+                            sys.maxsize
+                            if fallback_class_id is None or fallback_class_id < 0
+                            else fallback_class_id
                         )
                         class_name, class_id, confidence = (
                             fallback_class_name,


### PR DESCRIPTION
## 🚧 Work in progress — not ready for review

Draft PR from a batch addressing findings from an in-depth engineering review. Fixes **review finding 71** (Low, Docs).

## The bug
In the string-input path of `DetectionsClassesReplacementBlockV1.run`, the None-prediction fallback branch (`inference/core/workflows/core_steps/fusion/detections_classes_replacement/v1.py:263-267`) computed `resolved_fallback_id = fallback_class_id if fallback_class_id is not None else sys.maxsize`. This only remaps `None`; a negative `fallback_class_id` is used verbatim, contradicting the field description and `LONG_DESCRIPTION` which state the fallback id is set to `sys.maxsize` "if not specified or negative".

## Root cause
The None-branch normalization checked only for `None`, unlike `extract_leading_class_from_prediction` (lines 383 and 408) which correctly remaps both `None` and negative ids to `sys.maxsize`. The string path drifted from both the docs and the sibling code paths.

## Fix
`v1.py`: in the string-path None branch, treat `None` or negative `fallback_class_id` as `sys.maxsize` (`sys.maxsize if fallback_class_id is None or fallback_class_id < 0 else fallback_class_id`), matching `extract_leading_class_from_prediction`. Non-negative ids pass through unchanged.

## Verification
Standalone before/after of the resolution logic: with `fallback_class_id=-1`, OLD produced `-1` (bug); NEW produces `9223372036854775807` (`sys.maxsize`), as documented. `None` still maps to `sys.maxsize`; `0` and `5` pass through verbatim. Full runtime verification of the block deferred (WIP).

## Scope
Focused change; one of a coordinated batch (one PR per finding).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
