### PR TITLE
[WIP] Wrap str() failures in to_string query-language op

### DIFF
--- a/inference/core/workflows/core_steps/common/query_language/operations/strings/base.py
+++ b/inference/core/workflows/core_steps/common/query_language/operations/strings/base.py
@@ -32,7 +32,7 @@ def string_to_upper(value: Any, execution_context: str, **kwargs) -> str:
 def to_string(value: Any, execution_context: str, **kwargs) -> str:
     try:
         return str(value)
-    except (RuntimeError, RuntimeError) as e:
+    except Exception as e:
         raise InvalidInputTypeError(
             public_message=f"Using operation to_string(...) in context {execution_context} caused the following "
             f"error: {e} of type {type(value)}",


### PR DESCRIPTION
## 🚧 Work in progress — not ready for review

Draft PR from a batch addressing findings from an in-depth engineering review. Fixes **review finding 88** (Low, Error-handling).

## The bug
In `inference/core/workflows/core_steps/common/query_language/operations/strings/base.py:35`, `to_string(...)` guards `str(value)` with `except (RuntimeError, RuntimeError) as e:`. The tuple lists `RuntimeError` twice (dead entry) and, critically, a failing `__str__` typically raises `TypeError`/`ValueError` or a custom exception — never `RuntimeError`. So the intended "wrap str() failures into `InvalidInputTypeError`" contract never fires and the raw exception escapes the query-language boundary.

## Root cause
Copy-paste error in the `except` tuple: the caught types do not match the exceptions `str()` actually raises, so the handler is effectively dead for the real failure modes.

## Fix
`inference/core/workflows/core_steps/common/query_language/operations/strings/base.py`: broaden the handler to `except Exception as e:` so any failure from `str(value)` is wrapped in `InvalidInputTypeError` (a `RoboflowQueryLanguageError`), as documented. One-line change; the duplicate `RuntimeError` entry is removed as a consequence.

## Verification
Standalone repro of the old vs new handler with a class whose `__str__` raises `ValueError('boom')`:
- OLD `except (RuntimeError, RuntimeError)` → `ESCAPED raw ValueError boom`
- NEW `except Exception` → `wrapped as InvalidInputTypeError (inner: ValueError)`

## Scope
Focused change; one of a coordinated batch (one PR per finding).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
