### PR TITLE
[WIP] Fix width/height swap in multi-label classification response

### DIFF
--- a/inference/core/models/classification_base.py
+++ b/inference/core/models/classification_base.py
@@ -338,7 +338,7 @@ class ClassificationBaseOnnxRoboflowInferenceModel(OnnxRoboflowInferenceModel):
                         predicted_classes.append(cls_name)
                 response = MultiLabelClassificationInferenceResponse(
                     image=InferenceResponseImage(
-                        width=img_dims[ind][0], height=img_dims[ind][1]
+                        width=img_dims[ind][1], height=img_dims[ind][0]
                     ),
                     predicted_classes=predicted_classes,
                     predictions=results,

--- a/tests/inference/unit_tests/core/models/test_classification_base.py
+++ b/tests/inference/unit_tests/core/models/test_classification_base.py
@@ -1,0 +1,55 @@
+import numpy as np
+
+from inference.core.entities.responses.inference import (
+    ClassificationInferenceResponse,
+    MultiLabelClassificationInferenceResponse,
+)
+from inference.core.models.classification_base import (
+    ClassificationBaseOnnxRoboflowInferenceModel,
+)
+
+
+def _make_model(multiclass: bool) -> ClassificationBaseOnnxRoboflowInferenceModel:
+    # Bypass the weight-loading __init__ and set only the attributes
+    # make_response depends on.
+    model = ClassificationBaseOnnxRoboflowInferenceModel.__new__(
+        ClassificationBaseOnnxRoboflowInferenceModel
+    )
+    model.multiclass = multiclass
+    model.class_names = ["cat", "dog"]
+    return model
+
+
+def test_make_response_multilabel_reports_width_and_height_for_non_square_image() -> (
+    None
+):
+    # given
+    model = _make_model(multiclass=True)
+    predictions = [np.array([[0.9, 0.2]])]
+    # img_dims come from prepare() as (height, width); here 640 wide x 480 tall.
+    img_dims = [(480, 640)]
+
+    # when
+    responses = model.make_response(predictions, img_dims, confidence=0.5)
+
+    # then
+    assert isinstance(responses[0], MultiLabelClassificationInferenceResponse)
+    assert responses[0].image.width == 640
+    assert responses[0].image.height == 480
+
+
+def test_make_response_single_label_reports_width_and_height_for_non_square_image() -> (
+    None
+):
+    # given
+    model = _make_model(multiclass=False)
+    predictions = [np.array([[0.9, 0.2]])]
+    img_dims = [(480, 640)]
+
+    # when
+    responses = model.make_response(predictions, img_dims, confidence=0.0)
+
+    # then
+    assert isinstance(responses[0], ClassificationInferenceResponse)
+    assert responses[0].image.width == 640
+    assert responses[0].image.height == 480


### PR DESCRIPTION
## 🚧 Work in progress — not ready for review

Draft PR from a batch addressing findings from an in-depth engineering review. Fixes **review finding 63** (Low, Correctness).

## The bug
In `inference/core/models/classification_base.py:341`, the multi-label branch of `make_response` built `InferenceResponseImage(width=img_dims[ind][0], height=img_dims[ind][1])`. The elements of `img_dims` are `(h, w)` (produced by `prepare()` in `inference/core/utils/preprocess.py:79`), so this assigned `width=h` and `height=w` — inverted. For a 640-wide x 480-tall image (`img_dims[ind] = (480, 640)`) the response reported `width=480, height=640`. Square images hide the bug.

## Root cause
The multiclass branch indexed `img_dims` as `[0]=width, [1]=height`, the opposite of every other response builder in the codebase — single-label classification (`classification_base.py:364`), object detection (`object_detection_base.py:146`), instance segmentation (`instance_segmentation_base.py:271`), keypoints (`keypoints_detection_base.py:159`), and semantic segmentation (`semantic_segmentation_base.py:107`) all use `width=[1], height=[0]`. The multi-label branch was the sole outlier.

## Fix
- `inference/core/models/classification_base.py`: change the multiclass branch to `width=img_dims[ind][1], height=img_dims[ind][0]`, matching every other builder. One-line change.
- `tests/inference/unit_tests/core/models/test_classification_base.py`: new test module driving `make_response` for both multi-label and single-label on a non-square image (`img_dims=[(480, 640)]`), asserting `width==640, height==480`.

## Verification
Standalone before/after on the indexing logic with `img_dims=[(480, 640)]`: BEFORE (multiclass) -> width=480 height=640 (wrong); AFTER -> width=640 height=480 (correct), matching the single-label branch. Full pytest deferred — the sparse review worktree can't import the full `inference` package (WIP).

## Scope
Focused change; one of a coordinated batch (one PR per finding).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
