### PR TITLE
Enhance depth estimation documentation and response handling

### DIFF
--- a/docs/foundation/depth_estimation.md
+++ b/docs/foundation/depth_estimation.md
@@ -1,20 +1,32 @@
 <a href="https://huggingface.co/depth-anything/Depth-Anything-V2-Small-hf" target="_blank">Depth-Anything-V2-Small</a> is a depth estimation model developed by Hugging Face.
 
-You can use Depth-Anything-V2-Small to estimate the depth of objects in images, creating a depth map where:
-- Each pixel's value represents its relative distance from the camera
-- Lower values (darker colors) indicate closer objects
-- Higher values (lighter colors) indicate further objects
+You can use Depth-Anything-V2-Small to estimate the relative depth of objects
+in images. The served depth map is normalized independently for each image:
+
+- Higher values (lighter colors) indicate nearer objects, with `1.0` assigned
+  to the nearest prediction in the image.
+- Lower values (darker colors) indicate farther objects, with `0.0` assigned
+  to the farthest prediction in the image.
+- Intermediate values are ordinal proximity scores, not physical distances.
+  They should not be compared numerically across different images or model
+  families.
 
 You can deploy Depth-Anything-V2-Small with Inference.
 
 ### Available Models
 
-The depth estimation endpoint and the `depth_estimation@v1` workflow block serve two model families through one contract (per-image normalized depth, 1.0 = nearest):
+The depth estimation endpoint and the `depth_estimation@v1` workflow block
+serve two model families through one ordinal-depth contract: an image-sized
+map normalized per image, where `1.0` is nearest and `0.0` is farthest.
 
 - **Depth Anything** (relative depth): `depth-anything-v2/small`, `depth-anything-v3/small`, `depth-anything-v3/base`
 - **YOLO26 depth** (metric depth, normalized on this path; substantially faster): `yolo26n-depth-768`, `yolo26s-depth-768`, `yolo26m-depth-768`, `yolo26l-depth-768`, `yolo26x-depth-768`
 
-For absolute metric depth in meters from the YOLO26 checkpoints, load them directly with `inference_models.AutoModel` — see the `inference-models` YOLO26 depth documentation.
+This common output preserves shape, range, and near-to-far ordering across
+models. It does not make intermediate values geometrically equivalent between
+model families. For absolute metric depth in meters from the YOLO26
+checkpoints, load them directly with `inference_models.AutoModel` — see the
+`inference-models` YOLO26 depth documentation.
 
 ### Execution Modes
 
@@ -82,8 +94,8 @@ In this code, we:
 4. Display both the original image and the depth map visualization
 
 The depth map visualization uses a viridis colormap where:
-- Darker colors (purple/blue) represent objects closer to the camera
-- Lighter colors (yellow/green) represent objects further from the camera
+- Lighter colors (yellow/green) represent objects closer to the camera
+- Darker colors (purple/blue) represent objects further from the camera
 
 To use Depth-Anything-V2-Small with Inference, you will need a Hugging Face token. If you don't already have a Hugging Face account, <a href="https://huggingface.co/join" target="_blank">sign up for a free Hugging Face account</a>.
 

