### PR TITLE
Inference update after rfdetr optimization

### DIFF
--- a/docker/dockerfiles/Dockerfile.onnx.jetson.5.1.1
+++ b/docker/dockerfiles/Dockerfile.onnx.jetson.5.1.1
@@ -109,10 +109,14 @@ ENV VERSION_CHECK_MODE=continuous \
     ENABLE_STREAM_API=True \
     STREAM_API_PRELOADED_PROCESSES=2 \
     PYTHONPATH=/app:$PYTHONPATH
+# Triton imports in this deprecated JP 5.1.1 image, but cannot JIT-compile the
+# RF-DETR kernels. Keep those stages on their non-Triton implementations.
 ENV CORE_MODEL_SAM3_ENABLED=False \
     ALLOW_INFERENCE_MODELS_UNTRUSTED_PACKAGES=True \
     USE_INFERENCE_MODELS=True \
     RUNNING_ON_JETSON=True \
+    INFERENCE_MODELS_RFDETR_PREPROCESSOR=base \
+    INFERENCE_MODELS_RFDETR_POSTPROCESSOR=base \
     L4T_VERSION=35.2.1
 
 ENTRYPOINT ["/usr/local/bin/run_uvicorn.sh", "gpu_http:app"]

--- a/inference/core/models/inference_models_adapters.py
+++ b/inference/core/models/inference_models_adapters.py
@@ -2,6 +2,7 @@ import base64
 import io
 from collections import OrderedDict, deque
 from concurrent.futures import Future, ThreadPoolExecutor, TimeoutError
+from inspect import Parameter, signature
 from io import BytesIO
 from threading import local
 from time import perf_counter
@@ -175,6 +176,19 @@ class _PipelinePrimingSentinel:
 _PIPELINE_PRIMING = _PipelinePrimingSentinel()
 
 
+def _supports_independent_stage_execution(pre_process) -> bool:
+    """Return whether preprocessing declares the composed-execution control."""
+    try:
+        parameters = signature(pre_process).parameters
+    except (TypeError, ValueError):
+        return False
+    parameter = parameters.get("independent_stage_execution")
+    return parameter is not None and parameter.kind in {
+        Parameter.POSITIONAL_OR_KEYWORD,
+        Parameter.KEYWORD_ONLY,
+    }
+
+
 class InferenceModelsObjectDetectionAdapter(Model):
     def __init__(self, model_id: str, api_key: str = None, **kwargs):
         super().__init__()
@@ -205,6 +219,9 @@ class InferenceModelsObjectDetectionAdapter(Model):
             rf_detr_max_input_resolution=RFDETR_ONNX_MAX_RESOLUTION,
             **kwargs,
         )
+        self._preprocess_supports_independent_stage_execution = (
+            _supports_independent_stage_execution(self._model.pre_process)
+        )
         self.class_names = list(self._model.class_names)
 
     def map_inference_kwargs(self, kwargs: dict) -> dict:
@@ -230,6 +247,8 @@ class InferenceModelsObjectDetectionAdapter(Model):
             for v in images
         ]
         mapped_kwargs = self.map_inference_kwargs(kwargs)
+        if self._preprocess_supports_independent_stage_execution:
+            mapped_kwargs["independent_stage_execution"] = False
         return self._model.pre_process(np_images, **mapped_kwargs)
 
     def predict(self, img_in, **kwargs):

--- a/inference_models/docs/changelog.md
+++ b/inference_models/docs/changelog.md
@@ -31,6 +31,8 @@ Add user-facing changes below using `### Added`, `### Changed`, `### Fixed`, or
   `pre_process()` synchronizes before returning by default, so its output is ready for
   an independent `forward()` call. Composed `model(...)` and `infer()` calls explicitly
   use the asynchronous exact-tensor readiness handoff to avoid a host synchronization.
+  The inference-server object-detection adapter also enables this handoff for models
+  that explicitly declare the invocation-level preprocessing parameter.
 
 ### Fixed
 

--- a/inference_models/docs/contributors/inference-path-optimization-architecture.md
+++ b/inference_models/docs/contributors/inference-path-optimization-architecture.md
@@ -232,6 +232,12 @@ return asynchronously after associating its CUDA event with the exact output ten
 `forward()` always checks for such an entry and waits on its event when present; an
 independently prepared ready tensor has no entry and proceeds normally.
 
