### PR TITLE
Add changes to CI agent to make sure version bumps are not requested from contributors

### DIFF
--- a/.claude/skills/create-workflow-block/SKILL.md
+++ b/.claude/skills/create-workflow-block/SKILL.md
@@ -66,7 +66,7 @@ These hold regardless of category — the per-category references only add nuanc
 - [ ] Producing/moving detections: parent-coordinate metadata attached.
 - [ ] Stateful block: state keyed by `video_identifier` + evicted; `get_restrictions()` declared; `NotImplementedError` on `StepExecutionMode.REMOTE` if remote is incoherent.
 - [ ] Unit test under `tests/workflows/unit_tests/core_steps/...` + integration test under `tests/workflows/integration_tests/execution/...`.
-- [ ] Version bump `inference/core/version.py`; bump `EXECUTION_ENGINE_V1_VERSION` + `docs/workflows/execution_engine_changelog.md` ONLY if the EE itself changed.
+- [ ] Bump `EXECUTION_ENGINE_V1_VERSION` + `docs/workflows/execution_engine_changelog.md` ONLY if the EE itself changed (no `inference/core/version.py` bump — that is handled at release time).
 - [ ] Do NOT hand-write `docs/workflows/blocks/<block>.md` — it is generated from manifest field descriptions.
 
 Reviewer's checklist for block PRs: `review-workflows-blocks`.

