### PR TITLE
Add workflow mode to disable sink side effects

### DIFF
--- a/inference/core/entities/requests/workflows.py
+++ b/inference/core/entities/requests/workflows.py
@@ -37,6 +37,10 @@ class WorkflowInferenceRequest(BaseModel):
     workflow_id: Optional[str] = Field(
         default=None, description="Optional identifier of workflow"
     )
+    disable_sinks: bool = Field(
+        default=False,
+        description="Run the workflow without allowing sink blocks to produce side effects.",
+    )
 
 
 class PredefinedWorkflowInferenceRequest(WorkflowInferenceRequest):

--- a/inference/core/interfaces/http/http_api.py
+++ b/inference/core/interfaces/http/http_api.py
@@ -1360,6 +1360,7 @@ class HttpInterface(BaseInterface):
                     profiler=profiler,
                     executor=self.shared_thread_pool_executor,
                     workflow_id=workflow_request.workflow_id,
+                    disable_sinks=workflow_request.disable_sinks,
                 )
             is_preview = False
             if hasattr(workflow_request, "is_preview"):

--- a/inference/core/workflows/execution_engine/core.py
+++ b/inference/core/workflows/execution_engine/core.py
@@ -43,6 +43,7 @@ class ExecutionEngine(BaseExecutionEngine):
         step_error_handler: Optional[
             Union[str, Callable[[str, Exception], None]]
         ] = DEFAULT_WORKFLOWS_STEP_ERROR_HANDLER,
+        disable_sinks: bool = False,
     ) -> "ExecutionEngine":
         requested_engine_version = retrieve_requested_execution_engine_version(
             workflow_definition=workflow_definition,
@@ -59,6 +60,7 @@ class ExecutionEngine(BaseExecutionEngine):
             profiler=profiler,
             executor=executor,
             step_error_handler=step_error_handler,
+            disable_sinks=disable_sinks,
         )
         return cls(engine=engine)
 

--- a/inference/core/workflows/execution_engine/entities/engine.py
+++ b/inference/core/workflows/execution_engine/entities/engine.py
@@ -21,6 +21,7 @@ class BaseExecutionEngine(ABC):
         step_error_handler: Optional[
             Union[str, Callable[[str, Exception], None]]
         ] = None,
+        disable_sinks: bool = False,
     ) -> "BaseExecutionEngine":
         pass
 

--- a/inference/core/workflows/execution_engine/v1/compiler/core.py
+++ b/inference/core/workflows/execution_engine/v1/compiler/core.py
@@ -27,6 +27,9 @@ from inference.core.workflows.execution_engine.v1.compiler.entities import (
 from inference.core.workflows.execution_engine.v1.compiler.graph_constructor import (
     prepare_execution_graph,
 )
+from inference.core.workflows.execution_engine.v1.compiler.sink_disabling import (
+    disable_workflow_sinks,
+)
 from inference.core.workflows.execution_engine.v1.compiler.steps_initialiser import (
     initialise_steps,
 )
@@ -69,6 +72,7 @@ COMPILATION_CACHE = BasicWorkflowsCache[GraphCompilationResult](
             partial(json.dumps, sort_keys=True),
         ),
         ("execution_engine_version", lambda version: str(version)),
+        ("disable_sinks", str),
     ],
 )
 
