### PR TITLE
Fix flaky unit test

### DIFF
--- a/tests/inference/unit_tests/core/utils/test_image_utils.py
+++ b/tests/inference/unit_tests/core/utils/test_image_utils.py
@@ -396,7 +396,8 @@ def test_load_image_from_url_blocks_hostname_resolving_to_non_global(
     # "not allowed" only appears if the adapter resolved + rejected the target;
     # a dead adapter would surface a DNS/connection error message instead.
     assert "not allowed" in str(error.value).lower()
-    assert resolved == ["evil.com"]  # resolution ran on the real send() path
+    assert "evil.com" in resolved  # allowing other values due to other
+    # inference activity happening in background
 
 
 @mock.patch.object(image_utils, "ALLOW_NUMPY_INPUT", True)

--- a/tests/inference/unit_tests/core/utils/test_image_utils.py
+++ b/tests/inference/unit_tests/core/utils/test_image_utils.py
@@ -3,7 +3,7 @@ import pickle
 import socket
 from typing import Any
 from unittest import mock
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, Mock
 
 import cv2
 import numpy as np
@@ -368,8 +368,9 @@ def test_load_image_from_url_blocks_non_global_ip_literal() -> None:
 @mock.patch.object(image_utils, "ALLOW_URL_TO_NON_GLOBAL_ADDRESSES", False)
 @mock.patch.object(image_utils, "ALLOW_URL_INPUT", True)
 @mock.patch.object(image_utils, "ALLOW_NON_HTTPS_URL_INPUT", False)
+@mock.patch.object(url_input.socket, "getaddrinfo")
 def test_load_image_from_url_blocks_hostname_resolving_to_non_global(
-    monkeypatch,
+    getaddrinfo_mock: Mock,
 ) -> None:
     # End-to-end regression for the requests>=2.32 send() path: a public FQDN
     # that DNS-resolves to loopback must be blocked (and pinned), proving the
@@ -388,7 +389,7 @@ def test_load_image_from_url_blocks_hostname_resolving_to_non_global(
             )
         ]
 
-    monkeypatch.setattr(url_input.socket, "getaddrinfo", _fake_getaddrinfo)
+    getaddrinfo_mock.side_effect = _fake_getaddrinfo
 
     with pytest.raises(InputImageLoadError) as error:
         _ = load_image_from_url(value="https://evil.com/image.jpg")
@@ -396,8 +397,7 @@ def test_load_image_from_url_blocks_hostname_resolving_to_non_global(
     # "not allowed" only appears if the adapter resolved + rejected the target;
     # a dead adapter would surface a DNS/connection error message instead.
     assert "not allowed" in str(error.value).lower()
-    assert "evil.com" in resolved  # allowing other values due to other
-    # inference activity happening in background
+    assert resolved == ["evil.com"]
 
 
 @mock.patch.object(image_utils, "ALLOW_NUMPY_INPUT", True)


### PR DESCRIPTION
## What does this PR do?

Fixing flakyness in unit test

we monkeypatch `url_input.socket.getaddrinfo` with fake value but it happens we have other calls (probably from threded activity of inference) intercepted there - changed the way of mocking

## Type of Change

<!-- Please select one and delete the others, or describe if Other -->

- Bug fix (non-breaking change that fixes an issue)


## Testing

<!-- Describe how you tested your changes -->
- ci
- [ ] I have tested this change locally
- [x] I have added/updated tests for this change

**Test details:**
<!-- Describe what tests were added/updated and what they cover -->

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)

## Additional Context

<!-- Add any other context, screenshots, or notes about the PR here -->
