### PR TITLE
Add basic code rules

### DIFF
--- a/.cursor/rules/cli-options.mdc
+++ b/.cursor/rules/cli-options.mdc
@@ -1,0 +1,27 @@
+---
+description: CLI option conventions for Python scripts
+globs: **/*.py
+alwaysApply: false
+---
+
+# Python CLI Options
+
+When editing Python scripts that define command-line interfaces, use `click`
+for command-line options unless an existing script is already intentionally
+using another parser.
+
+Format each `@click.option(...)` decorator with every option argument and
+keyword parameter on its own line:
+
+```python
+@click.option(
+    "--batch-size",
+    type=click.IntRange(
+        min=1,
+    ),
+    default=1,
+    show_default=True,
+)
+```
+
+Avoid single-line option declarations, even for simple options.

--- a/.cursor/rules/empty-lines.mdc
+++ b/.cursor/rules/empty-lines.mdc
@@ -1,0 +1,35 @@
+---
+description: Python empty-line grouping style
+globs: **/*.py
+alwaysApply: false
+---
+
+# Empty Lines
+
+Use empty lines to make control flow and logical groups easy to scan.
+
+Add an empty line after guard clauses before the main body continues.
+
+```python
+if not items:
+    return []
+
+normalized_items = normalize_items(items=items)
+```
+
+Add an empty line between groups of logically consistent lines, such as input
+validation, setup, core computation, and result construction.
+
+```python
+validate_config(config=config)
+device = resolve_device(device=device)
+
+model = load_model(model_path=model_path, device=device)
+result = profile_model(model=model)
+
+serialized_result = serialize_result(result=result)
+
+return serialized_result
+```
+
+Always end files with a final empty line.

--- a/.cursor/rules/function-call.mdc
+++ b/.cursor/rules/function-call.mdc
@@ -1,0 +1,36 @@
+---
+description: Python function definition and call style
+globs: **/*.py
+alwaysApply: false
+---
+
+# Python Function And Call Style
+
+When a function has one obvious primary argument plus secondary configuration
+arguments, make the secondary arguments keyword-only with `*`.
+
+```python
+def profile_model(
+    model_path: str,
+    *,
+    device: str,
+    batch_size: int,
+) -> ProfileResult:
+    ...
+```
+
+When calling such functions, pass the primary argument positionally and pass
+keyword-only/configuration arguments with explicit names.
+
+```python
+profile_model(
+    model_path,
+    device=device,
+    batch_size=batch_size,
+)
+```
+
+For functions without a clear primary positional argument, prefer explicit
+keyword calls when passing through variables with matching names. Do not force
+this pattern when positional arguments are clearer for a small, well-known API
+or when matching an established third-party interface.

--- a/.cursor/rules/google-docstrings.mdc
+++ b/.cursor/rules/google-docstrings.mdc
@@ -1,0 +1,75 @@
+---
+description: Google-style docstrings for public Python APIs
+globs: **/*.py
+alwaysApply: false
+---
+
+# Docstrings (Google style)
+
+Match [CONTRIBUTING.md](CONTRIBUTING.md) and `mkdocs.yml` (`docstring_style: google`).
+Use full Google sections on **public** symbols; keep **private** helpers light.
+
+## Public vs private
+
+**Public** (require full Google docstrings):
+
+- Functions, methods, and classes whose names do **not** start with `_`
+- Symbols meant for import by other packages or workflow blocks
+
+**Private** (no full Google template required):
+
+- Names starting with `_` (including `_helper` nested functions)
+- May use a one-line summary, a short narrative docstring, or targeted `#` comments
+  where behavior is non-obvious
+
+## Public function template
+
+```python
+def collect_items(
+    workflow_definition: Dict[str, Any],
+    *,
+    include_nested: bool = True,
+) -> List[dict]:
+    """Collect dynamic block definitions from a workflow tree.
+
+    Walks ``workflow_definition`` and nested inner workflows depth-first.
+    When the same ``block_type`` appears twice, the first occurrence wins.
+
+    Args:
+        workflow_definition: Parsed workflow JSON (steps, nested definitions).
+        include_nested: If False, only read the root ``dynamic_blocks_definitions``.
+
+    Returns:
+        Merged list of dynamic block definition dicts, deduplicated by block type.
+
+    Raises:
+        WorkflowDefinitionError: If ``workflow_definition`` is not a mapping.
+    """
+```
+
+Rules:
+
+- Opening summary: imperative or descriptive, one line; add a blank line before sections.
+- Document every parameter in ``Args:`` as ``name (type): description`` (type may match annotations).
+- Add ``Returns:`` when the return value is not ``None`` or needs explanation.
+- Add ``Raises:`` only for exceptions callers should handle; omit the section if none apply.
+- Optional: ``Note:`` / ``Notes:`` / ``Example:`` for non-obvious behavior (same as existing core code).
+
+## Classes and modules
+
+- **Public classes**: class docstring plus Google sections on public methods.
+- **Modules**: a short module docstring at the top when the file exposes a cohesive API
+  (common in workflows and core).
+
+## When editing
+
+- Adding or changing a **public** function → add or update the full Google docstring.
+- Refactoring only **private** helpers → brief comment or narrative docstring is enough.
+- Do not convert private helpers to verbose Google docstrings unless the user asks.
+
+## Avoid
+
+- NumPy style (``Parameters:``, ``Attributes:``) and Sphinx reST (``:param:``).
+- Narrative-only public docstrings that skip ``Args:`` / ``Returns:`` when parameters or
+  return values exist.
+- Docstrings that duplicate types with no extra meaning (e.g. ``x (int): An int.``).