@@ -82,12 +86,14 @@ def compile_workflow(
     init_parameters: Dict[str, Union[Any, Callable[[None], Any]]],
     execution_engine_version: Optional[Version] = None,
     profiler: Optional[WorkflowsProfiler] = None,
+    disable_sinks: bool = False,
 ) -> CompiledWorkflow:
     graph_compilation_results = compile_workflow_graph(
         workflow_definition=workflow_definition,
         execution_engine_version=execution_engine_version,
         profiler=profiler,
         init_parameters=init_parameters,
+        disable_sinks=disable_sinks,
     )
     steps = initialise_steps(
         steps_manifest=graph_compilation_results.parsed_workflow_definition.steps,
@@ -110,6 +116,7 @@ def compile_workflow(
         input_substitutions=input_substitutions,
         kinds_serializers=graph_compilation_results.kinds_serializers,
         kinds_deserializers=graph_compilation_results.kinds_deserializers,
+        disabled_steps=graph_compilation_results.disabled_steps,
     )
 
 
@@ -118,12 +125,14 @@ def compile_workflow_graph(
     execution_engine_version: Optional[Version] = None,
     profiler: Optional[WorkflowsProfiler] = None,
     init_parameters: Optional[Dict[str, Union[Any, Callable[[None], Any]]]] = None,
+    disable_sinks: bool = False,
 ) -> GraphCompilationResult:
     if init_parameters is None:
         init_parameters = {}
     key = COMPILATION_CACHE.get_hash_key(
         workflow_definition=workflow_definition,
         execution_engine_version=execution_engine_version,
+        disable_sinks=disable_sinks,
     )
     cached_value = COMPILATION_CACHE.get(key=key)
     if cached_value is not None:
@@ -169,6 +178,14 @@ def compile_workflow_graph(
         available_blocks=available_blocks,
         profiler=profiler,
     )
+    disabled_steps = frozenset()
+    if disable_sinks:
+        sink_disabling_result = disable_workflow_sinks(
+            workflow_definition=inlined_raw_workflow_definition,
+            available_blocks=available_blocks,
+        )
+        inlined_raw_workflow_definition = sink_disabling_result.workflow_definition
+        disabled_steps = sink_disabling_result.steps_without_native_noop
     parsed_workflow_definition = parse_workflow_definition(
         raw_workflow_definition=inlined_raw_workflow_definition,
         available_blocks=available_blocks,
@@ -189,6 +206,7 @@ def compile_workflow_graph(
         initializers=initializers,
         kinds_serializers=kinds_serializers,
         kinds_deserializers=kinds_deserializers,
+        disabled_steps=disabled_steps,
     )
     COMPILATION_CACHE.cache(key=key, value=result)
     return result

--- a/inference/core/workflows/execution_engine/v1/compiler/entities.py
+++ b/inference/core/workflows/execution_engine/v1/compiler/entities.py
@@ -1,7 +1,18 @@
 from abc import abstractmethod
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Callable, Dict, Generator, List, Optional, Set, Type, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    FrozenSet,
+    Generator,
+    List,
+    Optional,
+    Set,
+    Type,
+    Union,
+)
 
 import networkx as nx
 
@@ -47,6 +58,7 @@ class GraphCompilationResult:
     initializers: Dict[str, Union[Any, Callable[[None], Any]]]
     kinds_serializers: Dict[str, Callable[[Any], Any]]
     kinds_deserializers: Dict[str, Callable[[str, Any], Any]]
+    disabled_steps: FrozenSet[str] = field(default_factory=frozenset)
 
 
 @dataclass(frozen=True)
@@ -64,6 +76,7 @@ class CompiledWorkflow:
     input_substitutions: List[InputSubstitution]
     workflow_json: Dict[str, Any]
     init_parameters: Dict[str, Any]
+    disabled_steps: FrozenSet[str] = field(default_factory=frozenset)
     kinds_serializers: Dict[str, Callable[[str, Any], Any]] = field(
         default_factory=dict
     )

--- a/inference/core/workflows/execution_engine/v1/compiler/sink_disabling.py
+++ b/inference/core/workflows/execution_engine/v1/compiler/sink_disabling.py
@@ -1,0 +1,66 @@
+from dataclasses import dataclass
+from typing import Dict, FrozenSet, List
+
+from inference.core.workflows.execution_engine.introspection.blocks_loader import (
+    get_manifest_type_identifiers,
+)
+from inference.core.workflows.execution_engine.v1.compiler.entities import (
+    BlockSpecification,
+)
+
+# These sink versions predate the `disable_sink` convention. Keep this compatibility
+# list until workflows using them can move to versions with native no-op support.
+LEGACY_SINK_TYPES = {
+    "roboflow_core/local_file_sink@v1",
+    "roboflow_core/onvif_sink@v1",
+    "roboflow_core/roboflow_custom_metadata@v1",
+    "RoboflowCustomMetadata",
+    "roboflow_core/model_monitoring_inference_aggregator@v1",
+    "roboflow_core/s3_sink@v1",
+    "roboflow_core/modbus_tcp@v1",
+    "roboflow_core/sinks@v1",
+    "roboflow_core/microsoft_sql_server_sink@v1",
+    "mqtt_writer_sink@v1",
+}
+
+
+@dataclass(frozen=True)
+class SinkDisablingResult:
+    workflow_definition: dict
+    steps_without_native_noop: FrozenSet[str]
+
+
+def disable_workflow_sinks(
+    workflow_definition: dict,
+    available_blocks: List[BlockSpecification],
+) -> SinkDisablingResult:
+    block_types = _index_block_types(available_blocks=available_blocks)
+    steps_without_native_noop = set()
+    updated_steps = []
+    for step in workflow_definition.get("steps", []):
+        step_type = step.get("type")
+        block = block_types.get(step_type)
+        if block is not None and "disable_sink" in block.manifest_class.model_fields:
+            updated_steps.append({**step, "disable_sink": True})
+        else:
+            updated_steps.append(step)
+            if step_type in LEGACY_SINK_TYPES:
+                steps_without_native_noop.add(step["name"])
+    return SinkDisablingResult(
+        workflow_definition={**workflow_definition, "steps": updated_steps},
+        steps_without_native_noop=frozenset(steps_without_native_noop),
+    )
+
+
+def _index_block_types(
+    available_blocks: List[BlockSpecification],
+) -> Dict[str, BlockSpecification]:
+    result = {}
+    for block in available_blocks:
+        identifiers = get_manifest_type_identifiers(
+            block_schema=block.manifest_class.model_json_schema(),
+            block_source=block.block_source,
+            block_identifier=block.identifier,
+        )
+        result.update({identifier: block for identifier in identifiers})
+    return result

--- a/inference/core/workflows/execution_engine/v1/core.py
+++ b/inference/core/workflows/execution_engine/v1/core.py
@@ -59,6 +59,7 @@ class ExecutionEngineV1(BaseExecutionEngine):
         step_error_handler: Optional[
             Union[str, Callable[[str, Exception], None]]
         ] = DEFAULT_WORKFLOWS_STEP_ERROR_HANDLER,
+        disable_sinks: bool = False,
     ) -> "ExecutionEngineV1":
         if init_parameters is None:
             init_parameters = {}
