### PR TITLE
Deploy modal webexec from inference Docker image

### DIFF
--- a/modal/modal_app.py
+++ b/modal/modal_app.py
@@ -38,7 +38,8 @@ class _NoopDebugTraces:
 app = modal.App("webexec")
 
 
-INFERENCE_VERSION = os.getenv("INFERENCE_VERSION")
+INFERENCE_VERSION = os.getenv("INFERENCE_VERSION", "latest")
+WEBEXEC_INFERENCE_DOCKER_IMAGE = os.getenv("WEBEXEC_INFERENCE_DOCKER_IMAGE", "roboflow/roboflow-inference-server-cpu")
 
 WEBEXEC_MODAL_CLOUD = os.environ.get("WEBEXEC_MODAL_CLOUD", "aws")
 WEBEXEC_MODAL_REGION = os.environ.get("WEBEXEC_MODAL_REGION", "us-east-1")
@@ -47,20 +48,10 @@ WEBEXEC_MODAL_ROUTING_REGION = os.environ.get("WEBEXEC_MODAL_ROUTING_REGION")
 
 def get_inference_image():
     """Get the Modal Image for inference."""
-    if INFERENCE_VERSION:
-        inference_version = f"inference=={INFERENCE_VERSION}"
-    else:
-        try:
-            from inference.core.version import __version__
-
-            inference_version = f"inference=={__version__}"
-        except ImportError:
-            # If we can't import inference (e.g., during deployment), use latest
-            inference_version = "inference"
 
     # Use the pre-built shared image or create on-the-fly
     image = (
-        modal.Image.debian_slim(python_version="3.11")
+        modal.Image.from_registry(f"{WEBEXEC_INFERENCE_DOCKER_IMAGE}:{INFERENCE_VERSION}")
         .apt_install(
             "libgl1-mesa-glx",
             "libglib2.0-0",
@@ -71,8 +62,8 @@ def get_inference_image():
             "ffmpeg",
             "wget",
         )
-        .pip_install(inference_version)
         .pip_install("fastapi[standard]")  # Add FastAPI for web endpoints
+        .entrypoint([])
     )
     return image
 

--- a/modal/modal_app.py
+++ b/modal/modal_app.py
@@ -38,7 +38,7 @@ class _NoopDebugTraces:
 app = modal.App("webexec")
 
 
-INFERENCE_VERSION = os.getenv("INFERENCE_VERSION", "latest")
+INFERENCE_VERSION = os.getenv("INFERENCE_VERSION")
 WEBEXEC_INFERENCE_DOCKER_IMAGE = os.getenv("WEBEXEC_INFERENCE_DOCKER_IMAGE", "roboflow/roboflow-inference-server-cpu")
 
 WEBEXEC_MODAL_CLOUD = os.environ.get("WEBEXEC_MODAL_CLOUD", "aws")
@@ -50,6 +50,15 @@ def get_inference_image():
     """Get the Modal Image for inference."""
 
     # Use the pre-built shared image or create on-the-fly
+    global INFERENCE_VERSION
+    if not INFERENCE_VERSION:
+        try:
+            from inference.core.version import __version__
+
+            INFERENCE_VERSION = __version__
+        except ImportError:
+            INFERENCE_VERSION = "latest"
+
     image = (
         modal.Image.from_registry(f"{WEBEXEC_INFERENCE_DOCKER_IMAGE}:{INFERENCE_VERSION}")
         .apt_install(


### PR DESCRIPTION
## What does this PR do?

Currently deploying webexec image requires inference published to pypi, this makes it difficult to test. This change allows us to deploy webexec from Docker image.

## Type of Change

- New feature (non-breaking change that adds functionality)
- Other:

## Testing

Tested locally

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)

## Additional Context

N/A