### PR TITLE
fix(sam3): make sam_configuration.json optional in package load

### DIFF
--- a/inference_models/docs/changelog.md
+++ b/inference_models/docs/changelog.md
@@ -5,6 +5,13 @@
 Add user-facing changes below using `### Added`, `### Changed`, `### Fixed`, or
 `### Removed` subsections as appropriate.
 
+### Fixed
+
+- Fine-tuned SAM3 model packages that ship without `sam_configuration.json` now load
+  correctly — the file is treated as optional (only base packages carry it). A present
+  but malformed `sam_configuration.json` (invalid JSON or missing `version` key) now
+  raises a clear `CorruptedModelPackageError` instead of an unhandled exception.
+
 ---
 
 ## `0.32.3`

--- a/inference_models/inference_models/models/sam3/sam3_torch.py
+++ b/inference_models/inference_models/models/sam3/sam3_torch.py
@@ -28,15 +28,13 @@ from inference_models.configuration import DEFAULT_DEVICE, SAM3_IMAGE_SIZE
 from inference_models.errors import CorruptedModelPackageError, ModelInputError
 from inference_models.models.common.model_packages import get_model_package_contents
 from inference_models.models.common.torch import torchscript_global_lock
-from inference_models.models.sam3.chunked_postprocessing import (
-    ChunkedPostProcessImage,
-)
 from inference_models.models.sam3.cache import (
     Sam3ImageEmbeddingsCache,
     Sam3ImageEmbeddingsCacheNullObject,
     Sam3LowResolutionMasksCache,
     Sam3LowResolutionMasksCacheNullObject,
 )
+from inference_models.models.sam3.chunked_postprocessing import ChunkedPostProcessImage
 from inference_models.models.sam3.entities import (
     SAM3ImageEmbeddings,
     SAM3MaskCacheEntry,

--- a/inference_models/inference_models/models/sam3/sam3_torch.py
+++ b/inference_models/inference_models/models/sam3/sam3_torch.py
@@ -102,7 +102,15 @@ class SAM3Torch:
             model_name_or_path, "sam_configuration.json"
         )
         if os.path.exists(sam_configuration_path):
-            version = decode_sam_version(config_path=sam_configuration_path)
+            try:
+                version = decode_sam_version(config_path=sam_configuration_path)
+            except (KeyError, ValueError) as error:
+                raise CorruptedModelPackageError(
+                    message="Could not decode sam_configuration.json in SAM3 model package. "
+                    "If you run inference locally, verify the correctness of SAM3 model package. "
+                    "If you see the error running on Roboflow platform - contact us to get help.",
+                    help_url="https://todo",
+                ) from error
             if version not in SUPPORTED_VERSIONS:
                 raise CorruptedModelPackageError(
                     message=f"Detected unsupported version of SAM3 model: {version}. Supported versions: "

--- a/inference_models/inference_models/models/sam3/sam3_torch.py
+++ b/inference_models/inference_models/models/sam3/sam3_torch.py
@@ -1,5 +1,6 @@
 import hashlib
 import json
+import os.path
 from copy import copy, deepcopy
 from threading import Lock, RLock
 from typing import Dict, Generator, List, Optional, Tuple, TypeVar, Union
@@ -97,14 +98,13 @@ class SAM3Torch:
             ],
         )
 
-        try:
-            config_content = get_model_package_contents(
-                model_package_dir=model_name_or_path,
-                elements=["sam_configuration.json"],
-            )
-            version = decode_sam_version(
-                config_path=config_content["sam_configuration.json"]
-            )
+        # sam_configuration.json is optional: fine-tuned packages produced by
+        # roboflow-train ship without it, only base packages carry it.
+        sam_configuration_path = os.path.join(
+            model_name_or_path, "sam_configuration.json"
+        )
+        if os.path.exists(sam_configuration_path):
+            version = decode_sam_version(config_path=sam_configuration_path)
             if version not in SUPPORTED_VERSIONS:
                 raise CorruptedModelPackageError(
                     message=f"Detected unsupported version of SAM3 model: {version}. Supported versions: "
@@ -113,8 +113,6 @@ class SAM3Torch:
                     "contact us to get help.",
                     help_url="https://todo",
                 )