@@ -83,6 +84,7 @@ class ExecutionEngineV1(BaseExecutionEngine):
             init_parameters=init_parameters,
             execution_engine_version=EXECUTION_ENGINE_V1_VERSION,
             profiler=profiler,
+            disable_sinks=disable_sinks,
         )
         return cls(
             compiled_workflow=compiled_workflow,

--- a/inference/core/workflows/execution_engine/v1/executor/core.py
+++ b/inference/core/workflows/execution_engine/v1/executor/core.py
@@ -257,6 +257,8 @@ def flush_stream_pipeline_outputs(
         else list(workflow.steps)
     )
     for step_name in step_names:
+        if step_name in workflow.disabled_steps:
+            continue
         step = workflow.steps[step_name]
         flush_fn = getattr(step.step, "flush_stream_pipeline_outputs", None)
         if not callable(flush_fn):
@@ -311,7 +313,9 @@ def _downstream_step_selectors(
 
 
 def close_stream_pipelines(workflow: CompiledWorkflow) -> None:
-    for step in workflow.steps.values():
+    for step_name, step in workflow.steps.items():
+        if step_name in workflow.disabled_steps:
+            continue
         close_fn = getattr(step.step, "close_stream_pipeline", None)
         if callable(close_fn):
             close_fn()
@@ -470,6 +474,9 @@ def run_step(
     execution_data_manager: ExecutionDataManager,
     profiler: WorkflowsProfiler,
 ) -> None:
+    step_name = get_last_chunk_of_selector(selector=step_selector)
+    if step_name in workflow.disabled_steps:
+        return
     if execution_data_manager.is_step_simd(step_selector=step_selector):
         return run_simd_step(
             step_selector=step_selector,

--- a/inference_sdk/http/client.py
+++ b/inference_sdk/http/client.py
@@ -2237,6 +2237,7 @@ class InferenceHTTPClient:
         use_cache: bool = True,
         enable_profiling: bool = False,
         workflow_version_id: Optional[str] = None,
+        disable_sinks: bool = False,
     ) -> List[Dict[str, Any]]:
         """Run inference using a workflow specification.
 
@@ -2260,6 +2261,7 @@ class InferenceHTTPClient:
             excluded_fields (Optional[List[str]], optional): Fields to exclude from results. Defaults to None.
             use_cache (bool, optional): Whether to use cached results. Defaults to True.
             enable_profiling (bool, optional): Whether to enable profiling. Defaults to False.
+            disable_sinks (bool, optional): Whether to disable workflow sink side effects. Defaults to False.
 
         Returns:
             List[Dict[str, Any]]: Results of the workflow execution.
@@ -2280,6 +2282,7 @@ class InferenceHTTPClient:
             use_cache=use_cache,
             enable_profiling=enable_profiling,
             workflow_version_id=workflow_version_id,
+            disable_sinks=disable_sinks,
         )
 
     @wrap_errors
@@ -2294,6 +2297,7 @@ class InferenceHTTPClient:
         use_cache: bool = True,
         enable_profiling: bool = False,
         workflow_version_id: Optional[str] = None,
+        disable_sinks: bool = False,
     ) -> List[Dict[str, Any]]:
         """Run inference using a workflow specification.
 
@@ -2325,6 +2329,7 @@ class InferenceHTTPClient:
             excluded_fields (Optional[List[str]], optional): Fields to exclude from results. Defaults to None.
             use_cache (bool, optional): Whether to use cached results. Defaults to True.
             enable_profiling (bool, optional): Whether to enable profiling. Defaults to False.
+            disable_sinks (bool, optional): Whether to disable workflow sink side effects. Defaults to False.
 
         Returns:
             List[Dict[str, Any]]: Results of the workflow execution.
@@ -2345,6 +2350,7 @@ class InferenceHTTPClient:
             use_cache=use_cache,
             enable_profiling=enable_profiling,
             workflow_version_id=workflow_version_id,
+            disable_sinks=disable_sinks,
         )
 
     def _run_workflow(
@@ -2359,6 +2365,7 @@ class InferenceHTTPClient:
         use_cache: bool = True,
         enable_profiling: bool = False,
         workflow_version_id: Optional[str] = None,
+        disable_sinks: bool = False,
     ) -> List[Dict[str, Any]]:
         response = self._execute_workflow_request(
             workspace_name=workspace_name,
@@ -2371,6 +2378,7 @@ class InferenceHTTPClient:
             use_cache=use_cache,
             enable_profiling=enable_profiling,
             workflow_version_id=workflow_version_id,
+            disable_sinks=disable_sinks,
         )
         response_data = response.json()
         workflow_outputs = response_data["outputs"]
@@ -2397,6 +2405,7 @@ class InferenceHTTPClient:
         use_cache: bool = True,
         enable_profiling: bool = False,
         workflow_version_id: Optional[str] = None,
+        disable_sinks: bool = False,
     ) -> Response:
         named_workflow_specified = (workspace_name is not None) and (
             workflow_id is not None
@@ -2415,6 +2424,8 @@ class InferenceHTTPClient:
             "use_cache": use_cache,
             "enable_profiling": enable_profiling,
         }
