### PR TITLE
Add accelerated tensor-native media runtimes

### DIFF
--- a/.github/workflows/docker.jetson.7.1.0.yml
+++ b/.github/workflows/docker.jetson.7.1.0.yml
@@ -8,6 +8,13 @@ on:
     branches: [main]
   workflow_dispatch:
     inputs:
+      image_target:
+        type: choice
+        description: "Container target to build"
+        options:
+          - server-jp71
+          - media-jp72
+        default: server-jp71
       force_push:
         type: boolean
         description: "Do you want to push image after build?"
@@ -20,6 +27,7 @@ on:
 env:
   VERSION: "0.0.0" # Default version, will be overwritten
   BASE_IMAGE: "roboflow/roboflow-inference-server-jetson-7.1.0"
+  MEDIA_BASE_IMAGE: "roboflow/roboflow-inference-media-jetson-7.2.0"
 
 jobs:
   docker:
@@ -40,13 +48,32 @@ jobs:
         uses: actions/checkout@v6
       - name: Read version from file
         run: echo "VERSION=$(DISABLE_VERSION_CHECK=true python ./inference/core/version.py)" >> $GITHUB_ENV
+      - name: Select build target
+        id: target
+        env:
+          IMAGE_TARGET: ${{ inputs.image_target || 'server-jp71' }}
+        run: |
+          case "$IMAGE_TARGET" in
+            server-jp71)
+              echo "dockerfile=./docker/dockerfiles/Dockerfile.onnx.jetson.7.1.0" >> "$GITHUB_OUTPUT"
+              echo "base_image=${BASE_IMAGE}" >> "$GITHUB_OUTPUT"
+              ;;
+            media-jp72)
+              echo "dockerfile=./docker/dockerfiles/Dockerfile.media.jetson.7.2.0" >> "$GITHUB_OUTPUT"
+              echo "base_image=${MEDIA_BASE_IMAGE}" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "Unsupported image target: $IMAGE_TARGET" >&2
+              exit 1
+              ;;
+          esac
       - name: Determine Image Tags
         id: tags
         uses: ./.github/actions/determine-tags
         with:
           custom_tag: ${{ github.event.inputs.custom_tag }}
           version: ${{ env.VERSION }}
-          base_image: ${{ env.BASE_IMAGE }}
+          base_image: ${{ steps.target.outputs.base_image }}
           force_push: ${{ github.event.inputs.force_push }}
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up Depot CLI
@@ -55,7 +82,9 @@ jobs:
         uses: depot/build-push-action@v1
         with:
           push: ${{ github.event_name == 'release' || (github.event.inputs.force_push == 'true')}}
+          save: ${{ github.event_name == 'workflow_dispatch' && inputs.image_target == 'media-jp72' }}
+          save-tag: media-jp72-${{ github.sha }}
           project: v1xzfwkc4b
           tags: ${{ steps.tags.outputs.image_tags }}
           platforms: linux/arm64
-          file: ./docker/dockerfiles/Dockerfile.onnx.jetson.7.1.0
+          file: ${{ steps.target.outputs.dockerfile }}

--- a/.github/workflows/docker.jetson.7.1.0.yml
+++ b/.github/workflows/docker.jetson.7.1.0.yml
@@ -81,9 +81,9 @@ jobs:
       - name: Build and Push
         uses: depot/build-push-action@v1
         with:
-          push: ${{ github.event_name == 'release' || (github.event.inputs.force_push == 'true')}}
+          push: ${{ inputs.image_target != 'media-jp72' && (github.event_name == 'release' || github.event.inputs.force_push == 'true') }}
           save: ${{ github.event_name == 'workflow_dispatch' && inputs.image_target == 'media-jp72' }}
-          save-tag: media-jp72-${{ github.sha }}
+          save-tag: ${{ inputs.image_target == 'media-jp72' && format('media-jp72-{0}', github.sha) || '' }}
           project: v1xzfwkc4b
           tags: ${{ steps.tags.outputs.image_tags }}
           platforms: linux/arm64

--- a/.github/workflows/docker.jetson.7.1.0.yml
+++ b/.github/workflows/docker.jetson.7.1.0.yml
@@ -8,13 +8,6 @@ on:
     branches: [main]
   workflow_dispatch:
     inputs:
-      image_target:
-        type: choice
-        description: "Container target to build"
-        options:
-          - server-jp71
-          - media-jp72
-        default: server-jp71
       force_push:
         type: boolean
         description: "Do you want to push image after build?"
@@ -27,7 +20,6 @@ on:
 env:
   VERSION: "0.0.0" # Default version, will be overwritten
   BASE_IMAGE: "roboflow/roboflow-inference-server-jetson-7.1.0"
-  MEDIA_BASE_IMAGE: "roboflow/roboflow-inference-media-jetson-7.2.0"
 
 jobs:
   docker:
@@ -48,32 +40,13 @@ jobs:
         uses: actions/checkout@v6
       - name: Read version from file
         run: echo "VERSION=$(DISABLE_VERSION_CHECK=true python ./inference/core/version.py)" >> $GITHUB_ENV
-      - name: Select build target
-        id: target
-        env:
-          IMAGE_TARGET: ${{ inputs.image_target || 'server-jp71' }}
-        run: |
-          case "$IMAGE_TARGET" in
-            server-jp71)
-              echo "dockerfile=./docker/dockerfiles/Dockerfile.onnx.jetson.7.1.0" >> "$GITHUB_OUTPUT"
-              echo "base_image=${BASE_IMAGE}" >> "$GITHUB_OUTPUT"
-              ;;
-            media-jp72)
-              echo "dockerfile=./docker/dockerfiles/Dockerfile.media.jetson.7.2.0" >> "$GITHUB_OUTPUT"
-              echo "base_image=${MEDIA_BASE_IMAGE}" >> "$GITHUB_OUTPUT"
-              ;;
-            *)
-              echo "Unsupported image target: $IMAGE_TARGET" >&2
-              exit 1
-              ;;
-          esac
       - name: Determine Image Tags
         id: tags
         uses: ./.github/actions/determine-tags
         with:
           custom_tag: ${{ github.event.inputs.custom_tag }}
           version: ${{ env.VERSION }}
-          base_image: ${{ steps.target.outputs.base_image }}
+          base_image: ${{ env.BASE_IMAGE }}
           force_push: ${{ github.event.inputs.force_push }}
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up Depot CLI
@@ -81,10 +54,8 @@ jobs:
       - name: Build and Push
         uses: depot/build-push-action@v1
         with:
-          push: ${{ inputs.image_target != 'media-jp72' && (github.event_name == 'release' || github.event.inputs.force_push == 'true') }}
-          save: ${{ github.event_name == 'workflow_dispatch' && inputs.image_target == 'media-jp72' }}
-          save-tag: ${{ inputs.image_target == 'media-jp72' && format('media-jp72-{0}', github.sha) || '' }}
+          push: ${{ github.event_name == 'release' || (github.event.inputs.force_push == 'true')}}
           project: v1xzfwkc4b
           tags: ${{ steps.tags.outputs.image_tags }}
           platforms: linux/arm64
-          file: ${{ steps.target.outputs.dockerfile }}
+          file: ./docker/dockerfiles/Dockerfile.onnx.jetson.7.1.0

--- a/.github/workflows/docker.jetson.7.2.0.yml
+++ b/.github/workflows/docker.jetson.7.2.0.yml
@@ -1,0 +1,74 @@
+name: Build and Push Jetson 7.2.0 Media Container
+
+permissions:
+  contents: read
+
+on:
+  release:
+    types: [created]
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/docker.jetson.7.2.0.yml"
+      - "docker/dockerfiles/Dockerfile.media.jetson.7.2.0"
+      - "docker/native/jetson_tensor_bridge/**"
+      - "docker/scripts/**"
+      - "LICENSE"
+      - "LICENSE.core"
+  workflow_dispatch:
+    inputs:
+      force_push:
+        type: boolean
+        description: "Do you want to push the image after building?"
+        default: false
+      custom_tag:
+        type: string
+        description: "Custom tag to use for the image"
+        default: ""
+
+env:
+  VERSION: "0.0.0"
+  BASE_IMAGE: "roboflow/roboflow-inference-media-jetson-7.2.0"
+
+jobs:
+  docker:
+    runs-on:
+      labels: depot-ubuntu-24.04-4
+      group: public-depot
+    timeout-minutes: 180
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Login to Docker Hub
+        if: ${{ github.event_name == 'release' || inputs.force_push }}
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Read version from file
+        run: echo "VERSION=$(DISABLE_VERSION_CHECK=true python ./inference/core/version.py)" >> "$GITHUB_ENV"
+      - name: Determine image tags
+        id: tags
+        uses: ./.github/actions/determine-tags
+        with:
+          custom_tag: ${{ inputs.custom_tag }}
+          version: ${{ env.VERSION }}
+          base_image: ${{ env.BASE_IMAGE }}
+          force_push: ${{ inputs.force_push }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Depot CLI
+        uses: depot/setup-action@v1
+      - name: Build image
+        uses: depot/build-push-action@v1
+        with:
+          project: v1xzfwkc4b
+          context: .
+          file: ./docker/dockerfiles/Dockerfile.media.jetson.7.2.0
+          platforms: linux/arm64
+          push: ${{ github.event_name == 'release' || inputs.force_push }}
+          save: ${{ github.event_name != 'release' && !inputs.force_push }}
+          save-tag: ${{ github.event_name != 'release' && !inputs.force_push && format('media-jp72-{0}', github.sha) || '' }}
+          tags: ${{ steps.tags.outputs.image_tags }}

--- a/.github/workflows/test.nvidia_t4.yml
+++ b/.github/workflows/test.nvidia_t4.yml
@@ -56,7 +56,32 @@ jobs:
       - name: �🔨 Build and Push Test Docker - GPU
         run: |
           docker build -t roboflow/roboflow-inference-server-gpu:test -f docker/dockerfiles/Dockerfile.onnx.gpu .
-      
+
+      - name: Verify CUDA OpenCV - GPU
+        run: |
+          docker run --rm --gpus all --entrypoint sh \
+            -e OPENCV_REQUIRE_CUDA_BUILD=true \
+            -e OPENCV_REQUIRE_CUDA_RUNTIME=true \
+            -v "$PWD/docker/scripts/verify_opencv.sh:/tmp/verify_opencv:ro" \
+            roboflow/roboflow-inference-server-gpu:test \
+            /tmp/verify_opencv
+
+      - name: Verify NVIDIA GStreamer codecs - GPU
+        run: |
+          docker run --rm --gpus all --entrypoint sh \
+            -e GSTREAMER_REQUIRE_NVCODEC=true \
+            -e GSTREAMER_REQUIRE_NVCODEC_RUNTIME=true \
+            -v "$PWD/docker/scripts/verify_gstreamer.sh:/tmp/verify_gstreamer:ro" \
+            roboflow/roboflow-inference-server-gpu:test \
+            /tmp/verify_gstreamer
+
+      - name: Verify CUDA GStreamer tensor bridge - GPU
+        run: |
+          docker run --rm --gpus all --entrypoint python3 \
+            -v "$PWD/docker/scripts/verify_gstreamer_cuda_tensor_runtime.py:/tmp/verify_gstreamer_cuda_tensor_runtime.py:ro" \
+            roboflow/roboflow-inference-server-gpu:test \
+            /tmp/verify_gstreamer_cuda_tensor_runtime.py
+
       - name: 🔋 Start Test Docker without Torch Preprocessing - GPU
         if: ${{ github.event.inputs.test_name == '' || github.event.inputs.test_name == 'regression_without_torch' }}
         run: |

--- a/development/stream_interface/run_workflow_on_video.py
+++ b/development/stream_interface/run_workflow_on_video.py
@@ -34,19 +34,9 @@ Examples:
         --model-id yolov8n-640
 """
 
-# jetson_utils must be imported before anything that initialises CUDA or GStreamer
-# state (cv2/torch, pulled in below via `inference`), so it comes first. It only
-# exists on the Jetson images — on dGPU builds the import fails and the hardware
-# decoder probes in VideoSource handle the absence at runtime.
-try:
-    import jetson_utils  # noqa: F401
-except Exception:  # noqa: BLE001 - any failure means "not a Jetson build"
-    jetson_utils = None
-
 import argparse
 import json
 import os
-import sys
 import time
 from collections import deque
 from typing import Any, Dict, List, Optional

--- a/docker/dockerfiles/Dockerfile.media.jetson.7.2.0
+++ b/docker/dockerfiles/Dockerfile.media.jetson.7.2.0
@@ -1,0 +1,335 @@
+# syntax=docker/dockerfile:1.7
+ARG CUDA_IMAGE_VERSION=13.2.0
+ARG FFMPEG_VERSION=7.1.3
+ARG FFMPEG_SHA256=f0bf043299db9e3caacb435a712fc541fbb07df613c4b893e8b77e67baf3adbe
+ARG GSTREAMER_VERSION=1.24.12
+ARG GSTREAMER_COMMIT=88e31216479a3f0c25096ca406369f3983efec14
+ARG GLIB_NETWORKING_SHA256=cd2a084c7bb91d78e849fb55d40e472f6d8f6862cddc9f12c39149359ba18268
+ARG OPENCV_VERSION=4.13.0
+ARG OPENCV_SHA256=1d40ca017ea51c533cf9fd5cbde5b5fe7ae248291ddf2af99d4c17cf8e13017d
+ARG OPENCV_CONTRIB_SHA256=1e0077a4fd2960a7d2f4c9e49d6ba7bb891cac2d1be36d7e8e47aa97a9d1039b
+ARG OPENCV_CUDA_ARCH_BIN=8.7;11.0
+ARG OPENCV_CUDA_ARCH_PTX=
+ARG JETSON_TENSOR_BRIDGE_CUDA_ARCHITECTURES=87;110
+ARG L4T_REPOSITORY=r39.2
+
+FROM ubuntu:24.04 AS ffmpeg-builder
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG FFMPEG_SHA256
+ARG FFMPEG_VERSION
+ARG TARGETARCH
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=apt-cache-ffmpeg-jp72-${TARGETARCH} \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked,id=apt-lib-ffmpeg-jp72-${TARGETARCH} \
+    apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        curl \
+        libbz2-dev \
+        liblzma-dev \
+        libssl-dev \
+        nasm \
+        pkg-config \
+        xz-utils \
+        zlib1g-dev
+
+COPY docker/scripts/build_ffmpeg.sh /usr/local/bin/build_ffmpeg
+COPY docker/scripts/verify_ffmpeg.sh /usr/local/bin/verify_ffmpeg
+
+ENV PATH=/opt/ffmpeg/bin:$PATH \
+    LD_LIBRARY_PATH=/opt/ffmpeg/lib \
+    PKG_CONFIG_PATH=/opt/ffmpeg/lib/pkgconfig
+
+RUN chmod +x /usr/local/bin/build_ffmpeg /usr/local/bin/verify_ffmpeg && \
+    FFMPEG_VERSION="${FFMPEG_VERSION}" \
+    FFMPEG_SHA256="${FFMPEG_SHA256}" \
+    build_ffmpeg && \
+    verify_ffmpeg && \
+    du -sh /opt/ffmpeg /opt/ffmpeg-runtime
+
+FROM nvcr.io/nvidia/cuda:${CUDA_IMAGE_VERSION}-devel-ubuntu24.04 AS gstreamer-builder
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG GLIB_NETWORKING_SHA256
+ARG GSTREAMER_COMMIT
+ARG GSTREAMER_VERSION
+ARG TARGETARCH
+
+COPY --from=ffmpeg-builder /opt/ffmpeg /opt/ffmpeg
+
+ENV PATH=/opt/ffmpeg/bin:$PATH \
+    LD_LIBRARY_PATH=/opt/ffmpeg/lib \
+    PKG_CONFIG_PATH=/opt/ffmpeg/lib/pkgconfig
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=apt-cache-gstreamer-jp72-${TARGETARCH} \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked,id=apt-lib-gstreamer-jp72-${TARGETARCH} \
+    apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        bison \
+        build-essential \
+        ca-certificates \
+        cmake \
+        curl \
+        flex \
+        git \
+        gobject-introspection \
+        libcurl4-openssl-dev \
+        libgl-dev \
+        libglib2.0-dev \
+        libgnutls28-dev \
+        libgirepository1.0-dev \
+        libjpeg-dev \
+        libopus-dev \
+        libpng-dev \
+        libsrtp2-dev \
+        libssl-dev \
+        libv4l-dev \
+        libvpx-dev \
+        ninja-build \
+        pkg-config \
+        python3 \
+        python3-pip \
+        python3-venv
+
+RUN python3 -m venv /opt/gstreamer-build-tools && \
+    /opt/gstreamer-build-tools/bin/pip install --no-cache-dir \
+        "meson>=1.4,<2" \
+        "ninja>=1.11,<2"
+
+ENV PATH=/opt/gstreamer/bin:/opt/gstreamer-build-tools/bin:/opt/ffmpeg/bin:$PATH \
+    GIO_EXTRA_MODULES=/opt/gstreamer/lib/gio/modules \
+    GI_TYPELIB_PATH=/opt/gstreamer/lib/girepository-1.0 \
+    GST_PLUGIN_SYSTEM_PATH_1_0=/opt/gstreamer/lib/gstreamer-1.0 \
+    LD_LIBRARY_PATH=/opt/gstreamer/lib:/opt/ffmpeg/lib \
+    PKG_CONFIG_PATH=/opt/gstreamer/lib/pkgconfig:/opt/ffmpeg/lib/pkgconfig
+
+COPY docker/scripts/build_gstreamer.sh /usr/local/bin/build_gstreamer
+COPY docker/scripts/verify_gstreamer.sh /usr/local/bin/verify_gstreamer
+
+RUN chmod +x /usr/local/bin/build_gstreamer /usr/local/bin/verify_gstreamer && \
+    GSTREAMER_VERSION="${GSTREAMER_VERSION}" \
+    GSTREAMER_COMMIT="${GSTREAMER_COMMIT}" \
+    GLIB_NETWORKING_SHA256="${GLIB_NETWORKING_SHA256}" \
+    GSTREAMER_NVCODEC=disabled \
+    build_gstreamer && \
+    verify_gstreamer && \
+    test ! -e /opt/gstreamer/lib/gstreamer-1.0/libgstnvcodec.so && \
+    du -sh /opt/gstreamer /opt/gstreamer-runtime
+
+FROM gstreamer-builder AS opencv-builder
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG OPENCV_VERSION
+ARG OPENCV_SHA256
+ARG OPENCV_CONTRIB_SHA256
+ARG OPENCV_CUDA_ARCH_BIN
+ARG OPENCV_CUDA_ARCH_PTX
+ARG TARGETARCH
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=apt-cache-opencv-jp72-${TARGETARCH} \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked,id=apt-lib-opencv-jp72-${TARGETARCH} \
+    apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        libtiff-dev \
+        python3-dev
+
+RUN python3 -m venv /opt/opencv-build-tools && \
+    /opt/opencv-build-tools/bin/pip install --no-cache-dir \
+        "numpy>=2.0.0,<2.4.0"
+
+COPY docker/scripts/build_opencv.sh /usr/local/bin/build_opencv
+COPY docker/scripts/verify_opencv.sh /usr/local/bin/verify_opencv
+
+RUN chmod +x /usr/local/bin/build_opencv /usr/local/bin/verify_opencv && \
+    OPENCV_VERSION="${OPENCV_VERSION}" \
+    OPENCV_SHA256="${OPENCV_SHA256}" \
+    OPENCV_CONTRIB_SHA256="${OPENCV_CONTRIB_SHA256}" \
+    OPENCV_PYTHON_EXECUTABLE=/opt/opencv-build-tools/bin/python3 \
+    OPENCV_WITH_CUDA=ON \
+    OPENCV_CUDA_ARCH_BIN="${OPENCV_CUDA_ARCH_BIN}" \
+    OPENCV_CUDA_ARCH_PTX="${OPENCV_CUDA_ARCH_PTX}" \
+    build_opencv && \
+    PATH=/opt/opencv-build-tools/bin:$PATH \
+    PYTHONPATH=/opt/opencv/python \
+    OPENCV_EXPECTED_CUDA_ARCH_BIN="${OPENCV_CUDA_ARCH_BIN}" \
+    OPENCV_REQUIRE_CUDA_BUILD=true \
+    verify_opencv && \
+    du -sh /opt/opencv /opt/opencv-runtime
+
+FROM ubuntu:24.04 AS nvidia-repository-key
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends ca-certificates curl && \
+    curl -fsSL https://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+        -o /nvidia-jetson.asc
+
+FROM gstreamer-builder AS jetson-tensor-bridge-builder
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG JETSON_TENSOR_BRIDGE_CUDA_ARCHITECTURES
+ARG L4T_REPOSITORY
+ARG TARGETARCH
+
+COPY --from=nvidia-repository-key /nvidia-jetson.asc /usr/share/keyrings/nvidia-jetson.asc
+COPY --from=nvidia-repository-key /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=apt-cache-jetson-tensor-bridge-jp72-${TARGETARCH} \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked,id=apt-lib-jetson-tensor-bridge-jp72-${TARGETARCH} \
+    echo "deb [signed-by=/usr/share/keyrings/nvidia-jetson.asc] https://repo.download.nvidia.com/jetson/common ${L4T_REPOSITORY} main" > /etc/apt/sources.list.d/nvidia-jetson.list && \
+    echo "deb [signed-by=/usr/share/keyrings/nvidia-jetson.asc] https://repo.download.nvidia.com/jetson/som ${L4T_REPOSITORY} main" >> /etc/apt/sources.list.d/nvidia-jetson.list && \
+    apt-get update -y && \
+    mkdir -p /tmp/l4t-api && \
+    cd /tmp/l4t-api && \
+    apt-get download nvidia-l4t-jetson-multimedia-api && \
+    dpkg-deb -x ./*.deb / && \
+    cd / && \
+    rm -rf /tmp/l4t-api
+
+COPY docker/native/jetson_tensor_bridge /src/jetson_tensor_bridge
+COPY docker/scripts/build_jetson_tensor_bridge.sh /usr/local/bin/build_jetson_tensor_bridge
+COPY docker/scripts/verify_jetson_tensor_bridge.sh /usr/local/bin/verify_jetson_tensor_bridge
+
+RUN chmod +x \
+        /usr/local/bin/build_jetson_tensor_bridge \
+        /usr/local/bin/verify_jetson_tensor_bridge && \
+    JETSON_TENSOR_BRIDGE_CUDA_ARCHITECTURES="${JETSON_TENSOR_BRIDGE_CUDA_ARCHITECTURES}" \
+    build_jetson_tensor_bridge && \
+    verify_jetson_tensor_bridge
+
+FROM gstreamer-builder AS cuda-runtime-export
+
+RUN mkdir -p /opt/cuda-runtime/lib /opt/cuda-runtime/share/licenses && \
+    for library in \
+        libcudart.so.13 \
+        libnvjpeg.so.13 \
+        libnppc.so.13 \
+        libnppial.so.13 \
+        libnppicc.so.13 \
+        libnppidei.so.13 \
+        libnppif.so.13 \
+        libnppig.so.13 \
+        libnppim.so.13 \
+        libnppist.so.13 \
+        libnppitc.so.13; do \
+        cp -L "/usr/local/cuda/lib64/${library}" \
+            "/opt/cuda-runtime/lib/${library}"; \
+    done && \
+    cp /usr/share/doc/cuda-cudart-13-2/copyright \
+        /opt/cuda-runtime/share/licenses/cuda-cudart && \
+    cp /usr/share/doc/libnvjpeg-13-2/copyright \
+        /opt/cuda-runtime/share/licenses/libnvjpeg && \
+    cp /usr/share/doc/libnpp-13-2/copyright \
+        /opt/cuda-runtime/share/licenses/libnpp && \
+    test "$(du -sm /opt/cuda-runtime | cut -f1)" -lt 165
+
+FROM ubuntu:24.04 AS runtime
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG L4T_REPOSITORY
+ARG OPENCV_CUDA_ARCH_BIN
+ARG TARGETARCH
+
+COPY --from=nvidia-repository-key /nvidia-jetson.asc /usr/share/keyrings/nvidia-jetson.asc
+COPY --from=nvidia-repository-key /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=apt-cache-media-runtime-jp72-${TARGETARCH} \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked,id=apt-lib-media-runtime-jp72-${TARGETARCH} \
+    echo "deb [signed-by=/usr/share/keyrings/nvidia-jetson.asc] https://repo.download.nvidia.com/jetson/common ${L4T_REPOSITORY} main" > /etc/apt/sources.list.d/nvidia-jetson.list && \
+    echo "deb [signed-by=/usr/share/keyrings/nvidia-jetson.asc] https://repo.download.nvidia.com/jetson/som ${L4T_REPOSITORY} main" >> /etc/apt/sources.list.d/nvidia-jetson.list && \
+    echo "deb [signed-by=/usr/share/keyrings/nvidia-jetson.asc] https://repo.download.nvidia.com/jetson/ffmpeg ${L4T_REPOSITORY} main" >> /etc/apt/sources.list.d/nvidia-jetson.list && \
+    apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        libasound2t64 \
+        libbz2-1.0 \
+        libcurl4t64 \
+        libdrm2 \
+        libglib2.0-0t64 \
+        libgles2 \
+        libgnutls30t64 \
+        libjpeg-turbo8 \
+        liblzma5 \
+        libopus0 \
+        libpng16-16t64 \
+        libsrtp2-1 \
+        libssl3t64 \
+        libtiff6 \
+        libv4l-0t64 \
+        libwebp7 \
+        libwebpdemux2 \
+        libwebpmux3 \
+        libvpx9 \
+        libwayland-client0 \
+        libwayland-egl1 \
+        libx11-6 \
+        libxext6 \
+        python3 \
+        zlib1g && \
+    mkdir -p /tmp/l4t-runtime && \
+    cd /tmp/l4t-runtime && \
+    apt-get download \
+        libegl1 \
+        nvidia-l4t-adaruntime \
+        nvidia-l4t-camera \
+        nvidia-l4t-core \
+        nvidia-l4t-gstreamer \
+        nvidia-l4t-multimedia \
+        nvidia-l4t-multimedia-utils \
+        nvidia-l4t-nvsci \
+        nvidia-l4t-openwfd && \
+    for package in ./*.deb; do dpkg-deb -x "${package}" /; done && \
+    cd / && \
+    rm -rf \
+        /etc/apt/sources.list.d/nvidia-jetson.list \
+        /tmp/l4t-runtime \
+        /usr/share/keyrings/nvidia-jetson.asc
+
+COPY --from=ffmpeg-builder /opt/ffmpeg-runtime /opt/ffmpeg
+COPY --from=gstreamer-builder /opt/gstreamer-runtime /opt/gstreamer
+COPY --from=opencv-builder /opt/opencv-runtime /opt/opencv
+COPY --from=cuda-runtime-export /opt/cuda-runtime /opt/cuda-runtime
+COPY --from=jetson-tensor-bridge-builder /opt/roboflow/lib /opt/roboflow/lib
+COPY LICENSE LICENSE.core /opt/roboflow/share/licenses/roboflow-media-bridges/
+
+ENV PATH=/opt/gstreamer/bin:/opt/ffmpeg/bin:$PATH \
+    GIO_EXTRA_MODULES=/opt/gstreamer/lib/gio/modules \
+    GI_TYPELIB_PATH=/opt/gstreamer/lib/girepository-1.0 \
+    GST_PLUGIN_PATH_1_0=/usr/lib/aarch64-linux-gnu/gstreamer-1.0 \
+    GST_PLUGIN_SYSTEM_PATH_1_0=/opt/gstreamer/lib/gstreamer-1.0 \
+    LD_LIBRARY_PATH=/opt/opencv/lib:/opt/gstreamer/lib:/opt/ffmpeg/lib:/opt/cuda-runtime/lib:/usr/lib/aarch64-linux-gnu/tegra:/usr/lib/aarch64-linux-gnu/nvidia \
+    NVIDIA_DRIVER_CAPABILITIES=compute,utility,video \
+    NVIDIA_VISIBLE_DEVICES=all \
+    PYTHONPATH=/opt/opencv/python
+
+RUN printf '/opt/opencv/lib\n/opt/gstreamer/lib\n/opt/ffmpeg/lib\n/opt/cuda-runtime/lib\n/usr/lib/aarch64-linux-gnu/tegra\n/usr/lib/aarch64-linux-gnu/nvidia\n' \
+        > /etc/ld.so.conf.d/roboflow-media.conf && \
+    ldconfig && \
+    rm -rf /root/.cache/gstreamer-1.0
+
+RUN --mount=type=bind,source=docker/scripts/verify_ffmpeg.sh,target=/tmp/verify_ffmpeg,ro \
+    --mount=type=bind,source=docker/scripts/verify_gstreamer.sh,target=/tmp/verify_gstreamer,ro \
+    --mount=type=bind,source=docker/scripts/verify_opencv.sh,target=/tmp/verify_opencv,ro \
+    --mount=type=bind,source=docker/scripts/verify_media_runtime.sh,target=/tmp/verify_media_runtime,ro \
+    --mount=from=opencv-builder,source=/opt/opencv-build-tools/lib/python3.12/site-packages,target=/tmp/opencv-python-deps,ro \
+    export GST_REGISTRY=/tmp/roboflow-gstreamer-registry.bin && \
+    sh /tmp/verify_ffmpeg && \
+    sh /tmp/verify_gstreamer && \
+    test ! -e /opt/gstreamer/lib/gstreamer-1.0/libgstnvcodec.so && \
+    PYTHONPATH=/tmp/opencv-python-deps:/opt/opencv/python \
+        OPENCV_EXPECTED_CUDA_ARCH_BIN="${OPENCV_CUDA_ARCH_BIN}" \
+        OPENCV_REQUIRE_CUDA_BUILD=true \
+        sh /tmp/verify_opencv && \
+    sh /tmp/verify_media_runtime && \
+    test -s /usr/lib/aarch64-linux-gnu/libEGL.so.1 && \
+    test -s /usr/lib/aarch64-linux-gnu/libGLESv2.so.2 && \
+    test -z "$(find /usr/lib/aarch64-linux-gnu -maxdepth 1 -type f \
+        \( -name 'libEGL_mesa.so*' -o -name 'libgbm.so*' \
+        -o -name 'libgallium-*.so' -o -name 'libLLVM.so*' \) -print -quit)" && \
+    test -s /opt/roboflow/lib/libroboflow_jetson_tensor.so.1 && \
+    rm -f "${GST_REGISTRY}"
+
+LABEL org.opencontainers.image.description="Roboflow Jetson 7.2 media runtime"

--- a/docker/dockerfiles/Dockerfile.onnx.gpu
+++ b/docker/dockerfiles/Dockerfile.onnx.gpu
@@ -1,4 +1,225 @@
-FROM nvcr.io/nvidia/cuda:12.4.1-cudnn-devel-ubuntu22.04 as builder
+# syntax=docker/dockerfile:1.7
+ARG FFMPEG_VERSION=7.1.3
+ARG FFMPEG_SHA256=f0bf043299db9e3caacb435a712fc541fbb07df613c4b893e8b77e67baf3adbe
+ARG GSTREAMER_VERSION=1.24.12
+ARG GSTREAMER_COMMIT=88e31216479a3f0c25096ca406369f3983efec14
+ARG GLIB_NETWORKING_SHA256=cd2a084c7bb91d78e849fb55d40e472f6d8f6862cddc9f12c39149359ba18268
+ARG OPENCV_VERSION=4.13.0
+ARG OPENCV_SHA256=1d40ca017ea51c533cf9fd5cbde5b5fe7ae248291ddf2af99d4c17cf8e13017d
+ARG OPENCV_CONTRIB_SHA256=1e0077a4fd2960a7d2f4c9e49d6ba7bb891cac2d1be36d7e8e47aa97a9d1039b
+ARG OPENCV_CUDA_ARCH_BIN=7.5;8.9
+ARG OPENCV_CUDA_ARCH_PTX=7.5
+
+FROM ubuntu:22.04 AS ffmpeg-builder
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG FFMPEG_SHA256
+ARG FFMPEG_VERSION
+ARG TARGETARCH
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=apt-cache-ffmpeg-gpu-${TARGETARCH} \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked,id=apt-lib-ffmpeg-gpu-${TARGETARCH} \
+    apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        curl \
+        libbz2-dev \
+        liblzma-dev \
+        libssl-dev \
+        nasm \
+        pkg-config \
+        xz-utils \
+        zlib1g-dev
+
+COPY docker/scripts/build_ffmpeg.sh /usr/local/bin/build_ffmpeg
+
+ENV PATH=/opt/ffmpeg/bin:$PATH \
+    LD_LIBRARY_PATH=/opt/ffmpeg/lib \
+    PKG_CONFIG_PATH=/opt/ffmpeg/lib/pkgconfig
+
+RUN chmod +x /usr/local/bin/build_ffmpeg && \
+    FFMPEG_VERSION="${FFMPEG_VERSION}" \
+    FFMPEG_SHA256="${FFMPEG_SHA256}" \
+    build_ffmpeg && \
+    du -sh /opt/ffmpeg /opt/ffmpeg-runtime
+
+COPY docker/scripts/verify_ffmpeg.sh /usr/local/bin/verify_ffmpeg
+
+RUN chmod +x /usr/local/bin/verify_ffmpeg && verify_ffmpeg
+
+FROM nvcr.io/nvidia/cuda:12.4.1-devel-ubuntu22.04 AS gstreamer-builder
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG GLIB_NETWORKING_SHA256
+ARG GSTREAMER_COMMIT
+ARG GSTREAMER_VERSION
+ARG TARGETARCH
+
+COPY --from=ffmpeg-builder /opt/ffmpeg /opt/ffmpeg
+
+ENV PATH=/opt/ffmpeg/bin:$PATH \
+    LD_LIBRARY_PATH=/opt/ffmpeg/lib \
+    PKG_CONFIG_PATH=/opt/ffmpeg/lib/pkgconfig
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=apt-cache-gstreamer-gpu-${TARGETARCH} \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked,id=apt-lib-gstreamer-gpu-${TARGETARCH} \
+    apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        bison \
+        build-essential \
+        ca-certificates \
+        cmake \
+        curl \
+        flex \
+        gobject-introspection \
+        git \
+        libbz2-dev \
+        libcurl4-openssl-dev \
+        libglib2.0-dev \
+        libgnutls28-dev \
+        libgirepository1.0-dev \
+        libgl-dev \
+        libjpeg-dev \
+        libopus-dev \
+        libpng-dev \
+        libsrtp2-dev \
+        libssl-dev \
+        libv4l-dev \
+        libvpx-dev \
+        liblzma-dev \
+        ninja-build \
+        pkg-config \
+        python3 \
+        python3-pip \
+        python3-venv \
+        zlib1g-dev
+
+RUN python3 -m venv /opt/gstreamer-build-tools && \
+    /opt/gstreamer-build-tools/bin/pip install --no-cache-dir \
+        "meson>=1.4,<2" \
+        "ninja>=1.11,<2"
+
+ENV PATH=/opt/gstreamer-build-tools/bin:$PATH
+
+COPY docker/scripts/build_gstreamer.sh /usr/local/bin/build_gstreamer
+
+RUN chmod +x /usr/local/bin/build_gstreamer && \
+    GSTREAMER_VERSION="${GSTREAMER_VERSION}" \
+    GSTREAMER_COMMIT="${GSTREAMER_COMMIT}" \
+    GLIB_NETWORKING_SHA256="${GLIB_NETWORKING_SHA256}" \
+    GSTREAMER_NVCODEC=enabled \
+    build_gstreamer
+
+ENV PATH=/opt/gstreamer/bin:/opt/ffmpeg/bin:$PATH \
+    GIO_EXTRA_MODULES=/opt/gstreamer/lib/gio/modules \
+    GI_TYPELIB_PATH=/opt/gstreamer/lib/girepository-1.0 \
+    LD_LIBRARY_PATH=/opt/gstreamer/lib:/opt/ffmpeg/lib \
+    PKG_CONFIG_PATH=/opt/gstreamer/lib/pkgconfig:/opt/ffmpeg/lib/pkgconfig \
+    GST_PLUGIN_SYSTEM_PATH_1_0=/opt/gstreamer/lib/gstreamer-1.0
+
+COPY docker/scripts/verify_gstreamer.sh /usr/local/bin/verify_gstreamer
+
+RUN chmod +x /usr/local/bin/verify_gstreamer && \
+    GSTREAMER_REQUIRE_NVCODEC=true verify_gstreamer && \
+    du -sh /opt/gstreamer /opt/gstreamer-runtime
+
+FROM gstreamer-builder AS gstreamer-cuda-tensor-bridge-builder
+
+COPY docker/native/gstreamer_cuda_tensor_bridge /src/gstreamer_cuda_tensor_bridge
+COPY docker/scripts/build_gstreamer_cuda_tensor_bridge.sh /usr/local/bin/build_gstreamer_cuda_tensor_bridge
+COPY docker/scripts/verify_gstreamer_cuda_tensor_bridge.sh /usr/local/bin/verify_gstreamer_cuda_tensor_bridge
+
+RUN chmod +x \
+        /usr/local/bin/build_gstreamer_cuda_tensor_bridge \
+        /usr/local/bin/verify_gstreamer_cuda_tensor_bridge && \
+    build_gstreamer_cuda_tensor_bridge && \
+    verify_gstreamer_cuda_tensor_bridge && \
+    du -sh /opt/roboflow/lib
+
+FROM gstreamer-builder AS opencv-builder
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG OPENCV_VERSION
+ARG OPENCV_SHA256
+ARG OPENCV_CONTRIB_SHA256
+ARG OPENCV_CUDA_ARCH_BIN
+ARG OPENCV_CUDA_ARCH_PTX
+ARG TARGETARCH
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=apt-cache-opencv-gpu-${TARGETARCH} \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked,id=apt-lib-opencv-gpu-${TARGETARCH} \
+    apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        libopenblas-dev \
+        libtiff-dev \
+        python3-dev
+
+RUN python3 -m venv /opt/opencv-build-tools && \
+    /opt/opencv-build-tools/bin/pip install --no-cache-dir \
+        "numpy>=2.0.0,<2.4.0"
+
+COPY docker/scripts/build_opencv.sh /usr/local/bin/build_opencv
+COPY docker/scripts/verify_opencv.sh /usr/local/bin/verify_opencv
+
+RUN chmod +x /usr/local/bin/build_opencv /usr/local/bin/verify_opencv && \
+    OPENCV_VERSION="${OPENCV_VERSION}" \
+    OPENCV_SHA256="${OPENCV_SHA256}" \
+    OPENCV_CONTRIB_SHA256="${OPENCV_CONTRIB_SHA256}" \
+    OPENCV_PYTHON_EXECUTABLE=/opt/opencv-build-tools/bin/python3 \
+    OPENCV_WITH_CUDA=ON \
+    OPENCV_CUDA_ARCH_BIN="${OPENCV_CUDA_ARCH_BIN}" \
+    OPENCV_CUDA_ARCH_PTX="${OPENCV_CUDA_ARCH_PTX}" \
+    build_opencv && \
+    du -sh /opt/opencv /opt/opencv-runtime
+
+RUN PATH=/opt/opencv-build-tools/bin:$PATH \
+    PYTHONPATH=/opt/opencv/python \
+    OPENCV_EXPECTED_CUDA_ARCH_BIN="${OPENCV_CUDA_ARCH_BIN}" \
+    OPENCV_REQUIRE_CUDA_BUILD=true \
+    verify_opencv
+
+FROM ubuntu:22.04 AS gstreamer-runtime
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG TARGETARCH
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=apt-cache-gstreamer-runtime-gpu-${TARGETARCH} \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked,id=apt-lib-gstreamer-runtime-gpu-${TARGETARCH} \
+    apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        libbz2-1.0 \
+        libcurl4 \
+        libglib2.0-0 \
+        libgnutls30 \
+        libjpeg-turbo8 \
+        libopus0 \
+        libsrtp2-1 \
+        libssl3 \
+        libv4l-0 \
+        libvpx7 \
+        liblzma5 \
+        zlib1g
+
+COPY --from=ffmpeg-builder /opt/ffmpeg-runtime /opt/ffmpeg
+COPY --from=gstreamer-builder /opt/gstreamer-runtime /opt/gstreamer
+
+ENV PATH=/opt/gstreamer/bin:/opt/ffmpeg/bin:$PATH \
+    GIO_EXTRA_MODULES=/opt/gstreamer/lib/gio/modules \
+    GI_TYPELIB_PATH=/opt/gstreamer/lib/girepository-1.0 \
+    LD_LIBRARY_PATH=/opt/gstreamer/lib:/opt/ffmpeg/lib \
+    GST_PLUGIN_SYSTEM_PATH_1_0=/opt/gstreamer/lib/gstreamer-1.0
+
+RUN --mount=type=bind,source=docker/scripts/verify_ffmpeg.sh,target=/tmp/verify_ffmpeg,ro \
+    --mount=type=bind,source=docker/scripts/verify_gstreamer.sh,target=/tmp/verify_gstreamer,ro \
+    --mount=type=bind,source=docker/scripts/verify_media_runtime.sh,target=/tmp/verify_media_runtime,ro \
+    sh /tmp/verify_ffmpeg && \
+    GSTREAMER_REQUIRE_NVCODEC=true sh /tmp/verify_gstreamer && \
+    sh /tmp/verify_media_runtime && \
+    rm -rf /root/.cache/gstreamer-1.0
+
+FROM nvcr.io/nvidia/cuda:12.4.1-cudnn-devel-ubuntu22.04 AS builder
 
 WORKDIR /app
 
@@ -33,12 +254,6 @@ COPY requirements/requirements.sam.txt \
 
 RUN python3 -m pip install -U pip uv
 
-# Well - this is good and bad, dependent on how we see this - on one end, we resolve exactly what
-# is in inference-models lock, but also install that prior other requirements and w/o the `inference-models`
-# package content, which lands in the `runtime` part - here we just install all dependencies and it works
-# so far. Given that there is more to come regading new inference, I would assume that the moment we fix
-# the main inference dependencies management is when we should structure build differently - but, given how
-# world works, sooner or later I will regret that.
 COPY inference_models/uv.lock inference_models/pyproject.toml build/inference_models/
 WORKDIR build/inference_models/
 RUN UV_PROJECT_ENVIRONMENT=/usr uv sync --locked --extra torch-cu124 --extra onnx-cu12 --extra trt10
@@ -62,75 +277,113 @@ RUN uv pip install --system \
     "setuptools<=75.5.0" \
     && rm -rf ~/.cache/pip
 
-# Install setup.py requirements for flash_attn
 RUN python3 -m pip install packaging==24.1 && rm -rf ~/.cache/pip
 
-# Install flash_attn required for Paligemma and Florence2
 RUN python3 -m pip install -r requirements.pali.flash_attn.txt --no-dependencies --no-build-isolation && rm -rf ~/.cache/pip
 
-# Start runtime stage
-FROM nvcr.io/nvidia/cuda:12.4.1-cudnn-runtime-ubuntu22.04 as runtime
+COPY . .
+
+RUN /bin/make create_wheels_for_gpu_notebook && \
+    python3 -m pip install --no-cache-dir \
+        dist/inference_cli*.whl \
+        dist/inference_core*.whl \
+        dist/inference_gpu*.whl \
+        dist/inference_sdk*.whl \
+        "setuptools<=75.5.0"
+
+RUN find /usr/local/lib/python3.10 -type d \
+        \( -name cv2 -o -name 'opencv_python.libs' -o -name 'opencv_contrib_python.libs' -o -name 'opencv_python_headless.libs' -o -name 'opencv_contrib_python_headless.libs' \) \
+        -prune -exec rm -rf {} + && \
+    python3 -m pip uninstall -y uv && \
+    rm -f /usr/local/bin/uv /usr/local/bin/uvx && \
+    python3 -m pip uninstall -y pip
+
+FROM nvcr.io/nvidia/cuda:12.4.1-cudnn-runtime-ubuntu22.04 AS runtime
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG TARGETARCH
 
 WORKDIR /app
 
-# Copy Python and installed packages from builder
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=apt-cache-runtime-gpu-${TARGETARCH} \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked,id=apt-lib-runtime-gpu-${TARGETARCH} \
+    apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        libbz2-1.0 \
+        libcurl4 \
+        libegl1 \
+        libexpat1 \
+        libgdal30 \
+        libgl1 \
+        libglib2.0-0 \
+        libgnutls30 \
+        libgomp1 \
+        libjpeg-turbo8 \
+        liblzma5 \
+        libopenblas0 \
+        libopus0 \
+        libpng16-16 \
+        libsm6 \
+        libsrtp2-1 \
+        libssl3 \
+        libtiff5 \
+        libv4l-0 \
+        libvips42 \
+        libvpx7 \
+        libxext6 \
+        zlib1g
+
+COPY --from=gstreamer-runtime /opt/ffmpeg /opt/ffmpeg
+COPY --from=gstreamer-runtime /opt/gstreamer /opt/gstreamer
+COPY --from=opencv-builder /opt/opencv-runtime /opt/opencv
+COPY --from=gstreamer-cuda-tensor-bridge-builder /opt/roboflow/lib /opt/roboflow/lib
 COPY --from=builder /usr/local/lib/python3.10 /usr/local/lib/python3.10
 COPY --from=builder /usr/local/bin /usr/local/bin
 
-# Install runtime dependencies
-ADD https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb /tmp/cuda-keyring.deb
-RUN set -eux; \
-    rm -rf /var/lib/apt/lists/*; apt-get clean; \
-    dpkg -i /tmp/cuda-keyring.deb || true; \
-    rm -f /tmp/cuda-keyring.deb; \
-    apt-get update -y; \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y \
-        libxext6 \
-        libopencv-dev \
-        uvicorn \
-        python3-pip \
-        git \
-        libgdal-dev \
-        libvips-dev \
-        wget \
-        rustc \
-        cargo; \
-    rm -rf /var/lib/apt/lists/*; \
-# apt's uvicorn drags in python3-h11 0.13.0 (CVE-2025-43859); the served process uses
-# pip's h11 from /usr/local, but scanners flag the apt copy - upgrade it in place in the
-# same layer so the vulnerable version never lands in any image layer
-    pip3 install --no-cache-dir --upgrade --target=/usr/lib/python3/dist-packages "h11>=0.16.0"; \
-    rm -rf /usr/lib/python3/dist-packages/h11-*.egg-info
+ENV PATH=/opt/gstreamer/bin:/opt/ffmpeg/bin:/usr/local/cuda/bin:$PATH \
+    GIO_EXTRA_MODULES=/opt/gstreamer/lib/gio/modules \
+    GI_TYPELIB_PATH=/opt/gstreamer/lib/girepository-1.0 \
+    LD_LIBRARY_PATH=/opt/opencv/lib:/opt/gstreamer/lib:/opt/ffmpeg/lib:/usr/local/cuda/lib64:/usr/local/nvidia/lib:/usr/local/nvidia/lib64 \
+    PYTHONPATH=/opt/opencv/python \
+    GST_PLUGIN_SYSTEM_PATH_1_0=/opt/gstreamer/lib/gstreamer-1.0 \
+    NVIDIA_DRIVER_CAPABILITIES=compute,utility,video
 
-WORKDIR /build
-COPY . .
-RUN ln -s /usr/bin/python3 /usr/bin/python
-RUN /bin/make create_wheels_for_gpu_notebook
-RUN pip3 install --no-cache-dir dist/inference_cli*.whl dist/inference_core*.whl dist/inference_gpu*.whl dist/inference_sdk*.whl "setuptools<=75.5.0"
+RUN ln -sf /usr/bin/python3 /usr/bin/python
+
+RUN --mount=type=bind,source=docker/scripts/verify_ffmpeg.sh,target=/tmp/verify_ffmpeg,ro \
+    --mount=type=bind,source=docker/scripts/verify_gstreamer.sh,target=/tmp/verify_gstreamer,ro \
+    --mount=type=bind,source=docker/scripts/verify_opencv.sh,target=/tmp/verify_opencv,ro \
+    --mount=type=bind,source=docker/scripts/verify_media_runtime.sh,target=/tmp/verify_media_runtime,ro \
+    sh /tmp/verify_ffmpeg && \
+    GSTREAMER_REQUIRE_NVCODEC=true sh /tmp/verify_gstreamer && \
+    sh /tmp/verify_media_runtime && \
+    OPENCV_REQUIRE_CUDA_BUILD=true sh /tmp/verify_opencv && \
+    rm -rf /root/.cache/gstreamer-1.0
 
 WORKDIR /notebooks
 COPY examples/notebooks .
 
-WORKDIR /app/
+WORKDIR /app
 COPY inference inference
 COPY docker/config/gpu_http.py gpu_http.py
 COPY docker/entrypoint/run_uvicorn.sh /usr/local/bin/run_uvicorn.sh
 RUN chmod +x /usr/local/bin/run_uvicorn.sh
 
-ENV VERSION_CHECK_MODE=continuous
-ENV PROJECT=roboflow-platform
-ENV NUM_WORKERS=1
-ENV HOST=0.0.0.0
-ENV PORT=9001
-ENV WORKFLOWS_STEP_EXECUTION_MODE=local
-ENV WORKFLOWS_MAX_CONCURRENT_STEPS=4
-ENV API_LOGGING_ENABLED=True
-ENV LMM_ENABLED=True
-ENV CORE_MODEL_SAM2_ENABLED=True
-ENV CORE_MODEL_SAM3_ENABLED=True
-ENV CORE_MODEL_OWLV2_ENABLED=True
-ENV ENABLE_STREAM_API=True
-ENV ENABLE_PROMETHEUS=True
-ENV STREAM_API_PRELOADED_PROCESSES=2
+ENV VERSION_CHECK_MODE=continuous \
+    PROJECT=roboflow-platform \
+    NUM_WORKERS=1 \
+    HOST=0.0.0.0 \
+    PORT=9001 \
+    WORKFLOWS_STEP_EXECUTION_MODE=local \
+    WORKFLOWS_MAX_CONCURRENT_STEPS=4 \
+    API_LOGGING_ENABLED=True \
+    LMM_ENABLED=True \
+    CORE_MODEL_SAM2_ENABLED=True \
+    CORE_MODEL_SAM3_ENABLED=True \
+    CORE_MODEL_OWLV2_ENABLED=True \
+    ENABLE_STREAM_API=True \
+    ENABLE_PROMETHEUS=True \
+    STREAM_API_PRELOADED_PROCESSES=2
 
 ENTRYPOINT ["/usr/local/bin/run_uvicorn.sh", "gpu_http:app"]

--- a/docker/dockerfiles/Dockerfile.onnx.jetson.6.2.0
+++ b/docker/dockerfiles/Dockerfile.onnx.jetson.6.2.0
@@ -1,35 +1,256 @@
 # syntax=docker/dockerfile:1.7
-# Jetson 6.2.0 with PyTorch/OpenCV compiled from source for numpy 2.x support
-# Stage 1: Builder - Compile everything from source
-FROM nvcr.io/nvidia/l4t-jetpack:r36.4.0 AS builder
+ARG FFMPEG_VERSION=7.1.3
+ARG FFMPEG_SHA256=f0bf043299db9e3caacb435a712fc541fbb07df613c4b893e8b77e67baf3adbe
+ARG GSTREAMER_VERSION=1.24.12
+ARG GSTREAMER_COMMIT=88e31216479a3f0c25096ca406369f3983efec14
+ARG GLIB_NETWORKING_SHA256=cd2a084c7bb91d78e849fb55d40e472f6d8f6862cddc9f12c39149359ba18268
+ARG OPENCV_VERSION=4.13.0
+ARG OPENCV_SHA256=1d40ca017ea51c533cf9fd5cbde5b5fe7ae248291ddf2af99d4c17cf8e13017d
+ARG OPENCV_CONTRIB_SHA256=1e0077a4fd2960a7d2f4c9e49d6ba7bb891cac2d1be36d7e8e47aa97a9d1039b
+ARG OPENCV_CUDA_ARCH_BIN=8.7
+ARG OPENCV_CUDA_ARCH_PTX=
+
+FROM ubuntu:22.04 AS ffmpeg-builder
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG FFMPEG_SHA256
+ARG FFMPEG_VERSION
+ARG TARGETARCH
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=apt-cache-ffmpeg-jp62-${TARGETARCH} \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked,id=apt-lib-ffmpeg-jp62-${TARGETARCH} \
+    apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        curl \
+        libbz2-dev \
+        liblzma-dev \
+        libssl-dev \
+        nasm \
+        pkg-config \
+        xz-utils \
+        zlib1g-dev
+
+COPY docker/scripts/build_ffmpeg.sh /usr/local/bin/build_ffmpeg
+
+ENV PATH=/opt/ffmpeg/bin:$PATH \
+    LD_LIBRARY_PATH=/opt/ffmpeg/lib \
+    PKG_CONFIG_PATH=/opt/ffmpeg/lib/pkgconfig
+
+RUN chmod +x /usr/local/bin/build_ffmpeg && \
+    FFMPEG_VERSION="${FFMPEG_VERSION}" \
+    FFMPEG_SHA256="${FFMPEG_SHA256}" \
+    build_ffmpeg && \
+    du -sh /opt/ffmpeg /opt/ffmpeg-runtime
+
+COPY docker/scripts/verify_ffmpeg.sh /usr/local/bin/verify_ffmpeg
+
+RUN chmod +x /usr/local/bin/verify_ffmpeg && verify_ffmpeg
+
+FROM ffmpeg-builder AS gstreamer-builder
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG GLIB_NETWORKING_SHA256
+ARG GSTREAMER_COMMIT
+ARG GSTREAMER_VERSION
+ARG TARGETARCH
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=apt-cache-gstreamer-jp62-${TARGETARCH} \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked,id=apt-lib-gstreamer-jp62-${TARGETARCH} \
+    apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        bison \
+        build-essential \
+        ca-certificates \
+        cmake \
+        flex \
+        gobject-introspection \
+        git \
+        libcurl4-openssl-dev \
+        libglib2.0-dev \
+        libgnutls28-dev \
+        libgirepository1.0-dev \
+        libjpeg-dev \
+        libopus-dev \
+        libpng-dev \
+        libsrtp2-dev \
+        libssl-dev \
+        libv4l-dev \
+        libvpx-dev \
+        ninja-build \
+        pkg-config \
+        python3 \
+        python3-pip \
+        python3-venv
+
+RUN python3 -m venv /opt/gstreamer-build-tools && \
+    /opt/gstreamer-build-tools/bin/pip install --no-cache-dir \
+        "meson>=1.4,<2" \
+        "ninja>=1.11,<2"
+
+ENV PATH=/opt/gstreamer-build-tools/bin:$PATH
+
+COPY docker/scripts/build_gstreamer.sh /usr/local/bin/build_gstreamer
+
+RUN chmod +x /usr/local/bin/build_gstreamer && \
+    GSTREAMER_VERSION="${GSTREAMER_VERSION}" \
+    GSTREAMER_COMMIT="${GSTREAMER_COMMIT}" \
+    GLIB_NETWORKING_SHA256="${GLIB_NETWORKING_SHA256}" \
+    GSTREAMER_NVCODEC=disabled \
+    build_gstreamer
+
+ENV PATH=/opt/gstreamer/bin:/opt/ffmpeg/bin:$PATH \
+    GIO_EXTRA_MODULES=/opt/gstreamer/lib/gio/modules \
+    GI_TYPELIB_PATH=/opt/gstreamer/lib/girepository-1.0 \
+    LD_LIBRARY_PATH=/opt/gstreamer/lib:/opt/ffmpeg/lib \
+    PKG_CONFIG_PATH=/opt/gstreamer/lib/pkgconfig:/opt/ffmpeg/lib/pkgconfig \
+    GST_PLUGIN_SYSTEM_PATH_1_0=/opt/gstreamer/lib/gstreamer-1.0
+
+COPY docker/scripts/verify_gstreamer.sh /usr/local/bin/verify_gstreamer
+
+RUN chmod +x /usr/local/bin/verify_gstreamer && \
+    verify_gstreamer && \
+    du -sh /opt/gstreamer /opt/gstreamer-runtime
+
+FROM ubuntu:22.04 AS gstreamer-runtime
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG TARGETARCH
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=apt-cache-gstreamer-runtime-jp62-${TARGETARCH} \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked,id=apt-lib-gstreamer-runtime-jp62-${TARGETARCH} \
+    apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        libbz2-1.0 \
+        libcurl4 \
+        libglib2.0-0 \
+        libgnutls30 \
+        libjpeg-turbo8 \
+        liblzma5 \
+        libopus0 \
+        libsrtp2-1 \
+        libssl3 \
+        libv4l-0 \
+        libvpx7 \
+        zlib1g
+
+COPY --from=ffmpeg-builder /opt/ffmpeg-runtime /opt/ffmpeg
+COPY --from=gstreamer-builder /opt/gstreamer-runtime /opt/gstreamer
+
+ENV PATH=/opt/gstreamer/bin:/opt/ffmpeg/bin:$PATH \
+    GIO_EXTRA_MODULES=/opt/gstreamer/lib/gio/modules \
+    GI_TYPELIB_PATH=/opt/gstreamer/lib/girepository-1.0 \
+    LD_LIBRARY_PATH=/opt/gstreamer/lib:/opt/ffmpeg/lib \
+    GST_PLUGIN_SYSTEM_PATH_1_0=/opt/gstreamer/lib/gstreamer-1.0
+
+RUN --mount=type=bind,source=docker/scripts/verify_ffmpeg.sh,target=/tmp/verify_ffmpeg,ro \
+    --mount=type=bind,source=docker/scripts/verify_gstreamer.sh,target=/tmp/verify_gstreamer,ro \
+    --mount=type=bind,source=docker/scripts/verify_media_runtime.sh,target=/tmp/verify_media_runtime,ro \
+    sh /tmp/verify_ffmpeg && \
+    sh /tmp/verify_gstreamer && \
+    sh /tmp/verify_media_runtime && \
+    rm -rf /root/.cache/gstreamer-1.0
+
+FROM nvcr.io/nvidia/l4t-jetpack:r36.4.0 AS jetson-build-base
+
+COPY --from=ffmpeg-builder /opt/ffmpeg /opt/ffmpeg
+COPY --from=gstreamer-builder /opt/gstreamer /opt/gstreamer
+
+ENV PATH=/opt/gstreamer/bin:/opt/ffmpeg/bin:/usr/local/cuda/bin:$PATH \
+    GIO_EXTRA_MODULES=/opt/gstreamer/lib/gio/modules \
+    GI_TYPELIB_PATH=/opt/gstreamer/lib/girepository-1.0 \
+    LD_LIBRARY_PATH=/usr/local/cuda/lib64:/opt/gstreamer/lib:/opt/ffmpeg/lib \
+    PKG_CONFIG_PATH=/opt/gstreamer/lib/pkgconfig:/opt/ffmpeg/lib/pkgconfig \
+    GST_PLUGIN_SYSTEM_PATH_1_0=/opt/gstreamer/lib/gstreamer-1.0
+
+FROM jetson-build-base AS jetson-tensor-bridge-builder
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG TARGETARCH
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=apt-cache-jetson-tensor-bridge-jp62-${TARGETARCH} \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked,id=apt-lib-jetson-tensor-bridge-jp62-${TARGETARCH} \
+    apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        libglib2.0-dev \
+        pkg-config
+
+COPY docker/native/jetson_tensor_bridge /src/jetson_tensor_bridge
+COPY docker/scripts/build_jetson_tensor_bridge.sh /usr/local/bin/build_jetson_tensor_bridge
+COPY docker/scripts/verify_jetson_tensor_bridge.sh /usr/local/bin/verify_jetson_tensor_bridge
+
+RUN chmod +x \
+        /usr/local/bin/build_jetson_tensor_bridge \
+        /usr/local/bin/verify_jetson_tensor_bridge && \
+    build_jetson_tensor_bridge && \
+    verify_jetson_tensor_bridge && \
+    du -sh /opt/roboflow/lib
+
+FROM jetson-build-base AS opencv-builder
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG OPENCV_VERSION
+ARG OPENCV_SHA256
+ARG OPENCV_CONTRIB_SHA256
+ARG OPENCV_CUDA_ARCH_BIN
+ARG OPENCV_CUDA_ARCH_PTX
+ARG TARGETARCH
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=apt-cache-opencv-jp62-${TARGETARCH} \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked,id=apt-lib-opencv-jp62-${TARGETARCH} \
+    apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        cmake \
+        curl \
+        libjpeg-dev \
+        libopenblas-dev \
+        libpng-dev \
+        libtiff-dev \
+        libv4l-dev \
+        ninja-build \
+        pkg-config \
+        python3-dev \
+        python3-pip \
+        python3-venv
+
+RUN python3 -m venv /opt/opencv-build-tools && \
+    /opt/opencv-build-tools/bin/pip install --no-cache-dir \
+        "numpy>=2.0.0,<2.4.0"
+
+COPY docker/scripts/build_opencv.sh /usr/local/bin/build_opencv
+COPY docker/scripts/verify_opencv.sh /usr/local/bin/verify_opencv
+
+RUN chmod +x /usr/local/bin/build_opencv /usr/local/bin/verify_opencv && \
+    OPENCV_VERSION="${OPENCV_VERSION}" \
+    OPENCV_SHA256="${OPENCV_SHA256}" \
+    OPENCV_CONTRIB_SHA256="${OPENCV_CONTRIB_SHA256}" \
+    OPENCV_PYTHON_EXECUTABLE=/opt/opencv-build-tools/bin/python3 \
+    OPENCV_WITH_CUDA=ON \
+    OPENCV_CUDA_ARCH_BIN="${OPENCV_CUDA_ARCH_BIN}" \
+    OPENCV_CUDA_ARCH_PTX="${OPENCV_CUDA_ARCH_PTX}" \
+    build_opencv && \
+    du -sh /opt/opencv /opt/opencv-runtime
+
+RUN PATH=/opt/opencv-build-tools/bin:$PATH \
+    PYTHONPATH=/opt/opencv/python \
+    OPENCV_EXPECTED_CUDA_ARCH_BIN="${OPENCV_CUDA_ARCH_BIN}" \
+    OPENCV_REQUIRE_CUDA_BUILD=true \
+    verify_opencv
+
+FROM jetson-build-base AS builder
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG CMAKE_VERSION=4.2.0
 ARG PYTORCH_VERSION=2.6.0
 ARG TORCHVISION_VERSION=0.21.0
 ARG TRITON_VERSION=3.2.0
-ARG OPENCV_VERSION=4.13.0
-# Per-Jetson-platform OpenCV build parameters. To replicate this from-source
-# OpenCV section in another Jetson dockerfile (jp51, jp71), copy the OpenCV
-# block below verbatim and update these four ARGs to match the target base.
-# Cross-reference the values already used by the same dockerfile's PyTorch /
-# torchvision / onnxruntime build steps so all components target the same SoC:
-#   OPENCV_CUDA_ARCH:           jp51 (Orin on L4T r35): 8.7
-#                               jp62 (Orin on L4T r36): 8.7
-#                               jp71 (Thor on L4T r38): 11.0
-#   OPENCV_PYTHON_INSTALL_PATH: dist-packages dir of the base's Python
-#                               (jp51: python3.12, jp62: python3.10, jp71: python3.12)
-#   OPENCV_PYTHON_INCLUDE_DIR:  matches the base's Python C headers
-#   OPENCV_PYTHON_VERSION:      cmake's PYTHON_VERSION flag (major+minor, no dot)
-ARG OPENCV_CUDA_ARCH=8.7
-ARG OPENCV_PYTHON_INSTALL_PATH=/usr/local/lib/python3.10/dist-packages
-ARG OPENCV_PYTHON_INCLUDE_DIR=/usr/include/python3.10
-ARG OPENCV_PYTHON_VERSION=310
 ARG ONNXRUNTIME_VERSION=1.20.0
-# jetson-utils (NVDEC GPU-tensor decode for the v2 video pipeline). Upstream
-# tags no releases - pinned to master (2026-07-08); master's python bindings
-# select by Ubuntu codename (jammy -> 3.10, this image's Python).
-ARG JETSON_UTILS_COMMIT=fae4b4250f985ab92180b6ec955b79995b7a34ff
+ARG TARGETARCH
 ENV LANG=en_US.UTF-8
 
 WORKDIR /build
@@ -62,26 +283,10 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=apt-cache-jp62-bu
     pkg-config \
     libjpeg-dev \
     libpng-dev \
-    libavcodec-dev \
-    libavformat-dev \
-    libswscale-dev \
     libv4l-dev \
-    libavutil-dev \
-    libgstreamer1.0-dev \
-    libgstreamer-plugins-base1.0-dev \
-    libgstreamer-plugins-bad1.0-dev \
-    libgstrtspserver-1.0-dev \
-    libjson-glib-dev \
-    libsoup2.4-dev \
-    libglew-dev \
-    libglu1-mesa-dev \
-    freeglut3-dev \
-    lsb-release \
-    unzip \
     libatlas-base-dev \
     liblapack-dev \
     gfortran \
-    ffmpeg \
     libhdf5-dev \
     libgflags-dev \
     libgoogle-glog-dev \
@@ -264,68 +469,6 @@ RUN --mount=type=cache,target=/build/triton/src,sharing=locked,id=triton-src-${T
     rm -rf /tmp/triton-wheels; \
     python3 -c "import triton; print('triton', triton.__version__)"
 
-# Build jetson-utils (dusty-nv) - hardware NVDEC decode for the v2 video
-# pipeline: inference/core/interfaces/camera/jetson_producer.py wraps
-# jetson_utils.videoSource and hands frames to torch as CUDA tensors via
-# cudaImage's __cuda_array_interface__. Pure cmake + make install (no pip),
-# so it cannot clobber the from-source cv2 built later in this stage. Placed
-# before the `COPY . .` layers so source edits never force a rebuild (the
-# build is ~2 min; no cache mount needed).
-# - Arch list: upstream hardcodes gencodes for SM 53/62/72/87; patched down to
-#   SM 87 only (Orin) - the pre-Orin gencodes are deprecated on CUDA 12.6 and
-#   dead weight in this image.
-# - Upstream still uses legacy find_package(CUDA), removed-by-policy in CMake
-#   3.27 (CMP0146). The Kitware cmake 4.2 installed above still ships the
-#   module when the policy is forced OLD - same CMAKE_POLICY_VERSION_MINIMUM
-#   family of workarounds the onnxruntime build in this file already uses.
-# - ENABLE_NVMM=off (explicit): upstream autodetects the legacy nvbuf_utils
-#   library, which r36 no longer ships, so it would land OFF anyway - pinning
-#   it keeps the choice visible. Non-NVMM decode stages frames through
-#   cudaAllocMapped (zero-copy CPU/GPU on the iGPU): one extra copy vs NVMM,
-#   acceptable baseline; NVMM via jetson-multimedia-api headers is a follow-up.
-# - The NVIDIA GStreamer elements it drives (nvv4l2decoder & co.) are NOT in
-#   this image - they arrive from the host BSP at container start via the same
-#   nvidia-container-runtime CSV mounts documented above the runtime stage.
-WORKDIR /build/jetson-utils
-RUN git clone https://github.com/dusty-nv/jetson-utils.git src && \
-    git -C src checkout ${JETSON_UTILS_COMMIT} && \
-    # Delete the standalone SM 72 / SM 87 gencode lines FIRST, then retarget
-    # the SM 53/62 line to SM 87 (substituting first would create a line the
-    # deletes also match). The greps assert the patch took: exactly one
-    # gencode line, targeting Orin.
-    sed -i '/-gencode arch=compute_72,code=sm_72)/d;/-gencode arch=compute_87,code=sm_87)/d' src/CMakeLists.txt && \
-    sed -i 's/-gencode arch=compute_53,code=sm_53 -gencode arch=compute_62,code=sm_62/-gencode arch=compute_87,code=sm_87/' src/CMakeLists.txt && \
-    test "$(grep -c -- '-gencode' src/CMakeLists.txt)" = "1" && \
-    grep -q 'compute_87' src/CMakeLists.txt
-RUN mkdir -p src/build && cd src/build && \
-    cmake -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
-          -DCMAKE_POLICY_DEFAULT_CMP0146=OLD \
-          -DENABLE_NVMM=off \
-          ../ && \
-    make -j$(nproc) && \
-    make install && \
-    ldconfig && \
-    # jetson_utils' __init__ eagerly imports every submodule (os/types/
-    # network/cuda), whose module-level deps are termcolor/tabulate/docker/
-    # numpy (upstream pyproject) + requests (imported by network/requests.py
-    # but missing from the pyproject). The cmake install path, unlike pip,
-    # installs no dependencies - and the runtime import in jetson_producer.py
-    # needs them too (they ride into the runtime stage via the dist-packages
-    # COPY; numpy/requests/docker are in the image anyway via requirements).
-    python3 -m pip install --break-system-packages --no-cache-dir \
-        termcolor tabulate docker requests && \
-    # Import smoke test (loads the C++ lib + GStreamer/GL deps; no GPU or
-    # driver needed at import time), then stage the python bindings into ONE
-    # known dir - `make install` picks the dist-packages dir itself and the
-    # runtime stage needs a stable COPY source. Handles both layouts (package
-    # dir vs single extension module).
-    LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH python3 -c "import jetson_utils; assert hasattr(jetson_utils, 'videoSource'), 'jetson_utils imported without the C extension'; print('jetson_utils import OK:', jetson_utils.__file__)" && \
-    BINDINGS_DIR=$(LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH python3 -c "import jetson_utils, pathlib; p = pathlib.Path(jetson_utils.__file__).resolve(); print(p.parent.parent if p.parent.name == 'jetson_utils' else p.parent)") && \
-    mkdir -p /build/out/jetson-utils-py && \
-    cp -a "${BINDINGS_DIR}"/jetson_utils* /build/out/jetson-utils-py/ && \
-    (cp -a "${BINDINGS_DIR}"/jetson "${BINDINGS_DIR}"/Jetson* /build/out/jetson-utils-py/ 2>/dev/null || true) && \
-    ls -la /build/out/jetson-utils-py/
-
 # Copy requirements files (done after compilation to improve cache efficiency)
 WORKDIR /build/reqs
 COPY requirements/_requirements.txt \
@@ -390,73 +533,6 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python && \
         dist/inference_sdk*.whl \
         "setuptools<=75.5.0"
 
-# Compile OpenCV from source with GStreamer / FFmpeg / CUDA support.
-# The pip opencv-python wheel ships without GStreamer, which blocks
-# cv2.VideoCapture from dispatching to NVIDIA's nv* GStreamer elements
-# (nvv4l2decoder, nvvidconv, nvjpegenc/dec). Built LAST in the builder so
-# nothing reinstalls the wheel-version cv2 over our from-source one.
-WORKDIR /build/opencv
-RUN wget -q https://github.com/opencv/opencv/archive/refs/tags/${OPENCV_VERSION}.zip -O opencv.zip && \
-    wget -q https://github.com/opencv/opencv_contrib/archive/refs/tags/${OPENCV_VERSION}.zip -O opencv_contrib.zip && \
-    unzip -q opencv.zip && unzip -q opencv_contrib.zip && \
-    rm opencv.zip opencv_contrib.zip && \
-    python3 -m pip uninstall -y opencv-python opencv-contrib-python opencv-python-headless || true && \
-    mkdir -p /build/opencv/opencv-${OPENCV_VERSION}/release
-WORKDIR /build/opencv/opencv-${OPENCV_VERSION}/release
-# release/ is cache-mounted, so the rebuild forced by `COPY . .` invalidation
-# above completes as a fast ninja no-op (CMakeCache + objects survive) instead
-# of a 30-60 min recompile. Cache id includes OPENCV_VERSION and CUDA_ARCH so
-# version/SoC bumps start clean.
-RUN --mount=type=cache,target=/build/opencv/opencv-${OPENCV_VERSION}/release,sharing=locked,id=opencv-build-${OPENCV_VERSION}-${TARGETARCH}-sm${OPENCV_CUDA_ARCH} \
-    --mount=type=cache,target=/root/.cache/pip,sharing=locked,id=pip-cache-jp62-${TARGETARCH} \
-    cmake -GNinja \
-        -D CMAKE_BUILD_TYPE=RELEASE \
-        -D CMAKE_INSTALL_PREFIX=/usr/local \
-        -D WITH_CUDA=ON \
-        -D WITH_CUDNN=ON \
-        -D CUDA_ARCH_BIN="${OPENCV_CUDA_ARCH}" \
-        -D CUDA_ARCH_PTX="" \
-        -D OPENCV_GENERATE_PKGCONFIG=ON \
-        -D OPENCV_EXTRA_MODULES_PATH=/build/opencv/opencv_contrib-${OPENCV_VERSION}/modules \
-        -D WITH_FFMPEG=ON \
-        -D WITH_GSTREAMER=ON \
-        -D WITH_LIBV4L=ON \
-        -D BUILD_opencv_python3=ON \
-        -D BUILD_TESTS=OFF \
-        -D BUILD_PERF_TESTS=OFF \
-        -D BUILD_EXAMPLES=OFF \
-        -D BUILD_DOCS=OFF \
-        -D PYTHON3_EXECUTABLE=/usr/bin/python3 \
-        -D PYTHON3_INCLUDE_DIR=${OPENCV_PYTHON_INCLUDE_DIR} \
-        -D PYTHON_VERSION=${OPENCV_PYTHON_VERSION} \
-        -D OPENCV_PYTHON3_INSTALL_PATH=${OPENCV_PYTHON_INSTALL_PATH} \
-        -D BUILD_SHARED_LIBS=OFF \
-        -D WITH_OPENCLAMDFFT=OFF \
-        -D WITH_OPENCLAMDBLAS=OFF \
-        -D WITH_VA_INTEL=OFF \
-        .. && \
-    ninja && \
-    ninja install && \
-    ldconfig && \
-    # Rescue install-tree config files before pip install clobbers them.
-    # `ninja install` writes ${OPENCV_PYTHON_INSTALL_PATH}/cv2/config*.py with
-    # install paths (correct). The `pip install` below installs a wheel built
-    # from the BUILD-TREE python_loader directory, whose config files reference
-    # /build/... paths that don't survive into the runtime stage. Save the
-    # install-tree versions now, restore them after pip install registers
-    # opencv with pip's metadata. Without this, cv2 import in the runtime image
-    # fails with "recursion is detected during loading of cv2 binary extensions".
-    mkdir -p /tmp/cv2-install-tree && \
-    cp ${OPENCV_PYTHON_INSTALL_PATH}/cv2/config*.py /tmp/cv2-install-tree/ && \
-    python3 -m pip wheel /build/opencv/opencv-${OPENCV_VERSION}/release/python_loader --wheel-dir /build/out/wheels && \
-    python3 -m pip install --break-system-packages /build/out/wheels/opencv-*.whl && \
-    cp /tmp/cv2-install-tree/config*.py ${OPENCV_PYTHON_INSTALL_PATH}/cv2/ && \
-    rm -rf /tmp/cv2-install-tree && \
-    # Sanity check: simulate the runtime stage by removing /build/ from sys.path.
-    # If config files still leak build-tree paths, the loader bootstrap fails here
-    # with a recursion error rather than at runtime on the device.
-    env -u PYTHONPATH python3 -c "import sys; sys.path = [p for p in sys.path if '/build' not in p]; import cv2; info = cv2.getBuildInformation(); assert 'YES' in info.split('GStreamer:')[1].split(chr(10))[0], 'GStreamer not enabled'; assert 'YES' in info.split('FFMPEG:')[1].split(chr(10))[0], 'FFMPEG not enabled'; print('cv2 ' + cv2.__version__ + ' OK from install path; GStreamer + FFmpeg + CUDA enabled')"
-
 # Pin boto3/botocore last so the final versions win regardless of what the
 # requirement sets resolved to (previously done as an extra layer in the
 # runtime stage, which shipped both copies).
@@ -470,6 +546,9 @@ RUN python3 -m pip uninstall -y boto3 botocore && \
 # with a warning (exit 0), so this block is idempotent across image variants.
 # ---- image-slim cleanup (re-executed verbatim by the local donor harness) ----
 RUN cd /usr/local/lib/python3.10/dist-packages && \
+    find . -maxdepth 1 -type d \
+        \( -name cv2 -o -name 'opencv_python.libs' -o -name 'opencv_contrib_python.libs' -o -name 'opencv_python_headless.libs' -o -name 'opencv_contrib_python_headless.libs' \) \
+        -prune -exec rm -rf {} + && \
     # Build-time tooling leaked in via pytorch/onnxruntime build requirements;
     # none has a runtime reverse-dependency (cmake pip pkg alone is 82MB)
     python3 -m pip uninstall -y cmake lintrunner hypothesis expecttest types-dataclasses astunparse optree \
@@ -526,22 +605,24 @@ FROM nvcr.io/nvidia/l4t-cuda:12.6.11-runtime AS cuda_rt
 # in the image). Net ~300MB smaller. GPU/BSP access is unchanged: on JetPack 6
 # the nvidia-container-runtime injects libcuda/tegra libs from the host at
 # container start, driven by the NVIDIA_* envs replicated below.
-FROM ubuntu:22.04
+FROM gstreamer-runtime AS runtime
 
 ARG DEBIAN_FRONTEND=noninteractive
+ARG TARGETARCH
 ENV LANG=en_US.UTF-8
 
 # Replicated verbatim from the l4t-cuda:12.6.11-runtime base / published image.
 ENV NVIDIA_VISIBLE_DEVICES=all \
-    NVIDIA_DRIVER_CAPABILITIES=compute,utility \
+    NVIDIA_DRIVER_CAPABILITIES=compute,utility,video \
     NVIDIA_REQUIRE_CUDA="cuda>=12.6" \
     NVIDIA_REQUIRE_JETPACK_HOST_MOUNTS=base-only \
     NVIDIA_PRODUCT_NAME=CUDA \
-    PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    PATH=/opt/gstreamer/bin:/opt/ffmpeg/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 # Library search paths the l4t-cuda base provided via ld.so.conf.d (tegra/nvidia
 # dirs are populated by the host mounts injected at container start).
-RUN printf '/usr/local/cuda/lib64\n/usr/lib/aarch64-linux-gnu/tegra\n/usr/lib/aarch64-linux-gnu/tegra-egl\n/usr/lib/aarch64-linux-gnu/nvidia\n/usr/lib/aarch64-linux-gnu/gstreamer-1.0\n' > /etc/ld.so.conf.d/nvidia-tegra.conf
+RUN mkdir -p /usr/lib/aarch64-linux-gnu/gstreamer-1.0 && \
+    printf '/usr/local/cuda/lib64\n/usr/lib/aarch64-linux-gnu/tegra\n/usr/lib/aarch64-linux-gnu/tegra-egl\n/usr/lib/aarch64-linux-gnu/nvidia\n/usr/lib/aarch64-linux-gnu/gstreamer-1.0\n' > /etc/ld.so.conf.d/nvidia-tegra.conf
 
 WORKDIR /app
 
@@ -552,17 +633,9 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python
 #   file (libmagic; nothing executes it), libproj22 (+proj-data; only served the
 #   removed system GDAL - rasterio bundles its own proj), python3-pip (pip already
 #   ships in dist-packages and the runtime stage no longer runs pip),
-#   gstreamer1.0-tools (debug CLIs), python3-gi + gir1.2-* (no `import gi`
-#   anywhere; cv2 links the GStreamer C libs directly), libatlas3-base (zero .so
-#   NEEDs ATLAS; BLAS is libopenblas0).
 # libegl1/libgles2 (glvnd loaders, ~1.8MB) are required by the host-injected NV
 # GStreamer plugins (nvarguscamerasrc/nvivafilter/nveglglessink/...); the actual
 # EGL/GLES drivers come from the host's tegra-egl mount at container start.
-# libgstreamer-plugins-bad1.0-0 (gstwebrtc/gstsdp), libgstrtspserver-1.0-0,
-# libjson-glib-1.0-0, libsoup2.4-1, libglew2.2/libglu1-mesa/libgl1: the link
-# closure of libjetson-utils.so (built in the builder stage); jetson-utils
-# links its WebRTC/RTSP output stack unconditionally even though this image
-# only uses videoSource decode.
 # The dpkg path-exclude keeps docs/man/locale out of every package this layer installs.
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=apt-cache-jp62-runtime-${TARGETARCH} \
     --mount=type=cache,target=/var/lib/apt,sharing=locked,id=apt-lib-jp62-runtime-${TARGETARCH} \
@@ -575,38 +648,25 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=apt-cache-jp62-ru
     libopenblas0 \
     libsqlite3-0 \
     libtiff5 \
-    libcurl4 \
-    libssl3 \
-    zlib1g \
     libgomp1 \
     python3 \
     libxext6 \
     libvips42 \
-    libglib2.0-0 \
     libsm6 \
-    libjpeg-turbo8 \
     libpng16-16 \
     libexpat1 \
-    ca-certificates \
     curl \
-    libv4l-0 \
-    libavcodec58 \
-    libavformat58 \
-    libswscale5 \
-    ffmpeg \
-    libgstreamer1.0-0 \
-    libgstreamer-plugins-base1.0-0 \
-    gstreamer1.0-plugins-base \
-    gstreamer1.0-plugins-good \
-    libgstreamer-plugins-bad1.0-0 \
-    libgstrtspserver-1.0-0 \
-    libjson-glib-1.0-0 \
-    libsoup2.4-1 \
-    libglew2.2 \
-    libglu1-mesa \
-    libgl1 \
+    libasound2 \
+    libdrm2 \
     libegl1 \
     libgles2 \
+    libpcre3 \
+    libwayland-client0 \
+    libwayland-egl1 \
+    libwebp7 \
+    libwebpdemux2 \
+    libwebpmux3 \
+    libx11-6 \
     build-essential \
     python3-dev \
     zlib1g-dev \
@@ -617,7 +677,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=apt-cache-jp62-ru
 # zero .so in the image links the from-source libgdal (verified via ldd scan +
 # live deletion test). GDAL_DATA must stay unset or it would override
 # rasterio's bundled data directory and break CRS handling.
-ENV LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
+ENV LD_LIBRARY_PATH=/usr/local/lib:/usr/local/cuda/lib64:/opt/opencv/lib:/opt/gstreamer/lib:/opt/ffmpeg/lib
 
 # CUDA runtime libraries, exact files (not globs: the source dir mixes real
 # files and symlinks, and COPY dereferences symlinks, which would triple-copy
@@ -680,14 +740,6 @@ COPY --from=builder /usr/lib/aarch64-linux-gnu/libnvinfer.so.*.*.* \
 COPY --from=builder /usr/lib/aarch64-linux-gnu/libnvonnxparser*.so.*.*.* /usr/local/cuda/lib64/
 COPY --from=builder /usr/lib/aarch64-linux-gnu/nvidia/libnvdla_compiler.so* /usr/local/cuda/lib64/
 
-# NOTE: NVIDIA's gstreamer plugins (nvv4l2decoder, nvvidconv, nvjpegenc/dec) and
-# their tegra runtime deps (libnvbufsurface, libnvjpeg, libnvargus, ...) are NOT
-# baked into the image -- they are tied to the host's JetPack BSP and are injected
-# at container start by `nvidia-container-runtime` via the CSVs under
-# /etc/nvidia-container-runtime/host-files-for-container.d/. The host system must
-# be configured to mount them; without that, cv2 here can dispatch a GStreamer
-# pipeline but `nvv4l2decoder` / `nvvidconv` / `nvjpegenc` won't resolve.
-
 # Create symlinks for CUDA/cuDNN/TensorRT (saves ~2GB by not duplicating files).
 # libnvrtc-builtins needs its two-level soname on top of the .so/.so.MAJ links
 # the loop creates: libnvrtc dlopens it as libnvrtc-builtins.so.12.6.
@@ -700,12 +752,11 @@ RUN cd /usr/local/cuda/lib64 && \
     done && \
     ln -sf libnvrtc-builtins.so.12.6.68 libnvrtc-builtins.so.12.6
 
-ENV LD_LIBRARY_PATH=/usr/local/cuda/lib64:$LD_LIBRARY_PATH
 RUN ldconfig
 
 # GStreamer plugin discovery: point at the standard arch dir (where libgstnv*.so live).
 # Clear stale plugin registry so it's rebuilt on first use against the copied plugins.
-ENV GST_PLUGIN_PATH=/usr/lib/aarch64-linux-gnu/gstreamer-1.0
+ENV GST_PLUGIN_PATH_1_0=/usr/lib/aarch64-linux-gnu/gstreamer-1.0
 RUN rm -rf /root/.cache/gstreamer-1.0 /home/*/.cache/gstreamer-1.0 2>/dev/null || true
 
 # build-essential/python3-dev/zlib1g-dev/libxml2-dev: required for Triton JIT kernel
@@ -714,6 +765,8 @@ RUN rm -rf /root/.cache/gstreamer-1.0 /home/*/.cache/gstreamer-1.0 2>/dev/null |
 # JIT toolchains are copied separately (llvm cache excluded at build time).
 
 # Copy Python packages
+COPY --from=opencv-builder /opt/opencv-runtime /opt/opencv
+COPY --from=jetson-tensor-bridge-builder /opt/roboflow/lib /opt/roboflow/lib
 COPY --from=builder /usr/local/lib/python3.10/dist-packages /usr/local/lib/python3.10/dist-packages
 COPY --from=builder /root/.triton/nvidia /root/.triton/nvidia
 COPY --from=builder /root/.triton/json /root/.triton/json
@@ -723,16 +776,9 @@ COPY --from=builder /usr/lib/python3.10/dist-packages/tensorrt /usr/local/lib/py
 COPY --from=builder /usr/lib/python3.10/dist-packages/tensorrt-10.7.0.dist-info /usr/local/lib/python3.10/dist-packages/tensorrt-10.7.0.dist-info
 COPY --from=builder /usr/lib/python3.10/dist-packages/tensorrt_lean /usr/local/lib/python3.10/dist-packages/tensorrt_lean
 COPY --from=builder /usr/lib/python3.10/dist-packages/tensorrt_lean-10.7.0.dist-info /usr/local/lib/python3.10/dist-packages/tensorrt_lean-10.7.0.dist-info
-# jetson-utils: NVDEC decode library + python bindings (staged by the builder
-# into one dir regardless of which dist-packages `make install` picked).
-# Resolved via LD_LIBRARY_PATH=/usr/local/lib (set above); the nvv4l2decoder
-# GStreamer elements it drives come from the host CSV mounts per the NOTE
-# above.
-COPY --from=builder /usr/local/lib/libjetson-utils.so /usr/local/lib/
-COPY --from=builder /build/out/jetson-utils-py/ /usr/local/lib/python3.10/dist-packages/
 COPY --from=builder /usr/local/bin/inference /usr/local/bin/inference
 
-ENV PYTHONPATH=/usr/local/lib/python3.10/dist-packages:$PYTHONPATH
+ENV PYTHONPATH=/opt/opencv/python:/usr/local/lib/python3.10/dist-packages
 
 # Copy application code
 COPY inference inference
@@ -741,6 +787,14 @@ COPY inference_sdk inference_sdk
 COPY docker/config/gpu_http.py gpu_http.py
 COPY docker/entrypoint/run_uvicorn.sh /usr/local/bin/run_uvicorn.sh
 RUN chmod +x /usr/local/bin/run_uvicorn.sh
+
+RUN --mount=type=bind,source=docker/scripts/verify_ffmpeg.sh,target=/tmp/verify_ffmpeg,ro \
+    --mount=type=bind,source=docker/scripts/verify_gstreamer.sh,target=/tmp/verify_gstreamer,ro \
+    --mount=type=bind,source=docker/scripts/verify_opencv.sh,target=/tmp/verify_opencv,ro \
+    sh /tmp/verify_ffmpeg && \
+    sh /tmp/verify_gstreamer && \
+    OPENCV_REQUIRE_CUDA_BUILD=true sh /tmp/verify_opencv && \
+    rm -rf /root/.cache/gstreamer-1.0
 
 # Environment variables
 ENV VERSION_CHECK_MODE=once \

--- a/docker/dockerfiles/Dockerfile.onnx.jetson.7.1.0
+++ b/docker/dockerfiles/Dockerfile.onnx.jetson.7.1.0
@@ -1,5 +1,301 @@
 # syntax=docker/dockerfile:1.7
 # Jetson 7.1.0 with PyTorch/OpenCV compiled from source for numpy 2.x support
+ARG GSTREAMER_VERSION=1.24.12
+ARG GSTREAMER_COMMIT=88e31216479a3f0c25096ca406369f3983efec14
+ARG GLIB_NETWORKING_SHA256=cd2a084c7bb91d78e849fb55d40e472f6d8f6862cddc9f12c39149359ba18268
+ARG OPENCV_VERSION=4.13.0
+ARG OPENCV_SHA256=1d40ca017ea51c533cf9fd5cbde5b5fe7ae248291ddf2af99d4c17cf8e13017d
+ARG OPENCV_CONTRIB_SHA256=1e0077a4fd2960a7d2f4c9e49d6ba7bb891cac2d1be36d7e8e47aa97a9d1039b
+ARG FFMPEG_VERSION=7.1.3
+ARG FFMPEG_SHA256=f0bf043299db9e3caacb435a712fc541fbb07df613c4b893e8b77e67baf3adbe
+ARG OPENCV_CUDA_ARCH_BIN=11.0
+ARG OPENCV_CUDA_ARCH_PTX=
+
+FROM ubuntu:24.04 AS ffmpeg-builder
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG FFMPEG_SHA256
+ARG FFMPEG_VERSION
+ARG TARGETARCH
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=apt-cache-ffmpeg-jp71-${TARGETARCH} \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked,id=apt-lib-ffmpeg-jp71-${TARGETARCH} \
+    apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        curl \
+        libbz2-dev \
+        liblzma-dev \
+        libssl-dev \
+        nasm \
+        pkg-config \
+        xz-utils \
+        zlib1g-dev
+
+COPY docker/scripts/build_ffmpeg.sh /usr/local/bin/build_ffmpeg
+
+ENV PATH=/opt/ffmpeg/bin:$PATH \
+    LD_LIBRARY_PATH=/opt/ffmpeg/lib \
+    PKG_CONFIG_PATH=/opt/ffmpeg/lib/pkgconfig
+
+RUN chmod +x /usr/local/bin/build_ffmpeg && \
+    FFMPEG_VERSION="${FFMPEG_VERSION}" \
+    FFMPEG_SHA256="${FFMPEG_SHA256}" \
+    build_ffmpeg && \
+    du -sh /opt/ffmpeg /opt/ffmpeg-runtime
+
+COPY docker/scripts/verify_ffmpeg.sh /usr/local/bin/verify_ffmpeg
+
+RUN chmod +x /usr/local/bin/verify_ffmpeg && \
+    verify_ffmpeg
+
+FROM ffmpeg-builder AS gstreamer-builder
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG GLIB_NETWORKING_SHA256
+ARG GSTREAMER_COMMIT
+ARG GSTREAMER_VERSION
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=apt-cache-gstreamer-jp71-${TARGETARCH} \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked,id=apt-lib-gstreamer-jp71-${TARGETARCH} \
+    apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        bison \
+        build-essential \
+        ca-certificates \
+        cmake \
+        flex \
+        gobject-introspection \
+        git \
+        libcurl4-openssl-dev \
+        libglib2.0-dev \
+        libgnutls28-dev \
+        libgirepository1.0-dev \
+        libjpeg-dev \
+        libopus-dev \
+        libpng-dev \
+        libsrtp2-dev \
+        libssl-dev \
+        libv4l-dev \
+        libvpx-dev \
+        ninja-build \
+        pkg-config \
+        python3 \
+        python3-pip \
+        python3-venv
+
+RUN python3 -m venv /opt/gstreamer-build-tools && \
+    /opt/gstreamer-build-tools/bin/pip install --no-cache-dir \
+        "meson>=1.4,<2" \
+        "ninja>=1.11,<2"
+
+ENV PATH=/opt/gstreamer-build-tools/bin:$PATH
+
+COPY docker/scripts/build_gstreamer.sh /usr/local/bin/build_gstreamer
+
+RUN chmod +x /usr/local/bin/build_gstreamer && \
+    GSTREAMER_VERSION="${GSTREAMER_VERSION}" \
+    GSTREAMER_COMMIT="${GSTREAMER_COMMIT}" \
+    GLIB_NETWORKING_SHA256="${GLIB_NETWORKING_SHA256}" \
+    GSTREAMER_NVCODEC=disabled \
+    build_gstreamer
+
+ENV PATH=/opt/gstreamer/bin:/opt/ffmpeg/bin:$PATH \
+    GIO_EXTRA_MODULES=/opt/gstreamer/lib/gio/modules \
+    GI_TYPELIB_PATH=/opt/gstreamer/lib/girepository-1.0 \
+    LD_LIBRARY_PATH=/opt/gstreamer/lib:/opt/ffmpeg/lib \
+    PKG_CONFIG_PATH=/opt/gstreamer/lib/pkgconfig:/opt/ffmpeg/lib/pkgconfig \
+    GST_PLUGIN_SYSTEM_PATH_1_0=/opt/gstreamer/lib/gstreamer-1.0
+
+COPY docker/scripts/verify_gstreamer.sh /usr/local/bin/verify_gstreamer
+
+RUN chmod +x /usr/local/bin/verify_gstreamer && \
+    verify_gstreamer && \
+    du -sh /opt/gstreamer /opt/gstreamer-runtime
+
+FROM ubuntu:24.04 AS nvidia-repository-key
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG TARGETARCH
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=apt-cache-nvidia-key-jp71-${TARGETARCH} \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked,id=apt-lib-nvidia-key-jp71-${TARGETARCH} \
+    apt-get update -y && \
+    apt-get install -y --no-install-recommends ca-certificates curl && \
+    curl -fsSL https://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+        -o /nvidia-jetson.asc
+
+FROM gstreamer-builder AS opencv-builder
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG OPENCV_VERSION
+ARG OPENCV_SHA256
+ARG OPENCV_CONTRIB_SHA256
+ARG OPENCV_CUDA_ARCH_BIN
+ARG OPENCV_CUDA_ARCH_PTX
+
+COPY --from=nvidia-repository-key /nvidia-jetson.asc /usr/share/keyrings/nvidia-jetson.asc
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=apt-cache-opencv-jp71-${TARGETARCH} \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked,id=apt-lib-opencv-jp71-${TARGETARCH} \
+    echo "deb [signed-by=/usr/share/keyrings/nvidia-jetson.asc] https://repo.download.nvidia.com/jetson/common r38.4 main" > /etc/apt/sources.list.d/nvidia-jetson.list && \
+    echo "deb [signed-by=/usr/share/keyrings/nvidia-jetson.asc] https://repo.download.nvidia.com/jetson/som r38.4 main" >> /etc/apt/sources.list.d/nvidia-jetson.list && \
+    apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        cuda-cudart-dev-13-0 \
+        cuda-nvcc-13-0 \
+        libnpp-dev-13-0 \
+        libopenblas-dev \
+        libtiff-dev \
+        python3-dev
+
+ENV CUDA_HOME=/usr/local/cuda \
+    PATH=/usr/local/cuda/bin:$PATH \
+    LD_LIBRARY_PATH=/usr/local/cuda/lib64:/opt/gstreamer/lib:/opt/ffmpeg/lib
+
+RUN python3 -m venv /opt/opencv-build-tools && \
+    /opt/opencv-build-tools/bin/pip install --no-cache-dir \
+        "numpy>=2.0.0,<2.4.0"
+
+COPY docker/scripts/build_opencv.sh /usr/local/bin/build_opencv
+COPY docker/scripts/verify_opencv.sh /usr/local/bin/verify_opencv
+
+RUN chmod +x /usr/local/bin/build_opencv /usr/local/bin/verify_opencv && \
+    OPENCV_VERSION="${OPENCV_VERSION}" \
+    OPENCV_SHA256="${OPENCV_SHA256}" \
+    OPENCV_CONTRIB_SHA256="${OPENCV_CONTRIB_SHA256}" \
+    OPENCV_PYTHON_EXECUTABLE=/opt/opencv-build-tools/bin/python3 \
+    OPENCV_WITH_CUDA=ON \
+    OPENCV_CUDA_ARCH_BIN="${OPENCV_CUDA_ARCH_BIN}" \
+    OPENCV_CUDA_ARCH_PTX="${OPENCV_CUDA_ARCH_PTX}" \
+    build_opencv && \
+    du -sh /opt/opencv /opt/opencv-runtime
+
+RUN PATH=/opt/opencv-build-tools/bin:$PATH \
+    PYTHONPATH=/opt/opencv/python \
+    OPENCV_EXPECTED_CUDA_ARCH_BIN="${OPENCV_CUDA_ARCH_BIN}" \
+    OPENCV_REQUIRE_CUDA_BUILD=true \
+    verify_opencv
+
+FROM ubuntu:24.04 AS gstreamer-runtime
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG TARGETARCH
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=apt-cache-gstreamer-runtime-jp71-${TARGETARCH} \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked,id=apt-lib-gstreamer-runtime-jp71-${TARGETARCH} \
+    apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        libbz2-1.0 \
+        libcurl4t64 \
+        libglib2.0-0t64 \
+        libgnutls30t64 \
+        libjpeg-turbo8 \
+        libopus0 \
+        libsrtp2-1 \
+        libssl3t64 \
+        libv4l-0t64 \
+        libvpx9 \
+        liblzma5 \
+        zlib1g
+
+COPY --from=ffmpeg-builder /opt/ffmpeg-runtime /opt/ffmpeg
+COPY --from=gstreamer-builder /opt/gstreamer-runtime /opt/gstreamer
+
+ENV PATH=/opt/gstreamer/bin:/opt/ffmpeg/bin:$PATH \
+    GIO_EXTRA_MODULES=/opt/gstreamer/lib/gio/modules \
+    GI_TYPELIB_PATH=/opt/gstreamer/lib/girepository-1.0 \
+    LD_LIBRARY_PATH=/opt/gstreamer/lib:/opt/ffmpeg/lib \
+    GST_PLUGIN_SYSTEM_PATH_1_0=/opt/gstreamer/lib/gstreamer-1.0
+
+RUN --mount=type=bind,source=docker/scripts/verify_ffmpeg.sh,target=/tmp/verify_ffmpeg,ro \
+    --mount=type=bind,source=docker/scripts/verify_gstreamer.sh,target=/tmp/verify_gstreamer,ro \
+    --mount=type=bind,source=docker/scripts/verify_media_runtime.sh,target=/tmp/verify_media_runtime,ro \
+    sh /tmp/verify_ffmpeg && \
+    sh /tmp/verify_gstreamer && \
+    sh /tmp/verify_media_runtime && \
+    rm -rf /root/.cache/gstreamer-1.0
+
+FROM gstreamer-runtime AS jetson-runtime-base
+
+ARG DEBIAN_FRONTEND=noninteractive
+ENV LANG=en_US.UTF-8 \
+    GST_PLUGIN_PATH_1_0=/usr/lib/aarch64-linux-gnu/gstreamer-1.0
+
+WORKDIR /app
+
+COPY --from=nvidia-repository-key /nvidia-jetson.asc /usr/share/keyrings/nvidia-jetson.asc
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=apt-cache-jp71-runtime-${TARGETARCH} \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked,id=apt-lib-jp71-runtime-${TARGETARCH} \
+    rm -f /etc/apt/apt.conf.d/docker-clean && \
+    echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache && \
+    echo "deb [signed-by=/usr/share/keyrings/nvidia-jetson.asc] https://repo.download.nvidia.com/jetson/common r38.4 main" > /etc/apt/sources.list.d/nvidia-jetson.list && \
+    echo "deb [signed-by=/usr/share/keyrings/nvidia-jetson.asc] https://repo.download.nvidia.com/jetson/som r38.4 main" >> /etc/apt/sources.list.d/nvidia-jetson.list && \
+    apt-get update -y
+
+RUN ln -sf /usr/bin/python3 /usr/bin/python
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=apt-cache-jp71-runtime-${TARGETARCH} \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked,id=apt-lib-jp71-runtime-${TARGETARCH} \
+    apt-get install -y --no-install-recommends \
+    cuda-cudart-13-0 \
+    cuda-libraries-13-0 \
+    cuda-nvcc-13-0 \
+    libcudnn9-cuda-13 \
+    tensorrt-libs \
+    python3-libnvinfer \
+    python3-libnvinfer-dispatch \
+    python3-libnvinfer-lean \
+    libopenblas0 \
+    libproj25 \
+    libsqlite3-0 \
+    libtiff6 \
+    libcurl4t64 \
+    zlib1g \
+    libgomp1 \
+    python3 \
+    libxext6 \
+    libvips42 \
+    libsm6 \
+    libpng16-16t64 \
+    libexpat1 \
+    libegl1 \
+    libgles2 \
+    libasound2t64 \
+    libwayland-client0 \
+    libwayland-egl1 \
+    libpcre3 \
+    libatlas3-base \
+    libgl1 \
+    libatomic1 \
+    build-essential \
+    python3-dev
+
+RUN --mount=type=bind,source=docker/scripts/verify_ffmpeg.sh,target=/tmp/verify_ffmpeg,ro \
+    --mount=type=bind,source=docker/scripts/verify_gstreamer.sh,target=/tmp/verify_gstreamer,ro \
+    --mount=type=cache,target=/var/cache/apt,sharing=locked,id=apt-cache-jp71-runtime-${TARGETARCH} \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked,id=apt-lib-jp71-runtime-${TARGETARCH} \
+    apt-get update -y && \
+    mkdir -p /tmp/l4t-debs && cd /tmp/l4t-debs && \
+    apt-get download $(apt-cache depends --recurse --no-recommends --no-suggests \
+        --no-conflicts --no-breaks --no-replaces --no-enhances \
+        nvidia-l4t-gstreamer | grep '^nvidia-l4t' | grep -v '^nvidia-l4t-cuda$' | sort -u) && \
+    for deb in ./*.deb; do dpkg-deb -x "$deb" /; done && \
+    cd / && rm -rf /tmp/l4t-debs && \
+    printf '/usr/lib/aarch64-linux-gnu/tegra\n/usr/lib/aarch64-linux-gnu/gstreamer-1.0\n' > /etc/ld.so.conf.d/nvidia-tegra.conf && \
+    ldconfig && \
+    ls /usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstnv*.so >/dev/null && \
+    missing="$(for plugin in /usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstnv*.so; do \
+        ldd "$plugin" 2>/dev/null || true; \
+    done | awk '/not found/ { print $1 }' | sort -u)" && \
+    case "$missing" in ''|libcuda.so.1) ;; *) printf '%s\n' "$missing" >&2; exit 1;; esac && \
+    sh /tmp/verify_ffmpeg && \
+    sh /tmp/verify_gstreamer && \
+    rm -rf /root/.cache/gstreamer-1.0
+
 # Stage 1: Builder - Compile everything from source
 FROM ubuntu:24.04 AS builder
 
@@ -8,12 +304,8 @@ ARG CMAKE_VERSION=4.2.0
 ARG PYTORCH_VERSION=2.10.0
 ARG TORCHVISION_VERSION=0.25.0
 ARG TRITON_VERSION=3.6.0
-ARG OPENCV_VERSION=4.10.0
 ARG ONNXRUNTIME_VERSION=1.24.2
-# jetson-utils (NVDEC GPU-tensor decode for the v2 video pipeline). Upstream
-# tags no releases - pinned to master (2026-07-08); master's python bindings
-# select by Ubuntu codename (noble -> 3.12, this image's Python).
-ARG JETSON_UTILS_COMMIT=fae4b4250f985ab92180b6ec955b79995b7a34ff
+ARG TARGETARCH
 ENV LANG=en_US.UTF-8
 
 WORKDIR /build
@@ -71,16 +363,6 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=apt-cache-jp71-bu
     libavformat-dev \
     libswscale-dev \
     libv4l-dev \
-    libgstreamer1.0-dev \
-    libgstreamer-plugins-base1.0-dev \
-    libgstreamer-plugins-bad1.0-dev \
-    libgstrtspserver-1.0-dev \
-    libjson-glib-dev \
-    libsoup2.4-dev \
-    libglew-dev \
-    libglu1-mesa-dev \
-    freeglut3-dev \
-    lsb-release \
     libatlas-base-dev \
     liblapack-dev \
     gfortran \
@@ -120,7 +402,7 @@ RUN wget https://github.com/OSGeo/gdal/releases/download/v3.11.5/gdal-3.11.5.tar
 # Set CUDA environment variables
 ENV CUDA_HOME=/usr/local/cuda \
     PATH=/usr/local/cuda/bin:$PATH \
-    LD_LIBRARY_PATH=/usr/local/cuda/lib64:$LD_LIBRARY_PATH
+    LD_LIBRARY_PATH=/usr/local/cuda/lib64
 
 # Compile PyTorch from source with Jetson Thor optimizations.
 # Clone in its own RUN so the build/ cache mount overlays cleanly (mount would
@@ -231,94 +513,6 @@ RUN --mount=type=cache,target=/build/triton/src,sharing=locked,id=triton-src-${T
     rm -rf /tmp/triton-wheels; \
     python3 -c "import triton; print('triton', triton.__version__)"
 
-# Build jetson-utils (dusty-nv) - hardware NVDEC decode for the v2 video
-# pipeline: inference/core/interfaces/camera/jetson_producer.py wraps
-# jetson_utils.videoSource and hands frames to torch as CUDA tensors via
-# cudaImage's __cuda_array_interface__. Pure cmake + make install (no pip).
-# Placed before the `COPY . .` layers so source edits never force a rebuild.
-# JP7/Thor-specific notes (upstream has no published r38/CUDA-13 support - this
-# is the frontier part of the build; expect to iterate on-device):
-# - The arch patch below is REQUIRED, not an optimization: upstream hardcodes
-#   gencodes for SM 53/62/72(/87), which nvcc 13 rejects outright (CUDA 13
-#   removed pre-Turing targets). Retargeted to SM 110 (Thor).
-# - Upstream still uses legacy find_package(CUDA), removed-by-policy in CMake
-#   3.27 (CMP0146); forcing the policy OLD re-enables the module on the
-#   Kitware cmake 4.2 installed above. Whether FindCUDA's probing copes with
-#   the CUDA 13 toolkit layout is a known verify-on-device point.
-# - ENABLE_NVMM=off (explicit): upstream autodetects the legacy nvbuf_utils
-#   library, which r38 does not ship, so it would land OFF anyway. Non-NVMM
-#   decode stages frames through cudaAllocMapped (zero-copy CPU/GPU on the
-#   iGPU): one extra copy vs NVMM, acceptable baseline.
-# - g++13 (noble) no longer provides uint32_t transitively through libstdc++
-#   headers: filesystem.h fails outright (observed in CI) and every sibling
-#   header with a pure-libc include chain is one shuffle from the same error,
-#   so <cstdint> is prepended to each header that uses fixed-width ints
-#   without including stdint itself (idempotent, self-adapting list).
-# - CUDA 13 removed nppGetStreamContext() (observed in CI). cudaBayer.cpp is
-#   upstream's only NPP user and nothing in the tree calls cudaBayerToRGB -
-#   it exists for raw Bayer CSI sensors, not NVDEC decode - so it is stubbed
-#   to fail loudly like its cudaBayerToRGBA sibling already does.
-# - nvv4l2decoder on r38 does not decode JPEG/MJPEG (per the L4T release
-#   notes); H.264/H.265 files and RTSP are the supported baseline here.
-WORKDIR /build/jetson-utils
-RUN git clone https://github.com/dusty-nv/jetson-utils.git src && \
-    git -C src checkout ${JETSON_UTILS_COMMIT} && \
-    # Delete the standalone SM 72 / SM 87 gencode lines FIRST, then retarget
-    # the SM 53/62 line to SM 110 (substituting first would create a line the
-    # deletes also match). The greps assert the patch took: exactly one
-    # gencode line, targeting Thor.
-    sed -i '/-gencode arch=compute_72,code=sm_72)/d;/-gencode arch=compute_87,code=sm_87)/d' src/CMakeLists.txt && \
-    sed -i 's/-gencode arch=compute_53,code=sm_53 -gencode arch=compute_62,code=sm_62/-gencode arch=compute_110,code=sm_110/' src/CMakeLists.txt && \
-    test "$(grep -c -- '-gencode' src/CMakeLists.txt)" = "1" && \
-    grep -q 'compute_110' src/CMakeLists.txt && \
-    # g++13 <cstdint> patch (see notes above); runs before cmake so the
-    # build-tree header copies inherit it. Prepending is idempotent, so every
-    # flagged header AND translation unit gets it (54 .cpp/.cu files share
-    # the latent issue) rather than chasing failures one CI round at a time.
-    grep -rl 'uint[0-9]*_t' src/cpp src/cuda src/python/bindings \
-        --include='*.h' --include='*.hpp' --include='*.cuh' \
-        --include='*.cpp' --include='*.cu' | xargs -r grep -L 'stdint' | \
-        xargs -r sed -i '1i #include <cstdint>' && \
-    grep -q '^#include <cstdint>' src/cpp/parsers/filesystem.h && \
-    # CUDA 13 Bayer stub (see notes above): early-return before the NPP
-    # context setup and drop the removed getter call - the NPP code below the
-    # return is dead but still compiles (nppiCFAToRGB_8u_C1C3R_Ctx is still
-    # declared in CUDA 13, only the getter is gone).
-    # NOTE: the inserted C++ comment must not contain the removed getter's name
-    # verbatim - the assertion two lines down greps for its absence.
-    sed -i 's|^\tNppStreamContext nppStreamContext;$|\treturn cudaErrorNotSupported; // CUDA 13 removed the NPP stream-context getter; Bayer-to-RGB unused by NVDEC decode\n\tNppStreamContext nppStreamContext;|' src/cuda/cudaBayer.cpp && \
-    sed -i '/nppGetStreamContext(&nppStreamContext);/d' src/cuda/cudaBayer.cpp && \
-    grep -q 'cudaErrorNotSupported' src/cuda/cudaBayer.cpp && \
-    ! grep -q 'nppGetStreamContext' src/cuda/cudaBayer.cpp
-RUN mkdir -p src/build && cd src/build && \
-    cmake -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
-          -DCMAKE_POLICY_DEFAULT_CMP0146=OLD \
-          -DENABLE_NVMM=off \
-          ../ && \
-    make -j$(nproc) && \
-    make install && \
-    ldconfig && \
-    # jetson_utils' __init__ eagerly imports every submodule (os/types/
-    # network/cuda), whose module-level deps are termcolor/tabulate/docker/
-    # numpy (upstream pyproject) + requests (imported by network/requests.py
-    # but missing from the pyproject). The cmake install path, unlike pip,
-    # installs no dependencies - and the runtime import in jetson_producer.py
-    # needs them too (they ride into the runtime stage via the dist-packages
-    # COPY; numpy/requests/docker are in the image anyway via requirements).
-    python3 -m pip install --break-system-packages --no-cache-dir \
-        termcolor tabulate docker requests && \
-    # Import smoke test (loads the C++ lib + GStreamer/GL deps; no GPU or
-    # driver needed at import time), then stage the python bindings into ONE
-    # known dir - `make install` picks the dist-packages dir itself and the
-    # runtime stage needs a stable COPY source. Handles both layouts (package
-    # dir vs single extension module).
-    LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH python3 -c "import jetson_utils; assert hasattr(jetson_utils, 'videoSource'), 'jetson_utils imported without the C extension'; print('jetson_utils import OK:', jetson_utils.__file__)" && \
-    BINDINGS_DIR=$(LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH python3 -c "import jetson_utils, pathlib; p = pathlib.Path(jetson_utils.__file__).resolve(); print(p.parent.parent if p.parent.name == 'jetson_utils' else p.parent)") && \
-    mkdir -p /build/out/jetson-utils-py && \
-    cp -a "${BINDINGS_DIR}"/jetson_utils* /build/out/jetson-utils-py/ && \
-    (cp -a "${BINDINGS_DIR}"/jetson "${BINDINGS_DIR}"/Jetson* /build/out/jetson-utils-py/ 2>/dev/null || true) && \
-    ls -la /build/out/jetson-utils-py/
-
 # Copy requirements files (done after compilation to improve cache efficiency)
 WORKDIR /build/reqs
 COPY requirements/_requirements.txt \
@@ -372,7 +566,13 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python && \
         dist/inference_core*.whl \
         dist/inference_cli*.whl \
         dist/inference_sdk*.whl \
-        "setuptools<=75.5.0"
+        "setuptools<=75.5.0" && \
+    find /usr/local/lib/python3.12/dist-packages -type d \
+        \( -name cv2 -o -name 'opencv_python.libs' -o -name 'opencv_contrib_python.libs' -o -name 'opencv_python_headless.libs' -o -name 'opencv_contrib_python_headless.libs' \) \
+        -prune -exec rm -rf {} + && \
+    python -m pip install --force-reinstall \
+        "boto3>=1.40.0,<=1.41.5" \
+        "botocore>=1.40.0,<=1.41.5"
 
 # Remove test directories, development tools, and unnecessary packages to reduce image size
 # This happens AFTER all package installations to ensure everything gets cleaned
@@ -386,131 +586,8 @@ RUN cd /usr/local/lib/python3.12/dist-packages && \
     rm -rf skimage/data || true
 
 # Stage 2: Runtime
-FROM ubuntu:24.04
+FROM jetson-runtime-base AS runtime
 
-ARG DEBIAN_FRONTEND=noninteractive
-ENV LANG=en_US.UTF-8
-
-WORKDIR /app
-
-# Add NVIDIA Jetson repositories for r38.4 (runtime stage cache id differs from builder).
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=apt-cache-jp71-runtime-${TARGETARCH} \
-    --mount=type=cache,target=/var/lib/apt,sharing=locked,id=apt-lib-jp71-runtime-${TARGETARCH} \
-    rm -f /etc/apt/apt.conf.d/docker-clean && \
-    echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache && \
-    apt-get update -y && \
-    apt-get install -y --no-install-recommends \
-    ca-certificates \
-    gnupg \
-    wget \
-    && wget -qO - https://repo.download.nvidia.com/jetson/jetson-ota-public.asc | gpg --dearmor -o /usr/share/keyrings/nvidia-jetson.gpg \
-    && echo "deb [signed-by=/usr/share/keyrings/nvidia-jetson.gpg] https://repo.download.nvidia.com/jetson/common r38.4 main" > /etc/apt/sources.list.d/nvidia-jetson.list \
-    && echo "deb [signed-by=/usr/share/keyrings/nvidia-jetson.gpg] https://repo.download.nvidia.com/jetson/som r38.4 main" >> /etc/apt/sources.list.d/nvidia-jetson.list \
-    && apt-get update -y
-
-RUN ln -sf /usr/bin/python3 /usr/bin/python
-
-# Install runtime dependencies including NVIDIA packages
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=apt-cache-jp71-runtime-${TARGETARCH} \
-    --mount=type=cache,target=/var/lib/apt,sharing=locked,id=apt-lib-jp71-runtime-${TARGETARCH} \
-    apt-get install -y --no-install-recommends \
-    cuda-cudart-13-0 \
-    cuda-libraries-13-0 \
-    cuda-nvcc-13-0 \
-    # ptxas for sm_110a; Triton bundled ptxas-blackwell is CUDA 12.9
-    libcudnn9-cuda-13 \
-    tensorrt-libs \
-    python3-libnvinfer \
-    python3-libnvinfer-dispatch \
-    python3-libnvinfer-lean \
-    file \
-    libopenblas0 \
-    libproj25 \
-    libsqlite3-0 \
-    libtiff6 \
-    libcurl4t64 \
-    libssl3t64 \
-    zlib1g \
-    libgomp1 \
-    python3 \
-    python3-pip \
-    libxext6 \
-    libvips42 \
-    libglib2.0-0 \
-    libsm6 \
-    libjpeg-turbo8 \
-    libpng16-16t64 \
-    libexpat1 \
-    curl \
-    libv4l-0 \
-    libavcodec60 \
-    libavformat60 \
-    libswscale7 \
-    ffmpeg \
-    # jetson-utils runtime closure: GStreamer core/base/good for videoSource,
-    # plugins-bad libs (gstwebrtc/gstsdp) + rtspserver + json-glib + soup +
-    # GLEW/GLU because libjetson-utils.so links its WebRTC/RTSP output stack
-    # unconditionally. The NV decode elements (nvv4l2decoder & deps) are NOT
-    # apt-installed here - see the dpkg-deb extraction RUN below.
-    libgstreamer1.0-0 \
-    libgstreamer-plugins-base1.0-0 \
-    gstreamer1.0-plugins-base \
-    gstreamer1.0-plugins-good \
-    libgstreamer-plugins-bad1.0-0 \
-    libgstrtspserver-1.0-0 \
-    libjson-glib-1.0-0 \
-    libsoup2.4-1 \
-    libglew2.2 \
-    libglu1-mesa \
-    # Link deps of the extracted NV gstreamer/multimedia libs (their Depends
-    # can't install transitively because the debs below are dpkg-deb -x'd):
-    libegl1 \
-    libgles2 \
-    libasound2t64 \
-    libwayland-client0 \
-    libwayland-egl1 \
-    libpcre3 \
-    libatlas3-base \
-    libgl1 \
-    libglib2.0-0 \
-    libatomic1 \
-    build-essential \
-    python3-dev \
-    zlib1g-dev \
-    libxml2-dev
-
-# NV decode elements (nvv4l2decoder & deps) for jetson-utils: EXTRACTED, not
-# apt-installed. `apt-get install nvidia-l4t-gstreamer` drags in
-# nvidia-l4t-core, whose maintainer scripts probe the tegra device tree
-# (/proc/device-tree) and exit 1 on the generic ARM CI builders this image is
-# built on (observed in CI: "Errors were encountered while processing:
-# .../nvidia-l4t-core_38.4.0...deb"). /proc cannot be faked during a docker
-# build, so dpkg-deb -x unpacks the payloads without running any maintainer
-# script - same files on disk, no platform probe.
-# Closure (resolved live from the r38.4 indices; gstreamer sits in
-# jetson/common, the rest in jetson/som): gstreamer -> camera, core,
-# multimedia, multimedia-utils, nvsci -> adaruntime. nvidia-l4t-cuda is
-# EXCLUDED: it ships libcuda.so, the iGPU *driver* library, which must come
-# from the host at container start (--runtime=nvidia / CDI injection) - a
-# baked copy risks skew against the host driver. Ordinary library deps come
-# from the ubuntu packages installed above. The trailing ls asserts the
-# decode plugins actually landed (fail at build, not first decode).
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=apt-cache-jp71-runtime-${TARGETARCH} \
-    --mount=type=cache,target=/var/lib/apt,sharing=locked,id=apt-lib-jp71-runtime-${TARGETARCH} \
-    apt-get update -y && \
-    mkdir -p /tmp/l4t-debs && cd /tmp/l4t-debs && \
-    apt-get download $(apt-cache depends --recurse --no-recommends --no-suggests \
-        --no-conflicts --no-breaks --no-replaces --no-enhances \
-        nvidia-l4t-gstreamer | grep '^nvidia-l4t' | grep -v '^nvidia-l4t-cuda$' | sort -u) && \
-    for deb in ./*.deb; do dpkg-deb -x "$deb" /; done && \
-    cd / && rm -rf /tmp/l4t-debs && \
-    # Loader path for the extracted tegra libs (the postinst that would have
-    # run ldconfig never executed) - same conf the JP6.2 image ships.
-    printf '/usr/lib/aarch64-linux-gnu/tegra\n/usr/lib/aarch64-linux-gnu/gstreamer-1.0\n' > /etc/ld.so.conf.d/nvidia-tegra.conf && \
-    ldconfig && \
-    ls /usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstnv*.so >/dev/null
-
-# Copy GDAL (skip headers - not needed in runtime)
 COPY --from=builder /usr/local/bin/gdal* /usr/local/bin/
 COPY --from=builder /usr/local/bin/ogr* /usr/local/bin/
 COPY --from=builder /usr/local/bin/gnm* /usr/local/bin/
@@ -518,27 +595,26 @@ COPY --from=builder /usr/local/lib/libgdal* /usr/local/lib/
 COPY --from=builder /usr/local/share/gdal /usr/local/share/gdal
 
 ENV GDAL_DATA=/usr/local/share/gdal
-ENV LD_LIBRARY_PATH=/usr/local/lib:/usr/local/cuda/lib64:$LD_LIBRARY_PATH
+ENV LD_LIBRARY_PATH=/usr/local/lib:/usr/local/cuda/lib64:/opt/opencv/lib:/opt/gstreamer/lib:/opt/ffmpeg/lib
 
 RUN ldconfig
-
-# build-essential/python3-dev/zlib1g-dev/libxml2-dev: required for Triton JIT kernel
-# compilation at runtime. Triton python pkg ships in dist-packages below.
 
 # Copy Python packages from builder
 COPY --from=builder /usr/local/lib/python3.12/dist-packages /usr/local/lib/python3.12/dist-packages
 COPY --from=builder /root/.triton/nvidia /root/.triton/nvidia
 COPY --from=builder /root/.triton/json /root/.triton/json
 
-# jetson-utils: NVDEC decode library + python bindings (staged by the builder
-# into one dir regardless of which dist-packages `make install` picked).
-# Resolved via LD_LIBRARY_PATH=/usr/local/lib (set above).
-COPY --from=builder /usr/local/lib/libjetson-utils.so /usr/local/lib/
-COPY --from=builder /build/out/jetson-utils-py/ /usr/local/lib/python3.12/dist-packages/
+COPY --from=opencv-builder /opt/opencv-runtime /opt/opencv
 
 # Copy TensorRT Python bindings (installed via apt in runtime stage, but ensure paths are correct)
 # Note: python3-libnvinfer packages install to /usr/lib/python3.12/dist-packages
-ENV PYTHONPATH=/usr/local/lib/python3.12/dist-packages:/usr/lib/python3.12/dist-packages:$PYTHONPATH
+ENV PYTHONPATH=/opt/opencv/python:/usr/local/lib/python3.12/dist-packages:/usr/lib/python3.12/dist-packages
+
+RUN --mount=type=bind,source=docker/scripts/verify_gstreamer.sh,target=/tmp/verify_gstreamer,ro \
+    --mount=type=bind,source=docker/scripts/verify_opencv.sh,target=/tmp/verify_opencv,ro \
+    OPENCV_REQUIRE_CUDA_BUILD=true sh /tmp/verify_opencv && \
+    sh /tmp/verify_gstreamer && \
+    rm -rf /root/.cache/gstreamer-1.0
 
 COPY --from=builder /usr/local/bin/inference /usr/local/bin/inference
 
@@ -550,13 +626,12 @@ COPY docker/config/gpu_http.py gpu_http.py
 COPY docker/entrypoint/run_uvicorn.sh /usr/local/bin/run_uvicorn.sh
 RUN chmod +x /usr/local/bin/run_uvicorn.sh
 
-RUN python -m pip install --break-system-packages --force-reinstall "boto3>=1.40.0,<=1.41.5" "botocore>=1.40.0,<=1.41.5"
-
 # Environment variables
 ENV CUDA_HOME=/usr/local/cuda \
     PATH=/usr/local/cuda/bin:$PATH \
     TRITON_PTXAS_BLACKWELL_PATH=/usr/local/cuda/bin/ptxas \
     NVIDIA_VISIBLE_DEVICES=all \
+    NVIDIA_DRIVER_CAPABILITIES=compute,utility,video \
     VERSION_CHECK_MODE=once \
     CORE_MODEL_SAM2_ENABLED=True \
     NUM_WORKERS=1 \
@@ -568,7 +643,7 @@ ENV CUDA_HOME=/usr/local/cuda \
     ORT_TENSORRT_MAX_WORKSPACE_SIZE=4294967296 \
     ORT_TENSORRT_BUILDER_OPTIMIZATION_LEVEL=5 \
     OPENBLAS_CORETYPE=ARMV8 \
-    GST_PLUGIN_PATH=/usr/lib/aarch64-linux-gnu/gstreamer-1.0 \
+    GST_PLUGIN_PATH_1_0=/usr/lib/aarch64-linux-gnu/gstreamer-1.0 \
     LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libgomp.so.1 \
     WORKFLOWS_STEP_EXECUTION_MODE=local \
     WORKFLOWS_MAX_CONCURRENT_STEPS=4 \

--- a/docker/native/gstreamer_cuda_tensor_bridge/gstreamer_cuda_tensor_bridge.cpp
+++ b/docker/native/gstreamer_cuda_tensor_bridge/gstreamer_cuda_tensor_bridge.cpp
@@ -1,0 +1,678 @@
+#include <cuda.h>
+#include <gst/app/gstappsink.h>
+#include <gst/cuda/gstcuda.h>
+#include <gst/video/video.h>
+
+#include <cstdarg>
+#include <atomic>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <mutex>
+#include <new>
+
+namespace {
+
+constexpr const char* kSinkName = "rf_tensor_sink";
+
+enum DLDeviceType : int32_t {
+    kDLCUDA = 2,
+};
+
+enum DLDataTypeCode : uint8_t {
+    kDLUInt = 1,
+};
+
+struct DLDevice {
+    DLDeviceType device_type;
+    int32_t device_id;
+};
+
+struct DLDataType {
+    uint8_t code;
+    uint8_t bits;
+    uint16_t lanes;
+};
+
+struct DLTensor {
+    void* data;
+    DLDevice device;
+    int32_t ndim;
+    DLDataType dtype;
+    int64_t* shape;
+    int64_t* strides;
+    uint64_t byte_offset;
+};
+
+struct DLManagedTensor {
+    DLTensor dl_tensor;
+    void* manager_ctx;
+    void (*deleter)(DLManagedTensor* self);
+};
+
+struct RfFrameInfo {
+    uint32_t width;
+    uint32_t height;
+    int32_t fps_numerator;
+    int32_t fps_denominator;
+    int64_t duration_ns;
+};
+
+struct RfCudaBridgeStats {
+    uint64_t frames;
+    uint64_t cuda_maps;
+    uint64_t host_pixel_maps;
+    uint64_t host_to_device_copies;
+    uint64_t device_to_host_copies;
+    uint64_t stream_synchronizations;
+    uint64_t active_leases;
+    int64_t last_channel_stride;
+    int64_t last_row_stride;
+};
+
+struct RfLeaseCounter {
+    std::atomic<uint64_t> references{1};
+    std::atomic<uint64_t> active{0};
+};
+
+struct RfCudaTensorContext {
+    GstSample* sample = nullptr;
+    GstMemory* memory = nullptr;
+    GstMapInfo map = GST_MAP_INFO_INIT;
+    bool mapped = false;
+    CUdevice device = 0;
+    bool primary_context_retained = false;
+    RfLeaseCounter* leases = nullptr;
+    int64_t shape[3] = {0, 0, 0};
+    int64_t strides[3] = {0, 0, 0};
+    DLManagedTensor managed{};
+};
+
+struct RfCudaPipeline {
+    GstElement* pipeline = nullptr;
+    GstAppSink* sink = nullptr;
+    GstSample* sample = nullptr;
+    GstCudaContext* cuda_context = nullptr;
+    CUcontext primary_context = nullptr;
+    CUdevice device = 0;
+    int device_id = 0;
+    RfCudaBridgeStats stats{};
+    RfLeaseCounter* leases = nullptr;
+    std::atomic<bool> interrupted{false};
+    std::mutex mutex;
+    std::mutex stats_mutex;
+};
+
+std::once_flag g_gstreamer_once;
+
+void write_error(char* destination, size_t capacity, const char* format, ...) {
+    if (destination == nullptr || capacity == 0) {
+        return;
+    }
+    va_list args;
+    va_start(args, format);
+    std::vsnprintf(destination, capacity, format, args);
+    va_end(args);
+    destination[capacity - 1] = '\0';
+}
+
+void initialize_gstreamer() {
+    gst_init(nullptr, nullptr);
+    gst_cuda_memory_init_once();
+}
+
+void delete_managed_tensor(DLManagedTensor* managed) {
+    if (managed == nullptr) {
+        return;
+    }
+    auto* context = static_cast<RfCudaTensorContext*>(managed->manager_ctx);
+    if (context == nullptr) {
+        return;
+    }
+    if (context->mapped && context->memory != nullptr) {
+        gst_memory_unmap(context->memory, &context->map);
+    }
+    if (context->sample != nullptr) {
+        gst_sample_unref(context->sample);
+    }
+    if (context->primary_context_retained) {
+        cuDevicePrimaryCtxRelease(context->device);
+    }
+    if (context->leases != nullptr) {
+        context->leases->active.fetch_sub(1, std::memory_order_relaxed);
+        if (context->leases->references.fetch_sub(1, std::memory_order_acq_rel) == 1) {
+            delete context->leases;
+        }
+    }
+    delete context;
+}
+
+bool sample_has_cuda_caps(GstSample* sample) {
+    GstCaps* caps = gst_sample_get_caps(sample);
+    if (caps == nullptr || gst_caps_is_empty(caps)) {
+        return false;
+    }
+    for (guint index = 0; index < gst_caps_get_size(caps); ++index) {
+        const GstCapsFeatures* features = gst_caps_get_features(caps, index);
+        if (features != nullptr && gst_caps_features_contains(
+                features, GST_CAPS_FEATURE_MEMORY_CUDA_MEMORY)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool read_sample_info(GstSample* sample, RfFrameInfo* info) {
+    if (sample == nullptr || info == nullptr) {
+        return false;
+    }
+    GstCaps* caps = gst_sample_get_caps(sample);
+    if (caps == nullptr || gst_caps_is_empty(caps)) {
+        return false;
+    }
+    GstVideoInfo video_info{};
+    if (!gst_video_info_from_caps(&video_info, caps)) {
+        return false;
+    }
+    info->width = GST_VIDEO_INFO_WIDTH(&video_info);
+    info->height = GST_VIDEO_INFO_HEIGHT(&video_info);
+    info->fps_numerator = GST_VIDEO_INFO_FPS_N(&video_info);
+    info->fps_denominator = GST_VIDEO_INFO_FPS_D(&video_info);
+    if (info->fps_denominator <= 0) {
+        info->fps_denominator = 1;
+    }
+    return true;
+}
+
+void read_bus_error(
+    RfCudaPipeline* handle,
+    char* error,
+    size_t error_capacity) {
+    GstBus* bus = gst_element_get_bus(handle->pipeline);
+    if (bus == nullptr) {
+        write_error(error, error_capacity, "GStreamer did not produce a frame");
+        return;
+    }
+    GstMessage* message = gst_bus_pop_filtered(
+        bus,
+        static_cast<GstMessageType>(GST_MESSAGE_ERROR | GST_MESSAGE_EOS));
+    if (message != nullptr && GST_MESSAGE_TYPE(message) == GST_MESSAGE_ERROR) {
+        GError* gst_error = nullptr;
+        gchar* debug = nullptr;
+        gst_message_parse_error(message, &gst_error, &debug);
+        write_error(
+            error,
+            error_capacity,
+            "%s",
+            gst_error != nullptr ? gst_error->message : "GStreamer pipeline error");
+        if (gst_error != nullptr) {
+            g_error_free(gst_error);
+        }
+        g_free(debug);
+    } else if (message != nullptr) {
+        write_error(error, error_capacity, "GStreamer reached end of stream");
+    } else {
+        write_error(error, error_capacity, "GStreamer did not produce a frame");
+    }
+    if (message != nullptr) {
+        gst_message_unref(message);
+    }
+    gst_object_unref(bus);
+}
+
+bool pipeline_has_factory(RfCudaPipeline* handle, const char* factory_name) {
+    if (handle == nullptr || handle->pipeline == nullptr || factory_name == nullptr ||
+        !GST_IS_BIN(handle->pipeline)) {
+        return false;
+    }
+    GstIterator* iterator = gst_bin_iterate_recurse(GST_BIN(handle->pipeline));
+    GValue item = G_VALUE_INIT;
+    bool found = false;
+    bool done = false;
+    while (!done && !found) {
+        switch (gst_iterator_next(iterator, &item)) {
+            case GST_ITERATOR_OK: {
+                auto* element = GST_ELEMENT(g_value_get_object(&item));
+                GstElementFactory* factory = gst_element_get_factory(element);
+                const gchar* name = factory == nullptr
+                    ? nullptr
+                    : gst_plugin_feature_get_name(GST_PLUGIN_FEATURE(factory));
+                found = name != nullptr && std::strcmp(name, factory_name) == 0;
+                g_value_reset(&item);
+                break;
+            }
+            case GST_ITERATOR_RESYNC:
+                gst_iterator_resync(iterator);
+                break;
+            default:
+                done = true;
+                break;
+        }
+    }
+    if (G_VALUE_TYPE(&item) != 0) {
+        g_value_unset(&item);
+    }
+    gst_iterator_free(iterator);
+    return found;
+}
+
+}  // namespace
+
+extern "C" {
+
+__attribute__((visibility("default")))
+const char* rf_gstreamer_cuda_tensor_bridge_version() {
+    return "2";
+}
+
+__attribute__((visibility("default")))
+RfCudaPipeline* rf_gstreamer_cuda_pipeline_create(
+    const char* pipeline_description,
+    int device_id,
+    char* error,
+    size_t error_capacity) {
+    if (pipeline_description == nullptr || pipeline_description[0] == '\0') {
+        write_error(error, error_capacity, "GStreamer pipeline is empty");
+        return nullptr;
+    }
+    std::call_once(g_gstreamer_once, initialize_gstreamer);
+
+    CUresult cuda_status = cuInit(0);
+    CUdevice device = 0;
+    CUcontext primary_context = nullptr;
+    if (cuda_status == CUDA_SUCCESS) {
+        cuda_status = cuDeviceGet(&device, device_id);
+    }
+    if (cuda_status == CUDA_SUCCESS) {
+        cuda_status = cuDevicePrimaryCtxRetain(&primary_context, device);
+    }
+    if (cuda_status != CUDA_SUCCESS) {
+        const char* cuda_error = nullptr;
+        cuGetErrorString(cuda_status, &cuda_error);
+        write_error(
+            error,
+            error_capacity,
+            "CUDA primary context is unavailable: %s",
+            cuda_error == nullptr ? "unknown error" : cuda_error);
+        return nullptr;
+    }
+
+    GError* parse_error = nullptr;
+    GstElement* pipeline = gst_parse_launch(pipeline_description, &parse_error);
+    if (pipeline == nullptr || parse_error != nullptr) {
+        write_error(
+            error,
+            error_capacity,
+            "GStreamer pipeline parse failed: %s",
+            parse_error == nullptr ? "unknown error" : parse_error->message);
+        if (parse_error != nullptr) {
+            g_error_free(parse_error);
+        }
+        if (pipeline != nullptr) {
+            gst_object_unref(pipeline);
+        }
+        cuDevicePrimaryCtxRelease(device);
+        return nullptr;
+    }
+    if (!GST_IS_BIN(pipeline)) {
+        write_error(error, error_capacity, "GStreamer pipeline is not a bin");
+        gst_object_unref(pipeline);
+        cuDevicePrimaryCtxRelease(device);
+        return nullptr;
+    }
+    GstElement* sink_element = gst_bin_get_by_name(GST_BIN(pipeline), kSinkName);
+    if (sink_element == nullptr || !GST_IS_APP_SINK(sink_element)) {
+        write_error(
+            error,
+            error_capacity,
+            "GStreamer pipeline requires appsink name=%s",
+            kSinkName);
+        if (sink_element != nullptr) {
+            gst_object_unref(sink_element);
+        }
+        gst_object_unref(pipeline);
+        cuDevicePrimaryCtxRelease(device);
+        return nullptr;
+    }
+
+    GstCudaContext* cuda_context =
+        gst_cuda_context_new_wrapped(primary_context, device);
+    if (cuda_context == nullptr) {
+        write_error(error, error_capacity, "Could not wrap the CUDA primary context");
+        gst_object_unref(sink_element);
+        gst_object_unref(pipeline);
+        cuDevicePrimaryCtxRelease(device);
+        return nullptr;
+    }
+    GstContext* gst_context = gst_context_new_cuda_context(cuda_context);
+    gst_element_set_context(pipeline, gst_context);
+    gst_context_unref(gst_context);
+
+    auto* handle = new (std::nothrow) RfCudaPipeline();
+    if (handle == nullptr) {
+        write_error(error, error_capacity, "Could not allocate pipeline state");
+        gst_object_unref(cuda_context);
+        gst_object_unref(sink_element);
+        gst_object_unref(pipeline);
+        cuDevicePrimaryCtxRelease(device);
+        return nullptr;
+    }
+    handle->pipeline = pipeline;
+    handle->sink = GST_APP_SINK(sink_element);
+    handle->cuda_context = cuda_context;
+    handle->primary_context = primary_context;
+    handle->device = device;
+    handle->device_id = device_id;
+    handle->leases = new (std::nothrow) RfLeaseCounter();
+    if (handle->leases == nullptr) {
+        write_error(error, error_capacity, "Could not allocate tensor lease state");
+        gst_object_unref(cuda_context);
+        gst_object_unref(sink_element);
+        gst_object_unref(pipeline);
+        cuDevicePrimaryCtxRelease(device);
+        delete handle;
+        return nullptr;
+    }
+
+    const GstStateChangeReturn state_status =
+        gst_element_set_state(pipeline, GST_STATE_PLAYING);
+    if (state_status == GST_STATE_CHANGE_FAILURE) {
+        write_error(error, error_capacity, "GStreamer could not enter PLAYING state");
+        gst_object_unref(cuda_context);
+        gst_object_unref(sink_element);
+        gst_object_unref(pipeline);
+        cuDevicePrimaryCtxRelease(device);
+        delete handle->leases;
+        delete handle;
+        return nullptr;
+    }
+    return handle;
+}
+
+__attribute__((visibility("default")))
+int rf_gstreamer_cuda_pipeline_grab(
+    RfCudaPipeline* handle,
+    uint64_t timeout_ns,
+    char* error,
+    size_t error_capacity) {
+    if (handle == nullptr) {
+        write_error(error, error_capacity, "Pipeline handle is null");
+        return -1;
+    }
+    if (handle->interrupted.load(std::memory_order_acquire)) {
+        return 0;
+    }
+    std::lock_guard<std::mutex> lock(handle->mutex);
+    if (handle->interrupted.load(std::memory_order_acquire)) {
+        return 0;
+    }
+    if (handle->sample != nullptr) {
+        gst_sample_unref(handle->sample);
+        handle->sample = nullptr;
+    }
+    handle->sample = gst_app_sink_try_pull_sample(handle->sink, timeout_ns);
+    if (handle->sample == nullptr) {
+        if (handle->interrupted.load(std::memory_order_acquire)) {
+            return 0;
+        }
+        read_bus_error(handle, error, error_capacity);
+        return gst_app_sink_is_eos(handle->sink) ? 0 : -1;
+    }
+    if (!sample_has_cuda_caps(handle->sample)) {
+        write_error(
+            error,
+            error_capacity,
+            "GStreamer appsink frame is not memory:CUDAMemory");
+        gst_sample_unref(handle->sample);
+        handle->sample = nullptr;
+        return -1;
+    }
+    return 1;
+}
+
+__attribute__((visibility("default")))
+int rf_gstreamer_cuda_pipeline_get_frame_info(
+    RfCudaPipeline* handle,
+    RfFrameInfo* info,
+    char* error,
+    size_t error_capacity) {
+    if (handle == nullptr || info == nullptr) {
+        write_error(error, error_capacity, "Frame-info arguments are invalid");
+        return -1;
+    }
+    std::lock_guard<std::mutex> lock(handle->mutex);
+    if (handle->sample == nullptr || !read_sample_info(handle->sample, info)) {
+        write_error(error, error_capacity, "Frame caps do not contain video metadata");
+        return -1;
+    }
+    gint64 duration = GST_CLOCK_TIME_NONE;
+    info->duration_ns = gst_element_query_duration(
+        handle->pipeline, GST_FORMAT_TIME, &duration) ? duration : 0;
+    return 1;
+}
+
+__attribute__((visibility("default")))
+int rf_gstreamer_cuda_pipeline_has_factory(
+    RfCudaPipeline* handle,
+    const char* factory_name) {
+    if (handle == nullptr) {
+        return 0;
+    }
+    std::lock_guard<std::mutex> lock(handle->mutex);
+    return pipeline_has_factory(handle, factory_name) ? 1 : 0;
+}
+
+__attribute__((visibility("default")))
+DLManagedTensor* rf_gstreamer_cuda_pipeline_retrieve(
+    RfCudaPipeline* handle,
+    char* error,
+    size_t error_capacity) {
+    if (handle == nullptr) {
+        write_error(error, error_capacity, "Pipeline handle is null");
+        return nullptr;
+    }
+    std::lock_guard<std::mutex> lock(handle->mutex);
+    if (handle->sample == nullptr) {
+        write_error(error, error_capacity, "No grabbed frame is available");
+        return nullptr;
+    }
+
+    GstSample* sample = handle->sample;
+    handle->sample = nullptr;
+    GstBuffer* buffer = gst_sample_get_buffer(sample);
+    if (buffer == nullptr || gst_buffer_n_memory(buffer) != 1) {
+        write_error(error, error_capacity, "CUDA frame must contain one GstMemory");
+        gst_sample_unref(sample);
+        return nullptr;
+    }
+    GstMemory* memory = gst_buffer_peek_memory(buffer, 0);
+    if (memory == nullptr || !gst_is_cuda_memory(memory)) {
+        write_error(error, error_capacity, "Frame memory is not GstCudaMemory");
+        gst_sample_unref(sample);
+        return nullptr;
+    }
+    if (GST_MEMORY_FLAG_IS_SET(
+            memory,
+            static_cast<GstMemoryFlags>(GST_CUDA_MEMORY_TRANSFER_NEED_UPLOAD))) {
+        write_error(error, error_capacity, "CUDA frame requires a host upload");
+        gst_sample_unref(sample);
+        return nullptr;
+    }
+
+    auto* cuda_memory = GST_CUDA_MEMORY_CAST(memory);
+    CUcontext memory_context = reinterpret_cast<CUcontext>(
+        gst_cuda_context_get_handle(cuda_memory->context));
+    if (memory_context != handle->primary_context) {
+        write_error(error, error_capacity, "CUDA frame uses a different context");
+        gst_sample_unref(sample);
+        return nullptr;
+    }
+    const GstVideoInfo* video_info = &cuda_memory->info;
+    if (GST_VIDEO_INFO_FORMAT(video_info) != GST_VIDEO_FORMAT_RGBP ||
+        GST_VIDEO_INFO_N_PLANES(video_info) != 3 ||
+        GST_VIDEO_INFO_COMP_PSTRIDE(video_info, 0) != 1 ||
+        GST_VIDEO_INFO_COMP_PSTRIDE(video_info, 1) != 1 ||
+        GST_VIDEO_INFO_COMP_PSTRIDE(video_info, 2) != 1) {
+        write_error(error, error_capacity, "CUDA frame is not planar uint8 RGB");
+        gst_sample_unref(sample);
+        return nullptr;
+    }
+    const int64_t row_stride = GST_VIDEO_INFO_PLANE_STRIDE(video_info, 0);
+    const int64_t second_row_stride = GST_VIDEO_INFO_PLANE_STRIDE(video_info, 1);
+    const int64_t third_row_stride = GST_VIDEO_INFO_PLANE_STRIDE(video_info, 2);
+    const int64_t channel_stride =
+        GST_VIDEO_INFO_PLANE_OFFSET(video_info, 1) -
+        GST_VIDEO_INFO_PLANE_OFFSET(video_info, 0);
+    const int64_t second_channel_stride =
+        GST_VIDEO_INFO_PLANE_OFFSET(video_info, 2) -
+        GST_VIDEO_INFO_PLANE_OFFSET(video_info, 1);
+    if (row_stride <= 0 || row_stride != second_row_stride ||
+        row_stride != third_row_stride || channel_stride <= 0 ||
+        channel_stride != second_channel_stride) {
+        write_error(error, error_capacity, "CUDA RGB plane strides are incompatible");
+        gst_sample_unref(sample);
+        return nullptr;
+    }
+
+    auto* tensor = new (std::nothrow) RfCudaTensorContext();
+    if (tensor == nullptr) {
+        write_error(error, error_capacity, "Could not allocate tensor lease");
+        gst_sample_unref(sample);
+        return nullptr;
+    }
+    tensor->sample = sample;
+    tensor->memory = memory;
+    tensor->device = handle->device;
+    tensor->managed.manager_ctx = tensor;
+    tensor->managed.deleter = delete_managed_tensor;
+    CUresult cuda_status = cuDevicePrimaryCtxRetain(
+        &memory_context, handle->device);
+    if (cuda_status != CUDA_SUCCESS) {
+        write_error(error, error_capacity, "Could not retain the CUDA primary context");
+        delete_managed_tensor(&tensor->managed);
+        return nullptr;
+    }
+    tensor->primary_context_retained = true;
+
+    gst_cuda_memory_sync(cuda_memory);
+    if (!gst_memory_map(
+            memory,
+            &tensor->map,
+            static_cast<GstMapFlags>(GST_MAP_READ | GST_MAP_CUDA))) {
+        write_error(error, error_capacity, "Could not map CUDA frame memory");
+        delete_managed_tensor(&tensor->managed);
+        return nullptr;
+    }
+    tensor->mapped = true;
+
+    tensor->shape[0] = 3;
+    tensor->shape[1] = GST_VIDEO_INFO_HEIGHT(video_info);
+    tensor->shape[2] = GST_VIDEO_INFO_WIDTH(video_info);
+    tensor->strides[0] = channel_stride;
+    tensor->strides[1] = row_stride;
+    tensor->strides[2] = 1;
+    tensor->managed.dl_tensor.data = tensor->map.data;
+    tensor->managed.dl_tensor.device = {kDLCUDA, handle->device_id};
+    tensor->managed.dl_tensor.ndim = 3;
+    tensor->managed.dl_tensor.dtype = {kDLUInt, 8, 1};
+    tensor->managed.dl_tensor.shape = tensor->shape;
+    tensor->managed.dl_tensor.strides = tensor->strides;
+    tensor->managed.dl_tensor.byte_offset =
+        GST_VIDEO_INFO_PLANE_OFFSET(video_info, 0);
+
+    {
+        std::lock_guard<std::mutex> stats_lock(handle->stats_mutex);
+        handle->stats.frames += 1;
+        handle->stats.cuda_maps += 1;
+        handle->stats.stream_synchronizations += 1;
+        handle->stats.last_channel_stride = channel_stride;
+        handle->stats.last_row_stride = row_stride;
+    }
+    handle->leases->references.fetch_add(1, std::memory_order_relaxed);
+    handle->leases->active.fetch_add(1, std::memory_order_relaxed);
+    tensor->leases = handle->leases;
+    return &tensor->managed;
+}
+
+__attribute__((visibility("default")))
+int rf_gstreamer_cuda_pipeline_get_stats(
+    RfCudaPipeline* handle,
+    RfCudaBridgeStats* stats) {
+    if (handle == nullptr || stats == nullptr) {
+        return -1;
+    }
+    std::lock_guard<std::mutex> lock(handle->stats_mutex);
+    *stats = handle->stats;
+    stats->active_leases = handle->leases->active.load(std::memory_order_relaxed);
+    return 1;
+}
+
+__attribute__((visibility("default")))
+void rf_gstreamer_cuda_dlpack_delete(DLManagedTensor* tensor) {
+    if (tensor != nullptr && tensor->deleter != nullptr) {
+        tensor->deleter(tensor);
+    }
+}
+
+__attribute__((visibility("default")))
+int rf_gstreamer_cuda_pipeline_interrupt(RfCudaPipeline* handle) {
+    if (handle == nullptr) {
+        return -1;
+    }
+    handle->interrupted.store(true, std::memory_order_release);
+    if (handle->sink != nullptr) {
+        gst_app_sink_set_drop(handle->sink, TRUE);
+        GstSample* queued_sample = nullptr;
+        while ((queued_sample = gst_app_sink_try_pull_sample(handle->sink, 0)) !=
+               nullptr) {
+            gst_sample_unref(queued_sample);
+        }
+    }
+    if (handle->pipeline != nullptr) {
+        gst_element_set_state(handle->pipeline, GST_STATE_NULL);
+    }
+    return 1;
+}
+
+__attribute__((visibility("default")))
+void rf_gstreamer_cuda_pipeline_release(RfCudaPipeline* handle) {
+    if (handle == nullptr) {
+        return;
+    }
+    rf_gstreamer_cuda_pipeline_interrupt(handle);
+    {
+        std::lock_guard<std::mutex> lock(handle->mutex);
+        if (handle->sample != nullptr) {
+            gst_sample_unref(handle->sample);
+            handle->sample = nullptr;
+        }
+        if (handle->sink != nullptr) {
+            gst_app_sink_set_drop(handle->sink, TRUE);
+            GstSample* queued_sample = nullptr;
+            while ((queued_sample =
+                        gst_app_sink_try_pull_sample(handle->sink, 0)) !=
+                   nullptr) {
+                gst_sample_unref(queued_sample);
+            }
+        }
+        if (handle->pipeline != nullptr) {
+            gst_element_set_state(handle->pipeline, GST_STATE_NULL);
+        }
+        if (handle->sink != nullptr) {
+            gst_object_unref(handle->sink);
+        }
+        if (handle->pipeline != nullptr) {
+            gst_object_unref(handle->pipeline);
+        }
+        if (handle->cuda_context != nullptr) {
+            gst_object_unref(handle->cuda_context);
+        }
+        cuDevicePrimaryCtxRelease(handle->device);
+        if (handle->leases->references.fetch_sub(1, std::memory_order_acq_rel) == 1) {
+            delete handle->leases;
+        }
+    }
+    delete handle;
+}
+
+}  // extern "C"

--- a/docker/native/jetson_tensor_bridge/jetson_tensor_bridge.cu
+++ b/docker/native/jetson_tensor_bridge/jetson_tensor_bridge.cu
@@ -1,0 +1,867 @@
+#include <cuda.h>
+#include <cudaEGL.h>
+#include <cuda_runtime.h>
+
+#pragma push_macro("__noinline__")
+#undef __noinline__
+#include <dlfcn.h>
+#include <gst/app/gstappsink.h>
+#include <gst/gst.h>
+#include <nvbufsurface.h>
+#pragma pop_macro("__noinline__")
+
+#include <cstdarg>
+#include <atomic>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <mutex>
+#include <new>
+
+namespace {
+
+constexpr const char* kSinkName = "rf_tensor_sink";
+constexpr const char* kNvmmCapsFeature = "memory:NVMM";
+
+enum DLDeviceType : int32_t {
+    kDLCUDA = 2,
+};
+
+enum DLDataTypeCode : uint8_t {
+    kDLUInt = 1,
+};
+
+struct DLDevice {
+    DLDeviceType device_type;
+    int32_t device_id;
+};
+
+struct DLDataType {
+    uint8_t code;
+    uint8_t bits;
+    uint16_t lanes;
+};
+
+struct DLTensor {
+    void* data;
+    DLDevice device;
+    int32_t ndim;
+    DLDataType dtype;
+    int64_t* shape;
+    int64_t* strides;
+    uint64_t byte_offset;
+};
+
+struct DLManagedTensor {
+    DLTensor dl_tensor;
+    void* manager_ctx;
+    void (*deleter)(DLManagedTensor* self);
+};
+
+struct RfFrameInfo {
+    uint32_t width;
+    uint32_t height;
+    int32_t fps_numerator;
+    int32_t fps_denominator;
+    int64_t duration_ns;
+};
+
+struct RfBridgeStats {
+    uint64_t frames;
+    uint64_t descriptor_maps;
+    uint64_t host_pixel_maps;
+    uint64_t host_to_device_copies;
+    uint64_t device_to_host_copies;
+    uint64_t array_flatten_copies;
+    uint64_t conversion_kernels;
+    uint64_t nvmm_frames;
+    int32_t last_nvbuf_memory_type;
+    int32_t last_egl_frame_type;
+    int32_t last_egl_color_format;
+};
+
+struct RfTensorContext {
+    void* allocation = nullptr;
+    int device_id = 0;
+    int64_t shape[3] = {0, 0, 0};
+    DLManagedTensor managed{};
+};
+
+struct RfJetsonPipeline {
+    GstElement* pipeline = nullptr;
+    GstAppSink* sink = nullptr;
+    GstSample* sample = nullptr;
+    cudaStream_t stream = nullptr;
+    int device_id = 0;
+    RfBridgeStats stats{};
+    std::atomic<bool> interrupted{false};
+    std::mutex mutex;
+};
+
+using NvBufSurfaceMapEglImageFn = int (*)(NvBufSurface*, int);
+using NvBufSurfaceUnMapEglImageFn = int (*)(NvBufSurface*, int);
+
+struct NvBufSurfaceApi {
+    void* library = nullptr;
+    NvBufSurfaceMapEglImageFn map_egl_image = nullptr;
+    NvBufSurfaceUnMapEglImageFn unmap_egl_image = nullptr;
+    const char* error = nullptr;
+};
+
+struct ChannelMap {
+    int red;
+    int green;
+    int blue;
+};
+
+std::once_flag g_gstreamer_once;
+std::once_flag g_nvbufsurface_once;
+NvBufSurfaceApi g_nvbufsurface;
+
+void write_error(char* destination, size_t capacity, const char* format, ...) {
+    if (destination == nullptr || capacity == 0) {
+        return;
+    }
+    va_list args;
+    va_start(args, format);
+    std::vsnprintf(destination, capacity, format, args);
+    va_end(args);
+    destination[capacity - 1] = '\0';
+}
+
+void initialize_gstreamer() {
+    gst_init(nullptr, nullptr);
+}
+
+void initialize_nvbufsurface() {
+    const char* candidates[] = {
+        "libnvbufsurface.so.1.0.0",
+        "libnvbufsurface.so",
+        "/usr/lib/aarch64-linux-gnu/nvidia/libnvbufsurface.so.1.0.0",
+        "/usr/lib/aarch64-linux-gnu/tegra/libnvbufsurface.so.1.0.0",
+    };
+    for (const char* candidate : candidates) {
+        g_nvbufsurface.library = dlopen(candidate, RTLD_NOW | RTLD_LOCAL);
+        if (g_nvbufsurface.library != nullptr) {
+            break;
+        }
+    }
+    if (g_nvbufsurface.library == nullptr) {
+        g_nvbufsurface.error = dlerror();
+        return;
+    }
+    g_nvbufsurface.map_egl_image =
+        reinterpret_cast<NvBufSurfaceMapEglImageFn>(
+            dlsym(g_nvbufsurface.library, "NvBufSurfaceMapEglImage"));
+    g_nvbufsurface.unmap_egl_image =
+        reinterpret_cast<NvBufSurfaceUnMapEglImageFn>(
+            dlsym(g_nvbufsurface.library, "NvBufSurfaceUnMapEglImage"));
+    if (g_nvbufsurface.map_egl_image == nullptr ||
+        g_nvbufsurface.unmap_egl_image == nullptr) {
+        g_nvbufsurface.error = dlerror();
+    }
+}
+
+bool get_channel_map(CUeglColorFormat format, ChannelMap* result) {
+    if (result == nullptr) {
+        return false;
+    }
+    switch (format) {
+        case CU_EGL_COLOR_FORMAT_ABGR:
+            *result = {0, 1, 2};
+            return true;
+        case CU_EGL_COLOR_FORMAT_RGBA:
+            *result = {3, 2, 1};
+            return true;
+        case CU_EGL_COLOR_FORMAT_ARGB:
+            *result = {2, 1, 0};
+            return true;
+        case CU_EGL_COLOR_FORMAT_BGRA:
+            *result = {1, 2, 3};
+            return true;
+        default:
+            return false;
+    }
+}
+
+__device__ inline void store_rgb_chw(
+    uchar4 pixel,
+    ChannelMap channels,
+    uint8_t* destination,
+    uint32_t index,
+    uint32_t plane_size) {
+    const uint8_t values[4] = {pixel.x, pixel.y, pixel.z, pixel.w};
+    destination[index] = values[channels.red];
+    destination[plane_size + index] = values[channels.green];
+    destination[2 * plane_size + index] = values[channels.blue];
+}
+
+__global__ void rgba_pitch_to_rgb_chw(
+    const uint8_t* source,
+    size_t source_pitch,
+    uint8_t* destination,
+    uint32_t width,
+    uint32_t height,
+    ChannelMap channels) {
+    const uint32_t x = blockIdx.x * blockDim.x + threadIdx.x;
+    const uint32_t y = blockIdx.y * blockDim.y + threadIdx.y;
+    if (x >= width || y >= height) {
+        return;
+    }
+    const uchar4* row = reinterpret_cast<const uchar4*>(source + y * source_pitch);
+    const uint32_t index = y * width + x;
+    store_rgb_chw(row[x], channels, destination, index, width * height);
+}
+
+__global__ void rgba_array_to_rgb_chw(
+    cudaTextureObject_t texture,
+    uint8_t* destination,
+    uint32_t width,
+    uint32_t height,
+    ChannelMap channels) {
+    const uint32_t x = blockIdx.x * blockDim.x + threadIdx.x;
+    const uint32_t y = blockIdx.y * blockDim.y + threadIdx.y;
+    if (x >= width || y >= height) {
+        return;
+    }
+    const uchar4 pixel = tex2D<uchar4>(texture, x + 0.5f, y + 0.5f);
+    const uint32_t index = y * width + x;
+    store_rgb_chw(pixel, channels, destination, index, width * height);
+}
+
+void delete_managed_tensor(DLManagedTensor* managed) {
+    if (managed == nullptr) {
+        return;
+    }
+    auto* context = static_cast<RfTensorContext*>(managed->manager_ctx);
+    if (context == nullptr) {
+        return;
+    }
+    cudaSetDevice(context->device_id);
+    if (context->allocation != nullptr) {
+        cudaFree(context->allocation);
+    }
+    delete context;
+}
+
+bool sample_has_nvmm_caps(GstSample* sample) {
+    GstCaps* caps = gst_sample_get_caps(sample);
+    if (caps == nullptr || gst_caps_is_empty(caps)) {
+        return false;
+    }
+    for (guint index = 0; index < gst_caps_get_size(caps); ++index) {
+        const GstCapsFeatures* features = gst_caps_get_features(caps, index);
+        if (features != nullptr &&
+            gst_caps_features_contains(features, kNvmmCapsFeature)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool read_sample_info(GstSample* sample, RfFrameInfo* info) {
+    if (sample == nullptr || info == nullptr) {
+        return false;
+    }
+    GstCaps* caps = gst_sample_get_caps(sample);
+    if (caps == nullptr || gst_caps_is_empty(caps)) {
+        return false;
+    }
+    const GstStructure* structure = gst_caps_get_structure(caps, 0);
+    int width = 0;
+    int height = 0;
+    int numerator = 0;
+    int denominator = 1;
+    if (!gst_structure_get_int(structure, "width", &width) ||
+        !gst_structure_get_int(structure, "height", &height)) {
+        return false;
+    }
+    gst_structure_get_fraction(
+        structure, "framerate", &numerator, &denominator);
+    info->width = static_cast<uint32_t>(width);
+    info->height = static_cast<uint32_t>(height);
+    info->fps_numerator = numerator;
+    info->fps_denominator = denominator > 0 ? denominator : 1;
+    return true;
+}
+
+void read_bus_error(
+    RfJetsonPipeline* handle,
+    char* error,
+    size_t error_capacity) {
+    GstBus* bus = gst_element_get_bus(handle->pipeline);
+    if (bus == nullptr) {
+        write_error(error, error_capacity, "GStreamer did not produce a frame");
+        return;
+    }
+    GstMessage* message = gst_bus_pop_filtered(
+        bus,
+        static_cast<GstMessageType>(GST_MESSAGE_ERROR | GST_MESSAGE_EOS));
+    if (message != nullptr && GST_MESSAGE_TYPE(message) == GST_MESSAGE_ERROR) {
+        GError* gst_error = nullptr;
+        gchar* debug = nullptr;
+        gst_message_parse_error(message, &gst_error, &debug);
+        write_error(
+            error,
+            error_capacity,
+            "%s",
+            gst_error != nullptr ? gst_error->message : "GStreamer pipeline error");
+        if (gst_error != nullptr) {
+            g_error_free(gst_error);
+        }
+        g_free(debug);
+    } else if (message != nullptr) {
+        write_error(error, error_capacity, "GStreamer reached end of stream");
+    } else {
+        write_error(error, error_capacity, "GStreamer did not produce a frame");
+    }
+    if (message != nullptr) {
+        gst_message_unref(message);
+    }
+    gst_object_unref(bus);
+}
+
+bool pipeline_has_factory(RfJetsonPipeline* handle, const char* factory_name) {
+    if (handle == nullptr || handle->pipeline == nullptr || factory_name == nullptr ||
+        !GST_IS_BIN(handle->pipeline)) {
+        return false;
+    }
+    GstIterator* iterator = gst_bin_iterate_recurse(GST_BIN(handle->pipeline));
+    GValue item = G_VALUE_INIT;
+    bool found = false;
+    bool done = false;
+    while (!done && !found) {
+        switch (gst_iterator_next(iterator, &item)) {
+            case GST_ITERATOR_OK: {
+                auto* element = GST_ELEMENT(g_value_get_object(&item));
+                GstElementFactory* factory = gst_element_get_factory(element);
+                const gchar* name = factory == nullptr
+                    ? nullptr
+                    : gst_plugin_feature_get_name(GST_PLUGIN_FEATURE(factory));
+                found = name != nullptr && std::strcmp(name, factory_name) == 0;
+                g_value_reset(&item);
+                break;
+            }
+            case GST_ITERATOR_RESYNC:
+                gst_iterator_resync(iterator);
+                break;
+            default:
+                done = true;
+                break;
+        }
+    }
+    if (G_VALUE_TYPE(&item) != 0) {
+        g_value_unset(&item);
+    }
+    gst_iterator_free(iterator);
+    return found;
+}
+
+}  // namespace
+
+extern "C" {
+
+__attribute__((visibility("default")))
+const char* rf_jetson_tensor_bridge_version() {
+    return "2";
+}
+
+__attribute__((visibility("default")))
+RfJetsonPipeline* rf_jetson_pipeline_create(
+    const char* pipeline_description,
+    int device_id,
+    char* error,
+    size_t error_capacity) {
+    if (pipeline_description == nullptr || pipeline_description[0] == '\0') {
+        write_error(error, error_capacity, "GStreamer pipeline is empty");
+        return nullptr;
+    }
+    std::call_once(g_gstreamer_once, initialize_gstreamer);
+    std::call_once(g_nvbufsurface_once, initialize_nvbufsurface);
+    if (g_nvbufsurface.map_egl_image == nullptr ||
+        g_nvbufsurface.unmap_egl_image == nullptr) {
+        write_error(
+            error,
+            error_capacity,
+            "NvBufSurface EGL API is unavailable: %s",
+            g_nvbufsurface.error == nullptr ? "unknown error" : g_nvbufsurface.error);
+        return nullptr;
+    }
+    cudaError_t cuda_status = cudaSetDevice(device_id);
+    if (cuda_status == cudaSuccess) {
+        cuda_status = cudaFree(nullptr);
+    }
+    if (cuda_status != cudaSuccess) {
+        write_error(
+            error,
+            error_capacity,
+            "CUDA device %d is unavailable: %s",
+            device_id,
+            cudaGetErrorString(cuda_status));
+        return nullptr;
+    }
+    CUresult driver_status = cuInit(0);
+    if (driver_status != CUDA_SUCCESS) {
+        const char* driver_error = nullptr;
+        cuGetErrorString(driver_status, &driver_error);
+        write_error(
+            error,
+            error_capacity,
+            "CUDA driver initialization failed: %s",
+            driver_error == nullptr ? "unknown error" : driver_error);
+        return nullptr;
+    }
+
+    GError* parse_error = nullptr;
+    GstElement* pipeline = gst_parse_launch(pipeline_description, &parse_error);
+    if (pipeline == nullptr || parse_error != nullptr) {
+        write_error(
+            error,
+            error_capacity,
+            "GStreamer pipeline parse failed: %s",
+            parse_error == nullptr ? "unknown error" : parse_error->message);
+        if (parse_error != nullptr) {
+            g_error_free(parse_error);
+        }
+        if (pipeline != nullptr) {
+            gst_object_unref(pipeline);
+        }
+        return nullptr;
+    }
+    if (!GST_IS_BIN(pipeline)) {
+        write_error(error, error_capacity, "GStreamer pipeline is not a bin");
+        gst_object_unref(pipeline);
+        return nullptr;
+    }
+    GstElement* sink_element = gst_bin_get_by_name(GST_BIN(pipeline), kSinkName);
+    if (sink_element == nullptr || !GST_IS_APP_SINK(sink_element)) {
+        write_error(
+            error,
+            error_capacity,
+            "GStreamer pipeline requires appsink name=%s",
+            kSinkName);
+        if (sink_element != nullptr) {
+            gst_object_unref(sink_element);
+        }
+        gst_object_unref(pipeline);
+        return nullptr;
+    }
+
+    auto* handle = new (std::nothrow) RfJetsonPipeline();
+    if (handle == nullptr) {
+        write_error(error, error_capacity, "Could not allocate pipeline state");
+        gst_object_unref(sink_element);
+        gst_object_unref(pipeline);
+        return nullptr;
+    }
+    handle->pipeline = pipeline;
+    handle->sink = GST_APP_SINK(sink_element);
+    handle->device_id = device_id;
+    cuda_status = cudaStreamCreateWithFlags(&handle->stream, cudaStreamNonBlocking);
+    if (cuda_status != cudaSuccess) {
+        write_error(
+            error,
+            error_capacity,
+            "CUDA stream creation failed: %s",
+            cudaGetErrorString(cuda_status));
+        gst_object_unref(sink_element);
+        gst_object_unref(pipeline);
+        delete handle;
+        return nullptr;
+    }
+    const GstStateChangeReturn state_status =
+        gst_element_set_state(pipeline, GST_STATE_PLAYING);
+    if (state_status == GST_STATE_CHANGE_FAILURE) {
+        write_error(error, error_capacity, "GStreamer could not enter PLAYING state");
+        cudaStreamDestroy(handle->stream);
+        gst_object_unref(sink_element);
+        gst_object_unref(pipeline);
+        delete handle;
+        return nullptr;
+    }
+    return handle;
+}
+
+__attribute__((visibility("default")))
+int rf_jetson_pipeline_grab(
+    RfJetsonPipeline* handle,
+    uint64_t timeout_ns,
+    char* error,
+    size_t error_capacity) {
+    if (handle == nullptr) {
+        write_error(error, error_capacity, "Pipeline handle is null");
+        return -1;
+    }
+    if (handle->interrupted.load(std::memory_order_acquire)) {
+        return 0;
+    }
+    std::lock_guard<std::mutex> lock(handle->mutex);
+    if (handle->interrupted.load(std::memory_order_acquire)) {
+        return 0;
+    }
+    if (handle->sample != nullptr) {
+        gst_sample_unref(handle->sample);
+        handle->sample = nullptr;
+    }
+    handle->sample = gst_app_sink_try_pull_sample(handle->sink, timeout_ns);
+    if (handle->sample == nullptr) {
+        if (handle->interrupted.load(std::memory_order_acquire)) {
+            return 0;
+        }
+        read_bus_error(handle, error, error_capacity);
+        return gst_app_sink_is_eos(handle->sink) ? 0 : -1;
+    }
+    if (!sample_has_nvmm_caps(handle->sample)) {
+        write_error(
+            error,
+            error_capacity,
+            "GStreamer appsink frame is not memory:NVMM");
+        gst_sample_unref(handle->sample);
+        handle->sample = nullptr;
+        return -1;
+    }
+    return 1;
+}
+
+__attribute__((visibility("default")))
+int rf_jetson_pipeline_get_frame_info(
+    RfJetsonPipeline* handle,
+    RfFrameInfo* info,
+    char* error,
+    size_t error_capacity) {
+    if (handle == nullptr || info == nullptr) {
+        write_error(error, error_capacity, "Frame-info arguments are invalid");
+        return -1;
+    }
+    std::lock_guard<std::mutex> lock(handle->mutex);
+    if (handle->sample == nullptr || !read_sample_info(handle->sample, info)) {
+        write_error(error, error_capacity, "Frame caps do not contain dimensions");
+        return -1;
+    }
+    gint64 duration = GST_CLOCK_TIME_NONE;
+    if (gst_element_query_duration(handle->pipeline, GST_FORMAT_TIME, &duration)) {
+        info->duration_ns = duration;
+    } else {
+        info->duration_ns = 0;
+    }
+    return 1;
+}
+
+__attribute__((visibility("default")))
+int rf_jetson_pipeline_has_factory(
+    RfJetsonPipeline* handle,
+    const char* factory_name) {
+    if (handle == nullptr) {
+        return 0;
+    }
+    std::lock_guard<std::mutex> lock(handle->mutex);
+    return pipeline_has_factory(handle, factory_name) ? 1 : 0;
+}
+
+__attribute__((visibility("default")))
+DLManagedTensor* rf_jetson_pipeline_retrieve(
+    RfJetsonPipeline* handle,
+    char* error,
+    size_t error_capacity) {
+    if (handle == nullptr) {
+        write_error(error, error_capacity, "Pipeline handle is null");
+        return nullptr;
+    }
+    std::lock_guard<std::mutex> lock(handle->mutex);
+    if (handle->sample == nullptr) {
+        write_error(error, error_capacity, "No grabbed frame is available");
+        return nullptr;
+    }
+
+    GstSample* sample = handle->sample;
+    handle->sample = nullptr;
+    GstBuffer* buffer = gst_sample_get_buffer(sample);
+    GstMapInfo map = GST_MAP_INFO_INIT;
+    bool buffer_mapped = false;
+    bool egl_mapped = false;
+    CUgraphicsResource graphics_resource = nullptr;
+    cudaTextureObject_t texture = 0;
+    RfTensorContext* tensor = nullptr;
+    DLManagedTensor* result = nullptr;
+
+    RfFrameInfo frame_info{};
+    if (!read_sample_info(sample, &frame_info) || !sample_has_nvmm_caps(sample)) {
+        write_error(error, error_capacity, "Frame caps are invalid");
+        goto cleanup;
+    }
+    if (buffer == nullptr || !gst_buffer_map(buffer, &map, GST_MAP_READ) ||
+        map.data == nullptr) {
+        write_error(error, error_capacity, "Could not map the NvBufSurface descriptor");
+        goto cleanup;
+    }
+    buffer_mapped = true;
+    handle->stats.descriptor_maps += 1;
+
+    {
+        auto* surface = reinterpret_cast<NvBufSurface*>(map.data);
+        handle->stats.last_nvbuf_memory_type = static_cast<int32_t>(surface->memType);
+        if (surface->memType != NVBUF_MEM_SURFACE_ARRAY ||
+            surface->surfaceList == nullptr || surface->batchSize == 0 ||
+            surface->numFilled == 0) {
+            write_error(
+                error,
+                error_capacity,
+                "Frame is not a populated NvBufSurface SURFACE_ARRAY");
+            goto cleanup;
+        }
+        if (surface->surfaceList[0].colorFormat != NVBUF_COLOR_FORMAT_RGBA) {
+            write_error(
+                error,
+                error_capacity,
+                "NvBufSurface is not RGBA (format=%d)",
+                static_cast<int>(surface->surfaceList[0].colorFormat));
+            goto cleanup;
+        }
+        if (g_nvbufsurface.map_egl_image(surface, 0) != 0) {
+            write_error(error, error_capacity, "NvBufSurface EGL mapping failed");
+            goto cleanup;
+        }
+        egl_mapped = true;
+        void* egl_image = surface->surfaceList[0].mappedAddr.eglImage;
+        if (egl_image == nullptr) {
+            write_error(error, error_capacity, "NvBufSurface EGL image is null");
+            goto cleanup;
+        }
+        CUresult driver_status = cuGraphicsEGLRegisterImage(
+            &graphics_resource,
+            reinterpret_cast<EGLImageKHR>(egl_image),
+            CU_GRAPHICS_MAP_RESOURCE_FLAGS_READ_ONLY);
+        if (driver_status != CUDA_SUCCESS) {
+            const char* driver_error = nullptr;
+            cuGetErrorString(driver_status, &driver_error);
+            write_error(
+                error,
+                error_capacity,
+                "CUDA EGL registration failed: %s",
+                driver_error == nullptr ? "unknown error" : driver_error);
+            goto cleanup;
+        }
+
+        CUeglFrame egl_frame{};
+        driver_status = cuGraphicsResourceGetMappedEglFrame(
+            &egl_frame, graphics_resource, 0, 0);
+        if (driver_status != CUDA_SUCCESS) {
+            const char* driver_error = nullptr;
+            cuGetErrorString(driver_status, &driver_error);
+            write_error(
+                error,
+                error_capacity,
+                "CUDA EGL frame mapping failed: %s",
+                driver_error == nullptr ? "unknown error" : driver_error);
+            goto cleanup;
+        }
+        handle->stats.last_egl_frame_type = static_cast<int32_t>(egl_frame.frameType);
+        handle->stats.last_egl_color_format =
+            static_cast<int32_t>(egl_frame.eglColorFormat);
+        if (egl_frame.width < frame_info.width || egl_frame.height < frame_info.height ||
+            egl_frame.planeCount != 1 || egl_frame.numChannels != 4 ||
+            egl_frame.cuFormat != CU_AD_FORMAT_UNSIGNED_INT8) {
+            write_error(error, error_capacity, "CUDA EGL RGBA frame layout is invalid");
+            goto cleanup;
+        }
+
+        ChannelMap channels{};
+        if (!get_channel_map(egl_frame.eglColorFormat, &channels)) {
+            write_error(
+                error,
+                error_capacity,
+                "CUDA EGL color format is unsupported: %d",
+                static_cast<int>(egl_frame.eglColorFormat));
+            goto cleanup;
+        }
+        tensor = new (std::nothrow) RfTensorContext();
+        if (tensor == nullptr) {
+            write_error(error, error_capacity, "Could not allocate tensor state");
+            goto cleanup;
+        }
+        tensor->device_id = handle->device_id;
+        tensor->managed.manager_ctx = tensor;
+        tensor->managed.deleter = delete_managed_tensor;
+        const size_t output_size =
+            static_cast<size_t>(frame_info.width) * frame_info.height * 3;
+        cudaError_t cuda_status = cudaMalloc(&tensor->allocation, output_size);
+        if (cuda_status != cudaSuccess) {
+            write_error(
+                error,
+                error_capacity,
+                "CUDA tensor allocation failed: %s",
+                cudaGetErrorString(cuda_status));
+            goto cleanup;
+        }
+
+        const dim3 threads(32, 8);
+        const dim3 blocks(
+            (frame_info.width + threads.x - 1) / threads.x,
+            (frame_info.height + threads.y - 1) / threads.y);
+        if (egl_frame.frameType == CU_EGL_FRAME_TYPE_PITCH) {
+            rgba_pitch_to_rgb_chw<<<blocks, threads, 0, handle->stream>>>(
+                static_cast<const uint8_t*>(egl_frame.frame.pPitch[0]),
+                egl_frame.pitch,
+                static_cast<uint8_t*>(tensor->allocation),
+                frame_info.width,
+                frame_info.height,
+                channels);
+        } else if (egl_frame.frameType == CU_EGL_FRAME_TYPE_ARRAY) {
+            cudaResourceDesc resource_description{};
+            resource_description.resType = cudaResourceTypeArray;
+            resource_description.res.array.array =
+                reinterpret_cast<cudaArray_t>(egl_frame.frame.pArray[0]);
+            cudaTextureDesc texture_description{};
+            texture_description.addressMode[0] = cudaAddressModeClamp;
+            texture_description.addressMode[1] = cudaAddressModeClamp;
+            texture_description.filterMode = cudaFilterModePoint;
+            texture_description.readMode = cudaReadModeElementType;
+            texture_description.normalizedCoords = 0;
+            cuda_status = cudaCreateTextureObject(
+                &texture, &resource_description, &texture_description, nullptr);
+            if (cuda_status != cudaSuccess) {
+                write_error(
+                    error,
+                    error_capacity,
+                    "CUDA texture creation failed: %s",
+                    cudaGetErrorString(cuda_status));
+                goto cleanup;
+            }
+            rgba_array_to_rgb_chw<<<blocks, threads, 0, handle->stream>>>(
+                texture,
+                static_cast<uint8_t*>(tensor->allocation),
+                frame_info.width,
+                frame_info.height,
+                channels);
+        } else {
+            write_error(error, error_capacity, "CUDA EGL frame storage is unsupported");
+            goto cleanup;
+        }
+        cuda_status = cudaGetLastError();
+        if (cuda_status == cudaSuccess) {
+            cuda_status = cudaStreamSynchronize(handle->stream);
+        }
+        if (cuda_status != cudaSuccess) {
+            write_error(
+                error,
+                error_capacity,
+                "CUDA frame conversion failed: %s",
+                cudaGetErrorString(cuda_status));
+            goto cleanup;
+        }
+
+        tensor->shape[0] = 3;
+        tensor->shape[1] = frame_info.height;
+        tensor->shape[2] = frame_info.width;
+        tensor->managed.dl_tensor.data = tensor->allocation;
+        tensor->managed.dl_tensor.device = {kDLCUDA, handle->device_id};
+        tensor->managed.dl_tensor.ndim = 3;
+        tensor->managed.dl_tensor.dtype = {kDLUInt, 8, 1};
+        tensor->managed.dl_tensor.shape = tensor->shape;
+        tensor->managed.dl_tensor.strides = nullptr;
+        tensor->managed.dl_tensor.byte_offset = 0;
+        result = &tensor->managed;
+        tensor = nullptr;
+        handle->stats.frames += 1;
+        handle->stats.conversion_kernels += 1;
+        handle->stats.nvmm_frames += 1;
+    }
+
+cleanup:
+    if (texture != 0) {
+        cudaDestroyTextureObject(texture);
+    }
+    if (graphics_resource != nullptr) {
+        cuGraphicsUnregisterResource(graphics_resource);
+    }
+    if (egl_mapped) {
+        auto* surface = reinterpret_cast<NvBufSurface*>(map.data);
+        g_nvbufsurface.unmap_egl_image(surface, 0);
+    }
+    if (buffer_mapped) {
+        gst_buffer_unmap(buffer, &map);
+    }
+    gst_sample_unref(sample);
+    if (tensor != nullptr) {
+        delete_managed_tensor(&tensor->managed);
+    }
+    return result;
+}
+
+__attribute__((visibility("default")))
+int rf_jetson_pipeline_get_stats(
+    RfJetsonPipeline* handle,
+    RfBridgeStats* stats) {
+    if (handle == nullptr || stats == nullptr) {
+        return -1;
+    }
+    std::lock_guard<std::mutex> lock(handle->mutex);
+    *stats = handle->stats;
+    return 1;
+}
+
+__attribute__((visibility("default")))
+void rf_jetson_dlpack_delete(DLManagedTensor* tensor) {
+    if (tensor != nullptr && tensor->deleter != nullptr) {
+        tensor->deleter(tensor);
+    }
+}
+
+__attribute__((visibility("default")))
+int rf_jetson_pipeline_interrupt(RfJetsonPipeline* handle) {
+    if (handle == nullptr) {
+        return -1;
+    }
+    handle->interrupted.store(true, std::memory_order_release);
+    if (handle->sink != nullptr) {
+        gst_app_sink_set_drop(handle->sink, TRUE);
+        GstSample* queued_sample = nullptr;
+        while ((queued_sample = gst_app_sink_try_pull_sample(handle->sink, 0)) !=
+               nullptr) {
+            gst_sample_unref(queued_sample);
+        }
+    }
+    if (handle->pipeline != nullptr) {
+        gst_element_set_state(handle->pipeline, GST_STATE_NULL);
+    }
+    return 1;
+}
+
+__attribute__((visibility("default")))
+void rf_jetson_pipeline_release(RfJetsonPipeline* handle) {
+    if (handle == nullptr) {
+        return;
+    }
+    rf_jetson_pipeline_interrupt(handle);
+    {
+        std::lock_guard<std::mutex> lock(handle->mutex);
+        if (handle->sample != nullptr) {
+            gst_sample_unref(handle->sample);
+            handle->sample = nullptr;
+        }
+        if (handle->sink != nullptr) {
+            gst_app_sink_set_drop(handle->sink, TRUE);
+            GstSample* queued_sample = nullptr;
+            while ((queued_sample =
+                        gst_app_sink_try_pull_sample(handle->sink, 0)) !=
+                   nullptr) {
+                gst_sample_unref(queued_sample);
+            }
+        }
+        if (handle->pipeline != nullptr) {
+            gst_element_set_state(handle->pipeline, GST_STATE_NULL);
+        }
+        if (handle->stream != nullptr) {
+            cudaStreamDestroy(handle->stream);
+        }
+        if (handle->sink != nullptr) {
+            gst_object_unref(handle->sink);
+        }
+        if (handle->pipeline != nullptr) {
+            gst_object_unref(handle->pipeline);
+        }
+    }
+    delete handle;
+}
+
+}  // extern "C"

--- a/docker/scripts/build_ffmpeg.sh
+++ b/docker/scripts/build_ffmpeg.sh
@@ -1,0 +1,59 @@
+#!/bin/sh
+
+set -eux
+
+FFMPEG_VERSION="${FFMPEG_VERSION:-7.1.3}"
+FFMPEG_SHA256="${FFMPEG_SHA256:?FFMPEG_SHA256 is required}"
+FFMPEG_PREFIX="${FFMPEG_PREFIX:-/opt/ffmpeg}"
+FFMPEG_SOURCE_DIR="${FFMPEG_SOURCE_DIR:-/tmp/ffmpeg-src}"
+
+mkdir -p "${FFMPEG_SOURCE_DIR}"
+ffmpeg_archive="/tmp/ffmpeg-${FFMPEG_VERSION}.tar.xz"
+curl \
+    --fail \
+    --location \
+    --retry 5 \
+    --retry-all-errors \
+    --retry-delay 2 \
+    "https://ffmpeg.org/releases/ffmpeg-${FFMPEG_VERSION}.tar.xz" \
+    -o "${ffmpeg_archive}"
+echo "${FFMPEG_SHA256}  ${ffmpeg_archive}" | sha256sum -c -
+tar -xJf "${ffmpeg_archive}" \
+    --strip-components=1 \
+    -C "${FFMPEG_SOURCE_DIR}"
+
+cd "${FFMPEG_SOURCE_DIR}"
+./configure \
+    --prefix="${FFMPEG_PREFIX}" \
+    --enable-shared \
+    --disable-static \
+    --enable-pic \
+    --disable-autodetect \
+    --enable-bzlib \
+    --enable-lzma \
+    --enable-openssl \
+    --enable-pthreads \
+    --enable-zlib \
+    --disable-debug \
+    --disable-doc \
+    --disable-ffplay \
+    --extra-cflags=-O3 \
+    --extra-ldflags="-Wl,-rpath,${FFMPEG_PREFIX}/lib"
+
+make -j"$(nproc)"
+make install
+
+mkdir -p "${FFMPEG_PREFIX}/share/licenses/ffmpeg"
+cp COPYING.LGPLv2.1 "${FFMPEG_PREFIX}/share/licenses/ffmpeg/"
+find "${FFMPEG_PREFIX}/bin" -type f -exec strip --strip-unneeded {} +
+find "${FFMPEG_PREFIX}/lib" -type f -name '*.so*' -exec strip --strip-unneeded {} +
+
+runtime_prefix="${FFMPEG_PREFIX}-runtime"
+cp -a "${FFMPEG_PREFIX}" "${runtime_prefix}"
+rm -rf \
+    "${runtime_prefix}/include" \
+    "${runtime_prefix}/lib/pkgconfig" \
+    "${runtime_prefix}/share/ffmpeg/examples"
+find "${runtime_prefix}" -type f \( -name '*.a' -o -name '*.la' \) -delete
+
+rm -rf "${ffmpeg_archive}" "${FFMPEG_SOURCE_DIR}"

--- a/docker/scripts/build_gstreamer.sh
+++ b/docker/scripts/build_gstreamer.sh
@@ -1,0 +1,200 @@
+#!/bin/sh
+
+set -eux
+
+GSTREAMER_VERSION="${GSTREAMER_VERSION:-1.24.12}"
+GSTREAMER_COMMIT="${GSTREAMER_COMMIT:?GSTREAMER_COMMIT is required}"
+GSTREAMER_PREFIX="${GSTREAMER_PREFIX:-/opt/gstreamer}"
+GSTREAMER_NVCODEC="${GSTREAMER_NVCODEC:-disabled}"
+GSTREAMER_NVRTC_COMPUTE_CAPABILITY="${GSTREAMER_NVRTC_COMPUTE_CAPABILITY:-75}"
+GSTREAMER_SOURCE_DIR="${GSTREAMER_SOURCE_DIR:-/tmp/gstreamer-src}"
+GSTREAMER_BUILD_DIR="${GSTREAMER_BUILD_DIR:-/tmp/gstreamer-build}"
+GLIB_NETWORKING_VERSION="${GLIB_NETWORKING_VERSION:-2.72.2}"
+GLIB_NETWORKING_SHA256="${GLIB_NETWORKING_SHA256:?GLIB_NETWORKING_SHA256 is required}"
+GLIB_NETWORKING_SERIES="${GLIB_NETWORKING_VERSION%.*}"
+GLIB_NETWORKING_SOURCE_DIR="${GLIB_NETWORKING_SOURCE_DIR:-/tmp/glib-networking-src}"
+GLIB_NETWORKING_BUILD_DIR="${GLIB_NETWORKING_BUILD_DIR:-/tmp/glib-networking-build}"
+
+case "${GSTREAMER_NVCODEC}" in
+    enabled|disabled) ;;
+    *)
+        echo "GSTREAMER_NVCODEC must be enabled or disabled" >&2
+        exit 2
+        ;;
+esac
+
+git clone \
+    --branch "${GSTREAMER_VERSION}" \
+    --depth 1 \
+    https://gitlab.freedesktop.org/gstreamer/gstreamer.git \
+    "${GSTREAMER_SOURCE_DIR}"
+test "$(git -C "${GSTREAMER_SOURCE_DIR}" rev-parse HEAD)" = \
+    "${GSTREAMER_COMMIT}"
+
+if [ "${GSTREAMER_NVCODEC}" = "enabled" ]; then
+    nvrtc_source="${GSTREAMER_SOURCE_DIR}/subprojects/gst-plugins-bad/gst-libs/gst/cuda/gstcudanvrtc.cpp"
+    test "$(grep -c -- '--gpu-architecture=compute_30' "${nvrtc_source}")" -eq 1
+    test "$(grep -c -- '--gpu-architecture=compute_52' "${nvrtc_source}")" -eq 1
+    sed -i \
+        -e "s/--gpu-architecture=compute_30/--gpu-architecture=compute_${GSTREAMER_NVRTC_COMPUTE_CAPABILITY}/" \
+        -e "s/--gpu-architecture=compute_52/--gpu-architecture=compute_${GSTREAMER_NVRTC_COMPUTE_CAPABILITY}/" \
+        "${nvrtc_source}"
+fi
+
+meson setup "${GSTREAMER_BUILD_DIR}" "${GSTREAMER_SOURCE_DIR}" \
+    --buildtype=release \
+    --prefix="${GSTREAMER_PREFIX}" \
+    --libdir=lib \
+    --strip \
+    --wrap-mode=default \
+    --force-fallback-for=libnice \
+    -Dauto_features=disabled \
+    -Db_ndebug=true \
+    -Dbase=enabled \
+    -Dgood=enabled \
+    -Dbad=enabled \
+    -Dugly=disabled \
+    -Dlibav=enabled \
+    -Drtsp_server=enabled \
+    -Ddevtools=disabled \
+    -Dges=disabled \
+    -Drs=disabled \
+    -Dvaapi=disabled \
+    -Dpython=disabled \
+    -Dsharp=disabled \
+    -Dlibnice=enabled \
+    -Dgst-full=disabled \
+    -Dgst-examples=disabled \
+    -Dgpl=disabled \
+    -Dtests=disabled \
+    -Dtools=enabled \
+    -Dexamples=disabled \
+    -Dintrospection=enabled \
+    -Dnls=disabled \
+    -Dorc=enabled \
+    -Dorc-source=subproject \
+    -Dqt5=disabled \
+    -Dqt6=disabled \
+    -Dwebrtc=enabled \
+    -Dgst-plugins-base:app=enabled \
+    -Dgst-plugins-base:audioconvert=enabled \
+    -Dgst-plugins-base:audioresample=enabled \
+    -Dgst-plugins-base:encoding=enabled \
+    -Dgst-plugins-base:gio=enabled \
+    -Dgst-plugins-base:gio-typefinder=enabled \
+    -Dgst-plugins-base:opus=enabled \
+    -Dgst-plugins-base:playback=enabled \
+    -Dgst-plugins-base:rawparse=enabled \
+    -Dgst-plugins-base:tcp=enabled \
+    -Dgst-plugins-base:typefind=enabled \
+    -Dgst-plugins-base:videoconvertscale=enabled \
+    -Dgst-plugins-base:videorate=enabled \
+    -Dgst-plugins-base:videotestsrc=enabled \
+    -Dgst-plugins-good:autodetect=enabled \
+    -Dgst-plugins-good:avi=enabled \
+    -Dgst-plugins-good:flv=enabled \
+    -Dgst-plugins-good:isomp4=enabled \
+    -Dgst-plugins-good:jpeg=enabled \
+    -Dgst-plugins-good:matroska=enabled \
+    -Dgst-plugins-good:multifile=enabled \
+    -Dgst-plugins-good:multipart=enabled \
+    -Dgst-plugins-good:rtp=enabled \
+    -Dgst-plugins-good:rtpmanager=enabled \
+    -Dgst-plugins-good:rtsp=enabled \
+    -Dgst-plugins-good:udp=enabled \
+    -Dgst-plugins-good:v4l2=enabled \
+    -Dgst-plugins-good:vpx=enabled \
+    -Dgst-plugins-good:wavparse=enabled \
+    -Dgst-plugins-bad:curl=enabled \
+    -Dgst-plugins-bad:bayer=enabled \
+    -Dgst-plugins-bad:dtls=enabled \
+    -Dgst-plugins-bad:jpegformat=enabled \
+    -Dgst-plugins-bad:mpegtsdemux=enabled \
+    -Dgst-plugins-bad:nvcodec="${GSTREAMER_NVCODEC}" \
+    -Dgst-plugins-bad:rtmp2=enabled \
+    -Dgst-plugins-bad:rtp=enabled \
+    -Dgst-plugins-bad:sctp=enabled \
+    -Dgst-plugins-bad:sdp=enabled \
+    -Dgst-plugins-bad:srtp=enabled \
+    -Dgst-plugins-bad:videoparsers=enabled \
+    -Dgst-plugins-bad:webrtc=enabled \
+    -Dgst-rtsp-server:rtspclientsink=enabled \
+    -Dlibnice:crypto-library=openssl \
+    -Dlibnice:gupnp=disabled
+
+meson compile -C "${GSTREAMER_BUILD_DIR}"
+meson install -C "${GSTREAMER_BUILD_DIR}"
+
+mkdir -p "${GLIB_NETWORKING_SOURCE_DIR}"
+glib_networking_archive="/tmp/glib-networking-${GLIB_NETWORKING_VERSION}.tar.xz"
+curl \
+    --fail \
+    --location \
+    --retry 5 \
+    --retry-all-errors \
+    --retry-delay 2 \
+    "https://download.gnome.org/sources/glib-networking/${GLIB_NETWORKING_SERIES}/glib-networking-${GLIB_NETWORKING_VERSION}.tar.xz" \
+    -o "${glib_networking_archive}"
+echo "${GLIB_NETWORKING_SHA256}  ${glib_networking_archive}" | sha256sum -c -
+tar -xJf "${glib_networking_archive}" \
+    --strip-components=1 \
+    -C "${GLIB_NETWORKING_SOURCE_DIR}"
+
+meson setup "${GLIB_NETWORKING_BUILD_DIR}" "${GLIB_NETWORKING_SOURCE_DIR}" \
+    --buildtype=release \
+    --prefix="${GSTREAMER_PREFIX}" \
+    --libdir=lib \
+    --strip \
+    -Db_ndebug=true \
+    -Dgnome_proxy=disabled \
+    -Dgnutls=enabled \
+    -Dinstalled_tests=false \
+    -Dlibproxy=disabled \
+    -Dopenssl=disabled \
+    -Dstatic_modules=false
+meson compile -C "${GLIB_NETWORKING_BUILD_DIR}"
+meson install -C "${GLIB_NETWORKING_BUILD_DIR}"
+gio-querymodules "${GSTREAMER_PREFIX}/lib/gio/modules"
+
+license_dir="${GSTREAMER_PREFIX}/share/licenses/gstreamer"
+mkdir -p "${license_dir}"
+cp "${GSTREAMER_SOURCE_DIR}/LICENSE" "${license_dir}/LICENSE"
+for project in \
+    gst-libav \
+    gst-plugins-bad \
+    gst-plugins-base \
+    gst-plugins-good \
+    gst-rtsp-server \
+    gstreamer
+do
+    cp "${GSTREAMER_SOURCE_DIR}/subprojects/${project}/COPYING" \
+        "${license_dir}/COPYING.${project}"
+done
+cp "${GSTREAMER_SOURCE_DIR}/subprojects/libnice/COPYING" \
+    "${license_dir}/COPYING.libnice"
+cp "${GSTREAMER_SOURCE_DIR}/subprojects/orc/COPYING" \
+    "${license_dir}/COPYING.orc"
+cp "${GSTREAMER_SOURCE_DIR}/subprojects/gst-plugins-bad/ext/sctp/usrsctp/LICENSE.md" \
+    "${license_dir}/LICENSE.usrsctp"
+cp "${GLIB_NETWORKING_SOURCE_DIR}/COPYING" \
+    "${license_dir}/COPYING.glib-networking"
+cp "${GLIB_NETWORKING_SOURCE_DIR}/LICENSE_EXCEPTION" \
+    "${license_dir}/LICENSE_EXCEPTION.glib-networking"
+
+runtime_prefix="${GSTREAMER_PREFIX}-runtime"
+cp -a "${GSTREAMER_PREFIX}" "${runtime_prefix}"
+rm -rf \
+    "${runtime_prefix}/include" \
+    "${runtime_prefix}/lib/pkgconfig" \
+    "${runtime_prefix}/share/aclocal" \
+    "${runtime_prefix}/share/gir-1.0" \
+    "${runtime_prefix}/share/gtk-doc" \
+    "${runtime_prefix}/share/man"
+find "${runtime_prefix}" -type f \( -name '*.a' -o -name '*.la' \) -delete
+
+rm -rf \
+    "${GSTREAMER_SOURCE_DIR}" \
+    "${GSTREAMER_BUILD_DIR}" \
+    "${glib_networking_archive}" \
+    "${GLIB_NETWORKING_SOURCE_DIR}" \
+    "${GLIB_NETWORKING_BUILD_DIR}"

--- a/docker/scripts/build_gstreamer_cuda_tensor_bridge.sh
+++ b/docker/scripts/build_gstreamer_cuda_tensor_bridge.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+set -eu
+
+SOURCE_DIR="${GSTREAMER_CUDA_TENSOR_BRIDGE_SOURCE_DIR:-/src/gstreamer_cuda_tensor_bridge}"
+OUTPUT_DIR="${GSTREAMER_CUDA_TENSOR_BRIDGE_OUTPUT_DIR:-/opt/roboflow/lib}"
+CUDA_INCLUDE_DIR="${CUDA_INCLUDE_DIR:-$(
+    find /usr/local/cuda/targets -path '*/include/cuda.h' -print -quit |
+        sed 's|/cuda.h$||'
+)}"
+CUDA_STUB_LIBRARY_DIR="${CUDA_STUB_LIBRARY_DIR:-$(
+    find /usr/local/cuda/targets -path '*/lib/stubs/libcuda.so' -print -quit |
+        sed 's|/libcuda.so$||'
+)}"
+
+test -f "${SOURCE_DIR}/gstreamer_cuda_tensor_bridge.cpp"
+test -f "${CUDA_INCLUDE_DIR}/cuda.h"
+test -f "${CUDA_STUB_LIBRARY_DIR}/libcuda.so"
+pkg-config --exists gstreamer-app-1.0 gstreamer-cuda-1.0 gstreamer-video-1.0
+mkdir -p "${OUTPUT_DIR}"
+
+c++ \
+    -std=c++17 \
+    -O3 \
+    -shared \
+    -fPIC \
+    -fvisibility=hidden \
+    -I"${CUDA_INCLUDE_DIR}" \
+    $(pkg-config --cflags gstreamer-app-1.0 gstreamer-cuda-1.0 gstreamer-video-1.0) \
+    "${SOURCE_DIR}/gstreamer_cuda_tensor_bridge.cpp" \
+    -o "${OUTPUT_DIR}/libroboflow_gstreamer_cuda_tensor.so.1" \
+    $(pkg-config --libs gstreamer-app-1.0 gstreamer-cuda-1.0 gstreamer-video-1.0) \
+    -L"${CUDA_STUB_LIBRARY_DIR}" \
+    -Wl,-rpath,/opt/gstreamer/lib:/usr/local/cuda/lib64 \
+    -lcuda
+
+strip --strip-unneeded \
+    "${OUTPUT_DIR}/libroboflow_gstreamer_cuda_tensor.so.1"
+ln -sf libroboflow_gstreamer_cuda_tensor.so.1 \
+    "${OUTPUT_DIR}/libroboflow_gstreamer_cuda_tensor.so"

--- a/docker/scripts/build_jetson_tensor_bridge.sh
+++ b/docker/scripts/build_jetson_tensor_bridge.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+
+set -eu
+
+SOURCE_DIR="${JETSON_TENSOR_BRIDGE_SOURCE_DIR:-/src/jetson_tensor_bridge}"
+OUTPUT_DIR="${JETSON_TENSOR_BRIDGE_OUTPUT_DIR:-/opt/roboflow/lib}"
+CUDA_ARCHITECTURES="${JETSON_TENSOR_BRIDGE_CUDA_ARCHITECTURES:-87}"
+NVBUF_SURFACE_INCLUDE_DIR="${NVBUF_SURFACE_INCLUDE_DIR:-/usr/src/jetson_multimedia_api/include}"
+CUDA_STUB_LIBRARY_DIR="${CUDA_STUB_LIBRARY_DIR:-$(
+    find /usr/local/cuda/targets -path '*/lib/stubs/libcuda.so' -print -quit |
+        sed 's|/libcuda.so$||'
+)}"
+
+test -f "${SOURCE_DIR}/jetson_tensor_bridge.cu"
+test -f "${NVBUF_SURFACE_INCLUDE_DIR}/nvbufsurface.h"
+test -f "${CUDA_STUB_LIBRARY_DIR}/libcuda.so"
+pkg-config --exists gstreamer-app-1.0
+
+mkdir -p "${OUTPUT_DIR}"
+
+gencode_flags=""
+old_ifs="${IFS}"
+IFS=';, '
+for architecture in ${CUDA_ARCHITECTURES}; do
+    test -n "${architecture}"
+    gencode_flags="${gencode_flags} -gencode arch=compute_${architecture},code=sm_${architecture}"
+done
+IFS="${old_ifs}"
+
+# shellcheck disable=SC2086
+nvcc \
+    -std=c++17 \
+    -O3 \
+    --shared \
+    --compiler-options=-fPIC,-fvisibility=hidden,-pthread \
+    ${gencode_flags} \
+    -I"${NVBUF_SURFACE_INCLUDE_DIR}" \
+    $(pkg-config --cflags-only-I gstreamer-app-1.0) \
+    "${SOURCE_DIR}/jetson_tensor_bridge.cu" \
+    -o "${OUTPUT_DIR}/libroboflow_jetson_tensor.so.1" \
+    $(pkg-config --libs-only-L --libs-only-l gstreamer-app-1.0) \
+    -L"${CUDA_STUB_LIBRARY_DIR}" \
+    -Xlinker=-rpath \
+    -Xlinker=/opt/gstreamer/lib:/usr/local/cuda/lib64 \
+    -lcuda \
+    -lcudart \
+    -ldl
+
+old_ifs="${IFS}"
+IFS=';, '
+for architecture in ${CUDA_ARCHITECTURES}; do
+    cuobjdump --list-elf \
+        "${OUTPUT_DIR}/libroboflow_jetson_tensor.so.1" |
+        grep -q "\.sm_${architecture}\.cubin$"
+done
+IFS="${old_ifs}"
+
+strip --strip-unneeded "${OUTPUT_DIR}/libroboflow_jetson_tensor.so.1"
+ln -sf libroboflow_jetson_tensor.so.1 \
+    "${OUTPUT_DIR}/libroboflow_jetson_tensor.so"

--- a/docker/scripts/build_opencv.sh
+++ b/docker/scripts/build_opencv.sh
@@ -1,0 +1,168 @@
+#!/bin/sh
+
+set -eux
+
+OPENCV_VERSION="${OPENCV_VERSION:-4.13.0}"
+OPENCV_SHA256="${OPENCV_SHA256:?OPENCV_SHA256 is required}"
+OPENCV_CONTRIB_SHA256="${OPENCV_CONTRIB_SHA256:?OPENCV_CONTRIB_SHA256 is required}"
+OPENCV_PREFIX="${OPENCV_PREFIX:-/opt/opencv}"
+OPENCV_PYTHON_EXECUTABLE="${OPENCV_PYTHON_EXECUTABLE:-python3}"
+OPENCV_WITH_CUDA="${OPENCV_WITH_CUDA:-OFF}"
+OPENCV_CUDA_ARCH_BIN="${OPENCV_CUDA_ARCH_BIN:-}"
+OPENCV_CUDA_ARCH_PTX="${OPENCV_CUDA_ARCH_PTX:-}"
+OPENCV_WITH_CUDNN="${OPENCV_WITH_CUDNN:-OFF}"
+OPENCV_WITH_CUBLAS="${OPENCV_WITH_CUBLAS:-OFF}"
+OPENCV_WITH_CUFFT="${OPENCV_WITH_CUFFT:-OFF}"
+OPENCV_DNN_CUDA="${OPENCV_DNN_CUDA:-OFF}"
+OPENCV_SOURCE_DIR="${OPENCV_SOURCE_DIR:-/tmp/opencv-src}"
+OPENCV_CONTRIB_SOURCE_DIR="${OPENCV_CONTRIB_SOURCE_DIR:-/tmp/opencv-contrib-src}"
+OPENCV_BUILD_DIR="${OPENCV_BUILD_DIR:-/tmp/opencv-build}"
+OPENCV_PYTHON_INCLUDE_DIR="$(
+    "${OPENCV_PYTHON_EXECUTABLE}" -c \
+        'import sysconfig; print(sysconfig.get_path("include"))'
+)"
+OPENCV_NUMPY_INCLUDE_DIR="$(
+    "${OPENCV_PYTHON_EXECUTABLE}" -c \
+        'import numpy; print(numpy.get_include())'
+)"
+
+case "${OPENCV_WITH_CUDA}" in
+    ON|OFF) ;;
+    *)
+        echo "OPENCV_WITH_CUDA must be ON or OFF" >&2
+        exit 2
+        ;;
+esac
+
+if [ "${OPENCV_WITH_CUDA}" = "ON" ] && [ -z "${OPENCV_CUDA_ARCH_BIN}" ]; then
+    echo "OPENCV_CUDA_ARCH_BIN is required when CUDA support is enabled" >&2
+    exit 2
+fi
+
+mkdir -p "${OPENCV_SOURCE_DIR}" "${OPENCV_CONTRIB_SOURCE_DIR}"
+opencv_archive="/tmp/opencv-${OPENCV_VERSION}.tar.gz"
+opencv_contrib_archive="/tmp/opencv_contrib-${OPENCV_VERSION}.tar.gz"
+curl \
+    --fail \
+    --location \
+    --retry 5 \
+    --retry-all-errors \
+    --retry-delay 2 \
+    "https://github.com/opencv/opencv/archive/refs/tags/${OPENCV_VERSION}.tar.gz" \
+    -o "${opencv_archive}"
+echo "${OPENCV_SHA256}  ${opencv_archive}" | sha256sum -c -
+tar -xzf "${opencv_archive}" --strip-components=1 -C "${OPENCV_SOURCE_DIR}"
+curl \
+    --fail \
+    --location \
+    --retry 5 \
+    --retry-all-errors \
+    --retry-delay 2 \
+    "https://github.com/opencv/opencv_contrib/archive/refs/tags/${OPENCV_VERSION}.tar.gz" \
+    -o "${opencv_contrib_archive}"
+echo "${OPENCV_CONTRIB_SHA256}  ${opencv_contrib_archive}" | sha256sum -c -
+tar -xzf "${opencv_contrib_archive}" \
+    --strip-components=1 \
+    -C "${OPENCV_CONTRIB_SOURCE_DIR}"
+
+if [ "${OPENCV_WITH_CUDA}" = "ON" ]; then
+    cuda_release="$(
+        nvcc --version |
+            sed -n 's/.*release \([0-9][0-9]*\)\.\([0-9][0-9]*\).*/\1 \2/p' |
+            head -n 1
+    )"
+    set -- ${cuda_release}
+    if [ "$#" -ne 2 ]; then
+        echo "Could not parse the CUDA compiler version" >&2
+        exit 2
+    fi
+    if [ "$1" -gt 13 ] || { [ "$1" -eq 13 ] && [ "$2" -ge 2 ]; }; then
+        cuda_13_2_patch=/tmp/opencv-contrib-cuda-13.2.patch
+        curl \
+            --fail \
+            --location \
+            --retry 5 \
+            --retry-all-errors \
+            --retry-delay 2 \
+            https://github.com/opencv/opencv_contrib/commit/f2854f4f5e7b67d4e073ea002ae0174d437e2962.patch \
+            -o "${cuda_13_2_patch}"
+        echo "d436681d50c61837f82f4f70b835b298e781491beadee43d11914bbe793c983e  ${cuda_13_2_patch}" |
+            sha256sum -c -
+        patch -d "${OPENCV_CONTRIB_SOURCE_DIR}" -p1 < "${cuda_13_2_patch}"
+        rm "${cuda_13_2_patch}"
+    fi
+fi
+
+cmake \
+    -S "${OPENCV_SOURCE_DIR}" \
+    -B "${OPENCV_BUILD_DIR}" \
+    -GNinja \
+    -D CMAKE_BUILD_TYPE=Release \
+    -D CMAKE_INSTALL_PREFIX="${OPENCV_PREFIX}" \
+    -D 'CMAKE_INSTALL_RPATH=/opt/gstreamer/lib;/opt/ffmpeg/lib' \
+    -D OPENCV_EXTRA_MODULES_PATH="${OPENCV_CONTRIB_SOURCE_DIR}/modules" \
+    -D OPENCV_PYTHON3_INSTALL_PATH="${OPENCV_PREFIX}/python" \
+    -D PYTHON3_EXECUTABLE="${OPENCV_PYTHON_EXECUTABLE}" \
+    -D Python3_EXECUTABLE="${OPENCV_PYTHON_EXECUTABLE}" \
+    -D PYTHON3_INCLUDE_DIR="${OPENCV_PYTHON_INCLUDE_DIR}" \
+    -D PYTHON3_NUMPY_INCLUDE_DIRS="${OPENCV_NUMPY_INCLUDE_DIR}" \
+    -D WITH_GSTREAMER=ON \
+    -D WITH_FFMPEG=ON \
+    -D WITH_LIBV4L=ON \
+    -D WITH_CUDA="${OPENCV_WITH_CUDA}" \
+    -D WITH_CUDNN="${OPENCV_WITH_CUDNN}" \
+    -D WITH_CUBLAS="${OPENCV_WITH_CUBLAS}" \
+    -D WITH_CUFFT="${OPENCV_WITH_CUFFT}" \
+    -D OPENCV_DNN_CUDA="${OPENCV_DNN_CUDA}" \
+    -D CUDA_ARCH_BIN="${OPENCV_CUDA_ARCH_BIN}" \
+    -D CUDA_ARCH_PTX="${OPENCV_CUDA_ARCH_PTX}" \
+    -D BUILD_opencv_cudacodec=OFF \
+    -D BUILD_opencv_cudafeatures2d=OFF \
+    -D BUILD_opencv_cudalegacy=OFF \
+    -D BUILD_opencv_cudaobjdetect=OFF \
+    -D BUILD_opencv_cudaoptflow=OFF \
+    -D BUILD_opencv_cudastereo=OFF \
+    -D WITH_NVCUVID=OFF \
+    -D WITH_NVCUVENC=OFF \
+    -D WITH_GTK=OFF \
+    -D WITH_QT=OFF \
+    -D VIDEOIO_ENABLE_PLUGINS=OFF \
+    -D BUILD_SHARED_LIBS=OFF \
+    -D BUILD_JAVA=OFF \
+    -D BUILD_opencv_apps=OFF \
+    -D BUILD_opencv_python3=ON \
+    -D BUILD_opencv_videoio=ON \
+    -D BUILD_TESTS=OFF \
+    -D BUILD_PERF_TESTS=OFF \
+    -D BUILD_EXAMPLES=OFF \
+    -D BUILD_DOCS=OFF
+
+cmake --build "${OPENCV_BUILD_DIR}" --parallel "$(nproc)"
+cmake --install "${OPENCV_BUILD_DIR}"
+
+license_dir="${OPENCV_PREFIX}/share/licenses/opencv"
+mkdir -p "${license_dir}"
+cp "${OPENCV_SOURCE_DIR}/LICENSE" "${license_dir}/LICENSE.opencv"
+cp "${OPENCV_CONTRIB_SOURCE_DIR}/LICENSE" \
+    "${license_dir}/LICENSE.opencv_contrib"
+
+PYTHONPATH="${OPENCV_PREFIX}/python" \
+    "${OPENCV_PYTHON_EXECUTABLE}" -c \
+    "import cv2; info = cv2.getBuildInformation(); assert cv2.videoio_registry.hasBackend(cv2.CAP_GSTREAMER); assert 'YES' in info.split('GStreamer:')[1].split(chr(10))[0]; assert 'YES' in info.split('FFMPEG:')[1].split(chr(10))[0]; print(info)"
+
+runtime_prefix="${OPENCV_PREFIX}-runtime"
+cp -a "${OPENCV_PREFIX}" "${runtime_prefix}"
+rm -rf \
+    "${runtime_prefix}/include" \
+    "${runtime_prefix}/lib/cmake" \
+    "${runtime_prefix}/lib/pkgconfig"
+find "${runtime_prefix}" -type f \( -name '*.a' -o -name '*.la' \) -delete
+find "${runtime_prefix}" -type f -name '*.so*' \
+    -exec strip --strip-unneeded {} +
+
+rm -rf \
+    "${opencv_archive}" \
+    "${opencv_contrib_archive}" \
+    "${OPENCV_SOURCE_DIR}" \
+    "${OPENCV_CONTRIB_SOURCE_DIR}" \
+    "${OPENCV_BUILD_DIR}"

--- a/docker/scripts/verify_ffmpeg.sh
+++ b/docker/scripts/verify_ffmpeg.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+
+set -eu
+
+decoders="aac av1 h264 hevc mjpeg mpeg4 opus vp8 vp9"
+decoder_list="$(ffmpeg -hide_banner -decoders 2>/dev/null)"
+for decoder in ${decoders}
+do
+    printf '%s\n' "${decoder_list}" |
+        awk -v name="${decoder}" '$2 == name { found = 1 } END { exit !found }'
+done
+
+demuxers="avi flv matroska mov mpegts rtsp"
+demuxer_list="$(ffmpeg -hide_banner -demuxers 2>/dev/null)"
+for demuxer in ${demuxers}
+do
+    printf '%s\n' "${demuxer_list}" |
+        awk -v name="${demuxer}" '
+            {
+                count = split($2, names, ",")
+                for (i = 1; i <= count; i++) {
+                    if (names[i] == name) {
+                        found = 1
+                    }
+                }
+            }
+            END { exit !found }
+        '
+done
+
+protocol_list="$(ffmpeg -hide_banner -protocols 2>/dev/null)"
+for protocol in file http https rtp tcp tls udp
+do
+    printf '%s\n' "${protocol_list}" | grep -Eq "^[[:space:]]+${protocol}$"
+done
+
+ffmpeg -hide_banner -loglevel error \
+    -f lavfi \
+    -i testsrc=size=16x16:rate=1 \
+    -frames:v 1 \
+    -c:v ffv1 \
+    -y /tmp/ffmpeg-smoke.mkv
+ffprobe -v error \
+    -select_streams v:0 \
+    -show_entries stream=codec_name,width,height \
+    -of default=noprint_wrappers=1 \
+    /tmp/ffmpeg-smoke.mkv | grep -q '^codec_name=ffv1$'
+rm /tmp/ffmpeg-smoke.mkv

--- a/docker/scripts/verify_gstreamer.sh
+++ b/docker/scripts/verify_gstreamer.sh
@@ -1,0 +1,147 @@
+#!/bin/sh
+
+set -eu
+
+GSTREAMER_REQUIRE_NVCODEC="${GSTREAMER_REQUIRE_NVCODEC:-false}"
+GSTREAMER_REQUIRE_NVCODEC_RUNTIME="${GSTREAMER_REQUIRE_NVCODEC_RUNTIME:-false}"
+
+for element in \
+    appsink \
+    appsrc \
+    avdec_h264 \
+    avdec_h265 \
+    avidemux \
+    bayer2rgb \
+    capsfilter \
+    curlhttpsrc \
+    decodebin \
+    decodebin3 \
+    dtlssrtpdec \
+    dtlssrtpenc \
+    fakesink \
+    filesrc \
+    h264parse \
+    h265parse \
+    jpegdec \
+    jpegenc \
+    jpegparse \
+    matroskademux \
+    nicesink \
+    nicesrc \
+    opusdec \
+    opusenc \
+    qtdemux \
+    queue \
+    rtpbin \
+    rtph264depay \
+    rtph264pay \
+    rtph265depay \
+    rtph265pay \
+    rtpjpegdepay \
+    rtpjpegpay \
+    rtpjitterbuffer \
+    rtpopusdepay \
+    rtpopuspay \
+    rtpvp8depay \
+    rtpvp8pay \
+    rtpvp9depay \
+    rtpvp9pay \
+    rtmp2sink \
+    rtmp2src \
+    rtspclientsink \
+    rtspsrc \
+    sctpdec \
+    sctpenc \
+    srtpdec \
+    srtpenc \
+    tcpclientsrc \
+    tcpserversink \
+    tee \
+    udpsink \
+    udpsrc \
+    uridecodebin \
+    videoconvert \
+    videorate \
+    videoscale \
+    videotestsrc \
+    vp8dec \
+    vp8enc \
+    vp9dec \
+    vp9enc \
+    webrtcbin
+do
+    gst-inspect-1.0 "${element}" >/dev/null
+done
+
+test -e /opt/gstreamer/lib/libgstrtspserver-1.0.so.0
+for typelib in Gst GstAllocators GstApp GstRtp GstRtsp GstSdp GstVideo GstWebRTC; do
+    test -s "/opt/gstreamer/lib/girepository-1.0/${typelib}-1.0.typelib"
+done
+ldd /opt/gstreamer/lib/gstreamer-1.0/libgstlibav.so |
+    grep -q '/opt/ffmpeg/lib/libavcodec'
+test -s /etc/ssl/certs/ca-certificates.crt
+test -e /opt/gstreamer/lib/gio/modules/libgiognutls.so
+grep -q 'libgiognutls' /opt/gstreamer/lib/gio/modules/giomodule.cache
+ldd /opt/gstreamer/lib/gio/modules/libgiognutls.so |
+    grep -q 'libgnutls.so'
+gst-inspect-1.0 rtspsrc | grep -Eq '^[[:space:]]+rtsps$'
+
+if [ "${GSTREAMER_REQUIRE_NVCODEC}" = "true" ]; then
+    test -e /opt/gstreamer/lib/gstreamer-1.0/libgstnvcodec.so
+    if ldd /opt/gstreamer/lib/gstreamer-1.0/libgstnvcodec.so | grep -q 'not found'; then
+        exit 1
+    fi
+fi
+
+if [ "${GSTREAMER_REQUIRE_NVCODEC_RUNTIME}" = "true" ]; then
+    for element in \
+        cudaconvertscale \
+        cudadownload \
+        cudaupload \
+        nvh264dec \
+        nvh264enc \
+        nvh265dec \
+        nvh265enc \
+        nvjpegdec \
+        nvjpegenc
+    do
+        gst-inspect-1.0 "${element}" >/dev/null
+    done
+    gst-launch-1.0 -q \
+        videotestsrc num-buffers=1 ! \
+        video/x-raw,format=I420,width=64,height=64 ! \
+        nvjpegenc ! \
+        filesink location=/tmp/nvjpeg-smoke.jpg
+    gst-launch-1.0 -q \
+        filesrc location=/tmp/nvjpeg-smoke.jpg ! \
+        jpegparse ! \
+        nvjpegdec ! \
+        fakesink
+    gst-launch-1.0 -q \
+        videotestsrc num-buffers=1 ! \
+        video/x-raw,format=I420,width=64,height=64 ! \
+        cudaupload ! \
+        cudaconvertscale ! \
+        'video/x-raw(memory:CUDAMemory),format=RGBP' ! \
+        cudadownload ! \
+        fakesink
+    rm /tmp/nvjpeg-smoke.jpg
+fi
+
+gst-launch-1.0 -q \
+    videotestsrc num-buffers=1 ! \
+    video/x-raw,format=BGR,width=16,height=16 ! \
+    appsink max-buffers=1 drop=true sync=false wait-on-eos=false
+
+for pattern in bggr gbrg grbg rggb; do
+    gst-launch-1.0 -q \
+        filesrc location=/dev/zero blocksize=64 num-buffers=1 ! \
+        "video/x-bayer,format=${pattern},width=8,height=8,framerate=1/1" ! \
+        bayer2rgb ! \
+        fakesink
+    gst-launch-1.0 -q \
+        filesrc location=/dev/zero blocksize=128 num-buffers=1 ! \
+        "video/x-bayer,format=${pattern}16le,width=8,height=8,framerate=1/1" ! \
+        bayer2rgb ! \
+        fakesink
+done

--- a/docker/scripts/verify_gstreamer_cuda_tensor_bridge.sh
+++ b/docker/scripts/verify_gstreamer_cuda_tensor_bridge.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+set -eu
+
+BRIDGE_LIBRARY="${GSTREAMER_CUDA_TENSOR_BRIDGE_LIBRARY:-/opt/roboflow/lib/libroboflow_gstreamer_cuda_tensor.so.1}"
+
+test -s "${BRIDGE_LIBRARY}"
+readelf -Ws "${BRIDGE_LIBRARY}" | grep -q 'rf_gstreamer_cuda_pipeline_create'
+readelf -Ws "${BRIDGE_LIBRARY}" | grep -q 'rf_gstreamer_cuda_pipeline_retrieve'
+readelf -Ws "${BRIDGE_LIBRARY}" | grep -q 'rf_gstreamer_cuda_pipeline_get_stats'
+readelf -Ws "${BRIDGE_LIBRARY}" | grep -q 'rf_gstreamer_cuda_pipeline_interrupt'
+
+if readelf -d "${BRIDGE_LIBRARY}" | grep -Eq 'libopencv|libtorch|libpython'; then
+    exit 1
+fi
+
+missing="$(ldd "${BRIDGE_LIBRARY}" 2>/dev/null | awk '/not found/ { print $1 }' | sort -u)"
+case "${missing}" in
+    ''|libcuda.so.1) ;;
+    *) printf '%s\n' "${missing}" >&2; exit 1 ;;
+esac

--- a/docker/scripts/verify_gstreamer_cuda_tensor_runtime.py
+++ b/docker/scripts/verify_gstreamer_cuda_tensor_runtime.py
@@ -1,0 +1,200 @@
+import gc
+import subprocess
+import tempfile
+import threading
+import time
+from pathlib import Path
+from typing import List
+
+import numpy as np
+import torch
+
+from inference.core.interfaces.camera.gstreamer_cuda_producer import (
+    GstreamerCudaVideoFrameProducer,
+)
+from inference.core.interfaces.camera.gstreamer_cuda_tensor_bridge import (
+    NativeGstreamerCudaTensorPipeline,
+)
+
+
+def _run_gstreamer(*arguments: str) -> None:
+    subprocess.run(
+        ["gst-launch-1.0", "-q", *arguments],
+        check=True,
+        timeout=60,
+    )
+
+
+def _create_h26x(path: Path, encoder: str, parser: str, pattern: str = "red") -> None:
+    _run_gstreamer(
+        "videotestsrc",
+        "num-buffers=8",
+        f"pattern={pattern}",
+        "!",
+        "video/x-raw,format=I420,width=320,height=180,framerate=30/1",
+        "!",
+        encoder,
+        "!",
+        parser,
+        "!",
+        "filesink",
+        f"location={path}",
+    )
+
+
+def _create_jpeg(path: Path) -> None:
+    _run_gstreamer(
+        "videotestsrc",
+        "num-buffers=1",
+        "pattern=red",
+        "!",
+        "video/x-raw,format=I420,width=320,height=180,framerate=1/1",
+        "!",
+        "nvjpegenc",
+        "!",
+        "filesink",
+        f"location={path}",
+    )
+
+
+def _validate_source(path: Path, minimum_frames: int) -> None:
+    producer = GstreamerCudaVideoFrameProducer(str(path), gpu_id=0)
+    properties = producer.discover_source_properties()
+    assert properties.width == 320
+    assert properties.height == 180
+
+    success, first = producer.retrieve()
+    assert success and first is not None
+    assert first.is_cuda
+    assert first.dtype == torch.uint8
+    assert tuple(first.shape) == (3, 180, 320)
+    assert first.device.index == 0
+    assert first.data_ptr() != 0
+
+    channel_means = first.float().mean(dim=(1, 2))
+    assert channel_means[0] > channel_means[1] + 80
+    assert channel_means[0] > channel_means[2] + 80
+    first_snapshot = first.clone()
+    tensors: List[torch.Tensor] = [first]
+    tensor = None
+
+    while len(tensors) < 5 and producer.grab():
+        success, tensor = producer.retrieve()
+        assert success and tensor is not None
+        assert tensor.is_cuda
+        assert tuple(tensor.shape) == (3, 180, 320)
+        tensors.append(tensor)
+
+    assert len(tensors) >= minimum_frames
+    stats = producer.tensor_bridge_stats
+    assert stats["frames"] == len(tensors)
+    assert stats["cuda_maps"] == len(tensors)
+    assert stats["host_pixel_maps"] == 0
+    assert stats["host_to_device_copies"] == 0
+    assert stats["device_to_host_copies"] == 0
+    assert stats["stream_synchronizations"] == len(tensors)
+    assert stats["active_leases"] == len(tensors)
+    assert tuple(first.stride()) == (
+        stats["last_channel_stride"],
+        stats["last_row_stride"],
+        1,
+    )
+
+    producer.release()
+    assert torch.equal(first, first_snapshot)
+    del first_snapshot
+    del first
+    tensor = None
+    tensors.clear()
+    gc.collect()
+    torch.cuda.synchronize()
+
+
+def _validate_numpy_source(path: Path) -> None:
+    producer = GstreamerCudaVideoFrameProducer(str(path), gpu_id=0, output_tensor=False)
+    properties = producer.discover_source_properties()
+    assert properties.width == 320
+    assert properties.height == 180
+
+    success, image = producer.retrieve()
+    assert success and image is not None
+    assert isinstance(image, np.ndarray)
+    assert image.dtype == np.uint8
+    assert image.shape == (180, 320, 3)
+    assert image.flags.c_contiguous
+    channel_means = image.mean(axis=(0, 1))
+    assert channel_means[2] > channel_means[1] + 80
+    assert channel_means[2] > channel_means[0] + 80
+    producer.release()
+
+
+def _validate_repeated_grab_advances(path: Path) -> None:
+    baseline = GstreamerCudaVideoFrameProducer(str(path), gpu_id=0)
+    baseline.discover_source_properties()
+    success, first_frame = baseline.retrieve()
+    assert success and first_frame is not None
+    assert baseline.grab()
+    success, second_frame = baseline.retrieve()
+    assert success and second_frame is not None
+    assert not torch.equal(first_frame, second_frame)
+    baseline.release()
+
+    producer = GstreamerCudaVideoFrameProducer(str(path), gpu_id=0)
+    producer.discover_source_properties()
+    assert producer.grab()
+    assert producer.grab()
+    success, frame_after_second_grab = producer.retrieve()
+    assert success and frame_after_second_grab is not None
+    assert torch.equal(frame_after_second_grab, second_frame)
+    producer.release()
+
+
+def _validate_interrupt_unblocks_pull() -> None:
+    pipeline = NativeGstreamerCudaTensorPipeline(
+        "appsrc is-live=true ! appsink name=rf_tensor_sink wait-on-eos=false",
+        device_id=0,
+    )
+    entered_grab = threading.Event()
+    result = {}
+
+    def pull_sample() -> None:
+        entered_grab.set()
+        result["grabbed"] = pipeline.grab()
+
+    thread = threading.Thread(target=pull_sample)
+    thread.start()
+    assert entered_grab.wait(timeout=1.0)
+    time.sleep(0.1)
+    started = time.monotonic()
+    pipeline.interrupt()
+    thread.join(timeout=2.0)
+    elapsed = time.monotonic() - started
+
+    assert not thread.is_alive()
+    assert result["grabbed"] is False
+    assert elapsed < 2.0
+    pipeline.close()
+
+
+def main() -> None:
+    assert torch.cuda.is_available()
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        h264_path = root / "test.h264"
+        h265_path = root / "test.h265"
+        jpeg_path = root / "test.jpg"
+        changing_h264_path = root / "changing.h264"
+        _create_h26x(h264_path, "nvh264enc", "h264parse")
+        _create_h26x(h265_path, "nvh265enc", "h265parse")
+        _create_h26x(changing_h264_path, "nvh264enc", "h264parse", pattern="ball")
+        _create_jpeg(jpeg_path)
+        _validate_source(h264_path, minimum_frames=5)
+        _validate_source(h265_path, minimum_frames=5)
+        _validate_source(jpeg_path, minimum_frames=1)
+        _validate_numpy_source(h264_path)
+        _validate_repeated_grab_advances(changing_h264_path)
+        _validate_interrupt_unblocks_pull()
+
+
+if __name__ == "__main__":
+    main()

--- a/docker/scripts/verify_jetson_tensor_bridge.sh
+++ b/docker/scripts/verify_jetson_tensor_bridge.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+set -eu
+
+BRIDGE_LIBRARY="${JETSON_TENSOR_BRIDGE_LIBRARY:-/opt/roboflow/lib/libroboflow_jetson_tensor.so.1}"
+
+test -s "${BRIDGE_LIBRARY}"
+readelf -Ws "${BRIDGE_LIBRARY}" | grep -q 'rf_jetson_pipeline_create'
+readelf -Ws "${BRIDGE_LIBRARY}" | grep -q 'rf_jetson_pipeline_retrieve'
+readelf -Ws "${BRIDGE_LIBRARY}" | grep -q 'rf_jetson_pipeline_get_stats'
+readelf -Ws "${BRIDGE_LIBRARY}" | grep -q 'rf_jetson_pipeline_interrupt'
+
+if readelf -d "${BRIDGE_LIBRARY}" | grep -Eq 'libopencv|libtorch|libpython'; then
+    exit 1
+fi
+
+missing="$(ldd "${BRIDGE_LIBRARY}" 2>/dev/null | awk '/not found/ { print $1 }' | sort -u)"
+case "${missing}" in
+    ''|libcuda.so.1) ;;
+    *) printf '%s\n' "${missing}" >&2; exit 1 ;;
+esac

--- a/docker/scripts/verify_jetson_tensor_runtime.py
+++ b/docker/scripts/verify_jetson_tensor_runtime.py
@@ -1,0 +1,208 @@
+import gc
+import subprocess
+import tempfile
+import threading
+import time
+from pathlib import Path
+from typing import List
+
+import numpy as np
+import torch
+
+from inference.core.interfaces.camera.jetson_producer import JetsonVideoFrameProducer
+from inference.core.interfaces.camera.jetson_tensor_bridge import (
+    NativeJetsonTensorPipeline,
+)
+
+
+def _run_gstreamer(*arguments: str) -> None:
+    subprocess.run(
+        ["gst-launch-1.0", "-q", *arguments],
+        check=True,
+        timeout=60,
+    )
+
+
+def _create_h26x(path: Path, encoder: str, parser: str, pattern: str = "red") -> None:
+    _run_gstreamer(
+        "videotestsrc",
+        "num-buffers=8",
+        f"pattern={pattern}",
+        "!",
+        "video/x-raw,format=I420,width=320,height=180,framerate=30/1",
+        "!",
+        "nvvidconv",
+        "!",
+        "video/x-raw(memory:NVMM),format=NV12",
+        "!",
+        encoder,
+        "!",
+        parser,
+        "!",
+        "filesink",
+        f"location={path}",
+    )
+
+
+def _create_jpeg(path: Path) -> None:
+    _run_gstreamer(
+        "videotestsrc",
+        "num-buffers=1",
+        "pattern=red",
+        "!",
+        "video/x-raw,format=I420,width=320,height=180,framerate=1/1",
+        "!",
+        "nvvidconv",
+        "!",
+        "video/x-raw(memory:NVMM),format=I420",
+        "!",
+        "nvjpegenc",
+        "!",
+        "filesink",
+        f"location={path}",
+    )
+
+
+def _validate_source(path: Path, minimum_frames: int) -> None:
+    producer = JetsonVideoFrameProducer(str(path), output_tensor=True)
+    properties = producer.discover_source_properties()
+    assert properties.width == 320
+    assert properties.height == 180
+
+    success, first = producer.retrieve()
+    assert success and first is not None
+    assert first.is_cuda
+    assert first.dtype == torch.uint8
+    assert tuple(first.shape) == (3, 180, 320)
+    assert first.device.index == 0
+    assert first.data_ptr() != 0
+    assert first.is_contiguous()
+
+    channel_means = first.float().mean(dim=(1, 2))
+    assert channel_means[0] > channel_means[1] + 80
+    assert channel_means[0] > channel_means[2] + 80
+    first_snapshot = first.clone()
+    tensors: List[torch.Tensor] = [first]
+    tensor = None
+
+    while len(tensors) < 5 and producer.grab():
+        success, tensor = producer.retrieve()
+        assert success and tensor is not None
+        assert tensor.is_cuda
+        assert tuple(tensor.shape) == (3, 180, 320)
+        tensors.append(tensor)
+
+    assert len(tensors) >= minimum_frames
+    stats = producer.tensor_bridge_stats
+    assert stats["frames"] == len(tensors)
+    assert stats["descriptor_maps"] == len(tensors)
+    assert stats["host_pixel_maps"] == 0
+    assert stats["host_to_device_copies"] == 0
+    assert stats["device_to_host_copies"] == 0
+    assert stats["array_flatten_copies"] == 0
+    assert stats["conversion_kernels"] == len(tensors)
+    assert stats["nvmm_frames"] == len(tensors)
+
+    producer.release()
+    assert torch.equal(first, first_snapshot)
+    del first_snapshot
+    del first
+    tensor = None
+    tensors.clear()
+    gc.collect()
+    torch.cuda.synchronize()
+
+
+def _validate_numpy_source(path: Path) -> None:
+    producer = JetsonVideoFrameProducer(str(path), output_tensor=False)
+    properties = producer.discover_source_properties()
+    assert properties.width == 320
+    assert properties.height == 180
+
+    success, image = producer.retrieve()
+    assert success and image is not None
+    assert isinstance(image, np.ndarray)
+    assert image.dtype == np.uint8
+    assert image.shape == (180, 320, 3)
+    assert image.flags.c_contiguous
+    channel_means = image.mean(axis=(0, 1))
+    assert channel_means[2] > channel_means[1] + 80
+    assert channel_means[2] > channel_means[0] + 80
+    producer.release()
+
+
+def _validate_repeated_grab_advances(path: Path) -> None:
+    baseline = JetsonVideoFrameProducer(str(path), output_tensor=True)
+    baseline.discover_source_properties()
+    success, first_frame = baseline.retrieve()
+    assert success and first_frame is not None
+    assert baseline.grab()
+    success, second_frame = baseline.retrieve()
+    assert success and second_frame is not None
+    assert not torch.equal(first_frame, second_frame)
+    baseline.release()
+
+    producer = JetsonVideoFrameProducer(str(path), output_tensor=True)
+    producer.discover_source_properties()
+    assert producer.grab()
+    assert producer.grab()
+    success, frame_after_second_grab = producer.retrieve()
+    assert success and frame_after_second_grab is not None
+    assert torch.equal(frame_after_second_grab, second_frame)
+    producer.release()
+
+
+def _validate_interrupt_unblocks_pull() -> None:
+    pipeline = NativeJetsonTensorPipeline(
+        "appsrc is-live=true ! appsink name=rf_tensor_sink wait-on-eos=false",
+        device_id=0,
+    )
+    entered_grab = threading.Event()
+    result = {}
+
+    def pull_sample() -> None:
+        entered_grab.set()
+        result["grabbed"] = pipeline.grab()
+
+    thread = threading.Thread(target=pull_sample)
+    thread.start()
+    assert entered_grab.wait(timeout=1.0)
+    time.sleep(0.1)
+    started = time.monotonic()
+    pipeline.interrupt()
+    thread.join(timeout=2.0)
+    elapsed = time.monotonic() - started
+
+    assert not thread.is_alive()
+    assert result["grabbed"] is False
+    assert elapsed < 2.0
+    pipeline.close()
+
+
+def main() -> None:
+    assert torch.cuda.is_available()
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        h264_path = root / "test.h264"
+        h265_path = root / "test.h265"
+        jpeg_path = root / "test.jpg"
+        changing_h264_path = root / "changing.h264"
+        _create_h26x(h264_path, "nvv4l2h264enc", "h264parse")
+        _create_h26x(h265_path, "nvv4l2h265enc", "h265parse")
+        _create_h26x(
+            changing_h264_path,
+            "nvv4l2h264enc",
+            "h264parse",
+            pattern="ball",
+        )
+        _create_jpeg(jpeg_path)
+        _validate_source(h264_path, minimum_frames=5)
+        _validate_source(h265_path, minimum_frames=5)
+        _validate_source(jpeg_path, minimum_frames=1)
+        _validate_numpy_source(h264_path)
+        _validate_repeated_grab_advances(changing_h264_path)
+        _validate_interrupt_unblocks_pull()
+
+
+if __name__ == "__main__":
+    main()

--- a/docker/scripts/verify_media_runtime.sh
+++ b/docker/scripts/verify_media_runtime.sh
@@ -1,0 +1,107 @@
+#!/bin/sh
+
+set -eu
+
+for command_name in \
+    cc \
+    c++ \
+    gcc \
+    g++ \
+    make \
+    cmake \
+    meson \
+    ninja \
+    git \
+    curl \
+    pip \
+    pip3
+do
+    if command -v "${command_name}" >/dev/null 2>&1; then
+        echo "Unexpected build command in media runtime: ${command_name}" >&2
+        exit 1
+    fi
+done
+
+development_packages="$(
+    dpkg-query -W -f='${binary:Package}\n' |
+        grep -E -- '-dev(:[^[:space:]]+)?$' || true
+)"
+if [ -n "${development_packages}" ]; then
+    printf 'Unexpected development packages in media runtime:\n%s\n' \
+        "${development_packages}" >&2
+    exit 1
+fi
+
+set -- /opt/ffmpeg /opt/gstreamer /opt/roboflow
+if [ -d /opt/opencv ]; then
+    set -- "$@" /opt/opencv
+fi
+if [ -d /opt/cuda-runtime ]; then
+    set -- "$@" /opt/cuda-runtime
+fi
+set -- \
+    "$@" \
+    /usr/lib/aarch64-linux-gnu/gstreamer-1.0 \
+    /usr/lib/aarch64-linux-gnu/nvidia
+if [ -d /usr/lib/aarch64-linux-gnu/tegra ]; then
+    set -- "$@" /usr/lib/aarch64-linux-gnu/tegra
+fi
+
+development_artifact="$(
+    find "$@" -type f \
+        \( -name '*.a' -o -name '*.la' -o -name '*.h' -o -name '*.pc' \) \
+        -print -quit
+)"
+if [ -n "${development_artifact}" ]; then
+    echo "Unexpected development artifact in media runtime: ${development_artifact}" >&2
+    exit 1
+fi
+
+set -- /opt/ffmpeg /opt/gstreamer /opt/roboflow
+if [ -d /opt/opencv ]; then
+    set -- "$@" /opt/opencv
+fi
+if [ -d /opt/cuda-runtime ]; then
+    set -- "$@" /opt/cuda-runtime
+fi
+
+required_jetson_plugins="
+/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstnvarguscamerasrc.so
+/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstnvjpeg.so
+/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstnvvidconv.so
+/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstnvvideo4linux2.so
+"
+for plugin in ${required_jetson_plugins}; do
+    test -s "${plugin}"
+done
+
+if [ -s /usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstnvjpeg.so ]; then
+    test -s /opt/cuda-runtime/lib/libnvjpeg.so.13
+fi
+
+find "$@" -type f -name '*.so*' -print0 |
+    xargs -0 sh -c '
+        for library do
+            missing="$(
+                ldd "${library}" 2>/dev/null |
+                    awk '\''/not found/ { print $1 }'\'' |
+                    grep -v -x '\''libcuda.so.1'\'' || true
+            )"
+            if [ -n "${missing}" ]; then
+                printf "%s\n%s\n" "${library}" "${missing}" >&2
+                exit 1
+            fi
+        done
+    ' sh
+
+for library in ${required_jetson_plugins}; do
+    missing="$(
+        ldd "${library}" 2>/dev/null |
+            awk '/not found/ { print $1 }' |
+            grep -v -x 'libcuda.so.1' || true
+    )"
+    if [ -n "${missing}" ]; then
+        printf '%s\n%s\n' "${library}" "${missing}" >&2
+        exit 1
+    fi
+done

--- a/docker/scripts/verify_opencv.sh
+++ b/docker/scripts/verify_opencv.sh
@@ -1,0 +1,138 @@
+#!/bin/sh
+
+set -eu
+
+OPENCV_REQUIRE_CUDA_BUILD="${OPENCV_REQUIRE_CUDA_BUILD:-false}"
+OPENCV_REQUIRE_CUDA_RUNTIME="${OPENCV_REQUIRE_CUDA_RUNTIME:-false}"
+OPENCV_EXPECTED_CUDA_ARCH_BIN="${OPENCV_EXPECTED_CUDA_ARCH_BIN:-}"
+export \
+    OPENCV_EXPECTED_CUDA_ARCH_BIN \
+    OPENCV_REQUIRE_CUDA_BUILD \
+    OPENCV_REQUIRE_CUDA_RUNTIME
+
+python3 - <<'PY'
+import os
+
+import cv2
+import numpy as np
+
+assert cv2.videoio_registry.hasBackend(cv2.CAP_GSTREAMER)
+info = cv2.getBuildInformation()
+assert "YES" in info.split("GStreamer:", 1)[1].splitlines()[0]
+assert "YES" in info.split("FFMPEG:", 1)[1].splitlines()[0]
+
+require_cuda_build = os.environ["OPENCV_REQUIRE_CUDA_BUILD"].lower() == "true"
+require_cuda_runtime = os.environ["OPENCV_REQUIRE_CUDA_RUNTIME"].lower() == "true"
+expected_cuda_arches = os.environ["OPENCV_EXPECTED_CUDA_ARCH_BIN"]
+cuda_section = info.split("NVIDIA CUDA:", 1)
+cuda_built = len(cuda_section) == 2 and "YES" in cuda_section[1].splitlines()[0]
+if require_cuda_build:
+    assert cuda_built
+    assert hasattr(cv2, "cuda_GpuMat")
+    assert hasattr(cv2.cuda, "cvtColor")
+    assert hasattr(cv2.cuda, "demosaicing")
+    assert hasattr(cv2.cuda, "resize")
+    assert hasattr(cv2.cuda, "createGaussianFilter")
+if expected_cuda_arches:
+    built_arches = (
+        info.split("NVIDIA GPU arch:", 1)[1].splitlines()[0].split()
+    )
+    for expected_arch in expected_cuda_arches.replace(",", ";").split(";"):
+        expected_arch = expected_arch.strip().replace(".", "")
+        if expected_arch:
+            assert expected_arch in built_arches
+
+gray = np.arange(16, dtype=np.uint8).reshape(4, 4)
+assert cv2.cvtColor(gray, cv2.COLOR_GRAY2BGR).shape == (4, 4, 3)
+assert cv2.cvtColor(
+    np.zeros((4, 4, 4), dtype=np.uint8), cv2.COLOR_BGRA2BGR
+).shape == (4, 4, 3)
+for dtype in (np.uint8, np.uint16):
+    bayer = np.arange(64, dtype=dtype).reshape(8, 8)
+    for conversion in (
+        cv2.COLOR_BAYER_BG2BGR,
+        cv2.COLOR_BAYER_GB2BGR,
+        cv2.COLOR_BAYER_RG2BGR,
+        cv2.COLOR_BAYER_GR2BGR,
+    ):
+        converted = cv2.cvtColor(bayer, conversion)
+        assert converted.shape == (8, 8, 3)
+        assert converted.dtype == dtype
+assert cv2.cvtColor(
+    np.zeros((2, 4, 2), dtype=np.uint8), cv2.COLOR_YUV2BGR_YUY2
+).shape == (2, 4, 3)
+assert cv2.resize(gray, (2, 2), interpolation=cv2.INTER_AREA).shape == (2, 2)
+
+frame = np.zeros((4, 4, 3), dtype=np.uint8)
+lut = np.arange(256, dtype=np.uint8)
+assert cv2.LUT(frame, lut).shape == frame.shape
+assert cv2.imencode(".jpg", frame)[0]
+assert cv2.SIFT_create() is not None
+assert cv2.QRCodeDetector() is not None
+assert cv2.createBackgroundSubtractorMOG2() is not None
+
+cuda_device_count = cv2.cuda.getCudaEnabledDeviceCount() if cuda_built else 0
+if require_cuda_runtime:
+    assert cuda_device_count > 0
+if cuda_device_count > 0:
+    gray = np.arange(64, dtype=np.uint8).reshape(8, 8)
+    gray_cuda = cv2.cuda_GpuMat()
+    gray_cuda.upload(gray)
+    assert np.array_equal(gray_cuda.download(), gray)
+
+    color_cuda = cv2.cuda.cvtColor(gray_cuda, cv2.COLOR_GRAY2BGR)
+    color = color_cuda.download()
+    assert color.shape == (8, 8, 3)
+    assert np.array_equal(color[:, :, 0], gray)
+    assert np.array_equal(color[:, :, 1], gray)
+    assert np.array_equal(color[:, :, 2], gray)
+
+    for dtype in (np.uint8, np.uint16):
+        bayer_cuda = cv2.cuda_GpuMat()
+        bayer_cuda.upload(np.arange(64, dtype=dtype).reshape(8, 8))
+        for conversion in (
+            cv2.COLOR_BAYER_BG2BGR,
+            cv2.COLOR_BAYER_GB2BGR,
+            cv2.COLOR_BAYER_RG2BGR,
+            cv2.COLOR_BAYER_GR2BGR,
+        ):
+            demosaiced_cuda = cv2.cuda.demosaicing(
+                bayer_cuda, conversion
+            )
+            converted = demosaiced_cuda.download()
+            assert converted.shape == (8, 8, 3)
+            assert converted.dtype == dtype
+            expected = cv2.cvtColor(bayer_cuda.download(), conversion)
+            assert np.allclose(converted, expected, atol=1)
+
+    resized_cuda = cv2.cuda.resize(
+        gray_cuda, (4, 4), interpolation=cv2.INTER_NEAREST
+    )
+    resized = resized_cuda.download()
+    assert resized.shape == (4, 4)
+    assert np.array_equal(
+        resized,
+        cv2.resize(gray, (4, 4), interpolation=cv2.INTER_NEAREST),
+    )
+
+    gaussian = cv2.cuda.createGaussianFilter(
+        cv2.CV_8UC1, cv2.CV_8UC1, (3, 3), 0
+    )
+    filtered = gaussian.apply(gray_cuda).download()
+    assert filtered.shape == (8, 8)
+    assert np.allclose(
+        filtered,
+        cv2.GaussianBlur(gray, (3, 3), 0, borderType=cv2.BORDER_REFLECT_101),
+        atol=1,
+    )
+
+capture = cv2.VideoCapture(
+    "videotestsrc num-buffers=1 ! "
+    "video/x-raw,format=BGR,width=16,height=16 ! appsink",
+    cv2.CAP_GSTREAMER,
+)
+assert capture.isOpened()
+ok, captured_frame = capture.read()
+capture.release()
+assert ok and captured_frame.shape == (16, 16, 3)
+PY

--- a/inference/core/interfaces/camera/dgpu_producer.py
+++ b/inference/core/interfaces/camera/dgpu_producer.py
@@ -1,20 +1,9 @@
 """GPU-native ``VideoFrameProducer`` for discrete NVIDIA GPUs, backed by ``PyNvVideoCodec`` (NVDEC).
 
-Decodes a video **file** through the NVIDIA Video Codec SDK and yields each frame as a
-``torch.Tensor`` on CUDA — zero-copy via DLPack, then ``.clone()`` for ownership. Every
-import of ``PyNvVideoCodec`` / ``torch`` is *local*, so importing this module is always
-safe; only instantiation requires the dependencies. Probe availability via
-``inference.core.interfaces.camera.discoverability.check_pynvvideocodec()``.
-
-Limitations (established during the design discussion):
-- ``SimpleDecoder`` is **file-only** — no RTSP / network. Live sources require demuxing
-  yourself and feeding the low-level packet decoder; out of scope for this experiment.
-- ``PyNvVideoCodec`` hard-links ``libnvidia-encode`` (NVENC) even for decode, so it will
-  not import on NVENC-less GPUs (e.g. A100) or containers without the ``video`` driver
-  capability. The discoverability probe surfaces that as "unavailable".
-
-Experimental scope: frames are ``.clone()``-ed (the NVDEC surface pool is finite and
-recycled as decoding advances); color order / layout / device left to the consumer.
+Decodes a video file through the NVIDIA Video Codec SDK and yields each frame as a
+``torch.Tensor`` on CUDA. DLPack wraps the decoded surface, then ``clone()`` gives the
+consumer independent storage. ``SimpleDecoder`` accepts file sources. Its runtime library
+closure includes ``libnvidia-encode`` and requires the NVIDIA ``video`` driver capability.
 """
 
 from typing import TYPE_CHECKING, Dict, Optional, Tuple
@@ -28,7 +17,6 @@ from inference.core.interfaces.camera.entities import (
 if TYPE_CHECKING:
     import torch
 
-# Planar CHW RGB — DL-friendly. Switch to "NV12" to isolate raw decode (no GPU colour conv).
 _DEFAULT_OUTPUT_COLOR_TYPE = "RGBP"
 
 
@@ -42,7 +30,6 @@ class PyNvVideoCodecFrameProducer(VideoFrameProducer):
         gpu_id: int = 0,
         output_color_type: str = _DEFAULT_OUTPUT_COLOR_TYPE,
     ):
-        # Local imports keep this module importable without the dGPU decode stack.
         try:
             import PyNvVideoCodec as nvc
             import torch  # noqa: F401 - needed at retrieve() time; imported here to fail fast
@@ -56,7 +43,6 @@ class PyNvVideoCodecFrameProducer(VideoFrameProducer):
 
         self._source_ref = video
         self._gpu_id = gpu_id
-        # SimpleDecoder is file-only and iterable; use_device_memory keeps frames on GPU.
         self._decoder = nvc.SimpleDecoder(
             video,
             gpu_id=gpu_id,
@@ -64,7 +50,6 @@ class PyNvVideoCodecFrameProducer(VideoFrameProducer):
             output_color_type=getattr(nvc.OutputColorType, output_color_type),
         )
         self._iterator = iter(self._decoder)
-        # DLPack-capable frame cached between grab() and retrieve().
         self._last_frame = None
         self._opened = True
 
@@ -87,25 +72,19 @@ class PyNvVideoCodecFrameProducer(VideoFrameProducer):
         self._last_frame = None
         if frame is None:
             return False, None
-        # Decoded frame exposes __dlpack__ -> zero-copy wrap on CUDA.
         tensor = torch.from_dlpack(frame)
-        # clone() for ownership: the NVDEC decode-surface pool is finite and recycled as
-        # decoding advances, so a held view would be use-after-overwrite.
         return True, tensor.clone()
 
     def initialize_source_properties(self, properties: Dict[str, float]) -> None:
-        # No-op: decoder options are fixed at construction. Present for contract parity.
         return None
 
     def discover_source_properties(self) -> SourceProperties:
-        # PyNvVideoCodec exposes container/stream metadata; the exact accessor/attribute
-        # names vary by version — verify against your installed PyNvVideoCodec.
         width, height, fps, total_frames = self._read_stream_metadata()
         return SourceProperties(
             width=width,
             height=height,
             total_frames=total_frames,
-            is_file=True,  # SimpleDecoder is file-only
+            is_file=True,
             fps=fps,
             is_reconnectable=False,
             timestamp_created=None,

--- a/inference/core/interfaces/camera/discoverability.py
+++ b/inference/core/interfaces/camera/discoverability.py
@@ -1,23 +1,13 @@
-"""Runtime discovery + verification of the optional hardware-decode ``VideoFrameProducer``s.
-
-These producers depend on libraries that are not always installed:
-- ``jetson_utils`` ships only with JetPack (Jetson devices), and
-- ``PyNvVideoCodec`` needs a discrete NVIDIA GPU + the Video Codec SDK (and it hard-links
-  ``libnvidia-encode`` even for decode, so it fails to import on NVENC-less GPUs / on
-  containers without the ``video`` driver capability).
-
-Every dependency import here is **local** (inside a function) and guarded, so importing
-this module never fails. Call the ``check_*`` functions at runtime to decide what's usable
-in the current environment, then build the matching producer with :func:`build_hw_producer`.
-"""
+"""Runtime discovery of hardware video frame producers."""
 
 from dataclasses import dataclass
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Union
 
 from inference.core.interfaces.camera.entities import VideoFrameProducer
 
 JETSON = "jetson"
 DGPU = "dgpu"
+GSTREAMER_CUDA = "gstreamer_cuda"
 
 
 @dataclass(frozen=True)
@@ -29,14 +19,39 @@ class ProducerAvailability:
     reason: str
 
 
-def check_jetson_utils() -> ProducerAvailability:
-    """Probe whether the Jetson (``jetson_utils``) producer is usable here."""
+def check_jetson_gstreamer(
+    video: Optional[Union[str, int]] = None,
+    *,
+    require_cuda_tensor: bool = True,
+) -> ProducerAvailability:
+    """Probe the in-repo Jetson GStreamer producer and its required elements."""
+
     try:
-        import jetson_utils  # noqa: F401
+        from inference.core.interfaces.camera.jetson_producer import (
+            probe_gstreamer_elements,
+            required_gstreamer_elements,
+        )
     except Exception as error:  # noqa: BLE001
         return ProducerAvailability(
-            JETSON, False, f"jetson_utils import failed: {error!r}"
+            JETSON, False, f"Jetson GStreamer producer import failed: {error!r}"
         )
+    gst_ok, gst_reason = probe_gstreamer_elements(
+        required_gstreamer_elements(video, output_tensor=True)
+    )
+    if not gst_ok:
+        return ProducerAvailability(JETSON, False, gst_reason)
+    try:
+        from inference.core.interfaces.camera.jetson_tensor_bridge import (
+            jetson_tensor_bridge_available,
+        )
+
+        bridge_ok, bridge_reason = jetson_tensor_bridge_available()
+    except Exception as error:  # noqa: BLE001
+        return ProducerAvailability(
+            JETSON, False, f"Jetson tensor bridge probe failed: {error!r}"
+        )
+    if not bridge_ok:
+        return ProducerAvailability(JETSON, False, bridge_reason)
     try:
         import torch
     except Exception as error:  # noqa: BLE001
@@ -75,18 +90,99 @@ def check_pynvvideocodec() -> ProducerAvailability:
     return ProducerAvailability(DGPU, True, "ok")
 
 
-def available_producers() -> Dict[str, ProducerAvailability]:
+def check_gstreamer_cuda(
+    video: Optional[Union[str, int]] = None,
+) -> ProducerAvailability:
+    if video is not None and (
+        not isinstance(video, str)
+        or video.startswith("/dev/video")
+        or video.lower().startswith("csi://")
+    ):
+        return ProducerAvailability(
+            GSTREAMER_CUDA,
+            False,
+            "GStreamer CUDA producer requires a URI or file path",
+        )
+    try:
+        from inference.core.interfaces.camera.gstreamer_cuda_producer import (
+            probe_gstreamer_cuda_elements,
+            required_gstreamer_cuda_elements,
+        )
+    except Exception as error:  # noqa: BLE001
+        return ProducerAvailability(
+            GSTREAMER_CUDA,
+            False,
+            f"GStreamer CUDA producer import failed: {error!r}",
+        )
+    gst_ok, gst_reason = probe_gstreamer_cuda_elements(
+        required_gstreamer_cuda_elements(video)
+    )
+    if not gst_ok:
+        return ProducerAvailability(GSTREAMER_CUDA, False, gst_reason)
+    try:
+        from inference.core.interfaces.camera.gstreamer_cuda_tensor_bridge import (
+            gstreamer_cuda_tensor_bridge_available,
+        )
+
+        bridge_ok, bridge_reason = gstreamer_cuda_tensor_bridge_available()
+    except Exception as error:  # noqa: BLE001
+        return ProducerAvailability(
+            GSTREAMER_CUDA,
+            False,
+            f"GStreamer CUDA tensor bridge probe failed: {error!r}",
+        )
+    if not bridge_ok:
+        return ProducerAvailability(GSTREAMER_CUDA, False, bridge_reason)
+    try:
+        import torch
+    except Exception as error:  # noqa: BLE001
+        return ProducerAvailability(
+            GSTREAMER_CUDA, False, f"torch import failed: {error!r}"
+        )
+    try:
+        cuda_ok = torch.cuda.is_available()
+    except Exception as error:  # noqa: BLE001
+        return ProducerAvailability(
+            GSTREAMER_CUDA, False, f"torch.cuda probe failed: {error!r}"
+        )
+    if not cuda_ok:
+        return ProducerAvailability(
+            GSTREAMER_CUDA, False, "torch.cuda.is_available() is False"
+        )
+    return ProducerAvailability(GSTREAMER_CUDA, True, "ok")
+
+
+def available_producers(
+    video: Optional[Union[str, int]] = None,
+    *,
+    require_cuda_tensor: bool = True,
+) -> Dict[str, ProducerAvailability]:
     """Probe every hardware-decode backend; map name -> :class:`ProducerAvailability`."""
+    if require_cuda_tensor and _dgpu_supports_source(video):
+        dgpu_availability = check_pynvvideocodec()
+    elif not require_cuda_tensor:
+        dgpu_availability = ProducerAvailability(
+            DGPU, False, "PyNvVideoCodec produces tensor frames"
+        )
+    else:
+        dgpu_availability = ProducerAvailability(
+            DGPU, False, "PyNvVideoCodec SimpleDecoder requires a file source"
+        )
+    gstreamer_cuda_availability = check_gstreamer_cuda(video)
     return {
-        JETSON: check_jetson_utils(),
-        DGPU: check_pynvvideocodec(),
+        GSTREAMER_CUDA: gstreamer_cuda_availability,
+        JETSON: check_jetson_gstreamer(
+            video=video, require_cuda_tensor=require_cuda_tensor
+        ),
+        DGPU: dgpu_availability,
     }
 
 
 def build_hw_producer(
-    video: str,
+    video: Union[str, int],
     *,
     prefer: Optional[str] = None,
+    output_tensor: bool = True,
     **producer_kwargs,
 ) -> Optional[VideoFrameProducer]:
     """Best-effort factory: return an instantiated GPU producer for ``video``, or ``None``.
@@ -96,23 +192,39 @@ def build_hw_producer(
     ``check_*`` probe are attempted, and instantiation failures fall through to the next
     candidate. The producer modules are imported locally so this stays import-safe.
 
-    NOTE: this only matches *installed-and-working* backends; it does not yet reason about
-    whether the backend supports the submitted input *type* (e.g. PyNvVideoCodec is
-    file-only — an rtsp:// URI should skip it). Add that input-capability gate when wiring
-    live sources.
+    Source capability is included in discovery. The PyNvVideoCodec backend accepts file
+    references, while the Jetson GStreamer backend accepts files, cameras, and network
+    streams.
     """
-    checks = available_producers()
+    checks = available_producers(
+        video=video,
+        require_cuda_tensor=output_tensor,
+    )
     for name in _resolution_order(prefer):
         if not checks[name].available:
             continue
         try:
+            if name == GSTREAMER_CUDA:
+                from inference.core.interfaces.camera.gstreamer_cuda_producer import (
+                    GstreamerCudaVideoFrameProducer,
+                )
+
+                return GstreamerCudaVideoFrameProducer(
+                    video,
+                    output_tensor=output_tensor,
+                    **producer_kwargs,
+                )
             if name == JETSON:
                 from inference.core.interfaces.camera.jetson_producer import (
                     JetsonVideoFrameProducer,
                 )
 
-                return JetsonVideoFrameProducer(video, **producer_kwargs)
-            if name == DGPU:
+                return JetsonVideoFrameProducer(
+                    video,
+                    output_tensor=output_tensor,
+                    **producer_kwargs,
+                )
+            if name == DGPU and output_tensor:
                 from inference.core.interfaces.camera.dgpu_producer import (
                     PyNvVideoCodecFrameProducer,
                 )
@@ -126,10 +238,21 @@ def build_hw_producer(
 
 
 def _resolution_order(prefer: Optional[str]) -> List[str]:
-    if prefer in (JETSON, DGPU):
-        return [prefer] + [n for n in (JETSON, DGPU) if n != prefer]
+    producer_names = (GSTREAMER_CUDA, JETSON, DGPU)
+    if prefer in producer_names:
+        return [prefer] + [name for name in producer_names if name != prefer]
     import platform
 
     if platform.machine() == "aarch64" and platform.system() == "Linux":
-        return [JETSON, DGPU]
-    return [DGPU, JETSON]
+        return [JETSON, GSTREAMER_CUDA, DGPU]
+    return [GSTREAMER_CUDA, DGPU, JETSON]
+
+
+def _dgpu_supports_source(video: Optional[Union[str, int]]) -> bool:
+    if video is None:
+        return True
+    return (
+        isinstance(video, str)
+        and "://" not in video
+        and not video.startswith("/dev/video")
+    )

--- a/inference/core/interfaces/camera/gstreamer_cuda_producer.py
+++ b/inference/core/interfaces/camera/gstreamer_cuda_producer.py
@@ -1,5 +1,3 @@
-"""Jetson video capture with NVIDIA GStreamer and CUDA tensor output."""
-
 import ctypes
 import ctypes.util
 import os
@@ -16,33 +14,13 @@ from inference.core.interfaces.camera.entities import (
 
 _GST_RANK_PRIMARY = 256
 _NVIDIA_DECODER_RANK = _GST_RANK_PRIMARY + 100
-
-_COMMON_ELEMENTS = (
-    "appsink",
-    "nvvidconv",
-    "queue",
-)
-_URI_DECODE_ELEMENTS = (
-    "decodebin",
+_BASE_ELEMENTS = ("appsink", "cudaconvertscale", "queue", "uridecodebin")
+_RTSP_ELEMENTS = (
     "h264parse",
     "h265parse",
-    "jpegparse",
-    "nvjpegdec",
-    "nvv4l2decoder",
-    "uridecodebin",
-)
-_RTSP_ELEMENTS = (
     "rtph264depay",
     "rtph265depay",
     "rtspsrc",
-)
-_SOFTWARE_DECODER_ELEMENTS = (
-    "avdec_h264",
-    "avdec_h265",
-    "avdec_mjpeg",
-    "jpegdec",
-    "libde265dec",
-    "openh264dec",
 )
 _FILE_DEMUXERS = {
     ".avi": "avidemux",
@@ -52,11 +30,47 @@ _FILE_DEMUXERS = {
     ".mp4": "qtdemux",
     ".webm": "matroskademux",
 }
+_DECODER_FACTORY_NAMES = tuple(
+    dict.fromkeys(
+        [
+            "nvh264dec",
+            "nvh264sldec",
+            "nvh265dec",
+            "nvh265sldec",
+            "nvjpegdec",
+            "nvvp8dec",
+            "nvvp9dec",
+            "nvav1dec",
+        ]
+        + [
+            f"{decoder}device{device_id}dec"
+            for decoder in (
+                "nvh264",
+                "nvh265",
+                "nvjpeg",
+                "nvvp8",
+                "nvvp9",
+                "nvav1",
+            )
+            for device_id in range(16)
+        ]
+    )
+)
+_FORBIDDEN_FACTORY_NAMES = (
+    "avdec_h264",
+    "avdec_h265",
+    "avdec_mjpeg",
+    "avdec_av1",
+    "avdec_vp8",
+    "avdec_vp9",
+    "cudadownload",
+    "cudaupload",
+    "jpegdec",
+    "videoconvert",
+)
 
 
-def probe_gstreamer_elements(elements: Iterable[str]) -> Tuple[bool, str]:
-    """Find required element factories and rank NVIDIA decoders first."""
-
+def probe_gstreamer_cuda_elements(elements: Iterable[str]) -> Tuple[bool, str]:
     library_name = ctypes.util.find_library("gstreamer-1.0")
     if not library_name:
         library_name = "libgstreamer-1.0.so.0"
@@ -94,42 +108,29 @@ def probe_gstreamer_elements(elements: Iterable[str]) -> Tuple[bool, str]:
         if missing:
             return False, f"missing GStreamer elements: {', '.join(missing)}"
 
-        for decoder_name in ("nvv4l2decoder", "nvjpegdec"):
-            decoder = factories.get(decoder_name)
+        decoder_found = False
+        for decoder_name in _DECODER_FACTORY_NAMES:
+            decoder = gst.gst_element_factory_find(decoder_name.encode("utf-8"))
             if decoder:
+                decoder_found = True
                 gst.gst_plugin_feature_set_rank(decoder, _NVIDIA_DECODER_RANK)
+                gst.gst_object_unref(decoder)
+        if not decoder_found:
+            return False, "no NVIDIA GStreamer decoder factory is available"
         return True, "ok"
     finally:
         for factory in factories.values():
             gst.gst_object_unref(factory)
 
 
-def required_gstreamer_elements(
+def required_gstreamer_cuda_elements(
     video: Optional[Union[str, int]] = None,
-    *,
-    output_tensor: bool = False,
 ) -> Sequence[str]:
-    """Return the element set needed by a source, or the common baseline."""
-
-    elements = list(_COMMON_ELEMENTS)
+    elements = list(_BASE_ELEMENTS)
     if video is None:
-        return tuple(elements + list(_URI_DECODE_ELEMENTS))
-    if _is_csi_source(video):
-        return tuple(elements + ["nvarguscamerasrc"])
-    if _is_v4l2_source(video):
-        return tuple(
-            elements
-            + [
-                "decodebin",
-                "h264parse",
-                "h265parse",
-                "jpegparse",
-                "nvjpegdec",
-                "nvv4l2decoder",
-                "v4l2src",
-            ]
-        )
-    elements.extend(_URI_DECODE_ELEMENTS)
+        return tuple(elements)
+    if not isinstance(video, str):
+        return tuple(elements)
     if _is_rtsp_source(video):
         elements.extend(_RTSP_ELEMENTS)
     local_file_path = _local_file_path(video)
@@ -140,38 +141,8 @@ def required_gstreamer_elements(
     return tuple(elements)
 
 
-def build_gstreamer_pipeline(
-    video: Union[str, int],
-    *,
-    output_tensor: bool = False,
-) -> str:
-    """Build a Jetson GStreamer pipeline ending in an NVMM appsink."""
-
-    is_live = _is_live_source(video)
-    sink = _build_sink(is_live=is_live)
-    if _is_csi_source(video):
-        sensor_id = _csi_sensor_id(video)
-        return (
-            f"nvarguscamerasrc sensor-id={sensor_id} ! "
-            "video/x-raw(memory:NVMM),format=NV12 ! "
-            f"{sink}"
-        )
-    if _is_v4l2_source(video):
-        device = _v4l2_device(video)
-        return (
-            f'v4l2src device="{_quote_gstreamer_value(device)}" ! '
-            f"decodebin ! {sink}"
-        )
-
-    uri = _source_uri(video)
-    return (
-        f'uridecodebin uri="{_quote_gstreamer_value(uri)}" '
-        'caps="video/x-raw(memory:NVMM)" ! '
-        f"{sink}"
-    )
-
-
-def _build_sink(is_live: bool) -> str:
+def build_gstreamer_cuda_pipeline(video: str, *, device_id: int = 0) -> str:
+    is_live = _local_file_path(video) is None
     queue_options = (
         "max-size-buffers=2 max-size-bytes=0 max-size-time=0 leaky=downstream"
         if is_live
@@ -182,65 +153,69 @@ def _build_sink(is_live: bool) -> str:
         if is_live
         else "max-buffers=4 drop=false sync=false"
     )
+    uri = _source_uri(video)
     return (
+        f'uridecodebin uri="{_quote_gstreamer_value(uri)}" '
+        'caps="video/x-raw(memory:CUDAMemory)" ! '
         f"queue {queue_options} ! "
-        "nvvidconv ! video/x-raw(memory:NVMM),format=RGBA ! "
+        f"cudaconvertscale cuda-device-id={device_id} ! "
+        "video/x-raw(memory:CUDAMemory),format=RGBP ! "
         f"appsink name=rf_tensor_sink {appsink_options} wait-on-eos=false"
     )
 
 
-class JetsonVideoFrameProducer(VideoFrameProducer):
-    """Decode Jetson file/camera/RTSP sources with NVIDIA GStreamer elements."""
-
+class GstreamerCudaVideoFrameProducer(VideoFrameProducer):
     def __init__(
         self,
-        video: Union[str, int],
+        video: str,
         *,
+        gpu_id: int = 0,
         output_tensor: bool = True,
-        tensor_device: str = "cuda",
-        pin_host_memory: bool = True,
-    ):
-        gst_ok, gst_reason = probe_gstreamer_elements(
-            required_gstreamer_elements(video, output_tensor=True)
+    ) -> None:
+        if not _supports_uri_source(video):
+            raise TypeError("GStreamer CUDA producer requires a URI or file path")
+
+        gst_ok, gst_reason = probe_gstreamer_cuda_elements(
+            required_gstreamer_cuda_elements(video)
         )
         if not gst_ok:
             raise RuntimeError(gst_reason)
 
-        self._source_ref = video
-        self._output_tensor = output_tensor
-        self._pipeline = build_gstreamer_pipeline(video, output_tensor=True)
-        self._decoder_validated = not _source_requires_decoder(video)
-        self._prerolled_frame_pending = False
-        self._cached_source_properties: Optional[SourceProperties] = None
-        del pin_host_memory
+        try:
+            import torch
+        except Exception as error:  # noqa: BLE001 - optional runtime capability
+            raise ImportError("GStreamer CUDA decoding requires torch") from error
+        if not torch.cuda.is_available():
+            raise RuntimeError("GStreamer CUDA decoding requires CUDA")
+        if gpu_id < 0 or gpu_id >= torch.cuda.device_count():
+            raise ValueError(f"CUDA device {gpu_id} is unavailable")
 
-        import torch
-
-        from inference.core.interfaces.camera.jetson_tensor_bridge import (
-            NativeJetsonTensorPipeline,
-            jetson_tensor_bridge_available,
+        from inference.core.interfaces.camera.gstreamer_cuda_tensor_bridge import (
+            NativeGstreamerCudaTensorPipeline,
+            gstreamer_cuda_tensor_bridge_available,
         )
 
-        device = torch.device(tensor_device)
-        if device.type != "cuda" or not torch.cuda.is_available():
-            raise RuntimeError("Jetson decoding requires an available CUDA device")
-        device_id = (
-            torch.cuda.current_device() if device.index is None else device.index
-        )
-        bridge_ok, bridge_reason = jetson_tensor_bridge_available()
+        bridge_ok, bridge_reason = gstreamer_cuda_tensor_bridge_available()
         if not bridge_ok:
             raise RuntimeError(bridge_reason)
-        self._native_pipeline = NativeJetsonTensorPipeline(
-            self._pipeline, device_id=device_id
+
+        self._source_ref = video
+        self._output_tensor = output_tensor
+        self._pipeline_description = build_gstreamer_cuda_pipeline(
+            video, device_id=gpu_id
         )
+        self._native_pipeline = NativeGstreamerCudaTensorPipeline(
+            self._pipeline_description, device_id=gpu_id
+        )
+        self._decoder_validated = False
+        self._prerolled_frame_pending = False
+        self._cached_source_properties: Optional[SourceProperties] = None
         self._closed = False
         self._eos = False
 
     @property
     def pipeline(self) -> str:
-        """Pipeline string exposed for diagnostics and on-device tests."""
-
-        return self._pipeline
+        return self._pipeline_description
 
     def isOpened(self) -> bool:
         return not self._closed and not self._eos
@@ -253,7 +228,7 @@ class JetsonVideoFrameProducer(VideoFrameProducer):
             return True
         grabbed = self._native_pipeline.grab()
         if grabbed and not self._decoder_validated:
-            self._validate_hardware_decoder()
+            self._validate_pipeline()
         if not grabbed:
             self._eos = True
         return grabbed
@@ -274,11 +249,11 @@ class JetsonVideoFrameProducer(VideoFrameProducer):
         if self._cached_source_properties is not None:
             return self._cached_source_properties
         if not self.grab():
-            raise RuntimeError("Jetson pipeline did not produce source metadata")
+            raise RuntimeError(
+                "GStreamer CUDA pipeline did not produce source metadata"
+            )
         self._prerolled_frame_pending = True
         frame_info = self._native_pipeline.frame_info()
-        width = frame_info.width
-        height = frame_info.height
         fps = (
             frame_info.fps_numerator / frame_info.fps_denominator
             if frame_info.fps_denominator > 0
@@ -297,8 +272,8 @@ class JetsonVideoFrameProducer(VideoFrameProducer):
             last_modified = datetime.fromtimestamp(os.path.getmtime(local_path))
             timestamp_created = last_modified - timedelta(seconds=file_length_seconds)
         properties = SourceProperties(
-            width=width,
-            height=height,
+            width=frame_info.width,
+            height=frame_info.height,
             total_frames=total_frames,
             is_file=is_file,
             fps=fps,
@@ -325,39 +300,39 @@ class JetsonVideoFrameProducer(VideoFrameProducer):
     def tensor_bridge_stats(self) -> Dict[str, int]:
         return self._native_pipeline.stats()
 
-    def _validate_hardware_decoder(self) -> None:
-        if any(
-            self._native_pipeline.has_factory(factory)
-            for factory in ("nvv4l2decoder", "nvjpegdec")
-        ):
-            self._decoder_validated = True
-            return
-        software_decoders = [
+    def _validate_pipeline(self) -> None:
+        if not self._native_pipeline.has_factory("cudaconvertscale"):
+            raise RuntimeError(
+                "GStreamer pipeline did not instantiate cudaconvertscale"
+            )
+        forbidden = [
             factory
-            for factory in _SOFTWARE_DECODER_ELEMENTS
+            for factory in _FORBIDDEN_FACTORY_NAMES
             if self._native_pipeline.has_factory(factory)
         ]
-        if software_decoders:
+        if forbidden:
             raise RuntimeError(
-                "Jetson pipeline instantiated software decoders: "
-                + ", ".join(software_decoders)
+                "GStreamer CUDA pipeline instantiated forbidden elements: "
+                + ", ".join(forbidden)
             )
-        if _is_v4l2_source(self._source_ref):
-            self._decoder_validated = True
-            return
-        raise RuntimeError("Jetson pipeline did not instantiate an NVIDIA decoder")
+        if not any(
+            self._native_pipeline.has_factory(factory)
+            for factory in _DECODER_FACTORY_NAMES
+        ):
+            raise RuntimeError(
+                "GStreamer CUDA pipeline did not instantiate an NVIDIA decoder"
+            )
+        self._decoder_validated = True
 
 
-def _source_uri(video: Union[str, int]) -> str:
+def _source_uri(video: str) -> str:
     local_path = _local_file_path(video)
     if local_path is not None:
         return Path(local_path).resolve().as_uri()
-    return str(video)
+    return video
 
 
-def _local_file_path(video: Union[str, int]) -> Optional[str]:
-    if not isinstance(video, str):
-        return None
+def _local_file_path(video: str) -> Optional[str]:
     if video.startswith("file://"):
         parsed = urlparse(video)
         return unquote(parsed.path)
@@ -366,41 +341,16 @@ def _local_file_path(video: Union[str, int]) -> Optional[str]:
     return video
 
 
-def _is_rtsp_source(video: Union[str, int]) -> bool:
-    return isinstance(video, str) and video.lower().startswith(("rtsp://", "rtsps://"))
+def _is_rtsp_source(video: str) -> bool:
+    return video.lower().startswith(("rtsp://", "rtsps://"))
 
 
-def _is_csi_source(video: Union[str, int]) -> bool:
-    return isinstance(video, str) and video.lower().startswith("csi://")
-
-
-def _csi_sensor_id(video: Union[str, int]) -> int:
-    try:
-        return int(str(video).split("://", 1)[1] or 0)
-    except ValueError as error:
-        raise ValueError(f"Invalid CSI source reference: {video!r}") from error
-
-
-def _is_v4l2_source(video: Union[str, int]) -> bool:
-    return isinstance(video, int) or (
-        isinstance(video, str) and video.startswith("/dev/video")
-    )
-
-
-def _v4l2_device(video: Union[str, int]) -> str:
-    return f"/dev/video{video}" if isinstance(video, int) else video
-
-
-def _is_live_source(video: Union[str, int]) -> bool:
+def _supports_uri_source(video: object) -> bool:
     return (
-        _is_csi_source(video)
-        or _is_v4l2_source(video)
-        or _local_file_path(video) is None
+        isinstance(video, str)
+        and not video.startswith("/dev/video")
+        and not video.lower().startswith("csi://")
     )
-
-
-def _source_requires_decoder(video: Union[str, int]) -> bool:
-    return not _is_csi_source(video)
 
 
 def _rgb_tensor_to_bgr_numpy(rgb_tensor):

--- a/inference/core/interfaces/camera/gstreamer_cuda_tensor_bridge.py
+++ b/inference/core/interfaces/camera/gstreamer_cuda_tensor_bridge.py
@@ -1,0 +1,250 @@
+import ctypes
+import ctypes.util
+import os
+from dataclasses import dataclass
+from typing import Dict, Optional, Tuple
+
+_ERROR_CAPACITY = 1024
+_INFINITE_TIMEOUT_NS = (1 << 64) - 1
+_DEFAULT_LIBRARY_PATH = "/opt/roboflow/lib/libroboflow_gstreamer_cuda_tensor.so.1"
+
+
+class _FrameInfo(ctypes.Structure):
+    _fields_ = [
+        ("width", ctypes.c_uint32),
+        ("height", ctypes.c_uint32),
+        ("fps_numerator", ctypes.c_int32),
+        ("fps_denominator", ctypes.c_int32),
+        ("duration_ns", ctypes.c_int64),
+    ]
+
+
+class _BridgeStats(ctypes.Structure):
+    _fields_ = [
+        ("frames", ctypes.c_uint64),
+        ("cuda_maps", ctypes.c_uint64),
+        ("host_pixel_maps", ctypes.c_uint64),
+        ("host_to_device_copies", ctypes.c_uint64),
+        ("device_to_host_copies", ctypes.c_uint64),
+        ("stream_synchronizations", ctypes.c_uint64),
+        ("active_leases", ctypes.c_uint64),
+        ("last_channel_stride", ctypes.c_int64),
+        ("last_row_stride", ctypes.c_int64),
+    ]
+
+
+@dataclass(frozen=True)
+class GstreamerCudaFrameInfo:
+    width: int
+    height: int
+    fps_numerator: int
+    fps_denominator: int
+    duration_ns: int
+
+
+def gstreamer_cuda_tensor_bridge_available() -> Tuple[bool, str]:
+    try:
+        library = _load_bridge_library()
+        version = library.rf_gstreamer_cuda_tensor_bridge_version()
+    except Exception as error:  # noqa: BLE001 - runtime capability probe
+        return False, f"GStreamer CUDA tensor bridge is unavailable: {error!r}"
+    if version != b"2":
+        return False, f"Unsupported GStreamer CUDA tensor bridge version: {version!r}"
+    return True, "ok"
+
+
+class NativeGstreamerCudaTensorPipeline:
+    def __init__(self, pipeline: str, *, device_id: int = 0) -> None:
+        self._library = _load_bridge_library()
+        error = ctypes.create_string_buffer(_ERROR_CAPACITY)
+        self._handle = self._library.rf_gstreamer_cuda_pipeline_create(
+            pipeline.encode("utf-8"),
+            device_id,
+            error,
+            len(error),
+        )
+        if not self._handle:
+            raise RuntimeError(_decode_error(error))
+
+    def grab(self, timeout_ns: Optional[int] = None) -> bool:
+        self._ensure_open()
+        error = ctypes.create_string_buffer(_ERROR_CAPACITY)
+        status = self._library.rf_gstreamer_cuda_pipeline_grab(
+            self._handle,
+            _INFINITE_TIMEOUT_NS if timeout_ns is None else timeout_ns,
+            error,
+            len(error),
+        )
+        if status < 0:
+            raise RuntimeError(_decode_error(error))
+        return status == 1
+
+    def retrieve(self):
+        self._ensure_open()
+        error = ctypes.create_string_buffer(_ERROR_CAPACITY)
+        managed_tensor = self._library.rf_gstreamer_cuda_pipeline_retrieve(
+            self._handle,
+            error,
+            len(error),
+        )
+        if not managed_tensor:
+            raise RuntimeError(_decode_error(error))
+
+        capsule = _create_dlpack_capsule(managed_tensor)
+        try:
+            import torch
+
+            tensor = torch.utils.dlpack.from_dlpack(capsule)
+        except Exception:
+            self._library.rf_gstreamer_cuda_dlpack_delete(managed_tensor)
+            raise
+        if not tensor.is_cuda or tensor.dtype != torch.uint8 or tensor.ndim != 3:
+            raise RuntimeError(
+                "GStreamer CUDA bridge returned an invalid CUDA uint8 CHW tensor"
+            )
+        return tensor
+
+    def frame_info(self) -> GstreamerCudaFrameInfo:
+        self._ensure_open()
+        info = _FrameInfo()
+        error = ctypes.create_string_buffer(_ERROR_CAPACITY)
+        status = self._library.rf_gstreamer_cuda_pipeline_get_frame_info(
+            self._handle,
+            ctypes.byref(info),
+            error,
+            len(error),
+        )
+        if status < 0:
+            raise RuntimeError(_decode_error(error))
+        return GstreamerCudaFrameInfo(
+            width=info.width,
+            height=info.height,
+            fps_numerator=info.fps_numerator,
+            fps_denominator=info.fps_denominator,
+            duration_ns=info.duration_ns,
+        )
+
+    def has_factory(self, factory_name: str) -> bool:
+        self._ensure_open()
+        return bool(
+            self._library.rf_gstreamer_cuda_pipeline_has_factory(
+                self._handle, factory_name.encode("utf-8")
+            )
+        )
+
+    def stats(self) -> Dict[str, int]:
+        self._ensure_open()
+        stats = _BridgeStats()
+        status = self._library.rf_gstreamer_cuda_pipeline_get_stats(
+            self._handle, ctypes.byref(stats)
+        )
+        if status < 0:
+            raise RuntimeError("Could not read GStreamer CUDA bridge statistics")
+        return {name: int(getattr(stats, name)) for name, _ in stats._fields_}
+
+    def interrupt(self) -> None:
+        handle = getattr(self, "_handle", None)
+        if handle:
+            status = self._library.rf_gstreamer_cuda_pipeline_interrupt(handle)
+            if status < 0:
+                raise RuntimeError("Could not interrupt GStreamer CUDA pipeline")
+
+    def close(self) -> None:
+        handle = getattr(self, "_handle", None)
+        if handle:
+            self._library.rf_gstreamer_cuda_pipeline_release(handle)
+            self._handle = None
+
+    def _ensure_open(self) -> None:
+        if not getattr(self, "_handle", None):
+            raise RuntimeError("GStreamer CUDA tensor pipeline is closed")
+
+    def __del__(self) -> None:
+        try:
+            self.close()
+        except Exception:  # noqa: BLE001 - interpreter shutdown
+            pass
+
+
+def _load_bridge_library():
+    configured_path = os.getenv("ROBOFLOW_GSTREAMER_CUDA_TENSOR_BRIDGE_LIBRARY")
+    candidates = [configured_path] if configured_path else []
+    candidates.extend(
+        [
+            _DEFAULT_LIBRARY_PATH,
+            ctypes.util.find_library("roboflow_gstreamer_cuda_tensor"),
+        ]
+    )
+    last_error = None
+    for candidate in candidates:
+        if not candidate:
+            continue
+        try:
+            library = ctypes.CDLL(candidate)
+            _configure_library(library)
+            return library
+        except OSError as error:
+            last_error = error
+    if last_error is not None:
+        raise last_error
+    raise OSError("GStreamer CUDA tensor bridge library was not found")
+
+
+def _configure_library(library) -> None:
+    library.rf_gstreamer_cuda_tensor_bridge_version.argtypes = []
+    library.rf_gstreamer_cuda_tensor_bridge_version.restype = ctypes.c_char_p
+    library.rf_gstreamer_cuda_pipeline_create.argtypes = [
+        ctypes.c_char_p,
+        ctypes.c_int,
+        ctypes.c_char_p,
+        ctypes.c_size_t,
+    ]
+    library.rf_gstreamer_cuda_pipeline_create.restype = ctypes.c_void_p
+    library.rf_gstreamer_cuda_pipeline_grab.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_uint64,
+        ctypes.c_char_p,
+        ctypes.c_size_t,
+    ]
+    library.rf_gstreamer_cuda_pipeline_grab.restype = ctypes.c_int
+    library.rf_gstreamer_cuda_pipeline_get_frame_info.argtypes = [
+        ctypes.c_void_p,
+        ctypes.POINTER(_FrameInfo),
+        ctypes.c_char_p,
+        ctypes.c_size_t,
+    ]
+    library.rf_gstreamer_cuda_pipeline_get_frame_info.restype = ctypes.c_int
+    library.rf_gstreamer_cuda_pipeline_has_factory.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_char_p,
+    ]
+    library.rf_gstreamer_cuda_pipeline_has_factory.restype = ctypes.c_int
+    library.rf_gstreamer_cuda_pipeline_retrieve.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_char_p,
+        ctypes.c_size_t,
+    ]
+    library.rf_gstreamer_cuda_pipeline_retrieve.restype = ctypes.c_void_p
+    library.rf_gstreamer_cuda_pipeline_get_stats.argtypes = [
+        ctypes.c_void_p,
+        ctypes.POINTER(_BridgeStats),
+    ]
+    library.rf_gstreamer_cuda_pipeline_get_stats.restype = ctypes.c_int
+    library.rf_gstreamer_cuda_pipeline_interrupt.argtypes = [ctypes.c_void_p]
+    library.rf_gstreamer_cuda_pipeline_interrupt.restype = ctypes.c_int
+    library.rf_gstreamer_cuda_dlpack_delete.argtypes = [ctypes.c_void_p]
+    library.rf_gstreamer_cuda_dlpack_delete.restype = None
+    library.rf_gstreamer_cuda_pipeline_release.argtypes = [ctypes.c_void_p]
+    library.rf_gstreamer_cuda_pipeline_release.restype = None
+
+
+def _create_dlpack_capsule(managed_tensor):
+    py_capsule_new = ctypes.pythonapi.PyCapsule_New
+    py_capsule_new.argtypes = [ctypes.c_void_p, ctypes.c_char_p, ctypes.c_void_p]
+    py_capsule_new.restype = ctypes.py_object
+    return py_capsule_new(managed_tensor, b"dltensor", None)
+
+
+def _decode_error(error_buffer) -> str:
+    message = error_buffer.value.decode("utf-8", errors="replace")
+    return message or "GStreamer CUDA tensor bridge failed"

--- a/inference/core/interfaces/camera/jetson_tensor_bridge.py
+++ b/inference/core/interfaces/camera/jetson_tensor_bridge.py
@@ -1,0 +1,252 @@
+import ctypes
+import ctypes.util
+import os
+from dataclasses import dataclass
+from typing import Dict, Optional, Tuple
+
+_ERROR_CAPACITY = 1024
+_INFINITE_TIMEOUT_NS = (1 << 64) - 1
+_DEFAULT_LIBRARY_PATH = "/opt/roboflow/lib/libroboflow_jetson_tensor.so.1"
+
+
+class _FrameInfo(ctypes.Structure):
+    _fields_ = [
+        ("width", ctypes.c_uint32),
+        ("height", ctypes.c_uint32),
+        ("fps_numerator", ctypes.c_int32),
+        ("fps_denominator", ctypes.c_int32),
+        ("duration_ns", ctypes.c_int64),
+    ]
+
+
+class _BridgeStats(ctypes.Structure):
+    _fields_ = [
+        ("frames", ctypes.c_uint64),
+        ("descriptor_maps", ctypes.c_uint64),
+        ("host_pixel_maps", ctypes.c_uint64),
+        ("host_to_device_copies", ctypes.c_uint64),
+        ("device_to_host_copies", ctypes.c_uint64),
+        ("array_flatten_copies", ctypes.c_uint64),
+        ("conversion_kernels", ctypes.c_uint64),
+        ("nvmm_frames", ctypes.c_uint64),
+        ("last_nvbuf_memory_type", ctypes.c_int32),
+        ("last_egl_frame_type", ctypes.c_int32),
+        ("last_egl_color_format", ctypes.c_int32),
+    ]
+
+
+@dataclass(frozen=True)
+class JetsonFrameInfo:
+    width: int
+    height: int
+    fps_numerator: int
+    fps_denominator: int
+    duration_ns: int
+
+
+def jetson_tensor_bridge_available() -> Tuple[bool, str]:
+    try:
+        library = _load_bridge_library()
+        version = library.rf_jetson_tensor_bridge_version()
+    except Exception as error:  # noqa: BLE001 - runtime capability probe
+        return False, f"Jetson tensor bridge is unavailable: {error!r}"
+    if version != b"2":
+        return False, f"Unsupported Jetson tensor bridge version: {version!r}"
+    return True, "ok"
+
+
+class NativeJetsonTensorPipeline:
+    def __init__(self, pipeline: str, *, device_id: int = 0) -> None:
+        self._library = _load_bridge_library()
+        error = ctypes.create_string_buffer(_ERROR_CAPACITY)
+        self._handle = self._library.rf_jetson_pipeline_create(
+            pipeline.encode("utf-8"),
+            device_id,
+            error,
+            len(error),
+        )
+        if not self._handle:
+            raise RuntimeError(_decode_error(error))
+
+    def grab(self, timeout_ns: Optional[int] = None) -> bool:
+        self._ensure_open()
+        error = ctypes.create_string_buffer(_ERROR_CAPACITY)
+        status = self._library.rf_jetson_pipeline_grab(
+            self._handle,
+            _INFINITE_TIMEOUT_NS if timeout_ns is None else timeout_ns,
+            error,
+            len(error),
+        )
+        if status < 0:
+            raise RuntimeError(_decode_error(error))
+        return status == 1
+
+    def retrieve(self):
+        self._ensure_open()
+        error = ctypes.create_string_buffer(_ERROR_CAPACITY)
+        managed_tensor = self._library.rf_jetson_pipeline_retrieve(
+            self._handle,
+            error,
+            len(error),
+        )
+        if not managed_tensor:
+            raise RuntimeError(_decode_error(error))
+
+        capsule = _create_dlpack_capsule(managed_tensor)
+        try:
+            import torch
+
+            tensor = torch.utils.dlpack.from_dlpack(capsule)
+        except Exception:
+            self._library.rf_jetson_dlpack_delete(managed_tensor)
+            raise
+        if not tensor.is_cuda or tensor.dtype != torch.uint8 or tensor.ndim != 3:
+            raise RuntimeError(
+                "Jetson tensor bridge returned an invalid CUDA uint8 CHW tensor"
+            )
+        return tensor
+
+    def frame_info(self) -> JetsonFrameInfo:
+        self._ensure_open()
+        info = _FrameInfo()
+        error = ctypes.create_string_buffer(_ERROR_CAPACITY)
+        status = self._library.rf_jetson_pipeline_get_frame_info(
+            self._handle,
+            ctypes.byref(info),
+            error,
+            len(error),
+        )
+        if status < 0:
+            raise RuntimeError(_decode_error(error))
+        return JetsonFrameInfo(
+            width=info.width,
+            height=info.height,
+            fps_numerator=info.fps_numerator,
+            fps_denominator=info.fps_denominator,
+            duration_ns=info.duration_ns,
+        )
+
+    def has_factory(self, factory_name: str) -> bool:
+        self._ensure_open()
+        return bool(
+            self._library.rf_jetson_pipeline_has_factory(
+                self._handle, factory_name.encode("utf-8")
+            )
+        )
+
+    def stats(self) -> Dict[str, int]:
+        self._ensure_open()
+        stats = _BridgeStats()
+        status = self._library.rf_jetson_pipeline_get_stats(
+            self._handle, ctypes.byref(stats)
+        )
+        if status < 0:
+            raise RuntimeError("Could not read Jetson tensor bridge statistics")
+        return {name: int(getattr(stats, name)) for name, _ in stats._fields_}
+
+    def interrupt(self) -> None:
+        handle = getattr(self, "_handle", None)
+        if handle:
+            status = self._library.rf_jetson_pipeline_interrupt(handle)
+            if status < 0:
+                raise RuntimeError("Could not interrupt Jetson tensor pipeline")
+
+    def close(self) -> None:
+        handle = getattr(self, "_handle", None)
+        if handle:
+            self._library.rf_jetson_pipeline_release(handle)
+            self._handle = None
+
+    def _ensure_open(self) -> None:
+        if not getattr(self, "_handle", None):
+            raise RuntimeError("Jetson tensor pipeline is closed")
+
+    def __del__(self) -> None:
+        try:
+            self.close()
+        except Exception:  # noqa: BLE001 - interpreter shutdown
+            pass
+
+
+def _load_bridge_library():
+    configured_path = os.getenv("ROBOFLOW_JETSON_TENSOR_BRIDGE_LIBRARY")
+    candidates = [configured_path] if configured_path else []
+    candidates.extend(
+        [
+            _DEFAULT_LIBRARY_PATH,
+            ctypes.util.find_library("roboflow_jetson_tensor"),
+        ]
+    )
+    last_error = None
+    for candidate in candidates:
+        if not candidate:
+            continue
+        try:
+            library = ctypes.CDLL(candidate)
+            _configure_library(library)
+            return library
+        except OSError as error:
+            last_error = error
+    if last_error is not None:
+        raise last_error
+    raise OSError("Jetson tensor bridge library was not found")
+
+
+def _configure_library(library) -> None:
+    library.rf_jetson_tensor_bridge_version.argtypes = []
+    library.rf_jetson_tensor_bridge_version.restype = ctypes.c_char_p
+    library.rf_jetson_pipeline_create.argtypes = [
+        ctypes.c_char_p,
+        ctypes.c_int,
+        ctypes.c_char_p,
+        ctypes.c_size_t,
+    ]
+    library.rf_jetson_pipeline_create.restype = ctypes.c_void_p
+    library.rf_jetson_pipeline_grab.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_uint64,
+        ctypes.c_char_p,
+        ctypes.c_size_t,
+    ]
+    library.rf_jetson_pipeline_grab.restype = ctypes.c_int
+    library.rf_jetson_pipeline_get_frame_info.argtypes = [
+        ctypes.c_void_p,
+        ctypes.POINTER(_FrameInfo),
+        ctypes.c_char_p,
+        ctypes.c_size_t,
+    ]
+    library.rf_jetson_pipeline_get_frame_info.restype = ctypes.c_int
+    library.rf_jetson_pipeline_has_factory.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_char_p,
+    ]
+    library.rf_jetson_pipeline_has_factory.restype = ctypes.c_int
+    library.rf_jetson_pipeline_retrieve.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_char_p,
+        ctypes.c_size_t,
+    ]
+    library.rf_jetson_pipeline_retrieve.restype = ctypes.c_void_p
+    library.rf_jetson_pipeline_get_stats.argtypes = [
+        ctypes.c_void_p,
+        ctypes.POINTER(_BridgeStats),
+    ]
+    library.rf_jetson_pipeline_get_stats.restype = ctypes.c_int
+    library.rf_jetson_pipeline_interrupt.argtypes = [ctypes.c_void_p]
+    library.rf_jetson_pipeline_interrupt.restype = ctypes.c_int
+    library.rf_jetson_dlpack_delete.argtypes = [ctypes.c_void_p]
+    library.rf_jetson_dlpack_delete.restype = None
+    library.rf_jetson_pipeline_release.argtypes = [ctypes.c_void_p]
+    library.rf_jetson_pipeline_release.restype = None
+
+
+def _create_dlpack_capsule(managed_tensor):
+    py_capsule_new = ctypes.pythonapi.PyCapsule_New
+    py_capsule_new.argtypes = [ctypes.c_void_p, ctypes.c_char_p, ctypes.c_void_p]
+    py_capsule_new.restype = ctypes.py_object
+    return py_capsule_new(managed_tensor, b"dltensor", None)
+
+
+def _decode_error(error_buffer) -> str:
+    message = error_buffer.value.decode("utf-8", errors="replace")
+    return message or "Jetson tensor bridge failed"

--- a/inference/core/interfaces/camera/video_source.py
+++ b/inference/core/interfaces/camera/video_source.py
@@ -195,19 +195,19 @@ def _is_test_pattern_reference(video: Union[str, int]) -> bool:
     )
 
 
-def _build_default_producer(stream_reference: Union[str, int]) -> VideoFrameProducer:
+def _build_default_producer(
+    stream_reference: Union[str, int],
+    *,
+    output_tensor: bool = False,
+) -> VideoFrameProducer:
     """Pick the decoder for a plain (non-callable, non-test-pattern) source reference.
 
-    When ``ENABLE_TENSOR_DATA_REPRESENTATION`` is on we attempt a hardware GPU-tensor
-    decoder (Jetson / dGPU NVDEC, discovered and verified at runtime), and fall back to
-    the cv2 CPU pathway when none is installed/usable or its construction fails. The flag
-    being off preserves the legacy behaviour exactly. The selection is always logged.
+    When ``ENABLE_TENSOR_DATA_REPRESENTATION`` is on, hardware decoders are discovered
+    and verified at runtime. ``output_tensor`` selects the representation requested by
+    the consumer. Construction failures fall back to the general cv2 decoder.
     """
     if not ENABLE_TENSOR_DATA_REPRESENTATION:
-        logger.debug(
-            "ENABLE_TENSOR_DATA_REPRESENTATION is off; using cv2 CPU decoder for source "
-            f"reference: {stream_reference}"
-        )
+        logger.debug("Using cv2 decoder for source " f"reference: {stream_reference}")
         return CV2VideoFrameProducer(stream_reference)
     # Local import: the discoverability layer pulls optional GPU-decode deps lazily.
     from inference.core.interfaces.camera.discoverability import (
@@ -217,27 +217,33 @@ def _build_default_producer(stream_reference: Union[str, int]) -> VideoFrameProd
 
     producer = None
     try:
-        producer = build_hw_producer(str(stream_reference))
+        producer = build_hw_producer(
+            stream_reference,
+            output_tensor=output_tensor,
+        )
     except (
         Exception
     ) as error:  # noqa: BLE001 - decoder selection must never break startup
         logger.warning(
-            "ENABLE_TENSOR_DATA_REPRESENTATION is on, but initialising a hardware "
-            f"GPU-tensor decoder for source reference {stream_reference} raised: "
+            "Initialising a hardware decoder for source reference "
+            f"{stream_reference} raised: "
             f"{error!r}. Falling back to the cv2 CPU decoder."
         )
     if producer is not None:
         logger.info(
-            "ENABLE_TENSOR_DATA_REPRESENTATION is on; selected hardware GPU-tensor decoder "
+            "Selected hardware decoder "
             f"'{type(producer).__name__}' for source reference: {stream_reference}"
         )
         return producer
     probe_reasons = {
         name: availability.reason
-        for name, availability in available_producers().items()
+        for name, availability in available_producers(
+            video=stream_reference,
+            require_cuda_tensor=output_tensor,
+        ).items()
     }
     logger.warning(
-        "ENABLE_TENSOR_DATA_REPRESENTATION is on, but no hardware GPU-tensor decoder is "
+        "No hardware decoder is "
         f"usable for source reference {stream_reference} (probes: {probe_reasons}). "
         "Falling back to the cv2 CPU decoder."
     )
@@ -260,6 +266,7 @@ class VideoSource:
         video_source_properties: Optional[Dict[str, float]] = None,
         source_id: Optional[int] = None,
         desired_fps: Optional[Union[float, int]] = None,
+        allow_tensor_frames: bool = False,
     ):
         """
         This class is meant to represent abstraction over video sources - both video files and
@@ -392,6 +399,7 @@ class VideoSource:
             video_consumer=video_consumer,
             video_source_properties=video_source_properties,
             source_id=source_id,
+            allow_tensor_frames=allow_tensor_frames,
         )
 
     def __init__(
@@ -403,6 +411,7 @@ class VideoSource:
         video_consumer: "VideoConsumer",
         video_source_properties: Optional[Dict[str, float]],
         source_id: Optional[int],
+        allow_tensor_frames: bool = False,
     ):
         self._stream_reference = stream_reference
         self._video: Optional[VideoFrameProducer] = None
@@ -418,6 +427,7 @@ class VideoSource:
         self._state_change_lock = Lock()
         self._video_source_properties = video_source_properties or {}
         self._source_id = source_id
+        self._allow_tensor_frames = allow_tensor_frames
         self._last_frame_timestamp: int = time.time_ns()
         self._fps: Optional[float] = None
         self._is_file: Optional[bool] = None
@@ -659,6 +669,7 @@ class VideoSource:
 
     def _start(self) -> None:
         self._change_state(target_state=StreamState.INITIALISING)
+        uses_default_producer = False
         try:
             if callable(self._stream_reference):
                 self._video = self._stream_reference()
@@ -669,14 +680,26 @@ class VideoSource:
 
                 self._video = TestPatternStreamProducer()
             else:
-                self._video = _build_default_producer(self._stream_reference)
-            if not self._video.isOpened():
-                self._change_state(target_state=StreamState.ERROR)
-                raise SourceConnectionError(
-                    f"Cannot connect to video source under reference: {self._stream_reference}"
+                uses_default_producer = True
+                self._video = _build_default_producer(
+                    self._stream_reference,
+                    output_tensor=self._allow_tensor_frames,
                 )
-            self._video.initialize_source_properties(self._video_source_properties)
-            self._source_properties = self._video.discover_source_properties()
+            try:
+                self._initialise_selected_video()
+            except Exception as hardware_error:
+                if not uses_default_producer or isinstance(
+                    self._video, CV2VideoFrameProducer
+                ):
+                    raise
+                self._release_video()
+                logger.warning(
+                    "Hardware video source initialisation failed for "
+                    f"{self._stream_reference}: {hardware_error!r}. "
+                    "Falling back to the cv2 decoder."
+                )
+                self._video = CV2VideoFrameProducer(self._stream_reference)
+                self._initialise_selected_video()
             self._video_consumer.reset(source_properties=self._source_properties)
             if self._source_properties.is_file:
                 self._set_file_mode_consumption_strategies()
@@ -690,7 +713,33 @@ class VideoSource:
             # discovery fails) leaves the source in ERROR, not INITIALISING, so
             # recovery (which keys off ERROR) fires. Re-raise for the caller.
             self._change_state(target_state=StreamState.ERROR)
+            self._release_video()
             raise
+
+    def _initialise_selected_video(self) -> None:
+        if not self._video.isOpened():
+            raise SourceConnectionError(
+                f"Cannot connect to video source under reference: {self._stream_reference}"
+            )
+        self._video.initialize_source_properties(self._video_source_properties)
+        self._source_properties = self._video.discover_source_properties()
+
+    def _interrupt_video(self) -> None:
+        interrupt = getattr(self._video, "interrupt", None)
+        if not callable(interrupt):
+            return
+        try:
+            interrupt()
+        except Exception as error:  # noqa: BLE001
+            logger.warning(f"Could not interrupt video source: {error}")
+
+    def _release_video(self) -> None:
+        if self._video is None:
+            return
+        try:
+            self._video.release()
+        except Exception as error:  # noqa: BLE001
+            logger.warning(f"Could not release video source: {error}")
 
     def _terminate(
         self, wait_on_frames_consumption: bool, purge_frames_buffer: bool
@@ -702,6 +751,7 @@ class VideoSource:
         if purge_frames_buffer:
             _ = get_from_queue(queue=self._frames_buffer, timeout=0.0, purge=True)
         if self._stream_consumption_thread is not None:
+            self._interrupt_video()
             self._stream_consumption_thread.join()
         if wait_on_frames_consumption:
             self._frames_buffer.join()
@@ -763,7 +813,7 @@ class VideoSource:
                 if not success:
                     break
             self._frames_buffer.put(POISON_PILL)
-            self._video.release()
+            self._release_video()
             self._change_state(target_state=StreamState.ENDED)
             send_video_source_status_update(
                 severity=UpdateSeverity.INFO,
@@ -774,6 +824,7 @@ class VideoSource:
             logger.info(f"Video consumption finished")
         except Exception as error:
             self._change_state(target_state=StreamState.ERROR)
+            self._release_video()
             # Emit a poison pill so a consumer blocked on read_frame gets
             # end-of-stream instead of timing out forever; ERROR is
             # restart-eligible, so reconnection fires.

--- a/inference/core/interfaces/stream/inference_pipeline.py
+++ b/inference/core/interfaces/stream/inference_pipeline.py
@@ -1,11 +1,14 @@
 import os
 from concurrent.futures import ThreadPoolExecutor
+from dataclasses import replace
 from datetime import datetime
 from enum import Enum
 from functools import partial
 from queue import Queue
 from threading import Thread
 from typing import Any, Callable, Dict, Generator, List, Optional, Tuple, Union
+
+import numpy as np
 
 from inference.core import logger
 from inference.core.active_learning.middlewares import (
@@ -19,6 +22,7 @@ from inference.core.env import (
     DEFAULT_BUFFER_SIZE,
     DISABLE_PREPROC_AUTO_ORIENT,
     ENABLE_FRAME_DROP_ON_VIDEO_FILE_RATE_LIMITING,
+    ENABLE_TENSOR_DATA_REPRESENTATION,
     ENABLE_WORKFLOWS_PROFILING,
     MAX_ACTIVE_MODELS,
     PREDICTIONS_QUEUE_SIZE,
@@ -698,6 +702,7 @@ class InferencePipeline:
             batch_collection_timeout=batch_collection_timeout,
             predictions_queue_size=predictions_queue_size,
             decoding_buffer_size=decoding_buffer_size,
+            allow_tensor_frames=ENABLE_TENSOR_DATA_REPRESENTATION,
         )
 
     @classmethod
@@ -718,6 +723,7 @@ class InferencePipeline:
         sink_mode: SinkMode = SinkMode.ADAPTIVE,
         predictions_queue_size: int = PREDICTIONS_QUEUE_SIZE,
         decoding_buffer_size: int = DEFAULT_BUFFER_SIZE,
+        allow_tensor_frames: bool = False,
     ) -> "InferencePipeline":
         """
         This class creates the abstraction for making inferences from given workflow against video stream.
@@ -814,6 +820,7 @@ class InferencePipeline:
             source_buffer_consumption_strategy=source_buffer_consumption_strategy,
             desired_source_fps=desired_source_fps,
             decoding_buffer_size=decoding_buffer_size,
+            allow_tensor_frames=allow_tensor_frames,
         )
         watchdog.register_video_sources(video_sources=video_sources)
         try:
@@ -1117,7 +1124,10 @@ class InferencePipeline:
         video_frames: Union[VideoFrame, List[Optional[VideoFrame]]],
     ) -> None:
         try:
-            self._on_prediction(predictions, video_frames)
+            self._on_prediction(
+                predictions,
+                _materialise_video_frames_for_sink(video_frames),
+            )
         except Exception as error:
             payload = {
                 "error_type": error.__class__.__name__,
@@ -1146,6 +1156,39 @@ class InferencePipeline:
             batch_collection_timeout=self._batch_collection_timeout,
             should_stop=lambda: self._stop,
         )
+
+
+def _materialise_video_frames_for_sink(
+    video_frames: Union[VideoFrame, List[Optional[VideoFrame]]],
+) -> Union[VideoFrame, List[Optional[VideoFrame]]]:
+    if isinstance(video_frames, list):
+        return [
+            _materialise_video_frame_for_sink(video_frame)
+            for video_frame in video_frames
+        ]
+    return _materialise_video_frame_for_sink(video_frames)
+
+
+def _materialise_video_frame_for_sink(
+    video_frame: Optional[VideoFrame],
+) -> Optional[VideoFrame]:
+    if video_frame is None or isinstance(video_frame.image, np.ndarray):
+        return video_frame
+
+    tensor_image = video_frame.image.detach().cpu()
+    if tensor_image.ndim == 2:
+        numpy_image = tensor_image.contiguous().numpy()
+    elif tensor_image.ndim == 3 and tensor_image.shape[0] == 1:
+        numpy_image = tensor_image[0].contiguous().numpy()
+    elif tensor_image.ndim == 3 and tensor_image.shape[0] in {3, 4}:
+        numpy_image = tensor_image.permute(1, 2, 0).contiguous().numpy()
+        channel_order = [2, 1, 0]
+        if tensor_image.shape[0] == 4:
+            channel_order.append(3)
+        numpy_image = np.ascontiguousarray(numpy_image[..., channel_order])
+    else:
+        raise ValueError("Tensor video frames must use HW, 1CHW, 3CHW, or 4CHW layout")
+    return replace(video_frame, image=numpy_image)
 
 
 def send_inference_pipeline_status_update(

--- a/inference/core/interfaces/stream/utils.py
+++ b/inference/core/interfaces/stream/utils.py
@@ -29,6 +29,7 @@ def prepare_video_sources(
     source_buffer_consumption_strategy: Optional[BufferConsumptionStrategy],
     desired_source_fps: Optional[Union[float, int]] = None,
     decoding_buffer_size: int = DEFAULT_BUFFER_SIZE,
+    allow_tensor_frames: bool = False,
 ) -> List[VideoSource]:
     video_reference = wrap_in_list(element=video_reference)
     if len(video_reference) < 1:
@@ -50,6 +51,7 @@ def prepare_video_sources(
         source_buffer_consumption_strategy=source_buffer_consumption_strategy,
         desired_source_fps=desired_source_fps,
         decoding_buffer_size=decoding_buffer_size,
+        allow_tensor_frames=allow_tensor_frames,
     )
 
 
@@ -79,6 +81,7 @@ def initialise_video_sources(
     source_buffer_consumption_strategy: Optional[BufferConsumptionStrategy],
     desired_source_fps: Optional[Union[float, int]] = None,
     decoding_buffer_size: int = DEFAULT_BUFFER_SIZE,
+    allow_tensor_frames: bool = False,
 ) -> List[VideoSource]:
     if isinstance(source_buffer_filling_strategy, str):
         source_buffer_filling_strategy = BufferFillingStrategy(
@@ -98,6 +101,7 @@ def initialise_video_sources(
             source_id=i,
             desired_fps=desired_source_fps,
             buffer_size=decoding_buffer_size,
+            allow_tensor_frames=allow_tensor_frames,
         )
         for i, (reference, source_properties) in enumerate(
             zip(video_reference, video_source_properties)

--- a/inference/core/managers/base.py
+++ b/inference/core/managers/base.py
@@ -439,8 +439,22 @@ class ModelManager:
         return model.infer_from_request(request)
 
     def run_tensor_native_inference(self, model_id: str, **kwargs) -> Any:
-        model = self._get_model_reference(model_id=model_id)
-        return model.run_tensor_native_inference(**kwargs)
+        with start_span(
+            "model.infer",
+            {
+                "model.id": model_id,
+                "model.infer.caller": "run_tensor_native_inference",
+            },
+        ):
+            try:
+                t_infer_start = time.perf_counter()
+                model = self._get_model_reference(model_id=model_id)
+                result = model.run_tensor_native_inference(**kwargs)
+                record_inference(model_id, time.perf_counter() - t_infer_start)
+                return result
+            except Exception as error:
+                record_error(error)
+                raise
 
     def make_response(
         self, model_id: str, predictions: List[List[float]], *args, **kwargs

--- a/inference/core/workflows/core_steps/common/deserializers_tensor.py
+++ b/inference/core/workflows/core_steps/common/deserializers_tensor.py
@@ -1,10 +1,7 @@
 """
-Tensor-native sibling of `common/deserializers.py`. Same public function
-names; loader swaps the import based on `ENABLE_TENSOR_DATA_REPRESENTATION`.
-
-Per the plan's locked decision [ITERATE 4.A], the numpy file is left
-untouched. Functions here add tensor-aware code paths and delegate to
-the numpy implementations for everything else.
+Tensor-native sibling of `common/deserializers.py`. The loader selects this module
+when `ENABLE_TENSOR_DATA_REPRESENTATION` is enabled. Functions here add tensor-aware
+code paths and delegate other inputs to the NumPy implementations.
 """
 
 from typing import Any, List, Optional, Tuple
@@ -52,12 +49,9 @@ _CHANNEL_AXIS_SIZES = (1, 3, 4)
 def _ensure_chw_layout(image: torch.Tensor) -> torch.Tensor:
     """Normalise a single-image tensor to the `WorkflowImageData` CHW contract.
 
-    `WorkflowImageData.tensor_image` is defined as CHW (RGB), but some producers
-    hand us a channels-last HWC tensor — e.g. the Jetson NVDEC producer wraps the
-    `jetson_utils` cudaImage (HWC `rgb8`) zero-copy. Stored as-is, the model
-    survives (its preprocessing auto-permutes channels-last input), but
-    `numpy_image` blindly does `permute(1, 2, 0)` and produces a `(W, C, H)`
-    canvas, which breaks every CHW-assuming consumer (annotators, shape reads).
+    `WorkflowImageData.tensor_image` uses CHW RGB. Producers may provide a
+    channels-last HWC tensor, which is normalised before constructing the workflow
+    image container.
 
     Detect channels-last with the same heuristic the model preprocessing uses
     (`pre_processing.py`: channels not at the front but present at the back) and

--- a/requirements/requirements.gpu.txt
+++ b/requirements/requirements.gpu.txt
@@ -1,3 +1,3 @@
 onnxruntime-gpu>=1.15.1,<1.22.0
 inference-models[torch-cu124,onnx-cu12]~=0.32.0rc1 # keep in sync between requirements.jetson requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt
-pynvvideocodec~=2.1.0
+pynvvideocodec~=2.1.0; platform_machine == "x86_64"

--- a/tests/inference/unit_tests/core/interfaces/camera/test_discoverability.py
+++ b/tests/inference/unit_tests/core/interfaces/camera/test_discoverability.py
@@ -1,0 +1,122 @@
+from unittest.mock import patch
+
+from inference.core.interfaces.camera.discoverability import (
+    DGPU,
+    GSTREAMER_CUDA,
+    JETSON,
+    ProducerAvailability,
+    _resolution_order,
+    available_producers,
+    build_hw_producer,
+    check_gstreamer_cuda,
+    check_jetson_gstreamer,
+)
+
+
+@patch("platform.system", return_value="Linux")
+@patch("platform.machine", return_value="aarch64")
+def test_jetson_backend_is_preferred_on_aarch64_linux(
+    machine_mock,
+    system_mock,
+) -> None:
+    assert _resolution_order(prefer=None) == [JETSON, GSTREAMER_CUDA, DGPU]
+
+
+@patch("platform.system", return_value="Linux")
+@patch("platform.machine", return_value="x86_64")
+def test_generic_cuda_backend_is_preferred_on_x86_linux(
+    machine_mock,
+    system_mock,
+) -> None:
+    assert _resolution_order(prefer=None) == [GSTREAMER_CUDA, DGPU, JETSON]
+
+
+def test_explicit_backend_preference_takes_priority() -> None:
+    assert _resolution_order(prefer=GSTREAMER_CUDA) == [
+        GSTREAMER_CUDA,
+        JETSON,
+        DGPU,
+    ]
+
+
+def test_generic_file_decoders_reject_v4l2_device_paths() -> None:
+    availability = check_gstreamer_cuda("/dev/video0")
+
+    assert not availability.available
+
+
+@patch(
+    "inference.core.interfaces.camera.discoverability.check_pynvvideocodec",
+    return_value=ProducerAvailability(DGPU, True, "ok"),
+)
+@patch(
+    "inference.core.interfaces.camera.discoverability.check_jetson_gstreamer",
+    return_value=ProducerAvailability(JETSON, True, "ok"),
+)
+@patch(
+    "inference.core.interfaces.camera.discoverability.check_gstreamer_cuda",
+    return_value=ProducerAvailability(GSTREAMER_CUDA, True, "ok"),
+)
+def test_generic_cuda_backend_remains_available_for_numpy_consumers(
+    check_gstreamer_cuda_mock,
+    check_jetson_gstreamer_mock,
+    check_pynvvideocodec_mock,
+) -> None:
+    availability = available_producers(video="sample.mp4", require_cuda_tensor=False)
+
+    assert availability[GSTREAMER_CUDA].available
+    check_gstreamer_cuda_mock.assert_called_once_with("sample.mp4")
+    check_jetson_gstreamer_mock.assert_called_once_with(
+        video="sample.mp4", require_cuda_tensor=False
+    )
+    check_pynvvideocodec_mock.assert_not_called()
+
+
+@patch("torch.cuda.is_available", return_value=True)
+@patch(
+    "inference.core.interfaces.camera.jetson_tensor_bridge.jetson_tensor_bridge_available",
+    return_value=(True, "ok"),
+)
+@patch(
+    "inference.core.interfaces.camera.jetson_producer.probe_gstreamer_elements",
+    return_value=(True, "ok"),
+)
+def test_jetson_numpy_probe_requires_the_native_cuda_bridge(
+    probe_gstreamer_elements_mock,
+    bridge_available_mock,
+    cuda_available_mock,
+) -> None:
+    availability = check_jetson_gstreamer(video="sample.mp4", require_cuda_tensor=False)
+
+    assert availability.available
+    bridge_available_mock.assert_called_once_with()
+    cuda_available_mock.assert_called_once_with()
+    required_elements = probe_gstreamer_elements_mock.call_args.args[0]
+    assert "nvvidconv" in required_elements
+    assert "videoconvert" not in required_elements
+
+
+@patch(
+    "inference.core.interfaces.camera.gstreamer_cuda_producer.GstreamerCudaVideoFrameProducer"
+)
+@patch(
+    "inference.core.interfaces.camera.discoverability.available_producers",
+    return_value={
+        GSTREAMER_CUDA: ProducerAvailability(GSTREAMER_CUDA, True, "ok"),
+        JETSON: ProducerAvailability(JETSON, False, "unavailable"),
+        DGPU: ProducerAvailability(DGPU, False, "unavailable"),
+    },
+)
+def test_factory_requests_numpy_from_the_native_generic_cuda_producer(
+    available_producers_mock,
+    producer_class_mock,
+) -> None:
+    producer = build_hw_producer(
+        "sample.mp4", prefer=GSTREAMER_CUDA, output_tensor=False
+    )
+
+    assert producer is producer_class_mock.return_value
+    producer_class_mock.assert_called_once_with("sample.mp4", output_tensor=False)
+    available_producers_mock.assert_called_once_with(
+        video="sample.mp4", require_cuda_tensor=False
+    )

--- a/tests/inference/unit_tests/core/interfaces/camera/test_gstreamer_cuda_producer.py
+++ b/tests/inference/unit_tests/core/interfaces/camera/test_gstreamer_cuda_producer.py
@@ -1,0 +1,167 @@
+from types import SimpleNamespace
+
+import numpy as np
+import torch
+
+from inference.core.interfaces.camera.gstreamer_cuda_producer import (
+    GstreamerCudaVideoFrameProducer,
+    build_gstreamer_cuda_pipeline,
+    required_gstreamer_cuda_elements,
+)
+
+
+class _NativePipeline:
+    def __init__(self, frame=None, factories=()) -> None:
+        self.grab_calls = 0
+        self.retrieve_calls = 0
+        self.frame = frame if frame is not None else object()
+        self.factories = set(factories)
+        self.factory_queries = []
+
+    def grab(self) -> bool:
+        self.grab_calls += 1
+        return True
+
+    def retrieve(self):
+        self.retrieve_calls += 1
+        return self.frame
+
+    def has_factory(self, factory: str) -> bool:
+        self.factory_queries.append(factory)
+        return factory in self.factories
+
+    def frame_info(self):
+        return SimpleNamespace(
+            width=320,
+            height=180,
+            fps_numerator=30,
+            fps_denominator=1,
+            duration_ns=0,
+        )
+
+
+def _producer(
+    native_pipeline: _NativePipeline, *, output_tensor: bool = True
+) -> GstreamerCudaVideoFrameProducer:
+    producer = GstreamerCudaVideoFrameProducer.__new__(GstreamerCudaVideoFrameProducer)
+    producer._source_ref = "rtsp://camera.example.test/live"
+    producer._native_pipeline = native_pipeline
+    producer._output_tensor = output_tensor
+    producer._decoder_validated = True
+    producer._prerolled_frame_pending = False
+    producer._cached_source_properties = None
+    producer._closed = False
+    producer._eos = False
+    return producer
+
+
+def test_metadata_preroll_is_consumable_once_and_later_grabs_advance() -> None:
+    native_pipeline = _NativePipeline()
+    producer = _producer(native_pipeline)
+
+    first_properties = producer.discover_source_properties()
+    second_properties = producer.discover_source_properties()
+
+    assert first_properties is second_properties
+    assert native_pipeline.grab_calls == 1
+    assert producer.grab()
+    assert native_pipeline.grab_calls == 1
+    assert producer.grab()
+    assert native_pipeline.grab_calls == 2
+
+
+def test_retrieving_preroll_requires_next_grab_to_advance_native_pipeline() -> None:
+    native_pipeline = _NativePipeline()
+    producer = _producer(native_pipeline)
+
+    producer.discover_source_properties()
+    success, _ = producer.retrieve()
+
+    assert success
+    assert native_pipeline.retrieve_calls == 1
+    assert producer.grab()
+    assert native_pipeline.grab_calls == 2
+
+
+def test_numpy_retrieve_materializes_bgr_hwc_from_native_rgb_tensor() -> None:
+    rgb_tensor = torch.tensor(
+        [
+            [[10, 20], [30, 40]],
+            [[50, 60], [70, 80]],
+            [[90, 100], [110, 120]],
+        ],
+        dtype=torch.uint8,
+    )
+    producer = _producer(_NativePipeline(frame=rgb_tensor), output_tensor=False)
+
+    success, image = producer.retrieve()
+
+    assert success
+    assert isinstance(image, np.ndarray)
+    assert image.dtype == np.uint8
+    assert image.flags.c_contiguous
+    np.testing.assert_array_equal(
+        image,
+        np.array(
+            [
+                [[90, 50, 10], [100, 60, 20]],
+                [[110, 70, 30], [120, 80, 40]],
+            ],
+            dtype=np.uint8,
+        ),
+    )
+
+
+def test_numpy_mode_validates_cuda_conversion_and_hardware_decoder() -> None:
+    native_pipeline = _NativePipeline(factories={"cudaconvertscale", "nvh264dec"})
+    producer = _producer(native_pipeline, output_tensor=False)
+    producer._decoder_validated = False
+
+    assert producer.grab()
+
+    assert producer._decoder_validated
+    assert "cudaconvertscale" in native_pipeline.factory_queries
+    assert "nvh264dec" in native_pipeline.factory_queries
+
+
+def test_tensor_pipeline_keeps_frames_in_cuda_memory() -> None:
+    pipeline = build_gstreamer_cuda_pipeline(
+        "rtsps://camera.example.test/live", device_id=2
+    )
+
+    assert 'caps="video/x-raw(memory:CUDAMemory)"' in pipeline
+    assert "cudaconvertscale cuda-device-id=2" in pipeline
+    assert "video/x-raw(memory:CUDAMemory),format=RGBP" in pipeline
+    assert "appsink name=rf_tensor_sink" in pipeline
+    assert "cudaupload" not in pipeline
+    assert "cudadownload" not in pipeline
+    assert "videoconvert" not in pipeline
+
+
+def test_rtsps_element_contract_includes_tls_capable_rtsp_source() -> None:
+    elements = set(required_gstreamer_cuda_elements("rtsps://camera.example.test/live"))
+
+    assert {
+        "cudaconvertscale",
+        "h264parse",
+        "h265parse",
+        "rtph264depay",
+        "rtph265depay",
+        "rtspsrc",
+        "uridecodebin",
+    }.issubset(elements)
+
+
+def test_local_mp4_contract_includes_demuxer() -> None:
+    elements = set(required_gstreamer_cuda_elements("sample.mp4"))
+
+    assert "qtdemux" in elements
+
+
+def test_v4l2_device_is_not_treated_as_a_regular_file() -> None:
+    try:
+        GstreamerCudaVideoFrameProducer("/dev/video0")
+    except TypeError:
+        pass
+    else:
+        raise AssertionError("V4L2 device path must not use the URI producer")

--- a/tests/inference/unit_tests/core/interfaces/camera/test_jetson_producer.py
+++ b/tests/inference/unit_tests/core/interfaces/camera/test_jetson_producer.py
@@ -1,0 +1,254 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+
+from inference.core.interfaces.camera.jetson_producer import (
+    JetsonVideoFrameProducer,
+    build_gstreamer_pipeline,
+    required_gstreamer_elements,
+)
+
+
+class _NativePipeline:
+    def __init__(self, frame=None, factories=()) -> None:
+        self.grab_calls = 0
+        self.retrieve_calls = 0
+        self.interrupt_calls = 0
+        self.frame = frame if frame is not None else object()
+        self.factories = set(factories)
+        self.factory_queries = []
+
+    def grab(self) -> bool:
+        self.grab_calls += 1
+        return True
+
+    def retrieve(self):
+        self.retrieve_calls += 1
+        return self.frame
+
+    def has_factory(self, factory: str) -> bool:
+        self.factory_queries.append(factory)
+        return factory in self.factories
+
+    def frame_info(self):
+        return SimpleNamespace(
+            width=320,
+            height=180,
+            fps_numerator=30,
+            fps_denominator=1,
+            duration_ns=0,
+        )
+
+    def interrupt(self) -> None:
+        self.interrupt_calls += 1
+
+
+def _native_producer(
+    native_pipeline: _NativePipeline,
+    *,
+    output_tensor: bool = True,
+    source_ref: str = "rtsp://camera.example.test/live",
+) -> JetsonVideoFrameProducer:
+    producer = JetsonVideoFrameProducer.__new__(JetsonVideoFrameProducer)
+    producer._source_ref = source_ref
+    producer._native_pipeline = native_pipeline
+    producer._capture = None
+    producer._output_tensor = output_tensor
+    producer._decoder_validated = True
+    producer._prerolled_frame_pending = False
+    producer._cached_source_properties = None
+    producer._closed = False
+    producer._eos = False
+    return producer
+
+
+def test_metadata_preroll_is_consumable_once_and_later_grabs_advance() -> None:
+    native_pipeline = _NativePipeline()
+    producer = _native_producer(native_pipeline)
+
+    first_properties = producer.discover_source_properties()
+    second_properties = producer.discover_source_properties()
+
+    assert first_properties is second_properties
+    assert native_pipeline.grab_calls == 1
+    assert producer.grab()
+    assert native_pipeline.grab_calls == 1
+    assert producer.grab()
+    assert native_pipeline.grab_calls == 2
+
+
+def test_retrieving_preroll_clears_pending_grab_and_interrupts_native_wait() -> None:
+    native_pipeline = _NativePipeline()
+    producer = _native_producer(native_pipeline)
+
+    producer.discover_source_properties()
+    success, _ = producer.retrieve()
+    producer.interrupt()
+
+    assert success
+    assert native_pipeline.retrieve_calls == 1
+    assert native_pipeline.interrupt_calls == 1
+    assert not producer.isOpened()
+
+
+def test_numpy_retrieve_materializes_bgr_hwc_from_native_rgb_tensor() -> None:
+    rgb_tensor = torch.tensor(
+        [
+            [[10, 20], [30, 40]],
+            [[50, 60], [70, 80]],
+            [[90, 100], [110, 120]],
+        ],
+        dtype=torch.uint8,
+    )
+    producer = _native_producer(_NativePipeline(frame=rgb_tensor), output_tensor=False)
+
+    success, image = producer.retrieve()
+
+    assert success
+    assert isinstance(image, np.ndarray)
+    assert image.dtype == np.uint8
+    assert image.flags.c_contiguous
+    np.testing.assert_array_equal(
+        image,
+        np.array(
+            [
+                [[90, 50, 10], [100, 60, 20]],
+                [[110, 70, 30], [120, 80, 40]],
+            ],
+            dtype=np.uint8,
+        ),
+    )
+
+
+def test_numpy_mode_validates_the_instantiated_hardware_decoder() -> None:
+    native_pipeline = _NativePipeline(factories={"nvv4l2decoder"})
+    producer = _native_producer(native_pipeline, output_tensor=False)
+    producer._decoder_validated = False
+
+    assert producer.grab()
+
+    assert producer._decoder_validated
+    assert "nvv4l2decoder" in native_pipeline.factory_queries
+
+
+def test_raw_v4l2_source_does_not_require_a_decoder_element() -> None:
+    producer = _native_producer(
+        _NativePipeline(), output_tensor=False, source_ref="/dev/video0"
+    )
+    producer._decoder_validated = False
+
+    assert producer.grab()
+
+    assert producer._decoder_validated
+
+
+def test_compressed_v4l2_source_rejects_a_software_decoder() -> None:
+    producer = _native_producer(
+        _NativePipeline(factories={"jpegdec"}),
+        output_tensor=False,
+        source_ref="/dev/video0",
+    )
+    producer._decoder_validated = False
+
+    with pytest.raises(RuntimeError, match="software decoders: jpegdec"):
+        producer.grab()
+
+
+def test_rtsps_source_uses_live_rtsp_pipeline() -> None:
+    pipeline = build_gstreamer_pipeline(
+        "rtsps://camera.example.test:7441/live?token=secret"
+    )
+
+    assert pipeline.startswith(
+        'uridecodebin uri="rtsps://camera.example.test:7441/live?token=secret"'
+    )
+    assert 'caps="video/x-raw(memory:NVMM)"' in pipeline
+    assert "nvvidconv" in pipeline
+    assert "appsink name=rf_tensor_sink" in pipeline
+    assert "max-buffers=1 drop=true sync=false" in pipeline
+
+
+def test_tensor_rtsps_pipeline_keeps_nvmm_at_named_appsink() -> None:
+    pipeline = build_gstreamer_pipeline(
+        "rtsps://camera.example.test:7441/live",
+        output_tensor=True,
+    )
+
+    assert "nvvidconv ! video/x-raw(memory:NVMM),format=RGBA" in pipeline
+    assert "appsink name=rf_tensor_sink" in pipeline
+    assert "videoconvert" not in pipeline
+    assert "video/x-raw,format=BGR" not in pipeline
+
+
+def test_rtsps_source_requires_rtsp_and_nvidia_decode_elements() -> None:
+    elements = set(required_gstreamer_elements("rtsps://camera.example.test/live"))
+
+    assert {
+        "appsink",
+        "h264parse",
+        "h265parse",
+        "jpegparse",
+        "nvvidconv",
+        "nvv4l2decoder",
+        "rtph264depay",
+        "rtph265depay",
+        "rtspsrc",
+        "uridecodebin",
+    } <= elements
+    assert "videoconvert" not in elements
+
+
+def test_tensor_source_requires_hardware_jpeg_without_cpu_converter() -> None:
+    elements = set(
+        required_gstreamer_elements(
+            "rtsps://camera.example.test/live", output_tensor=True
+        )
+    )
+
+    assert "nvjpegdec" in elements
+    assert "nvv4l2decoder" in elements
+    assert "videoconvert" not in elements
+
+
+def test_file_source_uses_non_dropping_sink_and_matching_demuxer() -> None:
+    pipeline = build_gstreamer_pipeline("/tmp/sample.mp4")
+    elements = set(required_gstreamer_elements("/tmp/sample.mp4"))
+
+    assert pipeline.startswith(
+        f'uridecodebin uri="{Path("/tmp/sample.mp4").resolve().as_uri()}"'
+    )
+    assert "max-buffers=4 drop=false sync=false" in pipeline
+    assert "qtdemux" in elements
+
+
+def test_csi_source_uses_nvargus_camera() -> None:
+    pipeline = build_gstreamer_pipeline("csi://2")
+
+    assert pipeline.startswith("nvarguscamerasrc sensor-id=2")
+    assert "video/x-raw(memory:NVMM),format=NV12" in pipeline
+
+
+def test_v4l2_device_path_uses_live_sink() -> None:
+    pipeline = build_gstreamer_pipeline("/dev/video3")
+
+    assert pipeline.startswith('v4l2src device="/dev/video3" ! decodebin !')
+    assert "max-buffers=1 drop=true sync=false" in pipeline
+
+
+def test_v4l2_decodebin_can_negotiate_raw_mjpeg_and_h264_sources() -> None:
+    pipeline = build_gstreamer_pipeline("/dev/video3", output_tensor=True)
+    elements = set(required_gstreamer_elements("/dev/video3", output_tensor=True))
+
+    assert 'v4l2src device="/dev/video3" ! decodebin ! queue' in pipeline
+    assert "video/x-raw(memory:NVMM),format=RGBA" in pipeline
+    assert {
+        "decodebin",
+        "h264parse",
+        "jpegparse",
+        "nvjpegdec",
+        "nvv4l2decoder",
+        "v4l2src",
+    } <= elements

--- a/tests/inference/unit_tests/core/interfaces/camera/test_video_source.py
+++ b/tests/inference/unit_tests/core/interfaces/camera/test_video_source.py
@@ -1,7 +1,7 @@
 import time
 from datetime import datetime
 from queue import Queue
-from threading import Thread
+from threading import Event, Thread
 from unittest import mock
 from unittest.mock import MagicMock, call, patch
 
@@ -29,11 +29,129 @@ from inference.core.interfaces.camera.video_source import (
     StreamState,
     VideoConsumer,
     VideoSource,
+    _build_default_producer,
     decode_video_frame_to_buffer,
     drop_single_frame_from_buffer,
     get_fps_if_tick_happens_now,
     get_from_queue,
 )
+
+
+@patch("inference.core.interfaces.camera.discoverability.build_hw_producer")
+@patch.object(video_source, "ENABLE_TENSOR_DATA_REPRESENTATION", True)
+def test_default_producer_requests_numpy_frames_for_standard_consumers(
+    build_hw_producer: MagicMock,
+) -> None:
+    producer = MagicMock()
+    build_hw_producer.return_value = producer
+
+    result = _build_default_producer("rtsps://camera.example.test/live")
+
+    assert result is producer
+    build_hw_producer.assert_called_once_with(
+        "rtsps://camera.example.test/live",
+        output_tensor=False,
+    )
+
+
+def test_async_hardware_initialisation_failure_releases_and_uses_cv2() -> None:
+    properties = SourceProperties(
+        width=320,
+        height=180,
+        total_frames=0,
+        is_file=False,
+        fps=30.0,
+    )
+    hardware_producer = MagicMock()
+    hardware_producer.isOpened.return_value = True
+    hardware_producer.discover_source_properties.side_effect = RuntimeError(
+        "decoder negotiation failed"
+    )
+
+    class FallbackProducer:
+        def __init__(self, video) -> None:
+            self.opened = True
+
+        def isOpened(self) -> bool:
+            return self.opened
+
+        def initialize_source_properties(self, properties) -> None:
+            return None
+
+        def discover_source_properties(self) -> SourceProperties:
+            return properties
+
+        def grab(self) -> bool:
+            self.opened = False
+            return False
+
+        def release(self) -> None:
+            self.opened = False
+
+    with patch.object(
+        video_source, "_build_default_producer", return_value=hardware_producer
+    ), patch.object(video_source, "CV2VideoFrameProducer", FallbackProducer):
+        source = VideoSource.init(video_reference="rtsp://camera.example.test/live")
+        source.start()
+        source._stream_consumption_thread.join(timeout=1.0)
+
+    hardware_producer.release.assert_called_once_with()
+    assert isinstance(source._video, FallbackProducer)
+    assert not source._stream_consumption_thread.is_alive()
+
+
+def test_termination_interrupts_a_producer_blocked_waiting_for_a_frame() -> None:
+    entered_grab = Event()
+    interrupted = Event()
+    properties = SourceProperties(
+        width=320,
+        height=180,
+        total_frames=0,
+        is_file=False,
+        fps=30.0,
+    )
+
+    class BlockingProducer:
+        def __init__(self) -> None:
+            self.opened = True
+            self.interrupt_calls = 0
+
+        def isOpened(self) -> bool:
+            return self.opened
+
+        def initialize_source_properties(self, properties) -> None:
+            return None
+
+        def discover_source_properties(self) -> SourceProperties:
+            return properties
+
+        def grab(self) -> bool:
+            entered_grab.set()
+            interrupted.wait()
+            return False
+
+        def retrieve(self):
+            raise AssertionError("retrieve must not run after interruption")
+
+        def interrupt(self) -> None:
+            self.interrupt_calls += 1
+            interrupted.set()
+
+        def release(self) -> None:
+            self.opened = False
+
+    producer = BlockingProducer()
+    source = VideoSource.init(video_reference=lambda: producer)
+    source.start()
+    assert entered_grab.wait(timeout=1.0)
+
+    started = time.monotonic()
+    source.terminate(wait_on_frames_consumption=False)
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 1.0
+    assert producer.interrupt_calls == 1
+    assert not source._stream_consumption_thread.is_alive()
 
 
 def tear_down_source(source: VideoSource) -> None:

--- a/tests/inference/unit_tests/core/interfaces/stream/test_tensor_sink_boundary.py
+++ b/tests/inference/unit_tests/core/interfaces/stream/test_tensor_sink_boundary.py
@@ -1,0 +1,100 @@
+from datetime import datetime
+
+import numpy as np
+import pytest
+
+from inference.core.interfaces.camera.entities import VideoFrame
+from inference.core.interfaces.stream.inference_pipeline import InferencePipeline
+
+torch = pytest.importorskip("torch")
+
+
+def test_tensor_frame_is_materialised_as_bgr_numpy_before_sink_call() -> None:
+    tensor_image = torch.tensor(
+        [
+            [[10, 11], [12, 13]],
+            [[20, 21], [22, 23]],
+            [[30, 31], [32, 33]],
+        ],
+        dtype=torch.uint8,
+    )
+    video_frame = VideoFrame(
+        image=tensor_image,
+        frame_id=1,
+        frame_timestamp=datetime.now(),
+        source_id=0,
+    )
+    received = {}
+
+    def sink(predictions, frame):
+        received["predictions"] = predictions
+        received["frame"] = frame
+        received["copy"] = frame.image.copy()
+
+    pipeline = InferencePipeline.__new__(InferencePipeline)
+    pipeline._on_prediction = sink
+    pipeline._status_update_handlers = []
+
+    pipeline._use_sink({"result": "ok"}, video_frame)
+
+    expected_bgr = np.array(
+        [
+            [[30, 20, 10], [31, 21, 11]],
+            [[32, 22, 12], [33, 23, 13]],
+        ],
+        dtype=np.uint8,
+    )
+    assert received["predictions"] == {"result": "ok"}
+    assert received["frame"] is not video_frame
+    assert received["frame"].image.flags.c_contiguous
+    np.testing.assert_array_equal(received["frame"].image, expected_bgr)
+    np.testing.assert_array_equal(received["copy"], expected_bgr)
+    assert video_frame.image is tensor_image
+
+
+def test_tensor_frames_are_materialised_in_batch_sink_payload() -> None:
+    video_frame = VideoFrame(
+        image=torch.arange(4, dtype=torch.uint8).reshape(1, 2, 2),
+        frame_id=1,
+        frame_timestamp=datetime.now(),
+        source_id=0,
+    )
+    received = {}
+
+    def sink(predictions, frames):
+        received["predictions"] = predictions
+        received["frames"] = frames
+
+    pipeline = InferencePipeline.__new__(InferencePipeline)
+    pipeline._on_prediction = sink
+    pipeline._status_update_handlers = []
+
+    pipeline._use_sink([{"result": "ok"}, None], [video_frame, None])
+
+    assert received["predictions"] == [{"result": "ok"}, None]
+    assert received["frames"][1] is None
+    np.testing.assert_array_equal(
+        received["frames"][0].image,
+        np.array([[0, 1], [2, 3]], dtype=np.uint8),
+    )
+
+
+def test_numpy_frame_is_passed_to_sink_without_copying() -> None:
+    video_frame = VideoFrame(
+        image=np.zeros((2, 2, 3), dtype=np.uint8),
+        frame_id=1,
+        frame_timestamp=datetime.now(),
+        source_id=0,
+    )
+    received = {}
+
+    def sink(predictions, frame):
+        received["frame"] = frame
+
+    pipeline = InferencePipeline.__new__(InferencePipeline)
+    pipeline._on_prediction = sink
+    pipeline._status_update_handlers = []
+
+    pipeline._use_sink({}, video_frame)
+
+    assert received["frame"] is video_frame

--- a/tests/inference/unit_tests/core/managers/test_base.py
+++ b/tests/inference/unit_tests/core/managers/test_base.py
@@ -160,6 +160,60 @@ def test_infer_from_request_sync_skips_model_monitoring_cache_when_disabled(
     cache_mock.zadd.assert_not_called()
 
 
+def test_run_tensor_native_inference_records_telemetry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model = MagicMock()
+    model.run_tensor_native_inference.return_value = "result"
+    model_manager = ModelManager(model_registry=MagicMock(), models={"some/1": model})
+    start_span_mock = MagicMock()
+    record_inference_mock = MagicMock()
+    record_error_mock = MagicMock()
+    monkeypatch.setattr(base_module, "start_span", start_span_mock)
+    monkeypatch.setattr(base_module, "record_inference", record_inference_mock)
+    monkeypatch.setattr(base_module, "record_error", record_error_mock)
+
+    result = model_manager.run_tensor_native_inference(
+        model_id="some/1", images="tensor"
+    )
+
+    assert result == "result"
+    model.run_tensor_native_inference.assert_called_once_with(images="tensor")
+    start_span_mock.assert_called_once_with(
+        "model.infer",
+        {
+            "model.id": "some/1",
+            "model.infer.caller": "run_tensor_native_inference",
+        },
+    )
+    record_inference_mock.assert_called_once()
+    assert record_inference_mock.call_args.args[0] == "some/1"
+    assert record_inference_mock.call_args.args[1] >= 0
+    record_error_mock.assert_not_called()
+
+
+def test_run_tensor_native_inference_records_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    error = RuntimeError("inference failed")
+    model = MagicMock()
+    model.run_tensor_native_inference.side_effect = error
+    model_manager = ModelManager(model_registry=MagicMock(), models={"some/1": model})
+    start_span_mock = MagicMock()
+    record_inference_mock = MagicMock()
+    record_error_mock = MagicMock()
+    monkeypatch.setattr(base_module, "start_span", start_span_mock)
+    monkeypatch.setattr(base_module, "record_inference", record_inference_mock)
+    monkeypatch.setattr(base_module, "record_error", record_error_mock)
+
+    with pytest.raises(RuntimeError) as raised_error:
+        model_manager.run_tensor_native_inference(model_id="some/1", images="tensor")
+
+    assert raised_error.value is error
+    record_inference_mock.assert_not_called()
+    record_error_mock.assert_called_once_with(error)
+
+
 def test_make_response_when_model_available() -> None:
     # given
     model_registry = MagicMock()


### PR DESCRIPTION
## Summary

This stacked PR adds accelerated, tensor-native media runtimes for NVIDIA Jetson and cloud GPUs. It is intentionally based on `mvp/new-inference-pipeline`.

- builds FFmpeg 7.1.3, GStreamer 1.24.12, and OpenCV 4.13 with the platform-appropriate NVIDIA acceleration paths
- adds native GStreamer/CUDA tensor bridges without a `jetson-utils` runtime dependency
- preserves Jetson BSP NVDEC/NVENC, NVJPEG, and NVMM support while retaining upstream nvcodec support for cloud/dGPU images
- enables RTSP, RTSPS, and the GStreamer WebRTC feature/dependency set
- adds a dedicated JetPack 7.2 media Dockerfile and GitHub Actions workflow
- keeps build toolchains, development packages, Mesa/LLVM, and intermediate artifacts out of runtime images
- gates tensor-frame delivery on consumer support and restores telemetry for tensor-native manager dispatches
- leaves camera-vendor SDKs out of the base image while retaining GStreamer, OpenCV, and V4L integration points for planned Basler/LUCID frame-grabber work

## Why

The pipeline needs both hardware acceleration and tensor-native frame transport. Depending on the unmaintained Dusty-NV `jetson-utils` project would enlarge and constrain the base runtime, so the required zero-copy bridge behavior is implemented directly in this repository. The source builds provide a consistent feature surface across Jetson and cloud GPU targets while preserving NVIDIA's Jetson BSP plugins where they are required.

## Validation

### Automated

- targeted Python suites: 122 passed
- camera/manager suites: 137 passed, 28 deselected
- workflow boundary/tensor suites: 114 passed
- Black, isort, selected flake8 checks, shell syntax, and Python compile checks passed
- the new workflow passes actionlint (excluding the repository's custom Depot runner label)
- cold cloud build: https://github.com/roboflow/inference/actions/runs/29276246356
- warm-cache cloud build: https://github.com/roboflow/inference/actions/runs/29279087897 (60 seconds total; 26-second Depot build step)

### JetPack 7.2 hardware (Thor)

- H.264 NVDEC, H.265 NVDEC, and NVJPEG hardware engines exercised
- OpenCV CUDA passed for Bayer 8/16-bit conversion, color conversion, resize, Gaussian filtering, and GStreamer capture
- H.264, H.265, and JPEG bridges reported zero host-pixel copies, zero H2D/D2H copies, and zero flatten copies; retained tensor lifetime passed
- product RTSPS path decoded 30 frames through `uridecodebin` with SAN-valid CA verification, NVMM, and nvJPEG
- WebRTC plugins and dependencies were verified; external signaling-peer interoperability was not exercised
- no Mesa, `jetson-utils`, compiler/dev dependencies, or build artifacts were present
- logical rootfs decreased from 1,100,011,666 bytes to 878,354,582 bytes (-20.15%); same-engine zstd export decreased from 358,816,837 bytes to 328,442,379 bytes (-8.47%)

### JetPack 6.2 hardware (Orin AGX and Orin NX)

- SM87 bridge, JPEG/MJPEG zero-copy, NVJPEG, RTSPS, and OpenCV CUDA paths passed on both devices
- the available Orin devices run JetPack 6.2, so the exact JetPack 7.2-on-Orin image has not yet been exercised
- H.264/H.265 validation was blocked by the codec state of those BSP installations, rather than a repository build failure

## Image/runtime notes

The Jetson image uses NVIDIA's BSP media plugins rather than the upstream GStreamer nvcodec plugin. Cloud GPU images retain the upstream nvcodec path. Runtime output contains only the libraries and plugins needed to execute these paths; compilation occurs in builder stages.
