### PR TITLE
Add CUDA allocator memory breakdown

### DIFF
--- a/inference/core/entities/responses/server_state.py
+++ b/inference/core/entities/responses/server_state.py
@@ -91,6 +91,25 @@ class ModelsDescriptions(BaseModel):
         None,
         description="Total GPU memory available in bytes.",
     )
+    torch_cuda_allocated: Optional[int] = Field(
+        None,
+        description="Live tensor memory allocated by PyTorch's CUDA allocator in bytes.",
+    )
+    torch_cuda_reserved: Optional[int] = Field(
+        None,
+        description="Total memory reserved by PyTorch's CUDA allocator in bytes.",
+    )
+    torch_cuda_allocator_cache: Optional[int] = Field(
+        None,
+        description="Reserved but currently unallocated PyTorch CUDA memory in bytes.",
+    )
+    non_torch_gpu_memory: Optional[int] = Field(
+        None,
+        description=(
+            "Device memory not reserved by PyTorch in bytes. This includes native "
+            "runtimes, CUDA context overhead, and allocations from other processes."
+        ),
+    )
 
     @classmethod
     def from_models_descriptions(
@@ -104,12 +123,23 @@ class ModelsDescriptions(BaseModel):
         ]
         vram_values = [m.vram_bytes for m in model_entities if m.vram_bytes is not None]
         total_vram = sum(vram_values) if vram_values else None
-        gpu_used, gpu_total = _get_gpu_memory_stats()
+        (
+            gpu_used,
+            gpu_total,
+            torch_allocated,
+            torch_reserved,
+        ) = _get_gpu_memory_stats()
+        allocator_cache = _non_negative_difference(torch_reserved, torch_allocated)
+        non_torch_memory = _non_negative_difference(gpu_used, torch_reserved)
         return cls(
             models=model_entities,
             total_vram_bytes=total_vram,
             gpu_memory_used=gpu_used,
             gpu_memory_total=gpu_total,
+            torch_cuda_allocated=torch_allocated,
+            torch_cuda_reserved=torch_reserved,
+            torch_cuda_allocator_cache=allocator_cache,
+            non_torch_gpu_memory=non_torch_memory,
         )
 
 
@@ -119,9 +149,22 @@ def _get_gpu_memory_stats() -> tuple:
 
         if torch.cuda.is_available():
             free, total = torch.cuda.mem_get_info()
-            return total - free, total
+            return (
+                total - free,
+                total,
+                torch.cuda.memory_allocated(),
+                torch.cuda.memory_reserved(),
+            )
     except ImportError:
         pass
     except Exception:
         pass
-    return None, None
+    return None, None, None, None
+
+
+def _non_negative_difference(
+    minuend: Optional[int], subtrahend: Optional[int]
+) -> Optional[int]:
+    if minuend is None or subtrahend is None:
+        return None
+    return max(0, minuend - subtrahend)

--- a/tests/inference/unit_tests/core/test_server_state.py
+++ b/tests/inference/unit_tests/core/test_server_state.py
@@ -1,0 +1,69 @@
+import sys
+from unittest import mock
+
+from inference.core.entities.responses import server_state
+from inference.core.managers.entities import ModelDescription
+
+
+def _fake_torch(
+    *,
+    free: int = 20,
+    total: int = 100,
+    allocated: int = 45,
+    reserved: int = 60,
+) -> mock.MagicMock:
+    torch = mock.MagicMock(name="torch")
+    torch.cuda.is_available.return_value = True
+    torch.cuda.mem_get_info.return_value = (free, total)
+    torch.cuda.memory_allocated.return_value = allocated
+    torch.cuda.memory_reserved.return_value = reserved
+    return torch
+
+
+def test_get_gpu_memory_stats_includes_pytorch_allocator_breakdown() -> None:
+    with mock.patch.dict(sys.modules, {"torch": _fake_torch()}):
+        assert server_state._get_gpu_memory_stats() == (80, 100, 45, 60)
+
+
+def test_models_descriptions_derives_allocator_and_non_torch_memory() -> None:
+    model = ModelDescription(
+        model_id="example/1",
+        task_type="object-detection",
+        batch_size=1,
+        input_height=640,
+        input_width=640,
+        vram_bytes=25,
+    )
+
+    with mock.patch.object(
+        server_state,
+        "_get_gpu_memory_stats",
+        return_value=(80, 100, 45, 60),
+    ):
+        response = server_state.ModelsDescriptions.from_models_descriptions([model])
+
+    assert response.total_vram_bytes == 25
+    assert response.gpu_memory_used == 80
+    assert response.torch_cuda_allocated == 45
+    assert response.torch_cuda_reserved == 60
+    assert response.torch_cuda_allocator_cache == 15
+    assert response.non_torch_gpu_memory == 20
+
+
+def test_memory_breakdown_is_optional_without_cuda() -> None:
+    with mock.patch.object(
+        server_state,
+        "_get_gpu_memory_stats",
+        return_value=(None, None, None, None),
+    ):
+        response = server_state.ModelsDescriptions.from_models_descriptions([])
+
+    assert response.torch_cuda_allocated is None
+    assert response.torch_cuda_reserved is None
+    assert response.torch_cuda_allocator_cache is None
+    assert response.non_torch_gpu_memory is None
+
+
+def test_memory_differences_are_clamped_when_samples_are_inconsistent() -> None:
+    assert server_state._non_negative_difference(10, 20) == 0
+


### PR DESCRIPTION
## Summary

Adds a low-overhead CUDA memory breakdown to `/model/registry` so production incidents can distinguish:

- live PyTorch tensor allocations
- memory reserved by PyTorch
- reserved-but-unallocated allocator cache
- device memory outside PyTorch's allocator

This is additive to the existing device-level and per-model VRAM fields.

## Why

During the July 15 async-serverless VRAM exhaustion incident, the gap between device memory used and registry-attributed model memory grew by several GiB per day. The existing metrics prove that memory is untracked, but cannot tell whether the growth is live PyTorch state, allocator slack, or ONNX/TensorRT/native CUDA memory.

These fields split that gap without adding per-request instrumentation or CUDA synchronization.

Incident analysis: https://gist.github.com/hansent/3029fda585b71605e53db8bc67b4010d

## Performance

The new values are O(1) allocator reads performed only when `/model/registry` is requested. The async consumer currently refreshes that endpoint every five seconds.

This does not add:

- per-request memory sampling
- `torch.cuda.synchronize()`
- `torch.cuda.memory_snapshot()`
- cache traversal
- model-ID metric labels

## Validation

- `uv run --no-project --with pytest --with 'pydantic>=2' --with requests --with packaging --with structlog --with python-dotenv --with pyyaml --with rich python -m pytest --noconftest tests/inference/unit_tests/core/test_server_state.py -q`
- `uvx black --check inference/core/entities/responses/server_state.py tests/inference/unit_tests/core/test_server_state.py`

Focused result: 4 tests passed.

## Follow-up

https://github.com/roboflow/async-serverless/pull/364 proxies these fields through the async consumer's existing Prometheus endpoint and adds an explicit untracked-VRAM gauge.