+        if disable_sinks:
+            payload["disable_sinks"] = True
         inputs = {}
         for image_name, image in images.items():
             loaded_image = load_nested_batches_of_inference_input(

--- a/tests/inference/unit_tests/core/entities/requests/test_workflows.py
+++ b/tests/inference/unit_tests/core/entities/requests/test_workflows.py
@@ -1,0 +1,22 @@
+from inference.core.entities.requests.workflows import (
+    WorkflowSpecificationInferenceRequest,
+)
+
+
+def test_workflow_request_runs_sinks_by_default() -> None:
+    request = WorkflowSpecificationInferenceRequest(
+        inputs={},
+        specification={},
+    )
+
+    assert request.disable_sinks is False
+
+
+def test_workflow_request_accepts_sink_disabling_mode() -> None:
+    request = WorkflowSpecificationInferenceRequest(
+        inputs={},
+        specification={},
+        disable_sinks=True,
+    )
+
+    assert request.disable_sinks is True

--- a/tests/inference_sdk/unit_tests/http/test_client.py
+++ b/tests/inference_sdk/unit_tests/http/test_client.py
@@ -4209,6 +4209,23 @@ def test_infer_from_workflow_when_faulty_response_given(
         )
 
 
+def test_run_workflow_can_request_sink_disabling(requests_mock: Mocker) -> None:
+    api_url = "http://some.com"
+    http_client = InferenceHTTPClient(api_key="my-api-key", api_url=api_url)
+    requests_mock.post(
+        f"{api_url}/workflows/run",
+        json={"outputs": [{"some": 3}]},
+    )
+
+    result = http_client.run_workflow(
+        specification={"my": "specification"},
+        disable_sinks=True,
+    )
+
+    assert result == [{"some": 3}]
+    assert requests_mock.request_history[0].json()["disable_sinks"] is True
+
+
 def test_infer_from_workflow_when_neither_workflow_name_nor_specs_given() -> None:
     # given
     api_url = "http://some.com"

--- a/tests/workflows/unit_tests/execution_engine/compiler/test_cache.py
+++ b/tests/workflows/unit_tests/execution_engine/compiler/test_cache.py
@@ -4,6 +4,7 @@ from inference.core.workflows.errors import WorkflowEnvironmentConfigurationErro
 from inference.core.workflows.execution_engine.v1.compiler.cache import (
     BasicWorkflowsCache,
 )
+from inference.core.workflows.execution_engine.v1.compiler.core import COMPILATION_CACHE
 
 
 def test_cache_when_hash_key_cannot_be_obtained() -> None:
@@ -83,3 +84,20 @@ def test_cache_being_emptied_properly() -> None:
     assert cache.get(key_one) is None
     assert cache.get(key_two) == "my_value_2"
     assert cache.get(key_three) == "my_value_3"
+
+
+def test_workflow_compilation_cache_distinguishes_sink_execution_modes() -> None:
+    workflow_definition = {"version": "1.0", "inputs": [], "steps": [], "outputs": []}
+
+    enabled_key = COMPILATION_CACHE.get_hash_key(
+        workflow_definition=workflow_definition,
+        execution_engine_version=None,
+        disable_sinks=False,
+    )
+    disabled_key = COMPILATION_CACHE.get_hash_key(
+        workflow_definition=workflow_definition,
+        execution_engine_version=None,
+        disable_sinks=True,
+    )
+
+    assert enabled_key != disabled_key

--- a/tests/workflows/unit_tests/execution_engine/compiler/test_core.py
+++ b/tests/workflows/unit_tests/execution_engine/compiler/test_core.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from unittest import mock
 
 from inference.core.workflows.execution_engine.entities.base import (
     JsonField,
@@ -7,11 +8,14 @@ from inference.core.workflows.execution_engine.entities.base import (
 )
 from inference.core.workflows.execution_engine.v1.compiler.core import (
     collect_input_substitutions,
+    compile_workflow_graph,
 )
 from inference.core.workflows.execution_engine.v1.compiler.entities import (
+    BlockSpecification,
     ParsedWorkflowDefinition,
 )
 from tests.workflows.unit_tests.execution_engine.compiler.plugin_with_test_blocks.blocks import (
+    ExampleModelBlock,
     ExampleModelBlockManifest,
 )
 
@@ -71,3 +75,93 @@ def test_collect_input_substitutions() -> None:
             "model_id": "model_2",
         },
     }