--- a/inference/core/entities/responses/inference.py
+++ b/inference/core/entities/responses/inference.py
@@ -445,14 +445,21 @@ class DepthEstimationResponse(BaseModel):
     """Response for depth estimation inference.
 
     Attributes:
-        normalized_depth (List[List[float]]): The normalized depth map as a 2D array of floats between 0 and 1.
+        normalized_depth (List[List[float]]): The per-image normalized ordinal
+            depth map as a 2D array of floats between 0 and 1. Higher values
+            indicate nearer predictions.
         image (Optional[str]): Base64 encoded visualization of the depth map if visualize_predictions is True.
         time (float): The processing time in seconds.
         visualization (Optional[str]): Base64 encoded visualization of the depth map if visualize_predictions is True.
     """
 
     normalized_depth: List[List[float]] = Field(
-        description="The normalized depth map as a 2D array of floats between 0 and 1"
+        description=(
+            "Per-image normalized ordinal depth as a 2D array of floats between "
+            "0 and 1, where 1 is nearest and 0 is farthest. Values are not "
+            "physical distances or directly comparable across images or model "
+            "families."
+        )
     )
     image: Optional[str] = Field(
         None,

--- a/inference/core/models/inference_models_adapters.py
+++ b/inference/core/models/inference_models_adapters.py
@@ -1778,9 +1778,9 @@ class InferenceModelsDepthEstimationAdapter(Model):
         depth_max = depth_map.max()
         if depth_max == depth_min:
             raise ValueError("Depth map has no variation (min equals max)")
-        # DepthAnything serves disparity-style values (larger = closer), so
-        # metric depth (larger = farther) is inverted while normalizing to
-        # keep the served convention identical across depth models.
+        # The endpoint exposes an ordinal proximity map where larger means
+        # closer. Reverse metric depth while normalizing so all supported
+        # models share the same range, direction, and near-to-far ordering.
         normalized_depth = (depth_max - depth_map) / (depth_max - depth_min)
 
         depth_for_viz = (normalized_depth * 255.0).astype(np.uint8)

--- a/inference/core/workflows/core_steps/models/foundation/depth_estimation/v1.py
+++ b/inference/core/workflows/core_steps/models/foundation/depth_estimation/v1.py
@@ -43,28 +43,30 @@ class BlockManifest(WorkflowBlockManifest):
         json_schema_extra={
             "name": "Depth Estimation",
             "version": "v1",
-            "short_description": "Run Depth Estimation on an image.",
+            "short_description": "Estimate relative scene depth in an image.",
             "long_description": (
                 """
-                🎯 This workflow block performs depth estimation on images using Apple's DepthPro model. It analyzes the spatial relationships
-                and depth information in images to create a depth map where:
-
-                📊 Each pixel's value represents its relative distance from the camera
-                🔍 Lower values (darker colors) indicate closer objects
-                🔭 Higher values (lighter colors) indicate further objects
+                🎯 This workflow block performs monocular depth estimation with a
+                selected Depth Anything or YOLO26 depth model.
 
                 The model outputs:
-                1. 🗺️ A depth map showing the relative distances of objects in the scene
-                2. 📐 The camera's field of view (in degrees)
-                3. 🔬 The camera's focal length
+                1. 🗺️ A visualization of the estimated scene depth
+                2. 📊 `normalized_depth`, an image-sized ordinal proximity map
+
+                `normalized_depth` is normalized independently for every image:
+                🔍 1.0 indicates the nearest prediction
+                🔭 0.0 indicates the farthest prediction
+
+                Intermediate values preserve relative near-to-far ordering. They are
+                not physical distances and should not be compared numerically across
+                images or model families. YOLO26's metric output is normalized by this
+                block; use `inference_models.AutoModel` directly when meters are needed.
 
                 This is particularly useful for:
                 - 🏗️ Understanding 3D structure from 2D images
                 - 🎨 Creating depth-aware visualizations
-                - 📏 Analyzing spatial relationships in scenes
-                - 🕶️ Applications in augmented reality and 3D reconstruction
-
-                ⚡ The model runs efficiently on Apple Silicon (M1-M4) using Metal Performance Shaders (MPS) for accelerated inference.
+                - 📏 Analyzing relative spatial relationships in scenes
+                - 🕶️ Depth-aware image processing
                 """
             ),
             "license": "Apache-2.0",

--- a/inference_models/docs/models/yolo26-depth-estimation.md
+++ b/inference_models/docs/models/yolo26-depth-estimation.md
@@ -88,13 +88,17 @@ The model returns a list of `torch.Tensor` depth maps, one per input image:
 !!! note "Metric vs relative depth"
     `AutoModel` returns **absolute metric depth in meters**. When served through the
     Roboflow hosted API or the `depth_estimation@v1` workflow block, the output is
-    min-max normalized per image to the disparity-style convention shared with
-    Depth Anything (1.0 = nearest, 0.0 = farthest) so the models are drop-in
-    interchangeable; the metric scale is not exposed on that path.
+    converted to the per-image ordinal-depth contract also used for Depth Anything
+    (`1.0` = nearest, `0.0` = farthest). The models therefore share the same output
+    shape, range, and near-to-far ordering, but intermediate values are not
+    geometrically equivalent or directly comparable across model families. The
+    metric scale is not exposed on that path.
 
 !!! note "Choosing between YOLO26 depth and Depth Anything"
     YOLO26 predicts at input/4 native resolution and is substantially faster at a
     matched budget, with metric calibration; [Depth Anything V3](depth-anything-v3.md)
     decodes at full network resolution, producing sharper relative-depth maps at
-    higher compute cost. Prefer YOLO26 for speed and absolute distances; prefer
-    Depth Anything for edge fidelity in relative maps.
+    higher compute cost. Prefer YOLO26 for speed and, when using `AutoModel`
+    directly, absolute distances. Prefer Depth Anything for edge fidelity in
+    relative maps. The hosted API and workflow block normalize both families and
+    do not expose YOLO26's absolute distances.

--- a/inference_sdk/http/client.py
+++ b/inference_sdk/http/client.py
@@ -1734,7 +1734,9 @@ class InferenceHTTPClient:
 
         Returns:
             Union[dict, List[dict]]: Depth estimation results containing:
-                - normalized_depth: The normalized depth map as a list
+                - normalized_depth: Per-image normalized ordinal depth as a list,
+                  where 1 is nearest and 0 is farthest. Values are not physical
+                  distances or directly comparable across images or model families.
                 - image: Hex-encoded visualization of the depth map
 
         Raises:
@@ -1772,7 +1774,8 @@ class InferenceHTTPClient:
                 request body.
 
         Returns:
-            Union[dict, List[dict]]: Depth estimation results.
+            Union[dict, List[dict]]: Depth estimation results containing per-image
+                normalized ordinal depth, where 1 is nearest and 0 is farthest.
 
         Raises:
             HTTPCallErrorError: If there is an error in the HTTP call.

--- a/tests/inference/unit_tests/core/models/test_inference_models_adapters.py
+++ b/tests/inference/unit_tests/core/models/test_inference_models_adapters.py
@@ -537,11 +537,10 @@ def test_pipeline_flush_raises_on_response_future_timeout(monkeypatch) -> None:
 def test_depth_estimation_adapter_normalization_matches_depth_anything_convention() -> (
     None
 ):
-    """DepthAnything models serve disparity-style relative depth - larger means
-    closer (see the "Flip to be consistent with V2" step in
-    DepthAnythingV3Torch.forward). The metric-depth adapter must invert while
-    normalizing so metric models are true drop-ins: nearest pixel -> 1.0,
-    farthest -> 0.0."""
+    """The endpoint's ordinal proximity convention uses larger values for nearer
+    predictions (see the "Flip to be consistent with V2" step in
+    DepthAnythingV3Torch.forward). The metric-depth adapter must reverse depth
+    while normalizing: nearest pixel -> 1.0, farthest -> 0.0."""
     import numpy as np
 
     adapter = InferenceModelsDepthEstimationAdapter.__new__(


### PR DESCRIPTION
## What does this PR do?

PR #2691 exposes YOLO26 depth models through the existing Depth Anything endpoint, but the documentation described their normalized outputs as fully interchangeable in disparity space. This overstated the contract and included contradictory guidance about whether higher or lower values represent nearer objects.

This update defines `normalized_depth` as a per-image ordinal proximity map rather than a physical or disparity-space measurement. Across supported models, `1.0` represents the nearest prediction and `0.0` represents the farthest prediction. The documentation now explains that intermediate values preserve near-to-far ordering but are not directly comparable across images or model families. It also clarifies that YOLO26’s metric output is available in meters only when loading the model directly through `inference_models.AutoModel`; the hosted endpoint and workflow block normalize it. API schema and SDK descriptions use the same terminology. The workflow UI description no longer references DepthPro, focal length, or field-of-view outputs that the block does not provide.

**Main elements:**
- Depth estimation foundation guide and YOLO26 model documentation
- Depth estimation response schema and SDK method documentation
- Workflow block UI description
- Adapter comments and normalization test documentation

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other:

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)

## Additional Context

This is a documentation-only follow-up stacked on PR #2691. It does not change depth normalization or other runtime behavior.