### PR TITLE
[WIP] Fix typo 'MP$' -> 'MP4' in VIDEOS_EXTENSIONS

### DIFF
--- a/inference_cli/lib/utils.py
+++ b/inference_cli/lib/utils.py
@@ -38,7 +38,7 @@ VIDEOS_EXTENSIONS = [
     "m4b",
     "m4r",
     "m4v",
-    "MP$",
+    "MP4",
     "M4A",
     "M4P",
     "M4B",


### PR DESCRIPTION
## 🚧 Work in progress — not ready for review

Draft PR from a batch addressing findings from an in-depth engineering review. Fixes **review finding 99** (Low, Correctness).

## The bug
`VIDEOS_EXTENSIONS` in `inference_cli/lib/utils.py:41` contains `"MP$"` where the uppercase counterpart of `mp4` was intended. On case-sensitive filesystems (Linux), `get_all_videos_in_directory` (utils.py:207-225) matches extensions exactly, so a file named `clip.MP4` matches neither `mp4` nor the bogus `MP$` and is silently omitted from directory video uploads — no error is shown.

## Root cause
A typo: `"MP$"` instead of `"MP4"` in the uppercase block of the extension list. The list pairs each lowercase suffix with its uppercase form (`mp4`/`MP4`, `avi`/`AVI`, …); the `mp4` uppercase entry was mistyped.

## Fix
`inference_cli/lib/utils.py`: change the single list entry `"MP$"` to `"MP4"`. One-line change, no behavior change beyond correctly recognizing uppercase `.MP4` files.

## Verification
Parsed the corrected `VIDEOS_EXTENSIONS` from the file: before, `MP$` present / `MP4` absent → a `clip.MP4` suffix (`MP4`) does not match under a case-sensitive scheme; after, `MP4` present / `MP$` absent → `clip.MP4` matches. Follows the review's proven remediation.

## Scope
Focused change; one of a coordinated batch (one PR per finding).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