+
+
+@mock.patch(
+    "inference.core.workflows.execution_engine.v1.compiler.core.validate_workflow_specification"
+)
+@mock.patch(
+    "inference.core.workflows.execution_engine.v1.compiler.core.prepare_execution_graph"
+)
+@mock.patch(
+    "inference.core.workflows.execution_engine.v1.compiler.core.parse_workflow_definition"
+)
+@mock.patch(
+    "inference.core.workflows.execution_engine.v1.compiler.core.inline_inner_workflow_steps"
+)
+@mock.patch(
+    "inference.core.workflows.execution_engine.v1.compiler.core.validate_inner_workflow_composition_from_raw_workflow_definition"
+)
+@mock.patch(
+    "inference.core.workflows.execution_engine.v1.compiler.core.compile_dynamic_blocks",
+    return_value=[],
+)
+@mock.patch(
+    "inference.core.workflows.execution_engine.v1.compiler.core.load_kinds_deserializers",
+    return_value={},
+)
+@mock.patch(
+    "inference.core.workflows.execution_engine.v1.compiler.core.load_kinds_serializers",
+    return_value={},
+)
+@mock.patch(
+    "inference.core.workflows.execution_engine.v1.compiler.core.load_initializers",
+    return_value={},
+)
+@mock.patch(
+    "inference.core.workflows.execution_engine.v1.compiler.core.load_workflow_blocks"
+)
+def test_sink_disabling_is_applied_after_inner_workflow_inlining(
+    load_workflow_blocks,
+    _load_initializers,
+    _load_kinds_serializers,
+    _load_kinds_deserializers,
+    _compile_dynamic_blocks,
+    _validate_inner_workflow,
+    inline_inner_workflow_steps,
+    parse_workflow_definition,
+    prepare_execution_graph,
+    _validate_workflow,
+) -> None:
+    class NativeSinkManifest(ExampleModelBlockManifest):
+        disable_sink: bool = False
+
+    native_sink = BlockSpecification(
+        block_source="test",
+        identifier="test.NativeSink",
+        block_class=ExampleModelBlock,
+        manifest_class=NativeSinkManifest,
+    )
+    load_workflow_blocks.return_value = [native_sink]
+    inline_inner_workflow_steps.return_value = {
+        "version": "1.0",
+        "inputs": [],
+        "steps": [
+            {
+                "type": "ExampleModel",
+                "name": "inner__sink",
+                "disable_sink": False,
+            }
+        ],
+        "outputs": [],
+    }
+    parsed = mock.MagicMock(steps=[], inputs=[], outputs=[])
+    parse_workflow_definition.return_value = parsed
+    prepare_execution_graph.return_value = mock.MagicMock()
+
+    result = compile_workflow_graph(
+        workflow_definition={
+            "version": "1.0",
+            "id": "sink-disabling-after-inlining-test",
+            "inputs": [],
+            "steps": [],
+            "outputs": [],
+        },
+        disable_sinks=True,
+    )
+
+    parsed_definition = parse_workflow_definition.call_args.kwargs[
+        "raw_workflow_definition"
+    ]
+    assert parsed_definition["steps"][0]["disable_sink"] is True
+    assert result.disabled_steps == frozenset()

