### PR TITLE
Add NVIDIA Cosmos AnomalyGen: mask-conditioned defect generation + workflow block

### DIFF
--- a/inference/core/workflows/core_steps/loader.py
+++ b/inference/core/workflows/core_steps/loader.py
@@ -241,6 +241,9 @@ from inference.core.workflows.core_steps.models.foundation.cog_vlm.v1 import (
 from inference.core.workflows.core_steps.models.foundation.cosmos3.v1 import (
     Cosmos3EdgeBlockV1,
 )
+from inference.core.workflows.core_steps.models.foundation.cosmos_anomalygen.v1 import (
+    CosmosAnomalyGenBlockV1,
+)
 from inference.core.workflows.core_steps.models.foundation.depth_estimation.v1 import (
     DepthEstimationBlockV1,
 )
@@ -1013,6 +1016,7 @@ def load_blocks() -> List[Type[WorkflowBlock]]:
         GoogleGemmaBlockV2,
         ImageSlicerBlockV2,
         Cosmos3EdgeBlockV1,
+        CosmosAnomalyGenBlockV1,
         Qwen25VLBlockV1,
         Qwen3VLBlockV1,
         Qwen35VLBlockV1,

--- a/inference/core/workflows/core_steps/models/foundation/cosmos_anomalygen/v1.py
+++ b/inference/core/workflows/core_steps/models/foundation/cosmos_anomalygen/v1.py
@@ -1,0 +1,231 @@
+from typing import List, Literal, Optional, Type, Union
+
+import cv2
+import numpy as np
+import supervision as sv
+from pydantic import ConfigDict, Field
+from supervision.draw.color import Color
+
+from inference.core.env import (
+    ALLOW_INFERENCE_MODELS_DIRECTLY_ACCESS_LOCAL_PACKAGES,
+    ALLOW_INFERENCE_MODELS_UNTRUSTED_PACKAGES,
+)
+from inference.core.roboflow_api import get_extra_weights_provider_headers
+from inference.core.workflows.core_steps.common.entities import StepExecutionMode
+from inference.core.workflows.execution_engine.entities.base import (
+    OutputDefinition,
+    WorkflowImageData,
+)
+from inference.core.workflows.execution_engine.entities.types import (
+    FLOAT_KIND,
+    IMAGE_KIND,
+    INSTANCE_SEGMENTATION_PREDICTION_KIND,
+    INTEGER_KIND,
+    ROBOFLOW_MODEL_ID_KIND,
+    STRING_KIND,
+    Selector,
+)
+from inference.core.workflows.prototypes.block import (
+    BlockResult,
+    Runtime,
+    RuntimeRestriction,
+    Severity,
+    WorkflowBlock,
+    WorkflowBlockManifest,
+)
+
+LONG_DESCRIPTION = """
+Generate synthetic defect images with NVIDIA Cosmos AnomalyGen.
+
+Given a clean (defect-free) image, a placement mask, and an anomaly type
+(e.g. `wood+crack`), the model inpaints a realistic defect into the mask's
+region. Fine-tuned per-defect checkpoints load through the same model id /
+local package path as the base model. Useful for bootstrapping defect
+detection datasets where real defect data is scarce.
+
+The placement mask comes in as an instance segmentation prediction - draw it
+upstream (e.g. a polygon zone converted to detections) or chain a
+segmentation model.
+"""
+
+
+class BlockManifest(WorkflowBlockManifest):
+    model_config = ConfigDict(
+        json_schema_extra={
+            "name": "Cosmos AnomalyGen",
+            "version": "v1",
+            "short_description": "Inpaint realistic synthetic defects into clean images.",
+            "long_description": LONG_DESCRIPTION,
+            "license": "Other",
+            "block_type": "model",
+            "search_keywords": [
+                "Cosmos",
+                "AnomalyGen",
+                "NVIDIA",
+                "defect",
+                "synthetic data",
+                "inpainting",
+                "anomaly",
+            ],
+            "ui_manifest": {
+                "section": "model",
+                "icon": "fal fa-hammer-crash",
+                "blockPriority": 5.9,
+            },
+        },
+        protected_namespaces=(),
+    )
+    type: Literal["roboflow_core/cosmos_anomalygen@v1"]
+
+    image: Selector(kind=[IMAGE_KIND]) = Field(
+        description="The clean (defect-free) image to inpaint a defect into.",
+        examples=["$inputs.image"],
+    )
+    segmentation_mask: Selector(kind=[INSTANCE_SEGMENTATION_PREDICTION_KIND]) = Field(
+        name="Placement Mask",
+        description="Segmentation prediction marking where the defect should appear.",
+        examples=["$steps.model.predictions"],
+    )
+    anomaly_type: Union[Selector(kind=[STRING_KIND]), str] = Field(
+        description="The trained anomaly type to generate, as `<texture>+<defect_class>`.",
+        examples=["wood+crack", "$inputs.anomaly_type"],
+    )
+    model_version: Union[Selector(kind=[ROBOFLOW_MODEL_ID_KIND]), str] = Field(
+        default="cosmos-anomalygen",
+        description="The Cosmos AnomalyGen checkpoint to use (model id or local package path).",
+        examples=["cosmos-anomalygen"],
+    )
+    guidance: Union[Selector(kind=[FLOAT_KIND]), float] = Field(
+        default=7.0,
+        description="Anomaly conditioning strength.",
+        examples=[7.0],
+    )
+    num_steps: Union[Selector(kind=[INTEGER_KIND]), int] = Field(
+        default=35,
+        description="Number of denoising steps.",
+        examples=[35],
+    )
+    seed: Union[Selector(kind=[INTEGER_KIND]), int] = Field(
+        default=0,
+        description="Random seed for reproducible generation.",
+        examples=[0],
+    )
+
+    @classmethod
+    def describe_outputs(cls) -> List[OutputDefinition]:
+        return [
+            OutputDefinition(
+                name="image",
+                kind=[IMAGE_KIND],
+                description="The clean image with the synthetic defect inpainted.",
+            ),
+        ]
+
+    @classmethod
+    def get_execution_engine_compatibility(cls) -> Optional[str]:
+        return ">=1.3.0,<2.0.0"
+
+    @classmethod
+    def get_restrictions(cls) -> List[RuntimeRestriction]:
+        return [
+            RuntimeRestriction(
+                severity=Severity.HARD,
+                note="Requires a GPU; the diffusion model needs CUDA.",
+                applies_to_runtimes=[Runtime.SELF_HOSTED_CPU],
+                applies_to_step_execution_modes=[StepExecutionMode.LOCAL],
+            ),
+            RuntimeRestriction(
+                severity=Severity.HARD,
+                note=(
+                    "Cosmos AnomalyGen has no remote endpoint - the block loads "
+                    "the model in-process and only supports local execution."
+                ),
+                applies_to_runtimes=[Runtime.HOSTED_SERVERLESS],
+                applies_to_step_execution_modes=[StepExecutionMode.REMOTE],
+            ),
+        ]
+
+    @classmethod
+    def get_supported_model_variants(cls) -> Optional[List[str]]:
+        return ["cosmos-anomalygen"]
+
+
+class CosmosAnomalyGenBlockV1(WorkflowBlock):
+    def __init__(
+        self,
+        api_key: Optional[str],
+        step_execution_mode: StepExecutionMode,
+    ):
+        self._api_key = api_key
+        self._step_execution_mode = step_execution_mode
+        self._model = None
+        self._current_model_id: Optional[str] = None
+
+    @classmethod
+    def get_init_parameters(cls) -> List[str]:
+        return ["api_key", "step_execution_mode"]
+
+    @classmethod
+    def get_manifest(cls) -> Type[WorkflowBlockManifest]:
+        return BlockManifest
+
+    def run(
+        self,
+        image: WorkflowImageData,
+        segmentation_mask: sv.Detections,
+        anomaly_type: str,
+        model_version: str,
+        guidance: float,
+        num_steps: int,
+        seed: int,
+    ) -> BlockResult:
+        if self._step_execution_mode is not StepExecutionMode.LOCAL:
+            raise NotImplementedError(
+                "Cosmos AnomalyGen only supports local execution - there is no "
+                "remote endpoint for this model."
+            )
+        model = self._resolve_model(model_id=model_version)
+        numpy_image = image.numpy_image
+        mask = rasterize_placement_mask(
+            image=numpy_image, segmentation_mask=segmentation_mask
+        )
+        generated = model.generate(
+            image=numpy_image,
+            mask=mask,
+            anomaly_type=anomaly_type,
+            guidance=guidance,
+            num_steps=num_steps,
+            seed=seed,
+            num_images=1,
+        )
+        return {
+            "image": WorkflowImageData.copy_and_replace(
+                origin_image_data=image,
+                numpy_image=generated[0],
+            ),
+        }
+
+    def _resolve_model(self, model_id: str):
+        if self._model is None or self._current_model_id != model_id:
+            from inference_models import AutoModel
+
+            extra_weights_provider_headers = get_extra_weights_provider_headers()
+            self._model = AutoModel.from_pretrained(
+                model_id_or_path=model_id,
+                api_key=self._api_key,
+                allow_untrusted_packages=ALLOW_INFERENCE_MODELS_UNTRUSTED_PACKAGES,
+                allow_direct_local_storage_loading=ALLOW_INFERENCE_MODELS_DIRECTLY_ACCESS_LOCAL_PACKAGES,
+                weights_provider_extra_headers=extra_weights_provider_headers,
+            )
+            self._current_model_id = model_id
+        return self._model
+
+
+def rasterize_placement_mask(
+    image: np.ndarray,
+    segmentation_mask: sv.Detections,
+) -> np.ndarray:
+    black_image = np.zeros_like(image)
+    mask_annotator = sv.MaskAnnotator(color=Color.WHITE, opacity=1.0)
+    mask = mask_annotator.annotate(black_image, segmentation_mask)
+    return cv2.cvtColor(mask, cv2.COLOR_BGR2GRAY)

--- a/inference_models/docs/changelog.md
+++ b/inference_models/docs/changelog.md
@@ -20,6 +20,12 @@ Add user-facing changes below using `### Added`, `### Changed`, `### Fixed`, or
 - NVIDIA Cosmos 3 Edge reasoner (`cosmos-3-edge`, task `vlm`, backend `hugging-face`):
   image/video + text prompting via `prompt(...)` / `prompt_video(...)`, following the
   standard VLM contract. The generative world-model tower ships separately.
+- NVIDIA Cosmos AnomalyGen (`cosmos-anomalygen`, new task `image-generation`, backend
+  `custom`): mask-conditioned defect inpainting via `generate(image, mask,
+  anomaly_type, ...)`, mirroring the upstream SDG generation-entry contract
+  (guidance / num_steps / seed / crop-and-paste) so JSONL-driven pipelines map one
+  entry to one call. Runtime ships inside the model package, like the Cosmos 3 Edge
+  generator.
 - NVIDIA Cosmos 3 Edge generator (`cosmos-3-edge-world`, task `world-model`, backend
   `custom`): image-to-video (`generate_video`), forward dynamics (`start_rollout` +
   `forward_dynamics` with explicit session-state threading), and inverse dynamics

--- a/inference_models/inference_models/models/auto_loaders/models_registry.py
+++ b/inference_models/inference_models/models/auto_loaders/models_registry.py
@@ -24,6 +24,7 @@ GAZE_DETECTION_TASK = "gaze-detection"
 OPEN_VOCABULARY_OBJECT_DETECTION_TASK = "open-vocabulary-object-detection"
 INTERACTIVE_INSTANCE_SEGMENTATION_TASK = "interactive-instance-segmentation"
 WORLD_MODEL_TASK = "world-model"
+IMAGE_GENERATION_TASK = "image-generation"
 
 
 @dataclass(frozen=True)
@@ -302,6 +303,10 @@ REGISTERED_MODELS: Dict[
     ("cosmos-3-edge-world", WORLD_MODEL_TASK, BackendType.CUSTOM): LazyClass(
         module_name="inference_models.models.cosmos3.cosmos3_world",
         class_name="Cosmos3EdgeWorldModel",
+    ),
+    ("cosmos-anomalygen", IMAGE_GENERATION_TASK, BackendType.CUSTOM): LazyClass(
+        module_name="inference_models.models.cosmos3.cosmos_anomalygen",
+        class_name="CosmosAnomalyGen",
     ),
     ("qwen3_5", VLM_TASK, BackendType.HF): LazyClass(
         module_name="inference_models.models.qwen3_5.qwen3_5_hf",

--- a/inference_models/inference_models/models/cosmos3/cosmos_anomalygen.py
+++ b/inference_models/inference_models/models/cosmos3/cosmos_anomalygen.py
@@ -1,0 +1,120 @@
+from threading import Lock
+from typing import List, Optional, Union
+
+import numpy as np
+import torch
+
+from inference_models.configuration import DEFAULT_DEVICE
+from inference_models.entities import ColorFormat
+from inference_models.errors import ModelInputError
+from inference_models.models.cosmos3.runtime_loading import load_runtime_from_package
+
+RUNTIME_MODULE_FILE = "cosmos_anomalygen_runtime.py"
+RUNTIME_CLASS_NAME = "CosmosAnomalyGenRuntime"
+
+DEFAULT_GUIDANCE = 7.0
+DEFAULT_NUM_STEPS = 35
+
+
+class CosmosAnomalyGen:
+    """NVIDIA Cosmos AnomalyGen - mask-conditioned defect inpainting.
+
+    Given a clean image, a binary placement mask, and an anomaly type, the
+    model inpaints a realistic defect into the mask's region. Fine-tuned
+    per-defect checkpoints load through the same weight-package path as the
+    base model. Parameters mirror the upstream SDG generation-entry contract
+    (guidance / num_steps / crop-and-paste), so callers currently driving
+    NVIDIA's `synthetic_dataset_generation` script via JSONL can map each
+    entry onto one `generate()` call.
+    """
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        model_name_or_path: str,
+        device: torch.device = DEFAULT_DEVICE,
+        **kwargs,
+    ) -> "CosmosAnomalyGen":
+        runtime_class = load_runtime_from_package(
+            model_name_or_path=model_name_or_path,
+            runtime_module_file=RUNTIME_MODULE_FILE,
+            runtime_class_name=RUNTIME_CLASS_NAME,
+        )
+        runtime = runtime_class.load(model_name_or_path, device=device)
+        return cls(runtime=runtime, device=device)
+
+    def __init__(self, runtime, device: torch.device):
+        self._runtime = runtime
+        self._device = device
+        self._lock = Lock()
+
+    def generate(
+        self,
+        image: np.ndarray,
+        mask: np.ndarray,
+        anomaly_type: str,
+        guidance: float = DEFAULT_GUIDANCE,
+        num_steps: int = DEFAULT_NUM_STEPS,
+        seed: int = 0,
+        num_images: int = 1,
+        crop_and_paste: bool = True,
+        crop_ratio: float = 2.0,
+        poisson_blend: bool = False,
+        input_color_format: ColorFormat = None,
+        **kwargs,
+    ) -> List[np.ndarray]:
+        """Inpaint `anomaly_type` into the white region of `mask` on `image`.
+
+        Returns `num_images` generated BGR images at the input resolution.
+        """
+        if not isinstance(image, np.ndarray) or image.ndim != 3:
+            raise ModelInputError(
+                message="generate() expects a single HxWx3 numpy image.",
+                help_url="https://inference-models.roboflow.com/errors/models-input/#modelinputerror",
+            )
+        binary_mask = _normalize_mask(mask=mask, image=image)
+        if input_color_format != "rgb":
+            image = image[:, :, ::-1]
+        image = np.ascontiguousarray(image)
+        with self._lock:
+            generated = self._runtime.generate(
+                image=image,
+                mask=binary_mask,
+                anomaly_type=anomaly_type,
+                guidance=guidance,
+                num_steps=num_steps,
+                seed=seed,
+                num_images=num_images,
+                crop_and_paste=crop_and_paste,
+                crop_ratio=crop_ratio,
+                poisson_blend=poisson_blend,
+            )
+        return [
+            np.ascontiguousarray(np.asarray(result)[:, :, ::-1]) for result in generated
+        ]
+
+
+def _normalize_mask(mask: Union[np.ndarray, None], image: np.ndarray) -> np.ndarray:
+    if not isinstance(mask, np.ndarray) or mask.ndim not in (2, 3):
+        raise ModelInputError(
+            message="generate() expects a HxW binary placement mask.",
+            help_url="https://inference-models.roboflow.com/errors/models-input/#modelinputerror",
+        )
+    if mask.ndim == 3:
+        mask = mask[:, :, 0]
+    if mask.shape[:2] != image.shape[:2]:
+        raise ModelInputError(
+            message=f"Mask resolution {mask.shape[:2]} does not match image "
+            f"resolution {image.shape[:2]}.",
+            help_url="https://inference-models.roboflow.com/errors/models-input/#modelinputerror",
+        )
+    binary_mask = (mask.astype(np.uint8) >= 128) if mask.dtype == np.uint8 else (
+        mask.astype(bool)
+    )
+    if not binary_mask.any():
+        raise ModelInputError(
+            message="Placement mask is empty - draw or place at least one "
+            "defect region before generating.",
+            help_url="https://inference-models.roboflow.com/errors/models-input/#modelinputerror",
+        )
+    return binary_mask.astype(np.uint8) * 255

--- a/inference_models/tests/unit_tests/models/test_cosmos_anomalygen.py
+++ b/inference_models/tests/unit_tests/models/test_cosmos_anomalygen.py
@@ -1,0 +1,96 @@
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+import torch
+
+from inference_models.errors import ModelInputError
+from inference_models.models.cosmos3.cosmos_anomalygen import CosmosAnomalyGen
+
+
+def _model() -> CosmosAnomalyGen:
+    return CosmosAnomalyGen(runtime=MagicMock(), device=torch.device("cpu"))
+
+
+def _image() -> np.ndarray:
+    return np.full((8, 8, 3), 128, dtype=np.uint8)
+
+
+def _mask() -> np.ndarray:
+    mask = np.zeros((8, 8), dtype=np.uint8)
+    mask[2:6, 2:6] = 255
+    return mask
+
+
+def test_generate_passes_sdg_parameters_to_runtime() -> None:
+    model = _model()
+    model._runtime.generate.return_value = [np.zeros((8, 8, 3), dtype=np.uint8)]
+
+    result = model.generate(
+        image=_image(),
+        mask=_mask(),
+        anomaly_type="wood+crack",
+        guidance=5.5,
+        num_steps=20,
+        seed=7,
+        num_images=1,
+    )
+
+    kwargs = model._runtime.generate.call_args.kwargs
+    assert kwargs["anomaly_type"] == "wood+crack"
+    assert kwargs["guidance"] == 5.5
+    assert kwargs["num_steps"] == 20
+    assert kwargs["seed"] == 7
+    assert kwargs["crop_and_paste"] is True
+    assert len(result) == 1
+
+
+def test_generate_binarizes_uint8_mask_with_128_threshold() -> None:
+    model = _model()
+    model._runtime.generate.return_value = []
+    mask = np.zeros((8, 8), dtype=np.uint8)
+    mask[0, 0] = 127  # below threshold
+    mask[1, 1] = 200  # above threshold
+
+    model.generate(image=_image(), mask=mask, anomaly_type="wood+crack")
+
+    sent = model._runtime.generate.call_args.kwargs["mask"]
+    assert sent[0, 0] == 0
+    assert sent[1, 1] == 255
+
+
+def test_generate_rejects_empty_mask() -> None:
+    model = _model()
+
+    with pytest.raises(ModelInputError):
+        model.generate(
+            image=_image(),
+            mask=np.zeros((8, 8), dtype=np.uint8),
+            anomaly_type="wood+crack",
+        )
+
+
+def test_generate_rejects_mismatched_mask_resolution() -> None:
+    model = _model()
+
+    with pytest.raises(ModelInputError):
+        model.generate(
+            image=_image(),
+            mask=np.full((4, 4), 255, dtype=np.uint8),
+            anomaly_type="wood+crack",
+        )
+
+
+def test_generate_converts_colors_both_ways() -> None:
+    model = _model()
+    rgb_out = np.zeros((8, 8, 3), dtype=np.uint8)
+    rgb_out[..., 0] = 255  # red in RGB
+    model._runtime.generate.return_value = [rgb_out]
+    bgr_in = np.zeros((8, 8, 3), dtype=np.uint8)
+    bgr_in[..., 0] = 255  # blue in BGR
+
+    result = model.generate(image=bgr_in, mask=_mask(), anomaly_type="wood+crack")
+
+    sent = model._runtime.generate.call_args.kwargs["image"]
+    assert sent[0, 0].tolist() == [0, 0, 255]  # runtime sees RGB
+    assert result[0][0, 0].tolist() == [0, 0, 255]  # caller gets BGR

--- a/tests/workflows/unit_tests/core_steps/models/foundation/test_cosmos_anomalygen.py
+++ b/tests/workflows/unit_tests/core_steps/models/foundation/test_cosmos_anomalygen.py
@@ -1,0 +1,89 @@
+"""Unit tests for the Cosmos AnomalyGen v1 block."""
+
+import numpy as np
+import pytest
+import supervision as sv
+from pydantic import ValidationError
+
+from inference.core.workflows.core_steps.common.entities import StepExecutionMode
+from inference.core.workflows.core_steps.models.foundation.cosmos_anomalygen.v1 import (
+    BlockManifest,
+    CosmosAnomalyGenBlockV1,
+    rasterize_placement_mask,
+)
+
+BASE = {
+    "type": "roboflow_core/cosmos_anomalygen@v1",
+    "name": "my_anomalygen_step",
+    "image": "$inputs.image",
+    "segmentation_mask": "$steps.model.predictions",
+    "anomaly_type": "wood+crack",
+}
+
+
+def test_manifest_parses_with_defaults():
+    result = BlockManifest.model_validate(BASE)
+    assert result.anomaly_type == "wood+crack"
+    assert result.model_version == "cosmos-anomalygen"
+    assert result.guidance == 7.0
+    assert result.num_steps == 35
+    assert result.seed == 0
+
+
+def test_manifest_accepts_selectors():
+    result = BlockManifest.model_validate(
+        {
+            **BASE,
+            "anomaly_type": "$inputs.anomaly_type",
+            "model_version": "$inputs.model_version",
+            "guidance": "$inputs.guidance",
+        }
+    )
+    assert result.anomaly_type == "$inputs.anomaly_type"
+    assert result.model_version == "$inputs.model_version"
+    assert result.guidance == "$inputs.guidance"
+
+
+def test_manifest_requires_segmentation_mask():
+    payload = dict(BASE)
+    del payload["segmentation_mask"]
+    with pytest.raises(ValidationError):
+        BlockManifest.model_validate(payload)
+
+
+def test_manifest_declares_image_output():
+    outputs = BlockManifest.describe_outputs()
+    assert [o.name for o in outputs] == ["image"]
+
+
+def test_remote_execution_raises():
+    block = CosmosAnomalyGenBlockV1(
+        api_key=None, step_execution_mode=StepExecutionMode.REMOTE
+    )
+    with pytest.raises(NotImplementedError):
+        block.run(
+            image=None,
+            segmentation_mask=None,
+            anomaly_type="wood+crack",
+            model_version="cosmos-anomalygen",
+            guidance=7.0,
+            num_steps=35,
+            seed=0,
+        )
+
+
+def test_rasterize_placement_mask_marks_masked_region_white():
+    image = np.zeros((10, 10, 3), dtype=np.uint8)
+    mask = np.zeros((1, 10, 10), dtype=bool)
+    mask[0, 2:6, 2:6] = True
+    detections = sv.Detections(
+        xyxy=np.array([[2.0, 2.0, 6.0, 6.0]]),
+        mask=mask,
+        class_id=np.array([0]),
+    )
+
+    result = rasterize_placement_mask(image=image, segmentation_mask=detections)
+
+    assert result.shape == (10, 10)
+    assert result[3, 3] == 255
+    assert result[0, 0] == 0


### PR DESCRIPTION
Follow-up to #2675, stacked on `peter/cosmos3-generative`. Adds **Cosmos AnomalyGen** (mask-conditioned synthetic-defect inpainting, [NVIDIA paidf-anomalygen](https://github.com/NVIDIA/paidf-anomalygen) / Cosmos-Predict2 2B) the same way the Cosmos 3 Edge towers were added.

## Model (`cosmos-anomalygen`, new task `image-generation`, backend `custom`)
- `CosmosAnomalyGen.generate(image, mask, anomaly_type, guidance=7.0, num_steps=35, seed=0, crop_and_paste=True, ...)` — parameters mirror the upstream SDG generation-entry (JSONL) contract 1:1, so pipelines currently driving `torchrun synthetic_dataset_generation` map one entry onto one call.
- Validates/binarizes the placement mask (128 threshold, resolution match, non-empty), converts colors both ways (BGR caller convention, RGB runtime).
- Runtime ships inside the model package (`cosmos_anomalygen_runtime.py`) via the same `import_class_from_file` seam as the Cosmos 3 Edge generator — no new core dependencies.

## Workflow block (`roboflow_core/cosmos_anomalygen@v1`)
- Inputs: clean `image`, `segmentation_mask` (instance-segmentation prediction, rasterized to a binary mask exactly like `stability_ai_inpainting@v1` — draw upstream or chain a segmentation model), `anomaly_type` (`texture+defect`), `model_version`, `guidance`/`num_steps`/`seed`.
- Output: `image` (`IMAGE_KIND`) with the defect inpainted.
- Loads in-process via `AutoModel` (the `segment_anything2_video@v1` precedent) — supports registered ids and local package paths. **Local execution only**: remote raises `NotImplementedError` and HARD `get_restrictions()` declare GPU-only + no-remote.

## Tests
- 5 model unit tests (SDG param passthrough, mask binarization/validation, color round-trip) + 6 block tests (manifest, selectors, remote-raises, mask rasterization) — all green; block verified present in `load_blocks()`.

## Outstanding
- [ ] Weight package: export the AnomalyGen checkpoint + a self-contained `cosmos_anomalygen_runtime.py` wrapping the paidf-anomalygen inference path (heavy deps: transformer-engine, apex, flash-attn — must ship in-package). No real-weights validation yet, unlike #2675.
- [ ] License review before hosting: NVIDIA Software and Model Evaluation License / NVIDIA Open Model License (not OpenMDW).
- [ ] Registry task type `image-generation` needs weights-service support before the model id can be registered.
- [ ] Fine-tuned per-defect checkpoints through the fine-tuned-weights path (the webapp's main flow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)