### PR TITLE
fix(sam3): make sam_configuration.json optional when loading SAM3 model packages

### DIFF
--- a/inference_models/inference_models/models/sam3/sam3_torch.py
+++ b/inference_models/inference_models/models/sam3/sam3_torch.py
@@ -102,6 +102,11 @@ class SAM3Torch:
                 model_package_dir=model_name_or_path,
                 elements=["sam_configuration.json"],
             )
+        except CorruptedModelPackageError:
+            # sam_configuration.json is optional: fine-tuned SAM3 packages
+            # produced by roboflow-train do not include it.
+            config_content = None
+        if config_content is not None:
             version = decode_sam_version(
                 config_path=config_content["sam_configuration.json"]
             )
@@ -113,8 +118,6 @@ class SAM3Torch:
                     "contact us to get help.",
                     help_url="https://todo",
                 )
-        except KeyError:
-            pass
 
         device_str = "cuda" if device.type == "cuda" else "cpu"
         # build_sam3_image_model runs torch.jit.script on torchvision transforms


### PR DESCRIPTION
> [!NOTE]
> _Code and PR description are LLM-written. Code has been reviewed and tested by Kai_

## Problem

Loading any **fine-tuned** SAM3 model through `inference_models` fails with:

```
CorruptedModelPackageError: Model package is incomplete. Could not find element sam_configuration.json.
```

wrapped in `ModelPackageAlternativesExhaustedError` — after the full multi-GB weights download completes.

`SAM3Torch.from_pretrained` treats `sam_configuration.json` as optional (it is only used to validate the model version) and wraps the lookup in `try/except KeyError`. But `get_model_package_contents` raises `CorruptedModelPackageError` — not `KeyError` — for a missing element, so the exception is never caught and the intended-optional file is effectively mandatory.

Fine-tuned SAM3 packages produced by the Roboflow training pipeline contain `weights.pt`, `bpe_simple_vocab_16e6.txt.gz`, and `inference_config.json` — no `sam_configuration.json` — so **every fine-tuned SAM3 model fails to load** on any surface that routes SAM3 through `inference_models` (`USE_INFERENCE_MODELS=True`). Present since the SAM3 port in #1946 (first released in v1.3.0); base `sam3/*` packages are unaffected.

## Fix

Scope the `try` to just the `sam_configuration.json` lookup and catch `CorruptedModelPackageError` there, treating the file as absent. The unsupported-version check still raises when the file **is** present — catching the broader exception around the whole original block would have swallowed it.

## Testing

Reproduced on a T4 (CUDA) with a fine-tuned SAM3-large instance-segmentation model and a clean model cache:

- **Before:** exact `CorruptedModelPackageError` above; model never loads.
- **After:** package loads (`SAM3Torch`) and serves `segment_with_text_prompts` predictions.

## Follow-ups (out of scope)

- The training pipeline could start shipping a `sam_configuration.json` (e.g. `{"version": "base"}`) so future packages are self-describing.
- Fine-tuned checkpoints do not contain the `inst_interactive_predictor.*` / `sam2_convs.*` weights (non-strict load leaves them at init); fine for text-prompt segmentation, but `enable_inst_interactivity` should likely be forced off for fine-tunes — separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)