### PR TITLE
Add classification support to Detections Filter v2

### DIFF
--- a/inference/core/workflows/core_steps/common/query_language/entities/enums.py
+++ b/inference/core/workflows/core_steps/common/query_language/entities/enums.py
@@ -51,6 +51,12 @@ class ClassificationProperty(Enum):
     ALL_CONFIDENCES = "all_confidences"
 
 
+class ClassificationPredictionProperty(Enum):
+    CLASS_NAME = "class_name"
+    CLASS_ID = "class_id"
+    CONFIDENCE = "confidence"
+
+
 class DetectionsProperty(Enum):
     CONFIDENCE = "confidence"
     CLASS_NAME = "class_name"

--- a/inference/core/workflows/core_steps/common/query_language/entities/operations.py
+++ b/inference/core/workflows/core_steps/common/query_language/entities/operations.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel, ConfigDict, Field
 from typing_extensions import Annotated
 
 from inference.core.workflows.core_steps.common.query_language.entities.enums import (
+    ClassificationPredictionProperty,
     ClassificationProperty,
     DetectionsProperty,
     DetectionsSelectionMode,
@@ -240,6 +241,39 @@ class ClassificationPropertyExtract(OperationDefinition):
     )
     type: Literal["ClassificationPropertyExtract"]
     property_name: ClassificationProperty
+
+
+class ExtractClassificationPredictionProperty(OperationDefinition):
+    model_config = ConfigDict(
+        json_schema_extra={
+            "description": "Extracts a property from one classification prediction.",
+            "compound": False,
+            "input_kind": [DICTIONARY_KIND],
+            "output_kind": [
+                STRING_KIND,
+                INTEGER_KIND,
+                FLOAT_ZERO_TO_ONE_KIND,
+            ],
+        },
+    )
+    type: Literal["ExtractClassificationPredictionProperty"]
+    property_name: ClassificationPredictionProperty
+
+
+class ClassificationFilter(OperationDefinition):
+    model_config = ConfigDict(
+        json_schema_extra={
+            "description": "Filters classification predictions by applying a predicate "
+            "to each selected class prediction.",
+            "compound": True,
+            "input_kind": [CLASSIFICATION_PREDICTION_KIND],
+            "output_kind": [CLASSIFICATION_PREDICTION_KIND],
+            "nested_operation_input_kind": [DICTIONARY_KIND],
+            "nested_operation_output_kind": [BOOLEAN_KIND],
+        },
+    )
+    type: Literal["ClassificationFilter"]
+    filter_operation: "StatementGroup"
 
 
 class DetectionsSelection(OperationDefinition):
