### PR TITLE
[WIP] Coerce blur kernel_size to positive odd for gaussian/median

### DIFF
--- a/inference/core/workflows/core_steps/classical_cv/image_blur/v1.py
+++ b/inference/core/workflows/core_steps/classical_cv/image_blur/v1.py
@@ -123,7 +123,7 @@ class ImageBlurManifest(WorkflowBlockManifest):
 
     kernel_size: Union[Selector(kind=[INTEGER_KIND]), int] = Field(
         default=5,
-        description="Size of the blur kernel (must be positive and typically odd). Controls the blur intensity - larger values create more blur, smaller values create less blur. For average and gaussian blur, this is the width and height of the kernel (e.g., 5 means 5x5 kernel). For median blur, this must be an odd integer (automatically handled). For bilateral blur, this controls the diameter of the pixel neighborhood. Typical values range from 3-15: smaller values (3-5) provide subtle blur, medium values (5-9) provide moderate blur, larger values (11-15) provide strong blur. Default is 5, which provides moderate blur. Adjust based on image size and desired blur intensity.",
+        description="Size of the blur kernel (must be positive and typically odd). Controls the blur intensity - larger values create more blur, smaller values create less blur. For average and gaussian blur, this is the width and height of the kernel (e.g., 5 means 5x5 kernel). For gaussian and median blur, the kernel size must be a positive odd integer; even or non-positive values are automatically coerced to the next positive odd value. For bilateral blur, this controls the diameter of the pixel neighborhood. Typical values range from 3-15: smaller values (3-5) provide subtle blur, medium values (5-9) provide moderate blur, larger values (11-15) provide strong blur. Default is 5, which provides moderate blur. Adjust based on image size and desired blur intensity.",
         examples=[5, "$inputs.kernel_size"],
     )
 
@@ -168,6 +168,18 @@ class ImageBlurBlockV1(WorkflowBlock):
         return {OUTPUT_IMAGE_KEY: output}
 
 
+def _to_positive_odd(ksize: int) -> int:
+    """Coerce a kernel size to a positive odd integer.
+
+    ``cv2.GaussianBlur`` and ``cv2.medianBlur`` require an odd, positive ksize
+    and raise ``cv2.error`` otherwise.
+    """
+    ksize = max(1, int(ksize))
+    if ksize % 2 == 0:
+        ksize += 1
+    return ksize
+
+
 def apply_blur(image: np.ndarray, blur_type: str, ksize: int = 5) -> np.ndarray:
     """
     Applies the specified blur to the image.
@@ -184,8 +196,10 @@ def apply_blur(image: np.ndarray, blur_type: str, ksize: int = 5) -> np.ndarray:
     if blur_type == "average":
         blurred_image = cv2.blur(image, (ksize, ksize))
     elif blur_type == "gaussian":
+        ksize = _to_positive_odd(ksize)
         blurred_image = cv2.GaussianBlur(image, (ksize, ksize), 0)
     elif blur_type == "median":
+        ksize = _to_positive_odd(ksize)
         blurred_image = cv2.medianBlur(image, ksize)
     elif blur_type == "bilateral":
         blurred_image = cv2.bilateralFilter(image, ksize, 75, 75)


### PR DESCRIPTION
## 🚧 Work in progress — not ready for review

Draft PR from a batch addressing findings from an in-depth engineering review. Fixes **review finding 72** (Low, Error-handling).

## The bug
`Image Blur` (`inference/core/workflows/core_steps/classical_cv/image_blur/v1.py`) accepts an unconstrained `kernel_size`. The default `gaussian` path (`v1.py:187`) and the `median` path (`v1.py:189`) pass `ksize` straight into `cv2.GaussianBlur` / `cv2.medianBlur`, which require a positive **odd** ksize. Any even (e.g. `kernel_size=4`) or non-positive value raises `cv2.error` (`ksize.width % 2 == 1` / `(ksize % 2 == 1)`), aborting the block. Additionally the `kernel_size` field docstring (`v1.py:126`) falsely claimed median parity is "automatically handled" — nothing coerced it.

## Root cause
`kernel_size` has no odd/positive constraint and no coercion before being handed to OpenCV. Average and bilateral blur tolerate arbitrary sizes, but gaussian and median assert an odd, positive kernel.

## Fix
`v1.py` only:
- Add a small `_to_positive_odd(ksize)` helper (`max(1, int(ksize))`, bump even → next odd).
- Apply it in the `gaussian` and `median` branches of `apply_blur` before calling cv2 (average/bilateral left untouched — they don't have the constraint).
- Correct the `kernel_size` field description to state that gaussian/median sizes must be positive odd and are coerced to the next positive odd value.

## Verification
Standalone check with a 20×20×3 uint8 image:
- Before: `cv2.GaussianBlur(img,(4,4),0)` and `cv2.medianBlur(img,4)` → `cv2.error` (assertion failed).
- After coercion: inputs `4→5`, `0→1`, `-3→1`, `8→9`; both `cv2.GaussianBlur` and `cv2.medianBlur` return correctly-shaped `(20,20,3)` arrays; odd values (`5→5`) pass through unchanged.

## Scope
Focused change; one of a coordinated batch (one PR per finding).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
