### PR TITLE
Fixes/smaller out of batch changes

### DIFF
--- a/inference/core/active_learning/core.py
+++ b/inference/core/active_learning/core.py
@@ -162,7 +162,7 @@ def register_datapoint_at_roboflow(
 def collect_tags(
     configuration: ActiveLearningConfiguration, sampling_strategy: str
 ) -> List[str]:
-    tags = ACTIVE_LEARNING_TAGS if ACTIVE_LEARNING_TAGS is not None else []
+    tags = list(ACTIVE_LEARNING_TAGS) if ACTIVE_LEARNING_TAGS is not None else []
     tags.extend(configuration.tags)
     tags.extend(configuration.strategies_tags[sampling_strategy])
     if configuration.persist_predictions:

--- a/inference/core/env.py
+++ b/inference/core/env.py
@@ -15,6 +15,22 @@ from inference.core.warnings import (
 
 load_dotenv(os.getcwd() + "/.env")
 
+# Install warning filters before any module-level ``warnings.warn`` calls below,
+# so these flags also suppress warnings emitted during this module's own import
+# (e.g. the gaze deprecation stub warning), not just warnings raised afterwards.
+INFERENCE_WARNINGS_DISABLED = str2bool(
+    os.getenv("INFERENCE_WARNINGS_DISABLED", "False")
+)
+if INFERENCE_WARNINGS_DISABLED:
+    warnings.simplefilter("ignore", InferenceDeprecationWarning)
+    warnings.simplefilter("ignore", InferenceModelsStackMissing)
+
+IGNORE_MODEL_DEPENDENCIES_WARNINGS = str2bool(
+    os.getenv("IGNORE_MODEL_DEPENDENCIES_WARNINGS", "False")
+)
+if IGNORE_MODEL_DEPENDENCIES_WARNINGS:
+    warnings.simplefilter("ignore", ModelDependencyMissing)
+
 # The project name, default is "roboflow-platform"
 PROJECT = os.getenv("PROJECT", "roboflow-platform")
 
@@ -754,14 +770,6 @@ MODAL_ANONYMOUS_WORKSPACE_NAME = os.getenv(
 
 MODEL_VALIDATION_DISABLED = str2bool(os.getenv("MODEL_VALIDATION_DISABLED", "False"))
 
-INFERENCE_WARNINGS_DISABLED = str2bool(
-    os.getenv("INFERENCE_WARNINGS_DISABLED", "False")
-)
-
-if INFERENCE_WARNINGS_DISABLED:
-    warnings.simplefilter("ignore", InferenceDeprecationWarning)
-    warnings.simplefilter("ignore", InferenceModelsStackMissing)
-
 HUGGINGFACE_TOKEN = os.getenv("HUGGINGFACE_TOKEN")
 DEVICE = os.getenv("DEVICE")
 
@@ -851,12 +859,6 @@ if ROBOFLOW_API_REQUEST_TIMEOUT:
 # Control SSL certificate verification for requests to the Roboflow API
 # Default is True (verify SSL). Set ROBOFLOW_API_VERIFY_SSL=false to disable in local dev.
 ROBOFLOW_API_VERIFY_SSL = str2bool(os.getenv("ROBOFLOW_API_VERIFY_SSL", "True"))
-
-IGNORE_MODEL_DEPENDENCIES_WARNINGS = str2bool(
-    os.getenv("IGNORE_MODEL_DEPENDENCIES_WARNINGS", "False")
-)
-if IGNORE_MODEL_DEPENDENCIES_WARNINGS:
-    warnings.simplefilter("ignore", ModelDependencyMissing)
 
 DISK_CACHE_CLEANUP = str2bool(os.getenv("DISK_CACHE_CLEANUP", "True"))
 MEMORY_FREE_THRESHOLD = float(

--- a/inference/core/env.py
+++ b/inference/core/env.py
@@ -129,7 +129,7 @@ GAZE_MODEL_ID = f"gaze/{GAZE_VERSION_ID}"
 # OWLv2 version ID, default is "owlv2-large-patch14-ensemble"
 OWLV2_VERSION_ID = os.getenv("OWLV2_VERSION_ID", "owlv2-large-patch14-ensemble")
 
-# OWLv2 image cache size, default is 1000 since each image has max <MAX_DETECTIONS> boxes at ~4kb each
+# OWLv2 image cache size, default is 10000 since each image has max <MAX_DETECTIONS> boxes at ~4kb each
 OWLV2_IMAGE_CACHE_SIZE = int(os.getenv("OWLV2_IMAGE_CACHE_SIZE", 10000))
 
 # OWLv2 model cache size, default is 100 as memory is num_prompts * ~4kb and num_prompts is rarely above 1000 (but could be much higher)
@@ -138,7 +138,7 @@ OWLV2_MODEL_CACHE_SIZE = int(os.getenv("OWLV2_MODEL_CACHE_SIZE", 100))
 # OWLv2 cache device placement, default sends cached embeddings to CPU to reduce GPU memory pressure
 OWLV2_CACHE_SEND_TO_CPU = str2bool(os.getenv("OWLV2_CACHE_SEND_TO_CPU", True))
 
-# OWLv2 CPU image cache size, default is 10000
+# OWLv2 CPU image cache size, default is 1000
 OWLV2_CPU_IMAGE_CACHE_SIZE = int(os.getenv("OWLV2_CPU_IMAGE_CACHE_SIZE", 1000))
 
 # OWLv2 compile model, default is True

--- a/inference/core/env.py
+++ b/inference/core/env.py
@@ -169,7 +169,7 @@ CLASS_AGNOSTIC_NMS = str2bool(
     os.getenv(CLASS_AGNOSTIC_NMS_ENV, DEFAULT_CLASS_AGNOSTIC_NMS)
 )
 
-# Confidence threshold, default is 50%
+# Confidence threshold, default is 40%
 CONFIDENCE_ENV = "CONFIDENCE"
 DEFAULT_CONFIDENCE = 0.4
 CONFIDENCE = float(os.getenv(CONFIDENCE_ENV, DEFAULT_CONFIDENCE))

--- a/inference/core/interfaces/http/error_handlers.py
+++ b/inference/core/interfaces/http/error_handlers.py
@@ -1,5 +1,6 @@
 from functools import wraps
 
+from fastapi import HTTPException
 from starlette.responses import JSONResponse
 
 from inference.core import logger
@@ -597,6 +598,8 @@ def with_route_exceptions(route):
                     **error.get_structured_public_error_details(),
                 },
             )
+        except HTTPException:
+            raise
         except Exception as error:
             logger.exception("%s: %s", type(error).__name__, error)
             resp = JSONResponse(status_code=500, content={"message": "Internal error."})
@@ -1069,6 +1072,8 @@ def with_route_exceptions_async(route):
                     **error.get_structured_public_error_details(),
                 },
             )
+        except HTTPException:
+            raise
         except Exception as error:
             logger.exception("%s: %s", type(error).__name__, error)
             resp = JSONResponse(status_code=500, content={"message": "Internal error."})

--- a/inference/core/interfaces/http/http_api.py
+++ b/inference/core/interfaces/http/http_api.py
@@ -509,6 +509,8 @@ def _log_serverless_authorization_denial(
     workspace_id: Optional[str],
     cache_hit: bool,
 ) -> None:
