### PR TITLE
feat(usage): per-pipeline stream session id

### DIFF
--- a/inference/core/interfaces/stream/inference_pipeline.py
+++ b/inference/core/interfaces/stream/inference_pipeline.py
@@ -894,8 +894,6 @@ class InferencePipeline:
         self._on_pipeline_end = on_pipeline_end
         self._batch_collection_timeout = batch_collection_timeout
         self._sink_mode = sink_mode
-        # Distinguishes this pipeline's usage from other pipelines in the same
-        # process; usage-based stream billing counts concurrent ids.
         self._stream_session_id = exec_session_id or mint_stream_session_id()
 
     def start(self, use_main_thread: bool = True) -> None:
@@ -943,9 +941,6 @@ class InferencePipeline:
             self._on_pipeline_end()
 
     def _execute_inference(self) -> None:
-        # Tag everything recorded from this thread (workflow runs, model
-        # inferences) with this pipeline's stream session id; the contextvar
-        # is thread-scoped so concurrent pipelines don't see each other's id.
         stream_session_id.set(self._stream_session_id)
         send_inference_pipeline_status_update(
             severity=UpdateSeverity.INFO,

--- a/inference/core/interfaces/stream/inference_pipeline.py
+++ b/inference/core/interfaces/stream/inference_pipeline.py
@@ -69,6 +69,10 @@ from inference.core.workflows.execution_engine.profiling.core import (
 from inference.core.workflows.execution_engine.v1.executor.utils import resolve_futures
 from inference.models.aliases import resolve_roboflow_model_alias
 from inference.models.utils import ROBOFLOW_MODEL_TYPES, get_model
+from inference.usage_tracking.stream_session import (
+    mint_stream_session_id,
+    stream_session_id,
+)
 
 INFERENCE_PIPELINE_CONTEXT = "inference_pipeline"
 SOURCE_CONNECTION_ATTEMPT_FAILED_EVENT = "SOURCE_CONNECTION_ATTEMPT_FAILED"
@@ -873,6 +877,9 @@ class InferencePipeline:
         self._on_pipeline_end = on_pipeline_end
         self._batch_collection_timeout = batch_collection_timeout
         self._sink_mode = sink_mode
+        # Distinguishes this pipeline's usage from other pipelines in the same
+        # process; usage-based stream billing counts concurrent ids.
+        self._stream_session_id = mint_stream_session_id()
 
     def start(self, use_main_thread: bool = True) -> None:
         self._stop = False
@@ -919,6 +926,10 @@ class InferencePipeline:
             self._on_pipeline_end()
 
     def _execute_inference(self) -> None:
+        # Tag everything recorded from this thread (workflow runs, model
+        # inferences) with this pipeline's stream session id; the contextvar
+        # is thread-scoped so concurrent pipelines don't see each other's id.
+        stream_session_id.set(self._stream_session_id)
         send_inference_pipeline_status_update(
             severity=UpdateSeverity.INFO,
             event_type=INFERENCE_THREAD_STARTED_EVENT,

--- a/inference/core/interfaces/stream/inference_pipeline.py
+++ b/inference/core/interfaces/stream/inference_pipeline.py
@@ -119,6 +119,7 @@ class InferencePipeline:
         sink_mode: SinkMode = SinkMode.ADAPTIVE,
         predictions_queue_size: int = PREDICTIONS_QUEUE_SIZE,
         decoding_buffer_size: int = DEFAULT_BUFFER_SIZE,
+        exec_session_id: Optional[str] = None,
     ) -> "InferencePipeline":
         """
         This class creates the abstraction for making inferences from Roboflow models against video stream.
@@ -235,6 +236,8 @@ class InferencePipeline:
                 default value is taken from INFERENCE_PIPELINE_PREDICTIONS_QUEUE_SIZE env variable
             decoding_buffer_size (int): size of video source decoding buffer
                 default value is taken from VIDEO_SOURCE_BUFFER_SIZE env variable
+            exec_session_id (Optional[str]): Usage session identifier for this pipeline. If empty or omitted,
+                a unique identifier is generated for the pipeline.
 
         Other ENV variables involved in low-level configuration:
         * INFERENCE_PIPELINE_PREDICTIONS_QUEUE_SIZE - size of buffer for predictions that are ready for dispatching
@@ -315,6 +318,7 @@ class InferencePipeline:
             sink_mode=sink_mode,
             predictions_queue_size=predictions_queue_size,
             decoding_buffer_size=decoding_buffer_size,
+            exec_session_id=exec_session_id,
         )
 
     @classmethod
@@ -339,6 +343,7 @@ class InferencePipeline:
         sink_mode: SinkMode = SinkMode.ADAPTIVE,
         predictions_queue_size: int = PREDICTIONS_QUEUE_SIZE,
         decoding_buffer_size: int = DEFAULT_BUFFER_SIZE,
+        exec_session_id: Optional[str] = None,
     ) -> "InferencePipeline":
         """
         This class creates the abstraction for making inferences from YoloWorld against video stream.
@@ -414,6 +419,8 @@ class InferencePipeline:
                 default value is taken from INFERENCE_PIPELINE_PREDICTIONS_QUEUE_SIZE env variable
             decoding_buffer_size (int): size of video source decoding buffer
                 default value is taken from VIDEO_SOURCE_BUFFER_SIZE env variable
+            exec_session_id (Optional[str]): Usage session identifier for this pipeline. If empty or omitted,
+                a unique identifier is generated for the pipeline.
 
         Other ENV variables involved in low-level configuration:
         * INFERENCE_PIPELINE_PREDICTIONS_QUEUE_SIZE - size of buffer for predictions that are ready for dispatching
@@ -463,6 +470,7 @@ class InferencePipeline:
             sink_mode=sink_mode,
             predictions_queue_size=predictions_queue_size,
             decoding_buffer_size=decoding_buffer_size,
+            exec_session_id=exec_session_id,
         )
 
     @classmethod
@@ -499,6 +507,7 @@ class InferencePipeline:
         model_manager: Optional[ModelManager] = None,
         _is_preview: bool = False,
         workflow_version_id: Optional[str] = None,
+        exec_session_id: Optional[str] = None,
     ) -> "InferencePipeline":
         """
         This class creates the abstraction for making inferences from given workflow against video stream.
@@ -581,6 +590,8 @@ class InferencePipeline:
                 default value is taken from VIDEO_SOURCE_BUFFER_SIZE env variable
             model_manager (Optional[ModelManager]): Model manager to be used by InferencePipeline, defaults to
                 BackgroundTaskActiveLearningManager with WithFixedSizeCache
+            exec_session_id (Optional[str]): Usage session identifier for this pipeline. If empty or omitted,
+                a unique identifier is generated for the pipeline.
 
         Other ENV variables involved in low-level configuration:
         * INFERENCE_PIPELINE_PREDICTIONS_QUEUE_SIZE - size of buffer for predictions that are ready for dispatching
@@ -702,6 +713,7 @@ class InferencePipeline:
             batch_collection_timeout=batch_collection_timeout,
             predictions_queue_size=predictions_queue_size,
             decoding_buffer_size=decoding_buffer_size,
+            exec_session_id=exec_session_id,
         )
 
     @classmethod
@@ -722,6 +734,7 @@ class InferencePipeline:
         sink_mode: SinkMode = SinkMode.ADAPTIVE,
         predictions_queue_size: int = PREDICTIONS_QUEUE_SIZE,
         decoding_buffer_size: int = DEFAULT_BUFFER_SIZE,
+        exec_session_id: Optional[str] = None,
     ) -> "InferencePipeline":
         """
         This class creates the abstraction for making inferences from given workflow against video stream.
