### PR TITLE
Check OWLv2 embeddings cache before materializing reference images

### DIFF
--- a/inference_models/inference_models/models/owlv2/owlv2_hf.py
+++ b/inference_models/inference_models/models/owlv2/owlv2_hf.py
@@ -612,19 +612,26 @@ class OWLv2HF(
         max_detections: int = INFERENCE_MODELS_OWLV2_DEFAULT_MAX_DETECTIONS,
         unload_after_use: bool = True,
     ) -> ImageEmbeddings:
+        # Resolve the hash and consult the cache BEFORE materializing pixels:
+        # for URL/base64 references the hash comes from the reference itself,
+        # so a cache hit must not pay the download + decode of the image.
         if isinstance(image, LazyImageWrapper):
             image_hash = image.get_hash()
-            image_instance = image.as_numpy()
-            if unload_after_use:
-                image.unload_image()
         else:
             image_hash = compute_image_hash(image=image)
-            image_instance = image
         cached_embeddings = self._owlv2_images_embeddings_cache.retrieve_embeddings(
             key=image_hash
         )
         if cached_embeddings:
+            if isinstance(image, LazyImageWrapper) and unload_after_use:
+                image.unload_image()
             return cached_embeddings
+        if isinstance(image, LazyImageWrapper):
+            image_instance = image.as_numpy()
+            if unload_after_use:
+                image.unload_image()
+        else:
+            image_instance = image
         pixel_values, image_dimensions = self.pre_process(image_instance)
         device_type = self._device.type
         with self._lock:

--- a/inference_models/tests/unit_tests/models/test_owlv2_embed_image_cache.py
+++ b/inference_models/tests/unit_tests/models/test_owlv2_embed_image_cache.py
@@ -1,0 +1,112 @@
+import numpy as np
+import pytest
+import torch
+
+from inference_models.models.owlv2.cache import InMemoryOwlV2ImageEmbeddingsCache
+from inference_models.models.owlv2.entities import ImageEmbeddings
+from inference_models.models.owlv2.owlv2_hf import OWLv2HF
+from inference_models.models.owlv2.reference_dataset import (
+    LazyImageWrapper,
+    compute_image_hash,
+)
+
+IMAGE_URL = "https://storage.googleapis.com/bucket/workspace/image-1/original.jpg"
+
+
+def build_model_shell(cache: InMemoryOwlV2ImageEmbeddingsCache) -> OWLv2HF:
+    """OWLv2HF with no weights loaded — cache-hit paths must not need them."""
+    return OWLv2HF(
+        model=None,
+        processor=None,
+        device=torch.device("cpu"),
+        owlv2_class_embeddings_cache=None,
+        owlv2_images_embeddings_cache=cache,
+        allow_url_input=True,
+        allow_non_https_url=False,
+        allow_url_without_fqdn=False,
+        whitelisted_domains=None,
+        blacklisted_domains=None,
+        allow_local_storage_access_for_reference_images=False,
+    )
+
+
+def build_embeddings(image_hash: str) -> ImageEmbeddings:
+    return ImageEmbeddings(
+        image_hash=image_hash,
+        objectness=torch.zeros(3),
+        boxes=torch.zeros(3, 4),
+        image_class_embeddings=torch.zeros(3, 8),
+        logit_shift=torch.zeros(3),
+        logit_scale=torch.ones(3),
+        image_size_wh=(640, 480),
+    )
+
+
+def wrap_url_reference(url: str) -> LazyImageWrapper:
+    return LazyImageWrapper.init(
+        image=url,
+        allow_url_input=True,
+        allow_non_https_url=False,
+        allow_url_without_fqdn=False,
+        whitelisted_domains=None,
+        blacklisted_domains=None,
+        allow_local_storage_access=False,
+    )
+
+
+def test_embed_image_cache_hit_does_not_materialize_url_reference(monkeypatch) -> None:
+    # given - embeddings for the URL's hash are already cached; downloading
+    # the image on this path is the regression this test guards against
+    cache = InMemoryOwlV2ImageEmbeddingsCache.init(size_limit=10, send_to_cpu=True)
+    wrapper = wrap_url_reference(IMAGE_URL)
+    cached = build_embeddings(image_hash=wrapper.get_hash())
+    cache.save_embeddings(embeddings=cached)
+    model = build_model_shell(cache=cache)
+
+    def fail_on_download() -> np.ndarray:
+        raise AssertionError("image was downloaded despite embeddings-cache hit")
+
+    monkeypatch.setattr(wrapper, "as_numpy", fail_on_download)
+
+    # when
+    result = model.embed_image(image=wrapper)
+
+    # then
+    assert result.image_hash == cached.image_hash
+
+
+def test_embed_image_cache_hit_for_in_memory_image(monkeypatch) -> None:
+    # given
+    image = np.zeros((32, 32, 3), dtype=np.uint8)
+    image_hash = compute_image_hash(image=image)
+    cache = InMemoryOwlV2ImageEmbeddingsCache.init(size_limit=10, send_to_cpu=True)
+    cache.save_embeddings(embeddings=build_embeddings(image_hash=image_hash))
+    model = build_model_shell(cache=cache)
+
+    # when
+    result = model.embed_image(image=image)
+
+    # then
+    assert result.image_hash == image_hash
+
+
+def test_embed_image_cache_miss_materializes_the_reference(monkeypatch) -> None:
+    # given - empty cache: the miss path MUST load the image (and then fail
+    # further down in this weightless shell, proving as_numpy was reached)
+    cache = InMemoryOwlV2ImageEmbeddingsCache.init(size_limit=10, send_to_cpu=True)
+    wrapper = wrap_url_reference(IMAGE_URL)
+    model = build_model_shell(cache=cache)
+    materialized = {"called": False}
+
+    def record_materialization() -> np.ndarray:
+        materialized["called"] = True
+        raise RuntimeError("stop after materialization")
+
+    monkeypatch.setattr(wrapper, "as_numpy", record_materialization)
+
+    # when
+    with pytest.raises(RuntimeError, match="stop after materialization"):
+        _ = model.embed_image(image=wrapper)
+
+    # then
+    assert materialized["called"] is True