--- a/.cursor/rules/pathlib.mdc
+++ b/.cursor/rules/pathlib.mdc
@@ -1,0 +1,31 @@
+---
+description: Prefer pathlib for Python path handling
+globs: **/*.py
+alwaysApply: false
+---
+
+# Path Handling
+
+When working with filesystem paths, prefer `pathlib.Path` objects and `pathlib`
+methods over `os.path` utilities when the surrounding code can accept `Path`
+values.
+
+```python
+from pathlib import Path
+
+model_path = Path(cache_dir) / "weights.onnx"
+
+if model_path.exists():
+    load_model(model_path=model_path)
+```
+
+Avoid new `os.path.join`, `os.path.exists`, `os.path.dirname`, or similar usage
+unless compatibility with an existing API or string-only path contract requires
+it.
+
+```python
+model_path = os.path.join(cache_dir, "weights.onnx")
+
+if os.path.exists(model_path):
+    load_model(model_path=model_path)
+```

--- a/.cursor/rules/pr-description.mdc
+++ b/.cursor/rules/pr-description.mdc
@@ -1,0 +1,131 @@
+---
+description: >-
+  Draft GitHub PR descriptions in Roboflow format (Linear link, testing,
+  checklist). Invoke with @pr-description — not applied automatically.
+alwaysApply: false
+---
+
+# Roboflow PR description
+
+Use this rule only when the user @mentions `pr-description` or asks to draft a
+PR body in Roboflow format. Do not apply for unrelated tasks.
+
+## Before writing
+
+1. Gather context from the branch (run in parallel when possible):
+   - `git log main...HEAD --oneline` (or the repo’s default base branch)
+   - `git diff main...HEAD`
+   - `git status`
+2. Ask for anything missing:
+   - **Linear issue ID** (e.g. `INF-1234`) and short issue title for the link
+   - **Type of change** (which checklist item applies)
+   - **Test commands** actually run, if not obvious from the diff
+3. Infer content from changed files, commit messages, and tests — do not invent
+   behavior or test results.
+
+## Output
+
+Return a single markdown block ready to paste into `gh pr create --body` or the
+GitHub UI. Use the template below exactly (headings and checklist structure).
+
+## Section guidelines
+
+### What does this PR do?
+
+Write three parts under the HTML comment (replace the comment with real text):
+
+1. **Context (2–3 sentences):** Initial problem, why this change was needed.
+2. **How it works (5–6 sentences):** High-level behavior — no implementation
+   detail, no line-by-line walkthrough.
+3. **Main elements:** Bullet list of major components touched (modules, utils,
+   new dependencies, API surface, docs).
+
+### Type of Change
+
+Check exactly one primary box. Use **Other** only when none fit; add a short label
+after the colon.
+
+### Testing
+
+Structure as:
+
+- **Unit tests** — bullet list of what is covered (files or behaviors), not
+  every assertion.
+- **Integration tests** — separate subsection; list **scenarios** exercised.
+- **Other** — benchmarks, profiling, manual/local runs during development.
+
+If a category does not apply, say so briefly (e.g. “No integration tests in
+this PR.”). Only list commands/tests that were run or are clearly added in the
+diff.
+
+### Checklist
+
+Leave boxes unchecked unless the user confirmed each item. Do not check items
+you cannot verify from the conversation or diff.
+
+### Additional Context
+
+Optional: screenshots, rollout notes, follow-ups, breaking-change migration.
+Omit the section if there is nothing to add.
+
+---
+
+## Template
+
+```markdown
+## What does this PR do?
+
+Linked issue: [<issue-id>](https://linear.app/roboflow/issue/<issue-id>/<issue-slug>)
+
+<Paragraph 1: context — problem and motivation, 2–3 sentences.>
+
+<Paragraph 2: how the feature/fix works at a high level, 5–6 sentences.>
+
+**Main elements:**
+- <component or area>
+- <component or area>
+
+## Type of Change
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
+- [ ] Refactoring (no functional changes)
+- [ ] Other:
+
+## Testing
+
+### Unit tests
+
+- <what was tested>
+
+### Integration tests
+
+- <scenario> (or: None for this PR.)
+
+### Other
+
+- <commands run, e.g. pytest paths, make check_code_quality, manual checks>
+
+## Checklist
+
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code where necessary, particularly in hard-to-understand areas
+- [ ] My changes generate no new warnings or errors
+- [ ] I have updated the documentation accordingly (if applicable)
+
+## Additional Context
+
+<!-- Optional: screenshots, migration notes, follow-ups -->
+```
+
+**Linear URL:** `issue-slug` is the lowercase hyphenated title segment Linear
+uses in the URL (e.g. `fix-dynamic-blocks-in-inner-workflow`). If unknown, use
+`i` + slug placeholder and ask the user to fix the link.
+
+## Creating the PR
+
+When the user wants the PR opened, use `gh pr create` with a HEREDOC body after
+pushing the branch. Do not push unless asked.

--- a/.cursor/rules/pydantic-field-descriptions.mdc
+++ b/.cursor/rules/pydantic-field-descriptions.mdc
@@ -1,0 +1,37 @@
+---
+description: Pydantic model field documentation style
+globs: **/*.py
+alwaysApply: false
+---
+
+# Pydantic `Field` descriptions and examples
+
+When defining Pydantic `BaseModel` classes (tool I/O, resources, metadata), document
+fields with `pydantic.Field` rather than bare annotations.
+
+Use `description` for every field. Add `examples` when a concrete value helps agents,
+CLI users, or schema consumers.
+
+```python
+from pydantic import BaseModel, Field
+
+
+class DownloadPackageResult(BaseModel):
+    package_id: str = Field(
+        description="Package identifier that was downloaded.",
+        examples=["pkg-trt-a"],
+    )
+    package_path: str = Field(
+        description="Local filesystem path to the package directory.",
+        examples=["/tmp/inference_model_packages/yolov8n-640/pkg-trt-a"],
+    )
+```
+
+Match the richness of existing metadata models such as `TorchBackendMetadata` in
+`src/metadata/metadata.py`.
+
+Exceptions:
+
+- `ToolManifest` / `ResourceManifest` may store `Type[BaseModel]` references and
+  require `model_config = {"arbitrary_types_allowed": True}`.
+- Private helpers do not need Pydantic models.

