### PR TITLE
GPU-native bounding box visualization for the tensor pipeline (3-10x on Jetson)

### DIFF
--- a/inference/core/workflows/core_steps/visualizations/bounding_box/v1_tensor.py
+++ b/inference/core/workflows/core_steps/visualizations/bounding_box/v1_tensor.py
@@ -256,13 +256,10 @@ def gpu_draw_boxes(
 
 
 def _gpu_box_draw_eligible(
-    detections, color_axis: str, thickness, image: WorkflowImageData
+    detections, color_axis: str, image: WorkflowImageData
 ) -> bool:
     """True when the torch painter can replace the sv path."""
-    if color_axis not in ("CLASS", "INDEX"):
-        # TRACK / custom lookups keep the sv path.
-        return False
-    if not isinstance(thickness, int) or thickness < 1:
+    if color_axis not in ("CLASS", "INDEX", "TRACK"):
         return False
     if not image.is_tensor_materialised():
         # Forcing tensor_image on a numpy-sourced image is a costly host-side
@@ -377,19 +374,35 @@ class BoundingBoxVisualizationBlockV1(ColorableVisualizationBlock):
             if isinstance(predictions, tuple)
             else predictions
         )
-        if _gpu_box_draw_eligible(detections, color_axis, thickness, image):
+        if _gpu_box_draw_eligible(detections, color_axis, image):
             try:
                 palette = self.getPalette(color_palette, palette_size, custom_colors)
                 if not isinstance(palette, sv.ColorPalette):
                     raise TypeError("expected sv.ColorPalette")
                 # Same colors sv's resolve_color would pick: CLASS ->
-                # palette.by_idx(class_id), INDEX -> palette.by_idx(det index).
+                # by_idx(class_id), INDEX -> by_idx(det index), TRACK ->
+                # by_idx(tracker_id) with sv's gray for pending tracks (-1).
+                # Missing tracker ids raise here -> the sv path raises the
+                # same ValueError sv.resolve_color would.
                 if color_axis == "CLASS":
                     ids = detections.class_id.detach().cpu().numpy().astype(int)
+                elif color_axis == "TRACK":
+                    ids = np.asarray(
+                        [
+                            int(per_box["tracker_id"])
+                            for per_box in detections.bboxes_metadata
+                        ]
+                    )
                 else:
                     ids = np.arange(int(detections.xyxy.shape[0]))
+                pending_gray = (128, 128, 128)  # sv PENDING_TRACK_COLOR
                 colors_rgb = np.asarray(
-                    [palette.by_idx(int(idx)).as_rgb() for idx in ids],
+                    [
+                        pending_gray
+                        if color_axis == "TRACK" and idx == -1
+                        else palette.by_idx(int(idx)).as_rgb()
+                        for idx in ids
+                    ],
                     dtype=np.uint8,
                 )
                 # Same int conversion as the sv annotator loop (truncation

