### PR TITLE
Update Execution Engine to v1.12.1

### DIFF
--- a/docs/workflows/execution_engine_changelog.md
+++ b/docs/workflows/execution_engine_changelog.md
@@ -9,6 +9,12 @@ Below you can find the changelog for Execution Engine.
 Add user-facing compile or execution behavior changes here. Maintainers replace
 this heading with the Execution Engine and inference versions when releasing.
 
+---
+
+## Execution Engine `v1.12.1` | inference `v1.3.7`
+
+**What changed**
+
 - Model-access failures raised while loading local workflow models now preserve HTTP
   402, 403, and 423 statuses instead of surfacing as generic HTTP 500 errors.
 

--- a/inference/core/workflows/execution_engine/v1/core.py
+++ b/inference/core/workflows/execution_engine/v1/core.py
@@ -32,7 +32,7 @@ from inference.core.workflows.execution_engine.v1.step_error_handlers import (
     legacy_step_error_handler,
 )
 
-EXECUTION_ENGINE_V1_VERSION = Version("1.12.0")
+EXECUTION_ENGINE_V1_VERSION = Version("1.12.1")
 
 DEFAULT_WORKFLOWS_STEP_ERROR_HANDLER = os.getenv(
     "DEFAULT_WORKFLOWS_STEP_ERROR_HANDLER", "extended_roboflow_errors"

--- a/tests/inference/hosted_platform_tests/test_workflows.py
+++ b/tests/inference/hosted_platform_tests/test_workflows.py
@@ -129,7 +129,7 @@ def test_get_versions_of_execution_engine(object_detection_service_url: str) -> 
     # then
     response.raise_for_status()
     response_data = response.json()
-    assert response_data["versions"] == ["1.12.0"]
+    assert response_data["versions"] == ["1.12.1"]
 
 
 FUNCTION = """

--- a/tests/inference/integration_tests/test_workflow_endpoints.py
+++ b/tests/inference/integration_tests/test_workflow_endpoints.py
@@ -691,7 +691,7 @@ def test_get_versions_of_execution_engine(server_url: str) -> None:
     # then
     response.raise_for_status()
     response_data = response.json()
-    assert response_data["versions"] == ["1.12.0"]
+    assert response_data["versions"] == ["1.12.1"]
 
 
 def test_getting_block_schema_using_get_endpoint(server_url) -> None:


### PR DESCRIPTION
## What does this PR do?

- Bump Execution Engine version to v1.12.1.
- Update changelog to reflect changes in model-access failure handling, preserving HTTP 402, 403, and 423 statuses instead of returning generic HTTP 500 errors.
- Adjust tests to verify the updated version in response data.

## Type of Change

- Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)

## Additional Context

<!-- Add any other context, screenshots, or notes about the PR here -->
