### PR TITLE
[WIP] Guard empty choices list in direct OpenRouter path

### DIFF
--- a/inference/core/workflows/core_steps/common/openrouter.py
+++ b/inference/core/workflows/core_steps/common/openrouter.py
@@ -338,7 +338,7 @@ def _execute_direct_openrouter_request(
         temperature=temperature,
         extra_body=extra_body,
     )
-    if response.choices is None:
+    if not response.choices:
         error_detail = getattr(response, "error", {}) or {}
         if isinstance(error_detail, dict):
             error_detail = error_detail.get("message", "N/A")


### PR DESCRIPTION
## 🚧 Work in progress — not ready for review

Draft PR from a batch addressing findings from an in-depth engineering review. Fixes **review finding 107** (Low, Error-handling).

## The bug
In the direct OpenRouter path, `_execute_direct_openrouter_request` guards only against `None` at `inference/core/workflows/core_steps/common/openrouter.py:341` (`if response.choices is None:`) and then indexes `response.choices[0]` at line 350. When the provider/SDK returns a response with an empty choices list (`choices == []`), the `None` check passes and the `[0]` index raises an unhandled `IndexError` instead of the intended descriptive `RuntimeError`.

## Root cause
The two OpenRouter code paths are asymmetric. The proxied sibling `_execute_proxied_openrouter_request` correctly uses `if not choices:` (line 290), which covers both `None` and empty-list. The direct path only checked `is None`, leaving the empty-list shape (which the OpenAI SDK tolerates — omitting `choices` entirely raises a pydantic `ValidationError`, so the reachable malformed shape is `[]`, not `None`) unhandled.

## Fix
- `inference/core/workflows/core_steps/common/openrouter.py`: change line 341 from `if response.choices is None:` to `if not response.choices:`, so the direct path treats an empty choices list the same as the proxied path and raises the descriptive `RuntimeError` (with the reasoning-model / `finish_reason` hint) instead of an `IndexError`. One-line change.

## Verification
Standalone check with `openai` 1.109.1:
```
cc = ChatCompletion.model_validate({...,'choices':[]})
cc.choices is None            -> False   (old `is None` guard does NOT trigger)
not cc.choices                -> True    (new guard DOES trigger)
cc.choices[0]                 -> IndexError: list index out of range
```
Before: empty list bypasses the `is None` guard and `choices[0]` raises `IndexError`. After: `if not response.choices` catches the empty list and raises the intended `RuntimeError`.

## Scope
Focused change; one of a coordinated batch (one PR per finding).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