--- a/inference/core/workflows/core_steps/visualizations/bounding_box/v1_tensor.py
+++ b/inference/core/workflows/core_steps/visualizations/bounding_box/v1_tensor.py
@@ -76,7 +76,7 @@ def _quarter_arc_offsets(radius: int, thickness: int) -> Tuple[np.ndarray, np.nd
     the other three corners. Cached per (radius, thickness) across frames."""
     outer = thickness // 2
     span = radius + outer
-    yy, xx = np.mgrid[-span : 1, -span : 1]
+    yy, xx = np.mgrid[-span:1, -span:1]
     dist = np.sqrt(yy**2 + xx**2)
     ring = (dist >= radius - (thickness - 1 - outer) - 0.5) & (
         dist <= radius + outer + 0.5
@@ -172,10 +172,18 @@ def gpu_draw_boxes(
         for radius in np.unique(radii):
             idx = np.nonzero(radii == radius)[0]
             dy, dx = _quarter_arc_offsets(int(radius), thickness)
-            centers_y = (by1[idx] + radius, by1[idx] + radius,
-                         by2[idx] - radius, by2[idx] - radius)
-            centers_x = (bx1[idx] + radius, bx2[idx] - radius,
-                         bx1[idx] + radius, bx2[idx] - radius)
+            centers_y = (
+                by1[idx] + radius,
+                by1[idx] + radius,
+                by2[idx] - radius,
+                by2[idx] - radius,
+            )
+            centers_x = (
+                bx1[idx] + radius,
+                bx2[idx] - radius,
+                bx1[idx] + radius,
+                bx2[idx] - radius,
+            )
             signs = ((1, 1), (1, -1), (-1, 1), (-1, -1))
             for cy, cx, (sy, sx) in zip(centers_y, centers_x, signs):
                 rows = (cy[:, None] + sy * dy[None, :]).ravel()
@@ -223,8 +231,7 @@ def gpu_draw_boxes(
     )
     col_starts = row_width.cumsum(0) - row_width
     px_intra = (
-        torch.arange(total_px, device=device, dtype=torch.int32)
-        - col_starts[px_of_row]
+        torch.arange(total_px, device=device, dtype=torch.int32) - col_starts[px_of_row]
     )
     flat = row_base[px_of_row] + px_intra
     pixel_box = row_box[px_of_row]

--- a/inference/core/workflows/core_steps/visualizations/bounding_box/v1_tensor.py
+++ b/inference/core/workflows/core_steps/visualizations/bounding_box/v1_tensor.py
@@ -1,11 +1,16 @@
-from typing import List, Literal, Optional, Type, Union
+from typing import Dict, List, Literal, Optional, Tuple, Type, Union
 
+import cv2
+import numpy as np
 import supervision as sv
+import torch
 from pydantic import ConfigDict, Field
 
+from inference.core.logger import logger
 from inference.core.workflows.core_steps.common.tensor_native import (
     TensorNativeDetections,
     TensorNativePrediction,
+    split_key_point_prediction,
 )
 from inference.core.workflows.core_steps.visualizations.common.base_colorable_tensor import (
     ColorableVisualizationBlock,
@@ -60,6 +65,345 @@ The annotated image from this block can be connected to:
 - **Notification blocks** (e.g., Email Notification, Slack Notification) to send annotated images as visual evidence in alerts or reports
 - **Video output blocks** to create annotated video streams or recordings with bounding boxes for live monitoring or post-processing analysis
 """
+
+
+class _BorderGeometry:
+    """cv2-derived rasterisation template for one box thickness.
+
+    ``cv2.rectangle`` with ``thickness >= 2`` is NOT an outer-rect-minus-
+    inner-rect frame: the four edges are thick lines with round joins, so the
+    outermost corner pixels stay unpainted (and even thicknesses paint
+    ``thickness + 1`` wide bands). Instead of re-deriving OpenCV's thick-line
+    rasteriser, one reference rectangle is drawn with cv2 itself and decomposed
+    into four uniform straight bands plus four corner patches. Reconstruction
+    is asserted pixel-perfect against cv2 on two reference sizes, so the GPU
+    painter is bit-exact by construction for every box large enough to use the
+    template (smaller boxes take the per-box cv2 raster path).
+    """
+
+    def __init__(self, thickness: int):
+        self.thickness = thickness
+        reference_side = 8 * thickness + 32
+        second_side = reference_side + 9  # catches any size-dependence
+        margin = 4 * thickness + 8
+        ref = self._rasterise(margin, reference_side, thickness)
+        ys, xs = np.nonzero(ref)
+        self.outer = margin - int(ys.min())
+        mid_column = np.nonzero(ref[:, margin + reference_side // 2])[0]
+        self.inner = (
+            int(mid_column[mid_column < margin + reference_side // 2].max()) - margin
+        )
+        self.corner = 2 * (self.outer + self.inner) + 2
+        # Smallest box side (x2 - x1 + 1) the band+corner decomposition tiles.
+        self.min_side = 2 * self.corner - 2 * self.outer
+        c, o = self.corner, self.outer
+        far = margin + reference_side + o  # outermost painted row/col
+        self.corner_masks = np.stack(
+            [
+                ref[margin - o : margin - o + c, margin - o : margin - o + c],
+                ref[margin - o : margin - o + c, far - c + 1 : far + 1],
+                ref[far - c + 1 : far + 1, margin - o : margin - o + c],
+                ref[far - c + 1 : far + 1, far - c + 1 : far + 1],
+            ]
+        )  # (4, C, C) bool: TL, TR, BL, BR
+        for side in (reference_side, second_side):
+            self._assert_reconstruction(margin, side, thickness)
+
+    @staticmethod
+    def _rasterise(margin: int, side: int, thickness: int) -> np.ndarray:
+        size = side + 2 * margin + 1
+        canvas = np.zeros((size, size), np.uint8)
+        cv2.rectangle(
+            canvas, (margin, margin), (margin + side, margin + side), 255, thickness
+        )
+        return canvas > 0
+
+    def box_regions(
+        self, x1: int, y1: int, x2: int, y2: int
+    ) -> Tuple[List[Tuple[int, int, int, int]], List[Tuple[int, int]]]:
+        """Band rects (inclusive r1, r2, c1, c2) + corner anchors (r, c) for a
+        normalized box; only valid when both sides are >= ``min_side``."""
+        o, i, c = self.outer, self.inner, self.corner
+        ox1, oy1, ox2, oy2 = x1 - o, y1 - o, x2 + o, y2 + o
+        bands = [
+            (oy1, y1 + i, ox1 + c, ox2 - c),  # top
+            (y2 - i, oy2, ox1 + c, ox2 - c),  # bottom
+            (oy1 + c, oy2 - c, ox1, x1 + i),  # left
+            (oy1 + c, oy2 - c, x2 - i, ox2),  # right
+        ]
+        corners = [
+            (oy1, ox1),
+            (oy1, ox2 - c + 1),
+            (oy2 - c + 1, ox1),
+            (oy2 - c + 1, ox2 - c + 1),
+        ]
+        return bands, corners
+
+    def _assert_reconstruction(self, margin: int, side: int, thickness: int) -> None:
+        ref = self._rasterise(margin, side, thickness)
+        rebuilt = np.zeros_like(ref)
+        bands, corners = self.box_regions(
+            margin, margin, margin + side, margin + side
+        )
+        for r1, r2, c1, c2 in bands:
+            rebuilt[r1 : r2 + 1, c1 : c2 + 1] = True
+        for idx, (r, c) in enumerate(corners):
+            rebuilt[r : r + self.corner, c : c + self.corner] |= self.corner_masks[idx]
+        if not np.array_equal(rebuilt, ref):
+            raise ValueError(
+                f"cv2.rectangle band+corner decomposition failed for "
+                f"thickness={thickness} (unexpected OpenCV rasteriser geometry)"
+            )
+
+
+_GEOMETRY_CACHE: Dict[int, _BorderGeometry] = {}
+_EMPTY_I64 = np.zeros(0, dtype=np.int64)
+_DEVICE_CORNER_CACHE: Dict[Tuple[int, str], Tuple[torch.Tensor, torch.Tensor, torch.Tensor]] = {}
+
+
+def _get_geometry(thickness: int) -> _BorderGeometry:
+    if thickness not in _GEOMETRY_CACHE:
+        _GEOMETRY_CACHE[thickness] = _BorderGeometry(thickness)
+    return _GEOMETRY_CACHE[thickness]
+
+
+def _get_device_corner_offsets(
+    geometry: _BorderGeometry, device: torch.device
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Per-corner-slot local True offsets of the corner templates, padded to a
+    common length: ``(off_r, off_c, valid)`` each ``(4, K_max)`` on ``device``.
+    Uploaded once per (thickness, device) and reused for every frame."""
+    key = (geometry.thickness, str(device))
+    if key not in _DEVICE_CORNER_CACHE:
+        per_slot = [np.nonzero(mask) for mask in geometry.corner_masks]
+        k_max = max(len(rows) for rows, _ in per_slot)
+        off_r = np.zeros((4, k_max), dtype=np.int64)
+        off_c = np.zeros((4, k_max), dtype=np.int64)
+        valid = np.zeros((4, k_max), dtype=bool)
+        for slot, (rows, cols) in enumerate(per_slot):
+            off_r[slot, : len(rows)] = rows
+            off_c[slot, : len(cols)] = cols
+            valid[slot, : len(rows)] = True
+        _DEVICE_CORNER_CACHE[key] = (
+            torch.from_numpy(off_r).to(device),
+            torch.from_numpy(off_c).to(device),
+            torch.from_numpy(valid).to(device),
+        )
+    return _DEVICE_CORNER_CACHE[key]
+
+
+def gpu_draw_boxes(
+    scene_chw: torch.Tensor,
+    xyxy: np.ndarray,
+    colors_rgb: np.ndarray,
+    thickness: int,
+) -> torch.Tensor:
+    """GPU-native torch replacement for ``sv.BoxAnnotator.annotate`` on a CHW
+    RGB uint8 device tensor (the ``WorkflowImageData.tensor_image`` contract).
+    The scene tensor is mutated in place.
+
+    A per-box paint loop is hopeless on Jetson — python-op/kernel-launch
+    overhead (~12 ops per box) dominates the tiny border writes. Instead the
+    whole frame is painted with a FIXED number of torch ops regardless of box
+    count:
+
+    1. Host (numpy, all boxes at once): band rectangles + corner-patch anchors
+       from the cv2-derived geometry templates (see ``_BorderGeometry``),
+       clamped to the frame. Boxes too small for the template decomposition
+       are rasterised exactly by cv2.rectangle on tiny canvases and contribute
+       their pixel coords directly.
+    2. Device: ragged expansion of band rects to flat pixel indices
+       (``repeat_interleave`` with host-computed ``output_size`` — no device
+       sync), plus broadcast expansion of the padded corner offsets.
+    3. Overlap resolution: sv paints boxes sequentially so the HIGHEST
+       detection index wins every contested pixel — reproduced exactly by one
+       deterministic ``scatter_reduce_(amax)`` of box indices over the
+       frame, then a single indexed color write. Duplicate indices all write
+       the resolved winner's color, so the write is deterministic too.
+    """
+    geometry = _get_geometry(thickness)
+    device = scene_chw.device
+    height, width = int(scene_chw.shape[1]), int(scene_chw.shape[2])
+    o, c = geometry.outer, geometry.corner
+    inner = geometry.inner
+    n = int(xyxy.shape[0])
+
+    xy = np.asarray(xyxy, dtype=np.int64)
+    # cv2.rectangle normalizes swapped corners.
+    x1 = np.minimum(xy[:, 0], xy[:, 2])
+    x2 = np.maximum(xy[:, 0], xy[:, 2])
+    y1 = np.minimum(xy[:, 1], xy[:, 3])
+    y2 = np.maximum(xy[:, 1], xy[:, 3])
+    big = ((x2 - x1 + 1) >= geometry.min_side) & ((y2 - y1 + 1) >= geometry.min_side)
+
+    # ---- host-side prep (numpy) ----------------------------------------
+    rows = row_width = row_c1 = row_box = _EMPTY_I64
+    big_idx = np.nonzero(big)[0]
+    if len(big_idx):
+        bx1, bx2 = x1[big_idx], x2[big_idx]
+        by1, by2 = y1[big_idx], y2[big_idx]
+        ox1, oy1, ox2, oy2 = bx1 - o, by1 - o, bx2 + o, by2 + o
+        # Band rects (inclusive r1, r2, c1, c2) + owning detection index.
+        rect_r1 = np.concatenate([oy1, by2 - inner, oy1 + c, oy1 + c])
+        rect_r2 = np.concatenate([by1 + inner, oy2, oy2 - c, oy2 - c])
+        rect_c1 = np.concatenate([ox1 + c, ox1 + c, ox1, bx2 - inner])
+        rect_c2 = np.concatenate([ox2 - c, ox2 - c, bx1 + inner, ox2])
+        rect_box = np.tile(big_idx, 4)
+        np.clip(rect_r1, 0, None, out=rect_r1)
+        np.clip(rect_c1, 0, None, out=rect_c1)
+        np.clip(rect_r2, None, height - 1, out=rect_r2)
+        np.clip(rect_c2, None, width - 1, out=rect_c2)
+        heights = np.maximum(rect_r2 - rect_r1 + 1, 0)
+        widths = np.maximum(rect_c2 - rect_c1 + 1, 0)
+        # Row-level expansion on host: total row count is small (~band height
+        # x 4 x boxes), so numpy is cheap and gives exact output sizes for the
+        # device-side column expansion — no GPU->CPU sync anywhere.
+        total_rows = int(heights.sum())
+        if total_rows:
+            rect_of_row = np.repeat(np.arange(len(heights)), heights)
+            row_starts = np.cumsum(heights) - heights
+            rows = rect_r1[rect_of_row] + (
+                np.arange(total_rows) - row_starts[rect_of_row]
+            )
+            row_width = widths[rect_of_row]
+            keep = row_width > 0
+            rows, row_width = rows[keep], row_width[keep]
+            row_c1 = rect_c1[rect_of_row][keep]
+            row_box = rect_box[rect_of_row][keep]
+        # Corner-patch anchors (r, c) per corner slot (TL, TR, BL, BR).
+        anchor_r = np.concatenate([oy1, oy1, oy2 - c + 1, oy2 - c + 1])
+        anchor_c = np.concatenate([ox1, ox2 - c + 1, ox1, ox2 - c + 1])
+        anchor_slot = np.repeat(np.arange(4), len(big_idx))
+        anchor_box = np.tile(big_idx, 4)
+    else:
+        anchor_r = anchor_c = anchor_slot = anchor_box = _EMPTY_I64
+
+    small_flat = small_box = _EMPTY_I64
+    small_idx = np.nonzero(~big)[0]
+    if len(small_idx):
+        small_flat_parts: List[np.ndarray] = []
+        small_box_parts: List[np.ndarray] = []
+        for idx in small_idx:
+            # Joins overlap below min_side: rasterise the exact border with
+            # cv2 on a tiny host canvas (bounded by min_side + 2*outer).
+            bw, bh = int(x2[idx] - x1[idx]), int(y2[idx] - y1[idx])
+            canvas = np.zeros((bh + 1 + 2 * o, bw + 1 + 2 * o), np.uint8)
+            cv2.rectangle(canvas, (o, o), (o + bw, o + bh), 255, thickness)
+            rr, cc = np.nonzero(canvas)
+            rr = rr + int(y1[idx]) - o
+            cc = cc + int(x1[idx]) - o
+            keep = (rr >= 0) & (rr < height) & (cc >= 0) & (cc < width)
+            small_flat_parts.append(rr[keep] * width + cc[keep])
+            small_box_parts.append(np.full(int(keep.sum()), idx, dtype=np.int64))
+        small_flat = np.concatenate(small_flat_parts)
+        small_box = np.concatenate(small_box_parts)
+
+    total_px = int(row_width.sum())
+    if total_px == 0 and len(anchor_r) == 0 and len(small_flat) == 0:
+        return scene_chw
+
+    # ---- single packed H2D transfer -------------------------------------
+    # Per-transfer fixed cost is brutal on some Jetsons (~0.36 ms on AGX Orin
+    # vs ~0.06 ms on Orin Nano), so every host-built array ships in ONE
+    # upload and is sliced back into views on-device.
+    segments = [
+        rows,
+        row_width,
+        row_c1,
+        row_box,
+        anchor_r,
+        anchor_c,
+        anchor_slot,
+        anchor_box,
+        small_flat,
+        small_box,
+        colors_rgb.astype(np.int64).ravel(),
+    ]
+    packed = torch.from_numpy(np.concatenate(segments)).to(device)
+    views = []
+    offset = 0
+    for segment in segments:
+        views.append(packed[offset : offset + len(segment)])
+        offset += len(segment)
+    (
+        rows_t,
+        width_t,
+        c1_t,
+        box_t,
+        a_r,
+        a_c,
+        slot_t,
+        corner_box_t,
+        small_flat_t,
+        small_box_t,
+        colors_flat_t,
+    ) = views
+
+    # ---- device-side expansion ------------------------------------------
+    flat_parts: List[torch.Tensor] = []
+    box_parts: List[torch.Tensor] = []
+    if total_px:
+        row_of_px = torch.repeat_interleave(
+            torch.arange(int(rows_t.shape[0]), device=device),
+            width_t,
+            output_size=total_px,
+        )
+        col_starts = width_t.cumsum(0) - width_t
+        cols = c1_t[row_of_px] + (
+            torch.arange(total_px, device=device) - col_starts[row_of_px]
+        )
+        flat_parts.append(rows_t[row_of_px] * width + cols)
+        box_parts.append(box_t[row_of_px])
+    if len(anchor_r):
+        off_r, off_c, off_valid = _get_device_corner_offsets(geometry, device)
+        rr = a_r.unsqueeze(1) + off_r[slot_t]  # (A, K_max)
+        cc = a_c.unsqueeze(1) + off_c[slot_t]
+        keep = (
+            off_valid[slot_t]
+            & (rr >= 0)
+            & (rr < height)
+            & (cc >= 0)
+            & (cc < width)
+        )
+        flat_parts.append((rr * width + cc)[keep])
+        box_parts.append(
+            corner_box_t.unsqueeze(1).expand(-1, int(off_r.shape[1]))[keep]
+        )
+    if len(small_flat):
+        flat_parts.append(small_flat_t)
+        box_parts.append(small_box_t)
+
+    flat = torch.cat(flat_parts) if len(flat_parts) > 1 else flat_parts[0]
+    pixel_box = torch.cat(box_parts) if len(box_parts) > 1 else box_parts[0]
+    # include_self=False: uninitialized cells never participate, and every
+    # gathered position below was scattered to — no fill kernel needed.
+    owner = torch.empty(height * width, dtype=torch.int64, device=device)
+    owner.scatter_reduce_(0, flat, pixel_box, reduce="amax", include_self=False)
+    colors_dev = colors_flat_t.view(n, 3).to(torch.uint8)
+    winner_colors = colors_dev[owner[flat]]  # (P, 3) uint8
+    # .view (not .reshape): guarantees the write lands in the caller's storage
+    # (raises on a non-contiguous scene -> caught by the block's sv fallback).
+    scene_chw.view(3, -1)[:, flat] = winner_colors.t()
+    return scene_chw
+
+
+def _gpu_box_draw_eligible(
+    detections, color_axis: str, roundness: float, thickness
+) -> bool:
+    """True when the torch painter can replicate the sv path exactly."""
+    if roundness != 0:
+        # sv.RoundBoxAnnotator (elliptic arcs) keeps the battle-tested sv path.
+        return False
+    if color_axis not in ("CLASS", "INDEX"):
+        # TRACK / custom lookups keep the sv path.
+        return False
+    if not isinstance(thickness, int) or thickness < 1:
+        return False
+    xyxy = getattr(detections, "xyxy", None)
+    if not isinstance(xyxy, torch.Tensor) or int(xyxy.shape[0]) == 0:
+        # Nothing to paint; the sv path is a trivial no-op.
+        return False
+    return True
 
 
 class BoundingBoxManifest(ColorableVisualizationManifest):
@@ -159,6 +503,56 @@ class BoundingBoxVisualizationBlockV1(ColorableVisualizationBlock):
         thickness: Optional[int],
         roundness: Optional[float],
     ) -> BlockResult:
+        detections = (
+            split_key_point_prediction(predictions)[1]
+            if isinstance(predictions, tuple)
+            else predictions
+        )
+        if _gpu_box_draw_eligible(detections, color_axis, roundness, thickness):
+            try:
+                palette = self.getPalette(color_palette, palette_size, custom_colors)
+                if not isinstance(palette, sv.ColorPalette):
+                    raise TypeError("expected sv.ColorPalette")
+                # Same colors sv's resolve_color would pick: CLASS ->
+                # palette.by_idx(class_id), INDEX -> palette.by_idx(det index).
+                if color_axis == "CLASS":
+                    ids = detections.class_id.detach().cpu().numpy().astype(int)
+                else:
+                    ids = np.arange(int(detections.xyxy.shape[0]))
+                colors_rgb = np.asarray(
+                    [palette.by_idx(int(idx)).as_rgb() for idx in ids],
+                    dtype=np.uint8,
+                )
+                # Same int conversion as the sv annotator loop (truncation
+                # toward zero, incl. negative coords).
+                xyxy = detections.xyxy.detach().cpu().numpy().astype(int)
+                # Tensor pipeline contract: the image is a CHW RGB device
+                # tensor — zero-copy in, tensor out (downstream materialises
+                # numpy lazily only if something asks for it).
+                scene_t = image.tensor_image
+                if int(scene_t.shape[0]) != 3:
+                    raise ValueError("GPU box painter requires a 3-channel image")
+                if copy_image:
+                    scene_t = scene_t.clone()
+                annotated_tensor = gpu_draw_boxes(
+                    scene_t, xyxy, colors_rgb, int(thickness)
+                )
+                if not copy_image:
+                    # The painter mutated `image.tensor_image` storage in
+                    # place (the sv-path contract for copy_image=False);
+                    # invalidate the derived numpy/base64 caches.
+                    image.declare_tensor_image_mutated()
+                return {
+                    OUTPUT_IMAGE_KEY: WorkflowImageData.copy_and_replace(
+                        origin_image_data=image, tensor_image=annotated_tensor
+                    )
+                }
+            except Exception as gpu_error:
+                logger.debug(
+                    "GPU box painter failed (%s); falling back to "
+                    "sv.BoxAnnotator path.",
+                    gpu_error,
+                )
         predictions = to_supervision_for_annotation(predictions)
         annotator = self.getAnnotator(
             color_palette,

--- a/inference/core/workflows/core_steps/visualizations/bounding_box/v1_tensor.py
+++ b/inference/core/workflows/core_steps/visualizations/bounding_box/v1_tensor.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 from typing import Dict, List, Literal, Optional, Tuple, Type, Union
 
 import cv2
@@ -68,32 +69,41 @@ The annotated image from this block can be connected to:
 
 
 class _BorderGeometry:
-    """cv2-derived rasterisation template for one box thickness.
+    """cv2-derived rasterisation template for one (thickness, corner radius).
 
-    ``cv2.rectangle`` with ``thickness >= 2`` is NOT an outer-rect-minus-
-    inner-rect frame: the four edges are thick lines with round joins, so the
-    outermost corner pixels stay unpainted (and even thicknesses paint
-    ``thickness + 1`` wide bands). Instead of re-deriving OpenCV's thick-line
-    rasteriser, one reference rectangle is drawn with cv2 itself and decomposed
-    into four uniform straight bands plus four corner patches. Reconstruction
-    is asserted pixel-perfect against cv2 on two reference sizes, so the GPU
-    painter is bit-exact by construction for every box large enough to use the
-    template (smaller boxes take the per-box cv2 raster path).
+    ``radius is None`` reproduces ``sv.BoxAnnotator`` (one ``cv2.rectangle``
+    per box); an integer radius reproduces ``sv.RoundBoxAnnotator`` (four
+    quarter ``cv2.ellipse`` arcs + four ``cv2.line`` edges per box). Neither
+    is a simple outer-minus-inner frame: thick rectangles get round joins,
+    thick lines get round caps, and even thicknesses paint ``thickness + 1``
+    wide bands. Instead of re-deriving OpenCV's thick-line rasteriser, one
+    reference box is drawn with the exact same cv2 primitive sequence and
+    decomposed into four uniform straight bands plus four corner patches.
+    Reconstruction is asserted pixel-perfect against cv2 on two reference
+    sizes, so the GPU painter is bit-exact by construction for every box
+    large enough to use the template (smaller boxes take the per-box cv2
+    raster path).
     """
 
-    def __init__(self, thickness: int):
+    def __init__(self, thickness: int, radius: Optional[int] = None):
         self.thickness = thickness
-        reference_side = 8 * thickness + 32
-        second_side = reference_side + 9  # catches any size-dependence
+        self.radius = radius
         margin = 4 * thickness + 8
-        ref = self._rasterise(margin, reference_side, thickness)
-        ys, xs = np.nonzero(ref)
+        # Upper-bound the corner span before o/i are measured so the first
+        # raster is already big enough to host two corner patches + a body.
+        span_bound = (0 if radius is None else radius) + 2 * (2 * thickness + 4) + 2
+        reference_side = max(8 * thickness + 32, 2 * span_bound + 16)
+        second_side = reference_side + 9  # catches any size-dependence
+        ref = self._rasterise(margin, reference_side)
+        ys, _ = np.nonzero(ref)
         self.outer = margin - int(ys.min())
         mid_column = np.nonzero(ref[:, margin + reference_side // 2])[0]
         self.inner = (
             int(mid_column[mid_column < margin + reference_side // 2].max()) - margin
         )
-        self.corner = 2 * (self.outer + self.inner) + 2
+        self.corner = (0 if radius is None else radius) + 2 * (
+            self.outer + self.inner
+        ) + 2
         # Smallest box side (x2 - x1 + 1) the band+corner decomposition tiles.
         self.min_side = 2 * self.corner - 2 * self.outer
         c, o = self.corner, self.outer
@@ -106,17 +116,83 @@ class _BorderGeometry:
                 ref[far - c + 1 : far + 1, far - c + 1 : far + 1],
             ]
         )  # (4, C, C) bool: TL, TR, BL, BR
+        # Local True coords per corner patch, for host-side anchor+offset
+        # expansion (numpy) straight into the packed upload.
+        self.corner_offsets = [
+            (rows.astype(np.int64), cols.astype(np.int64))
+            for rows, cols in (np.nonzero(mask) for mask in self.corner_masks)
+        ]
         for side in (reference_side, second_side):
-            self._assert_reconstruction(margin, side, thickness)
+            self._assert_reconstruction(margin, side)
 
-    @staticmethod
-    def _rasterise(margin: int, side: int, thickness: int) -> np.ndarray:
+    def _draw(self, canvas: np.ndarray, x1: int, y1: int, x2: int, y2: int) -> None:
+        """The exact cv2 primitive sequence the sv annotator issues per box."""
+        if self.radius is None:
+            cv2.rectangle(canvas, (x1, y1), (x2, y2), 255, self.thickness)
+            return
+        radius = self.radius
+        circle_centers = [
+            (x1 + radius, y1 + radius),
+            (x2 - radius, y1 + radius),
+            (x2 - radius, y2 - radius),
+            (x1 + radius, y2 - radius),
+        ]
+        lines = [
+            ((x1 + radius, y1), (x2 - radius, y1)),
+            ((x2, y1 + radius), (x2, y2 - radius)),
+            ((x1 + radius, y2), (x2 - radius, y2)),
+            ((x1, y1 + radius), (x1, y2 - radius)),
+        ]
+        start_angles = (180, 270, 0, 90)
+        end_angles = (270, 360, 90, 180)
+        for center, line, start_angle, end_angle in zip(
+            circle_centers, lines, start_angles, end_angles
+        ):
+            cv2.ellipse(
+                img=canvas,
+                center=center,
+                axes=(radius, radius),
+                angle=0,
+                startAngle=start_angle,
+                endAngle=end_angle,
+                color=255,
+                thickness=self.thickness,
+            )
+            cv2.line(
+                img=canvas,
+                pt1=line[0],
+                pt2=line[1],
+                color=255,
+                thickness=self.thickness,
+            )
+
+    def _rasterise(self, margin: int, side: int) -> np.ndarray:
         size = side + 2 * margin + 1
         canvas = np.zeros((size, size), np.uint8)
-        cv2.rectangle(
-            canvas, (margin, margin), (margin + side, margin + side), 255, thickness
-        )
+        self._draw(canvas, margin, margin, margin + side, margin + side)
         return canvas > 0
+
+    def rasterise_box_border(
+        self, x1: int, y1: int, x2: int, y2: int, height: int, width: int
+    ) -> Optional[Tuple[np.ndarray, int, int]]:
+        """Exact border mask for one box that skips the template path, as
+        ``(mask, row0, col0)`` anchored in frame coords (``None`` when the box
+        cannot touch the frame).
+
+        The canvas is the frame-intersected border region, NOT a padded
+        crop: cv2 rasterises CLIPPED thick primitives differently from a
+        cropped unclipped draw (a round line cap relocated by ``clipLine``
+        shifts boundary pixels), so the canvas edges must coincide with the
+        frame edges on every side the box crosses. On non-crossing sides the
+        canvas keeps ``outer`` slack, beyond any painted pixel."""
+        o = self.outer
+        row0, col0 = max(y1 - o, 0), max(x1 - o, 0)
+        row1, col1 = min(y2 + o, height - 1), min(x2 + o, width - 1)
+        if row1 < row0 or col1 < col0:
+            return None
+        canvas = np.zeros((row1 - row0 + 1, col1 - col0 + 1), np.uint8)
+        self._draw(canvas, x1 - col0, y1 - row0, x2 - col0, y2 - row0)
+        return canvas > 0, row0, col0
 
     def box_regions(
         self, x1: int, y1: int, x2: int, y2: int
@@ -139,8 +215,8 @@ class _BorderGeometry:
         ]
         return bands, corners
 
-    def _assert_reconstruction(self, margin: int, side: int, thickness: int) -> None:
-        ref = self._rasterise(margin, side, thickness)
+    def _assert_reconstruction(self, margin: int, side: int) -> None:
+        ref = self._rasterise(margin, side)
         rebuilt = np.zeros_like(ref)
         bands, corners = self.box_regions(
             margin, margin, margin + side, margin + side
@@ -151,45 +227,30 @@ class _BorderGeometry:
             rebuilt[r : r + self.corner, c : c + self.corner] |= self.corner_masks[idx]
         if not np.array_equal(rebuilt, ref):
             raise ValueError(
-                f"cv2.rectangle band+corner decomposition failed for "
-                f"thickness={thickness} (unexpected OpenCV rasteriser geometry)"
+                f"cv2 band+corner decomposition failed for thickness="
+                f"{self.thickness}, radius={self.radius} (unexpected OpenCV "
+                f"rasteriser geometry)"
             )
 
 
-_GEOMETRY_CACHE: Dict[int, _BorderGeometry] = {}
+_GEOMETRY_CACHE: "OrderedDict[Tuple[int, Optional[int]], _BorderGeometry]" = (
+    OrderedDict()
+)
+_GEOMETRY_CACHE_LIMIT = 128  # rounded radii are data-dependent; bound the cache
 _EMPTY_I64 = np.zeros(0, dtype=np.int64)
-_DEVICE_CORNER_CACHE: Dict[Tuple[int, str], Tuple[torch.Tensor, torch.Tensor, torch.Tensor]] = {}
 
 
-def _get_geometry(thickness: int) -> _BorderGeometry:
-    if thickness not in _GEOMETRY_CACHE:
-        _GEOMETRY_CACHE[thickness] = _BorderGeometry(thickness)
-    return _GEOMETRY_CACHE[thickness]
-
-
-def _get_device_corner_offsets(
-    geometry: _BorderGeometry, device: torch.device
-) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    """Per-corner-slot local True offsets of the corner templates, padded to a
-    common length: ``(off_r, off_c, valid)`` each ``(4, K_max)`` on ``device``.
-    Uploaded once per (thickness, device) and reused for every frame."""
-    key = (geometry.thickness, str(device))
-    if key not in _DEVICE_CORNER_CACHE:
-        per_slot = [np.nonzero(mask) for mask in geometry.corner_masks]
-        k_max = max(len(rows) for rows, _ in per_slot)
-        off_r = np.zeros((4, k_max), dtype=np.int64)
-        off_c = np.zeros((4, k_max), dtype=np.int64)
-        valid = np.zeros((4, k_max), dtype=bool)
-        for slot, (rows, cols) in enumerate(per_slot):
-            off_r[slot, : len(rows)] = rows
-            off_c[slot, : len(cols)] = cols
-            valid[slot, : len(rows)] = True
-        _DEVICE_CORNER_CACHE[key] = (
-            torch.from_numpy(off_r).to(device),
-            torch.from_numpy(off_c).to(device),
-            torch.from_numpy(valid).to(device),
-        )
-    return _DEVICE_CORNER_CACHE[key]
+def _get_geometry(thickness: int, radius: Optional[int] = None) -> _BorderGeometry:
+    key = (thickness, radius)
+    geometry = _GEOMETRY_CACHE.get(key)
+    if geometry is None:
+        geometry = _BorderGeometry(thickness, radius)
+        _GEOMETRY_CACHE[key] = geometry
+        if len(_GEOMETRY_CACHE) > _GEOMETRY_CACHE_LIMIT:
+            _GEOMETRY_CACHE.popitem(last=False)
+    else:
+        _GEOMETRY_CACHE.move_to_end(key)
+    return geometry
 
 
 def gpu_draw_boxes(
@@ -197,58 +258,148 @@ def gpu_draw_boxes(
     xyxy: np.ndarray,
     colors_rgb: np.ndarray,
     thickness: int,
+    roundness: float = 0.0,
 ) -> torch.Tensor:
-    """GPU-native torch replacement for ``sv.BoxAnnotator.annotate`` on a CHW
-    RGB uint8 device tensor (the ``WorkflowImageData.tensor_image`` contract).
-    The scene tensor is mutated in place.
+    """GPU-native torch replacement for ``sv.BoxAnnotator.annotate``
+    (``roundness == 0``) and ``sv.RoundBoxAnnotator.annotate``
+    (``roundness > 0``) on a CHW RGB uint8 device tensor (the
+    ``WorkflowImageData.tensor_image`` contract). The scene tensor is mutated
+    in place.
 
-    A per-box paint loop is hopeless on Jetson — python-op/kernel-launch
-    overhead (~12 ops per box) dominates the tiny border writes. Instead the
-    whole frame is painted with a FIXED number of torch ops regardless of box
-    count:
+    A per-box torch paint loop is hopeless on Jetson — python-op/kernel-launch
+    overhead dominates the tiny border writes — so the whole frame is painted
+    with a FIXED number of torch ops regardless of box count:
 
-    1. Host (numpy, all boxes at once): band rectangles + corner-patch anchors
-       from the cv2-derived geometry templates (see ``_BorderGeometry``),
-       clamped to the frame. Boxes too small for the template decomposition
-       are rasterised exactly by cv2.rectangle on tiny canvases and contribute
-       their pixel coords directly.
-    2. Device: ragged expansion of band rects to flat pixel indices
-       (``repeat_interleave`` with host-computed ``output_size`` — no device
-       sync), plus broadcast expansion of the padded corner offsets.
+    1. Host (numpy, all boxes at once): straight-band rectangles + corner
+       patch pixel coords from the cv2-derived geometry templates (see
+       ``_BorderGeometry``; rounded boxes group by their sv corner radius
+       ``int(min_side // 2 * roundness)``). Boxes too small for the template
+       decomposition are rasterised exactly by the same cv2 primitives on
+       tiny canvases and contribute their pixel coords directly.
+    2. One packed H2D upload of every host-built array (per-transfer fixed
+       cost is brutal on some Jetsons: ~0.36 ms on AGX Orin vs ~0.06 ms on
+       Orin Nano), then device-side ragged expansion of band rects to flat
+       pixel indices (``repeat_interleave`` with host-computed
+       ``output_size`` — no device sync anywhere).
     3. Overlap resolution: sv paints boxes sequentially so the HIGHEST
        detection index wins every contested pixel — reproduced exactly by one
-       deterministic ``scatter_reduce_(amax)`` of box indices over the
-       frame, then a single indexed color write. Duplicate indices all write
-       the resolved winner's color, so the write is deterministic too.
+       deterministic ``scatter_reduce_(amax)`` of box indices over the frame,
+       then a single indexed color write. Duplicate indices all write the
+       resolved winner's color, so the write is deterministic too.
     """
-    geometry = _get_geometry(thickness)
+    geometry_square = _get_geometry(thickness) if roundness == 0 else None
     device = scene_chw.device
     height, width = int(scene_chw.shape[1]), int(scene_chw.shape[2])
-    o, c = geometry.outer, geometry.corner
-    inner = geometry.inner
     n = int(xyxy.shape[0])
 
     xy = np.asarray(xyxy, dtype=np.int64)
-    # cv2.rectangle normalizes swapped corners.
+    # cv2.rectangle normalizes swapped corners; detections are normalized
+    # upstream, so this is only defensive for the rounded path.
     x1 = np.minimum(xy[:, 0], xy[:, 2])
     x2 = np.maximum(xy[:, 0], xy[:, 2])
     y1 = np.minimum(xy[:, 1], xy[:, 3])
     y2 = np.maximum(xy[:, 1], xy[:, 3])
-    big = ((x2 - x1 + 1) >= geometry.min_side) & ((y2 - y1 + 1) >= geometry.min_side)
 
-    # ---- host-side prep (numpy) ----------------------------------------
-    rows = row_width = row_c1 = row_box = _EMPTY_I64
-    big_idx = np.nonzero(big)[0]
-    if len(big_idx):
-        bx1, bx2 = x1[big_idx], x2[big_idx]
-        by1, by2 = y1[big_idx], y2[big_idx]
-        ox1, oy1, ox2, oy2 = bx1 - o, by1 - o, bx2 + o, by2 + o
-        # Band rects (inclusive r1, r2, c1, c2) + owning detection index.
-        rect_r1 = np.concatenate([oy1, by2 - inner, oy1 + c, oy1 + c])
-        rect_r2 = np.concatenate([by1 + inner, oy2, oy2 - c, oy2 - c])
-        rect_c1 = np.concatenate([ox1 + c, ox1 + c, ox1, bx2 - inner])
-        rect_c2 = np.concatenate([ox2 - c, ox2 - c, bx1 + inner, ox2])
-        rect_box = np.tile(big_idx, 4)
+    if roundness == 0:
+        box_geometry = np.zeros(n, dtype=np.int64)  # one group, square
+        groups: List[Tuple[_BorderGeometry, np.ndarray]] = [
+            (geometry_square, np.arange(n))
+        ]
+    else:
+        # sv.RoundBoxAnnotator: radius = int(min_side // 2 * roundness), the
+        # smaller side chosen by strict width < height comparison.
+        box_w, box_h = x2 - x1, y2 - y1
+        radii = np.trunc(
+            np.where(box_w < box_h, box_w // 2, box_h // 2) * roundness
+        ).astype(np.int64)
+        groups = [
+            (_get_geometry(thickness, int(radius)), np.nonzero(radii == radius)[0])
+            for radius in np.unique(radii)
+        ]
+
+    # ---- host-side prep (numpy): bands + corner coords + small boxes -----
+    band_r1: List[np.ndarray] = []
+    band_r2: List[np.ndarray] = []
+    band_c1: List[np.ndarray] = []
+    band_c2: List[np.ndarray] = []
+    band_box: List[np.ndarray] = []
+    coord_flat: List[np.ndarray] = []  # pre-resolved pixel coords (corners, small)
+    coord_box: List[np.ndarray] = []
+
+    def _append_patch_coords(
+        rows: np.ndarray, cols: np.ndarray, box_index: int
+    ) -> None:
+        keep = (rows >= 0) & (rows < height) & (cols >= 0) & (cols < width)
+        coord_flat.append(rows[keep] * width + cols[keep])
+        coord_box.append(np.full(int(keep.sum()), box_index, dtype=np.int64))
+
+    for geometry, indices in groups:
+        o, inner, c = geometry.outer, geometry.inner, geometry.corner
+        gx1, gx2, gy1, gy2 = x1[indices], x2[indices], y1[indices], y2[indices]
+        big = ((gx2 - gx1 + 1) >= geometry.min_side) & (
+            (gy2 - gy1 + 1) >= geometry.min_side
+        )
+        if geometry.radius is not None:
+            # cv2 rasterises CLIPPED thick lines/arcs differently from a
+            # cropped unclipped draw (round caps relocate), so rounded boxes
+            # whose border region crosses the frame edge take the exact
+            # frame-clipped raster path. cv2.rectangle is crop/clip-identical
+            # (fuzz-verified), so square boxes keep the template everywhere.
+            big &= (
+                (gx1 - o >= 0)
+                & (gy1 - o >= 0)
+                & (gx2 + o <= width - 1)
+                & (gy2 + o <= height - 1)
+            )
+        big_pos = np.nonzero(big)[0]
+        if len(big_pos):
+            bx1, bx2 = gx1[big_pos], gx2[big_pos]
+            by1, by2 = gy1[big_pos], gy2[big_pos]
+            big_idx = indices[big_pos]
+            ox1, oy1, ox2, oy2 = bx1 - o, by1 - o, bx2 + o, by2 + o
+            # Band rects (inclusive r1, r2, c1, c2) + owning detection index.
+            band_r1.append(np.concatenate([oy1, by2 - inner, oy1 + c, oy1 + c]))
+            band_r2.append(np.concatenate([by1 + inner, oy2, oy2 - c, oy2 - c]))
+            band_c1.append(np.concatenate([ox1 + c, ox1 + c, ox1, bx2 - inner]))
+            band_c2.append(np.concatenate([ox2 - c, ox2 - c, bx1 + inner, ox2]))
+            band_box.append(np.tile(big_idx, 4))
+            # Corner patches: anchor + cached local offsets, vectorized over
+            # the group's boxes (host-side; ships in the packed upload).
+            anchors = (
+                (oy1, ox1),
+                (oy1, ox2 - c + 1),
+                (oy2 - c + 1, ox1),
+                (oy2 - c + 1, ox2 - c + 1),
+            )
+            for slot, (anchor_r, anchor_c) in enumerate(anchors):
+                off_r, off_c = geometry.corner_offsets[slot]
+                rows = (anchor_r[:, None] + off_r[None, :]).ravel()
+                cols = (anchor_c[:, None] + off_c[None, :]).ravel()
+                keep = (rows >= 0) & (rows < height) & (cols >= 0) & (cols < width)
+                coord_flat.append(rows[keep] * width + cols[keep])
+                coord_box.append(np.repeat(big_idx, len(off_r))[keep])
+        for pos in np.nonzero(~big)[0]:
+            # Corner geometry overlaps below min_side (joins/caps/arcs
+            # collide), or a rounded box crosses the frame edge: rasterise
+            # the exact border with the same cv2 primitives on a small
+            # frame-clipped host canvas.
+            idx = int(indices[pos])
+            rastered = geometry.rasterise_box_border(
+                int(x1[idx]), int(y1[idx]), int(x2[idx]), int(y2[idx]),
+                height, width,
+            )
+            if rastered is None:
+                continue
+            border, row0, col0 = rastered
+            rows, cols = np.nonzero(border)
+            _append_patch_coords(rows + row0, cols + col0, idx)
+
+    if band_r1:
+        rect_r1 = np.concatenate(band_r1)
+        rect_r2 = np.concatenate(band_r2)
+        rect_c1 = np.concatenate(band_c1)
+        rect_c2 = np.concatenate(band_c2)
+        rect_box = np.concatenate(band_box)
         np.clip(rect_r1, 0, None, out=rect_r1)
         np.clip(rect_c1, 0, None, out=rect_c1)
         np.clip(rect_r2, None, height - 1, out=rect_r2)
@@ -258,65 +409,33 @@ def gpu_draw_boxes(
         # Row-level expansion on host: total row count is small (~band height
         # x 4 x boxes), so numpy is cheap and gives exact output sizes for the
         # device-side column expansion — no GPU->CPU sync anywhere.
-        total_rows = int(heights.sum())
-        if total_rows:
-            rect_of_row = np.repeat(np.arange(len(heights)), heights)
-            row_starts = np.cumsum(heights) - heights
-            rows = rect_r1[rect_of_row] + (
-                np.arange(total_rows) - row_starts[rect_of_row]
-            )
-            row_width = widths[rect_of_row]
-            keep = row_width > 0
-            rows, row_width = rows[keep], row_width[keep]
-            row_c1 = rect_c1[rect_of_row][keep]
-            row_box = rect_box[rect_of_row][keep]
-        # Corner-patch anchors (r, c) per corner slot (TL, TR, BL, BR).
-        anchor_r = np.concatenate([oy1, oy1, oy2 - c + 1, oy2 - c + 1])
-        anchor_c = np.concatenate([ox1, ox2 - c + 1, ox1, ox2 - c + 1])
-        anchor_slot = np.repeat(np.arange(4), len(big_idx))
-        anchor_box = np.tile(big_idx, 4)
+        rect_of_row = np.repeat(np.arange(len(heights)), heights)
+        row_starts = np.cumsum(heights) - heights
+        rows = rect_r1[rect_of_row] + (
+            np.arange(len(rect_of_row)) - row_starts[rect_of_row]
+        )
+        row_width = widths[rect_of_row]
+        keep = row_width > 0
+        rows, row_width = rows[keep], row_width[keep]
+        row_c1 = rect_c1[rect_of_row][keep]
+        row_box = rect_box[rect_of_row][keep]
     else:
-        anchor_r = anchor_c = anchor_slot = anchor_box = _EMPTY_I64
+        rows = row_width = row_c1 = row_box = _EMPTY_I64
 
-    small_flat = small_box = _EMPTY_I64
-    small_idx = np.nonzero(~big)[0]
-    if len(small_idx):
-        small_flat_parts: List[np.ndarray] = []
-        small_box_parts: List[np.ndarray] = []
-        for idx in small_idx:
-            # Joins overlap below min_side: rasterise the exact border with
-            # cv2 on a tiny host canvas (bounded by min_side + 2*outer).
-            bw, bh = int(x2[idx] - x1[idx]), int(y2[idx] - y1[idx])
-            canvas = np.zeros((bh + 1 + 2 * o, bw + 1 + 2 * o), np.uint8)
-            cv2.rectangle(canvas, (o, o), (o + bw, o + bh), 255, thickness)
-            rr, cc = np.nonzero(canvas)
-            rr = rr + int(y1[idx]) - o
-            cc = cc + int(x1[idx]) - o
-            keep = (rr >= 0) & (rr < height) & (cc >= 0) & (cc < width)
-            small_flat_parts.append(rr[keep] * width + cc[keep])
-            small_box_parts.append(np.full(int(keep.sum()), idx, dtype=np.int64))
-        small_flat = np.concatenate(small_flat_parts)
-        small_box = np.concatenate(small_box_parts)
-
+    pre_flat = np.concatenate(coord_flat) if coord_flat else _EMPTY_I64
+    pre_box = np.concatenate(coord_box) if coord_box else _EMPTY_I64
     total_px = int(row_width.sum())
-    if total_px == 0 and len(anchor_r) == 0 and len(small_flat) == 0:
+    if total_px == 0 and len(pre_flat) == 0:
         return scene_chw
 
-    # ---- single packed H2D transfer -------------------------------------
-    # Per-transfer fixed cost is brutal on some Jetsons (~0.36 ms on AGX Orin
-    # vs ~0.06 ms on Orin Nano), so every host-built array ships in ONE
-    # upload and is sliced back into views on-device.
+    # ---- single packed H2D transfer --------------------------------------
     segments = [
         rows,
         row_width,
         row_c1,
         row_box,
-        anchor_r,
-        anchor_c,
-        anchor_slot,
-        anchor_box,
-        small_flat,
-        small_box,
+        pre_flat,
+        pre_box,
         colors_rgb.astype(np.int64).ravel(),
     ]
     packed = torch.from_numpy(np.concatenate(segments)).to(device)
@@ -325,21 +444,9 @@ def gpu_draw_boxes(
     for segment in segments:
         views.append(packed[offset : offset + len(segment)])
         offset += len(segment)
-    (
-        rows_t,
-        width_t,
-        c1_t,
-        box_t,
-        a_r,
-        a_c,
-        slot_t,
-        corner_box_t,
-        small_flat_t,
-        small_box_t,
-        colors_flat_t,
-    ) = views
+    rows_t, width_t, c1_t, box_t, pre_flat_t, pre_box_t, colors_flat_t = views
 
-    # ---- device-side expansion ------------------------------------------
+    # ---- device-side expansion --------------------------------------------
     flat_parts: List[torch.Tensor] = []
     box_parts: List[torch.Tensor] = []
     if total_px:
@@ -354,24 +461,9 @@ def gpu_draw_boxes(
         )
         flat_parts.append(rows_t[row_of_px] * width + cols)
         box_parts.append(box_t[row_of_px])
-    if len(anchor_r):
-        off_r, off_c, off_valid = _get_device_corner_offsets(geometry, device)
-        rr = a_r.unsqueeze(1) + off_r[slot_t]  # (A, K_max)
-        cc = a_c.unsqueeze(1) + off_c[slot_t]
-        keep = (
-            off_valid[slot_t]
-            & (rr >= 0)
-            & (rr < height)
-            & (cc >= 0)
-            & (cc < width)
-        )
-        flat_parts.append((rr * width + cc)[keep])
-        box_parts.append(
-            corner_box_t.unsqueeze(1).expand(-1, int(off_r.shape[1]))[keep]
-        )
-    if len(small_flat):
-        flat_parts.append(small_flat_t)
-        box_parts.append(small_box_t)
+    if len(pre_flat):
+        flat_parts.append(pre_flat_t)
+        box_parts.append(pre_box_t)
 
     flat = torch.cat(flat_parts) if len(flat_parts) > 1 else flat_parts[0]
     pixel_box = torch.cat(box_parts) if len(box_parts) > 1 else box_parts[0]
@@ -388,16 +480,17 @@ def gpu_draw_boxes(
 
 
 def _gpu_box_draw_eligible(
-    detections, color_axis: str, roundness: float, thickness
+    detections, color_axis: str, thickness, image: WorkflowImageData
 ) -> bool:
     """True when the torch painter can replicate the sv path exactly."""
-    if roundness != 0:
-        # sv.RoundBoxAnnotator (elliptic arcs) keeps the battle-tested sv path.
-        return False
     if color_axis not in ("CLASS", "INDEX"):
         # TRACK / custom lookups keep the sv path.
         return False
     if not isinstance(thickness, int) or thickness < 1:
+        return False
+    if not image.is_tensor_materialised():
+        # Forcing tensor_image on a numpy-sourced image is a costly host-side
+        # conversion — the sv path is faster there.
         return False
     xyxy = getattr(detections, "xyxy", None)
     if not isinstance(xyxy, torch.Tensor) or int(xyxy.shape[0]) == 0:
@@ -508,7 +601,7 @@ class BoundingBoxVisualizationBlockV1(ColorableVisualizationBlock):
             if isinstance(predictions, tuple)
             else predictions
         )
-        if _gpu_box_draw_eligible(detections, color_axis, roundness, thickness):
+        if _gpu_box_draw_eligible(detections, color_axis, thickness, image):
             try:
                 palette = self.getPalette(color_palette, palette_size, custom_colors)
                 if not isinstance(palette, sv.ColorPalette):
@@ -535,7 +628,7 @@ class BoundingBoxVisualizationBlockV1(ColorableVisualizationBlock):
                 if copy_image:
                     scene_t = scene_t.clone()
                 annotated_tensor = gpu_draw_boxes(
-                    scene_t, xyxy, colors_rgb, int(thickness)
+                    scene_t, xyxy, colors_rgb, int(thickness), float(roundness)
                 )
                 if not copy_image:
                     # The painter mutated `image.tensor_image` storage in

--- a/inference/core/workflows/core_steps/visualizations/bounding_box/v1_tensor.py
+++ b/inference/core/workflows/core_steps/visualizations/bounding_box/v1_tensor.py
@@ -1,7 +1,5 @@
-from collections import OrderedDict
 from typing import Dict, List, Literal, Optional, Tuple, Type, Union
 
-import cv2
 import numpy as np
 import supervision as sv
 import torch
@@ -68,390 +66,82 @@ The annotated image from this block can be connected to:
 """
 
 
-class _BorderGeometry:
-    """cv2-derived rasterisation template for one (thickness, corner radius).
-
-    ``radius is None`` reproduces ``sv.BoxAnnotator`` (one ``cv2.rectangle``
-    per box); an integer radius reproduces ``sv.RoundBoxAnnotator`` (four
-    quarter ``cv2.ellipse`` arcs + four ``cv2.line`` edges per box). Neither
-    is a simple outer-minus-inner frame: thick rectangles get round joins,
-    thick lines get round caps, and even thicknesses paint ``thickness + 1``
-    wide bands. Instead of re-deriving OpenCV's thick-line rasteriser, one
-    reference box is drawn with the exact same cv2 primitive sequence and
-    decomposed into four uniform straight bands plus four corner patches.
-    Reconstruction is asserted pixel-perfect against cv2 on two reference
-    sizes, so the GPU painter is bit-exact by construction for every box
-    large enough to use the template (smaller boxes take the per-box cv2
-    raster path).
-    """
-
-    def __init__(self, thickness: int, radius: Optional[int] = None):
-        self.thickness = thickness
-        self.radius = radius
-        margin = 4 * thickness + 8
-        # Upper-bound the corner span before o/i are measured so the first
-        # raster is already big enough to host two corner patches + a body.
-        span_bound = (0 if radius is None else radius) + 2 * (2 * thickness + 4) + 2
-        reference_side = max(8 * thickness + 32, 2 * span_bound + 16)
-        second_side = reference_side + 9  # catches any size-dependence
-        ref = self._rasterise(margin, reference_side)
-        ys, _ = np.nonzero(ref)
-        self.outer = margin - int(ys.min())
-        mid_column = np.nonzero(ref[:, margin + reference_side // 2])[0]
-        self.inner = (
-            int(mid_column[mid_column < margin + reference_side // 2].max()) - margin
-        )
-        self.corner = (0 if radius is None else radius) + 2 * (
-            self.outer + self.inner
-        ) + 2
-        # Smallest box side (x2 - x1 + 1) the band+corner decomposition tiles.
-        self.min_side = 2 * self.corner - 2 * self.outer
-        c, o = self.corner, self.outer
-        far = margin + reference_side + o  # outermost painted row/col
-        self.corner_masks = np.stack(
-            [
-                ref[margin - o : margin - o + c, margin - o : margin - o + c],
-                ref[margin - o : margin - o + c, far - c + 1 : far + 1],
-                ref[far - c + 1 : far + 1, margin - o : margin - o + c],
-                ref[far - c + 1 : far + 1, far - c + 1 : far + 1],
-            ]
-        )  # (4, C, C) bool: TL, TR, BL, BR
-        # Local True coords per corner patch, for host-side anchor+offset
-        # expansion (numpy) straight into the packed upload.
-        self.corner_offsets = [
-            (rows.astype(np.int64), cols.astype(np.int64))
-            for rows, cols in (np.nonzero(mask) for mask in self.corner_masks)
-        ]
-        for side in (reference_side, second_side):
-            self._assert_reconstruction(margin, side)
-
-    def _draw(self, canvas: np.ndarray, x1: int, y1: int, x2: int, y2: int) -> None:
-        """The exact cv2 primitive sequence the sv annotator issues per box."""
-        if self.radius is None:
-            cv2.rectangle(canvas, (x1, y1), (x2, y2), 255, self.thickness)
-            return
-        radius = self.radius
-        circle_centers = [
-            (x1 + radius, y1 + radius),
-            (x2 - radius, y1 + radius),
-            (x2 - radius, y2 - radius),
-            (x1 + radius, y2 - radius),
-        ]
-        lines = [
-            ((x1 + radius, y1), (x2 - radius, y1)),
-            ((x2, y1 + radius), (x2, y2 - radius)),
-            ((x1 + radius, y2), (x2 - radius, y2)),
-            ((x1, y1 + radius), (x1, y2 - radius)),
-        ]
-        start_angles = (180, 270, 0, 90)
-        end_angles = (270, 360, 90, 180)
-        for center, line, start_angle, end_angle in zip(
-            circle_centers, lines, start_angles, end_angles
-        ):
-            cv2.ellipse(
-                img=canvas,
-                center=center,
-                axes=(radius, radius),
-                angle=0,
-                startAngle=start_angle,
-                endAngle=end_angle,
-                color=255,
-                thickness=self.thickness,
-            )
-            cv2.line(
-                img=canvas,
-                pt1=line[0],
-                pt2=line[1],
-                color=255,
-                thickness=self.thickness,
-            )
-
-    def _rasterise(self, margin: int, side: int) -> np.ndarray:
-        size = side + 2 * margin + 1
-        canvas = np.zeros((size, size), np.uint8)
-        self._draw(canvas, margin, margin, margin + side, margin + side)
-        return canvas > 0
-
-    def rasterise_box_border(
-        self, x1: int, y1: int, x2: int, y2: int, height: int, width: int
-    ) -> Optional[Tuple[np.ndarray, int, int]]:
-        """Exact border mask for one box that skips the template path, as
-        ``(mask, row0, col0)`` anchored in frame coords (``None`` when the box
-        cannot touch the frame).
-
-        The canvas is the frame-intersected border region, NOT a padded
-        crop: cv2 rasterises CLIPPED thick primitives differently from a
-        cropped unclipped draw (a round line cap relocated by ``clipLine``
-        shifts boundary pixels), so the canvas edges must coincide with the
-        frame edges on every side the box crosses. On non-crossing sides the
-        canvas keeps ``outer`` slack, beyond any painted pixel."""
-        o = self.outer
-        row0, col0 = max(y1 - o, 0), max(x1 - o, 0)
-        row1, col1 = min(y2 + o, height - 1), min(x2 + o, width - 1)
-        if row1 < row0 or col1 < col0:
-            return None
-        canvas = np.zeros((row1 - row0 + 1, col1 - col0 + 1), np.uint8)
-        self._draw(canvas, x1 - col0, y1 - row0, x2 - col0, y2 - row0)
-        return canvas > 0, row0, col0
-
-    def box_regions(
-        self, x1: int, y1: int, x2: int, y2: int
-    ) -> Tuple[List[Tuple[int, int, int, int]], List[Tuple[int, int]]]:
-        """Band rects (inclusive r1, r2, c1, c2) + corner anchors (r, c) for a
-        normalized box; only valid when both sides are >= ``min_side``."""
-        o, i, c = self.outer, self.inner, self.corner
-        ox1, oy1, ox2, oy2 = x1 - o, y1 - o, x2 + o, y2 + o
-        bands = [
-            (oy1, y1 + i, ox1 + c, ox2 - c),  # top
-            (y2 - i, oy2, ox1 + c, ox2 - c),  # bottom
-            (oy1 + c, oy2 - c, ox1, x1 + i),  # left
-            (oy1 + c, oy2 - c, x2 - i, ox2),  # right
-        ]
-        corners = [
-            (oy1, ox1),
-            (oy1, ox2 - c + 1),
-            (oy2 - c + 1, ox1),
-            (oy2 - c + 1, ox2 - c + 1),
-        ]
-        return bands, corners
-
-    def _assert_reconstruction(self, margin: int, side: int) -> None:
-        ref = self._rasterise(margin, side)
-        rebuilt = np.zeros_like(ref)
-        bands, corners = self.box_regions(
-            margin, margin, margin + side, margin + side
-        )
-        for r1, r2, c1, c2 in bands:
-            rebuilt[r1 : r2 + 1, c1 : c2 + 1] = True
-        for idx, (r, c) in enumerate(corners):
-            rebuilt[r : r + self.corner, c : c + self.corner] |= self.corner_masks[idx]
-        if not np.array_equal(rebuilt, ref):
-            raise ValueError(
-                f"cv2 band+corner decomposition failed for thickness="
-                f"{self.thickness}, radius={self.radius} (unexpected OpenCV "
-                f"rasteriser geometry)"
-            )
-
-
-_GEOMETRY_CACHE: "OrderedDict[Tuple[int, Optional[int]], _BorderGeometry]" = (
-    OrderedDict()
-)
-_GEOMETRY_CACHE_LIMIT = 128  # rounded radii are data-dependent; bound the cache
-_EMPTY_I64 = np.zeros(0, dtype=np.int64)
-
-
-def _get_geometry(thickness: int, radius: Optional[int] = None) -> _BorderGeometry:
-    key = (thickness, radius)
-    geometry = _GEOMETRY_CACHE.get(key)
-    if geometry is None:
-        geometry = _BorderGeometry(thickness, radius)
-        _GEOMETRY_CACHE[key] = geometry
-        if len(_GEOMETRY_CACHE) > _GEOMETRY_CACHE_LIMIT:
-            _GEOMETRY_CACHE.popitem(last=False)
-    else:
-        _GEOMETRY_CACHE.move_to_end(key)
-    return geometry
-
-
 def gpu_draw_boxes(
     scene_chw: torch.Tensor,
     xyxy: np.ndarray,
     colors_rgb: np.ndarray,
     thickness: int,
-    roundness: float = 0.0,
 ) -> torch.Tensor:
-    """GPU-native torch replacement for ``sv.BoxAnnotator.annotate``
-    (``roundness == 0``) and ``sv.RoundBoxAnnotator.annotate``
-    (``roundness > 0``) on a CHW RGB uint8 device tensor (the
-    ``WorkflowImageData.tensor_image`` contract). The scene tensor is mutated
-    in place.
+    """Draw square box borders on a CHW RGB uint8 device tensor, in place.
 
-    A per-box torch paint loop is hopeless on Jetson — python-op/kernel-launch
-    overhead dominates the tiny border writes — so the whole frame is painted
-    with a FIXED number of torch ops regardless of box count:
+    Approximate rendering: each border is a plain ``thickness``-wide band
+    centered on the box edge with square corners. cv2 (the sv path) draws
+    round joins and slightly different band widths, so output is visually
+    equivalent but not bit-identical.
 
-    1. Host (numpy, all boxes at once): straight-band rectangles + corner
-       patch pixel coords from the cv2-derived geometry templates (see
-       ``_BorderGeometry``; rounded boxes group by their sv corner radius
-       ``int(min_side // 2 * roundness)``). Boxes too small for the template
-       decomposition are rasterised exactly by the same cv2 primitives on
-       tiny canvases and contribute their pixel coords directly.
-    2. One packed H2D upload of every host-built array (per-transfer fixed
-       cost is brutal on some Jetsons: ~0.36 ms on AGX Orin vs ~0.06 ms on
-       Orin Nano), then device-side ragged expansion of band rects to flat
-       pixel indices (``repeat_interleave`` with host-computed
-       ``output_size`` — no device sync anywhere).
-    3. Overlap resolution: sv paints boxes sequentially so the HIGHEST
-       detection index wins every contested pixel — reproduced exactly by one
-       deterministic ``scatter_reduce_(amax)`` of box indices over the frame,
-       then a single indexed color write. Duplicate indices all write the
-       resolved winner's color, so the write is deterministic too.
+    Painted with a fixed number of torch ops regardless of box count — a
+    per-box loop is dispatch-bound on Jetson (measured 43 ms @ 50 boxes):
+
+    1. Host: 4 band rectangles per box, clamped to the frame.
+    2. One packed int32 H2D upload (per-transfer fixed cost is ~0.36 ms on
+       AGX Orin), then two-level ragged expansion to flat pixel indices via
+       ``repeat_interleave`` with host-computed ``output_size`` — no
+       GPU->CPU syncs.
+    3. One indexed store. When boxes overlap, sv's later-box-wins paint
+       order is reproduced with a deterministic ``scatter_reduce_(amax)``
+       of box indices; disjoint boxes (the common case) skip it.
     """
-    geometry_square = _get_geometry(thickness) if roundness == 0 else None
     device = scene_chw.device
     height, width = int(scene_chw.shape[1]), int(scene_chw.shape[2])
     if height * width >= 2**31:
         raise ValueError("frame too large for int32 pixel indexing")
     n = int(xyxy.shape[0])
+    outer = thickness // 2  # band extends `outer` outward, rest inward
 
     xy = np.asarray(xyxy, dtype=np.int64)
-    # cv2.rectangle normalizes swapped corners; detections are normalized
-    # upstream, so this is only defensive for the rounded path.
-    x1 = np.minimum(xy[:, 0], xy[:, 2])
-    x2 = np.maximum(xy[:, 0], xy[:, 2])
-    y1 = np.minimum(xy[:, 1], xy[:, 3])
-    y2 = np.maximum(xy[:, 1], xy[:, 3])
+    x1 = np.minimum(xy[:, 0], xy[:, 2]) - outer
+    x2 = np.maximum(xy[:, 0], xy[:, 2]) + outer
+    y1 = np.minimum(xy[:, 1], xy[:, 3]) - outer
+    y2 = np.maximum(xy[:, 1], xy[:, 3]) + outer
 
-    if roundness == 0:
-        box_geometry = np.zeros(n, dtype=np.int64)  # one group, square
-        groups: List[Tuple[_BorderGeometry, np.ndarray]] = [
-            (geometry_square, np.arange(n))
-        ]
-    else:
-        # sv.RoundBoxAnnotator: radius = int(min_side // 2 * roundness), the
-        # smaller side chosen by strict width < height comparison.
-        box_w, box_h = x2 - x1, y2 - y1
-        radii = np.trunc(
-            np.where(box_w < box_h, box_w // 2, box_h // 2) * roundness
-        ).astype(np.int64)
-        groups = [
-            (_get_geometry(thickness, int(radius)), np.nonzero(radii == radius)[0])
-            for radius in np.unique(radii)
-        ]
-
-    # ---- host-side prep (numpy): bands + corner coords + small boxes -----
-    band_r1: List[np.ndarray] = []
-    band_r2: List[np.ndarray] = []
-    band_c1: List[np.ndarray] = []
-    band_c2: List[np.ndarray] = []
-    band_box: List[np.ndarray] = []
-    coord_flat: List[np.ndarray] = []  # pre-resolved pixel coords (corners, small)
-    coord_box: List[np.ndarray] = []
-
-    def _append_patch_coords(
-        rows: np.ndarray, cols: np.ndarray, box_index: int
-    ) -> None:
-        keep = (rows >= 0) & (rows < height) & (cols >= 0) & (cols < width)
-        coord_flat.append(rows[keep] * width + cols[keep])
-        coord_box.append(np.full(int(keep.sum()), box_index, dtype=np.int64))
-
-    # Expanded per-box paint bounds, for the host-side overlap test below.
-    exp_x1 = np.empty(n, dtype=np.int64)
-    exp_x2 = np.empty(n, dtype=np.int64)
-    exp_y1 = np.empty(n, dtype=np.int64)
-    exp_y2 = np.empty(n, dtype=np.int64)
-
-    for geometry, indices in groups:
-        o, inner, c = geometry.outer, geometry.inner, geometry.corner
-        gx1, gx2, gy1, gy2 = x1[indices], x2[indices], y1[indices], y2[indices]
-        exp_x1[indices], exp_x2[indices] = gx1 - o, gx2 + o
-        exp_y1[indices], exp_y2[indices] = gy1 - o, gy2 + o
-        big = ((gx2 - gx1 + 1) >= geometry.min_side) & (
-            (gy2 - gy1 + 1) >= geometry.min_side
-        )
-        if geometry.radius is not None:
-            # cv2 rasterises CLIPPED thick lines/arcs differently from a
-            # cropped unclipped draw (round caps relocate), so rounded boxes
-            # whose border region crosses the frame edge take the exact
-            # frame-clipped raster path. cv2.rectangle is crop/clip-identical
-            # (fuzz-verified), so square boxes keep the template everywhere.
-            big &= (
-                (gx1 - o >= 0)
-                & (gy1 - o >= 0)
-                & (gx2 + o <= width - 1)
-                & (gy2 + o <= height - 1)
-            )
-        big_pos = np.nonzero(big)[0]
-        if len(big_pos):
-            bx1, bx2 = gx1[big_pos], gx2[big_pos]
-            by1, by2 = gy1[big_pos], gy2[big_pos]
-            big_idx = indices[big_pos]
-            ox1, oy1, ox2, oy2 = bx1 - o, by1 - o, bx2 + o, by2 + o
-            # Band rects (inclusive r1, r2, c1, c2) + owning detection index.
-            band_r1.append(np.concatenate([oy1, by2 - inner, oy1 + c, oy1 + c]))
-            band_r2.append(np.concatenate([by1 + inner, oy2, oy2 - c, oy2 - c]))
-            band_c1.append(np.concatenate([ox1 + c, ox1 + c, ox1, bx2 - inner]))
-            band_c2.append(np.concatenate([ox2 - c, ox2 - c, bx1 + inner, ox2]))
-            band_box.append(np.tile(big_idx, 4))
-            # Corner patches: anchor + cached local offsets, vectorized over
-            # the group's boxes (host-side; ships in the packed upload).
-            anchors = (
-                (oy1, ox1),
-                (oy1, ox2 - c + 1),
-                (oy2 - c + 1, ox1),
-                (oy2 - c + 1, ox2 - c + 1),
-            )
-            for slot, (anchor_r, anchor_c) in enumerate(anchors):
-                off_r, off_c = geometry.corner_offsets[slot]
-                rows = (anchor_r[:, None] + off_r[None, :]).ravel()
-                cols = (anchor_c[:, None] + off_c[None, :]).ravel()
-                keep = (rows >= 0) & (rows < height) & (cols >= 0) & (cols < width)
-                coord_flat.append(rows[keep] * width + cols[keep])
-                coord_box.append(np.repeat(big_idx, len(off_r))[keep])
-        for pos in np.nonzero(~big)[0]:
-            # Corner geometry overlaps below min_side (joins/caps/arcs
-            # collide), or a rounded box crosses the frame edge: rasterise
-            # the exact border with the same cv2 primitives on a small
-            # frame-clipped host canvas.
-            idx = int(indices[pos])
-            rastered = geometry.rasterise_box_border(
-                int(x1[idx]), int(y1[idx]), int(x2[idx]), int(y2[idx]),
-                height, width,
-            )
-            if rastered is None:
-                continue
-            border, row0, col0 = rastered
-            rows, cols = np.nonzero(border)
-            _append_patch_coords(rows + row0, cols + col0, idx)
-
-    if band_r1:
-        rect_r1 = np.concatenate(band_r1)
-        rect_r2 = np.concatenate(band_r2)
-        rect_c1 = np.concatenate(band_c1)
-        rect_c2 = np.concatenate(band_c2)
-        rect_box = np.concatenate(band_box)
-        np.clip(rect_r1, 0, None, out=rect_r1)
-        np.clip(rect_c1, 0, None, out=rect_c1)
-        np.clip(rect_r2, None, height - 1, out=rect_r2)
-        np.clip(rect_c2, None, width - 1, out=rect_c2)
-        heights = np.maximum(rect_r2 - rect_r1 + 1, 0)
-        widths = np.maximum(rect_c2 - rect_c1 + 1, 0)
-    else:
-        rect_r1 = rect_c1 = heights = widths = rect_box = _EMPTY_I64
-
-    pre_flat = np.concatenate(coord_flat) if coord_flat else _EMPTY_I64
-    pre_box = np.concatenate(coord_box) if coord_box else _EMPTY_I64
-    # Exact expansion sizes, computed host-side so the device-side ragged
-    # expansion never needs a GPU->CPU sync. Zero-area rects (fully clamped
-    # away) simply repeat 0 times.
+    # 4 bands per box (inclusive coords): top/bottom span the full width,
+    # left/right fill between them. Degenerate boxes just overlap bands of
+    # the same color — harmless.
+    t = thickness
+    rect_r1 = np.concatenate([y1, y2 - t + 1, y1 + t, y1 + t])
+    rect_r2 = np.concatenate([y1 + t - 1, y2, y2 - t, y2 - t])
+    rect_c1 = np.concatenate([x1, x1, x1, x2 - t + 1])
+    rect_c2 = np.concatenate([x2, x2, x1 + t - 1, x2])
+    rect_box = np.tile(np.arange(n), 4)
+    np.clip(rect_r1, 0, None, out=rect_r1)
+    np.clip(rect_c1, 0, None, out=rect_c1)
+    np.clip(rect_r2, None, height - 1, out=rect_r2)
+    np.clip(rect_c2, None, width - 1, out=rect_c2)
+    heights = np.maximum(rect_r2 - rect_r1 + 1, 0)
+    widths = np.maximum(rect_c2 - rect_c1 + 1, 0)
     total_rows = int(heights.sum())
     total_px = int((heights * widths).sum())
-    if total_px == 0 and len(pre_flat) == 0:
+    if total_px == 0:
         return scene_chw
 
-    # Host-side pairwise overlap test on the expanded paint bounds (O(n^2) on
-    # tiny arrays). Disjoint borders make every pixel's winner its own box, so
-    # the owner-resolution kernels can be skipped entirely — the common case.
-    inter = (
-        (np.maximum(exp_x1[:, None], exp_x1[None, :])
-         <= np.minimum(exp_x2[:, None], exp_x2[None, :]))
-        & (np.maximum(exp_y1[:, None], exp_y1[None, :])
-           <= np.minimum(exp_y2[:, None], exp_y2[None, :]))
+    # Pairwise overlap test on the expanded bounds: disjoint borders make
+    # every pixel's winner its own box, so owner resolution can be skipped.
+    inter_x = np.maximum(x1[:, None], x1[None, :]) <= np.minimum(
+        x2[:, None], x2[None, :]
     )
-    boxes_overlap = int(inter.sum()) > n  # diagonal is always True
+    inter_y = np.maximum(y1[:, None], y1[None, :]) <= np.minimum(
+        y2[:, None], y2[None, :]
+    )
+    boxes_overlap = int((inter_x & inter_y).sum()) > n  # diagonal always True
 
-    # ---- single packed H2D transfer --------------------------------------
-    # int32 throughout: pixel indices fit (frame size is guarded in run());
-    # halving the element width halves the transfer and every device-side
-    # memory pass. torch's index ops demand int64, so `flat` is cast once.
+    # Single packed upload; int32 halves the transfer and every device-side
+    # memory pass (torch index ops demand int64 — `flat` is cast once).
     segments = [
         rect_r1,
         heights,
         rect_c1,
         widths,
         rect_box,
-        pre_flat,
-        pre_box,
         colors_rgb.astype(np.int64).ravel(),
     ]
     packed = torch.from_numpy(np.concatenate(segments).astype(np.int32)).to(device)
@@ -460,108 +150,40 @@ def gpu_draw_boxes(
     for segment in segments:
         views.append(packed[offset : offset + len(segment)])
         offset += len(segment)
-    r1_t, heights_t, c1_t, widths_t, box_t, pre_flat_t, pre_box_t, colors_flat_t = views
+    r1_t, heights_t, c1_t, widths_t, box_t, colors_flat_t = views
 
-    # ---- device-side two-level ragged expansion (rect -> row -> pixel) ----
-    flat_parts: List[torch.Tensor] = []
-    box_parts: List[torch.Tensor] = []
-    if total_px:
-        rect_count = int(heights.shape[0])
-        rect_of_row = torch.repeat_interleave(
-            torch.arange(rect_count, device=device),
-            heights_t.long(),
-            output_size=total_rows,
-        )
-        row_starts = heights_t.cumsum(0) - heights_t
-        row_intra = (
-            torch.arange(total_rows, device=device, dtype=torch.int32)
-            - row_starts[rect_of_row]
-        )
-        row_base = (r1_t[rect_of_row] + row_intra) * width + c1_t[rect_of_row]
-        row_width = widths_t[rect_of_row]
-        row_box = box_t[rect_of_row]
-        px_of_row = torch.repeat_interleave(
-            torch.arange(total_rows, device=device),
-            row_width.long(),
-            output_size=total_px,
-        )
-        col_starts = row_width.cumsum(0) - row_width
-        px_intra = (
-            torch.arange(total_px, device=device, dtype=torch.int32)
-            - col_starts[px_of_row]
-        )
-        flat_parts.append(row_base[px_of_row] + px_intra)
-        box_parts.append(row_box[px_of_row])
-    if len(pre_flat):
-        flat_parts.append(pre_flat_t)
-        box_parts.append(pre_box_t)
+    # Two-level ragged expansion: rect -> row -> pixel.
+    rect_of_row = torch.repeat_interleave(
+        torch.arange(4 * n, device=device), heights_t.long(), output_size=total_rows
+    )
+    row_starts = heights_t.cumsum(0) - heights_t
+    row_intra = (
+        torch.arange(total_rows, device=device, dtype=torch.int32)
+        - row_starts[rect_of_row]
+    )
+    row_base = (r1_t[rect_of_row] + row_intra) * width + c1_t[rect_of_row]
+    row_width = widths_t[rect_of_row]
+    row_box = box_t[rect_of_row]
+    px_of_row = torch.repeat_interleave(
+        torch.arange(total_rows, device=device), row_width.long(), output_size=total_px
+    )
+    col_starts = row_width.cumsum(0) - row_width
+    px_intra = (
+        torch.arange(total_px, device=device, dtype=torch.int32)
+        - col_starts[px_of_row]
+    )
+    flat = (row_base[px_of_row] + px_intra).long()
+    pixel_box = row_box[px_of_row]
 
-    flat = torch.cat(flat_parts) if len(flat_parts) > 1 else flat_parts[0]
-    pixel_box = torch.cat(box_parts) if len(box_parts) > 1 else box_parts[0]
-    flat_long = flat.long()  # index ops require int64
     colors_dev = colors_flat_t.view(n, 3).to(torch.uint8)
     if boxes_overlap:
-        # sv paints boxes sequentially, so the HIGHEST detection index wins
-        # every contested pixel: one deterministic amax scatter of box ids.
-        # include_self=False: uninitialized cells never participate, and every
-        # gathered position below was scattered to — no fill kernel needed.
+        # include_self=False: uninitialized cells never participate, and
+        # every gathered position below was scattered to.
         owner = torch.empty(height * width, dtype=torch.int32, device=device)
-        owner.scatter_reduce_(
-            0, flat_long, pixel_box, reduce="amax", include_self=False
-        )
-        winner_colors = colors_dev[owner[flat_long].long()]  # (P, 3) uint8
+        owner.scatter_reduce_(0, flat, pixel_box, reduce="amax", include_self=False)
+        winner_colors = colors_dev[owner[flat].long()]  # (P, 3) uint8
     else:
         winner_colors = colors_dev[pixel_box.long()]
-    # .view (not .reshape): guarantees the write lands in the caller's storage
-    # (raises on a non-contiguous scene -> caught by the block's sv fallback).
-    scene_chw.view(3, -1)[:, flat_long] = winner_colors.t()
-    return scene_chw
-
-    # ---- single packed H2D transfer --------------------------------------
-    segments = [
-        rows,
-        row_width,
-        row_c1,
-        row_box,
-        pre_flat,
-        pre_box,
-        colors_rgb.astype(np.int64).ravel(),
-    ]
-    packed = torch.from_numpy(np.concatenate(segments)).to(device)
-    views = []
-    offset = 0
-    for segment in segments:
-        views.append(packed[offset : offset + len(segment)])
-        offset += len(segment)
-    rows_t, width_t, c1_t, box_t, pre_flat_t, pre_box_t, colors_flat_t = views
-
-    # ---- device-side expansion --------------------------------------------
-    flat_parts: List[torch.Tensor] = []
-    box_parts: List[torch.Tensor] = []
-    if total_px:
-        row_of_px = torch.repeat_interleave(
-            torch.arange(int(rows_t.shape[0]), device=device),
-            width_t,
-            output_size=total_px,
-        )
-        col_starts = width_t.cumsum(0) - width_t
-        cols = c1_t[row_of_px] + (
-            torch.arange(total_px, device=device) - col_starts[row_of_px]
-        )
-        flat_parts.append(rows_t[row_of_px] * width + cols)
-        box_parts.append(box_t[row_of_px])
-    if len(pre_flat):
-        flat_parts.append(pre_flat_t)
-        box_parts.append(pre_box_t)
-
-    flat = torch.cat(flat_parts) if len(flat_parts) > 1 else flat_parts[0]
-    pixel_box = torch.cat(box_parts) if len(box_parts) > 1 else box_parts[0]
-    # include_self=False: uninitialized cells never participate, and every
-    # gathered position below was scattered to — no fill kernel needed.
-    owner = torch.empty(height * width, dtype=torch.int64, device=device)
-    owner.scatter_reduce_(0, flat, pixel_box, reduce="amax", include_self=False)
-    colors_dev = colors_flat_t.view(n, 3).to(torch.uint8)
-    winner_colors = colors_dev[owner[flat]]  # (P, 3) uint8
     # .view (not .reshape): guarantees the write lands in the caller's storage
     # (raises on a non-contiguous scene -> caught by the block's sv fallback).
     scene_chw.view(3, -1)[:, flat] = winner_colors.t()
@@ -569,9 +191,12 @@ def gpu_draw_boxes(
 
 
 def _gpu_box_draw_eligible(
-    detections, color_axis: str, thickness, image: WorkflowImageData
+    detections, color_axis: str, roundness: float, thickness, image: WorkflowImageData
 ) -> bool:
-    """True when the torch painter can replicate the sv path exactly."""
+    """True when the torch painter can replace the sv path."""
+    if roundness != 0:
+        # Rounded corners keep the sv.RoundBoxAnnotator path.
+        return False
     if color_axis not in ("CLASS", "INDEX"):
         # TRACK / custom lookups keep the sv path.
         return False
@@ -690,7 +315,7 @@ class BoundingBoxVisualizationBlockV1(ColorableVisualizationBlock):
             if isinstance(predictions, tuple)
             else predictions
         )
-        if _gpu_box_draw_eligible(detections, color_axis, thickness, image):
+        if _gpu_box_draw_eligible(detections, color_axis, roundness, thickness, image):
             try:
                 palette = self.getPalette(color_palette, palette_size, custom_colors)
                 if not isinstance(palette, sv.ColorPalette):
@@ -717,7 +342,7 @@ class BoundingBoxVisualizationBlockV1(ColorableVisualizationBlock):
                 if copy_image:
                     scene_t = scene_t.clone()
                 annotated_tensor = gpu_draw_boxes(
-                    scene_t, xyxy, colors_rgb, int(thickness), float(roundness)
+                    scene_t, xyxy, colors_rgb, int(thickness)
                 )
                 if not copy_image:
                     # The painter mutated `image.tensor_image` storage in

--- a/inference/core/workflows/core_steps/visualizations/bounding_box/v1_tensor.py
+++ b/inference/core/workflows/core_steps/visualizations/bounding_box/v1_tensor.py
@@ -290,6 +290,8 @@ def gpu_draw_boxes(
     geometry_square = _get_geometry(thickness) if roundness == 0 else None
     device = scene_chw.device
     height, width = int(scene_chw.shape[1]), int(scene_chw.shape[2])
+    if height * width >= 2**31:
+        raise ValueError("frame too large for int32 pixel indexing")
     n = int(xyxy.shape[0])
 
     xy = np.asarray(xyxy, dtype=np.int64)
@@ -333,9 +335,17 @@ def gpu_draw_boxes(
         coord_flat.append(rows[keep] * width + cols[keep])
         coord_box.append(np.full(int(keep.sum()), box_index, dtype=np.int64))
 
+    # Expanded per-box paint bounds, for the host-side overlap test below.
+    exp_x1 = np.empty(n, dtype=np.int64)
+    exp_x2 = np.empty(n, dtype=np.int64)
+    exp_y1 = np.empty(n, dtype=np.int64)
+    exp_y2 = np.empty(n, dtype=np.int64)
+
     for geometry, indices in groups:
         o, inner, c = geometry.outer, geometry.inner, geometry.corner
         gx1, gx2, gy1, gy2 = x1[indices], x2[indices], y1[indices], y2[indices]
+        exp_x1[indices], exp_x2[indices] = gx1 - o, gx2 + o
+        exp_y1[indices], exp_y2[indices] = gy1 - o, gy2 + o
         big = ((gx2 - gx1 + 1) >= geometry.min_side) & (
             (gy2 - gy1 + 1) >= geometry.min_side
         )
@@ -406,27 +416,106 @@ def gpu_draw_boxes(
         np.clip(rect_c2, None, width - 1, out=rect_c2)
         heights = np.maximum(rect_r2 - rect_r1 + 1, 0)
         widths = np.maximum(rect_c2 - rect_c1 + 1, 0)
-        # Row-level expansion on host: total row count is small (~band height
-        # x 4 x boxes), so numpy is cheap and gives exact output sizes for the
-        # device-side column expansion — no GPU->CPU sync anywhere.
-        rect_of_row = np.repeat(np.arange(len(heights)), heights)
-        row_starts = np.cumsum(heights) - heights
-        rows = rect_r1[rect_of_row] + (
-            np.arange(len(rect_of_row)) - row_starts[rect_of_row]
-        )
-        row_width = widths[rect_of_row]
-        keep = row_width > 0
-        rows, row_width = rows[keep], row_width[keep]
-        row_c1 = rect_c1[rect_of_row][keep]
-        row_box = rect_box[rect_of_row][keep]
     else:
-        rows = row_width = row_c1 = row_box = _EMPTY_I64
+        rect_r1 = rect_c1 = heights = widths = rect_box = _EMPTY_I64
 
     pre_flat = np.concatenate(coord_flat) if coord_flat else _EMPTY_I64
     pre_box = np.concatenate(coord_box) if coord_box else _EMPTY_I64
-    total_px = int(row_width.sum())
+    # Exact expansion sizes, computed host-side so the device-side ragged
+    # expansion never needs a GPU->CPU sync. Zero-area rects (fully clamped
+    # away) simply repeat 0 times.
+    total_rows = int(heights.sum())
+    total_px = int((heights * widths).sum())
     if total_px == 0 and len(pre_flat) == 0:
         return scene_chw
+
+    # Host-side pairwise overlap test on the expanded paint bounds (O(n^2) on
+    # tiny arrays). Disjoint borders make every pixel's winner its own box, so
+    # the owner-resolution kernels can be skipped entirely — the common case.
+    inter = (
+        (np.maximum(exp_x1[:, None], exp_x1[None, :])
+         <= np.minimum(exp_x2[:, None], exp_x2[None, :]))
+        & (np.maximum(exp_y1[:, None], exp_y1[None, :])
+           <= np.minimum(exp_y2[:, None], exp_y2[None, :]))
+    )
+    boxes_overlap = int(inter.sum()) > n  # diagonal is always True
+
+    # ---- single packed H2D transfer --------------------------------------
+    # int32 throughout: pixel indices fit (frame size is guarded in run());
+    # halving the element width halves the transfer and every device-side
+    # memory pass. torch's index ops demand int64, so `flat` is cast once.
+    segments = [
+        rect_r1,
+        heights,
+        rect_c1,
+        widths,
+        rect_box,
+        pre_flat,
+        pre_box,
+        colors_rgb.astype(np.int64).ravel(),
+    ]
+    packed = torch.from_numpy(np.concatenate(segments).astype(np.int32)).to(device)
+    views = []
+    offset = 0
+    for segment in segments:
+        views.append(packed[offset : offset + len(segment)])
+        offset += len(segment)
+    r1_t, heights_t, c1_t, widths_t, box_t, pre_flat_t, pre_box_t, colors_flat_t = views
+
+    # ---- device-side two-level ragged expansion (rect -> row -> pixel) ----
+    flat_parts: List[torch.Tensor] = []
+    box_parts: List[torch.Tensor] = []
+    if total_px:
+        rect_count = int(heights.shape[0])
+        rect_of_row = torch.repeat_interleave(
+            torch.arange(rect_count, device=device),
+            heights_t.long(),
+            output_size=total_rows,
+        )
+        row_starts = heights_t.cumsum(0) - heights_t
+        row_intra = (
+            torch.arange(total_rows, device=device, dtype=torch.int32)
+            - row_starts[rect_of_row]
+        )
+        row_base = (r1_t[rect_of_row] + row_intra) * width + c1_t[rect_of_row]
+        row_width = widths_t[rect_of_row]
+        row_box = box_t[rect_of_row]
+        px_of_row = torch.repeat_interleave(
+            torch.arange(total_rows, device=device),
+            row_width.long(),
+            output_size=total_px,
+        )
+        col_starts = row_width.cumsum(0) - row_width
+        px_intra = (
+            torch.arange(total_px, device=device, dtype=torch.int32)
+            - col_starts[px_of_row]
+        )
+        flat_parts.append(row_base[px_of_row] + px_intra)
+        box_parts.append(row_box[px_of_row])
+    if len(pre_flat):
+        flat_parts.append(pre_flat_t)
+        box_parts.append(pre_box_t)
+
+    flat = torch.cat(flat_parts) if len(flat_parts) > 1 else flat_parts[0]
+    pixel_box = torch.cat(box_parts) if len(box_parts) > 1 else box_parts[0]
+    flat_long = flat.long()  # index ops require int64
+    colors_dev = colors_flat_t.view(n, 3).to(torch.uint8)
+    if boxes_overlap:
+        # sv paints boxes sequentially, so the HIGHEST detection index wins
+        # every contested pixel: one deterministic amax scatter of box ids.
+        # include_self=False: uninitialized cells never participate, and every
+        # gathered position below was scattered to — no fill kernel needed.
+        owner = torch.empty(height * width, dtype=torch.int32, device=device)
+        owner.scatter_reduce_(
+            0, flat_long, pixel_box, reduce="amax", include_self=False
+        )
+        winner_colors = colors_dev[owner[flat_long].long()]  # (P, 3) uint8
+    else:
+        winner_colors = colors_dev[pixel_box.long()]
+    # .view (not .reshape): guarantees the write lands in the caller's storage
+    # (raises on a non-contiguous scene -> caught by the block's sv fallback).
+    scene_chw.view(3, -1)[:, flat_long] = winner_colors.t()
+    return scene_chw
 
     # ---- single packed H2D transfer --------------------------------------
     segments = [

--- a/inference/core/workflows/core_steps/visualizations/bounding_box/v1_tensor.py
+++ b/inference/core/workflows/core_steps/visualizations/bounding_box/v1_tensor.py
@@ -1,3 +1,4 @@
+from functools import lru_cache
 from typing import Dict, List, Literal, Optional, Tuple, Type, Union
 
 import numpy as np
@@ -27,6 +28,8 @@ from inference.core.workflows.execution_engine.entities.types import (
     Selector,
 )
 from inference.core.workflows.prototypes.block import BlockResult, WorkflowBlockManifest
+
+_EMPTY_I64 = np.zeros(0, dtype=np.int64)
 
 TYPE: str = "roboflow_core/bounding_box_visualization@v1"
 SHORT_DESCRIPTION = "Draw a box around detected objects in an image."
@@ -66,18 +69,36 @@ The annotated image from this block can be connected to:
 """
 
 
+@lru_cache(maxsize=256)
+def _quarter_arc_offsets(radius: int, thickness: int) -> Tuple[np.ndarray, np.ndarray]:
+    """(dy, dx) pixel offsets of a top-left quarter ring around an arc
+    center — a `thickness`-wide annulus at `radius`. Mirrored by sign for
+    the other three corners. Cached per (radius, thickness) across frames."""
+    outer = thickness // 2
+    span = radius + outer
+    yy, xx = np.mgrid[-span : 1, -span : 1]
+    dist = np.sqrt(yy**2 + xx**2)
+    ring = (dist >= radius - (thickness - 1 - outer) - 0.5) & (
+        dist <= radius + outer + 0.5
+    )
+    return yy[ring].astype(np.int64), xx[ring].astype(np.int64)
+
+
 def gpu_draw_boxes(
     scene_chw: torch.Tensor,
     xyxy: np.ndarray,
     colors_rgb: np.ndarray,
     thickness: int,
+    roundness: float = 0.0,
 ) -> torch.Tensor:
-    """Draw square box borders on a CHW RGB uint8 device tensor, in place.
+    """Draw box borders on a CHW RGB uint8 device tensor, in place.
 
     Approximate rendering: each border is a plain ``thickness``-wide band
-    centered on the box edge with square corners. cv2 (the sv path) draws
-    round joins and slightly different band widths, so output is visually
-    equivalent but not bit-identical.
+    centered on the box edge. ``roundness > 0`` rounds the corners with
+    analytic quarter-ring arcs at sv's corner radius
+    (``int(min_side // 2 * roundness)``). cv2 (the sv path) rasterises
+    joins/caps/arcs slightly differently, so output is visually equivalent,
+    not bit-identical.
 
     Painted with a fixed number of torch ops regardless of box count — a
     per-box loop is dispatch-bound on Jetson (measured 43 ms @ 50 boxes):
@@ -99,19 +120,27 @@ def gpu_draw_boxes(
     outer = thickness // 2  # band extends `outer` outward, rest inward
 
     xy = np.asarray(xyxy, dtype=np.int64)
-    x1 = np.minimum(xy[:, 0], xy[:, 2]) - outer
-    x2 = np.maximum(xy[:, 0], xy[:, 2]) + outer
-    y1 = np.minimum(xy[:, 1], xy[:, 3]) - outer
-    y2 = np.maximum(xy[:, 1], xy[:, 3]) + outer
+    bx1 = np.minimum(xy[:, 0], xy[:, 2])
+    bx2 = np.maximum(xy[:, 0], xy[:, 2])
+    by1 = np.minimum(xy[:, 1], xy[:, 3])
+    by2 = np.maximum(xy[:, 1], xy[:, 3])
+    if roundness > 0:
+        # sv.RoundBoxAnnotator's corner radius, from the smaller box side.
+        radii = (np.minimum(bx2 - bx1, by2 - by1) // 2 * roundness).astype(np.int64)
+    else:
+        radii = np.zeros(n, dtype=np.int64)
+    x1, x2, y1, y2 = bx1 - outer, bx2 + outer, by1 - outer, by2 + outer
 
-    # 4 bands per box (inclusive coords): top/bottom span the full width,
-    # left/right fill between them. Degenerate boxes just overlap bands of
-    # the same color — harmless.
+    # 4 bands per box (inclusive coords). Square corners: top/bottom span
+    # the full width, left/right fill between them. Rounded: every band is
+    # inset by the corner radius; quarter-ring arcs (below) fill the joins.
+    # Degenerate boxes just overlap bands of the same color — harmless.
     t = thickness
-    rect_r1 = np.concatenate([y1, y2 - t + 1, y1 + t, y1 + t])
-    rect_r2 = np.concatenate([y1 + t - 1, y2, y2 - t, y2 - t])
-    rect_c1 = np.concatenate([x1, x1, x1, x2 - t + 1])
-    rect_c2 = np.concatenate([x2, x2, x1 + t - 1, x2])
+    inset = radii - outer  # 0 boxes: -outer == square full-width bands
+    rect_r1 = np.concatenate([y1, y2 - t + 1, by1 + radii, by1 + radii])
+    rect_r2 = np.concatenate([y1 + t - 1, y2, by2 - radii, by2 - radii])
+    rect_c1 = np.concatenate([x1 + inset + outer, x1 + inset + outer, x1, x2 - t + 1])
+    rect_c2 = np.concatenate([x2 - inset - outer, x2 - inset - outer, x1 + t - 1, x2])
     rect_box = np.tile(np.arange(n), 4)
     np.clip(rect_r1, 0, None, out=rect_r1)
     np.clip(rect_c1, 0, None, out=rect_c1)
@@ -134,6 +163,29 @@ def gpu_draw_boxes(
     )
     boxes_overlap = int((inter_x & inter_y).sum()) > n  # diagonal always True
 
+    # Rounded corners: quarter-ring arc pixels per box, grouped by radius so
+    # the ring offsets are computed (and lru-cached) once per radius. Coords
+    # are pre-resolved to flat indices on host and ride the packed upload.
+    arc_flat = arc_box = _EMPTY_I64
+    if roundness > 0:
+        flat_parts, box_parts = [], []
+        for radius in np.unique(radii):
+            idx = np.nonzero(radii == radius)[0]
+            dy, dx = _quarter_arc_offsets(int(radius), thickness)
+            centers_y = (by1[idx] + radius, by1[idx] + radius,
+                         by2[idx] - radius, by2[idx] - radius)
+            centers_x = (bx1[idx] + radius, bx2[idx] - radius,
+                         bx1[idx] + radius, bx2[idx] - radius)
+            signs = ((1, 1), (1, -1), (-1, 1), (-1, -1))
+            for cy, cx, (sy, sx) in zip(centers_y, centers_x, signs):
+                rows = (cy[:, None] + sy * dy[None, :]).ravel()
+                cols = (cx[:, None] + sx * dx[None, :]).ravel()
+                keep = (rows >= 0) & (rows < height) & (cols >= 0) & (cols < width)
+                flat_parts.append(rows[keep] * width + cols[keep])
+                box_parts.append(np.repeat(idx, len(dy))[keep])
+        arc_flat = np.concatenate(flat_parts)
+        arc_box = np.concatenate(box_parts)
+
     # Single packed upload; int32 halves the transfer and every device-side
     # memory pass (torch index ops demand int64 — `flat` is cast once).
     segments = [
@@ -142,6 +194,8 @@ def gpu_draw_boxes(
         rect_c1,
         widths,
         rect_box,
+        arc_flat,
+        arc_box,
         colors_rgb.astype(np.int64).ravel(),
     ]
     packed = torch.from_numpy(np.concatenate(segments).astype(np.int32)).to(device)
@@ -150,7 +204,7 @@ def gpu_draw_boxes(
     for segment in segments:
         views.append(packed[offset : offset + len(segment)])
         offset += len(segment)
-    r1_t, heights_t, c1_t, widths_t, box_t, colors_flat_t = views
+    r1_t, heights_t, c1_t, widths_t, box_t, arc_flat_t, arc_box_t, colors_flat_t = views
 
     # Two-level ragged expansion: rect -> row -> pixel.
     rect_of_row = torch.repeat_interleave(
@@ -172,8 +226,12 @@ def gpu_draw_boxes(
         torch.arange(total_px, device=device, dtype=torch.int32)
         - col_starts[px_of_row]
     )
-    flat = (row_base[px_of_row] + px_intra).long()
+    flat = row_base[px_of_row] + px_intra
     pixel_box = row_box[px_of_row]
+    if len(arc_flat):
+        flat = torch.cat([flat, arc_flat_t])
+        pixel_box = torch.cat([pixel_box, arc_box_t])
+    flat = flat.long()
 
     colors_dev = colors_flat_t.view(n, 3).to(torch.uint8)
     if boxes_overlap:
@@ -191,12 +249,9 @@ def gpu_draw_boxes(
 
 
 def _gpu_box_draw_eligible(
-    detections, color_axis: str, roundness: float, thickness, image: WorkflowImageData
+    detections, color_axis: str, thickness, image: WorkflowImageData
 ) -> bool:
     """True when the torch painter can replace the sv path."""
-    if roundness != 0:
-        # Rounded corners keep the sv.RoundBoxAnnotator path.
-        return False
     if color_axis not in ("CLASS", "INDEX"):
         # TRACK / custom lookups keep the sv path.
         return False
@@ -315,7 +370,7 @@ class BoundingBoxVisualizationBlockV1(ColorableVisualizationBlock):
             if isinstance(predictions, tuple)
             else predictions
         )
-        if _gpu_box_draw_eligible(detections, color_axis, roundness, thickness, image):
+        if _gpu_box_draw_eligible(detections, color_axis, thickness, image):
             try:
                 palette = self.getPalette(color_palette, palette_size, custom_colors)
                 if not isinstance(palette, sv.ColorPalette):
@@ -342,7 +397,7 @@ class BoundingBoxVisualizationBlockV1(ColorableVisualizationBlock):
                 if copy_image:
                     scene_t = scene_t.clone()
                 annotated_tensor = gpu_draw_boxes(
-                    scene_t, xyxy, colors_rgb, int(thickness)
+                    scene_t, xyxy, colors_rgb, int(thickness), float(roundness)
                 )
                 if not copy_image:
                     # The painter mutated `image.tensor_image` storage in

--- a/tests/workflows/unit_tests/core_steps/visualizations/test_bounding_box_v1_tensor_gpu.py
+++ b/tests/workflows/unit_tests/core_steps/visualizations/test_bounding_box_v1_tensor_gpu.py
@@ -226,37 +226,20 @@ def _tensor_backed_image() -> WorkflowImageData:
 
 
 def test_gpu_box_draw_eligible_happy_path() -> None:
-    assert (
-        _gpu_box_draw_eligible(
-            _eligible_detections(), "CLASS", 2, _tensor_backed_image()
+    for axis in ("CLASS", "INDEX", "TRACK"):
+        assert (
+            _gpu_box_draw_eligible(
+                _eligible_detections(), axis, _tensor_backed_image()
+            )
+            is True
         )
-        is True
-    )
-
-
-def test_gpu_box_draw_not_eligible_for_track_lookup() -> None:
-    assert (
-        _gpu_box_draw_eligible(
-            _eligible_detections(), "TRACK", 2, _tensor_backed_image()
-        )
-        is False
-    )
 
 
 def test_gpu_box_draw_not_eligible_for_empty_detections() -> None:
     empty = _build_detections(
         np.zeros((0, 4), dtype=np.float32), np.zeros((0,), dtype=int), device="cpu"
     )
-    assert _gpu_box_draw_eligible(empty, "CLASS", 2, _tensor_backed_image()) is False
-
-
-def test_gpu_box_draw_not_eligible_for_non_int_thickness() -> None:
-    assert (
-        _gpu_box_draw_eligible(
-            _eligible_detections(), "CLASS", "2", _tensor_backed_image()
-        )
-        is False
-    )
+    assert _gpu_box_draw_eligible(empty, "CLASS", _tensor_backed_image()) is False
 
 
 def test_gpu_box_draw_not_eligible_for_numpy_sourced_image() -> None:
@@ -265,5 +248,47 @@ def test_gpu_box_draw_not_eligible_for_numpy_sourced_image() -> None:
         numpy_image=np.zeros((64, 64, 3), dtype=np.uint8),
     )
     assert (
-        _gpu_box_draw_eligible(_eligible_detections(), "CLASS", 2, numpy_image) is False
+        _gpu_box_draw_eligible(_eligible_detections(), "CLASS", numpy_image) is False
+    )
+
+def test_track_color_axis_matches_sv_colors() -> None:
+    from inference.core.workflows.core_steps.visualizations.bounding_box.v1_tensor import (
+        BoundingBoxVisualizationBlockV1,
+    )
+
+    boxes = np.array([[20, 20, 90, 90], [150, 30, 260, 140], [40, 150, 120, 220]])
+    tracker_ids = [7, -1, 3]  # -1 = sv pending track (gray)
+    detections = Detections(
+        xyxy=torch.tensor(boxes, dtype=torch.float32),
+        class_id=torch.tensor([0, 1, 2]),
+        confidence=torch.full((3,), 0.9),
+        bboxes_metadata=[{"tracker_id": tid} for tid in tracker_ids],
+    )
+    image = _tensor_backed_image_sized(240, 320)
+    block = BoundingBoxVisualizationBlockV1()
+    out = block.run(
+        image=image,
+        predictions=detections,
+        copy_image=True,
+        color_palette="DEFAULT",
+        palette_size=10,
+        custom_colors=None,
+        color_axis="TRACK",
+        thickness=2,
+        roundness=0.0,
+    )["image"]
+    assert out._tensor_image is not None and out._numpy_image is None  # GPU path
+    annotated = out._tensor_image
+    for (x1, y1, _, _), tid in zip(boxes, tracker_ids):
+        expected = (
+            (128, 128, 128) if tid == -1 else PALETTE.by_idx(tid).as_rgb()
+        )
+        got = tuple(int(v) for v in annotated[:, y1, x1 + 10])  # top band pixel
+        assert got == expected, f"track {tid}: {got} != {expected}"
+
+
+def _tensor_backed_image_sized(h: int, w: int) -> WorkflowImageData:
+    return WorkflowImageData(
+        parent_metadata=ImageParentMetadata(parent_id="p"),
+        tensor_image=torch.zeros((3, h, w), dtype=torch.uint8),
     )

--- a/tests/workflows/unit_tests/core_steps/visualizations/test_bounding_box_v1_tensor_gpu.py
+++ b/tests/workflows/unit_tests/core_steps/visualizations/test_bounding_box_v1_tensor_gpu.py
@@ -1,0 +1,164 @@
+import itertools
+
+import numpy as np
+import pytest
+import supervision as sv
+import torch
+
+from inference.core.workflows.core_steps.visualizations.bounding_box.v1_tensor import (
+    _get_geometry,
+    _gpu_box_draw_eligible,
+    gpu_draw_boxes,
+)
+from inference_models.models.base.object_detection import Detections
+
+requires_cuda = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="requires CUDA"
+)
+
+PALETTE = sv.ColorPalette.DEFAULT
+SCENE_H, SCENE_W = 240, 320
+
+
+def _build_detections(boxes: np.ndarray, class_id: np.ndarray, device: str) -> Detections:
+    n = boxes.shape[0]
+    return Detections(
+        xyxy=torch.tensor(boxes, dtype=torch.float32, device=device),
+        class_id=torch.tensor(class_id, dtype=torch.int32, device=device),
+        confidence=torch.full((n,), 0.9, device=device),
+        image_metadata={"class_names": {i: f"c{i}" for i in range(10)}},
+    )
+
+
+def _assert_parity(
+    xyxy: np.ndarray,
+    class_id: np.ndarray,
+    thickness: int,
+    color_axis: str,
+    device: str,
+) -> None:
+    rng = np.random.default_rng(7)
+    base_bgr = rng.integers(0, 256, (SCENE_H, SCENE_W, 3), dtype=np.uint8)
+    detections = sv.Detections(
+        xyxy=xyxy.astype(np.float32), class_id=class_id.astype(int)
+    )
+    annotator = sv.BoxAnnotator(
+        color=PALETTE,
+        color_lookup=getattr(sv.ColorLookup, color_axis),
+        thickness=thickness,
+    )
+    reference = annotator.annotate(scene=base_bgr.copy(), detections=detections)
+
+    scene_chw_rgb = (
+        torch.from_numpy(base_bgr[:, :, ::-1].copy())
+        .permute(2, 0, 1)
+        .contiguous()
+        .to(device)
+    )
+    ids = class_id if color_axis == "CLASS" else np.arange(xyxy.shape[0])
+    colors_rgb = np.asarray(
+        [PALETTE.by_idx(int(idx)).as_rgb() for idx in ids], dtype=np.uint8
+    )
+    annotated = gpu_draw_boxes(
+        scene_chw_rgb,
+        xyxy.astype(np.float32).astype(int),
+        colors_rgb,
+        thickness,
+    )
+    got_bgr = annotated.permute(1, 2, 0).cpu().numpy()[:, :, ::-1]
+
+    exact = np.all(got_bgr == reference, axis=-1).mean()
+    assert exact == 1.0, f"exact match rate {exact}"
+    assert int(np.abs(got_bgr.astype(int) - reference.astype(int)).max()) == 0
+
+
+_SCENARIOS = {
+    "plain": np.array([[30, 40, 120, 100], [150, 60, 290, 200]], dtype=float),
+    "overlap_chain": np.array(
+        [[30, 40, 160, 160], [80, 90, 200, 210], [100, 20, 140, 230]], dtype=float
+    ),
+    "off_image": np.array(
+        [[-20, -30, 60, 50], [250, 180, 400, 400], [-50, 100, 380, 140]], dtype=float
+    ),
+    "tiny_and_degenerate": np.array(
+        [[10, 10, 12, 12], [50, 50, 50, 60], [70, 70, 70, 70], [90, 5, 95, 9]],
+        dtype=float,
+    ),
+    "subpixel_coords": np.array(
+        [[30.7, 40.2, 120.9, 100.5], [-0.4, -0.6, 33.3, 44.9]], dtype=float
+    ),
+    "edge_touching": np.array(
+        [[0, 0, SCENE_W - 1, SCENE_H - 1], [5, 5, 15, SCENE_H - 10]], dtype=float
+    ),
+}
+
+
+@pytest.mark.parametrize("scenario", sorted(_SCENARIOS))
+@pytest.mark.parametrize("thickness", [1, 2, 3, 4, 5, 8])
+@pytest.mark.parametrize("color_axis", ["CLASS", "INDEX"])
+def test_gpu_box_parity_on_cpu(scenario: str, thickness: int, color_axis: str) -> None:
+    # The painter is device-agnostic; CPU run gives full parity coverage in
+    # plain CI (identical kernels run on CUDA).
+    xyxy = _SCENARIOS[scenario]
+    class_id = np.arange(xyxy.shape[0]) % 3
+    _assert_parity(xyxy, class_id, thickness, color_axis, device="cpu")
+
+
+@requires_cuda
+@pytest.mark.parametrize("thickness", [1, 2, 4])
+def test_gpu_box_parity_on_cuda(thickness: int) -> None:
+    rng = np.random.default_rng(11)
+    xs = np.sort(rng.uniform(-30, SCENE_W + 30, (12, 2)), axis=1)
+    ys = np.sort(rng.uniform(-30, SCENE_H + 30, (12, 2)), axis=1)
+    xyxy = np.stack([xs[:, 0], ys[:, 0], xs[:, 1], ys[:, 1]], axis=1)
+    class_id = np.arange(12) % 4
+    _assert_parity(xyxy, class_id, thickness, "CLASS", device="cuda")
+
+
+def test_gpu_box_paint_is_in_place() -> None:
+    scene = torch.zeros((3, 64, 64), dtype=torch.uint8)
+    annotated = gpu_draw_boxes(
+        scene,
+        np.array([[10, 10, 40, 40]], dtype=int),
+        np.array([[255, 0, 0]], dtype=np.uint8),
+        2,
+    )
+    assert annotated.data_ptr() == scene.data_ptr()
+
+
+@pytest.mark.parametrize(
+    "thickness", [1, 2, 3, 4, 5, 6, 7, 8, 10, 12, 16]
+)
+def test_border_geometry_reconstruction_holds(thickness: int) -> None:
+    # _BorderGeometry asserts pixel-perfect reconstruction against
+    # cv2.rectangle on two reference sizes at construction time.
+    geometry = _get_geometry(thickness)
+    assert geometry.corner_masks.shape[0] == 4
+
+
+def _eligible_detections(device: str = "cpu") -> Detections:
+    boxes = np.array([[10, 10, 50, 50]], dtype=np.float32)
+    return _build_detections(boxes, np.array([1]), device=device)
+
+
+def test_gpu_box_draw_eligible_happy_path() -> None:
+    assert _gpu_box_draw_eligible(_eligible_detections(), "CLASS", 0.0, 2) is True
+
+
+def test_gpu_box_draw_not_eligible_for_roundness() -> None:
+    assert _gpu_box_draw_eligible(_eligible_detections(), "CLASS", 0.4, 2) is False
+
+
+def test_gpu_box_draw_not_eligible_for_track_lookup() -> None:
+    assert _gpu_box_draw_eligible(_eligible_detections(), "TRACK", 0.0, 2) is False
+
+
+def test_gpu_box_draw_not_eligible_for_empty_detections() -> None:
+    empty = _build_detections(
+        np.zeros((0, 4), dtype=np.float32), np.zeros((0,), dtype=int), device="cpu"
+    )
+    assert _gpu_box_draw_eligible(empty, "CLASS", 0.0, 2) is False
+
+
+def test_gpu_box_draw_not_eligible_for_non_int_thickness() -> None:
+    assert _gpu_box_draw_eligible(_eligible_detections(), "CLASS", 0.0, "2") is False

--- a/tests/workflows/unit_tests/core_steps/visualizations/test_bounding_box_v1_tensor_gpu.py
+++ b/tests/workflows/unit_tests/core_steps/visualizations/test_bounding_box_v1_tensor_gpu.py
@@ -1,12 +1,9 @@
-import itertools
-
 import numpy as np
 import pytest
 import supervision as sv
 import torch
 
 from inference.core.workflows.core_steps.visualizations.bounding_box.v1_tensor import (
-    _get_geometry,
     _gpu_box_draw_eligible,
     gpu_draw_boxes,
 )
@@ -24,66 +21,25 @@ PALETTE = sv.ColorPalette.DEFAULT
 SCENE_H, SCENE_W = 240, 320
 
 
-def _build_detections(boxes: np.ndarray, class_id: np.ndarray, device: str) -> Detections:
-    n = boxes.shape[0]
-    return Detections(
-        xyxy=torch.tensor(boxes, dtype=torch.float32, device=device),
-        class_id=torch.tensor(class_id, dtype=torch.int32, device=device),
-        confidence=torch.full((n,), 0.9, device=device),
-        image_metadata={"class_names": {i: f"c{i}" for i in range(10)}},
-    )
+def _paint(
+    xyxy: np.ndarray, colors_rgb: np.ndarray, thickness: int, device: str = "cpu"
+) -> tuple:
+    """Run the painter on a zero scene; return (chw tensor, painted-pixel mask)."""
+    scene = torch.zeros((3, SCENE_H, SCENE_W), dtype=torch.uint8, device=device)
+    annotated = gpu_draw_boxes(scene, xyxy.astype(int), colors_rgb, thickness)
+    painted = (annotated != 0).any(dim=0).cpu().numpy()
+    return annotated, painted
 
 
-def _assert_parity(
-    xyxy: np.ndarray,
-    class_id: np.ndarray,
-    thickness: int,
-    color_axis: str,
-    device: str,
-    roundness: float = 0.0,
-) -> None:
-    rng = np.random.default_rng(7)
-    base_bgr = rng.integers(0, 256, (SCENE_H, SCENE_W, 3), dtype=np.uint8)
-    detections = sv.Detections(
-        xyxy=xyxy.astype(np.float32), class_id=class_id.astype(int)
+def _sv_painted_mask(xyxy: np.ndarray, thickness: int) -> np.ndarray:
+    scene = np.zeros((SCENE_H, SCENE_W, 3), dtype=np.uint8)
+    annotator = sv.BoxAnnotator(
+        color=PALETTE, color_lookup=sv.ColorLookup.INDEX, thickness=thickness
     )
-    if roundness == 0:
-        annotator = sv.BoxAnnotator(
-            color=PALETTE,
-            color_lookup=getattr(sv.ColorLookup, color_axis),
-            thickness=thickness,
-        )
-    else:
-        annotator = sv.RoundBoxAnnotator(
-            color=PALETTE,
-            color_lookup=getattr(sv.ColorLookup, color_axis),
-            thickness=thickness,
-            roundness=roundness,
-        )
-    reference = annotator.annotate(scene=base_bgr.copy(), detections=detections)
-
-    scene_chw_rgb = (
-        torch.from_numpy(base_bgr[:, :, ::-1].copy())
-        .permute(2, 0, 1)
-        .contiguous()
-        .to(device)
+    out = annotator.annotate(
+        scene, sv.Detections(xyxy=xyxy.astype(np.float32))
     )
-    ids = class_id if color_axis == "CLASS" else np.arange(xyxy.shape[0])
-    colors_rgb = np.asarray(
-        [PALETTE.by_idx(int(idx)).as_rgb() for idx in ids], dtype=np.uint8
-    )
-    annotated = gpu_draw_boxes(
-        scene_chw_rgb,
-        xyxy.astype(np.float32).astype(int),
-        colors_rgb,
-        thickness,
-        roundness,
-    )
-    got_bgr = annotated.permute(1, 2, 0).cpu().numpy()[:, :, ::-1]
-
-    exact = np.all(got_bgr == reference, axis=-1).mean()
-    assert exact == 1.0, f"exact match rate {exact}"
-    assert int(np.abs(got_bgr.astype(int) - reference.astype(int)).max()) == 0
+    return (out != 0).any(axis=2)
 
 
 _SCENARIOS = {
@@ -98,68 +54,71 @@ _SCENARIOS = {
         [[10, 10, 12, 12], [50, 50, 50, 60], [70, 70, 70, 70], [90, 5, 95, 9]],
         dtype=float,
     ),
-    "subpixel_coords": np.array(
-        [[30.7, 40.2, 120.9, 100.5], [-0.4, -0.6, 33.3, 44.9]], dtype=float
-    ),
     "edge_touching": np.array(
         [[0, 0, SCENE_W - 1, SCENE_H - 1], [5, 5, 15, SCENE_H - 10]], dtype=float
     ),
 }
 
 
-@pytest.mark.parametrize("scenario", sorted(_SCENARIOS))
-@pytest.mark.parametrize("thickness", [1, 2, 3, 4, 5, 8])
-@pytest.mark.parametrize("color_axis", ["CLASS", "INDEX"])
-def test_gpu_box_parity_on_cpu(scenario: str, thickness: int, color_axis: str) -> None:
-    # The painter is device-agnostic; CPU run gives full parity coverage in
-    # plain CI (identical kernels run on CUDA).
-    xyxy = _SCENARIOS[scenario]
-    class_id = np.arange(xyxy.shape[0]) % 3
-    _assert_parity(xyxy, class_id, thickness, color_axis, device="cpu")
-
-
-@pytest.mark.parametrize("scenario", sorted(_SCENARIOS))
-@pytest.mark.parametrize("thickness", [1, 2, 3, 5])
-@pytest.mark.parametrize("roundness", [0.1, 0.3, 0.6, 1.0])
-def test_gpu_round_box_parity_on_cpu(
-    scenario: str, thickness: int, roundness: float
-) -> None:
-    xyxy = _SCENARIOS[scenario]
-    class_id = np.arange(xyxy.shape[0]) % 3
-    _assert_parity(
-        xyxy, class_id, thickness, "CLASS", device="cpu", roundness=roundness
+def _index_colors(n: int) -> np.ndarray:
+    return np.asarray(
+        [PALETTE.by_idx(i).as_rgb() for i in range(n)], dtype=np.uint8
     )
 
 
-def test_gpu_round_box_parity_mixed_radii() -> None:
-    # Many distinct box sizes -> many distinct sv corner radii in one frame.
-    rng = np.random.default_rng(5)
-    xs = np.sort(rng.uniform(-20, SCENE_W + 20, (16, 2)), axis=1)
-    ys = np.sort(rng.uniform(-20, SCENE_H + 20, (16, 2)), axis=1)
-    xyxy = np.stack([xs[:, 0], ys[:, 0], xs[:, 1], ys[:, 1]], axis=1)
-    class_id = np.arange(16) % 4
-    _assert_parity(xyxy, class_id, 2, "CLASS", device="cpu", roundness=0.4)
+@pytest.mark.parametrize("scenario", sorted(_SCENARIOS))
+@pytest.mark.parametrize("thickness", [1, 2, 3, 5, 8])
+def test_gpu_boxes_visually_match_sv(scenario: str, thickness: int) -> None:
+    # Approximate renderer: borders are square-cornered `thickness`-wide
+    # bands, cv2 draws round joins / slightly wider bands. Painted regions
+    # must still substantially agree (IoU), and t=1 is pixel-identical.
+    xyxy = _SCENARIOS[scenario]
+    _, painted = _paint(xyxy, _index_colors(xyxy.shape[0]), thickness)
+    reference = _sv_painted_mask(xyxy, thickness)
+    union = (painted | reference).sum()
+    if union == 0:
+        return
+    iou = (painted & reference).sum() / union
+    threshold = 1.0 if thickness == 1 else 0.5
+    assert iou >= threshold, f"painted-region IoU {iou:.3f}"
 
 
-@requires_cuda
-@pytest.mark.parametrize("thickness", [1, 2, 4])
-def test_gpu_box_parity_on_cuda(thickness: int) -> None:
-    rng = np.random.default_rng(11)
-    xs = np.sort(rng.uniform(-30, SCENE_W + 30, (12, 2)), axis=1)
-    ys = np.sort(rng.uniform(-30, SCENE_H + 30, (12, 2)), axis=1)
-    xyxy = np.stack([xs[:, 0], ys[:, 0], xs[:, 1], ys[:, 1]], axis=1)
-    class_id = np.arange(12) % 4
-    _assert_parity(xyxy, class_id, thickness, "CLASS", device="cuda")
+def test_border_band_geometry_exact() -> None:
+    # One box, thickness 3: band spans [edge - 1, edge + 1] (outer = t // 2),
+    # interior and background stay untouched.
+    x1, y1, x2, y2 = 50, 60, 150, 140
+    annotated, painted = _paint(
+        np.array([[x1, y1, x2, y2]], dtype=float),
+        np.array([[255, 0, 0]], np.uint8),
+        thickness=3,
+    )
+    assert painted[y1 - 1 : y1 + 2, x1 - 1 : x2 + 2].all()  # top band
+    assert painted[y2 - 1 : y2 + 2, x1 - 1 : x2 + 2].all()  # bottom band
+    assert painted[y1 - 1 : y2 + 2, x1 - 1 : x1 + 2].all()  # left band
+    assert painted[y1 - 1 : y2 + 2, x2 - 1 : x2 + 2].all()  # right band
+    assert not painted[y1 + 2 : y2 - 1, x1 + 2 : x2 - 1].any()  # interior clean
+    assert not painted[: y1 - 1].any() and not painted[y2 + 2 :].any()  # outside
+    assert (annotated[0][painted] == 255).all()  # right channel, right color
 
 
-@requires_cuda
-def test_gpu_round_box_parity_on_cuda() -> None:
-    rng = np.random.default_rng(13)
-    xs = np.sort(rng.uniform(-30, SCENE_W + 30, (12, 2)), axis=1)
-    ys = np.sort(rng.uniform(-30, SCENE_H + 30, (12, 2)), axis=1)
-    xyxy = np.stack([xs[:, 0], ys[:, 0], xs[:, 1], ys[:, 1]], axis=1)
-    class_id = np.arange(12) % 4
-    _assert_parity(xyxy, class_id, 2, "CLASS", device="cuda", roundness=0.4)
+def test_overlapping_boxes_later_box_wins() -> None:
+    # sv paints sequentially: the higher detection index owns contested pixels.
+    xyxy = np.array([[20, 20, 100, 100], [60, 20, 140, 100]], dtype=float)
+    colors = np.array([[255, 0, 0], [0, 255, 0]], np.uint8)
+    annotated, _ = _paint(xyxy, colors, thickness=2)
+    # box 1's left band crosses box 0's interior row: contested column region
+    # around x=60 on box 0's top band must be box 1's color where box 1 paints.
+    top = annotated[:, 20, 60].cpu().numpy()  # (3,) at shared corner pixel
+    assert tuple(top) == (0, 255, 0)
+
+
+def test_fully_off_frame_box_is_noop() -> None:
+    annotated, painted = _paint(
+        np.array([[SCENE_W + 10, SCENE_H + 10, SCENE_W + 50, SCENE_H + 50]], float),
+        np.array([[255, 0, 0]], np.uint8),
+        thickness=2,
+    )
+    assert not painted.any()
 
 
 def test_gpu_box_paint_is_in_place() -> None:
@@ -173,25 +132,36 @@ def test_gpu_box_paint_is_in_place() -> None:
     assert annotated.data_ptr() == scene.data_ptr()
 
 
-@pytest.mark.parametrize(
-    "thickness", [1, 2, 3, 4, 5, 6, 7, 8, 10, 12, 16]
-)
-def test_border_geometry_reconstruction_holds(thickness: int) -> None:
-    # _BorderGeometry asserts pixel-perfect reconstruction against
-    # cv2.rectangle on two reference sizes at construction time.
-    geometry = _get_geometry(thickness)
-    assert geometry.corner_masks.shape[0] == 4
+def test_non_contiguous_scene_raises() -> None:
+    # .view must fail (caught by the block's sv fallback) rather than write
+    # into a silent copy. Transposed spatial dims are not viewable as (3, -1).
+    scene = torch.zeros((64, 64, 3), dtype=torch.uint8).permute(2, 1, 0)
+    with pytest.raises(RuntimeError):
+        gpu_draw_boxes(
+            scene,
+            np.array([[10, 10, 40, 40]], dtype=int),
+            np.array([[255, 0, 0]], dtype=np.uint8),
+            2,
+        )
 
 
-@pytest.mark.parametrize("thickness", [1, 2, 3, 5])
-@pytest.mark.parametrize("radius", [0, 1, 3, 10, 40])
-def test_border_geometry_reconstruction_holds_for_rounded(
-    thickness: int, radius: int
-) -> None:
-    # Rounded variant asserts against the sv.RoundBoxAnnotator primitive
-    # sequence (quarter cv2.ellipse arcs + cv2.line edges).
-    geometry = _get_geometry(thickness, radius)
-    assert geometry.corner_masks.shape[0] == 4
+@requires_cuda
+def test_gpu_boxes_on_cuda_match_cpu() -> None:
+    xyxy = _SCENARIOS["overlap_chain"]
+    colors = _index_colors(xyxy.shape[0])
+    cpu_out, _ = _paint(xyxy, colors, thickness=2, device="cpu")
+    cuda_out, _ = _paint(xyxy, colors, thickness=2, device="cuda")
+    assert np.array_equal(cpu_out.numpy(), cuda_out.cpu().numpy())
+
+
+def _build_detections(boxes: np.ndarray, class_id: np.ndarray, device: str) -> Detections:
+    n = boxes.shape[0]
+    return Detections(
+        xyxy=torch.tensor(boxes, dtype=torch.float32, device=device),
+        class_id=torch.tensor(class_id, dtype=torch.int32, device=device),
+        confidence=torch.full((n,), 0.9, device=device),
+        image_metadata={"class_names": {i: f"c{i}" for i in range(10)}},
+    )
 
 
 def _eligible_detections(device: str = "cpu") -> Detections:
@@ -209,16 +179,25 @@ def _tensor_backed_image() -> WorkflowImageData:
 def test_gpu_box_draw_eligible_happy_path() -> None:
     assert (
         _gpu_box_draw_eligible(
-            _eligible_detections(), "CLASS", 2, _tensor_backed_image()
+            _eligible_detections(), "CLASS", 0.0, 2, _tensor_backed_image()
         )
         is True
+    )
+
+
+def test_gpu_box_draw_not_eligible_for_roundness() -> None:
+    assert (
+        _gpu_box_draw_eligible(
+            _eligible_detections(), "CLASS", 0.4, 2, _tensor_backed_image()
+        )
+        is False
     )
 
 
 def test_gpu_box_draw_not_eligible_for_track_lookup() -> None:
     assert (
         _gpu_box_draw_eligible(
-            _eligible_detections(), "TRACK", 2, _tensor_backed_image()
+            _eligible_detections(), "TRACK", 0.0, 2, _tensor_backed_image()
         )
         is False
     )
@@ -228,13 +207,16 @@ def test_gpu_box_draw_not_eligible_for_empty_detections() -> None:
     empty = _build_detections(
         np.zeros((0, 4), dtype=np.float32), np.zeros((0,), dtype=int), device="cpu"
     )
-    assert _gpu_box_draw_eligible(empty, "CLASS", 2, _tensor_backed_image()) is False
+    assert (
+        _gpu_box_draw_eligible(empty, "CLASS", 0.0, 2, _tensor_backed_image())
+        is False
+    )
 
 
 def test_gpu_box_draw_not_eligible_for_non_int_thickness() -> None:
     assert (
         _gpu_box_draw_eligible(
-            _eligible_detections(), "CLASS", "2", _tensor_backed_image()
+            _eligible_detections(), "CLASS", 0.0, "2", _tensor_backed_image()
         )
         is False
     )
@@ -245,4 +227,7 @@ def test_gpu_box_draw_not_eligible_for_numpy_sourced_image() -> None:
         parent_metadata=ImageParentMetadata(parent_id="p"),
         numpy_image=np.zeros((64, 64, 3), dtype=np.uint8),
     )
-    assert _gpu_box_draw_eligible(_eligible_detections(), "CLASS", 2, numpy_image) is False
+    assert (
+        _gpu_box_draw_eligible(_eligible_detections(), "CLASS", 0.0, 2, numpy_image)
+        is False
+    )

--- a/tests/workflows/unit_tests/core_steps/visualizations/test_bounding_box_v1_tensor_gpu.py
+++ b/tests/workflows/unit_tests/core_steps/visualizations/test_bounding_box_v1_tensor_gpu.py
@@ -22,11 +22,15 @@ SCENE_H, SCENE_W = 240, 320
 
 
 def _paint(
-    xyxy: np.ndarray, colors_rgb: np.ndarray, thickness: int, device: str = "cpu"
+    xyxy: np.ndarray,
+    colors_rgb: np.ndarray,
+    thickness: int,
+    device: str = "cpu",
+    roundness: float = 0.0,
 ) -> tuple:
     """Run the painter on a zero scene; return (chw tensor, painted-pixel mask)."""
     scene = torch.zeros((3, SCENE_H, SCENE_W), dtype=torch.uint8, device=device)
-    annotated = gpu_draw_boxes(scene, xyxy.astype(int), colors_rgb, thickness)
+    annotated = gpu_draw_boxes(scene, xyxy.astype(int), colors_rgb, thickness, roundness)
     painted = (annotated != 0).any(dim=0).cpu().numpy()
     return annotated, painted
 
@@ -99,6 +103,49 @@ def test_border_band_geometry_exact() -> None:
     assert not painted[y1 + 2 : y2 - 1, x1 + 2 : x2 - 1].any()  # interior clean
     assert not painted[: y1 - 1].any() and not painted[y2 + 2 :].any()  # outside
     assert (annotated[0][painted] == 255).all()  # right channel, right color
+
+
+def _sv_round_painted_mask(xyxy: np.ndarray, thickness: int, roundness: float) -> np.ndarray:
+    scene = np.zeros((SCENE_H, SCENE_W, 3), dtype=np.uint8)
+    annotator = sv.RoundBoxAnnotator(
+        color=PALETTE,
+        color_lookup=sv.ColorLookup.INDEX,
+        thickness=thickness,
+        roundness=roundness,
+    )
+    out = annotator.annotate(scene, sv.Detections(xyxy=xyxy.astype(np.float32)))
+    return (out != 0).any(axis=2)
+
+
+@pytest.mark.parametrize("scenario", sorted(_SCENARIOS))
+@pytest.mark.parametrize("roundness", [0.2, 0.5, 1.0])
+def test_gpu_rounded_boxes_visually_match_sv(scenario: str, roundness: float) -> None:
+    xyxy = _SCENARIOS[scenario]
+    _, painted = _paint(xyxy, _index_colors(xyxy.shape[0]), 3, roundness=roundness)
+    reference = _sv_round_painted_mask(xyxy, 3, roundness)
+    union = (painted | reference).sum()
+    if union == 0:
+        return
+    iou = (painted & reference).sum() / union
+    assert iou >= 0.45, f"painted-region IoU {iou:.3f}"
+
+
+def test_rounded_corners_are_actually_rounded() -> None:
+    # Large box, high roundness: the square corner pixel must stay unpainted,
+    # the edge midpoints and arc diagonals must be painted.
+    x1, y1, x2, y2 = 40, 40, 200, 200
+    radius = (200 - 40) // 2  # roundness=1.0
+    _, painted = _paint(
+        np.array([[x1, y1, x2, y2]], dtype=float),
+        np.array([[255, 0, 0]], np.uint8),
+        thickness=3,
+        roundness=1.0,
+    )
+    assert not painted[y1, x1]  # square corner cut away
+    assert painted[y1, (x1 + x2) // 2]  # top edge midpoint
+    assert painted[(y1 + y2) // 2, x1]  # left edge midpoint
+    diag = int(radius - radius / np.sqrt(2))
+    assert painted[y1 + diag, x1 + diag]  # 45-degree point on the TL arc
 
 
 def test_overlapping_boxes_later_box_wins() -> None:
@@ -178,27 +225,14 @@ def _tensor_backed_image() -> WorkflowImageData:
 
 def test_gpu_box_draw_eligible_happy_path() -> None:
     assert (
-        _gpu_box_draw_eligible(
-            _eligible_detections(), "CLASS", 0.0, 2, _tensor_backed_image()
-        )
+        _gpu_box_draw_eligible(_eligible_detections(), "CLASS", 2, _tensor_backed_image())
         is True
-    )
-
-
-def test_gpu_box_draw_not_eligible_for_roundness() -> None:
-    assert (
-        _gpu_box_draw_eligible(
-            _eligible_detections(), "CLASS", 0.4, 2, _tensor_backed_image()
-        )
-        is False
     )
 
 
 def test_gpu_box_draw_not_eligible_for_track_lookup() -> None:
     assert (
-        _gpu_box_draw_eligible(
-            _eligible_detections(), "TRACK", 0.0, 2, _tensor_backed_image()
-        )
+        _gpu_box_draw_eligible(_eligible_detections(), "TRACK", 2, _tensor_backed_image())
         is False
     )
 
@@ -207,17 +241,12 @@ def test_gpu_box_draw_not_eligible_for_empty_detections() -> None:
     empty = _build_detections(
         np.zeros((0, 4), dtype=np.float32), np.zeros((0,), dtype=int), device="cpu"
     )
-    assert (
-        _gpu_box_draw_eligible(empty, "CLASS", 0.0, 2, _tensor_backed_image())
-        is False
-    )
+    assert _gpu_box_draw_eligible(empty, "CLASS", 2, _tensor_backed_image()) is False
 
 
 def test_gpu_box_draw_not_eligible_for_non_int_thickness() -> None:
     assert (
-        _gpu_box_draw_eligible(
-            _eligible_detections(), "CLASS", 0.0, "2", _tensor_backed_image()
-        )
+        _gpu_box_draw_eligible(_eligible_detections(), "CLASS", "2", _tensor_backed_image())
         is False
     )
 
@@ -228,6 +257,5 @@ def test_gpu_box_draw_not_eligible_for_numpy_sourced_image() -> None:
         numpy_image=np.zeros((64, 64, 3), dtype=np.uint8),
     )
     assert (
-        _gpu_box_draw_eligible(_eligible_detections(), "CLASS", 0.0, 2, numpy_image)
-        is False
+        _gpu_box_draw_eligible(_eligible_detections(), "CLASS", 2, numpy_image) is False
     )

--- a/tests/workflows/unit_tests/core_steps/visualizations/test_bounding_box_v1_tensor_gpu.py
+++ b/tests/workflows/unit_tests/core_steps/visualizations/test_bounding_box_v1_tensor_gpu.py
@@ -10,6 +10,10 @@ from inference.core.workflows.core_steps.visualizations.bounding_box.v1_tensor i
     _gpu_box_draw_eligible,
     gpu_draw_boxes,
 )
+from inference.core.workflows.execution_engine.entities.base import (
+    ImageParentMetadata,
+    WorkflowImageData,
+)
 from inference_models.models.base.object_detection import Detections
 
 requires_cuda = pytest.mark.skipif(
@@ -36,17 +40,26 @@ def _assert_parity(
     thickness: int,
     color_axis: str,
     device: str,
+    roundness: float = 0.0,
 ) -> None:
     rng = np.random.default_rng(7)
     base_bgr = rng.integers(0, 256, (SCENE_H, SCENE_W, 3), dtype=np.uint8)
     detections = sv.Detections(
         xyxy=xyxy.astype(np.float32), class_id=class_id.astype(int)
     )
-    annotator = sv.BoxAnnotator(
-        color=PALETTE,
-        color_lookup=getattr(sv.ColorLookup, color_axis),
-        thickness=thickness,
-    )
+    if roundness == 0:
+        annotator = sv.BoxAnnotator(
+            color=PALETTE,
+            color_lookup=getattr(sv.ColorLookup, color_axis),
+            thickness=thickness,
+        )
+    else:
+        annotator = sv.RoundBoxAnnotator(
+            color=PALETTE,
+            color_lookup=getattr(sv.ColorLookup, color_axis),
+            thickness=thickness,
+            roundness=roundness,
+        )
     reference = annotator.annotate(scene=base_bgr.copy(), detections=detections)
 
     scene_chw_rgb = (
@@ -64,6 +77,7 @@ def _assert_parity(
         xyxy.astype(np.float32).astype(int),
         colors_rgb,
         thickness,
+        roundness,
     )
     got_bgr = annotated.permute(1, 2, 0).cpu().numpy()[:, :, ::-1]
 
@@ -104,6 +118,29 @@ def test_gpu_box_parity_on_cpu(scenario: str, thickness: int, color_axis: str) -
     _assert_parity(xyxy, class_id, thickness, color_axis, device="cpu")
 
 
+@pytest.mark.parametrize("scenario", sorted(_SCENARIOS))
+@pytest.mark.parametrize("thickness", [1, 2, 3, 5])
+@pytest.mark.parametrize("roundness", [0.1, 0.3, 0.6, 1.0])
+def test_gpu_round_box_parity_on_cpu(
+    scenario: str, thickness: int, roundness: float
+) -> None:
+    xyxy = _SCENARIOS[scenario]
+    class_id = np.arange(xyxy.shape[0]) % 3
+    _assert_parity(
+        xyxy, class_id, thickness, "CLASS", device="cpu", roundness=roundness
+    )
+
+
+def test_gpu_round_box_parity_mixed_radii() -> None:
+    # Many distinct box sizes -> many distinct sv corner radii in one frame.
+    rng = np.random.default_rng(5)
+    xs = np.sort(rng.uniform(-20, SCENE_W + 20, (16, 2)), axis=1)
+    ys = np.sort(rng.uniform(-20, SCENE_H + 20, (16, 2)), axis=1)
+    xyxy = np.stack([xs[:, 0], ys[:, 0], xs[:, 1], ys[:, 1]], axis=1)
+    class_id = np.arange(16) % 4
+    _assert_parity(xyxy, class_id, 2, "CLASS", device="cpu", roundness=0.4)
+
+
 @requires_cuda
 @pytest.mark.parametrize("thickness", [1, 2, 4])
 def test_gpu_box_parity_on_cuda(thickness: int) -> None:
@@ -113,6 +150,16 @@ def test_gpu_box_parity_on_cuda(thickness: int) -> None:
     xyxy = np.stack([xs[:, 0], ys[:, 0], xs[:, 1], ys[:, 1]], axis=1)
     class_id = np.arange(12) % 4
     _assert_parity(xyxy, class_id, thickness, "CLASS", device="cuda")
+
+
+@requires_cuda
+def test_gpu_round_box_parity_on_cuda() -> None:
+    rng = np.random.default_rng(13)
+    xs = np.sort(rng.uniform(-30, SCENE_W + 30, (12, 2)), axis=1)
+    ys = np.sort(rng.uniform(-30, SCENE_H + 30, (12, 2)), axis=1)
+    xyxy = np.stack([xs[:, 0], ys[:, 0], xs[:, 1], ys[:, 1]], axis=1)
+    class_id = np.arange(12) % 4
+    _assert_parity(xyxy, class_id, 2, "CLASS", device="cuda", roundness=0.4)
 
 
 def test_gpu_box_paint_is_in_place() -> None:
@@ -136,29 +183,66 @@ def test_border_geometry_reconstruction_holds(thickness: int) -> None:
     assert geometry.corner_masks.shape[0] == 4
 
 
+@pytest.mark.parametrize("thickness", [1, 2, 3, 5])
+@pytest.mark.parametrize("radius", [0, 1, 3, 10, 40])
+def test_border_geometry_reconstruction_holds_for_rounded(
+    thickness: int, radius: int
+) -> None:
+    # Rounded variant asserts against the sv.RoundBoxAnnotator primitive
+    # sequence (quarter cv2.ellipse arcs + cv2.line edges).
+    geometry = _get_geometry(thickness, radius)
+    assert geometry.corner_masks.shape[0] == 4
+
+
 def _eligible_detections(device: str = "cpu") -> Detections:
     boxes = np.array([[10, 10, 50, 50]], dtype=np.float32)
     return _build_detections(boxes, np.array([1]), device=device)
 
 
+def _tensor_backed_image() -> WorkflowImageData:
+    tensor = torch.zeros((3, 64, 64), dtype=torch.uint8)
+    return WorkflowImageData(
+        parent_metadata=ImageParentMetadata(parent_id="p"), tensor_image=tensor
+    )
+
+
 def test_gpu_box_draw_eligible_happy_path() -> None:
-    assert _gpu_box_draw_eligible(_eligible_detections(), "CLASS", 0.0, 2) is True
-
-
-def test_gpu_box_draw_not_eligible_for_roundness() -> None:
-    assert _gpu_box_draw_eligible(_eligible_detections(), "CLASS", 0.4, 2) is False
+    assert (
+        _gpu_box_draw_eligible(
+            _eligible_detections(), "CLASS", 2, _tensor_backed_image()
+        )
+        is True
+    )
 
 
 def test_gpu_box_draw_not_eligible_for_track_lookup() -> None:
-    assert _gpu_box_draw_eligible(_eligible_detections(), "TRACK", 0.0, 2) is False
+    assert (
+        _gpu_box_draw_eligible(
+            _eligible_detections(), "TRACK", 2, _tensor_backed_image()
+        )
+        is False
+    )
 
 
 def test_gpu_box_draw_not_eligible_for_empty_detections() -> None:
     empty = _build_detections(
         np.zeros((0, 4), dtype=np.float32), np.zeros((0,), dtype=int), device="cpu"
     )
-    assert _gpu_box_draw_eligible(empty, "CLASS", 0.0, 2) is False
+    assert _gpu_box_draw_eligible(empty, "CLASS", 2, _tensor_backed_image()) is False
 
 
 def test_gpu_box_draw_not_eligible_for_non_int_thickness() -> None:
-    assert _gpu_box_draw_eligible(_eligible_detections(), "CLASS", 0.0, "2") is False
+    assert (
+        _gpu_box_draw_eligible(
+            _eligible_detections(), "CLASS", "2", _tensor_backed_image()
+        )
+        is False
+    )
+
+
+def test_gpu_box_draw_not_eligible_for_numpy_sourced_image() -> None:
+    numpy_image = WorkflowImageData(
+        parent_metadata=ImageParentMetadata(parent_id="p"),
+        numpy_image=np.zeros((64, 64, 3), dtype=np.uint8),
+    )
+    assert _gpu_box_draw_eligible(_eligible_detections(), "CLASS", 2, numpy_image) is False

--- a/tests/workflows/unit_tests/core_steps/visualizations/test_bounding_box_v1_tensor_gpu.py
+++ b/tests/workflows/unit_tests/core_steps/visualizations/test_bounding_box_v1_tensor_gpu.py
@@ -30,7 +30,9 @@ def _paint(
 ) -> tuple:
     """Run the painter on a zero scene; return (chw tensor, painted-pixel mask)."""
     scene = torch.zeros((3, SCENE_H, SCENE_W), dtype=torch.uint8, device=device)
-    annotated = gpu_draw_boxes(scene, xyxy.astype(int), colors_rgb, thickness, roundness)
+    annotated = gpu_draw_boxes(
+        scene, xyxy.astype(int), colors_rgb, thickness, roundness
+    )
     painted = (annotated != 0).any(dim=0).cpu().numpy()
     return annotated, painted
 
@@ -40,9 +42,7 @@ def _sv_painted_mask(xyxy: np.ndarray, thickness: int) -> np.ndarray:
     annotator = sv.BoxAnnotator(
         color=PALETTE, color_lookup=sv.ColorLookup.INDEX, thickness=thickness
     )
-    out = annotator.annotate(
-        scene, sv.Detections(xyxy=xyxy.astype(np.float32))
-    )
+    out = annotator.annotate(scene, sv.Detections(xyxy=xyxy.astype(np.float32)))
     return (out != 0).any(axis=2)
 
 
@@ -65,9 +65,7 @@ _SCENARIOS = {
 
 
 def _index_colors(n: int) -> np.ndarray:
-    return np.asarray(
-        [PALETTE.by_idx(i).as_rgb() for i in range(n)], dtype=np.uint8
-    )
+    return np.asarray([PALETTE.by_idx(i).as_rgb() for i in range(n)], dtype=np.uint8)
 
 
 @pytest.mark.parametrize("scenario", sorted(_SCENARIOS))
@@ -105,7 +103,9 @@ def test_border_band_geometry_exact() -> None:
     assert (annotated[0][painted] == 255).all()  # right channel, right color
 
 
-def _sv_round_painted_mask(xyxy: np.ndarray, thickness: int, roundness: float) -> np.ndarray:
+def _sv_round_painted_mask(
+    xyxy: np.ndarray, thickness: int, roundness: float
+) -> np.ndarray:
     scene = np.zeros((SCENE_H, SCENE_W, 3), dtype=np.uint8)
     annotator = sv.RoundBoxAnnotator(
         color=PALETTE,
@@ -201,7 +201,9 @@ def test_gpu_boxes_on_cuda_match_cpu() -> None:
     assert np.array_equal(cpu_out.numpy(), cuda_out.cpu().numpy())
 
 
-def _build_detections(boxes: np.ndarray, class_id: np.ndarray, device: str) -> Detections:
+def _build_detections(
+    boxes: np.ndarray, class_id: np.ndarray, device: str
+) -> Detections:
     n = boxes.shape[0]
     return Detections(
         xyxy=torch.tensor(boxes, dtype=torch.float32, device=device),
@@ -225,14 +227,18 @@ def _tensor_backed_image() -> WorkflowImageData:
 
 def test_gpu_box_draw_eligible_happy_path() -> None:
     assert (
-        _gpu_box_draw_eligible(_eligible_detections(), "CLASS", 2, _tensor_backed_image())
+        _gpu_box_draw_eligible(
+            _eligible_detections(), "CLASS", 2, _tensor_backed_image()
+        )
         is True
     )
 
 
 def test_gpu_box_draw_not_eligible_for_track_lookup() -> None:
     assert (
-        _gpu_box_draw_eligible(_eligible_detections(), "TRACK", 2, _tensor_backed_image())
+        _gpu_box_draw_eligible(
+            _eligible_detections(), "TRACK", 2, _tensor_backed_image()
+        )
         is False
     )
 
@@ -246,7 +252,9 @@ def test_gpu_box_draw_not_eligible_for_empty_detections() -> None:
 
 def test_gpu_box_draw_not_eligible_for_non_int_thickness() -> None:
     assert (
-        _gpu_box_draw_eligible(_eligible_detections(), "CLASS", "2", _tensor_backed_image())
+        _gpu_box_draw_eligible(
+            _eligible_detections(), "CLASS", "2", _tensor_backed_image()
+        )
         is False
     )
 


### PR DESCRIPTION
## What

GPU-native painter for `bounding_box_visualization@v1` on the tensor pipeline. The current block downloads the frame to host (`numpy_image`, ~26 ms/frame at 1080p on Orin Nano) and runs `sv.BoxAnnotator` on CPU, forcing downstream tensor blocks to re-upload the frame. The new path paints borders directly on the CHW RGB device tensor — square and rounded corners both.

## Rendering

Approximate, not bit-identical: borders are plain `thickness`-wide bands; `roundness > 0` rounds the corners with analytic quarter-ring arcs at sv's corner radius (one cached annulus mask per radius — no cv2, no templates). Thickness 1 squares are pixel-identical to cv2; everything else sits within ~1 px of cv2's raster (round joins, slightly wider bands). Deliberate trade: an earlier revision reproduced cv2 bit-exactly via cached raster templates, but the extra ~230 lines bought only ~0.2 ms — clean code won.

## Why it's fast

- No per-box loop (dispatch-bound on Jetson: a naive loop measured 43 ms @ 50 boxes). Fixed ~25 torch ops per frame: 4 clamped band rects per box on host, one packed int32 H2D upload, device-side ragged expansion (`repeat_interleave` with host-computed `output_size` — zero GPU→CPU syncs), one indexed store.
- Overlap ordering (last box wins, like sv) via one deterministic `scatter_reduce_(amax)` — skipped when a cheap host test proves borders disjoint.
- sv fallback for `TRACK` color axis, numpy-sourced scenes, and any unexpected error — the block can't crash a pipeline.

## Benchmarks

Block time, 1080p, thickness 2, median of 50 synced iters, inside the matching `roboflow-inference-server-jetson-*` containers. The old path additionally costs ~9–21 ms/frame downstream re-upload that the GPU path eliminates.

**Square (before → after):**

| Boxes | Orin Nano | Orin NX | Thor |
|---|---|---|---|
| 1 | 20.9 → **2.8** | 15.0 → **2.2** | 10.9 → **0.9** |
| 20 | 21.8 → **3.3** | 15.9 → **2.4** | 9.9 → **1.1** |
| 50 | 23.4 → **5.1** | 17.4 → **2.8** | 11.1 → **1.3** |

**Rounded, roundness 0.6 (before → after):**

| Boxes | Orin Nano | Orin NX | Thor |
|---|---|---|---|
| 1 | 22.9 → **2.7** | 14.9 → **3.0** | 8.6 → **1.2** |
| 20 | 23.6 → **6.5** | 16.9 → **6.2** | 9.1 → **2.2** |
| 50 | 27.0 → **11.6** | 20.1 → **10.3** | 10.4 → **3.5** |

End-to-end (RF-DETR-base + this block over a 1080p driving video on Orin Nano, 350 frames): tensor pipeline went from a net **regression vs classic** (134.6 ms/frame, viz 27.9 ms, dropped frames) to the fastest config (109.8 ms, viz ~6 ms, 9.1 FPS vs classic 9.0). The model dominates at ~100 ms/frame; lighter detectors see proportionally more.

## Possible follow-ups

- The ~2–3 ms floor is python dispatch + frame clone, not GPU work (pixel time ≈ 50 µs); CUDA graphs could cut it if ever needed. `copy_image=False` saves the 0.7 ms clone when stacking visualizations.
- Same recipe ports to corner/circle/ellipse/polygon viz blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
