### PR TITLE
[WIP] Fix swapped OWLv2 image-cache-size default doc comments

### DIFF
--- a/inference/core/env.py
+++ b/inference/core/env.py
@@ -129,7 +129,7 @@ GAZE_MODEL_ID = f"gaze/{GAZE_VERSION_ID}"
 # OWLv2 version ID, default is "owlv2-large-patch14-ensemble"
 OWLV2_VERSION_ID = os.getenv("OWLV2_VERSION_ID", "owlv2-large-patch14-ensemble")
 
-# OWLv2 image cache size, default is 1000 since each image has max <MAX_DETECTIONS> boxes at ~4kb each
+# OWLv2 image cache size, default is 10000 since each image has max <MAX_DETECTIONS> boxes at ~4kb each
 OWLV2_IMAGE_CACHE_SIZE = int(os.getenv("OWLV2_IMAGE_CACHE_SIZE", 10000))
 
 # OWLv2 model cache size, default is 100 as memory is num_prompts * ~4kb and num_prompts is rarely above 1000 (but could be much higher)
@@ -138,7 +138,7 @@ OWLV2_MODEL_CACHE_SIZE = int(os.getenv("OWLV2_MODEL_CACHE_SIZE", 100))
 # OWLv2 cache device placement, default sends cached embeddings to CPU to reduce GPU memory pressure
 OWLV2_CACHE_SEND_TO_CPU = str2bool(os.getenv("OWLV2_CACHE_SEND_TO_CPU", True))
 
-# OWLv2 CPU image cache size, default is 10000
+# OWLv2 CPU image cache size, default is 1000
 OWLV2_CPU_IMAGE_CACHE_SIZE = int(os.getenv("OWLV2_CPU_IMAGE_CACHE_SIZE", 1000))
 
 # OWLv2 compile model, default is True


### PR DESCRIPTION
## 🚧 Work in progress — not ready for review

Draft PR from a batch addressing findings from an in-depth engineering review. Fixes **review finding 113** (Nit, Docs).

## The bug
The two OWLv2 image-cache-size doc comments in `inference/core/env.py` state each other's defaults. `env.py:132` says "default is 1000" but `env.py:133` sets `OWLV2_IMAGE_CACHE_SIZE = int(os.getenv("OWLV2_IMAGE_CACHE_SIZE", 10000))`; `env.py:141` says "default is 10000" but `env.py:142` sets `OWLV2_CPU_IMAGE_CACHE_SIZE = int(os.getenv("OWLV2_CPU_IMAGE_CACHE_SIZE", 1000))`. Both documented defaults are wrong — each is the other's value.

## Root cause
The two comment default values were transposed relative to the code they describe, so each comment reports the sibling variable's default instead of its own.

## Fix
Swap the documented default in each comment to match the actual `os.getenv` fallback:
- `inference/core/env.py:132` — GPU image cache comment now reads "default is 10000" (matches the `10000` fallback).
- `inference/core/env.py:141` — CPU image cache comment now reads "default is 1000" (matches the `1000` fallback).

No code behavior changes; comments only.

## Verification
Confirmed by inspection that comment and code now agree: line 132 comment "10000" ↔ line 133 default `10000`; line 141 comment "1000" ↔ line 142 default `1000`. Follows the review's proven remediation; comment-only change with no runtime surface.

## Scope
Focused change; one of a coordinated batch (one PR per finding).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
