### PR TITLE
[WIP] Fix pull_image cached-image log to print image name

### DIFF
--- a/inference_cli/lib/container_adapter.py
+++ b/inference_cli/lib/container_adapter.py
@@ -358,7 +358,7 @@ def pull_image(image: str, use_local_images: bool = False) -> None:
     try:
         _ = docker_client.images.get(image)
         if use_local_images:
-            print(f"Using locally cached image: {use_local_images}")
+            print(f"Using locally cached image: {image}")
             return None
     except ImageNotFound:
         pass


### PR DESCRIPTION
## 🚧 Work in progress — not ready for review

Draft PR from a batch addressing findings from an in-depth engineering review. Fixes **review finding 110** (Nit, Docs).

## The bug
When a locally cached Docker image is reused, `pull_image` logs `Using locally cached image: True` instead of the image name. The f-string at `inference_cli/lib/container_adapter.py:361` interpolates the boolean `use_local_images` flag rather than the `image` reference.

## Root cause
`use_local_images` is a `bool` parameter (defaulting from the `--use-local-images` CLI flag). The cached-image branch prints `{use_local_images}` — always `True` when the branch is reached — rather than `{image}`.

## Fix
`inference_cli/lib/container_adapter.py`: change `print(f"Using locally cached image: {use_local_images}")` to `print(f"Using locally cached image: {image}")`. Single-line change, no behavior change beyond the log text.

## Verification
Standalone before/after:
- Before: `python3 -c "use_local_images=True; image='myimg'; print(f'Using locally cached image: {use_local_images}')"` -> `Using locally cached image: True`
- After: `python3 -c "use_local_images=True; image='myimg'; print(f'Using locally cached image: {image}')"` -> `Using locally cached image: myimg`

## Scope
Focused change; one of a coordinated batch (one PR per finding).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
