### PR TITLE
Resolve stream_credentials in stream-manager pipeline init

### DIFF
--- a/inference/core/interfaces/camera/stream_auth.py
+++ b/inference/core/interfaces/camera/stream_auth.py
@@ -46,6 +46,16 @@ def decrypt_stream_credentials(stream_credentials: str, api_key: str) -> dict:
     return json.loads(plaintext.decode("utf-8"))
 
 
+def _sanitize_for_log(video_reference: str) -> str:
+    parsed = urlparse(video_reference)
+    if not (parsed.scheme and parsed.hostname):
+        return video_reference
+    if not (parsed.username or parsed.password):
+        return video_reference
+    netloc = parsed.hostname + (f":{parsed.port}" if parsed.port else "")
+    return urlunparse(parsed._replace(netloc=netloc))
+
+
 def _embed_credentials(video_reference: str, username: str, password: str) -> str:
     parsed = urlparse(video_reference)
     if not parsed.scheme or not parsed.hostname:
@@ -77,6 +87,6 @@ def resolve_operational_video_reference(
     except Exception:
         logger.warning(
             "Failed to decrypt stream_credentials for video reference %r",
-            video_reference,
+            _sanitize_for_log(video_reference),
         )
         return video_reference

--- a/inference/core/interfaces/camera/stream_auth.py
+++ b/inference/core/interfaces/camera/stream_auth.py
@@ -1,0 +1,82 @@
+import base64
+import json
+import logging
+from typing import Any, Optional
+from urllib.parse import quote, urlparse, urlunparse
+
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from cryptography.hazmat.primitives.hashes import SHA256
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+
+logger = logging.getLogger(__name__)
+
+_STREAM_CREDENTIALS_INFO = b"roboflow-stream-credentials-v1"
+_BLOB_VERSION = 1
+_SALT_LEN = 16
+_NONCE_LEN = 12
+
+
+def _derive_key(device_api_key: str, salt: bytes) -> bytes:
+    return HKDF(
+        algorithm=SHA256(),
+        length=32,
+        salt=salt,
+        info=_STREAM_CREDENTIALS_INFO,
+    ).derive(device_api_key.encode("utf-8"))
+
+
+def _decode_blob(stream_credentials: str) -> tuple[bytes, bytes, bytes]:
+    raw = base64.b64decode(stream_credentials, validate=True)
+    min_len = 1 + _SALT_LEN + _NONCE_LEN + 16
+    if len(raw) < min_len:
+        raise ValueError("stream_credentials blob too short")
+    version = raw[0]
+    if version != _BLOB_VERSION:
+        raise ValueError(f"unsupported stream_credentials version: {version}")
+    salt = raw[1 : 1 + _SALT_LEN]
+    nonce = raw[1 + _SALT_LEN : 1 + _SALT_LEN + _NONCE_LEN]
+    ciphertext = raw[1 + _SALT_LEN + _NONCE_LEN :]
+    return salt, nonce, ciphertext
+
+
+def decrypt_stream_credentials(stream_credentials: str, api_key: str) -> dict:
+    salt, nonce, ciphertext = _decode_blob(stream_credentials)
+    key = _derive_key(api_key, salt)
+    plaintext = AESGCM(key).decrypt(nonce, ciphertext, None)
+    return json.loads(plaintext.decode("utf-8"))
+
+
+def _embed_credentials(video_reference: str, username: str, password: str) -> str:
+    parsed = urlparse(video_reference)
+    if not parsed.scheme or not parsed.hostname:
+        return video_reference
+    userinfo = f"{quote(username, safe='')}:{quote(password, safe='')}"
+    host = parsed.hostname
+    if parsed.port is not None:
+        host = f"{host}:{parsed.port}"
+    netloc = f"{userinfo}@{host}"
+    return urlunparse(parsed._replace(netloc=netloc))
+
+
+def resolve_operational_video_reference(
+    video_reference: Any,
+    stream_credentials: Optional[str],
+    api_key: Optional[str],
+) -> Any:
+    if not stream_credentials or not api_key or not video_reference:
+        return video_reference
+    if not isinstance(video_reference, str):
+        return video_reference
+    try:
+        creds = decrypt_stream_credentials(stream_credentials, api_key)
+        username = creds.get("username", "")
+        password = creds.get("password", "")
+        if not username and not password:
+            return video_reference
+        return _embed_credentials(video_reference, username, password)
+    except Exception:
+        logger.warning(
+            "Failed to decrypt stream_credentials for video reference %r",
+            video_reference,
+        )
+        return video_reference

--- a/inference/core/interfaces/camera/stream_auth.py
+++ b/inference/core/interfaces/camera/stream_auth.py
@@ -1,6 +1,7 @@
 import base64
 import json
 import logging
+import re
 from typing import Any, Optional
 from urllib.parse import quote, urlparse, urlunparse
 
@@ -46,14 +47,26 @@ def decrypt_stream_credentials(stream_credentials: str, api_key: str) -> dict:
     return json.loads(plaintext.decode("utf-8"))
 
 
+_SCHEMELESS_USERINFO_RE = re.compile(r"^([^:@/\s]+(?::[^@/\s]*)?@)(.+)$")
+
+
+def _cred_free_netloc(netloc: str) -> str:
+    return netloc.split("@", 1)[-1]
+
+
 def _sanitize_for_log(video_reference: str) -> str:
     parsed = urlparse(video_reference)
-    if not (parsed.scheme and parsed.hostname):
-        return video_reference
-    if not (parsed.username or parsed.password):
-        return video_reference
-    netloc = parsed.hostname + (f":{parsed.port}" if parsed.port else "")
-    return urlunparse(parsed._replace(netloc=netloc))
+    if parsed.scheme and parsed.hostname:
+        if not (parsed.username or parsed.password):
+            return video_reference
+        return urlunparse(parsed._replace(netloc=_cred_free_netloc(parsed.netloc)))
+
+    schemeless = _SCHEMELESS_USERINFO_RE.match(video_reference)
+    if schemeless:
+        rest = schemeless.group(2)
+        return rest.split("?", 1)[0].split("#", 1)[0]
+
+    return video_reference
 
 
 def _embed_credentials(video_reference: str, username: str, password: str) -> str:
@@ -61,9 +74,7 @@ def _embed_credentials(video_reference: str, username: str, password: str) -> st
     if not parsed.scheme or not parsed.hostname:
         return video_reference
     userinfo = f"{quote(username, safe='')}:{quote(password, safe='')}"
-    host = parsed.hostname
-    if parsed.port is not None:
-        host = f"{host}:{parsed.port}"
+    host = _cred_free_netloc(parsed.netloc)
     netloc = f"{userinfo}@{host}"
     return urlunparse(parsed._replace(netloc=netloc))
 

--- a/inference/core/interfaces/stream_manager/manager_app/entities.py
+++ b/inference/core/interfaces/stream_manager/manager_app/entities.py
@@ -63,6 +63,7 @@ class VideoConfiguration(BaseModel):
     )
     video_source_properties: Optional[Dict[str, float]] = None
     batch_collection_timeout: Optional[float] = None
