### PR TITLE
[WIP] Install inference warning filters before env.py's own warn calls

### DIFF
--- a/inference/core/env.py
+++ b/inference/core/env.py
@@ -15,6 +15,22 @@ from inference.core.warnings import (
 
 load_dotenv(os.getcwd() + "/.env")
 
+# Install warning filters before any module-level ``warnings.warn`` calls below,
+# so these flags also suppress warnings emitted during this module's own import
+# (e.g. the gaze deprecation stub warning), not just warnings raised afterwards.
+INFERENCE_WARNINGS_DISABLED = str2bool(
+    os.getenv("INFERENCE_WARNINGS_DISABLED", "False")
+)
+if INFERENCE_WARNINGS_DISABLED:
+    warnings.simplefilter("ignore", InferenceDeprecationWarning)
+    warnings.simplefilter("ignore", InferenceModelsStackMissing)
+
+IGNORE_MODEL_DEPENDENCIES_WARNINGS = str2bool(
+    os.getenv("IGNORE_MODEL_DEPENDENCIES_WARNINGS", "False")
+)
+if IGNORE_MODEL_DEPENDENCIES_WARNINGS:
+    warnings.simplefilter("ignore", ModelDependencyMissing)
+
 # The project name, default is "roboflow-platform"
 PROJECT = os.getenv("PROJECT", "roboflow-platform")
 
@@ -754,14 +770,6 @@ MODAL_ANONYMOUS_WORKSPACE_NAME = os.getenv(
 
 MODEL_VALIDATION_DISABLED = str2bool(os.getenv("MODEL_VALIDATION_DISABLED", "False"))
 
-INFERENCE_WARNINGS_DISABLED = str2bool(
-    os.getenv("INFERENCE_WARNINGS_DISABLED", "False")
-)
-
-if INFERENCE_WARNINGS_DISABLED:
-    warnings.simplefilter("ignore", InferenceDeprecationWarning)
-    warnings.simplefilter("ignore", InferenceModelsStackMissing)
-
 HUGGINGFACE_TOKEN = os.getenv("HUGGINGFACE_TOKEN")
 DEVICE = os.getenv("DEVICE")
 
@@ -851,12 +859,6 @@ if ROBOFLOW_API_REQUEST_TIMEOUT:
 # Control SSL certificate verification for requests to the Roboflow API
 # Default is True (verify SSL). Set ROBOFLOW_API_VERIFY_SSL=false to disable in local dev.
 ROBOFLOW_API_VERIFY_SSL = str2bool(os.getenv("ROBOFLOW_API_VERIFY_SSL", "True"))
-
-IGNORE_MODEL_DEPENDENCIES_WARNINGS = str2bool(
-    os.getenv("IGNORE_MODEL_DEPENDENCIES_WARNINGS", "False")
-)
-if IGNORE_MODEL_DEPENDENCIES_WARNINGS:
-    warnings.simplefilter("ignore", ModelDependencyMissing)
 
 DISK_CACHE_CLEANUP = str2bool(os.getenv("DISK_CACHE_CLEANUP", "True"))
 MEMORY_FREE_THRESHOLD = float(


### PR DESCRIPTION
## 🚧 Work in progress — not ready for review

Draft PR from a batch addressing findings from an in-depth engineering review. Fixes **review finding 66** (Low, Correctness).

## The bug
Setting `INFERENCE_WARNINGS_DISABLED=True` fails to suppress env.py's own `CORE_MODEL_GAZE_ENABLED` deprecation warning. The gaze `InferenceDeprecationWarning` is emitted at `inference/core/env.py:216` during module import, but the `warnings.simplefilter("ignore", InferenceDeprecationWarning)` that the flag drives was installed later at `inference/core/env.py:762`. So on every startup the exact warning class the flag is meant to mute is still printed.

## Root cause
Module-level statements run top-to-bottom. The `INFERENCE_WARNINGS_DISABLED` / `IGNORE_MODEL_DEPENDENCIES_WARNINGS` `simplefilter` blocks were positioned below the earlier module-level `warnings.warn()` calls, so the ignore filters were registered *after* those warnings had already fired. Warnings emitted after the filter (e.g. the mediapipe one) were suppressed, warnings emitted before it were not — an ordering-dependent inconsistency.

## Fix
`inference/core/env.py`: moved both warning-filter install blocks (`INFERENCE_WARNINGS_DISABLED` → ignore `InferenceDeprecationWarning` / `InferenceModelsStackMissing`; `IGNORE_MODEL_DEPENDENCIES_WARNINGS` → ignore `ModelDependencyMissing`) to the top of the module, immediately after `load_dotenv(...)`, so the filters are registered before any module-level `warnings.warn()` call. The flag variables remain module exports (now defined once, at the top). No default behavior changes when the flags are unset.

## Verification
Standalone reproduction of the ordering logic (`conda run -n roboflow-inference python3`):
- OLD (filter installed late), flag ON → `['InferenceDeprecationWarning']` (leaks — the bug)
- NEW (filter installed early), flag ON → `[]` (suppressed — fixed)
- NEW (filter installed early), flag OFF → `['InferenceDeprecationWarning']` (default behavior preserved)

`python -m py_compile inference/core/env.py` passes. Full package import not exercised from the sparse worktree.

## Scope
Focused change; one of a coordinated batch (one PR per finding).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