+The inference-server object-detection adapter composes the stages itself instead of
+calling the model's `infer()`. It inspects the loaded model's explicit `pre_process()`
+parameters once during initialization and passes `independent_stage_execution=False`
+only when that parameter is declared. Models that merely accept generic `**kwargs` do
+not receive the control.
+
 ```python
 model = AutoModel.from_pretrained(
     "rfdetr-small",

--- a/inference_models/inference_models/models/rfdetr/triton_object_detection_postprocess.py
+++ b/inference_models/inference_models/models/rfdetr/triton_object_detection_postprocess.py
@@ -161,6 +161,13 @@ class _CachedTensor:
     ready_event: torch.cuda.Event
 
 
+def _canonical_device(device: torch.device) -> torch.device:
+    """Resolve an unindexed CUDA alias to the current concrete CUDA device."""
+    if device.type == "cuda" and device.index is None:
+        return torch.device("cuda", torch.cuda.current_device())
+    return device
+
+
 class FusedObjectDetectionPostprocessor:
     """Batched top-k plus one fused Triton object-detection postprocess."""
 
@@ -176,7 +183,7 @@ class FusedObjectDetectionPostprocessor:
                     "#modelruntimeerror"
                 ),
             )
-        self._device = device
+        self._device = _canonical_device(device)
         self._metadata_cache: OrderedDict[Tuple[Any, ...], _CachedTensor] = (
             OrderedDict()
         )
@@ -357,7 +364,10 @@ class FusedObjectDetectionPostprocessor:
             unsupported.append("Triton is not installed")
         if not bboxes.is_cuda or not logits.is_cuda:
             unsupported.append("boxes and logits must be CUDA tensors")
-        if bboxes.device != logits.device or bboxes.device != self._device:
+        bboxes_device = _canonical_device(bboxes.device)
+        logits_device = _canonical_device(logits.device)
+        target_device = _canonical_device(self._device)
+        if bboxes_device != logits_device or bboxes_device != target_device:
             unsupported.append(
                 "boxes, logits, and target must use the same CUDA device"
             )
@@ -386,7 +396,10 @@ class FusedObjectDetectionPostprocessor:
         if classes_re_mapping is not None:
             if not classes_re_mapping.class_mapping.is_cuda:
                 unsupported.append("class mapping must be a CUDA tensor")
-            if classes_re_mapping.class_mapping.device != self._device:
+            if (
+                _canonical_device(classes_re_mapping.class_mapping.device)
+                != target_device
+            ):
                 unsupported.append("class mapping must use the target CUDA device")
         if unsupported:
             result = CompatibilityResult.incompatible(*unsupported)

--- a/inference_models/tests/unit_tests/models/rfdetr/test_triton_object_detection_postprocess.py
+++ b/inference_models/tests/unit_tests/models/rfdetr/test_triton_object_detection_postprocess.py
@@ -18,6 +18,7 @@ from inference_models.models.rfdetr.optimization.ids import (
 from inference_models.models.rfdetr.triton_object_detection_postprocess import (
     TRITON_AVAILABLE,
     FusedObjectDetectionPostprocessor,
+    _canonical_device,
     _metadata_values,
 )
 
@@ -59,6 +60,22 @@ def test_fused_postprocessor_is_explicitly_selectable() -> None:
 def test_fused_postprocessor_requires_cuda() -> None:
     with pytest.raises(ModelRuntimeError, match="requires a CUDA target"):
         FusedObjectDetectionPostprocessor(torch.device("cpu"))
+
+
+def test_canonical_device_resolves_bare_cuda_to_current_device(monkeypatch) -> None:
+    monkeypatch.setattr(torch.cuda, "current_device", lambda: 1)
+
+    assert _canonical_device(torch.device("cuda")) == torch.device("cuda:1")
+    assert _canonical_device(torch.device("cuda:0")) == torch.device("cuda:0")
+    assert _canonical_device(torch.device("cpu")) == torch.device("cpu")
+
+
+def test_fused_postprocessor_canonicalizes_target_device(monkeypatch) -> None:
+    monkeypatch.setattr(torch.cuda, "current_device", lambda: 0)
+
+    postprocessor = FusedObjectDetectionPostprocessor(torch.device("cuda"))
+
+    assert postprocessor._device == torch.device("cuda:0")
 
 
 def test_fused_postprocessor_reports_request_incompatibility_without_cuda() -> None:

--- a/tests/inference/unit_tests/core/models/test_inference_models_adapters.py
+++ b/tests/inference/unit_tests/core/models/test_inference_models_adapters.py
@@ -14,6 +14,8 @@ from inference.core.entities.responses.inference import (
 from inference.core.exceptions import PostProcessingError
 from inference.core.models.inference_models_adapters import (
     InferenceModelsInstanceSegmentationAdapter,
+    InferenceModelsObjectDetectionAdapter,
+    _supports_independent_stage_execution,
     prepare_classification_response,
     prepare_multi_label_classification_response,
 )
@@ -78,6 +80,26 @@ class _FakePipelineModel:
         return ["sync-detections"]
 
 
+class _FakeObjectDetectionModel:
+    def __init__(self) -> None:
+        self.pre_process_calls = []
+
+    def pre_process(self, images, **kwargs):
+        self.pre_process_calls.append((images, kwargs))
+        return "preprocessed", "metadata"
+
+
+class _FakeIndependentStageObjectDetectionModel(_FakeObjectDetectionModel):
+    def pre_process(
+        self,
+        images,
+        independent_stage_execution: bool = True,
+        **kwargs,
+    ):
+        kwargs["independent_stage_execution"] = independent_stage_execution
+        return super().pre_process(images, **kwargs)
+
+
 def _make_meta(tag: str):
     return [
         SimpleNamespace(
@@ -85,6 +107,33 @@ def _make_meta(tag: str):
             original_size=SimpleNamespace(width=10, height=20),
         )
     ]
+
+
+@pytest.mark.parametrize(
+    ("model", "expected_flag"),
+    [
+        (_FakeObjectDetectionModel(), None),
+        (_FakeIndependentStageObjectDetectionModel(), False),
+    ],
+)
+def test_object_detection_preprocess_only_disables_independent_execution_for_models_that_support_it(
+    model,
+    expected_flag,
+) -> None:
+    adapter = object.__new__(InferenceModelsObjectDetectionAdapter)
+    adapter._model = model
+    adapter._preprocess_supports_independent_stage_execution = (
+        _supports_independent_stage_execution(model.pre_process)
+    )
+
+    result = adapter.preprocess(torch.zeros((8, 9, 3), dtype=torch.uint8).numpy())
+
+    assert result == ("preprocessed", "metadata")
+    _, call_kwargs = model.pre_process_calls[0]
+    if expected_flag is None:
+        assert "independent_stage_execution" not in call_kwargs
+    else:
+        assert call_kwargs["independent_stage_execution"] is expected_flag
 
 
 def _make_pipeline_adapter(


### PR DESCRIPTION
## What does this PR do?

Linked issue: None

RF-DETR’s optimized preprocessing handoff was not enabled when inference ran through the inference-server object-detection adapter. The fused postprocessor also treated equivalent CUDA device representations such as `cuda` and `cuda:0` as different devices, while the deprecated JetPack 5.1.1 image cannot execute the required Triton JIT kernels.

The object-detection adapter now detects whether a model explicitly supports the `independent_stage_execution` preprocessing parameter and passes `False` when composing inference stages. Models that only accept generic `**kwargs` do not receive the parameter. The fused RF-DETR postprocessor resolves unindexed CUDA aliases to a concrete current-device index before comparing tensors, class mappings, and the target device. Explicitly different CUDA devices remain incompatible. The deprecated JetPack 5.1.1 image selects the `base` RF-DETR preprocessor and postprocessor to avoid unsupported Triton JIT execution.

**Main elements:**
- Capability-aware asynchronous preprocessing in `InferenceModelsObjectDetectionAdapter`
- Canonical CUDA device handling in the fused RF-DETR postprocessor
- RF-DETR base implementation overrides for the deprecated JetPack 5.1.1 image
- Unit coverage for adapter capability detection and CUDA device normalization
- Updated changelog and inference-path architecture documentation

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other:

## Testing

### Unit tests

- Verified the object-detection adapter passes `independent_stage_execution=False` only to models that explicitly declare the parameter.
- Verified models exposing only generic `**kwargs` do not receive the new argument.
- Verified bare `cuda` resolves to the current concrete CUDA device.
- Verified explicit CUDA indices and CPU devices remain unchanged.
- Ran the complete RF-DETR and generic optimization unit suites.

### Integration tests

- No integration tests were run for this PR.
- The target-specific JetPack 5.1.1 Docker image was not built locally.

### Other

- `PYTHONPATH=inference_models:. .venv/bin/pytest -q tests/inference/unit_tests/core/models/test_inference_models_adapters.py` — 18 passed.
- `PYTHONPATH=inference_models .venv/bin/pytest -q inference_models/tests/unit_tests/models/rfdetr inference_models/tests/unit_tests/models/optimization` — 132 passed, 13 skipped.
- Black, isort, Python syntax compilation, and `git diff --check` passed.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where necessary, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have updated the documentation accordingly (if applicable)

## Additional Context

`Dockerfile.onnx.jetson.5.1.1` is deprecated. Its Triton installation can import successfully but cannot JIT-compile the RF-DETR kernels, so this image explicitly uses the non-Triton `base` implementations.