+    stream_credentials: Optional[str] = None
 
 
 class MemorySinkConfiguration(BaseModel):

--- a/inference/core/interfaces/stream_manager/manager_app/inference_pipeline_manager.py
+++ b/inference/core/interfaces/stream_manager/manager_app/inference_pipeline_manager.py
@@ -28,11 +28,11 @@ from inference.core.exceptions import (
 )
 from inference.core.interfaces.camera.entities import VideoFrame
 from inference.core.interfaces.camera.exceptions import StreamOperationNotAllowedError
-from inference.core.interfaces.http.orjson_utils import (
-    serialise_single_workflow_result_element,
-)
 from inference.core.interfaces.camera.stream_auth import (
     resolve_operational_video_reference,
+)
+from inference.core.interfaces.http.orjson_utils import (
+    serialise_single_workflow_result_element,
 )
 from inference.core.interfaces.stream.inference_pipeline import InferencePipeline
 from inference.core.interfaces.stream.sinks import InMemoryBufferSink, multi_sink

--- a/inference/core/interfaces/stream_manager/manager_app/inference_pipeline_manager.py
+++ b/inference/core/interfaces/stream_manager/manager_app/inference_pipeline_manager.py
@@ -18,6 +18,7 @@ import supervision as sv
 from pydantic import ValidationError
 
 from inference.core import logger
