### PR TITLE
[WIP] Fix stale file-lock timeout default in docstrings (10 -> 20)

### DIFF
--- a/inference_models/inference_models/model_pipelines/auto_loaders/core.py
+++ b/inference_models/inference_models/model_pipelines/auto_loaders/core.py
@@ -115,7 +115,7 @@ class AutoModelPipeline:
                 Default: False.
 
             model_download_file_lock_acquire_timeout: Timeout in seconds for acquiring
-                file locks during concurrent downloads. Default: 10.
+                file locks during concurrent downloads. Default: FILE_LOCK_ACQUIRE_TIMEOUT (20).
 
             allow_untrusted_packages: Allow loading model packages with custom code that
                 haven't been verified. **Security risk**. Default: False.

--- a/inference_models/inference_models/models/auto_loaders/core.py
+++ b/inference_models/inference_models/models/auto_loaders/core.py
@@ -534,7 +534,7 @@ class AutoModel:
                 package selection and download issues. Default: False.
 
             model_download_file_lock_acquire_timeout: Timeout in seconds for acquiring
-                file locks during concurrent downloads. Default: 10.
+                file locks during concurrent downloads. Default: FILE_LOCK_ACQUIRE_TIMEOUT (20).
 
             allow_untrusted_packages: Allow loading model packages with custom code that
                 haven't been verified. **Security risk** - only enable for trusted sources.

--- a/inference_models/inference_models/utils/download.py
+++ b/inference_models/inference_models/utils/download.py
@@ -137,7 +137,7 @@ def download_files_to_directory(
             single large file. Default: 8.
 
         file_lock_acquire_timeout: Timeout in seconds for acquiring file locks during
-            concurrent downloads. Default: 10.
+            concurrent downloads. Default: FILE_LOCK_ACQUIRE_TIMEOUT (20).
 
         verify_hash_while_download: Verify MD5 hash during download. Default: True.
 


### PR DESCRIPTION
## 🚧 Work in progress — not ready for review

Draft PR from a batch addressing findings from an in-depth engineering review. Fixes **review finding 114** (Nit, Docs).

## The bug
Three docstrings claim the file-lock acquire timeout defaults to 10 seconds, but the real default is 20. See `inference_models/inference_models/utils/download.py:140`, `inference_models/inference_models/model_pipelines/auto_loaders/core.py:118`, and `inference_models/inference_models/models/auto_loaders/core.py:537`.

## Root cause
`file_lock_acquire_timeout` (and its `model_download_file_lock_acquire_timeout` counterparts) default to the module constant `FILE_LOCK_ACQUIRE_TIMEOUT`, which `configuration.py:86-88` sets to `20` (env `INFERENCE_MODELS_FILE_LOCK_ACQUIRE_TIMEOUT`, default 20). The docstrings hard-coded a stale value of `10`, so a user tuning lock-contention/retry budgets would mis-size their wait windows.

## Fix
Docstring-only change in three files. Each affected parameter description now reads `Default: FILE_LOCK_ACQUIRE_TIMEOUT (20).` — naming the constant rather than a literal so the docs cannot drift again if the constant changes:
- `inference_models/inference_models/utils/download.py:140`
- `inference_models/inference_models/model_pipelines/auto_loaders/core.py:118`
- `inference_models/inference_models/models/auto_loaders/core.py:537`

No behavior change.

## Verification
Confirmed the source of truth directly: `configuration.py:86-88` sets `FILE_LOCK_ACQUIRE_TIMEOUT` `default=20`, and each of the three signatures binds the param default to that constant. Post-edit grep confirms zero remaining `concurrent downloads. Default: 10` occurrences and three `Default: FILE_LOCK_ACQUIRE_TIMEOUT (20)` lines. Docs-only change; no runtime surface to exercise.

## Scope
Focused change; one of a coordinated batch (one PR per finding).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
