### PR TITLE
fix(sdk): tolerate pts jitter in webrtc frame-prediction pairing

### DIFF
--- a/inference/core/version.py
+++ b/inference/core/version.py
@@ -1,4 +1,4 @@
-__version__ = "1.3.6"
+__version__ = "1.3.7"
 
 
 if __name__ == "__main__":

--- a/inference_sdk/webrtc/session.py
+++ b/inference_sdk/webrtc/session.py
@@ -235,6 +235,12 @@ class WebRTCSession:
         ) = {}
         self._pending_predictions: "Dict[int, dict]" = {}
         self._pairing_max_size = 150
+        # Some server paths (observed on serverless) deliver the returned
+        # track frame with a pts a few 90kHz ticks off the datachannel
+        # metadata pts (timebase-conversion rounding in transit). Frames are
+        # tens of milliseconds (thousands of ticks) apart, so a ±1ms window
+        # pairs those without ever being ambiguous between neighbours.
+        self._pairing_pts_tolerance = 90
         # Pairing health counters: detect a systematic pts mismatch between the
         # video track and the datachannel metadata (see _evict_pending_frames).
         self._pairing_matched = 0
@@ -767,8 +773,9 @@ class WebRTCSession:
             # No pts to pair on: deliver immediately without predictions.
             self._enqueue((frame, None, metadata))
             return
-        predictions = self._pending_predictions.pop(pts, None)
-        if predictions is not None:
+        matched_pts = self._nearest_pts(pts, self._pending_predictions)
+        if matched_pts is not None:
+            predictions = self._pending_predictions.pop(matched_pts)
             self._pairing_matched += 1
             self._enqueue((frame, predictions, metadata))
             return
@@ -784,14 +791,30 @@ class WebRTCSession:
         """
         if pts is None:
             return
-        pending = self._pending_frames.pop(pts, None)
-        if pending is not None:
-            frame, metadata = pending
+        matched_pts = self._nearest_pts(pts, self._pending_frames)
+        if matched_pts is not None:
+            frame, metadata = self._pending_frames.pop(matched_pts)
             self._pairing_matched += 1
             self._enqueue((frame, predictions, metadata))
             return
         self._pending_predictions[pts] = predictions
         self._evict_pending_predictions()
+
+    def _nearest_pts(self, pts: int, pending: dict) -> Optional[int]:
+        """Find the key in ``pending`` closest to ``pts`` within the pairing
+        tolerance, preferring an exact hit. Returns None when nothing is close
+        enough. Pending dicts are bounded by ``_pairing_max_size``, so the
+        fallback scan is cheap."""
+        if pts in pending:
+            return pts
+        best = None
+        best_delta = self._pairing_pts_tolerance + 1
+        for candidate in pending:
+            delta = abs(candidate - pts)
+            if delta < best_delta:
+                best = candidate
+                best_delta = delta
+        return best
 
     def _evict_pending_frames(self) -> None:
         """Bound the pending-frames dict, flushing evicted frames with data=None."""

--- a/tests/inference_sdk/unit_tests/webrtc/test_client_model_id.py
+++ b/tests/inference_sdk/unit_tests/webrtc/test_client_model_id.py
@@ -535,6 +535,61 @@ class TestTrackPairing:
             assert frame.shape == (10 + expected_pts, 20 + expected_pts, 3)
             assert data is None
 
+    def test_off_by_one_pts_pairs_within_tolerance(self):
+        # Serverless was observed delivering track frames with a pts a few
+        # 90kHz ticks off the datachannel metadata pts; nearest-match pairing
+        # within tolerance must absorb that.
+        session = _make_session()
+        img = np.zeros((100, 100, 3), dtype=np.uint8)
+        predictions = _predictions_dict()
+
+        session._pair_track_predictions(6000, predictions)
+        md = VideoMetadata(frame_id=1, received_at=datetime.now(), pts=6001)
+        session._pair_track_frame(6001, img, md)
+
+        frame, data, _ = session._video_queue.get_nowait()
+        assert data is predictions
+        assert not session._pending_predictions
+
+    def test_off_by_one_pts_pairs_frame_first(self):
+        session = _make_session()
+        img = np.zeros((100, 100, 3), dtype=np.uint8)
+        md = VideoMetadata(frame_id=1, received_at=datetime.now(), pts=6000)
+        session._pair_track_frame(6000, img, md)
+
+        predictions = _predictions_dict()
+        session._pair_track_predictions(6001, predictions)
+
+        frame, data, _ = session._video_queue.get_nowait()
+        assert data is predictions
+        assert not session._pending_frames
+
+    def test_pts_beyond_tolerance_does_not_pair(self):
+        session = _make_session()
+        img = np.zeros((100, 100, 3), dtype=np.uint8)
+        session._pair_track_predictions(6000, _predictions_dict())
+        md = VideoMetadata(frame_id=1, received_at=datetime.now(), pts=6200)
+        session._pair_track_frame(6200, img, md)
+
+        assert session._video_queue.empty()
+        assert 6200 in session._pending_frames
+        assert 6000 in session._pending_predictions
+
+    def test_exact_pts_wins_over_near_neighbour(self):
+        session = _make_session()
+        img = np.zeros((100, 100, 3), dtype=np.uint8)
+        exact = _predictions_dict()
+        near = _predictions_dict()
+        session._pair_track_predictions(6001, near)
+        session._pair_track_predictions(6000, exact)
+
+        md = VideoMetadata(frame_id=1, received_at=datetime.now(), pts=6000)
+        session._pair_track_frame(6000, img, md)
+
+        frame, data, _ = session._video_queue.get_nowait()
+        assert data is exact
+        assert 6001 in session._pending_predictions
+
     def test_pts_none_delivers_none_data_immediately(self):
         session = _make_session()
         img = np.zeros((30, 40, 3), dtype=np.uint8)  # H=30, W=40


### PR DESCRIPTION
## What

Follow-up to #2622. The live-source frame/prediction pairing in `webrtc.stream(model_id=...)` mode pairs returned video-track frames with datachannel predictions by `pts`. Live measurement showed exact-match pairing silently drops ~30% of frames.

## Why

Ran a 30-min drift harness (`ManualSource` at 15fps, reading `_pairing_matched`/`_pairing_evicted`) against **both** a local server and serverless. Finding:

- No cumulative drift, but ~30% of returned track frames arrive with a `pts` **exactly 1 tick (90kHz) off** the datachannel metadata `pts` — steady jitter from timebase conversion in transit, on both targets.
- Exact-match pairing evicted those frames with `data=None`. The mismatch warning correctly stayed silent (most frames still paired), so the loss was invisible.

| Run | Paired | Verdict |
|---|---|---|
| Serverless, pre-fix | 68% | drop confirmed |
| Local, pre-fix | 67% | drop confirmed |
| Serverless, post-fix (9min) | 7485/7485 → 7927/7927 | **PASS** |
| Local, post-fix (5min) | 1804/1804 | **PASS** |

## How

Pair by **nearest `pts` within ±90 ticks (1ms)**, exact hit preferred ([session.py](https://github.com/roboflow/inference/blob/fix/webrtc-pts-jitter-pairing/inference_sdk/webrtc/session.py)). Frames are ≥thousands of ticks apart at any realistic fps, so the window is unambiguous — no risk of pairing a frame to a neighbor's predictions.

## Testing

- 4 new unit tests: off-by-one both directions, beyond-tolerance (no pair), exact-beats-near.
- Full SDK unit suite: 488 passed.
- Live-verified on local + serverless (table above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)