--- a/.claude/skills/review-cli-cloud-tooling/SKILL.md
+++ b/.claude/skills/review-cli-cloud-tooling/SKILL.md
@@ -36,7 +36,7 @@ Two distinct cloud surfaces live here — do not conflate them:
 - Magic number hardcoded in `api_operations` instead of an `os.getenv`-backed constant in `config.py`.
 - Filesystem path handling: manual `"/"` split (#1051), glob missing the `*` wildcard (#1157), or non-deterministic/unlabeled aggregation (#891).
 - `isinstance` vs `issubclass` misuse in exception-type checks (#354).
-- Missing companions: version bump, tests, CI deps, docs, swagger (see Standards).
+- Missing companions: tests, CI deps, docs, swagger (see Standards).
 - Removal that leaves a dead export/command behind (#1211).
 
 **NIT**:
@@ -44,7 +44,7 @@ Two distinct cloud surfaces live here — do not conflate them:
 - Missing `help=` string on a new option.
 
 ### Not blocking
-- A functional CLI change with no `inference/core/version.py` bump can be dismissed by the contributor in a comment — parallel changes may share the release, and the bump is often coordinated at release time. Flag it, don't block.
+- Do NOT ask for an `inference/core/version.py` bump — inference releases are versioned separately from feature/bugfix PRs; the bump is coordinated at release time.
 - `inference_cli/version.py` `__version__` is auto-adjusted by the PyPI-build CI action — do NOT ask for a manual bump there.
 - The `cloud` app (SkyPilot) deliberately uses `str` options, single-char shorts, and a bare `except Exception` → exit-1 envelope with no `debug_mode`. Do NOT demand the `rf-cloud` conventions on `cloud.py`/`cloud_adapter.py` — it is a separate, older surface.
 - Speed/latency evidence for benchmark changes is verifiable via the PR description, not the diff.
@@ -76,7 +76,7 @@ Two distinct cloud surfaces live here — do not conflate them:
 **Enterprise extension isolation.** `inference_cli/lib/enterprise/**` ships its own `LICENSE.txt`, is mounted as the `enterprise` typer app, and its heavy/optional TRT deps (under `enterprise/inference_compiler/`) must be import-guarded so the base CLI still imports. (#2186, #1679.)
 
 ## Required companions
-- **Version bump** — most CLI PRs bump `inference/core/version.py` `__version__`. Flag if absent, but dismissible (see Not blocking). Ignore `inference_cli/version.py` (CI-managed).
+- **Versioning** — no `inference/core/version.py` bump is required (release-time concern, see Not blocking). Ignore `inference_cli/version.py` (CI-managed).
 - **Tests** — logic changes need unit tests under `tests/inference_cli/unit_tests/lib/...` mirroring the source tree; user-visible changes update integration tests under `tests/inference_cli/integration_tests/`. (#891 updated both.)
 - **CI deps** — new runtime imports must be covered by the unit-test CI install list; `inference` is an optional dep, so new deps typically belong in `requirements/requirements.cli.txt`.
 - **Docs** — user-facing command/option changes update `docs/inference_helpers/cli_commands/{benchmark,cloud,workflows,infer,server}.md`. Batch-processing API swagger is exposed externally - tag @Erol444.
@@ -90,11 +90,10 @@ Two distinct cloud surfaces live here — do not conflate them:
 - `inference_cli/lib/roboflow_cloud/{common,config,errors,core}.py` — shared HTTP/retry/config/error taxonomy + `rf_cloud_app`.
 - `inference_cli/lib/roboflow_cloud/{data_staging,batch_processing}/{core,api_operations,entities}.py` — `rf-cloud` commands + wire schemas.
 - `inference_cli/lib/enterprise/inference_compiler/**` — TRT compiler extension (own LICENSE).
-- `inference/core/version.py` — the `__version__` bumped by CLI PRs.
 - Tests: `tests/inference_cli/{unit_tests,integration_tests}/**`. Docs: `docs/inference_helpers/cli_commands/**`.
 
 ## Reference PRs
-- [#2399](https://github.com/roboflow/inference/pull/2399) — feature: Asset Library metadata threaded entity→api_op→core; version bump + CI deps.
+- [#2399](https://github.com/roboflow/inference/pull/2399) — feature: Asset Library metadata threaded entity→api_op→core; CI deps.
 - [#2062](https://github.com/roboflow/inference/pull/2062) — feature: selectable `InferenceBackend` enum for batch processing (+ swagger).
 - [#2143](https://github.com/roboflow/inference/pull/2143) — feature: add job name to batch jobs (+ swagger).
 - [#1950](https://github.com/roboflow/inference/pull/1950) — feature: env-configurable `ROBOFLOW_API_REQUEST_TIMEOUT` in `config.py`.

--- a/.claude/skills/review-core-infra/SKILL.md
+++ b/.claude/skills/review-core-infra/SKILL.md
@@ -25,7 +25,7 @@ Severity tags: **BLOCK** = fix before merge; **FLAG** = raise it; **NIT** = opti
 4. **BLOCK — Cache/registry:** new cache reads degrade gracefully — wrapped, fall back to the API on outage, do not fail the request (#2387).
 5. **BLOCK — Entities:** new fields are defaulted AND mirrored across the Pydantic model + `*DC` dataclass + `_is_*_dc_to_dict` mapper; serialized aliases (`class_name` → `"class"`) preserved (#2484).
 6. **BLOCK — Ordering:** any "mutate then persist/cache" sequence mutates BEFORE the cache write (#966).
-7. **FLAG — Version:** if user-facing behavior changed or it's a release, `inference/core/version.py` bumps exactly the one const (no imports/side effects), monotonically (except deliberate reverts, #2136).
+7. **FLAG — Version:** only when the diff itself touches `inference/core/version.py` — it must change exactly the one const (no imports/side effects), monotonically (except deliberate reverts, #2136). Never require a bump on a PR that doesn't touch it.
 8. **FLAG — New env var:** typed coercion + sensible default, placed near related vars, AND documented (see *Env docs*).
 9. **FLAG — Exceptions:** correct base class (`RoboflowAPIRequestError` for API failures; standalone `Exception` only for cross-cutting like `CacheUnavailableError`), docstring-with-Attributes style.
 10. **FLAG — Logging:** log-event output stays JSON-serializable; no raw tracebacks / non-serializable objects into the event dict (#1225, #1340).
@@ -33,8 +33,8 @@ Severity tags: **BLOCK** = fix before merge; **FLAG** = raise it; **NIT** = opti
 12. **NIT — User-facing strings:** package names / commands are correct (`inference`, not `roboflow-inference`, #154); model-id slugs use the platform's exact underscores-vs-hyphens (#1343).
 
 ### Not blocking
-- A pure refactor, docs-only, or test-only PR need not bump `version.py`.
-- `inference_models` has its own version+changelog — do NOT demand a `version.py` bump for changes that live in that package.
+- No PR is required to bump `version.py` — inference releases are versioned separately; review the bump only when the diff includes one.
+- `inference_models` has its own version+changelog — its `pyproject.toml` version is a separate concern.
 - New env vars that are internal/experimental and off-by-default do not need a security-doc row (`environmental_variables.md` is enough).
 - Don't demand a Docker-ENV row for a flag that is identical across all images.
 
@@ -62,7 +62,7 @@ Severity tags: **BLOCK** = fix before merge; **FLAG** = raise it; **NIT** = opti
   Removing, reordering, or short-circuiting any layer is a BLOCK.
 
 ## Required companions
-- **Version bump:** a release/feature/fix that ships to users bumps `version.py` (chore PRs #2505, #2396, #1838 do only this; #793, #966, #1140, #1340, #1389 bump alongside the change). Pure refactor/docs need not.
+- **Versioning:** no `version.py` bump is required — release chore PRs (#2505, #2396, #1838) handle that separately. When the diff does bump it, apply checklist item 7.
 - **Env docs:** any new/renamed env var → row in `docs/server_configuration/environmental_variables.md`; input/security flags also in `docs/server_configuration/accepted_input_formats.md` (#957, #1004). Security-posture changes → `docs/install/security.md` (#2417).
 - **Tests:** changes to `image_utils.py`, `roboflow_api.py`, `entities/**`, `nms.py`, `logger.py`, `environment.py` require unit tests under the matching `tests/inference/unit_tests/core/**` subdir. Security fixes assert rejection + that `requests.get` is NOT called for the rejected URL (#2500, #2501). Entity changes extend `tests/inference/unit_tests/core/entities/**` (#2484).
 - **CI env parity:** if a default flips or a flag changes backend selection, the relevant CI workflow pins the flag so the matrix stays deterministic (#2136 pinned `USE_INFERENCE_MODELS=False`).

--- a/.claude/skills/review-http-api-server/SKILL.md
+++ b/.claude/skills/review-http-api-server/SKILL.md
@@ -9,7 +9,7 @@ description: Review guidance for PRs touching inference/core/interfaces/http/** 
 Trigger this skill when a PR touches any of:
 - `inference/core/interfaces/http/**` — `http_api.py` (the FastAPI app factory `HttpInterface`, all route registrations, middleware wiring, serverless auth), `error_handlers.py`, `orjson_utils.py`, `dependencies.py`, `request_metrics.py`, `uvicorn_config.py`, `middlewares/{cors,gzip}.py`, `builder/routes.py`, `handlers/workflows.py`.
 - `inference_cli/server.py` — the `inference server start|status|stop` typer CLI.
-- Companion touch-points this surface owns the contract for: a new exception in `inference/core/exceptions.py` that needs an HTTP mapping; the status-code map in `inference/core/roboflow_api.py`; header constants in `inference/core/constants.py` / `request_metrics.py`; a route-gating env flag in `inference/core/env.py`; `inference/core/version.py`.
+- Companion touch-points this surface owns the contract for: a new exception in `inference/core/exceptions.py` that needs an HTTP mapping; the status-code map in `inference/core/roboflow_api.py`; header constants in `inference/core/constants.py` / `request_metrics.py`; a route-gating env flag in `inference/core/env.py`.
 
 OUT of scope (other skills own these): Workflows execution-engine internals, model implementations under `inference/models/`, stream-manager/pipeline internals, `inference_sdk` client. Only review the HTTP *surface* of those. Serverless/tenant auth semantics are co-owned with `review-topic-auth-and-tenant-security` — that skill owns the fail-open rule; this skill enforces that every route on the surface declares its auth story.
 
@@ -29,14 +29,13 @@ Severity-tagged. Resolve BLOCK before merge; raise FLAG; NIT is optional.
 - **FLAG** — A new response header is added to the CORS `expose_headers` list in the `PathAwareCORSMiddleware` block of `http_api.py`, and its constant lives in `constants.py` / `request_metrics.py`.
 - **FLAG** — Request body/stream is read exactly once, via `parse_body_content_for_legacy_request_handler` in `dependencies.py` (#1518).
 - **FLAG** — External numeric inputs (`confidence`, `usage_fps`, `frames`) are guarded before arithmetic: clamp order is correct for percentage-vs-fraction inputs (#1746), and non-numeric values are rejected with `isinstance(x, numbers.Number)` (#795).
-- **FLAG** — Behavior changes bump `inference/core/version.py` `__version__`.
 - **FLAG** — Tests added/updated under `tests/inference/unit_tests/core/interfaces/http/` for the new status / field / header / branch.
 - **NIT** — Exception log level matches severity: `logger.warning(...)` for client-caused/expected (402, missing key), `logger.exception(...)` for server faults; every caught exception is logged, not silently swallowed (#1104).
 - **NIT** — CLI options follow `Annotated[..., typer.Option("--x/--no-x", help=...)]` and are threaded into `start_inference_container(...)` (#1024).
 - **NIT** — Endpoint/CLI changes update `docs/api.md` / `docs/server_configuration/` / `docs/inference_helpers/`.
 
 ### Not blocking
-- Do NOT demand a version bump for pure-refactor / comment / test-only diffs that don't change behavior.
+- Do NOT demand an `inference/core/version.py` bump — inference releases are versioned separately from feature/bugfix PRs.
 - Do NOT demand CORS `expose_headers` changes for headers that are internal-only or never returned cross-origin.
 - Do NOT demand a new env flag for routes that are already unconditionally serverless-excluded and carry no perf/rollout risk.
 - Response-header aggregation, Prometheus/GPU metrics endpoints, and serializer swaps are recurring revert magnets (#2222, #721, #724, #190) — ask for justification + tests, but a well-tested change here is not automatically a BLOCK.
@@ -61,7 +60,7 @@ One canonical statement per rule. The checklist above references these.
 - `inference/core/interfaces/http/dependencies.py` — `parse_body_content_for_legacy_request_handler` (legacy body/multipart parsing).
 - `inference/core/interfaces/http/builder/routes.py` — builder UI routes (path safety, Firestore-shaped responses).
 - `inference/core/interfaces/http/middlewares/{cors,gzip}.py`, `request_metrics.py`, `uvicorn_config.py`.
-- `inference/core/exceptions.py`, `inference/core/env.py`, `inference/core/version.py`, `inference/core/constants.py`, `inference/core/roboflow_api.py` (`DEFAULT_ERROR_HANDLERS`).
+- `inference/core/exceptions.py`, `inference/core/env.py`, `inference/core/constants.py`, `inference/core/roboflow_api.py` (`DEFAULT_ERROR_HANDLERS`).
 - `inference_cli/server.py` — CLI. Tests: `tests/inference/unit_tests/core/interfaces/http/`.
 
 ## Reference PRs

--- a/.claude/skills/review-inference-models-pkg/SKILL.md
+++ b/.claude/skills/review-inference-models-pkg/SKILL.md
@@ -63,8 +63,7 @@ Severity tags: **BLOCK** = must fix before merge; **FLAG** = raise it; **NIT** =
 ## Required companions
 Block a functional change unless it carries these (condition → required file):
 
-- **Any functional change** → version bump in `inference_models/pyproject.toml` AND a `docs/changelog.md` entry under a new `` ## `{version}` `` heading with `Added`/`Fixed`/`Changed`.
-- **Change reaches the server** → bump `inference/core/version.py` (`__version__`) too (as in #2260).
+- **Any functional change** → version bump in `inference_models/pyproject.toml` AND a `docs/changelog.md` entry under a new `` ## `{version}` `` heading with `Added`/`Fixed`/`Changed`. (No `inference/core/version.py` bump — inference releases are versioned separately.)
 - **`pyproject.toml` deps changed** → `inference_models/uv.lock` regenerated (`uv sync`); shared server deps also mirrored into `requirements/*.txt` (#2047, #2449 security bumps, #2415/#2510 dep updates).
 - **New error class** → `docs/errors/<page>.md` section + `help_url` anchor.
 - **New model** → `REGISTERED_MODELS` entry + `docs/models/<model>.md` + a license file for the model-family dir, listed in `docs/models/index.md`.

--- a/.claude/skills/review-legacy-models-registries/SKILL.md
+++ b/.claude/skills/review-legacy-models-registries/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review-legacy-models-registries
-description: Load when a PR touches inference/models/** (legacy ORT/HF models, models/utils.py ROBOFLOW_MODEL_TYPES + get_roboflow_model, models/aliases.py), inference/core/models/** (base.py, roboflow.py CLASS_MAP parsing, *_base.py, stubs.py, inference_models_adapters.py), or inference/core/registries/** (get_model_type, GENERIC_MODELS). Diff signals: new ROBOFLOW_MODEL_TYPES key, resolve_roboflow_model_alias, _session_lock/_state_lock, ort_session.run, USE_INFERENCE_MODELS, no version.py bump.
+description: Load when a PR touches inference/models/** (legacy ORT/HF models, models/utils.py ROBOFLOW_MODEL_TYPES + get_roboflow_model, models/aliases.py), inference/core/models/** (base.py, roboflow.py CLASS_MAP parsing, *_base.py, stubs.py, inference_models_adapters.py), or inference/core/registries/** (get_model_type, GENERIC_MODELS). Diff signals: new ROBOFLOW_MODEL_TYPES key, resolve_roboflow_model_alias, _session_lock/_state_lock, ort_session.run, USE_INFERENCE_MODELS.
 ---
 
 # Reviewing legacy-models-registries changes
@@ -16,7 +16,6 @@ OUT of scope (defer to other skills): Workflows blocks, HTTP API handlers (`infe
 ## Review checklist
 Severity-tagged. Each item points at its canonical rule in **Standards** below.
 
-- **BLOCK** — behavioral change with no `__version__` bump in `inference/core/version.py`. (S1)
 - **BLOCK** — new model missing any leg of the wiring triple: env flag (`env.py`) + guarded `ROBOFLOW_MODEL_TYPES` entry (`utils.py`) + registry recognition (`GENERIC_MODELS` or API task type). (S3)
 - **BLOCK** — a served `(task, variant)` has no `ROBOFLOW_MODEL_TYPES` key → `ModelNotRecognisedError`. (S3)
 - **BLOCK** — a raw `model_id` reaches chunking / auth / weight fetch without `resolve_roboflow_model_alias` first. (S2)
@@ -34,7 +33,7 @@ Severity-tagged. Each item points at its canonical rule in **Standards** below.
 - **NIT** — HF/transformer artifact download not guarded by `FileLock`. (S13)
 
 ### Not blocking
-- Do NOT demand a version bump for pure comment/docstring/test-only edits, or for a change that is itself the version bump.
+- Do NOT demand an `inference/core/version.py` bump — inference releases are versioned separately from feature/bugfix PRs.
 - Do NOT demand the full wiring triple when the PR only edits an existing model's internals (no new `(task, variant)`).
 - Do NOT demand a new adapter when the touched model has no `inference_models` backend.
 - Do NOT block on `Optional`-vs-default when the field is genuinely nullable in the response contract and callers do not use `exclude_none`.
@@ -46,7 +45,6 @@ Severity-tagged. Each item points at its canonical rule in **Standards** below.
 
 **Registry / id resolution.** `inference/core/registries/roboflow.py::get_model_type(model_id, api_key)` returns `(task_type, model_type)` by: resolving aliases, `GENERIC_MODELS` (whole `model_id` then `dataset_id`), `_get_local_model_type` (local `inference_models` dirs), stub versions, then the Roboflow API. The tuple keys into `ROBOFLOW_MODEL_TYPES` (`inference/models/utils.py`) to pick a class.
 
-- **S1 — Version bump is mandatory on any behavioral change.** Bump `__version__` in `inference/core/version.py` (every reference bugfix/feature PR does this — #1920, #495, #225, #1036, #1848, #2105, #2270).
 - **S2 — Alias resolution first.** Call `resolve_roboflow_model_alias(model_id)` (`inference/models/aliases.py`) before `get_model_id_chunks`, before obtaining chunks/weights, and before auth checks (missing before chunk-fetch in `_check_if_api_key_has_access_to_model` broke aliased-model authorization, #1226; pattern established in both model and registry layers, #193).
 - **S3 — New model wiring is a triple.** (a) env enablement flag in `inference/core/env.py` (e.g. `QWEN_3_5_ENABLED`, `CORE_MODEL_*_ENABLED`, #2105); (b) guarded import + `ROBOFLOW_MODEL_TYPES` entry in `inference/models/utils.py`; (c) registry recognition via `GENERIC_MODELS` or API task type. A registry key must exist for every served variant name (missing bare `("object-detection","rfdetr")` / `("instance-segmentation","rfdetr")` keys yielded `ModelNotRecognisedError` even though the inference-models backend served the variant, #2128). Optional/deprecated imports (Gaze) must be wrapped in try/except emitting a `warnings.warn(category=ModelDependencyMissing)`, or a crash at import breaks the whole `utils.py` load in slim images (#2338).
 - **S4 — `get_model_type` never returns `None`.** Unknowns fall back via `MODEL_TYPE_DEFAULTS` (`inference/core/roboflow_api.py`); `_ensure_model_supported_on_this_deployment` still gates. A silent `None` surfaces downstream as `ModelArtefactError`.
@@ -61,7 +59,6 @@ Severity-tagged. Each item points at its canonical rule in **Standards** below.
 - **S13 — Logging is lazy and low-noise; downloads are race-safe.** Use `logger.debug` for per-inference logs (OWLv2 moved INFO→DEBUG, #1793) and `%`-style lazy args, not f-strings, in hot paths (#1578). Guard HF/transformer artifact downloads with `FileLock` to avoid worker races (#1578).
 
 ## Required companions
-- **`inference/core/version.py`** — bump `__version__` on any behavioral change.
 - **`inference/core/env.py`** — env flag for any new model or global toggle (`*_ENABLED`, `DISABLED_INFERENCE_MODELS_BACKENDS`).
 - **`inference/models/utils.py`** — new `(task, variant)` → class mapping, guarded by the enablement flag and try/except, plus the `USE_INFERENCE_MODELS` adapter swap when a backend exists.
 - **`GENERIC_MODELS` in `inference/core/registries/roboflow.py`** — for foundation/core models keyed by whole `model_id` or `dataset_id`.
@@ -76,7 +73,7 @@ Severity-tagged. Each item points at its canonical rule in **Standards** below.
 - `inference/core/models/inference_models_adapters.py` — `InferenceModels{ObjectDetection,InstanceSegmentation,KeyPointsDetection,Classification,SemanticSegmentation}Adapter`.
 - `inference/models/aliases.py` — `resolve_roboflow_model_alias`, `REGISTERED_ALIASES`.
 - `inference/core/models/{object_detection,instance_segmentation,keypoints_detection,classification,semantic_segmentation}_base.py`, `stubs.py`.
-- `inference/core/env.py` (flags), `inference/core/version.py`, `inference/core/roboflow_api.py` (`MODEL_TYPE_DEFAULTS`).
+- `inference/core/env.py` (flags), `inference/core/roboflow_api.py` (`MODEL_TYPE_DEFAULTS`).
 
 ## Reference PRs
 - [#2105](https://github.com/roboflow/inference/pull/2105) — redirect versionless model auth/metadata to new registry via `USE_INFERENCE_MODELS`.

--- a/.claude/skills/review-packaging-ci/SKILL.md
+++ b/.claude/skills/review-packaging-ci/SKILL.md
@@ -19,7 +19,7 @@ OUT of scope (defer): library/business logic under `inference/`, `inference_mode
 ## Review checklist
 
 **BLOCK**
-- Version changed anywhere → confirm ALL of `inference/core/version.py` (`__version__`), `inference_models/pyproject.toml` (`version`), `inference_models/uv.lock`, and the 4 `inference-models~=` requirement pins move together; RC suffix consistent everywhere (#2341).
+- Release PR (`inference/core/version.py` `__version__` changed) → confirm ALL of `inference_models/pyproject.toml` (`version`), `inference_models/uv.lock`, and the 4 `inference-models~=` requirement pins move together; RC suffix consistent everywhere (#2341). The reverse does NOT hold: an `inference_models` version bump alone does not require an `inference/core/version.py` bump (the package versions independently).
 - `inference-models` pin bumped in one requirements file but not all 4 (`requirements.{cpu,gpu,vino,jetson}.txt`), or the `# keep in sync` comment deleted (#2341, #2144).
 - `inference_models/pyproject.toml` deps changed with no regenerated `inference_models/uv.lock` in the same PR (#2301).
 - New/edited workflow missing top-level `permissions:` (least privilege) (#1242, #1484).
@@ -48,6 +48,7 @@ OUT of scope (defer): library/business logic under `inference/`, `inference_mode
 - Adding an upper bound to a dependency proactively is a normal maintainer move, not a regression — don't demand a linked failure for every bound.
 - Cosmetic reordering / comment rewording that preserves behavior.
 - A version bump PR that touches many files is expected; the release template legitimately spans version.py + pyproject + uv.lock + 4 requirements files.
+- Do NOT demand an `inference/core/version.py` bump on non-release PRs — inference releases are versioned separately; the lock-step checks above apply only when a version actually changes in the diff.
 
 ## Standards
 

--- a/.claude/skills/review-sdk/SKILL.md
+++ b/.claude/skills/review-sdk/SKILL.md
@@ -25,7 +25,7 @@ OUT of scope (other skills): server-side model code under `inference/models/**` 
 ## Review checklist
 Severity tags: **BLOCK** (fix before merge) / **FLAG** (raise it) / **NIT** (optional).
 
-- **BLOCK** — Behavioural change bumps `inference/core/version.py` (`__version__`); `inference_sdk/version.py` left untouched (it is generated).
+- **BLOCK** — `inference_sdk/version.py` left untouched (it is generated at build time; never hand-edited).
 - **BLOCK** — New HTTP call uses `api_key_safe_raise_for_status`, never bare `response.raise_for_status()`; every user-facing error/URL string passes through `deduct_api_key_from_string`.
 - **BLOCK** — New sync client method has a matching `_async` sibling, each decorated with the correct `@wrap_errors` (sync) / `@wrap_errors_async` (async).
 - **BLOCK** — V1-only endpoint calls `self.__ensure_v1_client_mode()` before building the request.
@@ -40,7 +40,8 @@ Severity tags: **BLOCK** (fix before merge) / **FLAG** (raise it) / **NIT** (opt
 - **NIT** — Public signatures fully type-hinted with Google-style docstrings; image params typed as `ImagesReference`; `WrongClientModeError` listed under `Raises:` for V1-gated methods.
 
 ### Not blocking
-- A pure-internal refactor (no public method/error/config/signature change and no behavioural change) does not require a version bump, docs, or new tests — only that existing tests still pass.
+- Do NOT demand an `inference/core/version.py` bump — inference releases are versioned separately from feature/bugfix PRs.
+- A pure-internal refactor (no public method/error/config/signature change and no behavioural change) does not require docs or new tests — only that existing tests still pass.
 - A method that is intrinsically V1-only *and* has no V0 route does not need a V0 fallback; the `WrongClientModeError` gate is the correct behaviour, not a gap.
 - Cosmetic docstring/typing nits (last two items) never block a merge on their own.
 
@@ -69,11 +70,11 @@ Severity tags: **BLOCK** (fix before merge) / **FLAG** (raise it) / **NIT** (opt
 - **Signatures + docstrings.** Type-hinted public signatures with Google-style `Args:`/`Returns:`/`Raises:`. Image params typed `ImagesReference = Union[np.ndarray, PIL.Image.Image, str]`.
 
 ## Required companions
-- **Version bump:** `inference/core/version.py` (`__version__`). `.release/pypi/inference.sdk.setup.py` copies it → `inference_sdk/version.py` at build time; never hand-edit the generated file (bumps: #248 rc17→rc19, #255 rc21→rc22, #1521 0.54.1→0.54.2).
+- **Versioning:** no `inference/core/version.py` bump is required (release-time concern). `.release/pypi/inference.sdk.setup.py` copies it → `inference_sdk/version.py` at build time; never hand-edit the generated file.
 - **Tests:** `tests/inference_sdk/unit_tests/**` — `http/test_client.py`, `test_entities.py`, `http/utils/test_*.py` (key redaction → `test_requests.py`; session reuse → `http/utils/test_executors.py`), `test_config.py` for env-flags, a dedicated file for deprecations, `webrtc/` for WebRTC.
 - **Docs:** `docs/inference_helpers/inference_sdk.md` and/or sub-pages (`inference_sdk/core_models.md`, `configuration.md`, `workflows.md`, `model_management.md`).
 - **Requirements:** a pin in `requirements/requirements.sdk.http.txt` / `.webrtc.txt` for any new runtime dependency.
-- There is **no dedicated SDK changelog** — version bump + docs are the changelog surface.
+- There is **no dedicated SDK changelog** — docs are the changelog surface.
 
 ## Key files & Reference PRs
 - `inference_sdk/http/client.py` — `InferenceHTTPClient`, `wrap_errors`/`wrap_errors_async`, `_determine_client_mode`, `__ensure_v1_client_mode`, endpoint methods.

--- a/.claude/skills/review-topic-backward-compat-and-versioning/SKILL.md
+++ b/.claude/skills/review-topic-backward-compat-and-versioning/SKILL.md
@@ -29,6 +29,8 @@ Severity tags: **BLOCK** = fix before merge; **FLAG** = raise it; **NIT** = opti
 ### Not blocking
 Pure internal refactor / types / comments / formatting under a public surface with **no** observable contract or behavior change requires NO companion. Say so explicitly so the contributor isn't asked to over-version. Types-only/comment changes under `execution_engine/**` do NOT require an EE bump.
 
+Never require an `inference/core/version.py` bump as a companion on any PR — inference releases are versioned separately (release chore PRs handle the bump). This does NOT relax the `inference_models/pyproject.toml` version+changelog rule (§5) or the EE version rule (§3).
+
 ## Standards
 One canonical statement per rule. The checklist references these by number.
 
@@ -42,14 +44,14 @@ One canonical statement per rule. The checklist references these by number.
 
 5. **inference_models public API/entity change → version + changelog.** Bump `version` in `inference_models/pyproject.toml` (currently `0.29.7`) and add an entry to `inference_models/docs/changelog.md` under the matching `## \`X.Y.Z\`` heading (`Added`/`Fixed`/`Removed`).
 
-6. **Release-bound pins stay in lock-step.** Any `inference-models~=X` change is identical across `requirements/requirements.{cpu,gpu,jetson,vino}.txt` (they carry a "keep in sync" comment) AND `inference/core/version.py` bumped for a release, changelog updated, `uv.lock` regenerated.
+6. **Release-bound pins stay in lock-step.** Any `inference-models~=X` change is identical across `requirements/requirements.{cpu,gpu,jetson,vino}.txt` (they carry a "keep in sync" comment), with `uv.lock` regenerated and changelog updated when `inference_models/pyproject.toml` changes. Do not demand an `inference/core/version.py` bump — that happens on release PRs only.
 
 7. **Deprecation done right.** Removing a model/block/command raises the agreed error (`FeatureDeprecatedError` from `inference/core/exceptions.py` for deprecation-scoped surfaces), keeps the symbol resolvable, and sweeps dockerfiles/CI/docs/packaging together — not a bare code delete.
 
 8. **HTTP behavior change is intentional and gated.** Changing error-on-failure / status semantics (e.g. serverless auth failure) is a client-visible contract; confirm it's deliberate, tested, and not an accidental regression.
 
 ## Key files & Reference PRs
-- `inference/core/version.py` — single source of truth for the inference package version; every release-bound PR touches it.
+- `inference/core/version.py` — single source of truth for the inference package version; release PRs touch it (never demand a bump on feature/bugfix PRs).
 - `inference/core/workflows/execution_engine/v1/core.py` — `EXECUTION_ENGINE_V1_VERSION` constant that `get_execution_engine_compatibility` gates against.
 - `docs/workflows/execution_engine_changelog.md` — canonical EE changelog format.
 - `.cursor/rules/execution-engine-version-changelog.mdc` — the repo's written contract for when/how to bump EE + changelog + version tests.
@@ -57,4 +59,4 @@ One canonical statement per rule. The checklist references these by number.
 - `inference_models/pyproject.toml` + `inference_models/docs/changelog.md` — the standalone package's version + changelog companion pair.
 - `requirements/requirements.{cpu,gpu,jetson,vino}.txt` — the four `inference-models~=0.29.7` pins carrying the "keep in sync" comment.
 
-Reference PRs that shipped a contract change WITH its companions: **#2383** (EE version + changelog + tests), **#2475** (EE perf change keeping parity), **#2384** (block schema + `inference/core/version.py` bump), **#2510 / #2341 / #2175 / #2102** (release: version + changelog + all four pins + lock), **#2334** (mediapipe gaze deprecation across dockerfiles/CI/docs/packaging), **#2395** (removing deprecated Gemini block versions), **#2528/#2529** (serverless auth-failure status change then revert), **#2115 / #2267** (stale mirrored version assertions fixed).
+Reference PRs that shipped a contract change WITH its companions: **#2383** (EE version + changelog + tests), **#2475** (EE perf change keeping parity), **#2384** (block schema shipped additively with defaults), **#2510 / #2341 / #2175 / #2102** (release: version + changelog + all four pins + lock), **#2334** (mediapipe gaze deprecation across dockerfiles/CI/docs/packaging), **#2395** (removing deprecated Gemini block versions), **#2528/#2529** (serverless auth-failure status change then revert), **#2115 / #2267** (stale mirrored version assertions fixed).

--- a/.claude/skills/review-workflows-blocks/SKILL.md
+++ b/.claude/skills/review-workflows-blocks/SKILL.md
@@ -17,19 +17,19 @@ Severity: **BLOCK** = must fix before merge; **FLAG** = raise it; **NIT** = opti
 
 1. **BLOCK — Output contract**: enumerate `describe_outputs()` keys; confirm EVERY `run()`/helper return dict (happy, empty, error, zero-area) carries exactly those keys (#2346).
 2. **BLOCK — Versioning discipline**: bug-fix patches the existing `vN.py`; behavior change / new inputs-outputs goes in a NEW `vN.py`. Confirm no shipped `type` identifier or legacy alias was removed or repurposed.
-3. **BLOCK — Version bump** in `inference/core/version.py` (`__version__`) for any functional change.
-4. **BLOCK — Loader wiring**: new block imported into `load_blocks()`; new kind into `load_kinds()` + defined in `types.py` with `*_KIND_DOCS`; serializable data-kind into `KINDS_SERIALIZERS`/`KINDS_DESERIALIZERS`.
-5. **BLOCK — `__init__.py`** exists in every new/nested block package (guarded by `test_init_files.py`).
-6. **BLOCK — `sv.Detections.data` density**: any new data key holds dense N-d numpy arrays (no `dtype="object"` ragged) and has serializer/deserializer parity if it must round-trip.
-7. **FLAG — Tests**: unit test under `tests/workflows/unit_tests/core_steps/{category}/`; integration test under `tests/workflows/integration_tests/execution/test_workflow_with_*_block.py` for new or output-changing blocks.
-8. **FLAG — EE compatibility**: `get_execution_engine_compatibility()` reflects features used. If the PR bumps `EXECUTION_ENGINE_V1_VERSION`, require a changelog entry + version-assert test updates; a plain block change touching that version is a red flag.
-9. **FLAG — Cross-block kinds**: output kinds upstream ⊆ input kinds accepted downstream (esp. detections/segmentation/keypoint interplay).
-10. **FLAG — Model-version changes** update defaults/enums (not silent deletion) and keep old identifiers loadable.
-11. **FLAG — Batch handling** for model/foundation blocks: `run` iterates `Batch[...]` correctly and declares `get_parameters_accepting_batches()`.
-12. **FLAG — UQL correctness over speed**: be skeptical of micro-optimizations to `common/query_language/**` ops that change behavior (#1112/#1161/#1162 were reverted).
-13. **NIT — Field metadata**: new inputs have `title`/`description`/`examples`; `default=` correct (no stray `default=None` on required fields); `json_schema_extra` (`relevant_for`, `always_visible`) sensible.
+3. **BLOCK — Loader wiring**: new block imported into `load_blocks()`; new kind into `load_kinds()` + defined in `types.py` with `*_KIND_DOCS`; serializable data-kind into `KINDS_SERIALIZERS`/`KINDS_DESERIALIZERS`.
+4. **BLOCK — `__init__.py`** exists in every new/nested block package (guarded by `test_init_files.py`).
+5. **BLOCK — `sv.Detections.data` density**: any new data key holds dense N-d numpy arrays (no `dtype="object"` ragged) and has serializer/deserializer parity if it must round-trip.
+6. **FLAG — Tests**: unit test under `tests/workflows/unit_tests/core_steps/{category}/`; integration test under `tests/workflows/integration_tests/execution/test_workflow_with_*_block.py` for new or output-changing blocks.
+7. **FLAG — EE compatibility**: `get_execution_engine_compatibility()` reflects features used. If the PR bumps `EXECUTION_ENGINE_V1_VERSION`, require a changelog entry + version-assert test updates; a plain block change touching that version is a red flag.
+8. **FLAG — Cross-block kinds**: output kinds upstream ⊆ input kinds accepted downstream (esp. detections/segmentation/keypoint interplay).
+9. **FLAG — Model-version changes** update defaults/enums (not silent deletion) and keep old identifiers loadable.
+10. **FLAG — Batch handling** for model/foundation blocks: `run` iterates `Batch[...]` correctly and declares `get_parameters_accepting_batches()`.
+11. **FLAG — UQL correctness over speed**: be skeptical of micro-optimizations to `common/query_language/**` ops that change behavior (#1112/#1161/#1162 were reverted).
+12. **NIT — Field metadata**: new inputs have `title`/`description`/`examples`; `default=` correct (no stray `default=None` on required fields); `json_schema_extra` (`relevant_for`, `always_visible`) sensible.
 
 ### Not blocking
+- Do NOT demand an `inference/core/version.py` bump — inference releases are versioned separately from feature/bugfix PRs.
 - Do NOT demand a new `vN.py` for a pure in-place bug-fix; surgical patches to a shipped version are correct (#2346, #1339, #1368).
 - Do NOT demand `EXECUTION_ENGINE_V1_VERSION` / changelog changes on an ordinary block PR — most block changes never touch the EE version.
 - Do NOT demand serializer/deserializer entries for a data key that is purely intra-block and never crosses the wire.
@@ -56,7 +56,6 @@ The one canonical statement of each rule. Past regressions are cited inline; see
 
 ## Required companions
 Block a functional change that lacks these (canonical rules above; conditions here):
-- **Version bump** — `__version__` in `inference/core/version.py`, on essentially every functional block change (#2351, #2384, #1596).
 - **Loader registration** — new block in `load_blocks()`; new kind in `load_kinds()` + `types.py`; new serializable data-kind in `KINDS_SERIALIZERS`/`KINDS_DESERIALIZERS`, all in `loader.py` (#2362, #804).
 - **Tests** — unit test always; integration test for new or output-changing blocks (#2362, #718).
 - **`__init__.py`** — in every new/nested block package (#2351, #830).
@@ -70,7 +69,6 @@ Block a functional change that lacks these (canonical rules above; conditions he
 - `inference/core/workflows/execution_engine/entities/types.py` — `Kind` definitions + `*_KIND_DOCS`.
 - `inference/core/workflows/execution_engine/entities/base.py` — `WorkflowImageData`, `Batch`, `OutputDefinition`.
 - `inference/core/workflows/prototypes/block.py` — `WorkflowBlock`, `WorkflowBlockManifest`, `BlockResult`.
-- `inference/core/version.py` — `__version__` (bump gate).
 - `inference/core/workflows/execution_engine/v1/core.py` — `EXECUTION_ENGINE_V1_VERSION`.
 - Docs: `docs/workflows/create_workflow_block.md`, `versioning.md`, `blocks_bundling.md`, `execution_engine_changelog.md`.
 - Tests: `tests/workflows/unit_tests/core_steps/**`, `tests/workflows/integration_tests/execution/**`, `test_init_files.py`.
@@ -80,7 +78,7 @@ Block a functional change that lacks these (canonical rules above; conditions he
 - [#2346](https://github.com/roboflow/inference/pull/2346) — missing declared output key on empty branch (output-contract).
 - [#2170](https://github.com/roboflow/inference/pull/2170) — object-dtype ragged keypoint arrays break supervision.
 - [#1368](https://github.com/roboflow/inference/pull/1368) — `sv.Detections.data` must hold numpy arrays + serializer parity.
-- [#2384](https://github.com/roboflow/inference/pull/2384) — backward-compat input field added in-place to v1/v2/v3 + version bump.
+- [#2384](https://github.com/roboflow/inference/pull/2384) — backward-compat input field added in-place to v1/v2/v3 with defaults.
 - [#804](https://github.com/roboflow/inference/pull/804) — new `INFERENCE_ID_KIND` across blocks (kinds discipline).
 - [#565](https://github.com/roboflow/inference/pull/565) — Workflows block versioning foundation.
 - [#2351](https://github.com/roboflow/inference/pull/2351) — missing `__init__.py` (packaging/docs).

--- a/.claude/skills/review-workflows-execution-engine/SKILL.md
+++ b/.claude/skills/review-workflows-execution-engine/SKILL.md
@@ -35,7 +35,7 @@ Severity-tagged. Verify each against the linked Standard before raising.
 ### Not blocking
 - Comment/type-only refactors, formatting, and pure test/doc mirroring with **no** behavior change do NOT require a version bump or changelog (explicit exemption in `.cursor/rules/execution-engine-version-changelog.mdc`).
 - A pure bug fix to a scenario already covered by an integration test does not require a *new* test file — an assertion added to the existing scenario is fine.
-- An `inference/core/version.py` `__version__` bump is only required when the change ships as a release; a standalone EE change can defer it (do not demand it on every EE PR).
+- Never demand an `inference/core/version.py` `__version__` bump — inference releases are versioned separately (the EE version + changelog, per Standards, is the required companion here).
 - Do not demand `flush_stream_pipeline` mirroring on the ABC — it is intentionally not part of `BaseExecutionEngine` (see Public engine API).
 
 ## Standards

--- a/.github/prompts/claude-pr-review.md
+++ b/.github/prompts/claude-pr-review.md
@@ -430,7 +430,9 @@ Severity:
 - **Critical** - likely production breakage, data loss, or security exposure.
 - **High** - significant bug or contract break under realistic usage.
 - **High** - clearly required version bump omitted for a breaking or
-  release-bound change.
+  release-bound change (`inference_models/pyproject.toml` version or
+  `EXECUTION_ENGINE_V1_VERSION` only — never `inference/core/version.py`,
+  which is bumped separately at release time and must not be demanded on PRs).
 - **Medium** - meaningful risk or maintainability issue worth addressing before
   merge.
 - **Medium** - missing docs, changelog, or release-note updates for user-visible


### PR DESCRIPTION
## What does this PR do?

CI bot requests inference version bump to often. Fixing that 

## Type of Change

<!-- Please select one and delete the others, or describe if Other -->

- Bug fix (non-breaking change that fixes an issue)

## Testing

<!-- Describe how you tested your changes -->
- CI vibe check
- [ ] I have tested this change locally
- [ ] I have added/updated tests for this change

**Test details:**
<!-- Describe what tests were added/updated and what they cover -->

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)

## Additional Context

<!-- Add any other context, screenshots, or notes about the PR here -->
