### PR TITLE
[WIP] Fix rename_detections crash on detections without class_name

### DIFF
--- a/inference/core/workflows/core_steps/common/query_language/operations/detections/base.py
+++ b/inference/core/workflows/core_steps/common/query_language/operations/detections/base.py
@@ -295,7 +295,9 @@ def rename_detections(
             context="step_execution | roboflow_query_language_evaluation",
         )
     detections_copy = deepcopy(detections)
-    original_class_names = detections_copy.data.get("class_name", []).tolist()
+    original_class_names = detections_copy.data.get(
+        "class_name", np.array([], dtype=object)
+    ).tolist()
     original_class_ids = detections_copy.class_id.tolist()
     new_class_names = []
     new_class_ids = []

--- a/tests/workflows/unit_tests/core_steps/common/query_language/operations/detections/test_base.py
+++ b/tests/workflows/unit_tests/core_steps/common/query_language/operations/detections/test_base.py
@@ -145,6 +145,32 @@ def test_rename_detections_when_non_strict_mode_enabled_and_not_all_classes_pres
     ], "Expected to change with mapping"
 
 
+def test_rename_detections_when_detections_have_no_class_name_data() -> None:
+    # given
+    detections = sv.Detections(
+        xyxy=np.array([[0, 1, 2, 3], [0, 1, 2, 3]]),
+        class_id=np.array([10, 11]),
+        confidence=np.array([0.3, 0.4]),
+    )
+
+    # when
+    result = rename_detections(
+        detections=detections,
+        class_map={"a": "A"},
+        strict=False,
+        new_classes_id_offset=1024,
+        global_parameters={},
+    )
+
+    # then
+    assert isinstance(
+        result, sv.Detections
+    ), "Expected a handled result, not a raw AttributeError"
+    assert (
+        result.data["class_name"].tolist() == []
+    ), "Expected empty class_name when input carries no class_name"
+
+
 def test_rename_detections_when_mapping_is_parametrised() -> None:
     # given
     detections = sv.Detections(


### PR DESCRIPTION
## 🚧 Work in progress — not ready for review

Draft PR from a batch addressing findings from an in-depth engineering review. Fixes **review finding 82** (Low, Error-handling).

## The bug
`rename_detections(...)` crashes with a raw `AttributeError: 'list' object has no attribute 'tolist'` when it receives `sv.Detections` that carry no `class_name` data key. The offending line is `inference/core/workflows/core_steps/common/query_language/operations/detections/base.py:298`, which does `detections_copy.data.get("class_name", []).tolist()`.

## Root cause
`sv.Detections` is a valid object when built from `xyxy` + `class_id` only, in which case `.data` is empty. `.get("class_name", [])` then returns the plain-list default `[]`, and `[].tolist()` raises `AttributeError`. Because it is an unwrapped `AttributeError` (not a `RoboflowQueryLanguageError`), it surfaces as an unexpected internal error instead of a clean handled result. This is inconsistent with `PROPERTIES_EXTRACTORS` (line 39), which correctly defaults to `np.array([], dtype=str)`.

## Fix
- `base.py`: default the missing `class_name` key to an ndarray — `detections_copy.data.get("class_name", np.array([], dtype=object)).tolist()` — matching the established `PROPERTIES_EXTRACTORS` convention, so `.tolist()` yields `[]` instead of raising.
- `tests/.../detections/test_base.py`: add `test_rename_detections_when_detections_have_no_class_name_data`, which builds detections without `class_name` and asserts the operation returns a handled `sv.Detections` (no `AttributeError`).

## Verification
Standalone (conda `roboflow-inference`, `supervision`):
- Before: `sv.Detections(xyxy=[[0,0,10,10]], class_id=[0])` has empty `.data`; `d.data.get("class_name", []).tolist()` → `AttributeError: 'list' object has no attribute 'tolist'`.
- After: `d.data.get("class_name", np.array([], dtype=object)).tolist()` → `[]`.
- Full corrected `rename_detections` body traced on a 2-box no-`class_name` input: returns cleanly with empty `class_name`/`class_id`, no exception.
Both edited files pass `py_compile`. Full-package pytest deferred (sparse worktree cannot import the whole `inference` package; installed env is not editable to this branch) — WIP.

## Scope
Focused change; one of a coordinated batch (one PR per finding).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