### PR DESCRIPTION
## Problem

`OWLv2HF.embed_image` calls `LazyImageWrapper.as_numpy()` — for URL references a **full download + JPEG decode** — *before* consulting the image-embeddings cache. On a cache hit the downloaded pixels are discarded unused. The legacy implementation (`inference/models/owlv2/owlv2.py`) checked the cache first (its comment: *"happy path … we avoid loading the image at all"*); the ordering was lost in the `inference_models` rewrite.

### Production impact (measured)

Label-assist ("magic label") sends the user's whole accumulated training set with every request, and each accepted label changes the set — which invalidates the class-embeddings cache key and makes `prepare_reference_examples_embeddings` walk all references. With this bug, that walk **re-downloads every reference image from object storage on every request**, even though all their embeddings are cached.

- Prod session traces (ck8s-prd async, 2026-07-15): sessions with 90–125 reference images ran **10–26 s on every request** — 71 consecutive requests on one warm pod, no warm-up drop ever; healthy small sessions drop 5.6 s → 0.5 s after request 1.
- Fit across 31 prod magic-label requests (request bodies joined to durations): `duration ≈ 1.4 s + 0.185 s × n_reference_images` (R² = 0.87) — the 0.185 s/image is one GCS download+decode. Requests re-sending an *identical* set return in 0.2–0.9 s even at 125 images, confirming the embeddings cache itself works and only this pre-cache download is on the hot path.
- With 5–6 requests in flight from one session (single-active-consumer queues), this stacks into 80–125 s tails → client-timeout 499s.

### Reproduction (L4, local HTTP server counting downloads, 40 ms/download, N=100 refs, one new box per request)

| | per request | image downloads per request |
|---|---|---|
| before | 13.8–14.0 s | **100 — every request** |
| after | **0.12 s** | **0** (100 once at warm-up) |

## Fix

Resolve the image hash (cheap: URL/base64 references hash the reference itself), look up the embeddings cache, and materialize pixels only on a miss. `unload_after_use` semantics preserved on both paths. No behavior change for in-memory images beyond skipping redundant work on a hit.

## Tests

`inference_models/tests/unit_tests/models/test_owlv2_embed_image_cache.py`:
- cache hit for a URL reference must **not** call `as_numpy()` (the test poisons it — fails on the pre-fix code),
- cache hit for an in-memory image returns the cached entry,
- cache miss still materializes the reference.

## Notes

- Related but independent: #2659 fixes the same cache being defeated by re-signed URLs (different callers). No merge conflict; either can land first.
- Like #2659, reaching serverless requires an `inference-models` release + pin bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)