### PR TITLE
Enhance error handling in HTTP interfaces by adding support for Inner…

### DIFF
--- a/inference/core/interfaces/http/error_handlers.py
+++ b/inference/core/interfaces/http/error_handlers.py
@@ -75,8 +75,11 @@ from inference.core.workflows.errors import (
     WorkflowSyntaxError,
 )
 from inference.core.workflows.execution_engine.v1.inner_workflow.errors import (
-    InnerWorkflowCompositionError,
+    InnerWorkflowCompositionCycleError,
+    InnerWorkflowInvalidStepEntryError,
+    InnerWorkflowNestingDepthError,
     InnerWorkflowParameterBindingsError,
+    InnerWorkflowTotalCountError,
 )
 from inference_models.errors import (
     EnvironmentConfigurationError,
@@ -249,7 +252,10 @@ def with_route_exceptions(route):
             InvalidInputTypeError,
             OperationTypeNotRecognisedError,
             DynamicBlockError,
-            InnerWorkflowCompositionError,
+            InnerWorkflowCompositionCycleError,
+            InnerWorkflowInvalidStepEntryError,
+            InnerWorkflowNestingDepthError,
+            InnerWorkflowTotalCountError,
             InnerWorkflowParameterBindingsError,
             WorkflowExecutionEngineVersionError,
             NotSupportedExecutionEngineError,
@@ -725,7 +731,10 @@ def with_route_exceptions_async(route):
             InvalidInputTypeError,
             OperationTypeNotRecognisedError,
             DynamicBlockError,
-            InnerWorkflowCompositionError,
+            InnerWorkflowCompositionCycleError,
+            InnerWorkflowInvalidStepEntryError,
+            InnerWorkflowNestingDepthError,
+            InnerWorkflowTotalCountError,
             InnerWorkflowParameterBindingsError,
             WorkflowExecutionEngineVersionError,
             NotSupportedExecutionEngineError,

--- a/inference/core/interfaces/http/error_handlers.py
+++ b/inference/core/interfaces/http/error_handlers.py
@@ -74,6 +74,10 @@ from inference.core.workflows.errors import (
     WorkflowExecutionEngineVersionError,
     WorkflowSyntaxError,
 )
+from inference.core.workflows.execution_engine.v1.inner_workflow.errors import (
+    InnerWorkflowCompositionError,
+    InnerWorkflowParameterBindingsError,
+)
 from inference_models.errors import (
     EnvironmentConfigurationError,
     FileHashSumMissmatch,
@@ -245,6 +249,8 @@ def with_route_exceptions(route):
             InvalidInputTypeError,
             OperationTypeNotRecognisedError,
             DynamicBlockError,
+            InnerWorkflowCompositionError,
+            InnerWorkflowParameterBindingsError,
             WorkflowExecutionEngineVersionError,
             NotSupportedExecutionEngineError,
         ) as error:
@@ -719,6 +725,8 @@ def with_route_exceptions_async(route):
             InvalidInputTypeError,
             OperationTypeNotRecognisedError,
             DynamicBlockError,
+            InnerWorkflowCompositionError,
+            InnerWorkflowParameterBindingsError,
             WorkflowExecutionEngineVersionError,
             NotSupportedExecutionEngineError,
         ) as error:

--- a/tests/inference/unit_tests/core/interfaces/http/test_error_handlers.py
+++ b/tests/inference/unit_tests/core/interfaces/http/test_error_handlers.py
@@ -13,6 +13,10 @@ from inference.core.workflows.errors import (
     ClientCausedStepExecutionError,
     RuntimeLimitsCausedStepExecutionError,
 )