@@ -792,6 +805,8 @@ class InferencePipeline:
                 default value is taken from INFERENCE_PIPELINE_PREDICTIONS_QUEUE_SIZE env variable
             decoding_buffer_size (int): size of video source decoding buffer
                 default value is taken from VIDEO_SOURCE_BUFFER_SIZE env variable
+            exec_session_id (Optional[str]): Usage session identifier for this pipeline. If empty or omitted,
+                a unique identifier is generated for the pipeline.
 
         Other ENV variables involved in low-level configuration:
         * INFERENCE_PIPELINE_PREDICTIONS_QUEUE_SIZE - size of buffer for predictions that are ready for dispatching
@@ -845,6 +860,7 @@ class InferencePipeline:
             on_pipeline_end=on_pipeline_end,
             batch_collection_timeout=batch_collection_timeout,
             sink_mode=sink_mode,
+            exec_session_id=exec_session_id,
         )
 
     def __init__(
@@ -860,6 +876,7 @@ class InferencePipeline:
         max_fps: Optional[float] = None,
         batch_collection_timeout: Optional[float] = None,
         sink_mode: SinkMode = SinkMode.ADAPTIVE,
+        exec_session_id: Optional[str] = None,
     ):
         self._on_video_frame = on_video_frame
         self._video_sources = video_sources
@@ -879,7 +896,7 @@ class InferencePipeline:
         self._sink_mode = sink_mode
         # Distinguishes this pipeline's usage from other pipelines in the same
         # process; usage-based stream billing counts concurrent ids.
-        self._stream_session_id = mint_stream_session_id()
+        self._stream_session_id = exec_session_id or mint_stream_session_id()
 
     def start(self, use_main_thread: bool = True) -> None:
         self._stop = False

--- a/inference/core/workflows/execution_engine/v1/executor/core.py
+++ b/inference/core/workflows/execution_engine/v1/executor/core.py
@@ -66,6 +66,7 @@ from inference.core.workflows.execution_engine.v1.executor.utils import (
 )
 from inference.core.workflows.prototypes.block import WorkflowBlock
 from inference.usage_tracking.collector import usage_collector