--- a/tests/workflows/unit_tests/execution_engine/compiler/test_sink_disabling.py
+++ b/tests/workflows/unit_tests/execution_engine/compiler/test_sink_disabling.py
@@ -1,0 +1,136 @@
+from typing import List, Literal, Type
+
+from inference.core.workflows.execution_engine.entities.base import OutputDefinition
+from inference.core.workflows.execution_engine.v1.compiler.entities import (
+    BlockSpecification,
+)
+from inference.core.workflows.execution_engine.v1.compiler.sink_disabling import (
+    disable_workflow_sinks,
+)
+from inference.core.workflows.prototypes.block import (
+    WorkflowBlock,
+    WorkflowBlockManifest,
+)
+
+
+class NativeSinkManifest(WorkflowBlockManifest):
+    type: Literal["test/native_sink@v1", "NativeSink"]
+    disable_sink: bool = False
+
+    @classmethod
+    def describe_outputs(cls) -> List[OutputDefinition]:
+        return []
+
+
+class NativeSinkBlock(WorkflowBlock):
+    @classmethod
+    def get_manifest(cls) -> Type[WorkflowBlockManifest]:
+        return NativeSinkManifest
+
+    def run(self, disable_sink: bool) -> dict:
+        return {}
+
+
+class OrdinaryBlockManifest(WorkflowBlockManifest):
+    type: Literal["test/ordinary@v1"]
+
+    @classmethod
+    def describe_outputs(cls) -> List[OutputDefinition]:
+        return []
+
+
+class OrdinaryBlock(WorkflowBlock):
+    @classmethod
+    def get_manifest(cls) -> Type[WorkflowBlockManifest]:
+        return OrdinaryBlockManifest
+
+    def run(self) -> dict:
+        return {}
+
+
+AVAILABLE_BLOCKS = [
+    BlockSpecification(
+        block_source="test",
+        identifier="test.NativeSinkBlock",
+        block_class=NativeSinkBlock,
+        manifest_class=NativeSinkManifest,
+    ),
+    BlockSpecification(
+        block_source="test",
+        identifier="test.OrdinaryBlock",
+        block_class=OrdinaryBlock,
+        manifest_class=OrdinaryBlockManifest,
+    ),
+]
+
+
+def test_native_sink_is_forced_into_its_noop_mode() -> None:
+    workflow = _workflow(
+        {"type": "test/native_sink@v1", "name": "sink", "disable_sink": False}
+    )
+
+    result = disable_workflow_sinks(workflow, available_blocks=AVAILABLE_BLOCKS)
+
+    assert result.workflow_definition["steps"][0]["disable_sink"] is True
+    assert result.steps_without_native_noop == frozenset()
+
+
+def test_native_sink_selector_is_replaced_with_literal_true() -> None:
+    workflow = _workflow(
+        {
+            "type": "NativeSink",
+            "name": "sink",
+            "disable_sink": "$inputs.disable_sink",
+        }
+    )
+
+    result = disable_workflow_sinks(workflow, available_blocks=AVAILABLE_BLOCKS)
+
+    assert result.workflow_definition["steps"][0]["disable_sink"] is True
+
+
+def test_legacy_sink_without_noop_is_marked_for_execution_skip() -> None:
+    workflow = _workflow(
+        {"type": "roboflow_core/local_file_sink@v1", "name": "local_file"}
+    )
+
+    result = disable_workflow_sinks(workflow, available_blocks=AVAILABLE_BLOCKS)
+
+    assert result.steps_without_native_noop == frozenset({"local_file"})
+    assert result.workflow_definition == workflow
+
+
+def test_legacy_sink_alias_is_marked_for_execution_skip() -> None:
+    workflow = _workflow({"type": "RoboflowCustomMetadata", "name": "metadata"})
+
+    result = disable_workflow_sinks(workflow, available_blocks=AVAILABLE_BLOCKS)
+
+    assert result.steps_without_native_noop == frozenset({"metadata"})
+
+
+def test_ordinary_block_is_not_changed_or_skipped() -> None:
+    step = {"type": "test/ordinary@v1", "name": "transform"}
+    workflow = _workflow(step)
+
+    result = disable_workflow_sinks(workflow, available_blocks=AVAILABLE_BLOCKS)
+
+    assert result.workflow_definition == workflow
+    assert result.steps_without_native_noop == frozenset()
+
+
+def test_disabling_sinks_does_not_mutate_caller_workflow() -> None:
+    step = {"type": "test/native_sink@v1", "name": "sink", "disable_sink": False}
+    workflow = _workflow(step)
+
+    disable_workflow_sinks(workflow, available_blocks=AVAILABLE_BLOCKS)
+
+    assert workflow["steps"][0]["disable_sink"] is False
+
+
+def _workflow(step: dict) -> dict:
+    return {
+        "version": "1.0",
+        "inputs": [],
+        "steps": [step],
+        "outputs": [],
+    }

