### PR TITLE
Add no-op versions for workflow sinks

### DIFF
--- a/inference/core/workflows/core_steps/loader.py
+++ b/inference/core/workflows/core_steps/loader.py
@@ -459,12 +459,17 @@ from inference.core.workflows.core_steps.sinks.email_notification.v2 import (
     EmailNotificationBlockV2,
 )
 from inference.core.workflows.core_steps.sinks.local_file.v1 import LocalFileSinkBlockV1
+from inference.core.workflows.core_steps.sinks.local_file.v2 import LocalFileSinkBlockV2
 from inference.core.workflows.core_steps.sinks.onvif_movement.v1 import ONVIFSinkBlockV1
+from inference.core.workflows.core_steps.sinks.onvif_movement.v2 import ONVIFSinkBlockV2
 from inference.core.workflows.core_steps.sinks.roboflow.asset_library_attributes.v1 import (
     RoboflowAssetLibraryAttributesBlockV1,
 )
 from inference.core.workflows.core_steps.sinks.roboflow.custom_metadata.v1 import (
     RoboflowCustomMetadataBlockV1,
+)
+from inference.core.workflows.core_steps.sinks.roboflow.custom_metadata.v2 import (
+    RoboflowCustomMetadataBlockV2,
 )
 from inference.core.workflows.core_steps.sinks.roboflow.dataset_upload.v1 import (
     RoboflowDatasetUploadBlockV1,
@@ -475,10 +480,14 @@ from inference.core.workflows.core_steps.sinks.roboflow.dataset_upload.v2 import
 from inference.core.workflows.core_steps.sinks.roboflow.model_monitoring_inference_aggregator.v1 import (
     ModelMonitoringInferenceAggregatorBlockV1,
 )
+from inference.core.workflows.core_steps.sinks.roboflow.model_monitoring_inference_aggregator.v2 import (
+    ModelMonitoringInferenceAggregatorBlockV2,
+)
 from inference.core.workflows.core_steps.sinks.roboflow.vision_events.v1 import (
     RoboflowVisionEventsBlockV1,
 )
 from inference.core.workflows.core_steps.sinks.s3.v1 import S3SinkBlockV1
+from inference.core.workflows.core_steps.sinks.s3.v2 import S3SinkBlockV2
 from inference.core.workflows.core_steps.sinks.slack.notification.v1 import (
     SlackNotificationBlockV1,
 )
@@ -933,7 +942,9 @@ def load_blocks() -> List[Type[WorkflowBlock]]:
         QRCodeDetectorBlockV1,
         RoboflowClassificationModelBlockV1,
         RoboflowCustomMetadataBlockV1,
+        RoboflowCustomMetadataBlockV2,
         ModelMonitoringInferenceAggregatorBlockV1,
+        ModelMonitoringInferenceAggregatorBlockV2,
         RoboflowDatasetUploadBlockV2,
         RoboflowInstanceSegmentationModelBlockV1,
         RoboflowKeypointDetectionModelBlockV1,
@@ -975,7 +986,9 @@ def load_blocks() -> List[Type[WorkflowBlock]]:
         EmailNotificationBlockV1,
         EmailNotificationBlockV2,
         LocalFileSinkBlockV1,
+        LocalFileSinkBlockV2,
         S3SinkBlockV1,
+        S3SinkBlockV2,
         TraceVisualizationBlockV1,
         ReferencePathVisualizationBlockV1,
         ByteTrackerBlockV3,
@@ -1028,6 +1041,7 @@ def load_blocks() -> List[Type[WorkflowBlock]]:
         Moondream2BlockV1,
         OverlapBlockV1,
         ONVIFSinkBlockV1,
+        ONVIFSinkBlockV2,
         RoboflowVisionEventsBlockV1,
         GLMOCRBlockV1,
         EasyOCRBlockV1,

--- a/inference/core/workflows/core_steps/sinks/local_file/v2.py
+++ b/inference/core/workflows/core_steps/sinks/local_file/v2.py
@@ -1,0 +1,45 @@
+from typing import Literal, Type
+
+from inference.core.workflows.core_steps.sinks.local_file.v1 import (
+    BlockManifest as BlockManifestV1,
+)
+from inference.core.workflows.core_steps.sinks.local_file.v1 import LocalFileSinkBlockV1
+from inference.core.workflows.core_steps.sinks.noop import (
+    DisableSink,
+    disabled_sink_response,
+    versioned_sink_manifest_config,
+)
+from inference.core.workflows.prototypes.block import BlockResult, WorkflowBlockManifest
+
+
+class BlockManifest(BlockManifestV1):
+    model_config = versioned_sink_manifest_config(BlockManifestV1, version="v2")
+    type: Literal["roboflow_core/local_file_sink@v2"]
+    disable_sink: DisableSink = False
+
+
+class LocalFileSinkBlockV2(LocalFileSinkBlockV1):
+    @classmethod
+    def get_manifest(cls) -> Type[WorkflowBlockManifest]:
+        return BlockManifest
+
+    def run(
+        self,
+        content: str,
+        file_type: Literal["csv", "json", "txt"],
+        output_mode: Literal["append_log", "separate_files"],
+        target_directory: str,
+        file_name_prefix: str,
+        max_entries_per_file: int,
+        disable_sink: bool = False,
+    ) -> BlockResult:
+        if disable_sink:
+            return disabled_sink_response()
+        return super().run(
+            content=content,
+            file_type=file_type,
+            output_mode=output_mode,
+            target_directory=target_directory,
+            file_name_prefix=file_name_prefix,
+            max_entries_per_file=max_entries_per_file,
+        )

--- a/inference/core/workflows/core_steps/sinks/noop.py
+++ b/inference/core/workflows/core_steps/sinks/noop.py
@@ -1,0 +1,35 @@
+from copy import deepcopy
+from typing import Union
+
+from pydantic import ConfigDict, Field
+from typing_extensions import Annotated
+
+from inference.core.workflows.execution_engine.entities.types import (
+    BOOLEAN_KIND,
+    Selector,
+)
+from inference.core.workflows.prototypes.block import BlockResult, WorkflowBlockManifest
+
+DisableSink = Annotated[
+    Union[bool, Selector(kind=[BOOLEAN_KIND])],
+    Field(
+        description="When true, prevents this sink from producing side effects.",
+        examples=[False, "$inputs.disable_sink"],
+    ),
+]
+
+
+def disabled_sink_response() -> BlockResult:
+    return {
+        "error_status": False,
+        "message": "Sink was disabled by parameter `disable_sink`",
+    }
+
+
+def versioned_sink_manifest_config(
+    manifest: type[WorkflowBlockManifest],
+    version: str,
+) -> ConfigDict:
+    json_schema_extra = deepcopy(manifest.model_config.get("json_schema_extra", {}))
+    json_schema_extra["version"] = version
+    return ConfigDict(json_schema_extra=json_schema_extra)

--- a/inference/core/workflows/core_steps/sinks/onvif_movement/v2.py
+++ b/inference/core/workflows/core_steps/sinks/onvif_movement/v2.py
@@ -1,0 +1,79 @@
+from typing import Literal, Type, Union
+
+import supervision as sv
+
+from inference.core.workflows.core_steps.sinks.noop import (
+    DisableSink,
+    versioned_sink_manifest_config,
+)
+from inference.core.workflows.core_steps.sinks.onvif_movement.v1 import (
+    PREDICTIONS_OUTPUT_KEY,
+    SEEKING_OUTPUT_KEY,
+)
+from inference.core.workflows.core_steps.sinks.onvif_movement.v1 import (
+    BlockManifest as BlockManifestV1,
+)
+from inference.core.workflows.core_steps.sinks.onvif_movement.v1 import ONVIFSinkBlockV1
+from inference.core.workflows.prototypes.block import BlockResult, WorkflowBlockManifest
+
+
+class BlockManifest(BlockManifestV1):
+    model_config = versioned_sink_manifest_config(BlockManifestV1, version="v2")
+    type: Literal["roboflow_core/onvif_sink@v2"]
+    disable_sink: DisableSink = False
+
+
+class ONVIFSinkBlockV2(ONVIFSinkBlockV1):
+    @classmethod
+    def get_manifest(cls) -> Type[WorkflowBlockManifest]:
+        return BlockManifest
+
+    def run(
+        self,
+        predictions: sv.Detections,
+        camera_ip: str,
+        camera_port: int,
+        camera_username: str,
+        camera_password: str,
+        movement_type: str,
+        default_position_preset: Union[str, None],
+        zoom_if_able: bool,
+        follow_tracker: bool,
+        dead_zone: int,
+        camera_update_rate_limit: int,
+        flip_y_movement: bool,
+        flip_x_movement: bool,
+        move_to_position_after_idle_seconds: int,
+        pid_kp: float,
+        pid_ki: float,
+        pid_kd: float,
+        minimum_camera_speed: float,
+        simulate_variable_speed: bool,
+        disable_sink: bool = False,
+    ) -> BlockResult:
+        if disable_sink:
+            return {
+                PREDICTIONS_OUTPUT_KEY: predictions,
+                SEEKING_OUTPUT_KEY: False,
+            }
+        return super().run(
+            predictions=predictions,
+            camera_ip=camera_ip,
+            camera_port=camera_port,
+            camera_username=camera_username,
+            camera_password=camera_password,
+            movement_type=movement_type,
+            default_position_preset=default_position_preset,
+            zoom_if_able=zoom_if_able,
+            follow_tracker=follow_tracker,
+            dead_zone=dead_zone,
+            camera_update_rate_limit=camera_update_rate_limit,
+            flip_y_movement=flip_y_movement,
+            flip_x_movement=flip_x_movement,
+            move_to_position_after_idle_seconds=move_to_position_after_idle_seconds,
+            pid_kp=pid_kp,
+            pid_ki=pid_ki,
+            pid_kd=pid_kd,
+            minimum_camera_speed=minimum_camera_speed,
+            simulate_variable_speed=simulate_variable_speed,
+        )

--- a/inference/core/workflows/core_steps/sinks/roboflow/custom_metadata/v2.py
+++ b/inference/core/workflows/core_steps/sinks/roboflow/custom_metadata/v2.py
@@ -1,0 +1,45 @@
+from typing import Literal, Type, Union
+
+import supervision as sv
+
+from inference.core.workflows.core_steps.sinks.noop import (
+    DisableSink,
+    disabled_sink_response,
+    versioned_sink_manifest_config,
+)
+from inference.core.workflows.core_steps.sinks.roboflow.custom_metadata.v1 import (
+    BlockManifest as BlockManifestV1,
+)
+from inference.core.workflows.core_steps.sinks.roboflow.custom_metadata.v1 import (
+    RoboflowCustomMetadataBlockV1,
+)
+from inference.core.workflows.prototypes.block import BlockResult, WorkflowBlockManifest
+
+
+class BlockManifest(BlockManifestV1):
+    model_config = versioned_sink_manifest_config(BlockManifestV1, version="v2")
+    type: Literal["roboflow_core/roboflow_custom_metadata@v2"]
+    disable_sink: DisableSink = False
+
+
+class RoboflowCustomMetadataBlockV2(RoboflowCustomMetadataBlockV1):
+    @classmethod
+    def get_manifest(cls) -> Type[WorkflowBlockManifest]:
+        return BlockManifest
+
+    def run(
+        self,
+        fire_and_forget: bool,
+        field_name: str,
+        field_value: str,
+        predictions: Union[sv.Detections, dict],
+        disable_sink: bool = False,
+    ) -> BlockResult:
+        if disable_sink:
+            return disabled_sink_response()
+        return super().run(
+            fire_and_forget=fire_and_forget,
+            field_name=field_name,
+            field_value=field_value,
+            predictions=predictions,
+        )

--- a/inference/core/workflows/core_steps/sinks/roboflow/model_monitoring_inference_aggregator/v2.py
+++ b/inference/core/workflows/core_steps/sinks/roboflow/model_monitoring_inference_aggregator/v2.py
@@ -1,0 +1,102 @@
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime
+from functools import partial
+from typing import Literal, Optional, Type, Union
+
+import supervision as sv
+from fastapi import BackgroundTasks
+
+from inference.core.cache.base import BaseCache
+from inference.core.workflows.core_steps.sinks.noop import (
+    DisableSink,
+    disabled_sink_response,
+    versioned_sink_manifest_config,
+)
+from inference.core.workflows.core_steps.sinks.roboflow.model_monitoring_inference_aggregator.v1 import (
+    BlockManifest as BlockManifestV1,
+)
+from inference.core.workflows.core_steps.sinks.roboflow.model_monitoring_inference_aggregator.v1 import (
+    ModelMonitoringInferenceAggregatorBlockV1,
+    PredictionsAggregator,
+    send_to_model_monitoring_request,
+)
+from inference.core.workflows.prototypes.block import BlockResult, WorkflowBlockManifest
+
+
+class BlockManifest(BlockManifestV1):
+    model_config = versioned_sink_manifest_config(BlockManifestV1, version="v2")
+    type: Literal["roboflow_core/model_monitoring_inference_aggregator@v2"]
+    disable_sink: DisableSink = False
+
+
+class ModelMonitoringInferenceAggregatorBlockV2(
+    ModelMonitoringInferenceAggregatorBlockV1
+):
+    def __init__(
+        self,
+        cache: BaseCache,
+        api_key: Optional[str],
+        background_tasks: Optional[BackgroundTasks],
+        thread_pool_executor: Optional[ThreadPoolExecutor],
+    ):
+        self._api_key = api_key
+        self._cache = cache
+        self._background_tasks = background_tasks
+        self._thread_pool_executor = thread_pool_executor
+        self._predictions_aggregator = PredictionsAggregator()
+
+    @classmethod
+    def get_manifest(cls) -> Type[WorkflowBlockManifest]:
+        return BlockManifest
+
+    def run(
+        self,
+        fire_and_forget: bool,
+        predictions: Union[sv.Detections, dict],
+        frequency: int,
+        unique_aggregator_key: str,
+        model_id: str,
+        disable_sink: bool = False,
+    ) -> BlockResult:
+        if disable_sink:
+            return disabled_sink_response()
+        if self._api_key is None:
+            raise ValueError(
+                "ModelMonitoringInferenceAggregator block cannot run without Roboflow API key. "
+                "If you do not know how to get API key - visit "
+                "https://docs.roboflow.com/api-reference/authentication#retrieve-an-api-key to learn how to "
+                "retrieve one."
+            )
+        self._last_report_time_cache_key = (
+            "workflows:steps_cache:"
+            "roboflow_core/model_monitoring_inference_aggregator@v2:"
+            f"{unique_aggregator_key}:last_report_time"
+        )
+        if predictions:
+            self._predictions_aggregator.collect(predictions, model_id)
+        if not self._is_in_reporting_range(frequency):
+            return {
+                "error_status": False,
+                "message": "Not in reporting range, skipping report. (Ok)",
+            }
+        predictions_to_report = self._predictions_aggregator.get_and_flush()
+        registration_task = partial(
+            send_to_model_monitoring_request,
+            cache=self._cache,
+            last_report_time_cache_key=self._last_report_time_cache_key,
+            api_key=self._api_key,
+            predictions=predictions_to_report,
+        )
+        error_status = False
+        message = "Reporting happens in the background task"
+        if fire_and_forget and self._background_tasks:
+            self._background_tasks.add_task(registration_task)
+        elif fire_and_forget and self._thread_pool_executor:
+            self._thread_pool_executor.submit(registration_task)
+        else:
+            error_status, message = registration_task()
+        self._cache.set(self._last_report_time_cache_key, datetime.now().isoformat())
+        return {
+            "error_status": error_status,
+            "message": message,
+        }

--- a/inference/core/workflows/core_steps/sinks/s3/v2.py
+++ b/inference/core/workflows/core_steps/sinks/s3/v2.py
@@ -1,0 +1,53 @@
+from typing import Literal, Optional, Type
+
+from inference.core.workflows.core_steps.sinks.noop import (
+    DisableSink,
+    disabled_sink_response,
+    versioned_sink_manifest_config,
+)
+from inference.core.workflows.core_steps.sinks.s3.v1 import (
+    BlockManifest as BlockManifestV1,
+)
+from inference.core.workflows.core_steps.sinks.s3.v1 import S3SinkBlockV1
+from inference.core.workflows.prototypes.block import BlockResult, WorkflowBlockManifest
+
+
+class BlockManifest(BlockManifestV1):
+    model_config = versioned_sink_manifest_config(BlockManifestV1, version="v2")
+    type: Literal["roboflow_core/s3_sink@v2"]
+    disable_sink: DisableSink = False
+
+
+class S3SinkBlockV2(S3SinkBlockV1):
+    @classmethod
+    def get_manifest(cls) -> Type[WorkflowBlockManifest]:
+        return BlockManifest
+
+    def run(
+        self,
+        content: str,
+        file_type: Literal["csv", "json", "txt"],
+        output_mode: Literal["append_log", "separate_files"],
+        bucket_name: str,
+        s3_prefix: str,
+        file_name_prefix: str,
+        max_entries_per_file: int,
+        aws_access_key_id: Optional[str] = None,
+        aws_secret_access_key: Optional[str] = None,
+        aws_region: Optional[str] = None,
+        disable_sink: bool = False,
+    ) -> BlockResult:
+        if disable_sink:
+            return disabled_sink_response()
+        return super().run(
+            content=content,
+            file_type=file_type,
+            output_mode=output_mode,
+            bucket_name=bucket_name,
+            s3_prefix=s3_prefix,
+            file_name_prefix=file_name_prefix,
+            max_entries_per_file=max_entries_per_file,
+            aws_access_key_id=aws_access_key_id,
+            aws_secret_access_key=aws_secret_access_key,
+            aws_region=aws_region,
+        )

--- a/inference/enterprise/workflows/enterprise_blocks/loader.py
+++ b/inference/enterprise/workflows/enterprise_blocks/loader.py
@@ -7,8 +7,14 @@ from inference.enterprise.workflows.enterprise_blocks.sinks.event_writer.v1 impo
 from inference.enterprise.workflows.enterprise_blocks.sinks.microsoft_sql_server.v1 import (
     MicrosoftSQLServerSinkBlockV1,
 )
+from inference.enterprise.workflows.enterprise_blocks.sinks.microsoft_sql_server.v2 import (
+    MicrosoftSQLServerSinkBlockV2,
+)
 from inference.enterprise.workflows.enterprise_blocks.sinks.mqtt_writer.v1 import (
     MQTTWriterSinkBlockV1,
+)
+from inference.enterprise.workflows.enterprise_blocks.sinks.mqtt_writer.v2 import (
+    MQTTWriterSinkBlockV2,
 )
 from inference.enterprise.workflows.enterprise_blocks.sinks.opc_writer.v1 import (
     OPCWriterSinkBlockV1,
@@ -20,8 +26,14 @@ from inference.enterprise.workflows.enterprise_blocks.sinks.plc.v1 import (
 from inference.enterprise.workflows.enterprise_blocks.sinks.PLC_modbus.v1 import (
     ModbusTCPBlockV1,
 )
+from inference.enterprise.workflows.enterprise_blocks.sinks.PLC_modbus.v2 import (
+    ModbusTCPBlockV2,
+)
 from inference.enterprise.workflows.enterprise_blocks.sinks.PLCethernetIP.v1 import (
     PLCBlockV1,
+)
+from inference.enterprise.workflows.enterprise_blocks.sinks.PLCethernetIP.v2 import (
+    PLCBlockV2,
 )
 
 
@@ -29,10 +41,14 @@ def load_enterprise_blocks() -> List[Type[WorkflowBlock]]:
     return [
         OPCWriterSinkBlockV1,
         MQTTWriterSinkBlockV1,
+        MQTTWriterSinkBlockV2,
         PLCBlockV1,
+        PLCBlockV2,
         PLCReaderBlockV1,
         PLCWriterBlockV1,
         ModbusTCPBlockV1,
+        ModbusTCPBlockV2,
         MicrosoftSQLServerSinkBlockV1,
+        MicrosoftSQLServerSinkBlockV2,
         EventWriterSinkBlockV1,
     ]

--- a/inference/enterprise/workflows/enterprise_blocks/sinks/PLC_modbus/v2.py
+++ b/inference/enterprise/workflows/enterprise_blocks/sinks/PLC_modbus/v2.py
@@ -1,0 +1,56 @@
+from typing import Dict, List, Literal, Optional, Type
+
+from inference.core.workflows.core_steps.sinks.noop import (
+    DisableSink,
+    versioned_sink_manifest_config,
+)
+from inference.core.workflows.execution_engine.entities.base import (
+    VideoMetadata,
+    WorkflowImageData,
+)
+from inference.core.workflows.prototypes.block import WorkflowBlockManifest
+from inference.enterprise.workflows.enterprise_blocks.sinks.PLC_modbus.v1 import (
+    ModbusTCPBlockManifest as ModbusTCPBlockManifestV1,
+)
+from inference.enterprise.workflows.enterprise_blocks.sinks.PLC_modbus.v1 import (
+    ModbusTCPBlockV1,
+)
+
+
+class ModbusTCPBlockManifest(ModbusTCPBlockManifestV1):
+    model_config = versioned_sink_manifest_config(
+        ModbusTCPBlockManifestV1, version="v2"
+    )
+    type: Literal["roboflow_core/modbus_tcp@v2"]
+    disable_sink: DisableSink = False
+
+
+class ModbusTCPBlockV2(ModbusTCPBlockV1):
+    @classmethod
+    def get_manifest(cls) -> Type[WorkflowBlockManifest]:
+        return ModbusTCPBlockManifest
+
+    def run(
+        self,
+        plc_ip: str,
+        plc_port: int,
+        mode: str,
+        registers_to_read: List[int],
+        registers_to_write: Dict[int, int],
+        depends_on: object,
+        image: Optional[WorkflowImageData] = None,
+        metadata: Optional[VideoMetadata] = None,
+        disable_sink: bool = False,
+    ) -> dict:
+        if disable_sink:
+            return {"modbus_results": []}
+        return super().run(
+            plc_ip=plc_ip,
+            plc_port=plc_port,
+            mode=mode,
+            registers_to_read=registers_to_read,
+            registers_to_write=registers_to_write,
+            depends_on=depends_on,
+            image=image,
+            metadata=metadata,
+        )

--- a/inference/enterprise/workflows/enterprise_blocks/sinks/PLCethernetIP/v2.py
+++ b/inference/enterprise/workflows/enterprise_blocks/sinks/PLCethernetIP/v2.py
@@ -1,0 +1,52 @@
+from typing import Dict, List, Literal, Optional, Type, Union
+
+from inference.core.workflows.core_steps.sinks.noop import (
+    DisableSink,
+    versioned_sink_manifest_config,
+)
+from inference.core.workflows.execution_engine.entities.base import (
+    VideoMetadata,
+    WorkflowImageData,
+)
+from inference.core.workflows.prototypes.block import WorkflowBlockManifest
+from inference.enterprise.workflows.enterprise_blocks.sinks.PLCethernetIP.v1 import (
+    PLCBlockManifest as BlockManifestV1,
+)
+from inference.enterprise.workflows.enterprise_blocks.sinks.PLCethernetIP.v1 import (
+    PLCBlockV1,
+)
+
+
+class BlockManifest(BlockManifestV1):
+    model_config = versioned_sink_manifest_config(BlockManifestV1, version="v2")
+    type: Literal["roboflow_core/sinks@v2"]
+    disable_sink: DisableSink = False
+
+
+class PLCBlockV2(PLCBlockV1):
+    @classmethod
+    def get_manifest(cls) -> Type[WorkflowBlockManifest]:
+        return BlockManifest
+
+    def run(
+        self,
+        plc_ip: str,
+        mode: str,
+        tags_to_read: List[str],
+        tags_to_write: Dict[str, Union[int, float, str]],
+        depends_on: object,
+        image: Optional[WorkflowImageData] = None,
+        metadata: Optional[VideoMetadata] = None,
+        disable_sink: bool = False,
+    ) -> dict:
+        if disable_sink:
+            return {"plc_results": []}
+        return super().run(
+            plc_ip=plc_ip,
+            mode=mode,
+            tags_to_read=tags_to_read,
+            tags_to_write=tags_to_write,
+            depends_on=depends_on,
+            image=image,
+            metadata=metadata,
+        )

--- a/inference/enterprise/workflows/enterprise_blocks/sinks/microsoft_sql_server/v2.py
+++ b/inference/enterprise/workflows/enterprise_blocks/sinks/microsoft_sql_server/v2.py
@@ -1,0 +1,51 @@
+from typing import Any, Dict, List, Literal, Optional, Type, Union
+
+from inference.core.workflows.core_steps.sinks.noop import (
+    DisableSink,
+    disabled_sink_response,
+    versioned_sink_manifest_config,
+)
+from inference.core.workflows.prototypes.block import BlockResult, WorkflowBlockManifest
+from inference.enterprise.workflows.enterprise_blocks.sinks.microsoft_sql_server.v1 import (
+    BlockManifest as BlockManifestV1,
+)
+from inference.enterprise.workflows.enterprise_blocks.sinks.microsoft_sql_server.v1 import (
+    MicrosoftSQLServerSinkBlockV1,
+)
+
+
+class BlockManifest(BlockManifestV1):
+    model_config = versioned_sink_manifest_config(BlockManifestV1, version="v2")
+    type: Literal["roboflow_core/microsoft_sql_server_sink@v2"]
+    disable_sink: DisableSink = False
+
+
+class MicrosoftSQLServerSinkBlockV2(MicrosoftSQLServerSinkBlockV1):
+    @classmethod
+    def get_manifest(cls) -> Type[WorkflowBlockManifest]:
+        return BlockManifest
+
+    def run(
+        self,
+        host: str,
+        port: int,
+        database: str,
+        table_name: str,
+        data: Union[Dict[str, Any], List[Dict[str, Any]]],
+        username: Optional[str] = None,
+        password: Optional[str] = None,
+        fire_and_forget: bool = True,
+        disable_sink: bool = False,
+    ) -> BlockResult:
+        if disable_sink:
+            return disabled_sink_response()
+        return super().run(
+            host=host,
+            port=port,
+            database=database,
+            table_name=table_name,
+            data=data,
+            username=username,
+            password=password,
+            fire_and_forget=fire_and_forget,
+        )

--- a/inference/enterprise/workflows/enterprise_blocks/sinks/mqtt_writer/v2.py
+++ b/inference/enterprise/workflows/enterprise_blocks/sinks/mqtt_writer/v2.py
@@ -1,0 +1,53 @@
+from typing import Literal, Optional, Type
+
+from inference.core.workflows.core_steps.sinks.noop import (
+    DisableSink,
+    disabled_sink_response,
+    versioned_sink_manifest_config,
+)
+from inference.core.workflows.prototypes.block import BlockResult, WorkflowBlockManifest
+from inference.enterprise.workflows.enterprise_blocks.sinks.mqtt_writer.v1 import (
+    BlockManifest as BlockManifestV1,
+)
+from inference.enterprise.workflows.enterprise_blocks.sinks.mqtt_writer.v1 import (
+    MQTTWriterSinkBlockV1,
+)
+
+
+class BlockManifest(BlockManifestV1):
+    model_config = versioned_sink_manifest_config(BlockManifestV1, version="v2")
+    type: Literal["mqtt_writer_sink@v2"]
+    disable_sink: DisableSink = False
+
+
+class MQTTWriterSinkBlockV2(MQTTWriterSinkBlockV1):
+    @classmethod
+    def get_manifest(cls) -> Type[WorkflowBlockManifest]:
+        return BlockManifest
+
+    def run(
+        self,
+        host: str,
+        port: int,
+        topic: str,
+        message: str,
+        username: Optional[str] = None,
+        password: Optional[str] = None,
+        qos: int = 0,
+        retain: bool = False,
+        timeout: float = 0.5,
+        disable_sink: bool = False,
+    ) -> BlockResult:
+        if disable_sink:
+            return disabled_sink_response()
+        return super().run(
+            host=host,
+            port=port,
+            topic=topic,
+            message=message,
+            username=username,
+            password=password,
+            qos=qos,
+            retain=retain,
+            timeout=timeout,
+        )

--- a/tests/workflows/unit_tests/core_steps/sinks/test_enterprise_noop_v2_sinks.py
+++ b/tests/workflows/unit_tests/core_steps/sinks/test_enterprise_noop_v2_sinks.py
@@ -1,0 +1,160 @@
+from unittest import mock
+
+import pytest
+
+from inference.core.workflows.core_steps.sinks.noop import disabled_sink_response
+from inference.enterprise.workflows.enterprise_blocks.loader import (
+    load_enterprise_blocks,
+)
+from inference.enterprise.workflows.enterprise_blocks.sinks.microsoft_sql_server.v1 import (
+    BlockManifest as SQLManifestV1,
+)
+from inference.enterprise.workflows.enterprise_blocks.sinks.microsoft_sql_server.v2 import (
+    BlockManifest as SQLManifestV2,
+)
+from inference.enterprise.workflows.enterprise_blocks.sinks.microsoft_sql_server.v2 import (
+    MicrosoftSQLServerSinkBlockV2,
+)
+from inference.enterprise.workflows.enterprise_blocks.sinks.mqtt_writer.v1 import (
+    BlockManifest as MQTTManifestV1,
+)
+from inference.enterprise.workflows.enterprise_blocks.sinks.mqtt_writer.v2 import (
+    BlockManifest as MQTTManifestV2,
+)
+from inference.enterprise.workflows.enterprise_blocks.sinks.mqtt_writer.v2 import (
+    MQTTWriterSinkBlockV2,
+)
+from inference.enterprise.workflows.enterprise_blocks.sinks.PLC_modbus.v1 import (
+    ModbusTCPBlockManifest as ModbusManifestV1,
+)
+from inference.enterprise.workflows.enterprise_blocks.sinks.PLC_modbus.v2 import (
+    ModbusTCPBlockManifest as ModbusManifestV2,
+)
+from inference.enterprise.workflows.enterprise_blocks.sinks.PLC_modbus.v2 import (
+    ModbusTCPBlockV2,
+)
+from inference.enterprise.workflows.enterprise_blocks.sinks.PLCethernetIP.v1 import (
+    PLCBlockManifest as PLCManifestV1,
+)
+from inference.enterprise.workflows.enterprise_blocks.sinks.PLCethernetIP.v2 import (
+    BlockManifest as PLCManifestV2,
+)
+from inference.enterprise.workflows.enterprise_blocks.sinks.PLCethernetIP.v2 import (
+    PLCBlockV2,
+)
+
+ENTERPRISE_MANIFESTS = [
+    (ModbusManifestV1, ModbusManifestV2, "roboflow_core/modbus_tcp@v2"),
+    (PLCManifestV1, PLCManifestV2, "roboflow_core/sinks@v2"),
+    (
+        SQLManifestV1,
+        SQLManifestV2,
+        "roboflow_core/microsoft_sql_server_sink@v2",
+    ),
+    (MQTTManifestV1, MQTTManifestV2, "mqtt_writer_sink@v2"),
+]
+
+
+@pytest.mark.parametrize("v1_manifest,v2_manifest,expected_type", ENTERPRISE_MANIFESTS)
+def test_v2_manifest_adds_noop_without_changing_v1(
+    v1_manifest,
+    v2_manifest,
+    expected_type: str,
+) -> None:
+    assert "disable_sink" not in v1_manifest.model_fields
+    assert v2_manifest.model_fields["disable_sink"].default is False
+    assert v2_manifest.model_fields["type"].annotation.__args__ == (expected_type,)
+    assert v2_manifest.model_config["json_schema_extra"]["version"] == "v2"
+
+
+def test_all_enterprise_v2_sinks_are_registered() -> None:
+    registered_blocks = set(load_enterprise_blocks())
+
+    assert {
+        ModbusTCPBlockV2,
+        PLCBlockV2,
+        MicrosoftSQLServerSinkBlockV2,
+        MQTTWriterSinkBlockV2,
+    } <= registered_blocks
+
+
+@mock.patch(
+    "inference.enterprise.workflows.enterprise_blocks.sinks.PLC_modbus.v1.ModbusClient"
+)
+def test_modbus_noop_precedes_client_access(modbus_client: mock.MagicMock) -> None:
+    block = ModbusTCPBlockV2()
+
+    result = block.run(
+        plc_ip="invalid",
+        plc_port=502,
+        mode="read_and_write",
+        registers_to_read=[1],
+        registers_to_write={1: 2},
+        depends_on=None,
+        disable_sink=True,
+    )
+
+    assert result == {"modbus_results": []}
+    modbus_client.assert_not_called()
+
+
+@mock.patch(
+    "inference.enterprise.workflows.enterprise_blocks.sinks.PLCethernetIP.v1.pylogix.PLC"
+)
+def test_ethernet_ip_noop_precedes_client_access(plc_client: mock.MagicMock) -> None:
+    block = PLCBlockV2()
+
+    result = block.run(
+        plc_ip="invalid",
+        mode="read_and_write",
+        tags_to_read=["tag"],
+        tags_to_write={"tag": 1},
+        depends_on=None,
+        disable_sink=True,
+    )
+
+    assert result == {"plc_results": []}
+    plc_client.assert_not_called()
+
+
+def test_sql_noop_precedes_task_and_connection_access() -> None:
+    background_tasks = mock.MagicMock()
+    executor = mock.MagicMock()
+    block = MicrosoftSQLServerSinkBlockV2(
+        background_tasks=background_tasks,
+        thread_pool_executor=executor,
+    )
+    block._process_data = mock.MagicMock()
+
+    result = block.run(
+        host="invalid",
+        port=1433,
+        database="database",
+        table_name="table",
+        data={"value": 1},
+        disable_sink=True,
+    )
+
+    assert result == disabled_sink_response()
+    block._process_data.assert_not_called()
+    background_tasks.add_task.assert_not_called()
+    executor.submit.assert_not_called()
+
+
+@mock.patch(
+    "inference.enterprise.workflows.enterprise_blocks.sinks.mqtt_writer.v1.mqtt.Client"
+)
+def test_mqtt_noop_precedes_client_access(mqtt_client: mock.MagicMock) -> None:
+    block = MQTTWriterSinkBlockV2()
+
+    result = block.run(
+        host="invalid",
+        port=1883,
+        topic="topic",
+        message="message",
+        disable_sink=True,
+    )
+
+    assert result == disabled_sink_response()
+    assert block.mqtt_client is None
+    mqtt_client.assert_not_called()

--- a/tests/workflows/unit_tests/core_steps/sinks/test_noop_v2_sinks.py
+++ b/tests/workflows/unit_tests/core_steps/sinks/test_noop_v2_sinks.py
@@ -1,0 +1,212 @@
+from unittest import mock
+
+import pytest
+import supervision as sv
+
+from inference.core.workflows.core_steps.loader import load_blocks
+from inference.core.workflows.core_steps.sinks.local_file.v1 import (
+    BlockManifest as LocalFileManifestV1,
+)
+from inference.core.workflows.core_steps.sinks.local_file.v2 import (
+    BlockManifest as LocalFileManifestV2,
+)
+from inference.core.workflows.core_steps.sinks.local_file.v2 import LocalFileSinkBlockV2
+from inference.core.workflows.core_steps.sinks.noop import disabled_sink_response
+from inference.core.workflows.core_steps.sinks.onvif_movement.v1 import (
+    BlockManifest as ONVIFManifestV1,
+)
+from inference.core.workflows.core_steps.sinks.onvif_movement.v2 import (
+    BlockManifest as ONVIFManifestV2,
+)
+from inference.core.workflows.core_steps.sinks.onvif_movement.v2 import ONVIFSinkBlockV2
+from inference.core.workflows.core_steps.sinks.roboflow.custom_metadata.v1 import (
+    BlockManifest as CustomMetadataManifestV1,
+)
+from inference.core.workflows.core_steps.sinks.roboflow.custom_metadata.v2 import (
+    BlockManifest as CustomMetadataManifestV2,
+)
+from inference.core.workflows.core_steps.sinks.roboflow.custom_metadata.v2 import (
+    RoboflowCustomMetadataBlockV2,
+)
+from inference.core.workflows.core_steps.sinks.roboflow.model_monitoring_inference_aggregator.v1 import (
+    BlockManifest as ModelMonitoringManifestV1,
+)
+from inference.core.workflows.core_steps.sinks.roboflow.model_monitoring_inference_aggregator.v2 import (
+    BlockManifest as ModelMonitoringManifestV2,
+)
+from inference.core.workflows.core_steps.sinks.roboflow.model_monitoring_inference_aggregator.v2 import (
+    ModelMonitoringInferenceAggregatorBlockV2,
+)
+from inference.core.workflows.core_steps.sinks.s3.v1 import (
+    BlockManifest as S3ManifestV1,
+)
+from inference.core.workflows.core_steps.sinks.s3.v2 import (
+    BlockManifest as S3ManifestV2,
+)
+from inference.core.workflows.core_steps.sinks.s3.v2 import S3SinkBlockV2
+
+CORE_MANIFESTS = [
+    (LocalFileManifestV1, LocalFileManifestV2, "roboflow_core/local_file_sink@v2"),
+    (ONVIFManifestV1, ONVIFManifestV2, "roboflow_core/onvif_sink@v2"),
+    (
+        CustomMetadataManifestV1,
+        CustomMetadataManifestV2,
+        "roboflow_core/roboflow_custom_metadata@v2",
+    ),
+    (
+        ModelMonitoringManifestV1,
+        ModelMonitoringManifestV2,
+        "roboflow_core/model_monitoring_inference_aggregator@v2",
+    ),
+    (S3ManifestV1, S3ManifestV2, "roboflow_core/s3_sink@v2"),
+]
+
+
+@pytest.mark.parametrize("v1_manifest,v2_manifest,expected_type", CORE_MANIFESTS)
+def test_v2_manifest_adds_noop_without_changing_v1(
+    v1_manifest,
+    v2_manifest,
+    expected_type: str,
+) -> None:
+    assert "disable_sink" not in v1_manifest.model_fields
+    assert v2_manifest.model_fields["disable_sink"].default is False
+    assert v2_manifest.model_fields["type"].annotation.__args__ == (expected_type,)
+    assert v2_manifest.model_config["json_schema_extra"]["version"] == "v2"
+
+
+def test_all_core_v2_sinks_are_registered() -> None:
+    registered_blocks = set(load_blocks())
+
+    assert {
+        LocalFileSinkBlockV2,
+        ONVIFSinkBlockV2,
+        RoboflowCustomMetadataBlockV2,
+        ModelMonitoringInferenceAggregatorBlockV2,
+        S3SinkBlockV2,
+    } <= registered_blocks
+
+
+def test_local_file_noop_precedes_environment_and_file_access() -> None:
+    block = LocalFileSinkBlockV2(
+        allow_access_to_file_system=False,
+        allowed_write_directory=None,
+    )
+    block._verify_write_access_to_directory = mock.MagicMock()
+
+    result = block.run(
+        content="content",
+        file_type="txt",
+        output_mode="separate_files",
+        target_directory="/not/allowed",
+        file_name_prefix="result",
+        max_entries_per_file=1,
+        disable_sink=True,
+    )
+
+    assert result == disabled_sink_response()
+    block._verify_write_access_to_directory.assert_not_called()
+
+
+def test_onvif_noop_preserves_predictions_without_camera_access() -> None:
+    block = object.__new__(ONVIFSinkBlockV2)
+    block.event_loop = mock.MagicMock()
+    block.get_camera = mock.MagicMock()
+    predictions = sv.Detections.empty()
+
+    result = block.run(
+        predictions=predictions,
+        camera_ip="invalid",
+        camera_port=80,
+        camera_username="user",
+        camera_password="password",
+        movement_type="Follow",
+        default_position_preset=None,
+        zoom_if_able=True,
+        follow_tracker=True,
+        dead_zone=10,
+        camera_update_rate_limit=10,
+        flip_y_movement=False,
+        flip_x_movement=False,
+        move_to_position_after_idle_seconds=0,
+        pid_kp=1,
+        pid_ki=0,
+        pid_kd=0,
+        minimum_camera_speed=0,
+        simulate_variable_speed=False,
+        disable_sink=True,
+    )
+
+    assert result == {"predictions": predictions, "seeking": False}
+    block.get_camera.assert_not_called()
+
+
+def test_custom_metadata_noop_precedes_api_key_and_task_access() -> None:
+    background_tasks = mock.MagicMock()
+    executor = mock.MagicMock()
+    cache = mock.MagicMock()
+    block = RoboflowCustomMetadataBlockV2(
+        cache=cache,
+        api_key=None,
+        background_tasks=background_tasks,
+        thread_pool_executor=executor,
+    )
+
+    result = block.run(
+        fire_and_forget=True,
+        field_name="field",
+        field_value="value",
+        predictions={},
+        disable_sink=True,
+    )
+
+    assert result == disabled_sink_response()
+    background_tasks.add_task.assert_not_called()
+    executor.submit.assert_not_called()
+    cache.assert_not_called()
+
+
+def test_model_monitoring_noop_precedes_api_key_cache_and_aggregation() -> None:
+    cache = mock.MagicMock()
+    block = ModelMonitoringInferenceAggregatorBlockV2(
+        cache=cache,
+        api_key=None,
+        background_tasks=mock.MagicMock(),
+        thread_pool_executor=mock.MagicMock(),
+    )
+    block._predictions_aggregator = mock.MagicMock()
+
+    result = block.run(
+        fire_and_forget=True,
+        predictions={"top": "class"},
+        frequency=1,
+        unique_aggregator_key="key",
+        model_id="model/1",
+        disable_sink=True,
+    )
+
+    assert result == disabled_sink_response()
+    cache.assert_not_called()
+    block._predictions_aggregator.collect.assert_not_called()
+
+
+@mock.patch("inference.core.workflows.core_steps.sinks.s3.v1.create_s3_client")
+def test_s3_noop_precedes_client_and_buffer_access(
+    create_s3_client: mock.MagicMock,
+) -> None:
+    block = S3SinkBlockV2()
+
+    result = block.run(
+        content="content",
+        file_type="txt",
+        output_mode="append_log",
+        bucket_name="bucket",
+        s3_prefix="prefix",
+        file_name_prefix="result",
+        max_entries_per_file=10,
+        disable_sink=True,
+    )
+
+    assert result == disabled_sink_response()
+    assert block._buffer == []
+    assert block._entries_in_buffer == 0
+    create_s3_client.assert_not_called()


### PR DESCRIPTION
## Summary

- add v2 no-op-capable versions of the nine sinks that lacked `disable_sink`
- register five core and four enterprise sink versions without modifying any v1 schema or behavior
- short-circuit before credentials, cache or buffer mutation, background scheduling, and network client creation
- preserve ONVIF predictions and return empty result lists for the PLC sinks when disabled

## Design

The v2 blocks are thin extensions of their proven v1 implementations, keeping the behavior change limited to the early no-op path. Shared manifest and response helpers keep the new contract consistent. Model monitoring moves its API-key guard to run time so a disabled block can initialize without credentials and uses a v2-specific cache key.

This PR is independent of the execution-mode PR. Any caller can use the new `disable_sink` field directly, while a generic execution mode can discover it from the manifest.

## Testing

- 148 focused new and existing sink and block-loader tests pass
- explicit no-side-effect assertions cover every new sink
- manifest tests verify all nine v1 schemas remain unchanged and all v2 manifests default to enabled
- loader registration and manifest/run-signature alignment verified for all nine versions
- Black, isort, syntax checks, and diff checks pass for every changed file