+from inference.core.workflows.execution_engine.v1.inner_workflow.errors import (
+    InnerWorkflowCompositionCycleError,
+    InnerWorkflowParameterBindingsUnknownInputError,
+)
 from inference_models.errors import (
     FileHashSumMissmatch,
     ModelInputError,
@@ -121,6 +125,60 @@ async def test_with_route_exceptions_async_when_model_input_error_raised():
 
     assert resp.status_code == 400
     assert "model input" in resp.body.decode().lower()
+
+
+def test_with_route_exceptions_when_inner_workflow_parameter_bindings_error_raised():
+    @with_route_exceptions
+    def my_route():
+        raise InnerWorkflowParameterBindingsUnknownInputError(
+            public_message="inner workflow parameter bindings reference unknown input"
+        )
+
+    resp = my_route()
+
+    assert resp.status_code == 400
+    assert "unknown input" in resp.body.decode().lower()
+
+
+@pytest.mark.asyncio
+async def test_with_route_exceptions_async_when_inner_workflow_parameter_bindings_error_raised():
+    @with_route_exceptions_async
+    async def my_route():
+        raise InnerWorkflowParameterBindingsUnknownInputError(
+            public_message="inner workflow parameter bindings reference unknown input"
+        )
+
+    resp = await my_route()
+
+    assert resp.status_code == 400
+    assert "unknown input" in resp.body.decode().lower()
+
+
+def test_with_route_exceptions_when_inner_workflow_composition_error_raised():
+    @with_route_exceptions
+    def my_route():
+        raise InnerWorkflowCompositionCycleError(
+            public_message="inner workflow composition contains a cycle"
+        )
+
+    resp = my_route()
+
+    assert resp.status_code == 400
+    assert "cycle" in resp.body.decode().lower()
+
+
+@pytest.mark.asyncio
+async def test_with_route_exceptions_async_when_inner_workflow_composition_error_raised():
+    @with_route_exceptions_async
+    async def my_route():
+        raise InnerWorkflowCompositionCycleError(
+            public_message="inner workflow composition contains a cycle"
+        )
+
+    resp = await my_route()
+
+    assert resp.status_code == 400
+    assert "cycle" in resp.body.decode().lower()
 
 
 def test_with_route_exceptions_when_cannot_initialise_model_due_to_input_size_error_raised():

--- a/tests/inference/unit_tests/core/interfaces/http/test_error_handlers.py
+++ b/tests/inference/unit_tests/core/interfaces/http/test_error_handlers.py
@@ -15,6 +15,7 @@ from inference.core.workflows.errors import (
 )
 from inference.core.workflows.execution_engine.v1.inner_workflow.errors import (
     InnerWorkflowCompositionCycleError,
+    InnerWorkflowInliningStructureError,
     InnerWorkflowParameterBindingsUnknownInputError,
 )
 from inference_models.errors import (
@@ -179,6 +180,31 @@ async def test_with_route_exceptions_async_when_inner_workflow_composition_error
 
     assert resp.status_code == 400
     assert "cycle" in resp.body.decode().lower()
+
+
+def test_with_route_exceptions_when_inner_workflow_inlining_structure_error_raised():
+    @with_route_exceptions
+    def my_route():
+        raise InnerWorkflowInliningStructureError(
+            public_message="inner workflow inlining made no progress"
+        )
+
+    resp = my_route()
+
+    assert resp.status_code == 500
+
+
+@pytest.mark.asyncio
+async def test_with_route_exceptions_async_when_inner_workflow_inlining_structure_error_raised():
+    @with_route_exceptions_async
+    async def my_route():
+        raise InnerWorkflowInliningStructureError(
+            public_message="inner workflow inlining made no progress"
+        )
+
+    resp = await my_route()
+
+    assert resp.status_code == 500
 
 
 def test_with_route_exceptions_when_cannot_initialise_model_due_to_input_size_error_raised():


### PR DESCRIPTION
## What does this PR do?

Inner workflow validation errors could surface as HTTP 500 responses from workflow inference endpoints. In particular, stale `parameter_bindings` entries that referenced removed child workflow inputs were treated as generic workflow failures, even though they are invalid workflow definitions.

This PR maps compile-time inner workflow validation errors to HTTP 400 responses in the shared route exception handlers. It covers both parameter binding failures, such as unknown or missing child workflow inputs, and composition failures, such as invalid nesting or cycles. The mapping is added to both sync and async HTTP wrappers so route behavior stays consistent across the API surface. Runtime `InnerWorkflowRunNotSupportedError` remains classified as a server-side failure because reaching `run()` means the compiler failed to inline the block. Focused unit tests lock in the new status-code behavior for both error families.

**Main elements:**
- HTTP route exception handling for inner workflow compile-time validation errors.
- Unit coverage for sync and async route wrappers.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other:

## Testing

### Unit tests

- Added coverage for `InnerWorkflowParameterBindingsError` subclasses returning HTTP 400 through sync and async route wrappers.
- Added coverage for `InnerWorkflowCompositionError` subclasses returning HTTP 400 through sync and async route wrappers.

### Integration tests

- None for this PR.

### Other

- `uv run pytest tests/inference/unit_tests/core/interfaces/http/test_error_handlers.py`
- `ReadLints` on edited files

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where necessary, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have updated the documentation accordingly (if applicable)