+    if not API_LOGGING_ENABLED:
+        return
     log_fields = {
         "method": request.method,
         "path": request.url.path,

--- a/inference/core/interfaces/stream/inference_pipeline.py
+++ b/inference/core/interfaces/stream/inference_pipeline.py
@@ -801,8 +801,7 @@ class InferencePipeline:
         """
         if watchdog is None:
             watchdog = NullPipelineWatchdog()
-        if status_update_handlers is None:
-            status_update_handlers = []
+        status_update_handlers = list(status_update_handlers or [])
         status_update_handlers.append(watchdog.on_status_update)
         desired_source_fps = None
         if ENABLE_FRAME_DROP_ON_VIDEO_FILE_RATE_LIMITING:

--- a/inference/core/workflows/core_steps/classical_cv/dominant_color/v1.py
+++ b/inference/core/workflows/core_steps/classical_cv/dominant_color/v1.py
@@ -184,10 +184,10 @@ class DominantColorBlockV1(WorkflowBlock):
 
         # Get the colors and their counts
         colors = centroids
-        _, counts = np.unique(labels, return_counts=True)
+        uniq, counts = np.unique(labels, return_counts=True)
 
         # Find the most dominant color
-        dominant_color = colors[np.argmax(counts)]
+        dominant_color = colors[uniq[np.argmax(counts)]]
         rgb_color = tuple(
             int(np.clip(round(x), 0, 255)) for x in reversed(dominant_color)
         )

--- a/inference/core/workflows/core_steps/classical_cv/image_blur/v1.py
+++ b/inference/core/workflows/core_steps/classical_cv/image_blur/v1.py
@@ -123,7 +123,7 @@ class ImageBlurManifest(WorkflowBlockManifest):
 
     kernel_size: Union[Selector(kind=[INTEGER_KIND]), int] = Field(
         default=5,
-        description="Size of the blur kernel (must be positive and typically odd). Controls the blur intensity - larger values create more blur, smaller values create less blur. For average and gaussian blur, this is the width and height of the kernel (e.g., 5 means 5x5 kernel). For median blur, this must be an odd integer (automatically handled). For bilateral blur, this controls the diameter of the pixel neighborhood. Typical values range from 3-15: smaller values (3-5) provide subtle blur, medium values (5-9) provide moderate blur, larger values (11-15) provide strong blur. Default is 5, which provides moderate blur. Adjust based on image size and desired blur intensity.",
+        description="Size of the blur kernel (must be positive and typically odd). Controls the blur intensity - larger values create more blur, smaller values create less blur. For average and gaussian blur, this is the width and height of the kernel (e.g., 5 means 5x5 kernel). For gaussian and median blur, the kernel size must be a positive odd integer; even or non-positive values are automatically coerced to the next positive odd value. For bilateral blur, this controls the diameter of the pixel neighborhood. Typical values range from 3-15: smaller values (3-5) provide subtle blur, medium values (5-9) provide moderate blur, larger values (11-15) provide strong blur. Default is 5, which provides moderate blur. Adjust based on image size and desired blur intensity.",
         examples=[5, "$inputs.kernel_size"],
     )
 
@@ -168,6 +168,18 @@ class ImageBlurBlockV1(WorkflowBlock):
         return {OUTPUT_IMAGE_KEY: output}
 
 
+def _to_positive_odd(ksize: int) -> int:
+    """Coerce a kernel size to a positive odd integer.
+
+    ``cv2.GaussianBlur`` and ``cv2.medianBlur`` require an odd, positive ksize
+    and raise ``cv2.error`` otherwise.
+    """
+    ksize = max(1, int(ksize))
+    if ksize % 2 == 0:
+        ksize += 1
+    return ksize
+
+
 def apply_blur(image: np.ndarray, blur_type: str, ksize: int = 5) -> np.ndarray:
     """
     Applies the specified blur to the image.
@@ -184,8 +196,10 @@ def apply_blur(image: np.ndarray, blur_type: str, ksize: int = 5) -> np.ndarray:
     if blur_type == "average":
         blurred_image = cv2.blur(image, (ksize, ksize))
     elif blur_type == "gaussian":
+        ksize = _to_positive_odd(ksize)
         blurred_image = cv2.GaussianBlur(image, (ksize, ksize), 0)
     elif blur_type == "median":
+        ksize = _to_positive_odd(ksize)
         blurred_image = cv2.medianBlur(image, ksize)
     elif blur_type == "bilateral":
         blurred_image = cv2.bilateralFilter(image, ksize, 75, 75)

--- a/inference/core/workflows/core_steps/classical_cv/sift_comparison/v1.py
+++ b/inference/core/workflows/core_steps/classical_cv/sift_comparison/v1.py
@@ -134,7 +134,12 @@ class SIFTComparisonBlockV1(WorkflowBlock):
         ratio_threshold: float = 0.7,
     ) -> BlockResult:
         # Check if both descriptor arrays have at least 2 descriptors