+from inference.core.env import API_KEY
 from inference.core.exceptions import (
     MissingApiKeyError,
     RoboflowAPIConnectionError,
@@ -185,7 +186,7 @@ class InferencePipelineManager(Process):
             parsed_payload = InitialisePipelinePayload.model_validate(payload)
             video_reference = parsed_payload.video_configuration.video_reference
             stream_credentials = parsed_payload.video_configuration.stream_credentials
-            api_key = parsed_payload.api_key or os.getenv("ROBOFLOW_API_KEY")
+            api_key = parsed_payload.api_key or API_KEY
             if stream_credentials and api_key:
                 video_reference = resolve_operational_video_reference(
                     video_reference, stream_credentials, api_key

--- a/inference/core/interfaces/stream_manager/manager_app/inference_pipeline_manager.py
+++ b/inference/core/interfaces/stream_manager/manager_app/inference_pipeline_manager.py
@@ -30,6 +30,9 @@ from inference.core.interfaces.camera.exceptions import StreamOperationNotAllowe
 from inference.core.interfaces.http.orjson_utils import (
     serialise_single_workflow_result_element,
 )
+from inference.core.interfaces.camera.stream_auth import (
+    resolve_operational_video_reference,
+)
 from inference.core.interfaces.stream.inference_pipeline import InferencePipeline
 from inference.core.interfaces.stream.sinks import InMemoryBufferSink, multi_sink
 from inference.core.interfaces.stream.watchdog import (
@@ -180,12 +183,19 @@ class InferencePipelineManager(Process):
         try:
             self._watchdog = BasePipelineWatchDog()
             parsed_payload = InitialisePipelinePayload.model_validate(payload)
+            video_reference = parsed_payload.video_configuration.video_reference
+            stream_credentials = parsed_payload.video_configuration.stream_credentials
+            api_key = parsed_payload.api_key or os.getenv("ROBOFLOW_API_KEY")
+            if stream_credentials and api_key:
+                video_reference = resolve_operational_video_reference(
+                    video_reference, stream_credentials, api_key
+                )
             buffer_sink = InMemoryBufferSink.init(
                 queue_size=parsed_payload.sink_configuration.results_buffer_size,
             )
             self._buffer_sink = buffer_sink
             self._inference_pipeline = InferencePipeline.init_with_workflow(
-                video_reference=parsed_payload.video_configuration.video_reference,
+                video_reference=video_reference,
                 workflow_specification=parsed_payload.processing_configuration.workflow_specification,
                 workspace_name=parsed_payload.processing_configuration.workspace_name,
                 workflow_id=parsed_payload.processing_configuration.workflow_id,

--- a/tests/inference/unit_tests/core/interfaces/camera/test_stream_auth.py
+++ b/tests/inference/unit_tests/core/interfaces/camera/test_stream_auth.py
@@ -3,7 +3,6 @@ import json
 import secrets
 from urllib.parse import urlparse
 
-import pytest
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 from cryptography.hazmat.primitives.kdf.hkdf import HKDF

--- a/tests/inference/unit_tests/core/interfaces/camera/test_stream_auth.py
+++ b/tests/inference/unit_tests/core/interfaces/camera/test_stream_auth.py
@@ -1,0 +1,64 @@
+import base64
+import json
+import secrets
+from urllib.parse import urlparse
+
+import pytest
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+
+from inference.core.interfaces.camera.stream_auth import (
+    decrypt_stream_credentials,
+    resolve_operational_video_reference,
+)
+
+_HKDF_INFO = b"roboflow-stream-credentials-v1"
+
+
+def _encrypt_stream_credentials(creds: dict, api_key: str) -> str:
+    salt = secrets.token_bytes(16)
+    nonce = secrets.token_bytes(12)
+    hkdf = HKDF(
+        algorithm=hashes.SHA256(),
+        length=32,
+        salt=salt,
+        info=_HKDF_INFO,
+    )
+    key = hkdf.derive(api_key.encode("utf-8"))
+    plaintext = json.dumps(creds).encode("utf-8")
+    ciphertext = AESGCM(key).encrypt(nonce, plaintext, None)
+    blob = bytes([1]) + salt + nonce + ciphertext
+    return base64.b64encode(blob).decode("ascii")
+
+
+def test_round_trip_encrypt_decrypt():
+    api_key = "test-device-api-key"
+    creds = {"username": "camera-user", "password": "camera-pass"}
+    blob = _encrypt_stream_credentials(creds, api_key)
+
+    assert decrypt_stream_credentials(blob, api_key) == creds
+
+
+def test_resolve_without_blob_returns_unchanged():
+    video_reference = "rtsp://cam.local/live/main"
+
+    result = resolve_operational_video_reference(video_reference, None, "api-key")
+
+    assert result == video_reference
+
+
+def test_resolve_with_blob_embeds_credentials():
+    api_key = "test-device-api-key"
+    video_reference = "rtsp://cam.local/live/main"
+    blob = _encrypt_stream_credentials(
+        {"username": "camera-user", "password": "camera-pass"}, api_key
+    )
+
+    result = resolve_operational_video_reference(video_reference, blob, api_key)
+    parsed = urlparse(result)
+
+    assert parsed.scheme == "rtsp"
+    assert parsed.username == "camera-user"
+    assert parsed.hostname == "cam.local"
+    assert parsed.password == "camera-pass"

--- a/tests/inference/unit_tests/core/interfaces/camera/test_stream_auth.py
+++ b/tests/inference/unit_tests/core/interfaces/camera/test_stream_auth.py
@@ -8,6 +8,7 @@ from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 
 from inference.core.interfaces.camera.stream_auth import (
+    _sanitize_for_log,
     decrypt_stream_credentials,
     resolve_operational_video_reference,
 )
@@ -61,3 +62,17 @@ def test_resolve_with_blob_embeds_credentials():
     assert parsed.username == "camera-user"
     assert parsed.hostname == "cam.local"
     assert parsed.password == "camera-pass"
+
+
+def test_sanitize_for_log_strips_schemeless_credentials():
+    assert (
+        _sanitize_for_log("admin:secret@192.168.1.1:554/stream")
+        == "192.168.1.1:554/stream"
+    )
+
+
+def test_sanitize_for_log_malformed_port_does_not_raise():
+    assert (
+        _sanitize_for_log("rtsp://user:pass@host:notaport/path")
+        == "rtsp://host:notaport/path"
+    )


### PR DESCRIPTION
# Description

Adds `stream_auth.py` decrypt helper and optional `stream_credentials` on `VideoConfiguration` for the stream-manager HTTP init path.

No behavior change when the field is absent. Complements roboflow-edge `build_pipeline_params` decrypt for direct stream-manager callers.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Maintenance (non-breaking, non-user facing changing such as dependency update, adding test, modifying secrets, etc.)
- [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

- `tests/inference/unit_tests/core/interfaces/camera/test_stream_auth.py` (round-trip, resolve with/without blob)
- CI unit test job

## Any specific deployment considerations

Dormant until configs include `stream_credentials`. Cloud encrypt (E1) should ship only after S1 + edge decrypt are deployed.

Made with [Cursor](https://cursor.com)