### PR TITLE
Add JetPack 7.2 build workflow

### DIFF
--- a/.github/workflows/docker.jetson.7.2.0.yml
+++ b/.github/workflows/docker.jetson.7.2.0.yml
@@ -1,0 +1,64 @@
+name: Build and Push Jetson 7.2.0 Container
+permissions:
+  contents: read
+on:
+  release:
+    types: [created]
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      force_push:
+        type: boolean
+        description: "Do you want to push image after build?"
+        default: false
+      custom_tag:
+        type: string
+        description: "Custom tag to use for the image (overrides VERSION)"
+        default: ""
+
+env:
+  VERSION: "0.0.0"
+  BASE_IMAGE: "roboflow/roboflow-inference-server-jetson-7.2.0"
+
+jobs:
+  docker:
+    runs-on:
+      labels: depot-ubuntu-24.04-4
+      group: public-depot
+    timeout-minutes: 360
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Login to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: 🛎️ Checkout
+        uses: actions/checkout@v6
+      - name: Read version from file
+        run: echo "VERSION=$(DISABLE_VERSION_CHECK=true python ./inference/core/version.py)" >> $GITHUB_ENV
+      - name: Determine Image Tags
+        id: tags
+        uses: ./.github/actions/determine-tags
+        with:
+          custom_tag: ${{ github.event.inputs.custom_tag }}
+          version: ${{ env.VERSION }}
+          base_image: ${{ env.BASE_IMAGE }}
+          force_push: ${{ github.event.inputs.force_push }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Depot CLI
+        uses: depot/setup-action@v1
+      - name: Build image
+        uses: depot/bake-action@v1
+        env:
+          JETSON_SERVER_TAGS: ${{ steps.tags.outputs.image_tags }}
+        with:
+          files: ./docker/docker-bake.jetson.7.2.0.hcl
+          targets: jetson-server-jp72
+          project: v1xzfwkc4b
+          push: ${{ github.event_name == 'release' || inputs.force_push }}
+          save: ${{ github.event_name != 'release' && !inputs.force_push }}
+          save-tag: ${{ github.event_name != 'release' && !inputs.force_push && format('server-jp72-{0}', github.sha) || '' }}


### PR DESCRIPTION
## What changed

Add only the JetPack 7.2 GitHub Actions build workflow.

## Why

GitHub requires a `workflow_dispatch` workflow to exist on the default branch before it can be selected for manual runs. Adding the workflow to `main` lets us dispatch the JetPack 7.2 build against `mvp/new-inference-pipeline`, where the Dockerfiles and bake definition live, without upstreaming those implementation files in this PR.

## Impact

This PR contains no Dockerfiles, runtime code, native bridges, package changes, or JetPack detection changes.

## Validation

- workflow YAML parses successfully
- PR diff contains exactly `.github/workflows/docker.jetson.7.2.0.yml`