-        except KeyError:
-            pass
 
         device_str = "cuda" if device.type == "cuda" else "cpu"
         # build_sam3_image_model runs torch.jit.script on torchvision transforms

--- a/inference_models/tests/unit_tests/models/test_sam3_torch.py
+++ b/inference_models/tests/unit_tests/models/test_sam3_torch.py
@@ -194,3 +194,21 @@ def test_from_pretrained_rejects_unsupported_sam_configuration_version(
             model_name_or_path=str(tmp_path),
             device=torch.device("cpu"),
         )
+
+
+def test_from_pretrained_rejects_malformed_sam_configuration(
+    sam3_torch_module: ModuleType, tmp_path
+) -> None:
+    # given - config present but missing the "version" key
+    from inference_models.errors import CorruptedModelPackageError
+
+    (tmp_path / "weights.pt").touch()
+    (tmp_path / "bpe_simple_vocab_16e6.txt.gz").touch()
+    (tmp_path / "sam_configuration.json").write_text('{"unexpected": "content"}')
+
+    # when / then
+    with pytest.raises(CorruptedModelPackageError):
+        sam3_torch_module.SAM3Torch.from_pretrained(
+            model_name_or_path=str(tmp_path),
+            device=torch.device("cpu"),
+        )

--- a/inference_models/tests/unit_tests/models/test_sam3_torch.py
+++ b/inference_models/tests/unit_tests/models/test_sam3_torch.py
@@ -141,3 +141,56 @@ def test_predict_for_single_image_selects_best_proposal_per_prompt(
 
     # then - proposal scores per prompt are [0.5, 0.9, 0.7], the best is kept
     assert torch.allclose(prediction.scores, torch.tensor([0.9, 0.9]).double())
+
+
+def test_from_pretrained_loads_package_without_sam_configuration(
+    sam3_torch_module: ModuleType, tmp_path
+) -> None:
+    # given - fine-tuned packages ship without sam_configuration.json
+    (tmp_path / "weights.pt").touch()
+    (tmp_path / "bpe_simple_vocab_16e6.txt.gz").touch()
+
+    # when
+    model = sam3_torch_module.SAM3Torch.from_pretrained(
+        model_name_or_path=str(tmp_path),
+        device=torch.device("cpu"),
+    )
+
+    # then
+    assert isinstance(model, sam3_torch_module.SAM3Torch)
+
+
+def test_from_pretrained_accepts_supported_sam_configuration_version(
+    sam3_torch_module: ModuleType, tmp_path
+) -> None:
+    # given
+    (tmp_path / "weights.pt").touch()
+    (tmp_path / "bpe_simple_vocab_16e6.txt.gz").touch()
+    (tmp_path / "sam_configuration.json").write_text('{"version": "base"}')
+
+    # when
+    model = sam3_torch_module.SAM3Torch.from_pretrained(
+        model_name_or_path=str(tmp_path),
+        device=torch.device("cpu"),
+    )
+
+    # then
+    assert isinstance(model, sam3_torch_module.SAM3Torch)
+
+
+def test_from_pretrained_rejects_unsupported_sam_configuration_version(
+    sam3_torch_module: ModuleType, tmp_path
+) -> None:
+    # given
+    from inference_models.errors import CorruptedModelPackageError
+
+    (tmp_path / "weights.pt").touch()
+    (tmp_path / "bpe_simple_vocab_16e6.txt.gz").touch()
+    (tmp_path / "sam_configuration.json").write_text('{"version": "unsupported"}')
+
+    # when / then
+    with pytest.raises(CorruptedModelPackageError):
+        sam3_torch_module.SAM3Torch.from_pretrained(
+            model_name_or_path=str(tmp_path),
+            device=torch.device("cpu"),
+        )


### PR DESCRIPTION
## What does this PR do?

get_model_package_contents raises CorruptedModelPackageError for a missing file, but the optional-config block caught KeyError, so every fine-tuned SAM3 package (shipped without sam_configuration.json by roboflow-train) failed to load. Check file existence instead; keep raising on unsupported version when the file is present.

## Type of Change

- Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] I have tested this change locally
- [x] I have added/updated tests for this change

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)

## Additional Context

N/A