### PR TITLE
[WIP] Raise InvalidInputTypeError for unmapped mode in select_detections

### DIFF
--- a/inference/core/workflows/core_steps/common/query_language/operations/detections/base.py
+++ b/inference/core/workflows/core_steps/common/query_language/operations/detections/base.py
@@ -192,7 +192,7 @@ def select_detections(
             context="step_execution | roboflow_query_language_evaluation",
         )
     if mode not in DETECTIONS_SELECTORS:
-        InvalidInputTypeError(
+        raise InvalidInputTypeError(
             public_message=f"Executing select_detections(...), expected mode to be one of {DETECTIONS_SELECTORS.values()}, "
             f"got {mode}.",
             context="step_execution | roboflow_query_language_evaluation",


### PR DESCRIPTION
## 🚧 Work in progress — not ready for review

Draft PR from a batch addressing findings from an in-depth engineering review. Fixes **review finding 76** (Low, Error-handling).

## The bug
In `select_detections`, the guard at `inference/core/workflows/core_steps/common/query_language/operations/detections/base.py:195` for an unmapped `DetectionsSelectionMode` constructs `InvalidInputTypeError(...)` but omits the `raise` keyword. The exception object is built and immediately discarded, so control falls through to `return DETECTIONS_SELECTORS[mode](value)`, which raises a bare `KeyError` instead of the intended, helpful message.

## Root cause
A missing `raise` keyword on the `InvalidInputTypeError(...)` statement inside `if mode not in DETECTIONS_SELECTORS:`. The analogous guard in `sort_detections` (line 234) correctly uses `raise`. The branch is currently dead because every `DetectionsSelectionMode` enum member is registered in `DETECTIONS_SELECTORS`, so the guard is nonfunctional but latent: adding a new enum value without a matching selector would surface a `KeyError` rather than the descriptive `InvalidInputTypeError`.

## Fix
`base.py`: prefix the statement with `raise` so the guard actually raises `InvalidInputTypeError` with its explanatory message, matching `sort_detections`. One-line change.

## Verification
Standalone reproduction of the corrected control flow:
- BEFORE (no `raise`): passing an unmapped mode → `KeyError`
- AFTER (`raise` added): passing an unmapped mode → `InvalidInputTypeError`

Confirms the guard now short-circuits with the intended error instead of degrading to a bare `KeyError`.

## Scope
Focused change; one of a coordinated batch (one PR per finding).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
