### PR TITLE
[WIP] Fix misleading divide() error message in query language numbers ops

### DIFF
--- a/inference/core/workflows/core_steps/common/query_language/operations/numbers/base.py
+++ b/inference/core/workflows/core_steps/common/query_language/operations/numbers/base.py
@@ -67,8 +67,8 @@ def divide(
     except (TypeError, ValueError, ZeroDivisionError) as e:
         value_as_str = safe_stringify(value=value)
         raise InvalidInputTypeError(
-            public_message=f"While executing multiply divide(...) in context {execution_context}, encountered "
-            f"value `{value_as_str}` of type {type(value)} which cannot be multiplied with {other}",
+            public_message=f"While executing divide(...) in context {execution_context}, encountered "
+            f"value `{value_as_str}` of type {type(value)} which cannot be divided by {other}",
             context=f"step_execution | roboflow_query_language_evaluation | {execution_context}",
             inner_error=e,
         )


### PR DESCRIPTION
## 🚧 Work in progress — not ready for review

Draft PR from a batch addressing findings from an in-depth engineering review. Fixes **review finding 111** (Nit, Docs).

## The bug
`divide()` in `inference/core/workflows/core_steps/common/query_language/operations/numbers/base.py:70-71` raises an `InvalidInputTypeError` whose `public_message` is copy-pasted from `multiply()`: it reads "While executing multiply divide(...) ... which cannot be multiplied with {other}". For a divide-by-zero or type error the workflow author is told the value "cannot be multiplied", which misreports the failing operation.

## Root cause
The message text was duplicated from `multiply()` when `divide()` was added and never updated to reference division. The `ZeroDivisionError` itself is correctly caught; only the user-facing string is wrong.

## Fix
In `numbers/base.py`, correct `divide()`'s `public_message` to reference the actual operation: "While executing divide(...)" and "which cannot be divided by {other}". Single-function change; `multiply()`/`number_round()` are outside this finding's scope and left untouched.

## Verification
Reproduced the corrected string with the exact caught-exception inputs (value=5, other=0):

Before: `While executing multiply divide(...) in context ctx, encountered value `5` of type <class 'int'> which cannot be multiplied with 0`
After:  `While executing divide(...) in context ctx, encountered value `5` of type <class 'int'> which cannot be divided by 0`

## Scope
Focused change; one of a coordinated batch (one PR per finding).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
