### PR TITLE
[WIP] Fix silent stitch failure when knnMatch returns <2 neighbours

### DIFF
--- a/inference/core/workflows/core_steps/transformations/stitch_images/v1.py
+++ b/inference/core/workflows/core_steps/transformations/stitch_images/v1.py
@@ -145,9 +145,10 @@ class StitchImagesBlockV1(WorkflowBlock):
         count_of_best_matches_per_query_descriptor: int,
         max_allowed_reprojection_error: float,
     ) -> BlockResult:
-        if count_of_best_matches_per_query_descriptor == 0:
+        if abs(int(round(count_of_best_matches_per_query_descriptor))) < 2:
             raise ValueError(
-                "count_of_best_matches_per_query_descriptor must be greater than 0"
+                "count_of_best_matches_per_query_descriptor must be at least 2 "
+                "because Lowe's ratio test compares the two best matches per query descriptor"
             )
         try:
             merged_image = stitch_images(
@@ -194,7 +195,11 @@ def stitch_images(
         k=count_of_best_matches_per_query_descriptor,
     )
 
-    good_matches = [m[0] for m in matches if m[0].distance < 0.75 * m[1].distance]
+    good_matches = [
+        m[0]
+        for m in matches
+        if len(m) >= 2 and m[0].distance < 0.75 * m[1].distance
+    ]
 
     image1_pts = np.float32([keypoints_1[m.queryIdx].pt for m in good_matches]).reshape(
         -1, 1, 2


### PR DESCRIPTION
## 🚧 Work in progress — not ready for review

Draft PR from a batch addressing findings from an in-depth engineering review. Fixes **review finding 81** (Low, Error-handling).

## The bug
`stitch_images` runs Lowe's ratio test as `good_matches = [m[0] for m in matches if m[0].distance < 0.75 * m[1].distance]` (`inference/core/workflows/core_steps/transformations/stitch_images/v1.py:198`), unconditionally dereferencing `m[1]`. `bf.knnMatch(..., k=...)` returns `min(k, available)` matches per query descriptor, so any query with fewer than 2 neighbours yields a length-1 (or length-0) list and `m[1]` raises `IndexError`, aborting the whole comprehension.

## Root cause
The run() guard only rejected `count_of_best_matches_per_query_descriptor == 0`, but the field's own description permits any value "greater than 0", so `k=1` passes validation. With `k=1` every match list has length 1, so the ratio test raises `IndexError`. That exception is swallowed by run()'s try/except, which returns `{"stitched_image": None}` with only an info-level log — the block silently produces no output on every frame. The same silent failure occurs whenever image2 has <2 SIFT descriptors, or any query descriptor has a single neighbour.

## Fix
Single file, `inference/core/workflows/core_steps/transformations/stitch_images/v1.py`:
- Filter the ratio test by list length first: `if len(m) >= 2 and m[0].distance < 0.75 * m[1].distance`, so short match lists are skipped instead of raising.
- Tighten the run() guard to reject `k < 2` (the ratio test structurally requires 2 neighbours) with a clear `ValueError` explaining why, instead of silently returning `None`.

## Verification
Standalone (conda env `roboflow-inference`), two random-textured 200x200 images, `bf.knnMatch(..., k=1)` -> all match lists length 1:
- Before: `[m[0] for m in matches if m[0].distance < 0.75*m[1].distance]` -> `IndexError: tuple index out of range`.
- After: `[m[0] for m in matches if len(m) >= 2 and ...]` -> OK, `good_matches = 0` (no exception).

Full runtime verification of the block's `run()` path deferred (WIP), but the guard now raises a descriptive `ValueError` for `k < 2` before any stitching is attempted.

## Scope
Focused change; one of a coordinated batch (one PR per finding).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
