### PR TITLE
Make TROCR adapter the dafault implementation given issues with HF compatibility of original package

### DIFF
--- a/inference/models/utils.py
+++ b/inference/models/utils.py
@@ -692,9 +692,11 @@ except:
 
 try:
     if CORE_MODEL_TROCR_ENABLED:
-        from inference.models import TrOCR
+        from inference.models.trocr.trocr_inference_models import (
+            InferenceModelsTrOCRAdapter,
+        )
 
-        ROBOFLOW_MODEL_TYPES[("ocr", "trocr")] = TrOCR
+        ROBOFLOW_MODEL_TYPES[("ocr", "trocr")] = InferenceModelsTrOCRAdapter
 except:
     warnings.warn(
         "Your `inference` configuration does not support TrOCR model. "


### PR DESCRIPTION
## What does this PR do?

In newest `transformers`, TR-OCR is going to break - fixed the packages for new inference, but patching old one may be hard (direct read from HF hub). This change solves the problem by running the the new inference as the only implementation (w/o hard removal yet).

## Type of Change

<!-- Please select one and delete the others, or describe if Other -->

- Bug fix (non-breaking change that fixes an issue)

## Testing

<!-- Describe how you tested your changes -->
- CI
- [ ] I have tested this change locally
- [ ] I have added/updated tests for this change

**Test details:**
<!-- Describe what tests were added/updated and what they cover -->

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)

## Additional Context

<!-- Add any other context, screenshots, or notes about the PR here -->