--- a/tests/workflows/unit_tests/execution_engine/executor/test_disabled_steps.py
+++ b/tests/workflows/unit_tests/execution_engine/executor/test_disabled_steps.py
@@ -1,0 +1,49 @@
+from unittest.mock import MagicMock
+
+from inference.core.workflows.execution_engine.v1.executor.core import (
+    close_stream_pipelines,
+    flush_stream_pipeline_outputs,
+    run_step,
+)
+
+
+def test_disabled_step_is_not_executed() -> None:
+    workflow = MagicMock(disabled_steps=frozenset({"sink"}))
+    execution_data_manager = MagicMock()
+
+    run_step(
+        step_selector="$steps.sink",
+        workflow=workflow,
+        execution_data_manager=execution_data_manager,
+        profiler=MagicMock(),
+    )
+
+    execution_data_manager.is_step_simd.assert_not_called()
+
+
+def test_disabled_step_stream_pipeline_is_not_flushed() -> None:
+    sink = MagicMock()
+    workflow = MagicMock(
+        steps={"sink": sink},
+        disabled_steps=frozenset({"sink"}),
+    )
+
+    result = flush_stream_pipeline_outputs(
+        workflow=workflow,
+        execution_data_manager=MagicMock(),
+    )
+
+    assert result == []
+    sink.step.flush_stream_pipeline_outputs.assert_not_called()
+
+
+def test_disabled_step_stream_pipeline_is_not_closed() -> None:
+    sink = MagicMock()
+    workflow = MagicMock(
+        steps={"sink": sink},
+        disabled_steps=frozenset({"sink"}),
+    )
+
+    close_stream_pipelines(workflow=workflow)
+
+    sink.step.close_stream_pipeline.assert_not_called()