@@ -628,6 +662,8 @@ AllOperationsType = Annotated[
         DetectionsSelection,
         SortDetections,
         ClassificationPropertyExtract,
+        ExtractClassificationPredictionProperty,
+        ClassificationFilter,
         ConvertImageToJPEG,
         ConvertImageToBase64,
         DetectionsToDictionary,

--- a/inference/core/workflows/core_steps/common/query_language/operations/classification_results/base.py
+++ b/inference/core/workflows/core_steps/common/query_language/operations/classification_results/base.py
@@ -1,7 +1,12 @@
-from typing import Any, List, Union
+from copy import copy, deepcopy
+from typing import Any, Callable, Dict, List, Union
 
 from inference.core.workflows.core_steps.common.query_language.entities.enums import (
+    ClassificationPredictionProperty,
     ClassificationProperty,
+)
+from inference.core.workflows.core_steps.common.query_language.entities.operations import (
+    DEFAULT_OPERAND_NAME,
 )
 from inference.core.workflows.core_steps.common.query_language.errors import (
     InvalidInputTypeError,
@@ -88,3 +93,134 @@ def extract_classification_property(
             context="step_execution | roboflow_query_language_evaluation",
         )
     return CLASSIFICATION_PROPERTY_EXTRACTORS[property_name](value)
+
+
+CLASSIFICATION_PREDICTION_PROPERTY_EXTRACTORS = {
+    ClassificationPredictionProperty.CLASS_NAME: lambda prediction: prediction.get(
+        "class", prediction.get("class_name")
+    ),
+    ClassificationPredictionProperty.CLASS_ID: lambda prediction: prediction[
+        "class_id"
+    ],
+    ClassificationPredictionProperty.CONFIDENCE: lambda prediction: prediction[
+        "confidence"
+    ],
+}
+
+
+def extract_classification_prediction_property(
+    value: Any,
+    property_name: ClassificationPredictionProperty,
+    execution_context: str,
+    **kwargs,
+) -> Union[str, int, float]:
+    if not isinstance(value, dict):
+        value_as_str = safe_stringify(value=value)
+        raise InvalidInputTypeError(
+            public_message=f"Executing extract_classification_prediction_property(...) in context "
+            f"{execution_context}, expected classification prediction dictionary as value, "
+            f"got {value_as_str} of type {type(value)}",
+            context=f"step_execution | roboflow_query_language_evaluation | {execution_context}",
+        )
+    try:
+        result = CLASSIFICATION_PREDICTION_PROPERTY_EXTRACTORS[property_name](value)
+    except (KeyError, TypeError) as error:
+        raise InvalidInputTypeError(
+            public_message=f"Executing extract_classification_prediction_property(...) in context "
+            f"{execution_context}, prediction does not contain a valid `{property_name.value}`.",
+            context=f"step_execution | roboflow_query_language_evaluation | {execution_context}",
+        ) from error
+    if result is None:
+        raise InvalidInputTypeError(
+            public_message=f"Executing extract_classification_prediction_property(...) in context "
+            f"{execution_context}, prediction does not contain a valid `{property_name.value}`.",
+            context=f"step_execution | roboflow_query_language_evaluation | {execution_context}",
+        )
+    return result
+
+
+def filter_classification_predictions(
+    value: Any,
+    filtering_fun: Callable[[Dict[str, Any]], bool],
+    global_parameters: Dict[str, Any],
+) -> dict:
+    if not isinstance(value, dict) or not isinstance(
+        value.get("predictions"), (list, dict)
+    ):
+        value_as_str = safe_stringify(value=value)
+        raise InvalidInputTypeError(
+            public_message="Executing filter_classification_predictions(...), expected a "
+            f"classification prediction dictionary, got {value_as_str} of type {type(value)}",
+            context="step_execution | roboflow_query_language_evaluation",
+        )
+
+    result = deepcopy(value)
+    predictions = value["predictions"]
+    if isinstance(predictions, list):
+        filtered_predictions = [
+            prediction
+            for prediction in predictions
+            if _evaluate_classification_prediction(
+                prediction=prediction,
+                filtering_fun=filtering_fun,
+                global_parameters=global_parameters,
+            )
+        ]
+        result["predictions"] = filtered_predictions
+        if not filtered_predictions:
+            result["top"] = ""
+            result["confidence"] = 0.0
+            return result
+        top_prediction = max(
+            filtered_predictions,
+            key=lambda prediction: prediction["confidence"],
+        )
+        result["top"] = top_prediction.get(
+            "class", top_prediction.get("class_name", "")
+        )
+        result["confidence"] = top_prediction["confidence"]
+        return result
+
+    predicted_classes = value.get("predicted_classes")
+    if not isinstance(predicted_classes, list):
+        raise InvalidInputTypeError(
+            public_message="Executing filter_classification_predictions(...), expected "
+            "`predicted_classes` list for multi-label classification predictions.",
+            context="step_execution | roboflow_query_language_evaluation",
+        )
+    filtered_classes = []
+    for class_name in predicted_classes:
+        if class_name not in predictions or not isinstance(
+            predictions[class_name], dict
+        ):
+            raise InvalidInputTypeError(
+                public_message="Executing filter_classification_predictions(...), "
+                f"`predicted_classes` references missing class `{class_name}`.",
+                context="step_execution | roboflow_query_language_evaluation",
+            )
+        prediction = copy(predictions[class_name])
+        prediction["class"] = class_name
+        if _evaluate_classification_prediction(
+            prediction=prediction,
+            filtering_fun=filtering_fun,
+            global_parameters=global_parameters,
+        ):
+            filtered_classes.append(class_name)
+    result["predicted_classes"] = filtered_classes
+    return result
+
+
+def _evaluate_classification_prediction(
+    prediction: Any,
+    filtering_fun: Callable[[Dict[str, Any]], bool],
+    global_parameters: Dict[str, Any],
+) -> bool:
+    if not isinstance(prediction, dict):
+        raise InvalidInputTypeError(
+            public_message="Executing filter_classification_predictions(...), expected each "
+            "classification prediction to be a dictionary.",
+            context="step_execution | roboflow_query_language_evaluation",
+        )
+    local_parameters = copy(global_parameters)
+    local_parameters[DEFAULT_OPERAND_NAME] = prediction
+    return filtering_fun(local_parameters)

--- a/inference/core/workflows/core_steps/common/query_language/operations/core.py
+++ b/inference/core/workflows/core_steps/common/query_language/operations/core.py
@@ -3,6 +3,7 @@ from typing import Any, Callable, Dict, List, Optional
 
 from inference.core.workflows.core_steps.common.query_language.entities.operations import (
     TYPE_PARAMETER_NAME,
+    ClassificationFilter,
     DetectionsFilter,
     OperationDefinition,
     OperationsChain,
@@ -19,7 +20,9 @@ from inference.core.workflows.core_steps.common.query_language.operations.boolea
     to_bool,
 )
 from inference.core.workflows.core_steps.common.query_language.operations.classification_results.base import (
+    extract_classification_prediction_property,
     extract_classification_property,
+    filter_classification_predictions,
 )
 from inference.core.workflows.core_steps.common.query_language.operations.detection.base import (
     extract_detection_property,
@@ -178,6 +181,25 @@ def build_detections_filter_operation(
     return partial(filter_detections, filtering_fun=filtering_fun)
 
 
+def build_classification_filter_operation(
+    definition: ClassificationFilter,
+    execution_context: str,
+) -> Callable[[T], V]:
+    # local import to avoid circular dependency of modules with operations and evaluation
+    from inference.core.workflows.core_steps.common.query_language.evaluation_engine.core import (
+        build_eval_function,
+    )
+
+    filtering_fun = build_eval_function(
+        definition=definition.filter_operation,
+        execution_context=execution_context,
+    )
+    return partial(
+        filter_classification_predictions,
+        filtering_fun=filtering_fun,
+    )
+
+
 REGISTERED_SIMPLE_OPERATIONS = {
     "StringToLowerCase": string_to_lower,
     "StringToUpperCase": string_to_upper,
@@ -205,6 +227,7 @@ REGISTERED_SIMPLE_OPERATIONS = {
     "DetectionsSelection": select_detections,
     "SortDetections": sort_detections,
     "ClassificationPropertyExtract": extract_classification_property,
+    "ExtractClassificationPredictionProperty": extract_classification_prediction_property,
     "DetectionsRename": rename_detections,
     "ConvertImageToJPEG": encode_image_to_jpeg,
     "ConvertImageToBase64": encode_image_to_base64,
@@ -217,4 +240,5 @@ REGISTERED_SIMPLE_OPERATIONS = {
 REGISTERED_COMPOUND_OPERATIONS_BUILDERS = {
     "SequenceApply": build_sequence_apply_operation,
     "DetectionsFilter": build_detections_filter_operation,
+    "ClassificationFilter": build_classification_filter_operation,
 }

--- a/inference/core/workflows/core_steps/loader.py
+++ b/inference/core/workflows/core_steps/loader.py
@@ -528,6 +528,9 @@ from inference.core.workflows.core_steps.transformations.detections_combine.v1 i
 from inference.core.workflows.core_steps.transformations.detections_filter.v1 import (
     DetectionsFilterBlockV1,
 )
+from inference.core.workflows.core_steps.transformations.detections_filter.v2 import (
+    DetectionsFilterBlockV2,
+)
 from inference.core.workflows.core_steps.transformations.detections_merge.v1 import (
     DetectionsMergeBlockV1,
 )
@@ -826,6 +829,7 @@ def load_blocks() -> List[Type[WorkflowBlock]]:
         AbsoluteStaticCropBlockV1,
         DynamicCropBlockV1,
         DetectionsFilterBlockV1,
+        DetectionsFilterBlockV2,
         DetectionOffsetBlockV1,
         PerClassConfidenceFilterBlockV1,
         DepthEstimationBlockV1,

--- a/inference/core/workflows/core_steps/transformations/detections_filter/v2.py
+++ b/inference/core/workflows/core_steps/transformations/detections_filter/v2.py
@@ -1,0 +1,270 @@
+from copy import copy
+from typing import Any, Dict, List, Literal, Optional, Type, Union
+
+import supervision as sv
+from pydantic import ConfigDict, Field, model_validator
+
+from inference.core.workflows.core_steps.common.query_language.entities.operations import (
+    DEFAULT_OPERAND_NAME,
+    AllOperationsType,
+    OperationDefinition,
+)
+from inference.core.workflows.core_steps.common.query_language.operations.core import (
+    build_operations_chain,
+)
+from inference.core.workflows.core_steps.common.utils import (
+    grab_batch_parameters,
+    grab_non_batch_parameters,
+)
+from inference.core.workflows.execution_engine.entities.base import (
+    Batch,
+    OutputDefinition,
+)
+from inference.core.workflows.execution_engine.entities.types import (
+    CLASSIFICATION_PREDICTION_KIND,
+    INSTANCE_SEGMENTATION_PREDICTION_KIND,
+    KEYPOINT_DETECTION_PREDICTION_KIND,
+    OBJECT_DETECTION_PREDICTION_KIND,
+    Selector,
+)
+from inference.core.workflows.prototypes.block import (
+    BlockResult,
+    WorkflowBlock,
+    WorkflowBlockManifest,
+)
+
+SHORT_DESCRIPTION = "Conditionally filter out model predictions."
+
+LONG_DESCRIPTION = """
+Filter detection or classification predictions using customizable UQL conditions while preserving the prediction container expected by downstream workflow blocks.
+
+## How This Block Works
+
+For object detection, instance segmentation, and keypoint detection inputs, this block behaves like Detections Filter v1: it evaluates a `DetectionsFilter` predicate for each spatial detection and returns an indexed `sv.Detections` subset.
+
+For classification inputs, it evaluates a `ClassificationFilter` predicate for each selected class prediction. Single-label results retain matching entries in `predictions` and recompute `top` and `confidence`. Multi-label results retain matching entries in `predicted_classes` while preserving the complete class score map in `predictions`.
+
+Use `ExtractDetectionProperty` inside `DetectionsFilter` conditions and `ExtractClassificationPredictionProperty` inside `ClassificationFilter` conditions. Both support filtering by class name, class ID, or confidence where applicable.
+
+When every candidate is removed, detection inputs return an empty `sv.Detections`; single-label classification returns `predictions=[]`, `top=""`, and `confidence=0.0`; multi-label classification returns `predicted_classes=[]`.
+
+## Version Differences
+
+Version 2 adds classification prediction inputs and classification-specific filtering. Existing v1 detection configurations remain valid after changing only the block type to `roboflow_core/detections_filter@v2`.
+"""
+
+CLASSIFICATION_OPERATIONS_EXAMPLE = [
+    {
+        "type": "ClassificationFilter",
+        "filter_operation": {
+            "type": "StatementGroup",
+            "statements": [
+                {
+                    "type": "BinaryStatement",
+                    "left_operand": {
+                        "type": "DynamicOperand",
+                        "operations": [
+                            {
+                                "type": "ExtractClassificationPredictionProperty",
+                                "property_name": "confidence",
+                            }
+                        ],
+                    },
+                    "comparator": {"type": "(Number) >="},
+                    "right_operand": {
+                        "type": "DynamicOperand",
+                        "operand_name": "threshold",
+                    },
+                }
+            ],
+        },
+    }
+]
+
+DETECTION_KINDS = [
+    OBJECT_DETECTION_PREDICTION_KIND,
+    INSTANCE_SEGMENTATION_PREDICTION_KIND,
+    KEYPOINT_DETECTION_PREDICTION_KIND,
+]
+
+
+class BlockManifest(WorkflowBlockManifest):
+    model_config = ConfigDict(
+        json_schema_extra={
+            "name": "Detections Filter",
+            "version": "v2",
+            "short_description": SHORT_DESCRIPTION,
+            "long_description": LONG_DESCRIPTION,
+            "license": "Apache-2.0",
+            "block_type": "transformation",
+            "ui_manifest": {
+                "section": "flow_control",
+                "icon": "far fa-filter",
+                "blockPriority": 1,
+            },
+        }
+    )
+    type: Literal["roboflow_core/detections_filter@v2"]
+    predictions: Selector(kind=DETECTION_KINDS + [CLASSIFICATION_PREDICTION_KIND]) = (
+        Field(
+            description="Detection or classification predictions to filter. Use a "
+            "`DetectionsFilter` operation for detection inputs and a "
+            "`ClassificationFilter` operation for classification inputs.",
+            examples=[
+                "$steps.object_detection_model.predictions",
+                "$steps.classification_model.predictions",
+            ],
+        )
+    )
+    operations: List[AllOperationsType] = Field(
+        description="UQL operation chain defining the filter. Existing detection "
+        "operation chains from v1 remain supported. Classification chains use "
+        "`ClassificationFilter` with per-class property extraction.",
+        examples=[CLASSIFICATION_OPERATIONS_EXAMPLE],
+    )
+    operations_parameters: Dict[str, Selector()] = Field(
+        description="Runtime values referenced by the operation chain. Values may be "
+        "scalars or batch-aligned selectors.",
+        examples=[{"threshold": "$inputs.threshold"}],
+        default_factory=lambda: {},
+    )
+
+    @model_validator(mode="after")
+    def validate_filter_family(self) -> "BlockManifest":
+        operation_types = {operation.type for operation in self.operations}
+        if {"DetectionsFilter", "ClassificationFilter"}.issubset(operation_types):
+            raise ValueError(
+                "Detections Filter v2 cannot mix `DetectionsFilter` and "
+                "`ClassificationFilter` operations in one chain."
+            )
+        return self
+
+    @classmethod
+    def get_parameters_accepting_batches(cls) -> List[str]:
+        return ["predictions"]
+
+    @classmethod
+    def get_parameters_accepting_batches_and_scalars(cls) -> List[str]:
+        return ["operations_parameters"]
+
+    @classmethod
+    def describe_outputs(cls) -> List[OutputDefinition]:
+        return [
+            OutputDefinition(
+                name="predictions",
+                kind=DETECTION_KINDS + [CLASSIFICATION_PREDICTION_KIND],
+            )
+        ]
+
+    def get_actual_outputs(self) -> List[OutputDefinition]:
+        if any(
+            operation.type == "ClassificationFilter" for operation in self.operations
+        ):
+            return [
+                OutputDefinition(
+                    name="predictions",
+                    kind=[CLASSIFICATION_PREDICTION_KIND],
+                )
+            ]
+        return [OutputDefinition(name="predictions", kind=DETECTION_KINDS)]
+
+    @classmethod
+    def get_execution_engine_compatibility(cls) -> Optional[str]:
+        return ">=1.3.0,<2.0.0"
+
+
+class DetectionsFilterBlockV2(WorkflowBlock):
+
+    @classmethod
+    def get_manifest(cls) -> Type[WorkflowBlockManifest]:
+        return BlockManifest
+
+    def run(
+        self,
+        predictions: Batch[Union[sv.Detections, dict]],
+        operations: List[OperationDefinition],
+        operations_parameters: Dict[str, Any],
+    ) -> BlockResult:
+        return execute_transformation(
+            predictions=predictions,
+            operations=operations,
+            operations_parameters=operations_parameters,
+        )
+
+
+def execute_transformation(
+    predictions: Batch[Union[sv.Detections, dict]],
+    operations: List[OperationDefinition],
+    operations_parameters: Dict[str, Any],
+) -> BlockResult:
+    if DEFAULT_OPERAND_NAME in operations_parameters:
+        raise ValueError(
+            f"Detected reserved parameter name: {DEFAULT_OPERAND_NAME} declared in "
+            "`operations_parameters` of Detections Filter v2."
+        )
+    operation_types = {operation.type for operation in operations}
+    classification_mode = "ClassificationFilter" in operation_types
+    if classification_mode and "DetectionsFilter" in operation_types:
+        raise ValueError(
+            "Detections Filter v2 cannot mix `DetectionsFilter` and "
+            "`ClassificationFilter` operations in one chain."
+        )
+
+    operations_chain = build_operations_chain(operations=operations)
+    batch_parameters = grab_batch_parameters(
+        operations_parameters=operations_parameters,
+        main_batch_size=len(predictions),
+    )
+    non_batch_parameters = grab_non_batch_parameters(
+        operations_parameters=operations_parameters,
+    )
+    batch_parameters_keys = list(batch_parameters.keys())
+    batches_to_align = [predictions] + [
+        batch_parameters[key] for key in batch_parameters_keys
+    ]
+    results = []
+    for payload in zip(*batches_to_align):
+        prediction = payload[0]
+        _validate_prediction_matches_mode(
+            prediction=prediction,
+            classification_mode=classification_mode,
+        )
+        single_evaluation_parameters = copy(non_batch_parameters)
+        for key, value in zip(batch_parameters_keys, payload[1:]):
+            single_evaluation_parameters[key] = value
+        transformed_prediction = operations_chain(
+            prediction,
+            global_parameters=single_evaluation_parameters,
+        )
+        _validate_prediction_matches_mode(
+            prediction=transformed_prediction,
+            classification_mode=classification_mode,
+        )
+        results.append({"predictions": transformed_prediction})
+    return results
+
+
+def _validate_prediction_matches_mode(
+    prediction: Any,
+    classification_mode: bool,
+) -> None:
+    if classification_mode and not isinstance(prediction, dict):
+        raise ValueError(
+            "A `ClassificationFilter` operation requires classification predictions."
+        )
+    if classification_mode and (
+        "image" not in prediction
+        or "predictions" not in prediction
+        or (
+            "predicted_classes" not in prediction
+            and ("top" not in prediction or "confidence" not in prediction)
+        )
+    ):
+        raise ValueError(
+            "A `ClassificationFilter` operation must preserve the classification "
+            "prediction response structure."
+        )
+    if not classification_mode and not isinstance(prediction, sv.Detections):
+        raise ValueError(
+            "Classification predictions require a `ClassificationFilter` operation."
+        )

--- a/tests/workflows/integration_tests/execution/test_workflow_with_classification_detections_filter.py
+++ b/tests/workflows/integration_tests/execution/test_workflow_with_classification_detections_filter.py
@@ -1,0 +1,130 @@
+import pytest
+
+from inference.core.env import WORKFLOWS_MAX_CONCURRENT_STEPS
+from inference.core.managers.base import ModelManager
+from inference.core.workflows.core_steps.common.entities import StepExecutionMode
+from inference.core.workflows.errors import ReferenceTypeError
+from inference.core.workflows.execution_engine.core import ExecutionEngine
+
+CLASSIFICATION_FILTER_OPERATION = {
+    "type": "ClassificationFilter",
+    "filter_operation": {
+        "type": "StatementGroup",
+        "statements": [
+            {
+                "type": "BinaryStatement",
+                "left_operand": {
+                    "type": "DynamicOperand",
+                    "operations": [
+                        {
+                            "type": "ExtractClassificationPredictionProperty",
+                            "property_name": "confidence",
+                        }
+                    ],
+                },
+                "comparator": {"type": "(Number) >="},
+                "right_operand": {
+                    "type": "DynamicOperand",
+                    "operand_name": "threshold",
+                },
+            }
+        ],
+    },
+}
+
+CLASSIFICATION_FILTER_WORKFLOW = {
+    "version": "1.3.0",
+    "inputs": [
+        {
+            "type": "WorkflowBatchInput",
+            "name": "predictions",
+            "kind": ["classification_prediction"],
+        },
+        {
+            "type": "WorkflowParameter",
+            "name": "threshold",
+            "default_value": 0.5,
+        },
+    ],
+    "steps": [
+        {
+            "type": "roboflow_core/detections_filter@v2",
+            "name": "filter",
+            "predictions": "$inputs.predictions",
+            "operations": [CLASSIFICATION_FILTER_OPERATION],
+            "operations_parameters": {"threshold": "$inputs.threshold"},
+        }
+    ],
+    "outputs": [
+        {
+            "type": "JsonField",
+            "name": "filtered",
+            "selector": "$steps.filter.predictions",
+        }
+    ],
+}
+
+
+def _init_engine(workflow: dict, model_manager: ModelManager) -> ExecutionEngine:
+    return ExecutionEngine.init(
+        workflow_definition=workflow,
+        init_parameters={
+            "workflows_core.model_manager": model_manager,
+            "workflows_core.api_key": None,
+            "workflows_core.step_execution_mode": StepExecutionMode.LOCAL,
+        },
+        max_concurrent_steps=WORKFLOWS_MAX_CONCURRENT_STEPS,
+    )
+
+
+def test_classification_detections_filter_end_to_end(
+    model_manager: ModelManager,
+) -> None:
+    engine = _init_engine(
+        workflow=CLASSIFICATION_FILTER_WORKFLOW,
+        model_manager=model_manager,
+    )
+    prediction = {
+        "image": {"width": 100, "height": 80},
+        "predictions": [
+            {"class": "cat", "class_id": 0, "confidence": 0.9},
+            {"class": "dog", "class_id": 1, "confidence": 0.4},
+        ],
+        "top": "cat",
+        "confidence": 0.9,
+    }
+
+    result = engine.run(
+        runtime_parameters={
+            "predictions": [prediction],
+            "threshold": 0.5,
+        }
+    )
+
+    assert len(result) == 1
+    assert result[0]["filtered"]["predictions"] == [
+        {"class": "cat", "class_id": 0, "confidence": 0.9}
+    ]
+    assert result[0]["filtered"]["top"] == "cat"
+    assert result[0]["filtered"]["confidence"] == 0.9
+
+
+def test_classification_configured_output_cannot_feed_detection_only_block(
+    model_manager: ModelManager,
+) -> None:
+    invalid_workflow = {
+        **CLASSIFICATION_FILTER_WORKFLOW,
+        "steps": [
+            *CLASSIFICATION_FILTER_WORKFLOW["steps"],
+            {
+                "type": "roboflow_core/detections_filter@v1",
+                "name": "detection_only_filter",
+                "predictions": "$steps.filter.predictions",
+                "operations": [],
+                "operations_parameters": {},
+            },
+        ],
+    }
+
+    with pytest.raises(ReferenceTypeError):
+        _init_engine(workflow=invalid_workflow, model_manager=model_manager)

--- a/tests/workflows/unit_tests/core_steps/common/query_language/test_introspection_operations.py
+++ b/tests/workflows/unit_tests/core_steps/common/query_language/test_introspection_operations.py
@@ -16,3 +16,39 @@ def test_detections_property_extract_includes_property_name_options_with_area_fi
     assert detections_extract.property_name_options is not None
     assert "area_px" in detections_extract.property_name_options
     assert "area_converted" in detections_extract.property_name_options
+
+
+def test_classification_filter_exposes_classification_nested_contract():
+    operations = prepare_operations_descriptions()
+    classification_filter = next(
+        op for op in operations if op.operation_type == "ClassificationFilter"
+    )
+
+    assert classification_filter.compound is True
+    assert [kind.name for kind in classification_filter.input_kind] == [
+        "classification_prediction"
+    ]
+    assert [kind.name for kind in classification_filter.output_kind] == [
+        "classification_prediction"
+    ]
+    assert [
+        kind.name for kind in classification_filter.nested_operation_input_kind
+    ] == ["dictionary"]
+    assert [
+        kind.name for kind in classification_filter.nested_operation_output_kind
+    ] == ["boolean"]
+
+
+def test_classification_prediction_extract_exposes_property_options():
+    operations = prepare_operations_descriptions()
+    classification_extract = next(
+        op
+        for op in operations
+        if op.operation_type == "ExtractClassificationPredictionProperty"
+    )
+
+    assert classification_extract.property_name_options == [
+        "class_name",
+        "class_id",
+        "confidence",
+    ]

--- a/tests/workflows/unit_tests/core_steps/transformations/test_detections_filter_v2.py
+++ b/tests/workflows/unit_tests/core_steps/transformations/test_detections_filter_v2.py
@@ -1,0 +1,391 @@
+from typing import Optional
+
+import numpy as np
+import pytest
+import supervision as sv
+from pydantic import ValidationError
+
+from inference.core.workflows.core_steps.common.query_language.entities.operations import (
+    OperationsChain,
+)
+from inference.core.workflows.core_steps.transformations.detections_filter.v1 import (
+    DetectionsFilterBlockV1,
+)
+from inference.core.workflows.core_steps.transformations.detections_filter.v2 import (
+    BlockManifest,
+    DetectionsFilterBlockV2,
+)
+from inference.core.workflows.execution_engine.entities.base import Batch
+
+
+def _classification_filter_operations(
+    threshold_operand: Optional[dict] = None,
+) -> list:
+    if threshold_operand is None:
+        threshold_operand = {
+            "type": "DynamicOperand",
+            "operand_name": "threshold",
+        }
+    return [
+        {
+            "type": "ClassificationFilter",
+            "filter_operation": {
+                "type": "StatementGroup",
+                "statements": [
+                    {
+                        "type": "BinaryStatement",
+                        "left_operand": {
+                            "type": "DynamicOperand",
+                            "operations": [
+                                {
+                                    "type": "ExtractClassificationPredictionProperty",
+                                    "property_name": "confidence",
+                                }
+                            ],
+                        },
+                        "comparator": {"type": "(Number) >="},
+                        "right_operand": threshold_operand,
+                    }
+                ],
+            },
+        }
+    ]
+
+
+def _detections_filter_operations() -> list:
+    return [
+        {
+            "type": "DetectionsFilter",
+            "filter_operation": {
+                "type": "StatementGroup",
+                "statements": [
+                    {
+                        "type": "BinaryStatement",
+                        "left_operand": {
+                            "type": "DynamicOperand",
+                            "operations": [
+                                {
+                                    "type": "ExtractDetectionProperty",
+                                    "property_name": "confidence",
+                                }
+                            ],
+                        },
+                        "comparator": {"type": "(Number) >="},
+                        "right_operand": {
+                            "type": "DynamicOperand",
+                            "operand_name": "threshold",
+                        },
+                    }
+                ],
+            },
+        }
+    ]
+
+
+def _classification_property_filter_operations(
+    property_name: str,
+    value: object,
+) -> list:
+    return [
+        {
+            "type": "ClassificationFilter",
+            "filter_operation": {
+                "type": "StatementGroup",
+                "statements": [
+                    {
+                        "type": "BinaryStatement",
+                        "left_operand": {
+                            "type": "DynamicOperand",
+                            "operations": [
+                                {
+                                    "type": "ExtractClassificationPredictionProperty",
+                                    "property_name": property_name,
+                                }
+                            ],
+                        },
+                        "comparator": {"type": "=="},
+                        "right_operand": {
+                            "type": "StaticOperand",
+                            "value": value,
+                        },
+                    }
+                ],
+            },
+        }
+    ]
+
+
+def _parse_operations(operations: list) -> list:
+    return OperationsChain.model_validate({"operations": operations}).operations
+
+
+def _single_label_prediction() -> dict:
+    return {
+        "image": {"width": 100, "height": 80},
+        "predictions": [
+            {"class": "cat", "class_id": 0, "confidence": 0.9},
+            {"class": "dog", "class_id": 1, "confidence": 0.4},
+        ],
+        "top": "cat",
+        "confidence": 0.9,
+        "parent_id": "parent",
+        "root_parent_id": "root",
+        "inference_id": "inference",
+        "prediction_type": "classification",
+    }
+
+
+def _multi_label_prediction() -> dict:
+    return {
+        "image": {"width": 100, "height": 80},
+        "predictions": {
+            "cat": {"class_id": 0, "confidence": 0.9},
+            "dog": {"class_id": 1, "confidence": 0.4},
+            "bird": {"class_id": 2, "confidence": 0.8},
+        },
+        "predicted_classes": ["cat", "dog"],
+        "parent_id": "parent",
+        "root_parent_id": "root",
+        "inference_id": "inference",
+        "prediction_type": "classification",
+    }
+
+
+def test_manifest_accepts_v1_detection_configuration_with_v2_type() -> None:
+    raw_manifest = {
+        "type": "roboflow_core/detections_filter@v2",
+        "name": "filter",
+        "predictions": "$steps.model.predictions",
+        "operations": _detections_filter_operations(),
+        "operations_parameters": {"threshold": "$inputs.threshold"},
+    }
+
+    result = BlockManifest.model_validate(raw_manifest)
+
+    assert result.type == "roboflow_core/detections_filter@v2"
+    assert result.operations[0].type == "DetectionsFilter"
+    assert {kind.name for kind in result.get_actual_outputs()[0].kind} == {
+        "object_detection_prediction",
+        "instance_segmentation_prediction",
+        "keypoint_detection_prediction",
+    }
+
+
+def test_manifest_does_not_claim_legacy_v1_alias() -> None:
+    with pytest.raises(ValidationError):
+        BlockManifest.model_validate(
+            {
+                "type": "DetectionsFilter",
+                "name": "filter",
+                "predictions": "$steps.model.predictions",
+                "operations": _detections_filter_operations(),
+            }
+        )
+
+
+def test_manifest_reports_classification_output_for_classification_filter() -> None:
+    manifest = BlockManifest.model_validate(
+        {
+            "type": "roboflow_core/detections_filter@v2",
+            "name": "filter",
+            "predictions": "$steps.model.predictions",
+            "operations": _classification_filter_operations(),
+        }
+    )
+
+    assert [kind.name for kind in manifest.get_actual_outputs()[0].kind] == [
+        "classification_prediction"
+    ]
+
+
+def test_manifest_rejects_mixed_detection_and_classification_filters() -> None:
+    with pytest.raises(ValidationError, match="cannot mix"):
+        BlockManifest.model_validate(
+            {
+                "type": "roboflow_core/detections_filter@v2",
+                "name": "filter",
+                "predictions": "$steps.model.predictions",
+                "operations": (
+                    _detections_filter_operations()
+                    + _classification_filter_operations()
+                ),
+            }
+        )
+
+
+def test_v2_preserves_v1_detection_filter_behavior() -> None:
+    detections = sv.Detections(
+        xyxy=np.array([[0, 0, 10, 10], [10, 10, 20, 20]], dtype=float),
+        class_id=np.array([0, 1]),
+        confidence=np.array([0.9, 0.4]),
+        data={"class_name": np.array(["cat", "dog"])},
+    )
+    predictions = Batch(content=[detections], indices=[(0,)])
+    operations = _parse_operations(_detections_filter_operations())
+
+    v1_result = DetectionsFilterBlockV1().run(
+        predictions=predictions,
+        operations=operations,
+        operations_parameters={"threshold": 0.5},
+    )
+    v2_result = DetectionsFilterBlockV2().run(
+        predictions=predictions,
+        operations=operations,
+        operations_parameters={"threshold": 0.5},
+    )
+
+    v1_predictions = v1_result[0]["predictions"]
+    v2_predictions = v2_result[0]["predictions"]
+    np.testing.assert_array_equal(v2_predictions.xyxy, v1_predictions.xyxy)
+    np.testing.assert_array_equal(v2_predictions.class_id, v1_predictions.class_id)
+    np.testing.assert_array_equal(v2_predictions.confidence, v1_predictions.confidence)
+    np.testing.assert_array_equal(
+        v2_predictions.data["class_name"],
+        v1_predictions.data["class_name"],
+    )
+
+
+def test_detection_filter_returns_empty_detections_when_all_are_removed() -> None:
+    detections = sv.Detections(
+        xyxy=np.array([[0, 0, 10, 10]], dtype=float),
+        class_id=np.array([0]),
+        confidence=np.array([0.9]),
+        data={"class_name": np.array(["cat"])},
+    )
+
+    result = DetectionsFilterBlockV2().run(
+        predictions=Batch(content=[detections], indices=[(0,)]),
+        operations=_parse_operations(_detections_filter_operations()),
+        operations_parameters={"threshold": 0.95},
+    )
+
+    assert isinstance(result[0]["predictions"], sv.Detections)
+    assert len(result[0]["predictions"]) == 0
+
+
+def test_single_label_classification_filter_recomputes_summary_and_metadata() -> None:
+    prediction = _single_label_prediction()
+
+    result = DetectionsFilterBlockV2().run(
+        predictions=Batch(content=[prediction], indices=[(0,)]),
+        operations=_parse_operations(_classification_filter_operations()),
+        operations_parameters={"threshold": 0.5},
+    )
+
+    filtered = result[0]["predictions"]
+    assert filtered["predictions"] == [
+        {"class": "cat", "class_id": 0, "confidence": 0.9}
+    ]
+    assert filtered["top"] == "cat"
+    assert filtered["confidence"] == 0.9
+    assert filtered["parent_id"] == "parent"
+    assert filtered["root_parent_id"] == "root"
+    assert filtered["inference_id"] == "inference"
+    assert prediction["predictions"][1]["class"] == "dog"
+
+
+@pytest.mark.parametrize(
+    ("property_name", "value"),
+    [
+        ("class_name", "dog"),
+        ("class_id", 1),
+    ],
+)
+def test_classification_filter_supports_class_properties(
+    property_name: str,
+    value: object,
+) -> None:
+    result = DetectionsFilterBlockV2().run(
+        predictions=Batch(content=[_single_label_prediction()], indices=[(0,)]),
+        operations=_parse_operations(
+            _classification_property_filter_operations(
+                property_name=property_name,
+                value=value,
+            )
+        ),
+        operations_parameters={},
+    )
+
+    filtered = result[0]["predictions"]
+    assert filtered["predictions"] == [
+        {"class": "dog", "class_id": 1, "confidence": 0.4}
+    ]
+    assert filtered["top"] == "dog"
+    assert filtered["confidence"] == 0.4
+
+
+def test_single_label_classification_filter_returns_canonical_empty_result() -> None:
+    result = DetectionsFilterBlockV2().run(
+        predictions=Batch(content=[_single_label_prediction()], indices=[(0,)]),
+        operations=_parse_operations(_classification_filter_operations()),
+        operations_parameters={"threshold": 0.95},
+    )
+
+    filtered = result[0]["predictions"]
+    assert filtered["predictions"] == []
+    assert filtered["top"] == ""
+    assert filtered["confidence"] == 0.0
+
+
+def test_multi_label_classification_filter_preserves_score_map_and_selection() -> None:
+    prediction = _multi_label_prediction()
+
+    result = DetectionsFilterBlockV2().run(
+        predictions=Batch(content=[prediction], indices=[(0,)]),
+        operations=_parse_operations(_classification_filter_operations()),
+        operations_parameters={"threshold": 0.5},
+    )
+
+    filtered = result[0]["predictions"]
+    assert filtered["predicted_classes"] == ["cat"]
+    assert filtered["predictions"] == prediction["predictions"]
+    assert "bird" not in filtered["predicted_classes"]
+    assert filtered["parent_id"] == "parent"
+    assert filtered["root_parent_id"] == "root"
+
+
+def test_multi_label_classification_filter_returns_canonical_empty_selection() -> None:
+    prediction = _multi_label_prediction()
+
+    result = DetectionsFilterBlockV2().run(
+        predictions=Batch(content=[prediction], indices=[(0,)]),
+        operations=_parse_operations(_classification_filter_operations()),
+        operations_parameters={"threshold": 0.95},
+    )
+
+    filtered = result[0]["predictions"]
+    assert filtered["predicted_classes"] == []
+    assert filtered["predictions"] == prediction["predictions"]
+
+
+def test_classification_filter_supports_batch_aligned_thresholds() -> None:
+    result = DetectionsFilterBlockV2().run(
+        predictions=Batch(
+            content=[_single_label_prediction(), _single_label_prediction()],
+            indices=[(0,), (1,)],
+        ),
+        operations=_parse_operations(_classification_filter_operations()),
+        operations_parameters={
+            "threshold": Batch(
+                content=[0.95, 0.5],
+                indices=[(0,), (1,)],
+            )
+        },
+    )
+
+    assert result[0]["predictions"]["predictions"] == []
+    assert [
+        prediction["class"] for prediction in result[1]["predictions"]["predictions"]
+    ] == ["cat"]
+
+
+def test_classification_input_requires_classification_filter() -> None:
+    with pytest.raises(
+        ValueError,
+        match="Classification predictions require a `ClassificationFilter`",
+    ):
+        DetectionsFilterBlockV2().run(
+            predictions=Batch(content=[_single_label_prediction()], indices=[(0,)]),
+            operations=[],
+            operations_parameters={},
+        )


### PR DESCRIPTION
# Description

Adds `roboflow_core/detections_filter@v2` while keeping the block displayed as **Detections Filter** and preserving v1 detection behavior.

The new version accepts classification predictions and introduces additive classification-specific UQL operations for filtering selected classes by confidence, class name, or class ID. Single-label outputs recompute `top` and `confidence`; multi-label outputs narrow `predicted_classes` while preserving the complete score map.

The manifest narrows its configured output kind so classification results cannot compile into detection-only downstream blocks.

Source: **Detections Filter v2 classification support** engineering intake, 2026-07-23 (`engineering-intake-2026-07-23-detections-filter-v2-classification.md`).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Maintenance (non-breaking, non-user facing changing such as dependency update, adding test, modifying secrets, etc.)
- [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

- 32 focused unit and integration tests pass, covering:
  - v1 detection parity and empty detections
  - single-label and multi-label confidence filtering
  - canonical empty classification outputs
  - class-name and class-ID predicates
  - batch-aligned operation parameters
  - operation introspection and loader registration
  - end-to-end workflow execution
  - compiler rejection of classification output connected to a detection-only block
- Changed-file Black, isort, flake8 syntax/undefined-name checks, and `git diff --check` pass.
- Python 3.10 syntax compilation passes.
- Full workflow unit suite: 3,544 passed, 2 skipped, and 2 unrelated macOS/OpenCV bounding-rectangle failures in untouched code.

## Will the change affect Universe? If so was this change tested in universe?

No.

## Any specific deployment considerations

- light-v2-query
- No migration or rollout flag is required; v1 remains registered and unchanged.

### Infrastructure impact

- [ ] This change affects infrastructure needs (GPUs, Cloud Function sizing, storage etc.)
