### PR TITLE
feat(sdk): VideoFileSource accepts http(s) URLs with disk caching

### DIFF
--- a/docs/inference_helpers/inference_sdk/webrtc.md
+++ b/docs/inference_helpers/inference_sdk/webrtc.md
@@ -229,6 +229,9 @@ Uploads a video file to the server over the data channel; the server processes i
 ```python
 source = VideoFileSource("video.mp4")
 
+# http(s) URLs work too - the video is downloaded before upload
+source = VideoFileSource("https://example.com/videos/cars.mp4")
+
 # Track upload progress and process at original FPS (live-preview pacing)
 source = VideoFileSource(
     "video.mp4",
@@ -238,6 +241,8 @@ source = VideoFileSource(
 ```
 
 By default frames come back through the data channel (guaranteed order and quality). Pass `use_datachannel_frames=False` to receive them via a hardware-accelerated WebRTC video track instead (lower bandwidth).
+
+URL sources are cached on disk (keyed by URL) in `~/.cache/inference-sdk/videos` (override with `INFERENCE_SDK_VIDEO_CACHE_DIR`), so re-running the same video skips the download. Pass `use_cache=False` to download to a temporary file that is deleted when the session ends. Downloads honour the SDK's URL-input policy and SSRF protections (same config flags as image URL input).
 
 ### ManualSource
 

--- a/inference/core/version.py
+++ b/inference/core/version.py
@@ -1,4 +1,4 @@
-__version__ = "1.3.6"
+__version__ = "1.3.7"
 
 
 if __name__ == "__main__":

--- a/inference_sdk/http/utils/url_utils.py
+++ b/inference_sdk/http/utils/url_utils.py
@@ -18,11 +18,12 @@ FQDN (empty for IPs and hosts without a public suffix) for the
 against the concatenated ``subdomain.domain.suffix`` network location.
 """
 
+import contextlib
 import ipaddress
 import socket
 import urllib.parse
 import warnings
-from typing import Any, Dict, List, Mapping, Optional, Set, Tuple, Union
+from typing import Any, Dict, Iterator, List, Mapping, Optional, Set, Tuple, Union
 
 import aiohttp
 import requests
@@ -324,16 +325,49 @@ def fetch_url_bytes(url: str, request_timeout: Optional[float] = None) -> bytes:
     honouring the SDK config flags. This is the sync entry point used by the
     loaders.
     """
