### PR TITLE
fix: PP-OCRv6 pipeline joins same-row text fragments with spaces

### DIFF
--- a/inference_models/docs/changelog.md
+++ b/inference_models/docs/changelog.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## `0.30.1`
+
+### Fixed
+
+- PP-OCRv6 pipeline assembles `text` by joining fragments detected on the same
+  visual line with spaces; newlines now separate only distinct lines. Previously
+  every detected fragment was joined with a newline, splitting single sentences
+  the detector returned as multiple boxes.
+
 ## `0.30.0`
 
 ### Added

--- a/inference_models/inference_models/models/pp_ocrv6/pp_ocrv6_pipeline.py
+++ b/inference_models/inference_models/models/pp_ocrv6/pp_ocrv6_pipeline.py
@@ -88,7 +88,8 @@ class PPOCRv6Pipeline:
     def _recognize_image(
         self, image: np.ndarray, detections: Detections
     ) -> PPOCRv6PipelineResult:
-        order = _reading_order(detections)
+        lines = _reading_order(detections)
+        order = [index for line in lines for index in line]
         if not order:
             return PPOCRv6PipelineResult(text="", line_texts=[], detections=detections)
         ordered_detections = _reorder_detections(detections, order)
@@ -102,7 +103,7 @@ class PPOCRv6Pipeline:
         ]
         line_texts = self._rec_model(crops)
         return PPOCRv6PipelineResult(
-            text="\n".join(line_texts),
+            text=_assemble_text(line_texts, lines),
             line_texts=line_texts,
             detections=ordered_detections,
         )
@@ -115,8 +116,8 @@ class PPOCRv6Pipeline:
         return self.infer(images, **kwargs)
 
 
-def _reading_order(detections: Detections) -> List[int]:
-    """Order detection indices top-to-bottom by line, each line left-to-right."""
+def _reading_order(detections: Detections) -> List[List[int]]:
+    """Group detection indices into visual lines, top-to-bottom, each left-to-right."""
     boxes = detections.xyxy.tolist()
     items = sorted(range(len(boxes)), key=lambda index: boxes[index][1])
     lines, current, line_bottom = [], [], None
@@ -131,10 +132,20 @@ def _reading_order(detections: Detections) -> List[int]:
             line_bottom = max(line_bottom, bottom)
     if current:
         lines.append(current)
-    ordered = []
+    return [sorted(line, key=lambda index: boxes[index][0]) for line in lines]
+
+
+def _assemble_text(line_texts: List[str], lines: List[List[int]]) -> str:
+    """Join fragments on the same visual line with spaces, lines with newlines.
+
+    ``line_texts`` follows the flattened reading order of ``lines``.
+    """
+    rows, cursor = [], 0
     for line in lines:
-        ordered.extend(sorted(line, key=lambda index: boxes[index][0]))
-    return ordered
+        fragments = line_texts[cursor : cursor + len(line)]
+        rows.append(" ".join(f for f in (t.strip() for t in fragments) if f))
+        cursor += len(line)
+    return "\n".join(rows)
 
 
 def _reorder_detections(detections: Detections, order: List[int]) -> Detections:

--- a/inference_models/pyproject.toml
+++ b/inference_models/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inference-models"
-version = "0.30.0"
+version = "0.30.1"
 description = "The new inference engine for Computer Vision models"
 readme = "README.md"
 requires-python = ">=3.10,<3.13"

--- a/inference_models/tests/unit_tests/models/test_pp_ocrv6_pipeline.py
+++ b/inference_models/tests/unit_tests/models/test_pp_ocrv6_pipeline.py
@@ -76,7 +76,27 @@ def test_infer_sorts_detections_into_reading_order() -> None:
         [60, 100, 100, 130],
     ]
     assert len(result.line_texts) == 4
-    assert result.text == "\n".join(result.line_texts)
+    # Fragments on the same visual line join with spaces, lines with newlines.
+    assert result.text == "40x30 40x30\n40x30 40x30"
+
+
+def test_infer_joins_same_row_fragments_with_space() -> None:
+    # One visual row split by the detector into two horizontally adjacent boxes
+    # (mirrors "This is a test image for " + "OCR." from the e2e image).
+    boxes = [
+        [0, 0, 638, 90],
+        [613, 0, 788, 72],
+    ]
+    detector = _FakeDetector([_detections(boxes, [_polygon(box) for box in boxes])])
+    recognizer = _FakeRecognizer()
+    pipeline = PPOCRv6Pipeline(det_model=detector, rec_model=recognizer)
+    image = np.zeros((200, 800, 3), dtype=np.uint8)
+
+    result = pipeline(image)[0]
+
+    assert len(result.line_texts) == 2
+    assert "\n" not in result.text
+    assert result.text == "638x90 175x72"
 
 
 def test_infer_perspective_crops_from_polygons() -> None:


### PR DESCRIPTION
## Problem

Post-merge e2e check on main is failing:

```
FAILED tests/e2e_platform_tests/test_pp_ocrv6_e2e.py::test_pp_ocrv6_pipeline
AssertionError: assert 'This is a test image for OCR' in 'This is a test image for \nOCR.'
```

The detector split one visual line into two horizontally adjacent boxes (`This is a test image for ` + `OCR.`). `_reading_order` already grouped boxes into visual lines, but the grouping was discarded and `text` joined **every** fragment with a newline.

## Fix

- `_reading_order` now returns the line grouping (`List[List[int]]`).
- New `_assemble_text` joins fragments on the same visual line with spaces (stripping fragment edges), and separate lines with newlines.
- `line_texts` / `detections` ordering unchanged.
- Regression unit test mirroring the e2e failure geometry; updated the reading-order test for the new assembly.
- Bumped `inference-models` to `0.30.1` + changelog entry.

cc @PawelPeczek-Roboflow — needs `inference-models` 0.30.1 release to make the platform e2e green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)