-        if len(descriptor_1) < 2 or len(descriptor_2) < 2:
+        if (
+            descriptor_1 is None
+            or descriptor_2 is None
+            or len(descriptor_1) < 2
+            or len(descriptor_2) < 2
+        ):
             return {
                 "good_matches_count": 0,
                 "images_match": False,

--- a/inference/core/workflows/core_steps/classical_cv/sift_comparison/v2.py
+++ b/inference/core/workflows/core_steps/classical_cv/sift_comparison/v2.py
@@ -228,7 +228,12 @@ class SIFTComparisonBlockV2(WorkflowBlock):
             visualization_2 = None
 
         # Check if both descriptor arrays have at least 2 descriptors
-        if len(descriptors_1) < 2 or len(descriptors_2) < 2:
+        if (
+            descriptors_1 is None
+            or descriptors_2 is None
+            or len(descriptors_1) < 2
+            or len(descriptors_2) < 2
+        ):
             return {
                 "good_matches_count": 0,
                 "images_match": False,

--- a/inference/core/workflows/core_steps/classical_cv/size_measurement/v1.py
+++ b/inference/core/workflows/core_steps/classical_cv/size_measurement/v1.py
@@ -291,7 +291,7 @@ class SizeMeasurementBlockV1(WorkflowBlock):
         dimensions = []
         for i in range(len(object_predictions)):
             obj_w_pixels, obj_h_pixels = get_detection_dimensions(object_predictions, i)
-            if obj_w_pixels > 0 and obj_h_pixels > 0:
+            if obj_w_pixels and obj_h_pixels and obj_w_pixels > 0 and obj_h_pixels > 0:
                 obj_w_actual = obj_w_pixels * width_scale
                 obj_h_actual = obj_h_pixels * height_scale
                 dimensions.append(

--- a/inference/core/workflows/core_steps/classical_cv/template_matching/v1.py
+++ b/inference/core/workflows/core_steps/classical_cv/template_matching/v1.py
@@ -202,7 +202,7 @@ def apply_template_matching(
     w, h = template_gray.shape[::-1]
     res = cv2.matchTemplate(img_gray, template_gray, cv2.TM_CCOEFF_NORMED)
     loc = np.where(res >= matching_threshold)
-    xyxy, confidence, class_id, class_name, detections_id = [], [], [], [], []
+    xyxy, confidence, class_id, class_name = [], [], [], []
     for pt in zip(*loc[::-1]):
         top_left = pt
         bottom_right = (pt[0] + w, pt[1] + h)
@@ -210,7 +210,6 @@ def apply_template_matching(
         confidence.append(1.0)
         class_id.append(0)
         class_name.append("template_match")
-        detections_id.append(str(uuid4()))
     if len(xyxy) == 0:
         return sv.Detections.empty()
     detections = sv.Detections(
@@ -225,7 +224,9 @@ def apply_template_matching(
         [image.parent_metadata.parent_id] * len(detections)
     )
     detections[PREDICTION_TYPE_KEY] = np.array(["object-detection"] * len(detections))
-    detections[DETECTION_ID_KEY] = np.array(detections_id)
+    detections[DETECTION_ID_KEY] = np.array(
+        [str(uuid4()) for _ in range(len(detections))]
+    )
     image_height, image_width = image.numpy_image.shape[:2]
     detections[IMAGE_DIMENSIONS_KEY] = np.array(
         [[image_height, image_width]] * len(detections)

--- a/inference/core/workflows/core_steps/common/openrouter.py
+++ b/inference/core/workflows/core_steps/common/openrouter.py
@@ -338,7 +338,7 @@ def _execute_direct_openrouter_request(
         temperature=temperature,
         extra_body=extra_body,
     )
-    if response.choices is None:
+    if not response.choices:
         error_detail = getattr(response, "error", {}) or {}
         if isinstance(error_detail, dict):
             error_detail = error_detail.get("message", "N/A")

--- a/inference/core/workflows/core_steps/common/query_language/operations/detections/base.py
+++ b/inference/core/workflows/core_steps/common/query_language/operations/detections/base.py
@@ -1,5 +1,5 @@
 from copy import copy, deepcopy
-from typing import Any, Callable, Dict, List, Union
+from typing import Any, Callable, Dict, List, Optional, Union
 
 import numpy as np
 import supervision as sv
@@ -295,9 +295,14 @@ def rename_detections(
             context="step_execution | roboflow_query_language_evaluation",
         )
     detections_copy = deepcopy(detections)
-    original_class_names = detections_copy.data.get(
-        "class_name", np.array([], dtype=object)
-    ).tolist()
+    if "class_name" not in detections_copy.data:
+        if strict and len(detections_copy) > 0:
+            _ensure_all_classes_covered_in_new_mapping(
+                original_class_names=None,
+                class_map=class_map,
+            )
+        return detections_copy
+    original_class_names = detections_copy.data["class_name"].tolist()
     original_class_ids = detections_copy.class_id.tolist()
     new_class_names = []
     new_class_ids = []
@@ -328,9 +333,15 @@ def rename_detections(
 
 
 def _ensure_all_classes_covered_in_new_mapping(
-    original_class_names: List[str],
+    original_class_names: Optional[List[str]],
     class_map: Dict[str, str],
 ) -> None:
+    if original_class_names is None:
+        raise OperationError(
+            public_message="Executing rename_detections(...) with strict=True, but the detections "
+            "carry no `class_name` field, so coverage by `class_map` cannot be guaranteed.",
+            context="step_execution | roboflow_query_language_evaluation",
+        )
     for original_class in original_class_names:
         if original_class not in class_map:
             raise OperationError(

--- a/inference/core/workflows/core_steps/common/query_language/operations/detections/base.py
+++ b/inference/core/workflows/core_steps/common/query_language/operations/detections/base.py
@@ -192,7 +192,7 @@ def select_detections(
             context="step_execution | roboflow_query_language_evaluation",
         )
     if mode not in DETECTIONS_SELECTORS:
-        InvalidInputTypeError(
+        raise InvalidInputTypeError(
             public_message=f"Executing select_detections(...), expected mode to be one of {DETECTIONS_SELECTORS.values()}, "
             f"got {mode}.",
             context="step_execution | roboflow_query_language_evaluation",

--- a/inference/core/workflows/core_steps/common/query_language/operations/detections/base.py
+++ b/inference/core/workflows/core_steps/common/query_language/operations/detections/base.py
@@ -295,7 +295,9 @@ def rename_detections(
             context="step_execution | roboflow_query_language_evaluation",
         )
     detections_copy = deepcopy(detections)
-    original_class_names = detections_copy.data.get("class_name", []).tolist()
+    original_class_names = detections_copy.data.get(
+        "class_name", np.array([], dtype=object)
+    ).tolist()
     original_class_ids = detections_copy.class_id.tolist()
     new_class_names = []
     new_class_ids = []

--- a/inference/core/workflows/core_steps/common/query_language/operations/numbers/base.py
+++ b/inference/core/workflows/core_steps/common/query_language/operations/numbers/base.py
@@ -67,8 +67,8 @@ def divide(
     except (TypeError, ValueError, ZeroDivisionError) as e:
         value_as_str = safe_stringify(value=value)
         raise InvalidInputTypeError(
-            public_message=f"While executing multiply divide(...) in context {execution_context}, encountered "
-            f"value `{value_as_str}` of type {type(value)} which cannot be multiplied with {other}",
+            public_message=f"While executing divide(...) in context {execution_context}, encountered "
+            f"value `{value_as_str}` of type {type(value)} which cannot be divided by {other}",
             context=f"step_execution | roboflow_query_language_evaluation | {execution_context}",
             inner_error=e,
         )

--- a/inference/core/workflows/core_steps/common/query_language/operations/strings/base.py
+++ b/inference/core/workflows/core_steps/common/query_language/operations/strings/base.py
@@ -62,4 +62,4 @@ def string_matches(value: Any, regex: str, execution_context: str, **kwargs) -> 
             f"got value which of type {type(value)}: {value_as_str}",
             context=f"step_execution | roboflow_query_language_evaluation | {execution_context}",
         )
-    return not re.match(pattern=regex, string=value)
+    return bool(re.search(pattern=regex, string=value))

--- a/inference/core/workflows/core_steps/common/query_language/operations/strings/base.py
+++ b/inference/core/workflows/core_steps/common/query_language/operations/strings/base.py
@@ -32,7 +32,7 @@ def string_to_upper(value: Any, execution_context: str, **kwargs) -> str:
 def to_string(value: Any, execution_context: str, **kwargs) -> str:
     try:
         return str(value)
-    except (RuntimeError, RuntimeError) as e:
+    except Exception as e:
         raise InvalidInputTypeError(
             public_message=f"Using operation to_string(...) in context {execution_context} caused the following "
             f"error: {e} of type {type(value)}",

--- a/inference/core/workflows/core_steps/formatters/csv/v1.py
+++ b/inference/core/workflows/core_steps/formatters/csv/v1.py
@@ -205,5 +205,18 @@ def unfold_parameters(
     return None
 
 
+CSV_INJECTION_PREFIXES = ("=", "+", "-", "@", "\t", "\r")
+
+
 def to_csv(data: List[Dict[str, Any]]) -> str:
-    return pd.DataFrame(data).to_csv(index=False)
+    sanitized_data = [
+        {key: neutralize_csv_injection(value) for key, value in row.items()}
+        for row in data
+    ]
+    return pd.DataFrame(sanitized_data).to_csv(index=False)
+
+
+def neutralize_csv_injection(value: Any) -> Any:
+    if isinstance(value, str) and value.startswith(CSV_INJECTION_PREFIXES):
+        return "'" + value
+    return value

--- a/inference/core/workflows/core_steps/formatters/vlm_as_detector/v1.py
+++ b/inference/core/workflows/core_steps/formatters/vlm_as_detector/v1.py
@@ -345,7 +345,7 @@ def parse_florence2_object_detection_response(
             for name in detections.data.get("class_name", ["unknown"] * len(detections))
         ]
         detections.class_id = np.array(class_ids)
-    if florence_task_type in "<OPEN_VOCABULARY_DETECTION>":
+    if florence_task_type == "<OPEN_VOCABULARY_DETECTION>":
         class_name_to_id = {name: idx for idx, name in enumerate(classes)}
         class_ids = [
             class_name_to_id.get(name, -1)

--- a/inference/core/workflows/core_steps/formatters/vlm_as_detector/v2.py
+++ b/inference/core/workflows/core_steps/formatters/vlm_as_detector/v2.py
@@ -425,7 +425,7 @@ def parse_florence2_object_detection_response(
             for name in detections.data.get("class_name", ["unknown"] * len(detections))
         ]
         detections.class_id = np.array(class_ids)
-    if florence_task_type in "<OPEN_VOCABULARY_DETECTION>":
+    if florence_task_type == "<OPEN_VOCABULARY_DETECTION>":
         class_name_to_id = {name: idx for idx, name in enumerate(classes)}
         class_ids = [
             class_name_to_id.get(name, -1)

--- a/inference/core/workflows/core_steps/fusion/detections_classes_replacement/v1.py
+++ b/inference/core/workflows/core_steps/fusion/detections_classes_replacement/v1.py
@@ -403,7 +403,7 @@ def extract_leading_class_from_prediction(
         elif not prediction.get("predictions") and fallback_class_name:
             try:
                 fallback_class_id = int(fallback_class_id)
-            except ValueError:
+            except (ValueError, TypeError):
                 fallback_class_id = None
             if fallback_class_id is None or fallback_class_id < 0:
                 fallback_class_id = sys.maxsize

--- a/inference/core/workflows/core_steps/fusion/detections_classes_replacement/v1.py
+++ b/inference/core/workflows/core_steps/fusion/detections_classes_replacement/v1.py
@@ -261,9 +261,9 @@ class DetectionsClassesReplacementBlockV1(WorkflowBlock):
                 if prediction is None:
                     if fallback_class_name:
                         resolved_fallback_id = (
-                            fallback_class_id
-                            if fallback_class_id is not None
-                            else sys.maxsize
+                            sys.maxsize
+                            if fallback_class_id is None or fallback_class_id < 0
+                            else fallback_class_id
                         )
                         class_name, class_id, confidence = (
                             fallback_class_name,

--- a/inference/core/workflows/core_steps/sampling/identify_changes/v1.py
+++ b/inference/core/workflows/core_steps/sampling/identify_changes/v1.py
@@ -321,9 +321,7 @@ class IdentifyChangesBlockV1(WorkflowBlock):
                 z_score = 0
                 percentile = 0.5
             else:
-                z_score = (
-                    cs - self.cosine_similarity_avg
-                ) / self.cosine_similarity_std
+                z_score = (cs - self.cosine_similarity_avg) / self.cosine_similarity_std
                 percentile = 1 - 0.5 * (1 + math.erf(z_score / np.sqrt(2)))
 
             # print(f"Z-score: {z_score}, Percentile: {percentile}, Cosine Similarity: {cs}, Average: {self.cosine_similarity_avg}, Std: {self.cosine_similarity_std}")

--- a/inference/core/workflows/core_steps/sampling/identify_changes/v1.py
+++ b/inference/core/workflows/core_steps/sampling/identify_changes/v1.py
@@ -314,8 +314,17 @@ class IdentifyChangesBlockV1(WorkflowBlock):
                         self.cosine_similarity_sliding_window
                     )
 
-            z_score = (cs - self.cosine_similarity_avg) / self.cosine_similarity_std
-            percentile = 1 - 0.5 * (1 + math.erf(z_score / np.sqrt(2)))
+            if self.cosine_similarity_std == 0:
+                # No variance in cosine similarity (e.g. a static scene) means
+                # there is nothing to compare against; treat as non-outlier
+                # instead of dividing by zero and emitting NaN downstream.
+                z_score = 0
+                percentile = 0.5
+            else:
+                z_score = (
+                    cs - self.cosine_similarity_avg
+                ) / self.cosine_similarity_std
+                percentile = 1 - 0.5 * (1 + math.erf(z_score / np.sqrt(2)))
 
             # print(f"Z-score: {z_score}, Percentile: {percentile}, Cosine Similarity: {cs}, Average: {self.cosine_similarity_avg}, Std: {self.cosine_similarity_std}")
 

--- a/inference/core/workflows/core_steps/sinks/local_file/v1.py
+++ b/inference/core/workflows/core_steps/sinks/local_file/v1.py
@@ -286,6 +286,7 @@ class LocalFileSinkBlockV1(WorkflowBlock):
             file_name_prefix=file_name_prefix,
             file_type=file_type,
         )
+        self._verify_write_access_to_directory(target_directory=target_path)
         return handle_content_saving(
             target_path=target_path,
             file_operation_mode="w",
@@ -356,6 +357,7 @@ class LocalFileSinkBlockV1(WorkflowBlock):
             file_name_prefix=file_name_prefix,
             file_type=extension,
         )
+        self._verify_write_access_to_directory(target_directory=file_path)
         parent_dir = os.path.dirname(file_path)
         os.makedirs(parent_dir, exist_ok=True)
         return open(file_path, "w")

--- a/inference/core/workflows/core_steps/sinks/slack/notification/v1.py
+++ b/inference/core/workflows/core_steps/sinks/slack/notification/v1.py
@@ -399,6 +399,7 @@ def _send_slack_notification(
             channel=channel,
             text=message,
         )
+        return
     file_uploads = [
         {
             "title": name,

--- a/inference/core/workflows/core_steps/transformations/absolute_static_crop/v1.py
+++ b/inference/core/workflows/core_steps/transformations/absolute_static_crop/v1.py
@@ -151,6 +151,13 @@ def take_static_crop(
     y_min = round(y_center - height / 2)
     x_max = round(x_min + width)
     y_max = round(y_min + height)
+    image_height, image_width = image.numpy_image.shape[:2]
+    x_min = max(0, x_min)
+    y_min = max(0, y_min)
+    x_max = min(image_width, x_max)
+    y_max = min(image_height, y_max)
+    if x_max <= x_min or y_max <= y_min:
+        return None
     cropped_image = image.numpy_image[y_min:y_max, x_min:x_max]
     if not cropped_image.size:
         return None

--- a/inference/core/workflows/core_steps/transformations/detection_offset/v1.py
+++ b/inference/core/workflows/core_steps/transformations/detection_offset/v1.py
@@ -155,7 +155,7 @@ class DetectionOffsetBlockV1(WorkflowBlock):
         offset_height: int,
         units: str = "Pixels",
     ) -> BlockResult:
-        use_percentage = units == "Percent (%) - of bounding box width / height"
+        use_percentage = units == "Percent (%)"
         return [
             {
                 "predictions": offset_detections(

--- a/inference/core/workflows/core_steps/transformations/dynamic_zones/v1.py
+++ b/inference/core/workflows/core_steps/transformations/dynamic_zones/v1.py
@@ -361,12 +361,12 @@ class DynamicZonesBlockV1(WorkflowBlock):
                     simplified_polygon = simplified_polygon[
                         :required_number_of_vertices
                     ]
-                updated_detection[POLYGON_KEY_IN_SV_DETECTIONS] = np.array(
-                    [simplified_polygon]
-                )
                 simplified_polygon = scale_polygon(
                     polygon=simplified_polygon,
                     scale=scale_ratio,
+                )
+                updated_detection[POLYGON_KEY_IN_SV_DETECTIONS] = np.array(
+                    [simplified_polygon]
                 )
                 simplified_polygons.append(simplified_polygon.tolist())
                 mask_bool = sv.polygon_to_mask(

--- a/inference/core/workflows/core_steps/transformations/stabilize_detections/v1.py
+++ b/inference/core/workflows/core_steps/transformations/stabilize_detections/v1.py
@@ -182,10 +182,12 @@ class StabilizeTrackedDetectionsBlockV1(WorkflowBlock):
         bbox_smoothing_coefficient: float,
     ) -> BlockResult:
         metadata = image.video_metadata
-        if detections.tracker_id is None:
+        if len(detections) > 0 and detections.tracker_id is None:
             raise ValueError(
                 f"tracker_id not initialized, {self.__class__.__name__} requires detections to be tracked"
             )
+        if detections.tracker_id is None:
+            detections.tracker_id = np.array([])
         cached_detections = self._batch_of_last_known_detections.setdefault(
             metadata.video_identifier, {}
         )

--- a/inference/core/workflows/execution_engine/introspection/utils.py
+++ b/inference/core/workflows/execution_engine/introspection/utils.py
@@ -5,10 +5,9 @@ CLASS_NAME_WORD_PATTERN = re.compile(r"[A-Z](?:[a-z1-9]+|[A-Z]*(?=[A-Z]|$))")
 
 
 def get_full_type_name(selected_type: type) -> str:
-    t_class = selected_type.__name__
     t_module = selected_type.__module__
     if t_module == "builtins":
-        return t_class.__qualname__
+        return selected_type.__qualname__
     return t_module + "." + selected_type.__qualname__
 
 

--- a/inference_cli/lib/cloud_adapter.py
+++ b/inference_cli/lib/cloud_adapter.py
@@ -1,4 +1,6 @@
+import os
 import random
+import shlex
 import string
 import tempfile
 
@@ -196,7 +198,7 @@ def cloud_deploy(provider, compute_type, dry_run, custom, help, roboflow_api_key
         return
 
     placeholder_string = (
-        f" --env ROBOFLOW_API_KEY={roboflow_api_key} "
+        f" --env ROBOFLOW_API_KEY={shlex.quote(roboflow_api_key)} "
         if roboflow_api_key is not None
         else ""
     )
@@ -208,11 +210,14 @@ def cloud_deploy(provider, compute_type, dry_run, custom, help, roboflow_api_key
 
     yaml_string = yaml_string.replace("PLACEHOLDER", placeholder_string)
 
-    with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
-        file_path = f.name
-        f.write(yaml_string)
-        f.close()
+    tmp_file = tempfile.NamedTemporaryFile(mode="w", delete=False)
+    file_path = tmp_file.name
+    try:
+        tmp_file.write(yaml_string)
+        tmp_file.close()
         task = sky.Task.from_yaml(file_path)
+    finally:
+        os.unlink(file_path)
 
     cluster_name = f"roboflow-inference-{provider}-{compute_type}-{_random_char(5)}"
 

--- a/inference_cli/lib/container_adapter.py
+++ b/inference_cli/lib/container_adapter.py
@@ -358,7 +358,7 @@ def pull_image(image: str, use_local_images: bool = False) -> None:
     try:
         _ = docker_client.images.get(image)
         if use_local_images:
-            print(f"Using locally cached image: {use_local_images}")
+            print(f"Using locally cached image: {image}")
             return None
     except ImageNotFound:
         pass

--- a/inference_cli/lib/container_adapter.py
+++ b/inference_cli/lib/container_adapter.py
@@ -250,7 +250,7 @@ def start_inference_container(
     )
     pull_image(image, use_local_images=use_local_images)
     print(f"Starting inference server container...")
-    ports = {"9001": port}
+    ports = {str(port): port}
     if development:
         ports["9002"] = 9002
     docker_client = docker.from_env()

--- a/inference_cli/lib/roboflow_cloud/data_staging/api_operations.py
+++ b/inference_cli/lib/roboflow_cloud/data_staging/api_operations.py
@@ -1677,11 +1677,12 @@ def pull_batch_element_to_directory(
     interval=1,
 )
 def pull_file_to_directory(url: str, target_directory: str, file_name: str) -> str:
-    response = requests.get(url)
+    response = requests.get(url, stream=True, timeout=REQUEST_TIMEOUT)
     response.raise_for_status()
     target_path = os.path.join(target_directory, file_name)
     with open(target_path, "wb") as f:
-        f.write(response.content)
+        for chunk in response.iter_content(chunk_size=8192):
+            f.write(chunk)
     return target_path
 
 

--- a/inference_cli/lib/utils.py
+++ b/inference_cli/lib/utils.py
@@ -38,7 +38,7 @@ VIDEOS_EXTENSIONS = [
     "m4b",
     "m4r",
     "m4v",
-    "MP$",
+    "MP4",
     "M4A",
     "M4P",
     "M4B",

--- a/inference_models/inference_models/model_pipelines/auto_loaders/core.py
+++ b/inference_models/inference_models/model_pipelines/auto_loaders/core.py
@@ -115,7 +115,7 @@ class AutoModelPipeline:
                 Default: False.
 
             model_download_file_lock_acquire_timeout: Timeout in seconds for acquiring
-                file locks during concurrent downloads. Default: 10.
+                file locks during concurrent downloads. Default: FILE_LOCK_ACQUIRE_TIMEOUT (20).
 
             allow_untrusted_packages: Allow loading model packages with custom code that
                 haven't been verified. **Security risk**. Default: False.

--- a/inference_models/inference_models/models/auto_loaders/core.py
+++ b/inference_models/inference_models/models/auto_loaders/core.py
@@ -534,7 +534,7 @@ class AutoModel:
                 package selection and download issues. Default: False.
 
             model_download_file_lock_acquire_timeout: Timeout in seconds for acquiring
-                file locks during concurrent downloads. Default: 10.
+                file locks during concurrent downloads. Default: FILE_LOCK_ACQUIRE_TIMEOUT (20).
 
             allow_untrusted_packages: Allow loading model packages with custom code that
                 haven't been verified. **Security risk** - only enable for trusted sources.

--- a/inference_models/inference_models/models/clip/clip_onnx.py
+++ b/inference_models/inference_models/models/clip/clip_onnx.py
@@ -138,7 +138,7 @@ class ClipOnnx(TextImageEmbeddingModel):
     def embed_text(self, texts: Union[str, List[str]], **kwargs) -> torch.Tensor:
         if not isinstance(texts, list):
             texts = [texts]
-        tokenized_batch = clip.tokenize(texts)
+        tokenized_batch = clip.tokenize(texts).to(self._device)
         with self._textual_session_thread_lock:
             return run_onnx_session_with_batch_size_limit(
                 session=self._textual_onnx_session,

--- a/inference_models/inference_models/models/common/roboflow/pre_processing.py
+++ b/inference_models/inference_models/models/common/roboflow/pre_processing.py
@@ -39,7 +39,7 @@ def pre_process_network_input(
     if network_input.input_channels != 3:
         raise ModelRuntimeError(
             message=f"`inference` currently does not support Roboflow pre-processing for model inputs with "
-            f"channels numbers different than 1. Let us know if you need this feature.",
+            f"channels numbers different than 3. Let us know if you need this feature.",
             help_url="https://inference-models.roboflow.com/errors/models-runtime/#modelruntimeerror",
         )
     input_color_mode = None

--- a/inference_models/inference_models/utils/download.py
+++ b/inference_models/inference_models/utils/download.py
@@ -137,7 +137,7 @@ def download_files_to_directory(
             single large file. Default: 8.
 
         file_lock_acquire_timeout: Timeout in seconds for acquiring file locks during
-            concurrent downloads. Default: 10.
+            concurrent downloads. Default: FILE_LOCK_ACQUIRE_TIMEOUT (20).
 
         verify_hash_while_download: Verify MD5 hash during download. Default: True.
 

--- a/inference_models/inference_models/weights_providers/roboflow.py
+++ b/inference_models/inference_models/weights_providers/roboflow.py
@@ -335,8 +335,7 @@ def append_extra_headers(
 ) -> Dict[str, str]:
     if not extra_headers:
         return headers
-    extra_headers.update(headers)
-    return extra_headers
+    return {**extra_headers, **headers}
 
 
 def _add_query_params_to_url(url: str, query: Dict[str, List[str]]) -> str:

--- a/inference_sdk/http/client.py
+++ b/inference_sdk/http/client.py
@@ -147,7 +147,7 @@ def wrap_errors(function: callable) -> callable:
                 status_code=error.response.status_code,
                 api_message=api_message,
             ) from error
-        except ConnectionError as error:
+        except (ConnectionError, requests.exceptions.ConnectionError) as error:
             raise HTTPClientError(
                 f"Error with server connection: {deduct_api_key_from_string(str(error))}"
             ) from error

--- a/inference_sdk/http/utils/executors.py
+++ b/inference_sdk/http/utils/executors.py
@@ -337,7 +337,7 @@ def _reset_thread_local_requests_session() -> None:
 )
 @backoff.on_exception(
     backoff.constant,
-    exception=ConnectionError,
+    exception=(ConnectionError, requests.exceptions.ConnectionError),
     max_tries=3,
     interval=1,
     backoff_log_level=logging.DEBUG,

--- a/inference_sdk/http/utils/loaders.py
+++ b/inference_sdk/http/utils/loaders.py
@@ -272,6 +272,11 @@ async def load_image_from_string_async(
             url=reference, max_height=max_height, max_width=max_width
         )
     if os.path.exists(reference):
+        if max_height is None or max_width is None:
+            with open(reference, "rb") as f:
+                img_bytes = f.read()
+            img_base64_str = encode_base_64(payload=img_bytes)
+            return img_base64_str, None
         local_image = cv2.imread(reference)
         if local_image is None:
             raise EncodingError(f"Could not load image from {reference}")

--- a/tests/inference/unit_tests/core/interfaces/http/test_http_api.py
+++ b/tests/inference/unit_tests/core/interfaces/http/test_http_api.py
@@ -702,6 +702,7 @@ def test_serverless_auth_middleware_adds_observability_headers_and_logs_on_denia
 
     monkeypatch.setattr(http_api, "EXECUTION_ID_HEADER", "X-Execution-Id")
     monkeypatch.setattr(http_api, "get_trace_id", lambda: "trace-123")
+    monkeypatch.setattr(http_api, "API_LOGGING_ENABLED", True)
     denied_log_mock = MagicMock()
     monkeypatch.setattr(http_api.logger, "info", denied_log_mock)
     interface, _, _, _ = _build_serverless_interface(

--- a/tests/workflows/unit_tests/core_steps/common/query_language/operations/detections/test_base.py
+++ b/tests/workflows/unit_tests/core_steps/common/query_language/operations/detections/test_base.py
@@ -145,7 +145,9 @@ def test_rename_detections_when_non_strict_mode_enabled_and_not_all_classes_pres
     ], "Expected to change with mapping"
 
 
-def test_rename_detections_when_detections_have_no_class_name_data() -> None:
+def test_rename_detections_when_detections_have_no_class_name_data_and_not_strict() -> (
+    None
+):
     # given
     detections = sv.Detections(
         xyxy=np.array([[0, 1, 2, 3], [0, 1, 2, 3]]),
@@ -162,13 +164,65 @@ def test_rename_detections_when_detections_have_no_class_name_data() -> None:
         global_parameters={},
     )
 
-    # then
-    assert isinstance(
-        result, sv.Detections
-    ), "Expected a handled result, not a raw AttributeError"
+    # then - with no class names to rename, non-strict mode is a no-op: the
+    # detections pass through length-consistent and unchanged, rather than having
+    # class_id / class_name overwritten with zero-length arrays for the 2 real boxes.
+    assert isinstance(result, sv.Detections)
+    assert len(result) == 2, "Expected the 2 input boxes to be preserved"
+    assert np.allclose(result.xyxy, np.array([[0, 1, 2, 3], [0, 1, 2, 3]]))
+    assert np.allclose(
+        result.class_id, np.array([10, 11])
+    ), "Expected class_id unchanged in the no-op path"
+    assert np.allclose(result.confidence, np.array([0.3, 0.4]))
     assert (
-        result.data["class_name"].tolist() == []
-    ), "Expected empty class_name when input carries no class_name"
+        "class_name" not in result.data
+    ), "Expected no fabricated class_name field on the no-op path"
+
+
+def test_rename_detections_when_detections_have_no_class_name_data_and_strict() -> None:
+    # given
+    detections = sv.Detections(
+        xyxy=np.array([[0, 1, 2, 3], [0, 1, 2, 3]]),
+        class_id=np.array([10, 11]),
+        confidence=np.array([0.3, 0.4]),
+    )
+
+    # when / then - strict mode cannot guarantee class_map coverage without class
+    # names, so it raises rather than emitting a length-mismatched result.
+    with pytest.raises(OperationError):
+        rename_detections(
+            detections=detections,
+            class_map={"a": "A"},
+            strict=True,
+            new_classes_id_offset=1024,
+            global_parameters={},
+        )
+
+
+def test_rename_detections_when_detections_are_empty_is_a_noop() -> None:
+    # given
+    detections = sv.Detections.empty()
+
+    # when - empty detections have nothing to rename; both modes return a
+    # consistent (empty) result without raising.
+    non_strict = rename_detections(
+        detections=detections,
+        class_map={"a": "A"},
+        strict=False,
+        new_classes_id_offset=1024,
+        global_parameters={},
+    )
+    strict = rename_detections(
+        detections=detections,
+        class_map={"a": "A"},
+        strict=True,
+        new_classes_id_offset=1024,
+        global_parameters={},
+    )
+
+    # then
+    assert isinstance(non_strict, sv.Detections) and len(non_strict) == 0
+    assert isinstance(strict, sv.Detections) and len(strict) == 0
 
 
 def test_rename_detections_when_mapping_is_parametrised() -> None:

--- a/tests/workflows/unit_tests/core_steps/common/query_language/operations/detections/test_base.py
+++ b/tests/workflows/unit_tests/core_steps/common/query_language/operations/detections/test_base.py
@@ -145,6 +145,32 @@ def test_rename_detections_when_non_strict_mode_enabled_and_not_all_classes_pres
     ], "Expected to change with mapping"
 
 
+def test_rename_detections_when_detections_have_no_class_name_data() -> None:
+    # given
+    detections = sv.Detections(
+        xyxy=np.array([[0, 1, 2, 3], [0, 1, 2, 3]]),
+        class_id=np.array([10, 11]),
+        confidence=np.array([0.3, 0.4]),
+    )
+
+    # when
+    result = rename_detections(
+        detections=detections,
+        class_map={"a": "A"},
+        strict=False,
+        new_classes_id_offset=1024,
+        global_parameters={},
+    )
+
+    # then
+    assert isinstance(
+        result, sv.Detections
+    ), "Expected a handled result, not a raw AttributeError"
+    assert (
+        result.data["class_name"].tolist() == []
+    ), "Expected empty class_name when input carries no class_name"
+
+
 def test_rename_detections_when_mapping_is_parametrised() -> None:
     # given
     detections = sv.Detections(

--- a/tests/workflows/unit_tests/core_steps/common/query_language/operations/test_strings_operations.py
+++ b/tests/workflows/unit_tests/core_steps/common/query_language/operations/test_strings_operations.py
@@ -1,0 +1,34 @@
+import pytest
+
+from inference.core.workflows.core_steps.common.query_language.errors import (
+    InvalidInputTypeError,
+)
+from inference.core.workflows.core_steps.common.query_language.operations.core import (
+    execute_operations,
+)
+
+
+@pytest.mark.parametrize(
+    "value, regex, expected",
+    [
+        ("hello", "hello", True),
+        ("hello world", "hello", True),
+        ("say hello", "hello", True),
+        ("hello", "^hello$", True),
+        ("hello", "world", False),
+        ("world", "hello", False),
+        ("hell", "hello", False),
+    ],
+)
+def test_string_matches_operation(value: str, regex: str, expected: bool) -> None:
+    """StringMatches returns True when the string matches the regex and False otherwise."""
+    operations = [{"type": "StringMatches", "regex": regex}]
+    result = execute_operations(value=value, operations=operations)
+    assert result is expected
+
+
+def test_string_matches_operation_invalid_input_raises() -> None:
+    """StringMatches raises InvalidInputTypeError for non-string input."""
+    operations = [{"type": "StringMatches", "regex": "hello"}]
+    with pytest.raises(InvalidInputTypeError):
+        execute_operations(value=123, operations=operations)

--- a/tests/workflows/unit_tests/core_steps/fusion/test_detections_classes_replacement.py
+++ b/tests/workflows/unit_tests/core_steps/fusion/test_detections_classes_replacement.py
@@ -1,3 +1,5 @@
+import sys
+
 import numpy as np
 import pytest
 import supervision as sv
@@ -392,6 +394,78 @@ def test_classes_replacement_when_empty_classification_predictions_fallback_clas
     assert (
         detections.class_id[1] == 123
     ), "class id expected to be set to value passed with fallback_class_id parameter"
+    assert (
+        detections.data["class_name"][1] == "unknown"
+    ), "class name expected to be set to value passed with fallback_class_name parameter"
+
+
+def test_classes_replacement_when_empty_classification_predictions_fallback_class_provided_with_default_class_id():
+    # given
+    step = DetectionsClassesReplacementBlockV1()
+    detections = sv.Detections(
+        xyxy=np.array(
+            [
+                [10, 20, 30, 40],
+                [11, 21, 31, 41],
+            ]
+        ),
+        class_id=np.array([7, 7]),
+        confidence=np.array([0.36, 0.91]),
+        data={
+            "class_name": np.array(["animal", "animal"]),
+            "detection_id": np.array(["zero", "one"]),
+        },
+    )
+    first_cls_prediction = ClassificationInferenceResponse(
+        image=InferenceResponseImage(width=128, height=256),
+        predictions=[
+            ClassificationPrediction(
+                **{"class": "cat", "class_id": 0, "confidence": 0.6}
+            ),
+            ClassificationPrediction(
+                **{"class": "dog", "class_id": 1, "confidence": 0.4}
+            ),
+        ],
+        top="cat",
+        confidence=0.6,
+        parent_id="some",
+    ).dict(by_alias=True, exclude_none=True)
+    first_cls_prediction["parent_id"] = "zero"
+    second_cls_prediction = ClassificationInferenceResponse(
+        image=InferenceResponseImage(width=128, height=256),
+        predictions=[],
+        top="cat",
+        confidence=0.6,
+        parent_id="some",
+    ).dict(by_alias=True, exclude_none=True)
+    second_cls_prediction["parent_id"] = "one"
+    classification_predictions = Batch(
+        content=[
+            first_cls_prediction,
+            second_cls_prediction,
+        ],
+        indices=[(0, 0), (0, 1)],
+    )
+
+    # when
+    result = step.run(
+        object_detection_predictions=detections,
+        classification_predictions=classification_predictions,
+        fallback_class_name="unknown",
+        fallback_class_id=None,
+    )
+
+    # then
+    assert (
+        len(result["predictions"]) == 2
+    ), "Expected both detections to be preserved via fallback class"
+    detections = result["predictions"]
+    assert (
+        detections.confidence[1] == 0
+    ), "Fallback class confidence expected to be set to 0"
+    assert (
+        detections.class_id[1] == sys.maxsize
+    ), "class id expected to fall back to sys.maxsize when fallback_class_id left as None"
     assert (
         detections.data["class_name"][1] == "unknown"
     ), "class name expected to be set to value passed with fallback_class_name parameter"

--- a/tests/workflows/unit_tests/core_steps/sinks/test_local_file.py
+++ b/tests/workflows/unit_tests/core_steps/sinks/test_local_file.py
@@ -177,6 +177,62 @@ def test_saving_files_when_allowed_write_directory_does_not_match(
         )
 
 
+def test_saving_separate_file_when_file_name_prefix_attempts_path_traversal(
+    empty_directory: str,
+) -> None:
+    # given
+    sandbox = os.path.join(empty_directory, "sandbox")
+    os.makedirs(sandbox, exist_ok=True)
+    escaped_target = os.path.join(empty_directory, "escaped.txt")
+    block = LocalFileSinkBlockV1(
+        allow_access_to_file_system=True, allowed_write_directory=sandbox
+    )
+
+    # when
+    with pytest.raises(ValueError):
+        _ = block.run(
+            content="content-1",
+            file_type="txt",
+            output_mode="separate_files",
+            target_directory=sandbox,
+            file_name_prefix="../escaped",
+            max_entries_per_file=100,
+        )
+
+    # then
+    assert not glob(
+        os.path.join(empty_directory, "escaped_*.txt")
+    ), "Traversal via file_name_prefix must not write outside the allowed directory"
+    assert not os.path.exists(escaped_target)
+
+
+def test_saving_append_log_when_file_name_prefix_attempts_path_traversal(
+    empty_directory: str,
+) -> None:
+    # given
+    sandbox = os.path.join(empty_directory, "sandbox")
+    os.makedirs(sandbox, exist_ok=True)
+    block = LocalFileSinkBlockV1(
+        allow_access_to_file_system=True, allowed_write_directory=sandbox
+    )
+
+    # when
+    result = block.run(
+        content="content-1",
+        file_type="txt",
+        output_mode="append_log",
+        target_directory=sandbox,
+        file_name_prefix="../escaped",
+        max_entries_per_file=100,
+    )
+
+    # then
+    assert result["error_status"] is True
+    assert not glob(
+        os.path.join(empty_directory, "escaped_*.txt")
+    ), "Traversal via file_name_prefix must not write outside the allowed directory"
+
+
 def test_saving_json_into_separate_files(empty_directory: str) -> None:
     # given
     block = LocalFileSinkBlockV1(

--- a/tests/workflows/unit_tests/core_steps/sinks/test_slack_notification.py
+++ b/tests/workflows/unit_tests/core_steps/sinks/test_slack_notification.py
@@ -222,6 +222,7 @@ def test_send_slack_notification_when_operation_succeeds_without_attachments() -
         channel="some",
         text="msg",
     )
+    client.files_upload_v2.assert_not_called()
     assert result[0] is False
 
 
@@ -238,7 +239,7 @@ def test_send_slack_notification_when_operation_succeeds_with_attachments() -> N
     )
 
     # then
-    client.chat_postMessage.files_upload_v2(
+    client.files_upload_v2.assert_called_once_with(
         channel="some",
         initial_comment="msg",
         file_uploads=[{"title": "some", "content": b"data"}],

--- a/tests/workflows/unit_tests/core_steps/transformations/test_detection_offset.py
+++ b/tests/workflows/unit_tests/core_steps/transformations/test_detection_offset.py
@@ -7,8 +7,10 @@ from pydantic import ValidationError
 
 from inference.core.workflows.core_steps.transformations.detection_offset.v1 import (
     BlockManifest,
+    DetectionOffsetBlockV1,
     offset_detections,
 )
+from inference.core.workflows.execution_engine.entities.base import Batch
 
 
 @pytest.mark.parametrize(
@@ -181,6 +183,41 @@ def test_offset_detection_with_percentage() -> None:
 
     # then
     x1, y1, x2, y2 = result.xyxy[0]
+    assert x1 == 85, "Left corner should be moved by 5% of detection width to the left"
+    assert y1 == 180, "Top corner should be moved by 5% of detection height to the top"
+    assert (
+        x2 == 415
+    ), "Right corner should be moved by 5% of detection width to the right"
+    assert (
+        y2 == 620
+    ), "Bottom corner should be moved by 5% of detection height to the bottom"
+
+
+def test_run_offsets_by_percentage_when_percent_units_selected() -> None:
+    # given
+    detections = sv.Detections(
+        xyxy=np.array([[100, 200, 400, 600]], dtype=np.float64),
+        class_id=np.array([1]),
+        confidence=np.array([0.5], dtype=np.float64),
+        data={
+            "detection_id": np.array(["three"]),
+            "class_name": np.array(["truck"]),
+            "parent_id": np.array(["p3"]),
+            "image_dimensions": np.array([[640, 640]]),
+        },
+    )
+    block = DetectionOffsetBlockV1()
+
+    # when
+    result = block.run(
+        predictions=Batch(content=[detections], indices=[(0,)]),
+        offset_width=10,
+        offset_height=10,
+        units="Percent (%)",
+    )
+
+    # then
+    x1, y1, x2, y2 = result[0]["predictions"].xyxy[0]
     assert x1 == 85, "Left corner should be moved by 5% of detection width to the left"
     assert y1 == 180, "Top corner should be moved by 5% of detection height to the top"
     assert (


### PR DESCRIPTION
## What does this PR do?

Rolls up **37 small, independent, low-risk fixes** onto one integration branch (`fixes/smaller-out-of-batch-changes`) so they can land in `main` as a single merge. Each fix originated as its own standalone PR from an in-depth engineering review of the codebase; these are the ones judged safe to merge at first glance. Every change is self-contained — no shared refactors, no behavioral change beyond fixing the documented bug — and touches a narrow surface.

**+368 / −65 across 40 files · 37 commits** (one squashed fix per commit).

**Related Issue(s):** surfaced by an internal engineering review (no external issue).

## Type of Change

- **Bug fix (non-breaking)** — the bulk of the batch.
- A handful are **documentation / comment corrections** (stale defaults, misleading messages).

## Highlights — silent wrong-output & reliability

These are the fixes most worth a second look; each is a bug that produced a *wrong result or outage on a normal path*, not a crash:

- **Inverted `StringMatches` UQL operator** (#2559) — the operator returned the negation of the correct result, so any Workflow using it to filter or branch silently took the wrong path.
- **Detection Offset `percentage` mode never activated** (#2558) — the percentage code path was unreachable, so percentage-configured offsets were silently mis-applied.
- **Every intended 4xx became a 500** (#2557) — route decorators swallowed `HTTPException` status/detail, turning deliberate 400/401/404 responses into opaque 500s.
- **Server unreachable on a non-default `--port`** (#2552) — the CLI bound the wrong port.
- **`collect_tags` mutated a module-global in place** (#2551) — active-learning tags bled across requests.

## Security

| Fix | Severity | Source |
|---|---|---|
| Path traversal via `file_name_prefix` in the Local File sink | High | #2572 |
| Cloud-deploy left a temp YAML holding the Roboflow API key on disk | Medium | #2574 |
| CSV formula injection in the CSV Formatter block | Medium | #2578 |
| Token/header leak from `append_extra_headers` mutating the caller's dict | Low | #2599 |

## Full contents

### High (7)
| Fix | Source |
|---|---|
| Fix inverted StringMatches query-language operation | #2559 |
| Fix Detection Offset percentage mode never activating | #2558 |
| Catch TypeError for None fallback_class_id in detections classes replacement | #2556 |
| Preserve HTTPException status/detail in route decorators | #2557 |
| Fix collect_tags mutating global ACTIVE_LEARNING_TAGS in place | #2551 |
| Fix inference server unreachable on non-default --port | #2552 |
| Prevent path traversal via file_name_prefix in local file sink | #2572 |

### Medium (9)
| Fix | Source |
|---|---|
| Fix async image loader re-encoding local files to JPEG | #2568 |
| Guard SIFT comparison against None descriptors | #2569 |
| Fix dominant color returning wrong color when a K-means cluster is empty | #2571 |
| Guard size measurement object loop against None dimensions | #2573 |
| Delete cloud-deploy temp YAML holding the Roboflow API key | #2574 |
| Clip absolute static crop to image bounds instead of numpy wrap-around | #2575 |
| Neutralize CSV formula injection in CSV Formatter block | #2578 |
| Guard serverless auth-denial logger when API logging disabled | #2580 |
| Fix Dynamic Zones polygon metadata to match scaled mask and zones | #2581 |

### Low (14)
| Fix | Source |
|---|---|
| Copy status_update_handlers before appending watchdog handler | #2584 |
| Install inference warning filters before env.py's own warn calls | #2589 |
| Remap negative fallback_class_id to sys.maxsize in string-input None branch | #2588 |
| Coerce blur kernel_size to positive odd for gaussian/median | #2590 |
| Raise InvalidInputTypeError for unmapped mode in select_detections | #2593 |
| Guard zero-std division in Identify Changes outlier detection | #2591 |
| Add request timeout to data-staging file download | #2594 |
| Fix rename_detections crash on detections without class_name | #2606 |
| Fix florence open-vocabulary branch to use equality not substring match | #2596 |
| Wrap str() failures in to_string query-language op | #2592 |
| Fix append_extra_headers mutating caller's headers dict (token leak) | #2599 |
| Fix typo 'MP$' -> 'MP4' in VIDEOS_EXTENSIONS | #2600 |
| Guard empty choices list in direct OpenRouter path | #2602 |
| Fix stabilize_detections crash on empty frame with tracker_id=None | #2608 |

### Nit (7)
| Fix | Source |
|---|---|
| Fix pull_image cached-image log to print image name | #2601 |
| Fix misleading divide() error message in query language numbers ops | #2604 |
| Fix CONFIDENCE default comment (40%, not 50%) | #2605 |
| Fix swapped OWLv2 image-cache-size default doc comments | #2607 |
| Fix stale file-lock timeout default in docstrings (10 -> 20) | #2612 |
| Fix contradictory channel-count error message in pre-processing | #2609 |
| Fix AttributeError in get_full_type_name builtins branch | #2611 |

## Testing

Each fix was verified before its source PR was opened — standalone repros where the logic was self-contained (regex / arithmetic / numpy / pure logic), careful re-analysis against the reviewed code otherwise — and several carry added or updated unit tests that drive the corrected path. Every source fix was adversarially reviewed. The full suite runs on this branch in CI.

- [x] I have tested this change locally (per-fix repros)
- [x] I have added/updated tests for this change (subset of fixes)

## Scope — deliberately excluded

Three higher-touch **High-severity** fixes from the same review were retargeted onto this branch but **left as separate open PRs** pending a closer look — they are *not* in this batch:

- **#2553** — template-matching `detection_id` length mismatch after NMS
- **#2562** — SDK sync-infer path leaks the API key inside a `ConnectionError`
- **#2563** — Slack sink fires a spurious empty `files_upload_v2` on text-only notifications

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review
- [x] I have commented code where necessary
- [x] My changes generate no new warnings or errors
- [ ] Documentation updated (several fixes *are* doc/comment corrections)

## Additional Context

Source PRs squashed into this branch: #2551, #2552, #2556, #2557, #2558, #2559, #2568, #2569, #2571, #2572, #2573, #2574, #2575, #2578, #2580, #2581, #2584, #2588, #2589, #2590, #2591, #2592, #2593, #2594, #2596, #2599, #2600, #2601, #2602, #2604, #2605, #2606, #2607, #2608, #2609, #2611, #2612