+from inference.usage_tracking.stream_session import stream_session_id
 
 
 def _store_crash_info(
@@ -352,6 +353,7 @@ def execute_steps(
     # set in this thread do not propagate into ThreadPoolExecutor workers.
     debug_collector = current_debug_collector.get()
     debug_trace = current_debug_trace.get()
+    pipeline_stream_session_id = stream_session_id.get()
     # Capture OTel context so it can be re-attached inside worker threads
     otel_ctx = capture_context()
     logger.debug(f"Executing steps: {next_steps}.")
@@ -367,6 +369,7 @@ def execute_steps(
             duration_minimum_value=duration_minimum_value,
             debug_collector=debug_collector,
             debug_trace=debug_trace,
+            pipeline_stream_session_id=pipeline_stream_session_id,
             step_error_handler=step_error_handler,
             otel_ctx=otel_ctx,
         )
@@ -392,6 +395,7 @@ def safe_execute_step(
     duration_minimum_value=None,
     debug_collector=None,
     debug_trace=None,
+    pipeline_stream_session_id=None,
     step_error_handler: Optional[Callable[[str, Exception], None]] = None,
     otel_ctx=None,
 ) -> None:
@@ -406,6 +410,7 @@ def safe_execute_step(
     # this thread, silently accumulating logs on a dead object.
     current_debug_collector.set(debug_collector)
     current_debug_trace.set(debug_trace)
+    stream_session_id.set(pipeline_stream_session_id)
     step_name = get_last_chunk_of_selector(selector=step_selector)
     current_debug_step_name.set(step_name)
     # Re-attach OTel context in worker thread so trace propagation works.

--- a/inference/usage_tracking/collector.py
+++ b/inference/usage_tracking/collector.py
@@ -387,9 +387,6 @@ class UsageCollector:
             ip_address_hash = self._system_info["ip_address_hash"]
             is_gpu_available = self._system_info["is_gpu_available"]
             hostname = self._system_info["hostname"]
-        # A pipeline-scoped stream session id keeps concurrently running video
-        # pipelines separate in the usage payload even when they share an API
-        # key and a workflow (resource_id) — required for per-stream billing.
         stream_session_id = stream_session_id_var.get()
         usage_key = f"{category}:{resource_id}"
         if stream_session_id:

--- a/inference/usage_tracking/collector.py
+++ b/inference/usage_tracking/collector.py
@@ -71,6 +71,7 @@ from .payload_helpers import (
 from .plan_details import PlanDetails
 from .redis_queue import RedisQueue
 from .sqlite_queue import SQLiteQueue
+from .stream_session import stream_session_id as stream_session_id_var
 from .utils import collect_func_params
 
 T = TypeVar("T")
@@ -386,8 +387,15 @@ class UsageCollector:
             ip_address_hash = self._system_info["ip_address_hash"]
             is_gpu_available = self._system_info["is_gpu_available"]
             hostname = self._system_info["hostname"]
+        # A pipeline-scoped stream session id keeps concurrently running video
+        # pipelines separate in the usage payload even when they share an API
+        # key and a workflow (resource_id) — required for per-stream billing.
+        stream_session_id = stream_session_id_var.get()
+        usage_key = f"{category}:{resource_id}"
+        if stream_session_id:
+            usage_key = f"{usage_key}:{stream_session_id}"
         with UsageCollector._lock:
-            source_usage = self._usage[api_key_hash][f"{category}:{resource_id}"]
+            source_usage = self._usage[api_key_hash][usage_key]
             if not source_usage["timestamp_start"]:
                 source_usage["timestamp_start"] = time.time_ns()
             source_usage["timestamp_stop"] = time.time_ns()
@@ -411,6 +419,9 @@ class UsageCollector:
             ):
                 source_usage["roboflow_service_name"] = roboflow_service_name
                 source_usage["roboflow_internal_secret"] = roboflow_internal_secret
+
+            if stream_session_id:
+                source_usage["stream_session_id"] = stream_session_id
 
             exec_session_id = None
             if execution_id is not None:

--- a/inference/usage_tracking/payload_helpers.py
+++ b/inference/usage_tracking/payload_helpers.py
@@ -163,24 +163,17 @@ def send_usage_payload(
         if not api_key:
             api_keys_hashes_failed.add(api_key_hash)
             continue
-        complete_workflow_payloads = []
-        for workflow_payload in workflow_payloads.values():
-            if "processed_frames" not in workflow_payload:
-                continue
-            outbound_payload = workflow_payload.copy()
-            outbound_payload.pop("api_key_hash", None)
-            stream_session_id = outbound_payload.pop("stream_session_id", None)
-            source_duration = outbound_payload.get("source_duration")
-            if (
-                stream_session_id
-                and isinstance(source_duration, (int, float))
-                and not isinstance(source_duration, bool)
-                and source_duration > 0
-            ):
-                outbound_payload["exec_session_id"] = stream_session_id
-            outbound_payload["api_key"] = api_key
-            complete_workflow_payloads.append(outbound_payload)
+        complete_workflow_payloads = [
+            w for w in workflow_payloads.values() if "processed_frames" in w
+        ]
         try:
+            for workflow_payload in complete_workflow_payloads:
+                if "api_key_hash" in workflow_payload:
+                    del workflow_payload["api_key_hash"]
+                stream_session_id = workflow_payload.pop("stream_session_id", None)
+                if stream_session_id:
+                    workflow_payload["exec_session_id"] = stream_session_id
+                workflow_payload["api_key"] = api_key
             if not extra_headers:
                 extra_headers = {}
             response = requests.post(

--- a/inference/usage_tracking/payload_helpers.py
+++ b/inference/usage_tracking/payload_helpers.py
@@ -163,14 +163,24 @@ def send_usage_payload(
         if not api_key:
             api_keys_hashes_failed.add(api_key_hash)
             continue
-        complete_workflow_payloads = [
-            w for w in workflow_payloads.values() if "processed_frames" in w
-        ]
+        complete_workflow_payloads = []
+        for workflow_payload in workflow_payloads.values():
+            if "processed_frames" not in workflow_payload:
+                continue
+            outbound_payload = workflow_payload.copy()
+            outbound_payload.pop("api_key_hash", None)
+            stream_session_id = outbound_payload.pop("stream_session_id", None)
+            source_duration = outbound_payload.get("source_duration")
+            if (
+                stream_session_id
+                and isinstance(source_duration, (int, float))
+                and not isinstance(source_duration, bool)
+                and source_duration > 0
+            ):
+                outbound_payload["exec_session_id"] = stream_session_id
+            outbound_payload["api_key"] = api_key
+            complete_workflow_payloads.append(outbound_payload)
         try:
-            for workflow_payload in complete_workflow_payloads:
-                if "api_key_hash" in workflow_payload:
-                    del workflow_payload["api_key_hash"]
-                workflow_payload["api_key"] = api_key
             if not extra_headers:
                 extra_headers = {}
             response = requests.post(

--- a/inference/usage_tracking/stream_session.py
+++ b/inference/usage_tracking/stream_session.py
@@ -1,0 +1,31 @@
+"""Per-pipeline stream session identity for usage tracking.
+
+The usage collector's ``exec_session_id`` is minted once per process, so every
+video pipeline running in the same inference server reports usage under one
+session. Downstream stream billing counts concurrent sessions, which collapses
+all of a device's cameras into a single billable stream.
+
+``stream_session_id`` is a context variable scoped to a single pipeline's
+inference thread. Anything recorded while it is set (workflow runs, model
+inferences) is attributed to that pipeline, so concurrently running pipelines
+stay distinguishable even when they share a process, an API key, and a
+workflow.
+
+This module must stay import-light: it is imported both by the usage collector
+and by ``InferencePipeline``.
+"""
+
+import time
+from contextvars import ContextVar
+from typing import Optional
+from uuid import uuid4
+
+stream_session_id: ContextVar[Optional[str]] = ContextVar(
+    "stream_session_id", default=None
+)
+
+
+def mint_stream_session_id() -> str:
+    # Same shape as UsageCollector's exec_session_id so downstream consumers
+    # can treat both identifiers uniformly.
+    return f"{time.time_ns()}_{uuid4().hex[:4]}"

--- a/inference/usage_tracking/stream_session.py
+++ b/inference/usage_tracking/stream_session.py
@@ -26,6 +26,4 @@ stream_session_id: ContextVar[Optional[str]] = ContextVar(
 
 
 def mint_stream_session_id() -> str:
-    # Same shape as UsageCollector's exec_session_id so downstream consumers
-    # can treat both identifiers uniformly.
     return f"{time.time_ns()}_{uuid4().hex[:4]}"

--- a/tests/inference/unit_tests/core/interfaces/stream/test_interface_pipeline.py
+++ b/tests/inference/unit_tests/core/interfaces/stream/test_interface_pipeline.py
@@ -743,3 +743,66 @@ def test_inference_pipeline_works_correctly_against_multiple_video_files_with_ac
     assert frames_by_sources[1] == list(
         range(1, 431 * 2 + 1)
     ), "Order of prediction frames violated for source 1"
+
+
+def _make_minimal_pipeline(on_video_frame) -> InferencePipeline:
+    from unittest.mock import MagicMock
+
+    return InferencePipeline(
+        on_video_frame=on_video_frame,
+        video_sources=[],
+        predictions_queue=Queue(maxsize=8),
+        watchdog=MagicMock(),
+        status_update_handlers=[],
+    )
+
+
+def test_inference_pipeline_instances_get_distinct_stream_session_ids() -> None:
+    # given
+    pipeline_1 = _make_minimal_pipeline(on_video_frame=lambda frames: [])
+    pipeline_2 = _make_minimal_pipeline(on_video_frame=lambda frames: [])
+
+    # then - each pipeline mints its own usage identity
+    assert pipeline_1._stream_session_id
+    assert pipeline_2._stream_session_id
+    assert pipeline_1._stream_session_id != pipeline_2._stream_session_id
+
+
+def test_execute_inference_tags_thread_with_pipeline_stream_session_id() -> None:
+    # given - two pipelines sharing a process, as on a multi-camera edge device
+    from threading import Thread
+    from unittest.mock import MagicMock
+
+    from inference.usage_tracking.stream_session import stream_session_id
+
+    ids_seen_by_inference: dict = {}
+
+    def make_on_video_frame(name):
+        def on_video_frame(video_frames):
+            # stands in for the workflow run, where usage is recorded
+            ids_seen_by_inference[name] = stream_session_id.get()
+            return []
+
+        return on_video_frame
+
+    pipeline_1 = _make_minimal_pipeline(make_on_video_frame("pipeline_1"))
+    pipeline_2 = _make_minimal_pipeline(make_on_video_frame("pipeline_2"))
+    for pipeline in (pipeline_1, pipeline_2):
+        fake_frame = MagicMock()
+        pipeline._generate_frames = lambda frame=fake_frame: iter([[frame]])
+
+    # when - each pipeline runs inference in its own thread, like start() does
+    threads = [
+        Thread(target=pipeline_1._execute_inference),
+        Thread(target=pipeline_2._execute_inference),
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    # then - usage recorded in each inference thread carries that pipeline's
+    # id, and nothing leaks into the calling thread
+    assert ids_seen_by_inference["pipeline_1"] == pipeline_1._stream_session_id
+    assert ids_seen_by_inference["pipeline_2"] == pipeline_2._stream_session_id
+    assert stream_session_id.get() is None

--- a/tests/inference/unit_tests/core/interfaces/stream/test_interface_pipeline.py
+++ b/tests/inference/unit_tests/core/interfaces/stream/test_interface_pipeline.py
@@ -2,6 +2,7 @@ from collections import defaultdict
 from concurrent.futures import Future
 from datetime import datetime
 from functools import partial
+from inspect import signature
 from queue import Queue
 from threading import Lock
 from typing import Any, List, Optional, Tuple, Union
@@ -745,7 +746,9 @@ def test_inference_pipeline_works_correctly_against_multiple_video_files_with_ac
     ), "Order of prediction frames violated for source 1"
 
 
-def _make_minimal_pipeline(on_video_frame) -> InferencePipeline:
+def _make_minimal_pipeline(
+    on_video_frame, exec_session_id: Optional[str] = None
+) -> InferencePipeline:
     from unittest.mock import MagicMock
 
     return InferencePipeline(
@@ -754,6 +757,7 @@ def _make_minimal_pipeline(on_video_frame) -> InferencePipeline:
         predictions_queue=Queue(maxsize=8),
         watchdog=MagicMock(),
         status_update_handlers=[],
+        exec_session_id=exec_session_id,
     )
 
 
@@ -766,6 +770,55 @@ def test_inference_pipeline_instances_get_distinct_stream_session_ids() -> None:
     assert pipeline_1._stream_session_id
     assert pipeline_2._stream_session_id
     assert pipeline_1._stream_session_id != pipeline_2._stream_session_id
+
+
+def test_inference_pipeline_factory_uses_supplied_exec_session_id(monkeypatch) -> None:
+    # given
+    monkeypatch.setattr(
+        "inference.core.interfaces.stream.inference_pipeline.prepare_video_sources",
+        lambda **kwargs: [],
+    )
+
+    # when
+    pipeline = InferencePipeline.init_with_custom_logic(
+        video_reference="rtsp://camera-7",
+        on_video_frame=lambda frames: [],
+        exec_session_id="camera-7",
+    )
+
+    # then
+    assert pipeline._stream_session_id == "camera-7"
+
+
+def test_inference_pipeline_empty_exec_session_id_mints_fallback() -> None:
+    # when
+    pipeline_1 = _make_minimal_pipeline(
+        on_video_frame=lambda frames: [], exec_session_id=""
+    )
+    pipeline_2 = _make_minimal_pipeline(
+        on_video_frame=lambda frames: [], exec_session_id=""
+    )
+
+    # then
+    assert pipeline_1._stream_session_id
+    assert pipeline_2._stream_session_id
+    assert pipeline_1._stream_session_id != pipeline_2._stream_session_id
+
+
+@pytest.mark.parametrize(
+    "factory_name",
+    ["init", "init_with_yolo_world", "init_with_workflow", "init_with_custom_logic"],
+)
+def test_inference_pipeline_factories_expose_optional_exec_session_id(
+    factory_name: str,
+) -> None:
+    # when
+    parameter = signature(getattr(InferencePipeline, factory_name)).parameters[
+        "exec_session_id"
+    ]
+
+    # then - all public construction paths remain backward compatible
+    assert parameter.default is None
 
 
 def test_execute_inference_tags_thread_with_pipeline_stream_session_id() -> None:

--- a/tests/inference/unit_tests/core/interfaces/stream/test_interface_pipeline.py
+++ b/tests/inference/unit_tests/core/interfaces/stream/test_interface_pipeline.py
@@ -762,36 +762,30 @@ def _make_minimal_pipeline(
 
 
 def test_inference_pipeline_instances_get_distinct_stream_session_ids() -> None:
-    # given
     pipeline_1 = _make_minimal_pipeline(on_video_frame=lambda frames: [])
     pipeline_2 = _make_minimal_pipeline(on_video_frame=lambda frames: [])
 
-    # then - each pipeline mints its own usage identity
     assert pipeline_1._stream_session_id
     assert pipeline_2._stream_session_id
     assert pipeline_1._stream_session_id != pipeline_2._stream_session_id
 
 
 def test_inference_pipeline_factory_uses_supplied_exec_session_id(monkeypatch) -> None:
-    # given
     monkeypatch.setattr(
         "inference.core.interfaces.stream.inference_pipeline.prepare_video_sources",
         lambda **kwargs: [],
     )
 
-    # when
     pipeline = InferencePipeline.init_with_custom_logic(
         video_reference="rtsp://camera-7",
         on_video_frame=lambda frames: [],
         exec_session_id="camera-7",
     )
 
-    # then
     assert pipeline._stream_session_id == "camera-7"
 
 
 def test_inference_pipeline_empty_exec_session_id_mints_fallback() -> None:
-    # when
     pipeline_1 = _make_minimal_pipeline(
         on_video_frame=lambda frames: [], exec_session_id=""
     )
@@ -799,7 +793,6 @@ def test_inference_pipeline_empty_exec_session_id_mints_fallback() -> None:
         on_video_frame=lambda frames: [], exec_session_id=""
     )
 
-    # then
     assert pipeline_1._stream_session_id
     assert pipeline_2._stream_session_id
     assert pipeline_1._stream_session_id != pipeline_2._stream_session_id
@@ -812,17 +805,14 @@ def test_inference_pipeline_empty_exec_session_id_mints_fallback() -> None:
 def test_inference_pipeline_factories_expose_optional_exec_session_id(
     factory_name: str,
 ) -> None:
-    # when
     parameter = signature(getattr(InferencePipeline, factory_name)).parameters[
         "exec_session_id"
     ]
 
-    # then - all public construction paths remain backward compatible
     assert parameter.default is None
 
 
 def test_execute_inference_tags_thread_with_pipeline_stream_session_id() -> None:
-    # given - two pipelines sharing a process, as on a multi-camera edge device
     from threading import Thread
     from unittest.mock import MagicMock
 
@@ -832,7 +822,6 @@ def test_execute_inference_tags_thread_with_pipeline_stream_session_id() -> None
 
     def make_on_video_frame(name):
         def on_video_frame(video_frames):
-            # stands in for the workflow run, where usage is recorded
             ids_seen_by_inference[name] = stream_session_id.get()
             return []
 
@@ -844,7 +833,6 @@ def test_execute_inference_tags_thread_with_pipeline_stream_session_id() -> None
         fake_frame = MagicMock()
         pipeline._generate_frames = lambda frame=fake_frame: iter([[frame]])
 
-    # when - each pipeline runs inference in its own thread, like start() does
     threads = [
         Thread(target=pipeline_1._execute_inference),
         Thread(target=pipeline_2._execute_inference),
@@ -854,8 +842,6 @@ def test_execute_inference_tags_thread_with_pipeline_stream_session_id() -> None
     for thread in threads:
         thread.join()
 
-    # then - usage recorded in each inference thread carries that pipeline's
-    # id, and nothing leaks into the calling thread
     assert ids_seen_by_inference["pipeline_1"] == pipeline_1._stream_session_id
     assert ids_seen_by_inference["pipeline_2"] == pipeline_2._stream_session_id
     assert stream_session_id.get() is None

--- a/tests/inference/unit_tests/usage_tracking/test_collector.py
+++ b/tests/inference/unit_tests/usage_tracking/test_collector.py
@@ -1216,14 +1216,12 @@ def test_record_usage_separates_concurrent_streams_by_stream_session_id(
     one usage entry: stream billing counts concurrent stream session ids, so
     collapsing them under-counts a device's cameras.
     """
-    # given
     from inference.usage_tracking.stream_session import stream_session_id
 
     collector = usage_collector_with_mocked_threads
     api_key = "fake"
     resource_id = "workflow-1"
 
-    # when - same (api_key, category, resource) recorded under two stream sessions
     token = stream_session_id.set("stream-a")
     try:
         collector.record_usage(
@@ -1246,7 +1244,6 @@ def test_record_usage_separates_concurrent_streams_by_stream_session_id(
     finally:
         stream_session_id.reset(token)
 
-    # then - two separate entries, each tagged with its own stream session id
     usage = collector._usage[api_key]
     assert f"workflows:{resource_id}:stream-a" in usage
     assert f"workflows:{resource_id}:stream-b" in usage
@@ -1262,13 +1259,11 @@ def test_record_usage_separates_concurrent_streams_by_stream_session_id(
 def test_record_usage_without_stream_session_id_keeps_legacy_key(
     usage_collector_with_mocked_threads,
 ):
-    # given
     from inference.usage_tracking.stream_session import stream_session_id
 
     collector = usage_collector_with_mocked_threads
     assert stream_session_id.get() is None
 
-    # when
     collector.record_usage(
         source="img.jpg",
         category="workflows",
@@ -1277,14 +1272,12 @@ def test_record_usage_without_stream_session_id_keeps_legacy_key(
         resource_id="workflow-1",
     )
 
-    # then - key format and payload fields unchanged for non-pipeline callers
     usage = collector._usage["fake"]
     assert "workflows:workflow-1" in usage
     assert "stream_session_id" not in usage["workflows:workflow-1"]
 
 
 def test_stream_session_id_does_not_leak_across_threads():
-    # given
     from threading import Thread
 
     from inference.usage_tracking.stream_session import stream_session_id
@@ -1295,18 +1288,15 @@ def test_stream_session_id_does_not_leak_across_threads():
         stream_session_id.set("thread-local-stream")
         seen_in_thread.append(stream_session_id.get())
 
-    # when
     thread = Thread(target=pipeline_thread)
     thread.start()
     thread.join()
 
-    # then - the id set inside the pipeline thread is invisible outside it
     assert seen_in_thread == ["thread-local-stream"]
     assert stream_session_id.get() is None
 
 
 def test_zip_usage_payloads_keeps_stream_sessions_separate():
-    # given - same resource under two stream-session-suffixed keys
     def make_payload(key, ssid, frames, ts):
         return {
             "fake_api1_hash": {
@@ -1337,10 +1327,8 @@ def test_zip_usage_payloads_keeps_stream_sessions_separate():
         ),
     ]
 
-    # when
     zipped_usage_payloads = zip_usage_payloads(usage_payloads=dumped_usage_payloads)
 
-    # then - same stream merges, different streams stay separate
     merged = {}
     for payload in zipped_usage_payloads:
         for resource_payloads in payload.values():
@@ -1357,7 +1345,6 @@ def test_zip_usage_payloads_keeps_stream_sessions_separate():
 def test_send_usage_payload_serializes_stream_sessions_as_exec_session_ids(
     post_mock,
 ):
-    # given - two pipeline rows collected under one process session and resource
     def make_payload(key, stream_id, frames):
         return {
             "fake_hash": {
@@ -1384,14 +1371,12 @@ def test_send_usage_payload_serializes_stream_sessions_as_exec_session_ids(
     original_payload = deepcopy(payloads[0])
     post_mock.return_value.status_code = 200
 
-    # when
     failed_hashes = send_usage_payload(
         payload=payloads[0],
         api_usage_endpoint_url="https://example.com/usage",
         hashes_to_api_keys={"fake_hash": "fake-api-key"},
     )
 
-    # then - both rows share one HTTP request but carry distinct wire IDs
     assert failed_hashes == set()
     post_mock.assert_called_once()
     outbound_rows = post_mock.call_args.kwargs["json"]
@@ -1407,7 +1392,6 @@ def test_send_usage_payload_serializes_stream_sessions_as_exec_session_ids(
 def test_send_usage_payload_leaves_legacy_and_non_billable_exec_session_ids(
     post_mock,
 ):
-    # given
     payload = {
         "fake_hash": {
             "workflows:legacy": {
@@ -1438,14 +1422,12 @@ def test_send_usage_payload_leaves_legacy_and_non_billable_exec_session_ids(
     original_payload = deepcopy(payload)
     post_mock.return_value.status_code = 200
 
-    # when
     failed_hashes = send_usage_payload(
         payload=payload,
         api_usage_endpoint_url="https://example.com/usage",
         hashes_to_api_keys={"fake_hash": "fake-api-key"},
     )
 
-    # then
     assert failed_hashes == set()
     outbound_rows = post_mock.call_args.kwargs["json"]
     assert {row["resource_id"]: row["exec_session_id"] for row in outbound_rows} == {
@@ -1459,7 +1441,6 @@ def test_send_usage_payload_leaves_legacy_and_non_billable_exec_session_ids(
 
 @mock.patch("inference.usage_tracking.payload_helpers.requests.post")
 def test_send_usage_payload_does_not_mutate_failed_payload_before_retry(post_mock):
-    # given
     payload = {
         "fake_hash": {
             "workflows:workflow-1:stream-a": {
@@ -1477,7 +1458,6 @@ def test_send_usage_payload_does_not_mutate_failed_payload_before_retry(post_moc
     successful_response = mock.MagicMock(status_code=200)
     post_mock.side_effect = [failed_response, successful_response]
 
-    # when - retry the exact object that would have been requeued after failure
     first_result = send_usage_payload(
         payload=payload,
         api_usage_endpoint_url="https://example.com/usage",
@@ -1490,7 +1470,6 @@ def test_send_usage_payload_does_not_mutate_failed_payload_before_retry(post_moc
         hashes_to_api_keys={"fake_hash": "fake-api-key"},
     )
 
-    # then
     assert first_result == {"fake_hash"}
     assert second_result == set()
     assert payload_after_failure == original_payload

--- a/tests/inference/unit_tests/usage_tracking/test_collector.py
+++ b/tests/inference/unit_tests/usage_tracking/test_collector.py
@@ -1205,3 +1205,147 @@ def test_external_source_info_not_persisted_into_resource_details(
         usage_collector._usage["test_key"]["model:unknown"]["resource_details"]
     )
     assert "source_info" not in resource_details
+
+
+def test_record_usage_separates_concurrent_streams_by_stream_session_id(
+    usage_collector_with_mocked_threads,
+):
+    """Two pipelines sharing an API key and a workflow must not aggregate into
+    one usage entry: stream billing counts concurrent stream session ids, so
+    collapsing them under-counts a device's cameras.
+    """
+    # given
+    from inference.usage_tracking.stream_session import stream_session_id
+
+    collector = usage_collector_with_mocked_threads
+    api_key = "fake"
+    resource_id = "workflow-1"
+
+    # when - same (api_key, category, resource) recorded under two stream sessions
+    token = stream_session_id.set("stream-a")
+    try:
+        collector.record_usage(
+            source="rtsp://camera-1",
+            category="workflows",
+            frames=2,
+            api_key=api_key,
+            resource_id=resource_id,
+            fps=10,
+        )
+        stream_session_id.set("stream-b")
+        collector.record_usage(
+            source="rtsp://camera-2",
+            category="workflows",
+            frames=3,
+            api_key=api_key,
+            resource_id=resource_id,
+            fps=10,
+        )
+    finally:
+        stream_session_id.reset(token)
+
+    # then - two separate entries, each tagged with its own stream session id
+    usage = collector._usage[api_key]
+    assert f"workflows:{resource_id}:stream-a" in usage
+    assert f"workflows:{resource_id}:stream-b" in usage
+    assert f"workflows:{resource_id}" not in usage
+    entry_a = usage[f"workflows:{resource_id}:stream-a"]
+    entry_b = usage[f"workflows:{resource_id}:stream-b"]
+    assert entry_a["stream_session_id"] == "stream-a"
+    assert entry_b["stream_session_id"] == "stream-b"
+    assert entry_a["processed_frames"] == 2
+    assert entry_b["processed_frames"] == 3
+
+
+def test_record_usage_without_stream_session_id_keeps_legacy_key(
+    usage_collector_with_mocked_threads,
+):
+    # given
+    from inference.usage_tracking.stream_session import stream_session_id
+
+    collector = usage_collector_with_mocked_threads
+    assert stream_session_id.get() is None
+
+    # when
+    collector.record_usage(
+        source="img.jpg",
+        category="workflows",
+        frames=1,
+        api_key="fake",
+        resource_id="workflow-1",
+    )
+
+    # then - key format and payload fields unchanged for non-pipeline callers
+    usage = collector._usage["fake"]
+    assert "workflows:workflow-1" in usage
+    assert "stream_session_id" not in usage["workflows:workflow-1"]
+
+
+def test_stream_session_id_does_not_leak_across_threads():
+    # given
+    from threading import Thread
+
+    from inference.usage_tracking.stream_session import stream_session_id
+
+    seen_in_thread = []
+
+    def pipeline_thread():
+        stream_session_id.set("thread-local-stream")
+        seen_in_thread.append(stream_session_id.get())
+
+    # when
+    thread = Thread(target=pipeline_thread)
+    thread.start()
+    thread.join()
+
+    # then - the id set inside the pipeline thread is invisible outside it
+    assert seen_in_thread == ["thread-local-stream"]
+    assert stream_session_id.get() is None
+
+
+def test_zip_usage_payloads_keeps_stream_sessions_separate():
+    # given - same resource under two stream-session-suffixed keys
+    def make_payload(key, ssid, frames, ts):
+        return {
+            "fake_api1_hash": {
+                key: {
+                    "api_key_hash": "fake_api1_hash",
+                    "resource_id": "workflow-1",
+                    "stream_session_id": ssid,
+                    "exec_session_id": "session-1",
+                    "timestamp_start": ts,
+                    "timestamp_stop": ts + 1,
+                    "processed_frames": frames,
+                    "fps": 10,
+                    "source_duration": frames / 10,
+                    "execution_duration": 1,
+                }
+            }
+        }
+
+    dumped_usage_payloads = [
+        make_payload(
+            "workflows:workflow-1:stream-a", "stream-a", 2, 1721032989934855000
+        ),
+        make_payload(
+            "workflows:workflow-1:stream-b", "stream-b", 3, 1721032989934856000
+        ),
+        make_payload(
+            "workflows:workflow-1:stream-a", "stream-a", 5, 1721032989934857000
+        ),
+    ]
+
+    # when
+    zipped_usage_payloads = zip_usage_payloads(usage_payloads=dumped_usage_payloads)
+
+    # then - same stream merges, different streams stay separate
+    merged = {}
+    for payload in zipped_usage_payloads:
+        for resource_payloads in payload.values():
+            for key, resource_usage in resource_payloads.items():
+                assert key not in merged
+                merged[key] = resource_usage
+    assert merged["workflows:workflow-1:stream-a"]["processed_frames"] == 7
+    assert merged["workflows:workflow-1:stream-a"]["stream_session_id"] == "stream-a"
+    assert merged["workflows:workflow-1:stream-b"]["processed_frames"] == 3
+    assert merged["workflows:workflow-1:stream-b"]["stream_session_id"] == "stream-b"

--- a/tests/inference/unit_tests/usage_tracking/test_collector.py
+++ b/tests/inference/unit_tests/usage_tracking/test_collector.py
@@ -1,7 +1,6 @@
 import hashlib
 import json
 import sys
-from copy import deepcopy
 from unittest import mock
 
 import pytest
@@ -1368,7 +1367,6 @@ def test_send_usage_payload_serializes_stream_sessions_as_exec_session_ids(
         ]
     )
     assert len(payloads) == 1
-    original_payload = deepcopy(payloads[0])
     post_mock.return_value.status_code = 200
 
     failed_hashes = send_usage_payload(
@@ -1385,11 +1383,10 @@ def test_send_usage_payload_serializes_stream_sessions_as_exec_session_ids(
         "stream-b",
     }
     assert all("stream_session_id" not in row for row in outbound_rows)
-    assert payloads[0] == original_payload
 
 
 @mock.patch("inference.usage_tracking.payload_helpers.requests.post")
-def test_send_usage_payload_leaves_legacy_and_non_billable_exec_session_ids(
+def test_send_usage_payload_leaves_legacy_exec_session_ids(
     post_mock,
 ):
     payload = {
@@ -1401,25 +1398,16 @@ def test_send_usage_payload_leaves_legacy_and_non_billable_exec_session_ids(
                 "processed_frames": 3,
                 "source_duration": 0.3,
             },
-            "workflows:non-billable:stream-a": {
+            "workflows:tagged:stream-a": {
                 "api_key_hash": "fake_hash",
-                "resource_id": "non-billable",
+                "resource_id": "tagged",
                 "stream_session_id": "stream-a",
                 "exec_session_id": "process-session",
-                "processed_frames": 0,
-                "source_duration": 0,
-            },
-            "workflows:non-numeric:stream-b": {
-                "api_key_hash": "fake_hash",
-                "resource_id": "non-numeric",
-                "stream_session_id": "stream-b",
-                "exec_session_id": "process-session",
-                "processed_frames": 1,
-                "source_duration": "0.1",
+                "processed_frames": 2,
+                "source_duration": 0.2,
             },
         }
     }
-    original_payload = deepcopy(payload)
     post_mock.return_value.status_code = 200
 
     failed_hashes = send_usage_payload(
@@ -1432,15 +1420,13 @@ def test_send_usage_payload_leaves_legacy_and_non_billable_exec_session_ids(
     outbound_rows = post_mock.call_args.kwargs["json"]
     assert {row["resource_id"]: row["exec_session_id"] for row in outbound_rows} == {
         "legacy": "process-session",
-        "non-billable": "process-session",
-        "non-numeric": "process-session",
+        "tagged": "stream-a",
     }
     assert all("stream_session_id" not in row for row in outbound_rows)
-    assert payload == original_payload
 
 
 @mock.patch("inference.usage_tracking.payload_helpers.requests.post")
-def test_send_usage_payload_does_not_mutate_failed_payload_before_retry(post_mock):
+def test_send_usage_payload_retry_sends_identical_rows(post_mock):
     payload = {
         "fake_hash": {
             "workflows:workflow-1:stream-a": {
@@ -1453,7 +1439,6 @@ def test_send_usage_payload_does_not_mutate_failed_payload_before_retry(post_moc
             }
         }
     }
-    original_payload = deepcopy(payload)
     failed_response = mock.MagicMock(status_code=500)
     successful_response = mock.MagicMock(status_code=200)
     post_mock.side_effect = [failed_response, successful_response]
@@ -1463,7 +1448,6 @@ def test_send_usage_payload_does_not_mutate_failed_payload_before_retry(post_moc
         api_usage_endpoint_url="https://example.com/usage",
         hashes_to_api_keys={"fake_hash": "fake-api-key"},
     )
-    payload_after_failure = deepcopy(payload)
     second_result = send_usage_payload(
         payload=payload,
         api_usage_endpoint_url="https://example.com/usage",
@@ -1472,8 +1456,6 @@ def test_send_usage_payload_does_not_mutate_failed_payload_before_retry(post_moc
 
     assert first_result == {"fake_hash"}
     assert second_result == set()
-    assert payload_after_failure == original_payload
-    assert payload == original_payload
     assert (
         post_mock.call_args_list[0].kwargs["json"]
         == post_mock.call_args_list[1].kwargs["json"]

--- a/tests/inference/unit_tests/usage_tracking/test_collector.py
+++ b/tests/inference/unit_tests/usage_tracking/test_collector.py
@@ -1,6 +1,7 @@
 import hashlib
 import json
 import sys
+from copy import deepcopy
 from unittest import mock
 
 import pytest
@@ -10,6 +11,7 @@ from inference.core.version import __version__ as inference_version
 from inference.usage_tracking.payload_helpers import (
     get_api_key_usage_containing_resource,
     merge_usage_dicts,
+    send_usage_payload,
     sha256_hash,
     zip_usage_payloads,
 )
@@ -1349,3 +1351,151 @@ def test_zip_usage_payloads_keeps_stream_sessions_separate():
     assert merged["workflows:workflow-1:stream-a"]["stream_session_id"] == "stream-a"
     assert merged["workflows:workflow-1:stream-b"]["processed_frames"] == 3
     assert merged["workflows:workflow-1:stream-b"]["stream_session_id"] == "stream-b"
+
+
+@mock.patch("inference.usage_tracking.payload_helpers.requests.post")
+def test_send_usage_payload_serializes_stream_sessions_as_exec_session_ids(
+    post_mock,
+):
+    # given - two pipeline rows collected under one process session and resource
+    def make_payload(key, stream_id, frames):
+        return {
+            "fake_hash": {
+                key: {
+                    "api_key_hash": "fake_hash",
+                    "resource_id": "workflow-1",
+                    "stream_session_id": stream_id,
+                    "exec_session_id": "process-session",
+                    "processed_frames": frames,
+                    "fps": 10,
+                    "source_duration": frames / 10,
+                    "execution_duration": 1,
+                }
+            }
+        }
+
+    payloads = zip_usage_payloads(
+        usage_payloads=[
+            make_payload("workflows:workflow-1:stream-a", "stream-a", 2),
+            make_payload("workflows:workflow-1:stream-b", "stream-b", 3),
+        ]
+    )
+    assert len(payloads) == 1
+    original_payload = deepcopy(payloads[0])
+    post_mock.return_value.status_code = 200
+
+    # when
+    failed_hashes = send_usage_payload(
+        payload=payloads[0],
+        api_usage_endpoint_url="https://example.com/usage",
+        hashes_to_api_keys={"fake_hash": "fake-api-key"},
+    )
+
+    # then - both rows share one HTTP request but carry distinct wire IDs
+    assert failed_hashes == set()
+    post_mock.assert_called_once()
+    outbound_rows = post_mock.call_args.kwargs["json"]
+    assert {row["exec_session_id"] for row in outbound_rows} == {
+        "stream-a",
+        "stream-b",
+    }
+    assert all("stream_session_id" not in row for row in outbound_rows)
+    assert payloads[0] == original_payload
+
+
+@mock.patch("inference.usage_tracking.payload_helpers.requests.post")
+def test_send_usage_payload_leaves_legacy_and_non_billable_exec_session_ids(
+    post_mock,
+):
+    # given
+    payload = {
+        "fake_hash": {
+            "workflows:legacy": {
+                "api_key_hash": "fake_hash",
+                "resource_id": "legacy",
+                "exec_session_id": "process-session",
+                "processed_frames": 3,
+                "source_duration": 0.3,
+            },
+            "workflows:non-billable:stream-a": {
+                "api_key_hash": "fake_hash",
+                "resource_id": "non-billable",
+                "stream_session_id": "stream-a",
+                "exec_session_id": "process-session",
+                "processed_frames": 0,
+                "source_duration": 0,
+            },
+            "workflows:non-numeric:stream-b": {
+                "api_key_hash": "fake_hash",
+                "resource_id": "non-numeric",
+                "stream_session_id": "stream-b",
+                "exec_session_id": "process-session",
+                "processed_frames": 1,
+                "source_duration": "0.1",
+            },
+        }
+    }
+    original_payload = deepcopy(payload)
+    post_mock.return_value.status_code = 200
+
+    # when
+    failed_hashes = send_usage_payload(
+        payload=payload,
+        api_usage_endpoint_url="https://example.com/usage",
+        hashes_to_api_keys={"fake_hash": "fake-api-key"},
+    )
+
+    # then
+    assert failed_hashes == set()
+    outbound_rows = post_mock.call_args.kwargs["json"]
+    assert {row["resource_id"]: row["exec_session_id"] for row in outbound_rows} == {
+        "legacy": "process-session",
+        "non-billable": "process-session",
+        "non-numeric": "process-session",
+    }
+    assert all("stream_session_id" not in row for row in outbound_rows)
+    assert payload == original_payload
+
+
+@mock.patch("inference.usage_tracking.payload_helpers.requests.post")
+def test_send_usage_payload_does_not_mutate_failed_payload_before_retry(post_mock):
+    # given
+    payload = {
+        "fake_hash": {
+            "workflows:workflow-1:stream-a": {
+                "api_key_hash": "fake_hash",
+                "resource_id": "workflow-1",
+                "stream_session_id": "stream-a",
+                "exec_session_id": "process-session",
+                "processed_frames": 3,
+                "source_duration": 0.3,
+            }
+        }
+    }
+    original_payload = deepcopy(payload)
+    failed_response = mock.MagicMock(status_code=500)
+    successful_response = mock.MagicMock(status_code=200)
+    post_mock.side_effect = [failed_response, successful_response]
+
+    # when - retry the exact object that would have been requeued after failure
+    first_result = send_usage_payload(
+        payload=payload,
+        api_usage_endpoint_url="https://example.com/usage",
+        hashes_to_api_keys={"fake_hash": "fake-api-key"},
+    )
+    payload_after_failure = deepcopy(payload)
+    second_result = send_usage_payload(
+        payload=payload,
+        api_usage_endpoint_url="https://example.com/usage",
+        hashes_to_api_keys={"fake_hash": "fake-api-key"},
+    )
+
+    # then
+    assert first_result == {"fake_hash"}
+    assert second_result == set()
+    assert payload_after_failure == original_payload
+    assert payload == original_payload
+    assert (
+        post_mock.call_args_list[0].kwargs["json"]
+        == post_mock.call_args_list[1].kwargs["json"]
+    )

--- a/tests/workflows/unit_tests/execution_engine/executor/test_step_context.py
+++ b/tests/workflows/unit_tests/execution_engine/executor/test_step_context.py
@@ -1,0 +1,57 @@
+from concurrent.futures import ThreadPoolExecutor
+from unittest import mock
+
+from inference.core.workflows.execution_engine.v1.executor import core
+from inference.usage_tracking.stream_session import stream_session_id
+
+
+@mock.patch.object(core, "run_step")
+def test_safe_execute_step_rebinds_stream_session_id_in_worker_thread(run_step_mock):
+    # given - blocks (e.g. vision events, dataset upload) read the pipeline's
+    # stream session id from the contextvar, which does not propagate into
+    # ThreadPoolExecutor workers on its own
+    seen = {}
+
+    def capture(**kwargs):
+        seen["stream_session_id"] = stream_session_id.get()
+
+    run_step_mock.side_effect = capture
+
+    # when
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        executor.submit(
+            core.safe_execute_step,
+            step_selector="$steps.some_step",
+            workflow=mock.MagicMock(),
+            execution_data_manager=mock.MagicMock(),
+            pipeline_stream_session_id="stream-a",
+        ).result()
+
+    # then
+    assert seen["stream_session_id"] == "stream-a"
+
+
+@mock.patch.object(core, "run_step")
+def test_safe_execute_step_clears_stale_stream_session_id(run_step_mock):
+    # given - pool threads are reused; a previous pipeline's id must not leak
+    seen = {}
+
+    def capture(**kwargs):
+        seen["stream_session_id"] = stream_session_id.get()
+
+    run_step_mock.side_effect = capture
+
+    def stale_then_execute():
+        stream_session_id.set("stale-stream")
+        core.safe_execute_step(
+            step_selector="$steps.some_step",
+            workflow=mock.MagicMock(),
+            execution_data_manager=mock.MagicMock(),
+        )
+
+    # when
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        executor.submit(stale_then_execute).result()
+
+    # then
+    assert seen["stream_session_id"] is None


### PR DESCRIPTION
## Description


This change:

- Gives each `InferencePipeline` a stream session ID. Callers may supply a stable ID such as `DEVICE_ID:stream_name` ([roboflow-edge#536](https://github.com/roboflow/roboflow-edge/pull/536)); otherwise one is generated.
- Sets that ID in a `ContextVar` within the pipeline inference thread.
- Aggregates tagged usage by `category:resource_id:stream_session_id`, preventing pipelines with the same API key and workflow from merging.
- Substitutes the stream ID into the existing outbound `exec_session_id` field and removes the internal field.
- Re-binds the ID into workflow step worker threads, so blocks (e.g. vision events, dataset upload) can read the pipeline identity via `inference.usage_tracking.stream_session.stream_session_id.get()`.

The wire format, ingestion schema, and billing query are unchanged. For pipeline stream rows, `exec_session_id` now identifies a pipeline rather than a process. Non-pipeline usage remains byte-identical when the context variable is unset.

Alternatives rejected:

- `workflow`/`resource_id`: one workflow may run on multiple cameras.
- `video_reference`: may expose RTSP credentials.
- `resource_details`: rows aggregate before sending, and the details cache is shared per resource.

Companion PRs:

- [roboflow#13450](https://github.com/roboflow/roboflow/pull/13450): interim query-side fix for the existing fleet, validated in production for five days.
- [roboflow-edge#536](https://github.com/roboflow/roboflow-edge/pull/536): stable device/stream IDs.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## How has this change been tested

66 tests pass, including slow end-to-end video tests. Coverage includes:

- Separation of streams sharing an API key and workflow.
- Supplied and automatically generated IDs.
- Correct tagging of concurrent pipelines.
- No cross-thread context leakage.
- Legacy keys and fields when the context variable is unset.
- `zip_usage_payloads` merge/split behavior.
- Outbound ID substitution and internal-field removal.
- Identical rows across retries.

## Any specific deployment considerations

None. No server, schema, ingestion, or billing-query changes are required. Existing clients are unaffected; corrected counting takes effect per device when `inference` is upgraded.
