### PR TITLE
[WIP] Add request timeout to data-staging file download

### DIFF
--- a/inference_cli/lib/roboflow_cloud/data_staging/api_operations.py
+++ b/inference_cli/lib/roboflow_cloud/data_staging/api_operations.py
@@ -1677,11 +1677,12 @@ def pull_batch_element_to_directory(
     interval=1,
 )
 def pull_file_to_directory(url: str, target_directory: str, file_name: str) -> str:
-    response = requests.get(url)
+    response = requests.get(url, stream=True, timeout=REQUEST_TIMEOUT)
     response.raise_for_status()
     target_path = os.path.join(target_directory, file_name)
     with open(target_path, "wb") as f:
-        f.write(response.content)
+        for chunk in response.iter_content(chunk_size=8192):
+            f.write(chunk)
     return target_path
 
 


### PR DESCRIPTION
## 🚧 Work in progress — not ready for review

Draft PR from a batch addressing findings from an in-depth engineering review. Fixes **review finding 79** (Low, Error-handling).

## The bug
`pull_file_to_directory` in `inference_cli/lib/roboflow_cloud/data_staging/api_operations.py:1680` issued `requests.get(url)` with no `timeout`, unlike every other HTTP call in this package (which pass `timeout=REQUEST_TIMEOUT`). A stalled or half-open connection never raises, so the whole read blocks indefinitely.

## Root cause
The function is wrapped in `@backoff.on_exception(..., exception=Exception, max_tries=3)`, but that retry only fires on exceptions. With no timeout, a stalled signed-URL download never raises, so the backoff is effectively dead code and the call hangs. Because it runs inside `ThreadPool(MAX_DOWNLOAD_THREADS)`, a single hung download wedges a worker forever and the overall `rf-cloud data-staging` batch download never completes and never errors out.

## Fix
In `api_operations.py`, `pull_file_to_directory` now passes `timeout=REQUEST_TIMEOUT` (already imported and used package-wide) and downloads with `stream=True`, writing the body via `response.iter_content(chunk_size=8192)` instead of `response.content`. A stalled read now raises `Timeout`, letting the existing `@backoff` retry fire, and streaming avoids buffering large archives fully in memory. No other files touched.

## Verification
Standalone check in `roboflow-inference`: `requests.get` forwards `**kwargs` (so `stream`/`timeout` are valid), `requests.Response.iter_content` exists, and `requests.get`'s effective default `timeout` is `None` (the pre-fix indefinite block). Confirms the corrected call is valid and closes the no-timeout hang. Full runtime batch-download exercise deferred (WIP).

## Scope
Focused change; one of a coordinated batch (one PR per finding).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
