### PR TITLE
[WIP] Fix stabilize_detections crash on empty frame with tracker_id=None

### DIFF
--- a/inference/core/workflows/core_steps/transformations/stabilize_detections/v1.py
+++ b/inference/core/workflows/core_steps/transformations/stabilize_detections/v1.py
@@ -182,10 +182,12 @@ class StabilizeTrackedDetectionsBlockV1(WorkflowBlock):
         bbox_smoothing_coefficient: float,
     ) -> BlockResult:
         metadata = image.video_metadata
-        if detections.tracker_id is None:
+        if len(detections) > 0 and detections.tracker_id is None:
             raise ValueError(
                 f"tracker_id not initialized, {self.__class__.__name__} requires detections to be tracked"
             )
+        if detections.tracker_id is None:
+            detections.tracker_id = np.array([])
         cached_detections = self._batch_of_last_known_detections.setdefault(
             metadata.video_identifier, {}
         )


### PR DESCRIPTION
## 🚧 Work in progress — not ready for review

Draft PR from a batch addressing findings from an in-depth engineering review. Fixes **review finding 108** (Low, Error-handling).

## The bug
`StabilizeTrackedDetectionsBlockV1.run` guards tracked input with a bare `if detections.tracker_id is None: raise ValueError(...)` (`inference/core/workflows/core_steps/transformations/stabilize_detections/v1.py:185`). An empty frame produced by `sv.Detections.empty()` or `sv.Detections.merge([])` has `tracker_id is None`, so a detection-free frame arriving from a non-ByteTrack source crashes the block mid-video with "tracker_id not initialized", even though a zero-detection frame is normal.

## Root cause
The guard conflates "untracked detections" with "empty frame". Both have `tracker_id is None`, but only the former is an error. The sibling stateful block `track_class_lock/v1.py:211` already guards correctly with `len(detections) > 0 and detections.tracker_id is None`; this block was missing the length check.

## Fix
`stabilize_detections/v1.py` only:
- Add the length guard: `if len(detections) > 0 and detections.tracker_id is None: raise ...` so empty frames no longer raise.
- Normalize the empty case: `if detections.tracker_id is None: detections.tracker_id = np.array([])`. This is required because merely skipping the raise would relocate the crash — the downstream loop does `zip(detections.tracker_id, ...)`, and `zip(None, ...)` throws `TypeError: 'NoneType' object is not iterable`. Setting it to an empty array (the same shape line 253 already emits on empty output) lets the gap-fill path run with zero current detections.

## Verification
Standalone (conda env roboflow-inference):
- Before: `sv.Detections.empty().tracker_id is None` -> True; the length-guard-only variant then hits `zip(None, xyxy)` -> `TypeError: 'NoneType' object is not iterable`.
- After: normalized tracker_id -> `[]`; both loops iterate 0 times; `sv.Detections.merge([])` -> len 0 with `tracker_id=[]`. Empty-frame path returns cleanly with no crash.

Full block import isn't possible from the sparse worktree, so the block-level flow was simulated with the exact run-method logic; this matches the review's proven remediation (guard mirrors `track_class_lock`, empty-array path confirmed OK by the review).

## Scope
Focused change; one of a coordinated batch (one PR per finding).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
