### PR TITLE
chore: bump inference-models to ~=0.30.1

### DIFF
--- a/inference/core/version.py
+++ b/inference/core/version.py
@@ -1,4 +1,4 @@
-__version__ = "1.3.6"
+__version__ = "1.3.7"
 
 
 if __name__ == "__main__":

--- a/requirements/requirements.cpu.txt
+++ b/requirements/requirements.cpu.txt
@@ -1,3 +1,3 @@
 onnxruntime>=1.15.1,<1.22.0
 nvidia-ml-py<13.0.0
-inference-models[torch-cpu,onnx-cpu]~=0.30.0  # keep in sync between requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt
+inference-models[torch-cpu,onnx-cpu]~=0.30.1  # keep in sync between requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt

--- a/requirements/requirements.gpu.txt
+++ b/requirements/requirements.gpu.txt
@@ -1,2 +1,2 @@
 onnxruntime-gpu>=1.15.1,<1.22.0
-inference-models[torch-cu124,onnx-cu12]~=0.30.0 # keep in sync between requirements.jetson requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt
+inference-models[torch-cu124,onnx-cu12]~=0.30.1 # keep in sync between requirements.jetson requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt

--- a/requirements/requirements.jetson.txt
+++ b/requirements/requirements.jetson.txt
@@ -1,3 +1,3 @@
 pypdfium2>=4.11.0,<5.0.0
 PyYAML~=6.0.0
-inference-models~=0.30.0  # keep in sync between requirements.jetson requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt
+inference-models~=0.30.1  # keep in sync between requirements.jetson requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt

--- a/requirements/requirements.vino.txt
+++ b/requirements/requirements.vino.txt
@@ -1,2 +1,2 @@
 onnxruntime-openvino>=1.15.0,<1.22.0
-inference-models[torch-cpu]~=0.30.0  # keep in sync between requirements.jetson requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt
+inference-models[torch-cpu]~=0.30.1  # keep in sync between requirements.jetson requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt


### PR DESCRIPTION
## What
Bump `inference-models` requirement `~=0.30.0` → `~=0.30.1` across all 4 synced requirements files (cpu, gpu, jetson, vino). Bump `inference` to `1.3.7`.

## Why
`inference-models` 0.30.1 was published to PyPI with the PP-OCR test fix (follow-up to #2530). This pins inference to that patch.

## Notes
- Depends on the inference-models 0.30.1 PyPI publish (already live).
- No code changes; requirement pin + version bump only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)