### PR TITLE
[WIP] Fix append_extra_headers mutating caller's headers dict (token leak)

### DIFF
--- a/inference_models/inference_models/weights_providers/roboflow.py
+++ b/inference_models/inference_models/weights_providers/roboflow.py
@@ -335,8 +335,7 @@ def append_extra_headers(
 ) -> Dict[str, str]:
     if not extra_headers:
         return headers
-    extra_headers.update(headers)
-    return extra_headers
+    return {**extra_headers, **headers}
 
 
 def _add_query_params_to_url(url: str, query: Dict[str, List[str]]) -> str:


### PR DESCRIPTION
## 🚧 Work in progress — not ready for review

Draft PR from a batch addressing findings from an in-depth engineering review. Fixes **review finding 91** (Low, Security).

## The bug
`append_extra_headers()` in `inference_models/inference_models/weights_providers/roboflow.py:333-339` mutates the caller-supplied `extra_headers` dict in place (`extra_headers.update(headers); return extra_headers`). At that call site `headers` is `{'Authorization': f'Bearer {api_key}'}`, so the user's `weights_provider_extra_headers` dict is permanently modified to contain the API-key bearer token. The dict flows unchanged from `AutoModel/AutoModelPipeline.from_pretrained` → `get_roboflow_model` → `get_model_metadata` → `get_one_page_of_model_metadata`, so it is the exact object the user passed.

## Root cause
The merge used `dict.update()` on the argument object and returned that same object, giving the function a side effect on its input rather than producing a fresh result.

## Fix
`inference_models/inference_models/weights_providers/roboflow.py` — replace the in-place `extra_headers.update(headers); return extra_headers` with `return {**extra_headers, **headers}`, building a new merged dict. Header precedence is unchanged (`headers`/`Authorization` still wins on key collisions), but the caller's dict is left untouched and no auth token can persist across reuses.

## Verification
Standalone before/after of the merge logic:
- Before: after a call with `Bearer KEY_A`, the caller dict was mutated to include `Authorization: Bearer KEY_A`; the returned object was the caller dict; a subsequent public call (`headers={}`) still carried the stale `Bearer KEY_A`.
- After: caller dict stays `{'X-Custom': 'v'}` (not mutated), `returned is caller` is `False`, and the second public call returns `Authorization = None` — no credential bleed. Merged result still contains the intended `Authorization` header.

## Scope
Focused change; one of a coordinated batch (one PR per finding).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
