### PR TITLE
[WIP] Bound re-enqueue of usage payloads with unresolvable API key hash

### DIFF
--- a/inference/usage_tracking/collector.py
+++ b/inference/usage_tracking/collector.py
@@ -79,6 +79,10 @@ P = ParamSpec("P")
 
 class UsageCollector:
     _lock = Lock()
+    # Bound how many times a persisted payload whose plaintext API key cannot be
+    # resolved (e.g. after a restart, before the key is re-seen) is re-enqueued,
+    # so such rows do not accumulate in the persistent queue indefinitely.
+    _MAX_UNRESOLVED_RESEND_ATTEMPTS = 5
 
     def __new__(cls, *args, **kwargs):
         with UsageCollector._lock:
@@ -107,6 +111,7 @@ class UsageCollector:
         )
 
         self._hashed_api_keys: Dict[APIKey, APIKeyHash] = {}
+        self._unresolved_resend_attempts: Dict[APIKeyHash, int] = {}
         self._api_keys_hashing_enabled = True
 
         self._plan_details = PlanDetails(
@@ -571,7 +576,28 @@ class UsageCollector:
                 )
             for api_key_hash in list(payload.keys()):
                 if api_key_hash not in api_keys_hashes_failed:
+                    # Delivered successfully.
                     del payload[api_key_hash]
+                    self._unresolved_resend_attempts.pop(api_key_hash, None)
+                elif api_key_hash in hashes_to_api_keys:
+                    # Transient failure with a known key; keep retrying.
+                    self._unresolved_resend_attempts.pop(api_key_hash, None)
+                else:
+                    # The plaintext API key for this hash is not known (e.g. it
+                    # was never re-seen after a restart), so the payload can
+                    # never be authenticated. Drop it after a bounded number of
+                    # attempts instead of re-enqueuing it forever.
+                    attempts = self._unresolved_resend_attempts.get(api_key_hash, 0) + 1
+                    if attempts >= self._MAX_UNRESOLVED_RESEND_ATTEMPTS:
+                        logger.debug(
+                            "Dropping usage payload; api key hash could not be "
+                            "resolved after %s attempts",
+                            attempts,
+                        )
+                        del payload[api_key_hash]
+                        self._unresolved_resend_attempts.pop(api_key_hash, None)
+                    else:
+                        self._unresolved_resend_attempts[api_key_hash] = attempts
             if payload:
                 logger.debug("Enqueuing back unsent payload")
                 self._enqueue_payload(payload=payload)


### PR DESCRIPTION
## 🚧 Work in progress — not ready for review

Draft PR from a batch addressing findings from an in-depth engineering review. Fixes **review finding 92** (Low, Correctness).

## The bug
When usage telemetry is persisted to SQLite, rows are keyed by `api_key_hash`. After a process restart the in-memory `_hashed_api_keys` map is empty, so `hashes_to_api_keys` in `_offload_to_api` (`inference/usage_tracking/collector.py:544`) cannot resolve a persisted hash to its plaintext key. `send_usage_payload` then either marks the hash failed or sends it with the SHA256 hash used as the Bearer token, which the server rejects. The failed hash is kept in the payload and re-enqueued by `_offload_to_api` (`collector.py:594-596` pre-fix). Because `SQLiteQueue.full()` is hardcoded to `False`, nothing bounds this, so rows for a key that is never re-seen re-enqueue forever, accumulating in `usage.db` and wasting a request every flush.

## Root cause
The re-enqueue loop treated an unresolvable-key failure identically to a transient failure and retried it indefinitely, even though it can never succeed until the same plaintext key issues another request.

## Fix
`inference/usage_tracking/collector.py` only:
- Add class constant `_MAX_UNRESOLVED_RESEND_ATTEMPTS = 5` and an instance counter `self._unresolved_resend_attempts: Dict[APIKeyHash, int]`.
- In `_offload_to_api`, split the re-enqueue decision three ways: delivered payloads are dropped and their counter cleared; failures whose hash **is** resolvable (transient, e.g. network down) still retry indefinitely with the counter reset; failures whose hash is **not** resolvable increment the counter and are dropped once it reaches the bound.

No plaintext API keys are persisted to disk (avoiding a security regression), and legitimate retry behaviour for known keys is preserved.

## Verification
Standalone simulation of the corrected re-enqueue loop (full package import isn't possible from the sparse worktree):
- Unresolvable hash, key never re-seen: re-enqueued 4 times then dropped on cycle 5 (previously unbounded).
- Key becomes resolvable on cycle 3: payload is sent, not dropped, counter reset.
- Known key with persistent transient failure: never dropped (retry behaviour intact).

`python3 -m py_compile inference/usage_tracking/collector.py` passes.

## Scope
Focused change; one of a coordinated batch (one PR per finding).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
