### PR TITLE
Implement 404 error handling for PP-OCR route when inference models in disabled

### DIFF
--- a/inference/core/interfaces/http/http_api.py
+++ b/inference/core/interfaces/http/http_api.py
@@ -4054,6 +4054,12 @@ class HttpInterface(BaseInterface):
                     Returns:
                         OCRInferenceResponse: The response containing the retrieved text.
                     """
+                    if not USE_INFERENCE_MODELS:
+                        raise HTTPException(
+                            status_code=404,
+                            detail="PP-OCR is not supported by this inference server configuration.",
+                        )
+
                     logger.debug(f"Reached /ocr/pp-ocr")
                     pp_ocr_model_id = load_pp_ocr_model(
                         inference_request,

--- a/tests/inference/unit_tests/core/interfaces/http/test_http_api.py
+++ b/tests/inference/unit_tests/core/interfaces/http/test_http_api.py
@@ -213,6 +213,7 @@ def test_serverless_registers_pp_ocr_route_when_model_flag_is_enabled(
     import inference.core.interfaces.http.http_api as http_api
 
     monkeypatch.setattr(http_api, "CORE_MODEL_PPOCR_ENABLED", True)
+    monkeypatch.setattr(http_api, "USE_INFERENCE_MODELS", True)
     interface, _, _, _ = _build_serverless_interface(
         monkeypatch=monkeypatch,
         usage_check_result=ServerlessUsageCheckResponse(
@@ -232,6 +233,7 @@ def test_serverless_does_not_register_pp_ocr_route_when_model_flag_is_disabled(
     import inference.core.interfaces.http.http_api as http_api
 
     monkeypatch.setattr(http_api, "CORE_MODEL_PPOCR_ENABLED", False)
+    monkeypatch.setattr(http_api, "USE_INFERENCE_MODELS", True)
     interface, _, _, _ = _build_serverless_interface(
         monkeypatch=monkeypatch,
         usage_check_result=ServerlessUsageCheckResponse(
@@ -243,6 +245,39 @@ def test_serverless_does_not_register_pp_ocr_route_when_model_flag_is_disabled(
 
     paths = _route_paths(interface)
     assert "/ocr/pp-ocr" not in paths
+
+
+def test_serverless_pp_ocr_route_returns_404_without_inference_models(
+    monkeypatch,
+) -> None:
+    import inference.core.interfaces.http.http_api as http_api
+
+    monkeypatch.setattr(http_api, "CORE_MODEL_PPOCR_ENABLED", True)
+    monkeypatch.setattr(http_api, "USE_INFERENCE_MODELS", False)
+    interface, model_manager, _, _ = _build_serverless_interface(
+        monkeypatch=monkeypatch,
+        usage_check_result=ServerlessUsageCheckResponse(
+            status_code=200,
+            workspace_id="rf-inference-benchmark",
+            under_cap=True,
+        ),
+    )
+
+    paths = _route_paths(interface)
+    assert "/ocr/pp-ocr" in paths
+    with TestClient(interface.app) as client:
+        response = client.post(
+            "/ocr/pp-ocr",
+            params={"api_key": "test-api-key"},
+            json={
+                "image": {
+                    "type": "url",
+                    "value": "https://example.com/test.jpg",
+                }
+            },
+        )
+    assert response.status_code == 404
+    model_manager.add_model.assert_not_called()
 
 
 def test_infer_lmm_with_model_id_uses_alias_registry_key(monkeypatch) -> None:


### PR DESCRIPTION
## What does this PR do?

Fixes incorrect error on PP-OCR not available when `USE_INFERENCE_MODELS=False`
- Added a check in the HttpInterface to raise a 404 HTTPException if PP-OCR is not supported by the current server configuration.
- Updated unit tests to verify that the PP-OCR route returns a 404 status when inference models are disabled, ensuring proper error handling in serverless environments.

## Type of Change

- Bug fix (non-breaking change that fixes an issue)

## Testing

<!-- Describe how you tested your changes -->

- [x] I have added/updated tests for this change

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)