### PR TITLE
[WIP] ci: `skip-claude-review` opt-out label + draft-PR review notice

### DIFF
--- a/.github/workflows/claude-pr-review-draft-notice.yml
+++ b/.github/workflows/claude-pr-review-draft-notice.yml
@@ -38,6 +38,7 @@ jobs:
       github.event.pull_request.user.type != 'Bot' &&
       !contains(github.event.pull_request.labels.*.name, 'skip-claude-review')
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Post draft notice (once)
         env:

--- a/.github/workflows/claude-pr-review-draft-notice.yml
+++ b/.github/workflows/claude-pr-review-draft-notice.yml
@@ -1,0 +1,86 @@
+name: Claude PR Review — Draft Notice
+
+# Companion to `claude-pr-review.yml`. That workflow excludes drafts at the job-level
+# `if:` (`!github.event.pull_request.draft`), so a draft PR never triggers it and the
+# author gets no signal about what will (or won't) happen. This workflow fills that gap:
+# when a PR is opened as — or converted to — a draft, it posts a single informational
+# comment explaining that automated review is paused until the PR is marked ready, and
+# how to opt out entirely with the `skip-claude-review` label.
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+on:
+  pull_request:
+    branches: [main]
+    # A draft can arrive three ways: opened straight as a draft, reopened while a draft,
+    # or a ready PR flipped back to draft. The step is idempotent, so overlap is safe.
+    types: [opened, reopened, converted_to_draft]
+
+concurrency:
+  # Never cancel an in-flight post (that could interrupt the comment mid-create); the
+  # marker check below is what prevents duplicates across events on the same PR.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  notice:
+    name: Post draft-review notice
+    # Cheap eligibility filter; the step re-checks authoritatively. Scope matches the
+    # review workflow so we never promise a review that would not run: same-repo only
+    # (forks are not reviewed), human authors only, and not already opted out via
+    # `skip-claude-review` (no point advertising review to a PR that declined it).
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.draft &&
+      github.event.pull_request.user.type != 'Bot' &&
+      !contains(github.event.pull_request.labels.*.name, 'skip-claude-review')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post draft notice (once)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          MARKER='<!-- claude-pr-review:draft-notice -->'
+          SKIP_LABEL='skip-claude-review'
+
+          # Re-fetch authoritatively: the job-level filter reads the event payload, which
+          # can be stale by the time the runner starts (the PR may have been marked ready,
+          # closed, or opted out in the interim). Fail closed — post nothing — on any of
+          # those, mirroring how the review workflow re-validates before acting.
+          pr_json="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}")"
+          state="$(echo "$pr_json" | jq -r '.state')"
+          draft="$(echo "$pr_json" | jq -r '.draft')"
+
+          skip() { echo "::notice::PR #${PR_NUMBER}: $1 — not posting draft notice."; exit 0; }
+
+          [ "$state" = "open" ] || skip "not open"
+          [ "$draft" = "true" ] || skip "no longer a draft"
+
+          # Case-insensitive opt-out check, matching the review workflow's authoritative
+          # re-check (GitHub label names are case-insensitively unique).
+          if echo "$pr_json" | jq -e --arg l "$SKIP_LABEL" '.labels[]? | select((.name // "" | ascii_downcase) == ($l | ascii_downcase))' >/dev/null; then
+            skip "labeled '${SKIP_LABEL}'"
+          fi
+
+          # Idempotent: post the notice at most once per PR. Re-fires (reopen, flipped
+          # back to draft) find the marker and no-op.
+          comments="$(gh api --paginate "repos/${REPO}/issues/${PR_NUMBER}/comments" | jq -s 'add // []')"
+          if echo "$comments" | jq -e --arg m "$MARKER" 'any(.[]; .body // "" | contains($m))' >/dev/null; then
+            skip "draft notice already present"
+          fi
+
+          body="$(printf '%s\n' \
+            "$MARKER" \
+            '🤖 **Automated Claude review is paused while this PR is a draft.**' \
+            '' \
+            "- Mark this PR **Ready for review** to trigger the automatic Claude review." \
+            "- Prefer to skip automated review entirely? Add the **\`${SKIP_LABEL}\`** label.")"
+          gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$body"
+          echo "::notice::PR #${PR_NUMBER}: posted draft-review notice."

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -27,6 +27,8 @@ jobs:
     name: Decide whether to review
     # Cheap eligibility filter; the step does the full validation + gate decision.
     # A `labeled` event only survives when the label is exactly `claude-review`.
+    # The `skip-claude-review` label is an explicit opt-out: its presence short-circuits
+    # every automatic pull_request trigger here (the step re-checks it authoritatively).
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (
@@ -34,6 +36,7 @@ jobs:
         github.event.pull_request.head.repo.full_name == github.repository &&
         !github.event.pull_request.draft &&
         github.event.pull_request.user.type != 'Bot' &&
+        !contains(github.event.pull_request.labels.*.name, 'skip-claude-review') &&
         (
           github.event.action != 'labeled' ||
           github.event.label.name == 'claude-review'
@@ -61,6 +64,7 @@ jobs:
 
           MARKER='<!-- claude-pr-review:run-marker -->'
           REVIEW_LABEL='claude-review'
+          SKIP_LABEL='skip-claude-review'
 
           case "$GH_EVENT_NAME" in
             workflow_dispatch) pr_number="$DISPATCH_PR" ;;
@@ -86,6 +90,15 @@ jobs:
             } >> "$GITHUB_OUTPUT"
           }
           skip() { echo "::notice::PR #${pr_number}: $1 — skipping review."; emit false; exit 0; }
+
+          # Explicit opt-out. Checked FIRST so the `skip-claude-review` label suppresses
+          # the review ahead of every other path — the automatic initial review, a
+          # `claude-review` re-review request, and a manual workflow_dispatch alike.
+          # Case-insensitive match to mirror GitHub's contains() in the job-level filter
+          # (GitHub label names are case-insensitively unique).
+          if echo "$pr_json" | jq -e --arg l "$SKIP_LABEL" '.labels[]? | select((.name // "" | ascii_downcase) == ($l | ascii_downcase))' >/dev/null; then
+            skip "labeled '${SKIP_LABEL}'"
+          fi
 
           [ "$state" = "open" ]          || skip "not open"
           [ "$base_ref" = "main" ]       || skip "targets ${base_ref}, not main"


### PR DESCRIPTION
## 🚧 Work in progress — not ready for review

Two small, additive changes to the **Claude PR Review** automation, both focused on the contributor-facing edges of when review does and doesn't run.

---

## 1. `skip-claude-review` opt-out label

A PR labeled **`skip-claude-review`** is not reviewed by the automated Claude review.

- **Step-level gate (authoritative, first check):** the `skip-claude-review` label is the **first** termination check in the *Resolve, validate, and gate* step — it short-circuits ahead of every other path: the automatic initial review, a `claude-review` re-review request, and a manual `workflow_dispatch`. It reads the live PR JSON (`gh api .../pulls/{n}`), so it is authoritative regardless of trigger.
- **Job-level cheap filter:** `!contains(github.event.pull_request.labels.*.name, 'skip-claude-review')` on the `pull_request` branch of the `gate` job `if:`, so the runner does not even spin up for automatic events on a labeled PR.
- Matching is **case-insensitive** on both layers (GitHub label names are case-insensitively unique), so the two gates stay semantically identical.

**Behavior:** label absent → behavior is byte-for-byte unchanged. Label present → review is skipped on every trigger (skip wins over `claude-review` and manual dispatch). Adding the label itself (a `labeled` event with `label.name='skip-claude-review'`) is already filtered by the existing `label.name == 'claude-review'` gate, so it triggers nothing. Fails **closed** (skips) on ambiguity.

---

## 2. Draft-PR notice (new companion workflow)

The review workflow excludes drafts at its job-level `if:` (`!github.event.pull_request.draft`), so a draft PR triggers **nothing** — and the author gets no signal about why no review shows up, or how the new opt-out works. New file **`.github/workflows/claude-pr-review-draft-notice.yml`** closes that gap.

When a same-repo, human-authored PR is **opened as a draft, reopened while a draft, or converted to a draft**, it posts a single informational comment:

> 🤖 Automated Claude review is paused while this PR is a draft.
> - Mark this PR **Ready for review** to trigger the automatic Claude review.
> - Prefer to skip automated review entirely? Add the **`skip-claude-review`** label.

Design choices, all mirroring the reviewer for consistency:
- **Exactly-once:** a hidden marker comment (`<!-- claude-pr-review:draft-notice -->`) is scanned before posting, so reopen / flip-to-draft events no-op instead of spamming.
- **Same guards:** same-repo only (forks aren't reviewed, so we don't promise a review that won't run), non-bot authors, and it honors `skip-claude-review` (no point advertising review to a PR that already opted out).
- **Fails closed:** an authoritative `gh api .../pulls/{n}` re-fetch re-checks open/draft/label at run time, so a PR marked ready (or opted out) between the event and the runner gets no stale comment.
- **Mutually exclusive with the reviewer** by draft state — the two workflows never both fire on the same event, so there's no double comment.
- Posted as a deterministic templated comment by `github-actions[bot]`. If you'd rather the notice come from the Claude agent's identity/voice, that's a small swap to `claude-code-action` — say the word.

---

## Verification
- Both files parse; **`actionlint`** and **`shellcheck`** are clean on the new workflow.
- jq gates exercised for match / no-match / empty / null / mixed-case, and the marker idempotency and case-insensitive label checks, all under `set -euo pipefail`.
- The label opt-out was reviewed adversarially across three lenses (Actions expression & event-context, gate logic & precedence, regression & security); the draft-notice workflow across two lenses (trigger/expression semantics, idempotency/races/shell) — every finding verified, none confirmed.

## Design note
The `skip-claude-review` label is treated as authoritative even over a manual `workflow_dispatch` (skip wins), per "one of the first termination checks". If you'd rather manual dispatch override the label, that's a one-line reordering.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
