### PR TITLE
[WIP] Guard zero-std division in Identify Changes outlier detection

### DIFF
--- a/inference/core/workflows/core_steps/sampling/identify_changes/v1.py
+++ b/inference/core/workflows/core_steps/sampling/identify_changes/v1.py
@@ -314,8 +314,17 @@ class IdentifyChangesBlockV1(WorkflowBlock):
                         self.cosine_similarity_sliding_window
                     )
 
-            z_score = (cs - self.cosine_similarity_avg) / self.cosine_similarity_std
-            percentile = 1 - 0.5 * (1 + math.erf(z_score / np.sqrt(2)))
+            if self.cosine_similarity_std == 0:
+                # No variance in cosine similarity (e.g. a static scene) means
+                # there is nothing to compare against; treat as non-outlier
+                # instead of dividing by zero and emitting NaN downstream.
+                z_score = 0
+                percentile = 0.5
+            else:
+                z_score = (
+                    cs - self.cosine_similarity_avg
+                ) / self.cosine_similarity_std
+                percentile = 1 - 0.5 * (1 + math.erf(z_score / np.sqrt(2)))
 
             # print(f"Z-score: {z_score}, Percentile: {percentile}, Cosine Similarity: {cs}, Average: {self.cosine_similarity_avg}, Std: {self.cosine_similarity_std}")
 


### PR DESCRIPTION
## 🚧 Work in progress — not ready for review

Draft PR from a batch addressing findings from an in-depth engineering review. Fixes **review finding 77** (Low, Correctness).

## The bug
In the Identify Changes sampling block, `z_score = (cs - self.cosine_similarity_avg) / self.cosine_similarity_std` (`inference/core/workflows/core_steps/sampling/identify_changes/v1.py:317`) divides by the running cosine-similarity std. For a static/near-constant embedding stream (e.g. a fixed camera on an unchanging scene) the EMA/SMA/sliding-window variance converges to 0, so std → 0 and the division yields NaN (numpy scalar divide → NaN + RuntimeWarning, not an exception). NaN fails every comparison, so `is_outlier` stays `False` forever and the block silently never flags changes while emitting NaN `z_score`/`percentile` to downstream blocks.

## Root cause
`cosine_similarity` returns a numpy scalar (`inference/core/utils/postprocess.py`), so `0/0` produces a silent NaN rather than raising `ZeroDivisionError`. The division was performed unconditionally whenever `self.average` was set, with no guard for the zero-variance case (which also occurs on the very first initialization sample where std is set to 0).

## Fix
`inference/core/workflows/core_steps/sampling/identify_changes/v1.py`: guard the division. When `self.cosine_similarity_std == 0`, treat the sample as a non-outlier (`z_score = 0`, `percentile = 0.5`) instead of dividing; otherwise compute `z_score`/`percentile` exactly as before. Minimal, single-file change.

## Verification
Standalone before/after (numpy warnings escalated to errors):
- `std=0`: OLD → `RuntimeWarning: invalid value encountered in scalar divide` (NaN); NEW → `z=0, percentile=0.5` (non-outlier).
- `std!=0` (cs=0.7, avg=0.9, std=0.05): OLD and NEW both → `z≈-4.0, percentile≈0.99997` (identical), so genuine outliers are still detected once variance is nonzero.

## Scope
Focused change; one of a coordinated batch (one PR per finding).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
