### PR TITLE
[WIP] Fix CONFIDENCE default comment (40%, not 50%)

### DIFF
--- a/inference/core/env.py
+++ b/inference/core/env.py
@@ -169,7 +169,7 @@ CLASS_AGNOSTIC_NMS = str2bool(
     os.getenv(CLASS_AGNOSTIC_NMS_ENV, DEFAULT_CLASS_AGNOSTIC_NMS)
 )
 
-# Confidence threshold, default is 50%
+# Confidence threshold, default is 40%
 CONFIDENCE_ENV = "CONFIDENCE"
 DEFAULT_CONFIDENCE = 0.4
 CONFIDENCE = float(os.getenv(CONFIDENCE_ENV, DEFAULT_CONFIDENCE))


### PR DESCRIPTION
## 🚧 Work in progress — not ready for review

Draft PR from a batch addressing findings from an in-depth engineering review. Fixes **review finding 112** (Nit, Docs).

## The bug
The inline documentation comment `# Confidence threshold, default is 50%` at `inference/core/env.py:172` contradicts the code two lines below it, where `DEFAULT_CONFIDENCE = 0.4` (i.e. 40%). The comment is off by 10 percentage points.

## Root cause
The comment was left stale after (or never updated to match) the actual default value of `0.4`.

## Fix
`inference/core/env.py`: change the comment from `# Confidence threshold, default is 50%` to `# Confidence threshold, default is 40%` to match `DEFAULT_CONFIDENCE = 0.4`. No behavior change.

## Verification
Trivial arithmetic: `DEFAULT_CONFIDENCE = 0.4` equals 40%, which the corrected comment now states. The code value is unchanged; only the comment was aligned. Follows the review's proven remediation; full runtime verification not applicable for a comment-only change.

## Scope
Focused change; one of a coordinated batch (one PR per finding).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