--- a/.cursor/rules/return-values.mdc
+++ b/.cursor/rules/return-values.mdc
@@ -1,0 +1,25 @@
+---
+description: Python return value style
+globs: **/*.py
+alwaysApply: false
+---
+
+# Return Values
+
+Prefer returning named variables rather than calling functions directly on
+`return` lines. This keeps the final step easy to inspect and gives the
+intermediate value a meaningful name.
+
+```python
+serialized_result = serialize_result(result=result)
+
+return serialized_result
+```
+
+Avoid:
+
+```python
+return serialize_result(result=result)
+```
+
+Simple literal or already-bound returns are fine.

--- a/.cursor/rules/uv-package-management.mdc
+++ b/.cursor/rules/uv-package-management.mdc
@@ -1,0 +1,60 @@
+---
+description: Bootstrap and manage new Python projects with uv
+alwaysApply: true
+---
+
+# New Python projects — use uv
+
+When managing Python project,s use [uv](https://docs.astral.sh/uv/) for environments, dependencies, and packaging. Do not use Poetry, Pipenv, or a bare `requirements.txt` unless migrating an existing project.
+
+## Initializing projects
+
+```bash
+uv init <project-name>
+cd <project-name>
+```
+
+Or adopt an existing package: add `pyproject.toml` (PEP 621), then `uv lock` and `uv sync`.
+
+## Day-to-day
+
+| Task | Command |
+|------|---------|
+| Create venv only | `uv venv --python 3.12` |
+| Install from lockfile | `uv sync` |
+| Add / remove dependency | `uv add <pkg>` / `uv remove <pkg>` |
+| Add dev / test deps | `uv add --dev <pkg>` or `uv add --group dev <pkg>` |
+| Upgrade one package | `uv lock --upgrade-package <pkg>` |
+| Run in project env | `uv run pytest` / `uv run python -m ...` |
+| One-off script with deps | `uv add --script script.py <pkg>` then `uv run script.py` |
+
+Prefer `uv sync` for local development (creates `.venv`, editable install, honors lockfile). Use `uv pip install` when targeting a non-default environment (CI matrix, `--system`, `--python path/to/python`).
+
+## Lockfile and packaging
+
+- Commit `uv.lock` with dependency changes; update via `uv add` / `uv remove` / `uv lock`, not by editing the lockfile by hand.
+- Keep runtime deps in `[project.dependencies]`; use optional extras or dependency groups for dev/test/tooling.
+- Build and publish with `uv build` and `uv publish` in new release pipelines.
+
+## CI
+
+Reproducible installs:
+
+```bash
+uv sync --locked --all-extras   # or pass only needed --extra flags
+```
+
+Or, when installing into a pre-created venv:
+
+```bash
+uv venv
+uv pip install -e ".[test]" --python .venv
+```
+
+## Do not
+
+- Add `requirements.in` / `requirements.txt` as the primary dependency source.
+- Use `pip install` or `conda install` to mutate project dependencies outside uv.
+- Mix multiple lock systems (e.g. Poetry lock + `uv.lock`) in the same package.
+
+When joining an **existing** repo, follow that repo's established tooling unless the user asks to migrate.


### PR DESCRIPTION
## What does this PR do?

Introduces rules to standardise code writing in repo:
- `cli-options.mdc`: For Python CLI scripts, prefer click options unless the file already uses another parser. Format each @click.option(...) over multiple lines, with each argument and keyword on its own line.
- `empty-lines.mdc`: Use blank lines to separate guard clauses and logical phases like validation, setup, computation, and result construction. Python files should end with a final empty line.
- `function-call.mdc`: For Python functions with one primary argument plus configuration, make configuration arguments keyword-only with *. Calls should pass the primary argument positionally and configuration arguments by explicit keyword.
- `google-docstrings.mdc`: Public Python APIs should use full Google-style docstrings with Args, Returns, and Raises where relevant. Private helpers can stay lightweight with short docstrings or comments.
- `pathlib.mdc`: Prefer pathlib.Path and Path methods for filesystem paths when surrounding code supports it. Avoid adding new os.path.* usage unless required by a string-only API or existing compatibility constraint.
- `pr-description.mdc`: When explicitly asked for a Roboflow PR description, gather branch context, Linear issue info, change type, and real test commands. Output the exact Roboflow markdown template without inventing behavior or test results.
- `pydantic-field-descriptions.mdc`: Pydantic BaseModel fields should use Field(...) with a description, and examples when concrete values help schema consumers or agents. Private helpers do not need Pydantic models.
- `return-values.mdc`: Prefer assigning computed return values to a named variable before returning. Simple literals and already-bound values can be returned directly.
- `uv-package-management.mdc`: For new Python projects, use uv for environments, dependency management, locking, building, and publishing. In existing repos, follow the repo’s established tooling unless asked to migrate.