--- a/tests/workflows/unit_tests/execution_engine/test_core.py
+++ b/tests/workflows/unit_tests/execution_engine/test_core.py
@@ -88,3 +88,14 @@ def test_execution_engine_init_with_invalid_step_error_handler() -> None:
             workflow_definition={},
             step_error_handler="invalid",
         )
+
+
+@mock.patch.object(core.ExecutionEngineV1, "init")
+def test_execution_engine_forwards_disable_sinks_flag(
+    execution_engine_init: mock.MagicMock,
+) -> None:
+    execution_engine_init.return_value = mock.MagicMock()
+
+    ExecutionEngine.init(workflow_definition={}, disable_sinks=True)
+
+    assert execution_engine_init.call_args.kwargs["disable_sinks"] is True


### PR DESCRIPTION
## Summary

- add a `disable_sinks` workflow run option to HTTP requests, the Python SDK, and the execution engine
- force sinks with native `disable_sink` support into their no-op path after inner-workflow inlining
- safely skip the nine legacy sink versions that do not yet expose a no-op, including stream flush and close hooks
- isolate compilation cache entries by execution mode

## Design

Only the public run flag crosses the API boundary. Sink classification and the legacy compatibility set remain internal to the compiler/executor. Ordinary blocks are unchanged, and existing runs keep the current behavior by default.

The companion no-op-version PR is an independent improvement; this mode works without it through the legacy fallback.

## Testing

- 207 focused compiler, executor, request, SDK, and existing SDK tests pass
- coverage includes native sinks, legacy sinks, aliases, ordinary blocks, input immutability, inner-workflow ordering, cache isolation, disabled stream hooks, engine forwarding, and SDK payloads
- Black and isort pass for every changed file
- repository-wide `make check_code_quality` reaches two unrelated pre-existing Black failures in `inference/core/entities/responses/workflows.py` and `inference/core/workflows/core_steps/common/query_language/entities/introspection.py`