### PR TITLE
[WIP] Fix florence open-vocabulary branch to use equality not substring match

### DIFF
--- a/inference/core/workflows/core_steps/formatters/vlm_as_detector/v1.py
+++ b/inference/core/workflows/core_steps/formatters/vlm_as_detector/v1.py
@@ -345,7 +345,7 @@ def parse_florence2_object_detection_response(
             for name in detections.data.get("class_name", ["unknown"] * len(detections))
         ]
         detections.class_id = np.array(class_ids)
-    if florence_task_type in "<OPEN_VOCABULARY_DETECTION>":
+    if florence_task_type == "<OPEN_VOCABULARY_DETECTION>":
         class_name_to_id = {name: idx for idx, name in enumerate(classes)}
         class_ids = [
             class_name_to_id.get(name, -1)

--- a/inference/core/workflows/core_steps/formatters/vlm_as_detector/v2.py
+++ b/inference/core/workflows/core_steps/formatters/vlm_as_detector/v2.py
@@ -425,7 +425,7 @@ def parse_florence2_object_detection_response(
             for name in detections.data.get("class_name", ["unknown"] * len(detections))
         ]
         detections.class_id = np.array(class_ids)
-    if florence_task_type in "<OPEN_VOCABULARY_DETECTION>":
+    if florence_task_type == "<OPEN_VOCABULARY_DETECTION>":
         class_name_to_id = {name: idx for idx, name in enumerate(classes)}
         class_ids = [
             class_name_to_id.get(name, -1)


### PR DESCRIPTION
## 🚧 Work in progress — not ready for review

Draft PR from a batch addressing findings from an in-depth engineering review. Fixes **review finding 84** (Low, Correctness).

## The bug
In the florence detection-to-`sv.Detections` conversion, the open-vocabulary class-id remapping branch is gated by a substring test rather than an equality check: `if florence_task_type in "<OPEN_VOCABULARY_DETECTION>":` at `inference/core/workflows/core_steps/formatters/vlm_as_detector/v1.py:348` (and identically at `v2.py:428`). `x in some_str` is a substring membership test, not the intended equality against the task token.

## Root cause
`in` against a `str` literal checks whether `florence_task_type` is a substring of `"<OPEN_VOCABULARY_DETECTION>"`, unlike the correct set-membership form (`in {...}`) used two lines above at line 338. It works today only because none of the other florence task tokens (`<OD>`, `<DENSE_REGION_CAPTION>`, `<CAPTION_TO_PHRASE_GROUNDING>`, `<REGION_PROPOSAL>`, `<OCR_WITH_REGION>`) happen to be substrings of the literal. It is latent and fragile: an empty task token matches (`"" in s` is always `True`), and any future token that is a substring of the literal would erroneously enter the branch and call `enumerate(classes)`, overwriting class ids or raising when `classes=None`.

## Fix
Change `in` to `==` so the branch matches the exact task token, consistent with the sibling checks in the same function. Applied to both siblings, minimal one-character-per-line change:
- `inference/core/workflows/core_steps/formatters/vlm_as_detector/v1.py:348`
- `inference/core/workflows/core_steps/formatters/vlm_as_detector/v2.py:428`

## Verification
Standalone check over all current florence task tokens plus edge cases:

```
token                            OLD(in-substr) NEW(==)
'<OD>'                           False          False
'<OPEN_VOCABULARY_DETECTION>'    True           True
'<DENSE_REGION_CAPTION>'         False          False
'<CAPTION_TO_PHRASE_GROUNDING>'  False          False
'<REGION_PROPOSAL>'              False          False
'<OCR_WITH_REGION>'              False          False
''                               True           False
```

Behavior is unchanged for all real tokens (only the exact token matches under both), and the empty-string false positive is eliminated under `==`.

## Scope
Focused change; one of a coordinated batch (one PR per finding).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
