### PR TITLE
[WIP] Fix S3 append_log quadratic re-upload of growing buffer

### DIFF
--- a/inference/core/workflows/core_steps/sinks/s3/v1.py
+++ b/inference/core/workflows/core_steps/sinks/s3/v1.py
@@ -248,6 +248,9 @@ class S3SinkBlockV1(WorkflowBlock):
         self._buffer: List[str] = []
         self._entries_in_buffer: int = 0
         self._current_key: Optional[str] = None
+        self._s3_client: Optional[Any] = None
+        self._bucket_name: Optional[str] = None
+        self._content_type: Optional[str] = None
 
     @classmethod
     def get_manifest(cls) -> Type[WorkflowBlockManifest]:
@@ -336,15 +339,24 @@ class S3SinkBlockV1(WorkflowBlock):
                 )
                 return {"error_status": True, "message": "Invalid JSON content"}
 
+        # Remember the S3 destination so the buffer can be flushed on rotation or
+        # at teardown, matching the documented append-log behaviour.
+        self._s3_client = s3_client
+        self._bucket_name = bucket_name
+        self._content_type = content_type
+
         needs_rotation = (
             self._current_key is not None
             and self._entries_in_buffer >= max_entries_per_file
         )
-        is_first_entry = self._current_key is None
+        rotation_result: Optional[BlockResult] = None
+        if needs_rotation:
+            # Upload the completed object before starting a fresh one; a
+            # successful flush clears the buffer and current key.
+            rotation_result = self._flush_buffer()
 
-        if needs_rotation or is_first_entry:
-            self._buffer = []
-            self._entries_in_buffer = 0
+        is_first_entry = self._current_key is None
+        if is_first_entry:
             self._current_key = generate_s3_key(
                 s3_prefix=s3_prefix,
                 file_name_prefix=file_name_prefix,
@@ -358,17 +370,48 @@ class S3SinkBlockV1(WorkflowBlock):
         self._buffer.append(content)
         self._entries_in_buffer += 1
 
-        # Always upload the full accumulated buffer so that every run() call
-        # validates credentials and permissions, and errors are surfaced immediately
-        # rather than only when the buffer rotation limit is reached.
+        # Entries are buffered in memory and only uploaded on rotation or at
+        # teardown, so the growing buffer is not re-uploaded on every run().
+        if rotation_result is not None:
+            return rotation_result
+        return {
+            "error_status": False,
+            "message": (
+                f"Buffered entry for s3://{bucket_name}/{self._current_key} "
+                f"({self._entries_in_buffer} entr"
+                f"{'y' if self._entries_in_buffer == 1 else 'ies'} pending upload)"
+            ),
+        }
+
+    def _flush_buffer(self) -> BlockResult:
+        if (
+            not self._buffer
+            or self._current_key is None
+            or self._s3_client is None
+        ):
+            return {"error_status": False, "message": "No buffered data to upload."}
         full_content = "".join(self._buffer)
-        return upload_content_to_s3(
-            s3_client=s3_client,
-            bucket_name=bucket_name,
+        result = upload_content_to_s3(
+            s3_client=self._s3_client,
+            bucket_name=self._bucket_name,
             s3_key=self._current_key,
             content=full_content,
-            content_type=content_type,
+            content_type=self._content_type,
         )
+        if not result["error_status"]:
+            self._buffer = []
+            self._entries_in_buffer = 0
+            self._current_key = None
+        return result
+
+    def __del__(self):
+        # Flush any entries still buffered in memory when the block is destroyed
+        # at workflow teardown, as documented for append-log mode.
+        try:
+            if self._buffer:
+                self._flush_buffer()
+        except Exception as error:
+            logging.warning(f"Failed to flush S3 sink buffer on teardown: {error}")
 
 
 def create_s3_client(


### PR DESCRIPTION
## 🚧 Work in progress — not ready for review

Draft PR from a batch addressing findings from an in-depth engineering review. Fixes **review finding 46** (Medium, Performance).

## The bug
In `append_log` output mode, `S3SinkBlockV1._append_to_buffer` appended each entry to `self._buffer` and then, on **every** `run()`, rebuilt `full_content = "".join(self._buffer)` and `put_object`-ed the whole accumulated buffer (`inference/core/workflows/core_steps/sinks/s3/v1.py:358-371`). Within one rotation window of `max_entries_per_file` entries, entry *k* re-uploaded all *k* buffered entries, so total bytes uploaded ≈ `S * N*(N+1)/2` — quadratic. It also contradicted the block's own `LONG_DESCRIPTION` (lines 91-97: "data is buffered in memory and only uploaded to S3 when the limit is reached or the block is destroyed"), and the documented teardown flush had no implementation (there was no `__del__`). On rotation the old code also reset the buffer *without* uploading the completed object, silently dropping data.

## Root cause
The append path used the S3 `put_object` call as a per-run "validate credentials / surface errors immediately" mechanism, treating the accumulated buffer as the payload on every call. That makes cumulative upload volume grow as O(n²) per rotation window and diverges from the documented buffered semantics.

## Fix
`inference/core/workflows/core_steps/sinks/s3/v1.py` only:
- Buffer entries in memory; do **not** upload on ordinary `run()` calls. A buffered run now returns `error_status=False` with a "N entries pending upload" message.
- Add `_flush_buffer()` that uploads the current buffer as one complete object and, on success, clears the buffer / entry count / current key.
- Upload only on **rotation** (when `max_entries_per_file` is reached, the completed object is flushed before a fresh key/buffer starts — fixing the previous silent data loss on rotation) and on **teardown** via a new `__del__` that flushes any remaining buffered entries (matching the documented behaviour).
- Stash `s3_client` / `bucket_name` / `content_type` on the instance so the buffer can be flushed at teardown.

No `LONG_DESCRIPTION` change was needed — the docs already described this buffered behaviour; the code now matches them.

## Verification
Standalone simulation of the buffer/rotation/flush accounting (S=10KB entries, N=1024):
- OLD (main): 1024 puts, 5373.95 MB uploaded, 512.5x amplification (matches closed-form `S*N*(N+1)/2`).
- NEW: 1 put, 10.49 MB, 1.00x amplification. At 1025 entries → 2 puts (one rotation flush + one teardown flush), confirming rotation and teardown both fire correctly.

Full runtime verification within the `inference` package deferred (WIP); the standalone repro reproduces the review's proven closed-form and the corrected behaviour.

## Scope
Focused change; one of a coordinated batch (one PR per finding).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