-    prepared_url = validate_url_destination(url)
-    session = _build_sync_session(config.ALLOW_URL_TO_NON_GLOBAL_ADDRESSES)
-    try:
-        if config.VALIDATE_IMAGE_URL_REDIRECTS:
-            return _fetch_validating_redirects_sync(
+    with _map_url_fetch_errors(resource_name="image"):
+        prepared_url = validate_url_destination(url)
+        session = _build_sync_session(config.ALLOW_URL_TO_NON_GLOBAL_ADDRESSES)
+        try:
+            response = _open_url_response_sync(
                 session=session, url=prepared_url, request_timeout=request_timeout
             )
-        return _fetch_legacy_sync(
-            session=session, url=prepared_url, request_timeout=request_timeout
-        )
+            with response:
+                return response.content
+        finally:
+            session.close()
+
+
+def fetch_url_to_file(
+    url: str, destination_path: str, request_timeout: Optional[float] = None
+) -> None:
+    """Validate ``url`` and stream its content to ``destination_path`` with the
+    same SSRF protections as :func:`fetch_url_bytes`. Suitable for large files
+    (e.g. videos) that should not be buffered in memory.
+    """
+    with _map_url_fetch_errors(resource_name="file"):
+        prepared_url = validate_url_destination(url)
+        session = _build_sync_session(config.ALLOW_URL_TO_NON_GLOBAL_ADDRESSES)
+        try:
+            response = _open_url_response_sync(
+                session=session, url=prepared_url, request_timeout=request_timeout
+            )
+            with response, open(destination_path, "wb") as f:
+                for chunk in response.iter_content(
+                    chunk_size=_FILE_DOWNLOAD_CHUNK_SIZE
+                ):
+                    f.write(chunk)
+        finally:
+            session.close()
+
+
+_FILE_DOWNLOAD_CHUNK_SIZE = 1024 * 1024  # 1 MiB
+
+
+@contextlib.contextmanager
+def _map_url_fetch_errors(resource_name: str) -> Iterator[None]:
+    try:
+        yield
     except HTTPError:
         # HTTP-status errors keep flowing so wrap_errors maps them to
         # HTTPCallErrorError (status code + api message preserved).
@@ -344,28 +378,36 @@ def fetch_url_bytes(url: str, request_timeout: Optional[float] = None) -> bytes:
     except requests.exceptions.RequestException as error:
         # ConnectionError, TooManyRedirects, Timeout, ... -> uniform SDK error.
         raise HTTPClientError(
-            f"Could not load image from URL. Details: "
+            f"Could not load {resource_name} from URL. Details: "
             f"{deduct_api_key_from_string(str(error))}"
         ) from error
-    finally:
-        session.close()
 
 
-def _fetch_legacy_sync(
+def _open_url_response_sync(
     session: requests.Session, url: str, request_timeout: Optional[float]
-) -> bytes:
+) -> requests.Response:
+    if config.VALIDATE_IMAGE_URL_REDIRECTS:
+        return _open_validating_redirects_sync(
+            session=session, url=url, request_timeout=request_timeout
+        )
+    return _open_legacy_sync(session=session, url=url, request_timeout=request_timeout)
+
+
+def _open_legacy_sync(
+    session: requests.Session, url: str, request_timeout: Optional[float]
+) -> requests.Response:
     _warn_legacy_redirect_handling()
     session.max_redirects = config.MAX_IMAGE_URL_REDIRECTS
     response = session.get(
         url, stream=True, allow_redirects=True, timeout=request_timeout
     )
     api_key_safe_raise_for_status(response=response)
-    return response.content
+    return response
 
 
-def _fetch_validating_redirects_sync(
+def _open_validating_redirects_sync(
     session: requests.Session, url: str, request_timeout: Optional[float]
-) -> bytes:
+) -> requests.Response:
     current_url = url
     for _ in range(config.MAX_IMAGE_URL_REDIRECTS + 1):
         response = session.get(
@@ -380,7 +422,7 @@ def _fetch_validating_redirects_sync(
             current_url = validate_url_destination(next_url)
             continue
         api_key_safe_raise_for_status(response=response)
-        return response.content
+        return response
     raise requests.exceptions.TooManyRedirects(
         f"Exceeded maximum of {config.MAX_IMAGE_URL_REDIRECTS} redirects."
     )

--- a/inference_sdk/webrtc/sources.py
+++ b/inference_sdk/webrtc/sources.py
@@ -5,10 +5,14 @@ for different video streaming sources (webcam, RTSP, video files, manual frames)
 """
 
 import asyncio
+import hashlib
+import os
+import tempfile
 import threading
 import time
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Tuple
+from urllib.parse import urlparse
 
 import cv2
 import numpy as np
@@ -18,6 +22,7 @@ from aiortc.mediastreams import VIDEO_CLOCK_RATE, VIDEO_PTIME, VIDEO_TIME_BASE
 from av import VideoFrame
 
 from inference_sdk.http.errors import InvalidParameterError
+from inference_sdk.http.utils.url_utils import fetch_url_to_file
 from inference_sdk.webrtc.datachannel import VideoFileUploader
 
 if TYPE_CHECKING:
@@ -27,6 +32,58 @@ if TYPE_CHECKING:
 
 # Type alias for upload progress callback
 UploadProgressCallback = Callable[[int, int], None]  # (uploaded_chunks, total_chunks)
+
+# Cache directory for videos downloaded from http(s) URLs
+VIDEO_DOWNLOAD_CACHE_DIR = os.getenv(
+    "INFERENCE_SDK_VIDEO_CACHE_DIR",
+    os.path.join(os.path.expanduser("~"), ".cache", "inference-sdk", "videos"),
+)
+VIDEO_DOWNLOAD_TIMEOUT_SECONDS = int(
+    os.getenv("INFERENCE_SDK_VIDEO_DOWNLOAD_TIMEOUT", "300")
+)
+
+
+def _download_video(url: str, use_cache: bool) -> str:
+    """Download a video from an http(s) URL to a local file.
+
+    The download goes through fetch_url_to_file, which applies the SDK's
+    URL-input policy and SSRF protections. With use_cache=True the file lands
+    in VIDEO_DOWNLOAD_CACHE_DIR keyed by a hash of the URL and is reused on
+    subsequent calls. With use_cache=False it lands in a fresh temporary file
+    which the caller is expected to delete.
+
+    Returns:
+        Path to the local video file.
+    """
+    ext = os.path.splitext(urlparse(url).path)[1] or ".mp4"
+    if use_cache:
+        os.makedirs(VIDEO_DOWNLOAD_CACHE_DIR, exist_ok=True)
+        cache_key = hashlib.sha256(url.encode("utf-8")).hexdigest()[:32]
+        target_path = os.path.join(VIDEO_DOWNLOAD_CACHE_DIR, f"{cache_key}{ext}")
+        if os.path.isfile(target_path) and os.path.getsize(target_path) > 0:
+            return target_path
+    else:
+        fd, target_path = tempfile.mkstemp(suffix=ext, prefix="inference-sdk-video-")
+        os.close(fd)
+
+    # Download to a sibling temp file, then atomically move into place so a
+    # partially-downloaded file is never mistaken for a cached video.
+    tmp_path = f"{target_path}.part-{os.getpid()}"
+    try:
+        fetch_url_to_file(
+            url=url,
+            destination_path=tmp_path,
+            request_timeout=VIDEO_DOWNLOAD_TIMEOUT_SECONDS,
+        )
+        os.replace(tmp_path, target_path)
+    except Exception:
+        for stale in (tmp_path,) if use_cache else (tmp_path, target_path):
+            try:
+                os.remove(stale)
+            except OSError:
+                pass
+        raise
+    return target_path
 
 
 class StreamSource(ABC):
@@ -385,11 +442,14 @@ class VideoFileSource(StreamSource):
         on_upload_progress: Optional[UploadProgressCallback] = None,
         use_datachannel_frames: bool = True,
         realtime_processing: bool = False,
+        use_cache: bool = True,
     ):
         """Initialize video file source.
 
         Args:
-            path: Path to video file (any format supported by FFmpeg)
+            path: Path to video file (any format supported by FFmpeg), or an
+                http(s) URL to a video file. URLs are downloaded before upload;
+                see use_cache.
             on_upload_progress: Optional callback called during upload with
                 (uploaded_chunks, total_chunks). Use to track upload progress.
             use_datachannel_frames: If enabled, frames are received through the
@@ -400,8 +460,15 @@ class VideoFileSource(StreamSource):
             realtime_processing: If True, process frames at original video FPS
                 (throttled playback for live preview). If False (default),
                 process all frames as fast as possible (batch mode).
+            use_cache: Only relevant when path is an http(s) URL. If True
+                (default), the downloaded video is cached on disk (keyed by
+                URL) and reused on subsequent runs. If False, it is downloaded
+                to a temporary file and deleted when the session ends.
         """
         self.path = path
+        self.use_cache = use_cache
+        self._is_url = path.startswith(("http://", "https://"))
+        self._temp_download_path: Optional[str] = None
         self.on_upload_progress = on_upload_progress
         self.use_datachannel_frames = use_datachannel_frames
         self.realtime_processing = realtime_processing
@@ -471,13 +538,26 @@ class VideoFileSource(StreamSource):
         if not self._upload_channel:
             raise RuntimeError("Upload channel not configured")
 
-        self._uploader = VideoFileUploader(self.path, self._upload_channel)
+        local_path = self.path
+        if self._is_url:
+            local_path = await asyncio.to_thread(
+                _download_video, self.path, self.use_cache
+            )
+            if not self.use_cache:
+                self._temp_download_path = local_path
+
+        self._uploader = VideoFileUploader(local_path, self._upload_channel)
         await self._uploader.upload(on_progress=self.on_upload_progress)
         # self._upload_complete.set()
 
     async def cleanup(self) -> None:
-        """No cleanup needed - upload channel is managed by peer connection."""
-        pass
+        """Remove temporary download (URL source with use_cache=False)."""
+        if self._temp_download_path:
+            try:
+                os.remove(self._temp_download_path)
+            except OSError:
+                pass
+            self._temp_download_path = None
 
 
 # Configuration constants for manual source

--- a/tests/inference_sdk/unit_tests/webrtc/test_video_file_url_source.py
+++ b/tests/inference_sdk/unit_tests/webrtc/test_video_file_url_source.py
@@ -1,0 +1,110 @@
+"""Unit tests for VideoFileSource http(s) URL support."""
+
+import os
+from unittest import mock
+
+import pytest
+
+from inference_sdk.webrtc import sources
+from inference_sdk.webrtc.sources import VideoFileSource, _download_video
+
+VIDEO_URL = "https://example.com/videos/cars.mp4"
+
+
+def _fake_fetch(payload: bytes = b"video-bytes"):
+    def fetch(url: str, destination_path: str, request_timeout=None) -> None:
+        with open(destination_path, "wb") as f:
+            f.write(payload)
+
+    return fetch
+
+
+class TestVideoFileSourceUrlDetection:
+    def test_local_path_is_not_url(self) -> None:
+        source = VideoFileSource("cars.mp4")
+        assert source._is_url is False
+
+    def test_http_and_https_paths_are_urls(self) -> None:
+        assert VideoFileSource("http://example.com/a.mp4")._is_url is True
+        assert VideoFileSource(VIDEO_URL)._is_url is True
+
+    def test_use_cache_defaults_to_true(self) -> None:
+        assert VideoFileSource(VIDEO_URL).use_cache is True
+
+
+class TestDownloadVideo:
+    def test_downloads_to_cache_dir_and_reuses_cached_file(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        cache_dir = str(tmp_path / "cache")
+        monkeypatch.setattr(sources, "VIDEO_DOWNLOAD_CACHE_DIR", cache_dir)
+
+        with mock.patch.object(
+            sources, "fetch_url_to_file", side_effect=_fake_fetch()
+        ) as fetch_mock:
+            first = _download_video(VIDEO_URL, use_cache=True)
+            second = _download_video(VIDEO_URL, use_cache=True)
+
+        assert first == second
+        assert first.startswith(cache_dir)
+        assert first.endswith(".mp4")
+        with open(first, "rb") as f:
+            assert f.read() == b"video-bytes"
+        # Second call served from cache - only one network request
+        assert fetch_mock.call_count == 1
+
+    def test_use_cache_false_downloads_to_temp_file(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        cache_dir = str(tmp_path / "cache")
+        monkeypatch.setattr(sources, "VIDEO_DOWNLOAD_CACHE_DIR", cache_dir)
+
+        with mock.patch.object(sources, "fetch_url_to_file", side_effect=_fake_fetch()):
+            path = _download_video(VIDEO_URL, use_cache=False)
+
+        try:
+            assert not path.startswith(cache_dir)
+            with open(path, "rb") as f:
+                assert f.read() == b"video-bytes"
+        finally:
+            os.remove(path)
+
+    def test_failed_download_leaves_no_cached_file(self, tmp_path, monkeypatch) -> None:
+        cache_dir = str(tmp_path / "cache")
+        monkeypatch.setattr(sources, "VIDEO_DOWNLOAD_CACHE_DIR", cache_dir)
+
+        with mock.patch.object(
+            sources, "fetch_url_to_file", side_effect=RuntimeError("HTTP 404")
+        ):
+            with pytest.raises(RuntimeError):
+                _download_video(VIDEO_URL, use_cache=True)
+
+        assert os.listdir(cache_dir) == []
+
+    def test_url_without_extension_defaults_to_mp4(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.setattr(sources, "VIDEO_DOWNLOAD_CACHE_DIR", str(tmp_path))
+
+        with mock.patch.object(sources, "fetch_url_to_file", side_effect=_fake_fetch()):
+            path = _download_video("https://example.com/stream", use_cache=True)
+
+        assert path.endswith(".mp4")
+
+
+class TestVideoFileSourceCleanup:
+    @pytest.mark.asyncio
+    async def test_cleanup_removes_temp_download(self, tmp_path) -> None:
+        temp_file = tmp_path / "downloaded.mp4"
+        temp_file.write_bytes(b"x")
+
+        source = VideoFileSource(VIDEO_URL, use_cache=False)
+        source._temp_download_path = str(temp_file)
+
+        await source.cleanup()
+
+        assert not temp_file.exists()
+        assert source._temp_download_path is None
+
+    @pytest.mark.asyncio
+    async def test_cleanup_noop_for_local_path(self) -> None:
+        source = VideoFileSource("cars.mp4")
+        await source.cleanup()  # must not raise


### PR DESCRIPTION
## Summary

`VideoFileSource` now accepts http(s) URLs in addition to local paths:

```python
VideoFileSource("https://example.com/cars.mp4")                  # downloaded + cached
VideoFileSource("https://example.com/cars.mp4", use_cache=False) # temp file, deleted on session end
```

- Download happens in `start_upload()` via `asyncio.to_thread` (event loop not blocked).
- Cache: `~/.cache/inference-sdk/videos/<sha256(url)>.<ext>`; override dir with `INFERENCE_SDK_VIDEO_CACHE_DIR`, timeout with `INFERENCE_SDK_VIDEO_DOWNLOAD_TIMEOUT` (default 300 s). Download goes to a `.part` file then atomic `os.replace`, so an interrupted download never poisons the cache.
- New `fetch_url_to_file()` in `url_utils.py` streams to disk in 1 MiB chunks through the existing SSRF-protected fetch path (URL-string policy, non-global address blocking + DNS-rebinding pinning, redirect validation, api_key redaction). `fetch_url_bytes` refactored onto the same internals — behavior unchanged.
- Version bump 1.3.6 → 1.3.7 (behavioral SDK change).

> **Note:** stacked on #2622 (branch `claude/ecstatic-edison-f8b998`). Retargets to `main` automatically once #2622 merges and its branch is deleted.

## Testing

- 9 new unit tests (`tests/inference_sdk/unit_tests/webrtc/test_video_file_url_source.py`): cache hit skips refetch, `use_cache=False` temp path, failed download leaves cache empty, extension fallback, cleanup semantics.
- Full SDK unit suite: 475 passed.
- `black --check` and `isort --check-only` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)