### PR TITLE
[WIP] Fix AttributeError in get_full_type_name builtins branch

### DIFF
--- a/inference/core/workflows/execution_engine/introspection/utils.py
+++ b/inference/core/workflows/execution_engine/introspection/utils.py
@@ -5,10 +5,9 @@ CLASS_NAME_WORD_PATTERN = re.compile(r"[A-Z](?:[a-z1-9]+|[A-Z]*(?=[A-Z]|$))")
 
 
 def get_full_type_name(selected_type: type) -> str:
-    t_class = selected_type.__name__
     t_module = selected_type.__module__
     if t_module == "builtins":
-        return t_class.__qualname__
+        return selected_type.__qualname__
     return t_module + "." + selected_type.__qualname__
 
 


### PR DESCRIPTION
## 🚧 Work in progress — not ready for review

Draft PR from a batch addressing findings from an in-depth engineering review. Fixes **review finding 117** (Nit, Correctness).

## The bug
In `inference/core/workflows/execution_engine/introspection/utils.py:11`, the builtins branch of `get_full_type_name` returned `t_class.__qualname__`, where `t_class` is `selected_type.__name__` — a `str`. Strings have no `__qualname__` attribute, so this branch raises `AttributeError: 'str' object has no attribute '__qualname__'`.

## Root cause
The `__qualname__` access was applied to the extracted name string (`t_class`) instead of the type object (`selected_type`). The branch is near-unreachable in practice (workflow block classes are never defined in `builtins`; dynamic blocks are created via `type()` in named modules), so the latent bug was never triggered.

## Fix
`utils.py`: return `selected_type.__qualname__` in the builtins branch. The now-unused `t_class = selected_type.__name__` binding is removed since it was only referenced by that branch.

## Verification
Standalone check of the corrected function:
- `get_full_type_name(str)` → `'str'` (previously raised `AttributeError`).
- `get_full_type_name(Foo)` (named module) → `'__main__.Foo'` (unchanged).
- Confirmed the old path fails: `'str'.__qualname__` raises `AttributeError: 'str' object has no attribute '__qualname__'`.

## Scope
Focused change; one of a coordinated batch (one PR per finding).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
