### PR TITLE
[WIP] Require classes for florence-2 open-vocabulary detection

### DIFF
--- a/inference/core/workflows/core_steps/formatters/vlm_as_detector/v1.py
+++ b/inference/core/workflows/core_steps/formatters/vlm_as_detector/v1.py
@@ -224,6 +224,15 @@ class BlockManifest(WorkflowBlockManifest):
             raise ValueError(
                 "Must pass list of classes to this block when using gemini or claude"
             )
+        if (
+            self.model_type == "florence-2"
+            and self.task_type == "open-vocabulary-object-detection"
+            and self.classes is None
+        ):
+            raise ValueError(
+                "Must pass list of classes to this block when using florence-2 "
+                "with open-vocabulary-object-detection task"
+            )
 
         return self
 

--- a/inference/core/workflows/core_steps/formatters/vlm_as_detector/v2.py
+++ b/inference/core/workflows/core_steps/formatters/vlm_as_detector/v2.py
@@ -244,6 +244,15 @@ class BlockManifest(WorkflowBlockManifest):
             raise ValueError(
                 "Must pass list of classes to this block when using gemini or claude"
             )
+        if (
+            self.model_type == "florence-2"
+            and self.task_type == "open-vocabulary-object-detection"
+            and self.classes is None
+        ):
+            raise ValueError(
+                "Must pass list of classes to this block when using florence-2 "
+                "with open-vocabulary-object-detection task"
+            )
 
         return self
 


### PR DESCRIPTION
## 🚧 Work in progress — not ready for review

Draft PR from a batch addressing findings from an in-depth engineering review. Fixes **review finding 106** (Low, API-contract).

## The bug
The `VLMAsDetector` manifest validator only enforces `classes` for non-florence-2 models (`inference/core/workflows/core_steps/formatters/vlm_as_detector/v1.py:223`, and identically `v2.py:243`). But florence-2 with `task_type=open-vocabulary-object-detection` also needs `classes`. With that combination and `classes` omitted, the manifest validates OK, then `parse_florence2_object_detection_response` runs `{name: idx for idx, name in enumerate(classes)}` with `classes=None` → `TypeError: 'NoneType' object is not iterable`, which `run()` swallows into a silent `error_status=True`/`predictions=None` plus a warning log — no config-time error to diagnose.

## Root cause
The `model_validator` guard was `if self.model_type != "florence-2" and self.classes is None`. It exempted florence-2 wholesale, missing that the open-vocabulary-object-detection task still requires classes (as the `classes` field docstring itself states).

## Fix
Extended the `model_validator` in both `v1.py` and `v2.py` to additionally raise when `model_type == "florence-2"` and `task_type == "open-vocabulary-object-detection"` and `classes is None`, turning the swallowed runtime `TypeError` into a clear config-time `ValueError`. Other florence-2 tasks that legitimately don't need classes remain unaffected.

## Verification
Standalone replication of the two guard clauses:
- `florence-2` + `open-vocabulary-object-detection` + no classes → now raises (was silently OK → runtime TypeError before)
- `florence-2` + `object-detection` + no classes → OK (unchanged)
- `florence-2` + `open-vocabulary-object-detection` + classes → OK (unchanged)
- `google-gemini` + no classes → raises (unchanged)

Both files also pass `python -m py_compile`. Full runtime verification via the workflow engine deferred (WIP).

## Scope
Focused change; one of a coordinated batch (one PR per finding).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
