### PR TITLE
ci: right-size build-dev-test workflow runner (16c -> 4c)

### DIFF
--- a/.github/workflows/integration_tests_workflows_x86.yml
+++ b/.github/workflows/integration_tests_workflows_x86.yml
@@ -37,8 +37,12 @@ jobs:
   build-dev-test:
     needs: call_is_mergeable
     if: ${{ (github.event.pull_request.head.repo.fork == false) && (github.event_name != 'pull_request' || needs.call_is_mergeable.outputs.mergeable_state != 'not_clean') }}
+    # These are workflow integration tests (pytest + Modal staging calls) — I/O-bound,
+    # not compute-bound. Measured on Depot across the 3.10/3.11/3.12 x true/false matrix:
+    # ~10-13% average CPU and ~9.3GB peak RAM, so the 16c/64GB machine sat almost idle.
+    # 4c/16GB keeps ~7GB headroom over the measured peak at a quarter of the per-minute cost.
     runs-on:
-      labels: depot-ubuntu-22.04-16
+      labels: depot-ubuntu-22.04-4
       group: public-depot
     strategy:
       matrix:


### PR DESCRIPTION
## What this does

Right-sizes the `build-dev-test` runner in the workflows integration-test suite from `depot-ubuntu-22.04-16` (16 vCPU / 64 GB) to `depot-ubuntu-22.04-4` (4 vCPU / 16 GB). One `runs-on` drives the full `3.10/3.11/3.12 × true/false` matrix.

## Why

These are pytest workflow integration tests + Modal staging calls — I/O-bound, not compute-bound. Observed peak memory ~9 GB and low average CPU, so the 16-core / 64 GB machine was almost idle. 4c/16 GB keeps ample headroom over the observed peak, and the lighter `build-dev-test` variants in this repo already run on 4c. CI on this PR runs the matrix on 4c to confirm.

If any variant turns out to be tight on memory, bumping to `depot-ubuntu-22.04-8` (32 GB) is a safe middle ground.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
