### PR TITLE
[WIP] Fix contradictory channel-count error message in pre-processing

### DIFF
--- a/inference_models/inference_models/models/common/roboflow/pre_processing.py
+++ b/inference_models/inference_models/models/common/roboflow/pre_processing.py
@@ -39,7 +39,7 @@ def pre_process_network_input(
     if network_input.input_channels != 3:
         raise ModelRuntimeError(
             message=f"`inference` currently does not support Roboflow pre-processing for model inputs with "
-            f"channels numbers different than 1. Let us know if you need this feature.",
+            f"channels numbers different than 3. Let us know if you need this feature.",
             help_url="https://inference-models.roboflow.com/errors/models-runtime/#modelruntimeerror",
         )
     input_color_mode = None


### PR DESCRIPTION
## 🚧 Work in progress — not ready for review

Draft PR from a batch addressing findings from an in-depth engineering review. Fixes **review finding 116** (Nit, Error-handling).

## The bug
`pre_process_network_input` guards with `if network_input.input_channels != 3:` but the raised `ModelRuntimeError` says the library "does not support ... model inputs with channels numbers different than **1**." The guard rejects everything except 3 channels, yet the text names 1 — the opposite of what is actually rejected (`inference_models/inference_models/models/common/roboflow/pre_processing.py:41-42`).

## Root cause
The error message text drifted out of sync with the boolean guard. The condition allows only 3-channel inputs, but the message describes a constraint against 1-channel inputs, so anyone debugging a 1-channel (grayscale) or 4-channel model gets a message describing the opposite of the true constraint.

## Fix
`inference_models/inference_models/models/common/roboflow/pre_processing.py`: change the message text from "channels numbers different than 1" to "channels numbers different than 3" so the reported constraint matches the `!= 3` guard. One-line, message-only change; no behavioral change to the guard.

## Verification
Standalone check confirms consistency after the edit: the guard rejects everything except channel count 3, and the message now references 3 (before: 1). Regex-extracted channel count in the message == guard's allowed count (3). No runtime path was altered.

## Scope
Focused change; one of a coordinated batch (one PR per finding).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
