### PR TITLE
Fix tests and update inference-models version

### DIFF
--- a/inference_models/docs/changelog.md
+++ b/inference_models/docs/changelog.md
@@ -7,6 +7,13 @@ Add user-facing changes below using `### Added`, `### Changed`, `### Fixed`, or
 
 ---
 
+## `0.32.2`
+
+### Fixed
+- Patch `triton-fused-v1` post-processor to use correctly current device alias for comparison.
+
+---
+
 ## `0.32.1`
 
 ### Fixed

--- a/inference_models/pyproject.toml
+++ b/inference_models/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inference-models"
-version = "0.32.1"
+version = "0.32.1rc1"
 description = "The new inference engine for Computer Vision models"
 readme = "README.md"
 requires-python = ">=3.10,<3.13"

--- a/inference_models/pyproject.toml
+++ b/inference_models/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inference-models"
-version = "0.32.1rc1"
+version = "0.32.2"
 description = "The new inference engine for Computer Vision models"
 readme = "README.md"
 requires-python = ">=3.10,<3.13"

--- a/inference_models/tests/integration_tests/models/test_rfdetr_predictions_trt.py
+++ b/inference_models/tests/integration_tests/models/test_rfdetr_predictions_trt.py
@@ -1,8 +1,59 @@
+from typing import Any
 from unittest.mock import patch
 
 import numpy as np
 import pytest
 import torch
+
+
+def _assert_detections_match(
+    actual: Any,
+    expected_confidence: torch.Tensor,
+    expected_class_id: torch.Tensor,
+    expected_xyxy: torch.Tensor,
+) -> None:
+    """Match detections as a set while enforcing confidence-descending output."""
+    actual_confidence = actual.confidence.cpu()
+    actual_class_id = actual.class_id.cpu()
+    actual_xyxy = actual.xyxy.cpu()
+    expected_confidence = expected_confidence.cpu()
+    expected_class_id = expected_class_id.cpu()
+    expected_xyxy = expected_xyxy.cpu()
+
+    assert actual_confidence.shape == expected_confidence.shape
+    assert actual_class_id.shape == expected_class_id.shape
+    assert actual_xyxy.shape == expected_xyxy.shape
+    assert torch.all(actual_confidence[:-1] >= actual_confidence[1:]), (
+        f"Detections are not ordered by decreasing confidence: "
+        f"{actual_confidence.tolist()}"
+    )
+
+    unmatched_actual_indices = set(range(actual_confidence.shape[0]))
+    for expected_index in range(expected_confidence.shape[0]):
+        matching_actual_indices = [
+            actual_index
+            for actual_index in unmatched_actual_indices
+            if actual_class_id[actual_index] == expected_class_id[expected_index]
+            and torch.isclose(
+                actual_confidence[actual_index],
+                expected_confidence[expected_index],
+                atol=0.01,
+            )
+            and torch.allclose(
+                actual_xyxy[actual_index],
+                expected_xyxy[expected_index],
+                atol=5,
+            )
+        ]
+        assert matching_actual_indices, (
+            f"No detection matches expected index {expected_index}: "
+            f"confidence={expected_confidence[expected_index].item()}, "
+            f"class_id={expected_class_id[expected_index].item()}, "
+            f"xyxy={expected_xyxy[expected_index].tolist()}"
+        )
+        unmatched_actual_indices.remove(matching_actual_indices[0])
+
+    assert not unmatched_actual_indices
 
 
 @pytest.mark.slow
@@ -25,28 +76,23 @@ def test_trt_package_numpy(
     predictions = model(coins_counting_image_numpy)
 
     # then
-    assert torch.allclose(
-        predictions[0].confidence.cpu(),
-        torch.tensor(
-            [
-                0.9697,
-                0.9622,
-                0.9612,
-                0.9607,
-                0.9602,
-                0.9601,
-                0.9563,
-                0.9522,
-                0.8563,
-                0.8026,
-                0.4912,
-            ]
-        ).cpu(),
-        atol=0.01,
+    expected_confidence = torch.tensor(
+        [
+            0.9697,
+            0.9622,
+            0.9612,
+            0.9607,
+            0.9602,
+            0.9601,
+            0.9563,
+            0.9522,
+            0.8563,
+            0.8026,
+            0.4912,
+        ]
     )
-    assert torch.allclose(
-        predictions[0].class_id.cpu(),
-        torch.tensor([1, 1, 4, 1, 1, 1, 1, 1, 1, 1, 3], dtype=torch.int32).cpu(),
+    expected_class_id = torch.tensor(
+        [1, 1, 4, 1, 1, 1, 1, 1, 1, 1, 3], dtype=torch.int32
     )
     expected_xyxy = torch.tensor(
         [
@@ -64,10 +110,11 @@ def test_trt_package_numpy(
         ],
         dtype=torch.int32,
     )
-    assert torch.allclose(
-        predictions[0].xyxy.cpu(),
-        expected_xyxy.cpu(),
-        atol=5,
+    _assert_detections_match(
+        actual=predictions[0],
+        expected_confidence=expected_confidence,
+        expected_class_id=expected_class_id,
+        expected_xyxy=expected_xyxy,
     )
 
 
@@ -128,28 +175,23 @@ def test_trt_package_batch_numpy(
     predictions = model([coins_counting_image_numpy, coins_counting_image_numpy])
 
     # then
-    assert torch.allclose(
-        predictions[0].confidence.cpu(),
-        torch.tensor(
-            [
-                0.9697,
-                0.9622,
-                0.9612,
-                0.9607,
-                0.9602,
-                0.9601,
-                0.9563,
-                0.9522,
-                0.8563,
-                0.8026,
-                0.4912,
-            ]
-        ).cpu(),
-        atol=0.01,
+    expected_confidence = torch.tensor(
+        [
+            0.9697,
+            0.9622,
+            0.9612,
+            0.9607,
+            0.9602,
+            0.9601,
+            0.9563,
+            0.9522,
+            0.8563,
+            0.8026,
+            0.4912,
+        ]
     )
-    assert torch.allclose(
-        predictions[0].class_id.cpu(),
-        torch.tensor([1, 1, 4, 1, 1, 1, 1, 1, 1, 1, 3], dtype=torch.int32).cpu(),
+    expected_class_id = torch.tensor(
+        [1, 1, 4, 1, 1, 1, 1, 1, 1, 1, 3], dtype=torch.int32
     )
     expected_xyxy = torch.tensor(
         [
@@ -167,55 +209,13 @@ def test_trt_package_batch_numpy(
         ],
         dtype=torch.int32,
     )
-    assert torch.allclose(
-        predictions[0].xyxy.cpu(),
-        expected_xyxy.cpu(),
-        atol=5,
-    )
-    assert torch.allclose(
-        predictions[1].confidence.cpu(),
-        torch.tensor(
-            [
-                0.9697,
-                0.9622,
-                0.9612,
-                0.9607,
-                0.9602,
-                0.9601,
-                0.9563,
-                0.9522,
-                0.8563,
-                0.8026,
-                0.4912,
-            ]
-        ).cpu(),
-        atol=0.01,
-    )
-    assert torch.allclose(
-        predictions[1].class_id.cpu(),
-        torch.tensor([1, 1, 4, 1, 1, 1, 1, 1, 1, 1, 3], dtype=torch.int32).cpu(),
-    )
-    expected_xyxy = torch.tensor(
-        [
-            [1172, 2633, 1376, 2848],
-            [1091, 2356, 1259, 2523],
-            [1316, 531, 3024, 1962],
-            [1741, 2299, 1918, 2469],
-            [1458, 2304, 1628, 2473],
-            [1254, 2061, 1425, 2231],
-            [1706, 2579, 1888, 2761],
-            [1501, 1884, 1724, 2095],
-            [922, 1842, 1095, 2007],
-            [2677, 803, 2874, 978],
-            [2677, 803, 2874, 978],
-        ],
-        dtype=torch.int32,
-    )
-    assert torch.allclose(
-        predictions[1].xyxy.cpu(),
-        expected_xyxy.cpu(),
-        atol=5,
-    )
+    for prediction in predictions:
+        _assert_detections_match(
+            actual=prediction,
+            expected_confidence=expected_confidence,
+            expected_class_id=expected_class_id,
+            expected_xyxy=expected_xyxy,
+        )
 
 
 @pytest.mark.slow
@@ -238,29 +238,24 @@ def test_trt_package_torch(
     predictions = model(coins_counting_image_torch)
 
     # then
-    assert torch.allclose(
-        predictions[0].confidence.cpu(),
-        torch.tensor(
-            [
-                0.9686,
-                0.9668,
-                0.9668,
-                0.9292,
-                0.9239,
-                0.8371,
-                0.8295,
-                0.7957,
-                0.7114,
-                0.5794,
-                0.5176,
-                0.4922,
-            ]
-        ).cpu(),
-        atol=0.01,
+    expected_confidence = torch.tensor(
+        [
+            0.9686,
+            0.9668,
+            0.9668,
+            0.9292,
+            0.9239,
+            0.8371,
+            0.8295,
+            0.7957,
+            0.7114,
+            0.5794,
+            0.5176,
+            0.4922,
+        ]
     )
-    assert torch.allclose(
-        predictions[0].class_id.cpu(),
-        torch.tensor([1, 1, 1, 4, 1, 3, 1, 1, 3, 3, 6, 1], dtype=torch.int32).cpu(),
+    expected_class_id = torch.tensor(
+        [1, 1, 1, 4, 1, 3, 1, 1, 3, 3, 6, 1], dtype=torch.int32
     )
     expected_xyxy = torch.tensor(
         [
@@ -279,10 +274,11 @@ def test_trt_package_torch(
         ],
         dtype=torch.int32,
     )
-    assert torch.allclose(
-        predictions[0].xyxy.cpu(),
-        expected_xyxy.cpu(),
-        atol=5,
+    _assert_detections_match(
+        actual=predictions[0],
+        expected_confidence=expected_confidence,
+        expected_class_id=expected_class_id,
+        expected_xyxy=expected_xyxy,
     )
 
 
@@ -307,29 +303,24 @@ def test_trt_package_torch_multiple_predictions_in_row(
         predictions = model(coins_counting_image_torch)
 
         # then
-        assert torch.allclose(
-            predictions[0].confidence.cpu(),
-            torch.tensor(
-                [
-                    0.9686,
-                    0.9668,
-                    0.9668,
-                    0.9292,
-                    0.9239,
-                    0.8371,
-                    0.8295,
-                    0.7957,
-                    0.7114,
-                    0.5794,
-                    0.5176,
-                    0.4922,
-                ]
-            ).cpu(),
-            atol=0.01,
+        expected_confidence = torch.tensor(
+            [
+                0.9686,
+                0.9668,
+                0.9668,
+                0.9292,
+                0.9239,
+                0.8371,
+                0.8295,
+                0.7957,
+                0.7114,
+                0.5794,
+                0.5176,
+                0.4922,
+            ]
         )
-        assert torch.allclose(
-            predictions[0].class_id.cpu(),
-            torch.tensor([1, 1, 1, 4, 1, 3, 1, 1, 3, 3, 6, 1], dtype=torch.int32).cpu(),
+        expected_class_id = torch.tensor(
+            [1, 1, 1, 4, 1, 3, 1, 1, 3, 3, 6, 1], dtype=torch.int32
         )
         expected_xyxy = torch.tensor(
             [
@@ -348,10 +339,11 @@ def test_trt_package_torch_multiple_predictions_in_row(
             ],
             dtype=torch.int32,
         )
-        assert torch.allclose(
-            predictions[0].xyxy.cpu(),
-            expected_xyxy.cpu(),
-            atol=5,
+        _assert_detections_match(
+            actual=predictions[0],
+            expected_confidence=expected_confidence,
+            expected_class_id=expected_class_id,
+            expected_xyxy=expected_xyxy,
         )
 
 
@@ -375,29 +367,24 @@ def test_trt_package_torch_list(
     predictions = model([coins_counting_image_torch, coins_counting_image_torch])
 
     # then
-    assert torch.allclose(
-        predictions[0].confidence.cpu(),
-        torch.tensor(
-            [
-                0.9686,
-                0.9668,
-                0.9668,
-                0.9292,
-                0.9239,
-                0.8371,
-                0.8295,
-                0.7957,
-                0.7114,
-                0.5794,
-                0.5176,
-                0.4922,
-            ]
-        ).cpu(),
-        atol=0.01,
+    expected_confidence = torch.tensor(
+        [
+            0.9686,
+            0.9668,
+            0.9668,
+            0.9292,
+            0.9239,
+            0.8371,
+            0.8295,
+            0.7957,
+            0.7114,
+            0.5794,
+            0.5176,
+            0.4922,
+        ]
     )
-    assert torch.allclose(
-        predictions[0].class_id.cpu(),
-        torch.tensor([1, 1, 1, 4, 1, 3, 1, 1, 3, 3, 6, 1], dtype=torch.int32).cpu(),
+    expected_class_id = torch.tensor(
+        [1, 1, 1, 4, 1, 3, 1, 1, 3, 3, 6, 1], dtype=torch.int32
     )
     expected_xyxy = torch.tensor(
         [
@@ -416,57 +403,13 @@ def test_trt_package_torch_list(
         ],
         dtype=torch.int32,
     )
-    assert torch.allclose(
-        predictions[0].xyxy.cpu(),
-        expected_xyxy.cpu(),
-        atol=5,
-    )
-    assert torch.allclose(
-        predictions[1].confidence.cpu(),
-        torch.tensor(
-            [
-                0.9686,
-                0.9668,
-                0.9668,
-                0.9292,
-                0.9239,
-                0.8371,
-                0.8295,
-                0.7957,
-                0.7114,
-                0.5794,
-                0.5176,
-                0.4922,
-            ]
-        ).cpu(),
-        atol=0.01,
-    )
-    assert torch.allclose(
-        predictions[1].class_id.cpu(),
-        torch.tensor([1, 1, 1, 4, 1, 3, 1, 1, 3, 3, 6, 1], dtype=torch.int32).cpu(),
-    )
-    expected_xyxy = torch.tensor(
-        [
-            [1171, 2632, 1379, 2845],
-            [1458, 2305, 1631, 2471],
-            [1090, 2354, 1261, 2520],
-            [1315, 523, 3029, 1963],
-            [1498, 1883, 1726, 2093],
-            [2674, 801, 2878, 980],
-            [1702, 2571, 1892, 2760],
-            [1249, 2059, 1428, 2233],
-            [918, 1838, 1099, 2007],
-            [1737, 2289, 1922, 2472],
-            [1249, 2059, 1428, 2233],
-            [918, 1838, 1099, 2007],
-        ],
-        dtype=torch.int32,
-    )
-    assert torch.allclose(
-        predictions[1].xyxy.cpu(),
-        expected_xyxy.cpu(),
-        atol=5,
-    )
+    for prediction in predictions:
+        _assert_detections_match(
+            actual=prediction,
+            expected_confidence=expected_confidence,
+            expected_class_id=expected_class_id,
+            expected_xyxy=expected_xyxy,
+        )
 
 
 @pytest.mark.slow
@@ -491,29 +434,24 @@ def test_trt_package_torch_batch(
     )
 
     # then
-    assert torch.allclose(
-        predictions[0].confidence.cpu(),
-        torch.tensor(
-            [
-                0.9686,
-                0.9668,
-                0.9668,
-                0.9292,
-                0.9239,
-                0.8371,
-                0.8295,
-                0.7957,
-                0.7114,
-                0.5794,
-                0.5176,
-                0.4922,
-            ]
-        ).cpu(),
-        atol=0.01,
+    expected_confidence = torch.tensor(
+        [
+            0.9686,
+            0.9668,
+            0.9668,
+            0.9292,
+            0.9239,
+            0.8371,
+            0.8295,
+            0.7957,
+            0.7114,
+            0.5794,
+            0.5176,
+            0.4922,
+        ]
     )
-    assert torch.allclose(
-        predictions[0].class_id.cpu(),
-        torch.tensor([1, 1, 1, 4, 1, 3, 1, 1, 3, 3, 6, 1], dtype=torch.int32).cpu(),
+    expected_class_id = torch.tensor(
+        [1, 1, 1, 4, 1, 3, 1, 1, 3, 3, 6, 1], dtype=torch.int32
     )
     expected_xyxy = torch.tensor(
         [
@@ -532,57 +470,13 @@ def test_trt_package_torch_batch(
         ],
         dtype=torch.int32,
     )
-    assert torch.allclose(
-        predictions[0].xyxy.cpu(),
-        expected_xyxy.cpu(),
-        atol=5,
-    )
-    assert torch.allclose(
-        predictions[1].confidence.cpu(),
-        torch.tensor(
-            [
-                0.9686,
-                0.9668,
-                0.9668,
-                0.9292,
-                0.9239,
-                0.8371,
-                0.8295,
-                0.7957,
-                0.7114,
-                0.5794,
-                0.5176,
-                0.4922,
-            ]
-        ).cpu(),
-        atol=0.01,
-    )
-    assert torch.allclose(
-        predictions[1].class_id.cpu(),
-        torch.tensor([1, 1, 1, 4, 1, 3, 1, 1, 3, 3, 6, 1], dtype=torch.int32).cpu(),
-    )
-    expected_xyxy = torch.tensor(
-        [
-            [1171, 2632, 1379, 2845],
-            [1458, 2305, 1631, 2471],
-            [1090, 2354, 1261, 2520],
-            [1315, 523, 3029, 1963],
-            [1498, 1883, 1726, 2093],
-            [2674, 801, 2878, 980],
-            [1702, 2571, 1892, 2760],
-            [1249, 2059, 1428, 2233],
-            [918, 1838, 1099, 2007],
-            [1737, 2289, 1922, 2472],
-            [1249, 2059, 1428, 2233],
-            [918, 1838, 1099, 2007],
-        ],
-        dtype=torch.int32,
-    )
-    assert torch.allclose(
-        predictions[1].xyxy.cpu(),
-        expected_xyxy.cpu(),
-        atol=5,
-    )
+    for prediction in predictions:
+        _assert_detections_match(
+            actual=prediction,
+            expected_confidence=expected_confidence,
+            expected_class_id=expected_class_id,
+            expected_xyxy=expected_xyxy,
+        )
 
 
 @pytest.mark.slow

--- a/inference_models/tests/unit_tests/models/rfdetr/test_triton_object_detection_postprocess.py
+++ b/inference_models/tests/unit_tests/models/rfdetr/test_triton_object_detection_postprocess.py
@@ -212,6 +212,9 @@ def test_fused_postprocessor_matches_reference(
     stream.synchronize()
 
     for actual_image, expected_image in zip(actual, expected):
+        assert torch.all(
+            actual_image.confidence[:-1] >= actual_image.confidence[1:]
+        ), f"Confidence is not decreasing: {actual_image.confidence.tolist()}"
         torch.testing.assert_close(actual_image.xyxy, expected_image.xyxy)
         torch.testing.assert_close(actual_image.class_id, expected_image.class_id)
         torch.testing.assert_close(

--- a/requirements/requirements.cpu.txt
+++ b/requirements/requirements.cpu.txt
@@ -1,3 +1,3 @@
 onnxruntime>=1.15.1,<1.22.0
 nvidia-ml-py<13.0.0
-inference-models[torch-cpu,onnx-cpu]~=0.32.1  # keep in sync between requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt
+inference-models[torch-cpu,onnx-cpu]~=0.32.2  # keep in sync between requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt

--- a/requirements/requirements.gpu.txt
+++ b/requirements/requirements.gpu.txt
@@ -1,2 +1,2 @@
 onnxruntime-gpu>=1.15.1,<1.22.0
-inference-models[torch-cu124,onnx-cu12]~=0.32.1 # keep in sync between requirements.jetson requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt
+inference-models[torch-cu124,onnx-cu12]~=0.32.2 # keep in sync between requirements.jetson requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt

--- a/requirements/requirements.jetson.txt
+++ b/requirements/requirements.jetson.txt
@@ -1,3 +1,3 @@
 pypdfium2>=4.11.0,<5.0.0
 PyYAML~=6.0.0
-inference-models~=0.32.1  # keep in sync between requirements.jetson requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt
+inference-models~=0.32.2  # keep in sync between requirements.jetson requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt

--- a/requirements/requirements.vino.txt
+++ b/requirements/requirements.vino.txt
@@ -1,2 +1,2 @@
 onnxruntime-openvino>=1.15.0,<1.22.0
-inference-models[torch-cpu]~=0.32.1  # keep in sync between requirements.jetson requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt
+inference-models[torch-cpu]~=0.32.2  # keep in sync between requirements.jetson requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt


### PR DESCRIPTION
## Summary
Update RF-DETR TensorRT prediction tests to tolerate undefined ordering between equal-confidence detections.

## Changes
- Compare expected RF-DETR detections as an unordered set using the existing confidence and bounding-box tolerances.
- Continue enforcing that returned detections are ordered by non-increasing confidence.
- Add an explicit confidence-order assertion to the triton-fused-v1 postprocessor parity test.

## Motivation
`BasePostprocessor` and `TritonFusedPostprocessor` both return detections sorted by confidence, but PyTorch does not guarantee stable indices for tied torch.topk values.

The failing tests contained two detections with equal confidence and class IDs. triton-fused-v1 returned the same detections with those two bounding boxes swapped, causing position-based xyxy assertions to fail despite equivalent output.

## Verification
- 8 passed, 4 skipped in the focused RF-DETR postprocessor unit tests. Skipped tests require CUDA and Triton.
- Verified the amended assertion against the swapped equal-confidence detections from CI.
- Black, isort, strict Flake8, syntax compilation, and git diff --check passed.
- The full trt_extras integration suite requires a GPU CI runner.