### PR TITLE
Feat/offline mode fixes

### DIFF
--- a/inference/core/cache/__init__.py
+++ b/inference/core/cache/__init__.py
@@ -3,9 +3,18 @@ from redis.exceptions import ConnectionError, TimeoutError
 from inference.core import logger
 from inference.core.cache.memory import MemoryCache
 from inference.core.cache.redis import RedisCache
-from inference.core.env import REDIS_HOST, REDIS_PORT, REDIS_SSL, REDIS_TIMEOUT
+from inference.core.env import (
+    OFFLINE_MODE,
+    REDIS_HOST,
+    REDIS_PORT,
+    REDIS_SSL,
+    REDIS_TIMEOUT,
+)
 
-if REDIS_HOST is not None:
+if OFFLINE_MODE:
+    cache = MemoryCache()
+    logger.info("Memory Cache initialised for OFFLINE_MODE")
+elif REDIS_HOST is not None:
     try:
         cache = RedisCache(
             host=REDIS_HOST, port=REDIS_PORT, ssl=REDIS_SSL, timeout=REDIS_TIMEOUT

--- a/inference/core/registries/roboflow.py
+++ b/inference/core/registries/roboflow.py
@@ -182,6 +182,17 @@ FINE_TUNED_SAM3_DEPLOYMENT_ERROR = (
 )
 
 
+def _get_in_process_metadata_cache_key(
+    dataset_id: Union[DatasetID, ModelID],
+    version_id: Optional[VersionID],
+    api_key: Optional[str],
+) -> Tuple[Union[DatasetID, ModelID], Optional[VersionID], str]:
+    credential_cache_key = hashlib.sha256(
+        f"{api_key is None}:{api_key or ''}".encode("utf-8")
+    ).hexdigest()
+    return dataset_id, version_id, credential_cache_key
+
+
 def _find_cached_model_package_dir_compat(
     model_id: str,
     api_key: Optional[str] = None,
@@ -492,6 +503,7 @@ def get_model_type(
             version_id=version_id,
             project_task_type=project_task_type,
             model_type=model_type,
+            api_key=api_key,
         )
         return project_task_type, model_type
 
@@ -543,6 +555,7 @@ def get_model_type(
         version_id=version_id,
         project_task_type=project_task_type,
         model_type=model_type,
+        api_key=api_key,
     )
 
     return project_task_type, model_type
@@ -571,10 +584,11 @@ def get_model_metadata_from_cache(
 ) -> Optional[Tuple[TaskType, ModelType]]:
     model_id = _combine_model_id(dataset_id=dataset_id, version_id=version_id)
     validate_model_id_for_cache(model_id=model_id)
-    credential_cache_key = hashlib.sha256(
-        f"{api_key is None}:{api_key or ''}".encode("utf-8")
-    ).hexdigest()
-    cache_key = (dataset_id, version_id, credential_cache_key)
+    cache_key = _get_in_process_metadata_cache_key(
+        dataset_id=dataset_id,
+        version_id=version_id,
+        api_key=api_key,
+    )
     cached = _in_process_metadata_cache.get(cache_key)
     if cached is not None:
         return cached
@@ -764,6 +778,7 @@ def save_model_metadata_in_cache(
     version_id: Optional[VersionID],
     project_task_type: TaskType,
     model_type: ModelType,
+    api_key: Optional[str] = None,
 ) -> None:
     model_id = _combine_model_id(dataset_id=dataset_id, version_id=version_id)
     validate_model_id_for_cache(model_id=model_id)
@@ -786,7 +801,12 @@ def save_model_metadata_in_cache(
                 model_type=model_type,
             )
     _in_process_metadata_cache.set(
-        (dataset_id, version_id), (project_task_type, model_type)
+        _get_in_process_metadata_cache_key(
+            dataset_id=dataset_id,
+            version_id=version_id,
+            api_key=api_key,
+        ),
+        (project_task_type, model_type),
     )
 
 

--- a/inference/core/roboflow_api.py
+++ b/inference/core/roboflow_api.py
@@ -1601,8 +1601,10 @@ def get_workflow_specification(
         api_key: Roboflow API key, or None for unauthenticated fetches.
         workspace_id: Workspace slug, or ``local`` for filesystem-backed workflows.
         workflow_id: Workflow identifier within the workspace.
-        use_cache: If True, read and write the ephemeral workflow-definition cache.
+        use_cache: If True, read and write the ephemeral workflow-definition
+            cache while online. Ephemeral caches are always bypassed offline.
         ephemeral_cache: Cache backend; defaults to the process-global cache.
+            This backend is not accessed while offline.
         workflow_version_id: Optional pinned workflow version.
 
     Returns:
@@ -1614,8 +1616,9 @@ def get_workflow_specification(
         FileNotFoundError: Local workspace workflow file is missing.
         ValueError: Invalid local workflow id.
     """
-    ephemeral_cache = ephemeral_cache or cache
-    if use_cache:
+    use_ephemeral_cache = use_cache and not OFFLINE_MODE
+    if use_ephemeral_cache:
+        ephemeral_cache = ephemeral_cache or cache
         cached_entry = _try_retrieve_workflow_specification_from_ephemeral_cache(
             api_key=api_key,
             workspace_id=workspace_id,
@@ -1696,7 +1699,7 @@ def get_workflow_specification(
         if not isinstance(specification, dict):
             raise TypeError("Workflow specification must be a dictionary")
         specification["id"] = response["workflow"].get("id")
-        if use_cache:
+        if use_ephemeral_cache:
             _try_cache_workflow_specification_in_ephemeral_cache(
                 api_key=api_key,
                 workspace_id=workspace_id,

--- a/inference_models/inference_models/models/auto_loaders/core.py
+++ b/inference_models/inference_models/models/auto_loaders/core.py
@@ -2221,6 +2221,15 @@ class AutoModel:
                 )
                 raise error
             except RetryError:
+                if not OFFLINE_MODE:
+                    verbose_info(
+                        message=(
+                            f"API unreachable for model {model_id_or_path}; "
+                            "cache fallback is disabled while running online."
+                        ),
+                        verbose_requested=verbose,
+                    )
+                    raise
                 if credential_bound_cache_request:
                     verbose_info(
                         message=(

--- a/inference_models/inference_models/models/auto_loaders/core.py
+++ b/inference_models/inference_models/models/auto_loaders/core.py
@@ -956,6 +956,7 @@ def _remove_unattributed_unhashed_artifacts(
 def _validate_cached_package_artifacts(
     package_dir: str,
     identities: Optional[List[dict]],
+    on_invalid_cache_entry: Optional[Callable[[str], None]] = None,
 ) -> bool:
     try:
         parsed_identities = _parse_package_artifact_identities(identities)
@@ -965,21 +966,38 @@ def _validate_cached_package_artifacts(
                 identities=parsed_identities
             ),
         )
-    except (OSError, CorruptedModelPackageError) as error:
+    except OSError as error:
+        LOGGER.warning(
+            "Ignoring cached package %s because artefact identity validation "
+            "is temporarily unavailable: %s",
+            package_dir,
+            error,
+        )
+        return False
+    except CorruptedModelPackageError as error:
         LOGGER.warning(
             "Ignoring cached package %s because artefact identity validation "
             "failed: %s",
             package_dir,
             error,
         )
+        if on_invalid_cache_entry is not None:
+            on_invalid_cache_entry(str(error))
         return False
-    return current_identities == parsed_identities
+    if current_identities != parsed_identities:
+        if on_invalid_cache_entry is not None:
+            on_invalid_cache_entry(
+                "cached package artefacts no longer match their warmed identities"
+            )
+        return False
+    return True
 
 
 def _validate_cached_package_layout(
     package_dir: str,
     artifact_identities: Optional[List[dict]],
     dependency_identities: Optional[List[dict]],
+    on_invalid_cache_entry: Optional[Callable[[str], None]] = None,
 ) -> bool:
     try:
         parsed_artifacts = _parse_package_artifact_identities(artifact_identities)
@@ -993,13 +1011,23 @@ def _validate_cached_package_layout(
             ),
             dependency_package_paths=parsed_dependencies,
         )
-    except (OSError, CorruptedModelPackageError) as error:
+    except OSError as error:
+        LOGGER.warning(
+            "Ignoring cached package %s because its directory layout is "
+            "temporarily unavailable: %s",
+            package_dir,
+            error,
+        )
+        return False
+    except CorruptedModelPackageError as error:
         LOGGER.warning(
             "Ignoring cached package %s because its directory layout is not "
             "fully declared by the package manifest: %s",
             package_dir,
             error,
         )
+        if on_invalid_cache_entry is not None:
+            on_invalid_cache_entry(str(error))
         return False
     return True
 
@@ -1204,6 +1232,7 @@ def _parse_dependency_package_path_identities(value: object) -> List[dict]:
 def _validate_cached_dependency_package_paths(
     package_dir: str,
     identities: Optional[List[dict]],
+    on_invalid_cache_entry: Optional[Callable[[str], None]] = None,
 ) -> bool:
     try:
         parsed_identities = _parse_dependency_package_path_identities(identities)
@@ -1241,13 +1270,23 @@ def _validate_cached_dependency_package_paths(
                     ),
                     help_url="https://inference-models.roboflow.com/errors/model-loading/#corruptedmodelpackageerror",
                 )
-    except (OSError, CorruptedModelPackageError) as error:
+    except OSError as error:
+        LOGGER.warning(
+            "Ignoring cached package %s because dependency path validation "
+            "is temporarily unavailable: %s",
+            package_dir,
+            error,
+        )
+        return False
+    except CorruptedModelPackageError as error:
         LOGGER.warning(
             "Ignoring cached package %s because dependency path validation "
             "failed: %s",
             package_dir,
             error,
         )
+        if on_invalid_cache_entry is not None:
+            on_invalid_cache_entry(str(error))
         return False
     return True
 
@@ -2403,7 +2442,13 @@ class AutoModel:
 
 def _verified_auto_cache_package_dir(
     cache_entry: AutoResolutionCacheEntry,
+    on_invalid_cache_entry: Optional[Callable[[str], None]] = None,
 ) -> Optional[str]:
+    def reject_invalid_entry(reason: str) -> None:
+        LOGGER.warning("Ignoring invalid auto-load cache entry: %s", reason)
+        if on_invalid_cache_entry is not None:
+            on_invalid_cache_entry(reason)
+
     if (
         cache_entry.cache_attribution_version != CACHE_ATTRIBUTION_VERSION
         or not cache_entry.canonical_model_id
@@ -2413,6 +2458,7 @@ def _verified_auto_cache_package_dir(
         or not isinstance(cache_entry.package_manifest_hash, str)
         or re.fullmatch(r"[0-9a-f]{64}", cache_entry.package_manifest_hash) is None
     ):
+        reject_invalid_entry("canonical package attribution is missing or malformed")
         return None
     try:
         package_dir = resolve_existing_model_package_cache_path(
@@ -2424,11 +2470,16 @@ def _verified_auto_cache_package_dir(
         package_config = parse_model_config(
             config_path=os.path.join(package_dir, MODEL_CONFIG_FILE_NAME)
         )
-    except Exception as error:
+    except OSError as error:
         LOGGER.warning(
             "Ignoring auto-load cache entry because its package attribution "
-            "manifest could not be verified: %s",
+            "manifest is temporarily unavailable: %s",
             error,
+        )
+        return None
+    except Exception as error:
+        reject_invalid_entry(
+            f"package attribution manifest could not be verified: {error}"
         )
         return None
     if (
@@ -2455,24 +2506,27 @@ def _verified_auto_cache_package_dir(
         or package_config.runtime_compatibility_hash
         != _runtime_compatibility_hash(runtime_x_ray=x_ray_runtime_environment())
     ):
-        LOGGER.warning(
-            "Ignoring auto-load cache entry because its metadata does not "
-            "match the package manifest published by the successful warm."
+        reject_invalid_entry(
+            "resolution metadata does not match the package manifest "
+            "published by the successful warm"
         )
         return None
     if (
         not _validate_cached_package_artifacts(
             package_dir=package_dir,
             identities=package_config.package_artifacts,
+            on_invalid_cache_entry=reject_invalid_entry,
         )
         or not _validate_cached_dependency_package_paths(
             package_dir=package_dir,
             identities=package_config.dependency_package_paths,
+            on_invalid_cache_entry=reject_invalid_entry,
         )
         or not _validate_cached_package_layout(
             package_dir=package_dir,
             artifact_identities=package_config.package_artifacts,
             dependency_identities=package_config.dependency_package_paths,
+            on_invalid_cache_entry=reject_invalid_entry,
         )
     ):
         return None
@@ -2519,12 +2573,27 @@ def attempt_loading_model_with_auto_load_cache(
             verbose_requested=verbose,
         )
         return None
+    cache_entry_invalidated = False
+
+    def invalidate_cache_entry(reason: str) -> None:
+        nonlocal cache_entry_invalidated
+        if cache_entry_invalidated:
+            return
+        LOGGER.warning(
+            "Invalidating unusable auto-load cache entry for model %s: %s",
+            model_name_or_path,
+            reason,
+        )
+        auto_resolution_cache.invalidate(auto_negotiation_hash=auto_negotiation_hash)
+        cache_entry_invalidated = True
+
     if cache_entry.model_id != model_name_or_path:
         LOGGER.warning(
             "Ignoring auto-load cache entry for model %s while loading %s.",
             cache_entry.model_id,
             model_name_or_path,
         )
+        invalidate_cache_entry("cached requested-model identity does not match")
         return None
     if (
         expected_offline_compatibility_hash is not None
@@ -2546,7 +2615,10 @@ def attempt_loading_model_with_auto_load_cache(
             verbose_requested=verbose,
         )
         return None
-    model_package_cache_dir = _verified_auto_cache_package_dir(cache_entry=cache_entry)
+    model_package_cache_dir = _verified_auto_cache_package_dir(
+        cache_entry=cache_entry,
+        on_invalid_cache_entry=invalidate_cache_entry,
+    )
     if model_package_cache_dir is None:
         return None
     if not model_access_manager.is_model_package_access_granted(
@@ -2563,6 +2635,13 @@ def attempt_loading_model_with_auto_load_cache(
         return None
     try:
         model_dependencies = cache_entry.model_dependencies or []
+        if model_dependencies and not allow_loading_dependency_models:
+            LOGGER.warning(
+                "Ignoring auto-load cache entry for %s because dependency "
+                "loading is disabled for this request.",
+                model_name_or_path,
+            )
+            return None
         package_config = parse_model_config(
             config_path=os.path.join(
                 model_package_cache_dir,
@@ -2573,14 +2652,6 @@ def attempt_loading_model_with_auto_load_cache(
             model_dependencies=model_dependencies,
             identities=package_config.dependency_package_paths,
         )
-        if model_dependencies and not allow_loading_dependency_models:
-            raise CorruptedModelPackageError(
-                message=f"Could not load model {cache_entry.model_id} as it defines another models which are "
-                f"it's dependency, but the auto-loader prevents loading dependencies at certain "
-                f"nesting depth to avoid excessive resolution procedure. This is a limitation of "
-                f"current implementation. Provide us the context of your use-case to get help.",
-                help_url="https://inference-models.roboflow.com/errors/model-loading/#corruptedmodelpackageerror",
-            )
         model_dependencies_instances = {}
         dependency_models_params = dependency_models_params or {}
         for model_dependency in model_dependencies:
@@ -2697,6 +2768,9 @@ def attempt_loading_model_with_auto_load_cache(
             verbose_requested=verbose,
         )
         return model
+    except CorruptedModelPackageError as error:
+        invalidate_cache_entry(str(error))
+        return None
     except Exception as error:
         LOGGER.warning(
             f"Encountered error {error} of type {type(error)} when attempted to load model using "

--- a/inference_models/inference_models/models/auto_loaders/core.py
+++ b/inference_models/inference_models/models/auto_loaders/core.py
@@ -1951,6 +1951,10 @@ class AutoModel:
             runtime_compatibility = _runtime_compatibility_content(
                 runtime_x_ray=runtime_x_ray
             )
+            # This digest describes whether an already-warmed package can be
+            # loaded, so it deliberately excludes provider transport, retry,
+            # and download-integrity options. Those still belong to the exact
+            # online negotiation key below because they can affect acquisition.
             offline_compatibility_content = {
                 "provider": weights_provider,
                 "model_id": model_id_or_path,
@@ -1969,13 +1973,8 @@ class AutoModel:
                 "allow_untrusted_packages": allow_untrusted_packages,
                 "trt_engine_host_code_allowed": trt_engine_host_code_allowed,
                 "allow_local_code_packages": allow_local_code_packages,
-                "verify_hash_while_download": verify_hash_while_download,
-                "download_files_without_hash": download_files_without_hash,
                 "allow_loading_dependency_models": allow_loading_dependency_models,
-                "max_package_loading_attempts": max_package_loading_attempts,
                 "nms_fusion_preferences": nms_fusion_preferences,
-                "weights_provider_extra_query_params": weights_provider_extra_query_params,
-                "weights_provider_extra_headers": weights_provider_extra_headers,
                 "dependency_models_params": _canonicalize_cache_hash_value(
                     dependency_models_params
                 ),
@@ -1990,6 +1989,11 @@ class AutoModel:
             auto_negotiation_hash = hash_dict_content(
                 content={
                     **offline_compatibility_content,
+                    "verify_hash_while_download": verify_hash_while_download,
+                    "download_files_without_hash": download_files_without_hash,
+                    "max_package_loading_attempts": max_package_loading_attempts,
+                    "weights_provider_extra_query_params": weights_provider_extra_query_params,
+                    "weights_provider_extra_headers": weights_provider_extra_headers,
                     "api_key": api_key,
                 }
             )

--- a/inference_models/tests/unit_tests/models/auto_loaders/test_core.py
+++ b/inference_models/tests/unit_tests/models/auto_loaders/test_core.py
@@ -4611,43 +4611,30 @@ def test_attempt_loading_model_from_offline_cache_requires_matching_runtime(
     mock_load.assert_not_called()
 
 
-def test_from_pretrained_falls_back_to_offline_cache_on_retry_error(
-    empty_local_dir: str,
-) -> None:
-    # given
+def test_online_retry_error_does_not_use_cache_fallback() -> None:
     model_id = "test/1"
-    package_dir = _write_offline_package(
-        inference_home=empty_local_dir,
-        model_id=model_id,
-        package_id="pkg001",
-        config={
-            **_OFFLINE_PACKAGE_CONFIG,
-            "offline_compatibility_hash": (
-                _offline_compatibility_hash_for_default_request(model_id)
-            ),
-        },
-    )
-    mock_model = MagicMock()
+    auto_resolution_cache = MagicMock(spec=AutoResolutionCache)
 
-    # when
-    with mock.patch.object(core, "ROBOFLOW_API_KEY", None), mock.patch.object(
-        model_cache_paths, "INFERENCE_HOME", empty_local_dir
+    with mock.patch.object(core, "OFFLINE_MODE", False), mock.patch.object(
+        core, "ROBOFLOW_API_KEY", None
     ), mock.patch.object(
         core,
         "get_model_from_provider",
         side_effect=RetryError(message="network down", help_url="https://help"),
     ), mock.patch.object(
-        core, "attempt_loading_model_from_local_storage", return_value=mock_model
-    ) as mock_load:
-        result = core.AutoModel.from_pretrained(
-            model_id,
-            api_key=None,
-            use_auto_resolution_cache=False,
-        )
+        core, "attempt_loading_model_with_auto_load_cache", return_value=None
+    ), mock.patch.object(
+        core, "attempt_loading_model_from_offline_cache"
+    ) as raw_cache_load:
+        with pytest.raises(RetryError):
+            core.AutoModel.from_pretrained(
+                model_id,
+                api_key=None,
+                auto_resolution_cache=auto_resolution_cache,
+            )
 
-    # then
-    assert result is mock_model
-    assert mock_load.call_args[1]["model_dir_or_weights_path"] == package_dir
+    auto_resolution_cache.find_compatible_candidates.assert_not_called()
+    raw_cache_load.assert_not_called()
 
 
 def test_custom_cache_compatible_lookup_supports_no_key_offline_restart() -> None:

--- a/inference_models/tests/unit_tests/models/auto_loaders/test_core.py
+++ b/inference_models/tests/unit_tests/models/auto_loaders/test_core.py
@@ -3230,13 +3230,8 @@ def _offline_compatibility_hash_for_default_request(model_id: str) -> str:
             "allow_untrusted_packages": False,
             "trt_engine_host_code_allowed": True,
             "allow_local_code_packages": True,
-            "verify_hash_while_download": True,
-            "download_files_without_hash": False,
             "allow_loading_dependency_models": True,
-            "max_package_loading_attempts": None,
             "nms_fusion_preferences": None,
-            "weights_provider_extra_query_params": None,
-            "weights_provider_extra_headers": None,
             "dependency_models_params": {},
             "forwarded_dependency_kwargs": {},
             "runtime_compatibility": core._runtime_compatibility_content(
@@ -5193,7 +5188,7 @@ def test_from_pretrained_env_api_key_does_not_use_credential_free_fallback(
     raw_cache_load.assert_not_called()
 
 
-def test_max_package_loading_attempts_is_bound_into_cache_identity() -> None:
+def test_max_package_loading_attempts_only_affects_exact_cache_identity() -> None:
     auto_resolution_cache = MagicMock(spec=AutoResolutionCache)
     auto_resolution_cache.find_compatible_candidates.return_value = []
 
@@ -5220,10 +5215,10 @@ def test_max_package_loading_attempts_is_bound_into_cache_identity() -> None:
         for call in auto_resolution_cache.find_compatible_candidates.call_args_list
     ]
     assert len(set(exact_hashes)) == 2
-    assert len(set(compatibility_hashes)) == 2
+    assert len(set(compatibility_hashes)) == 1
 
 
-def test_provider_version_header_is_bound_into_cache_identity() -> None:
+def test_provider_version_header_only_affects_exact_cache_identity() -> None:
     auto_resolution_cache = MagicMock(spec=AutoResolutionCache)
     auto_resolution_cache.find_compatible_candidates.return_value = []
 
@@ -5252,7 +5247,77 @@ def test_provider_version_header_is_bound_into_cache_identity() -> None:
         for call in raw_cache_load.call_args_list
     ]
     assert len(set(exact_hashes)) == 2
-    assert len(set(compatibility_hashes)) == 2
+    assert len(set(compatibility_hashes)) == 1
+
+
+@pytest.mark.parametrize(
+    ("first_acquisition_options", "second_acquisition_options"),
+    [
+        (
+            {"verify_hash_while_download": True},
+            {"verify_hash_while_download": False},
+        ),
+        (
+            {"download_files_without_hash": False},
+            {"download_files_without_hash": True},
+        ),
+        (
+            {
+                "weights_provider_extra_query_params": [
+                    ("service", "inference"),
+                    ("version", "1"),
+                ]
+            },
+            {
+                "weights_provider_extra_query_params": [
+                    ("version", "1"),
+                    ("service", "inference"),
+                ]
+            },
+        ),
+    ],
+    ids=[
+        "download-hash-verification",
+        "unhashed-download-policy",
+        "provider-query-order",
+    ],
+)
+def test_acquisition_options_do_not_affect_offline_compatibility(
+    first_acquisition_options: dict,
+    second_acquisition_options: dict,
+) -> None:
+    auto_resolution_cache = MagicMock(spec=AutoResolutionCache)
+    auto_resolution_cache.find_compatible_candidates.return_value = []
+
+    with mock.patch.object(core, "OFFLINE_MODE", True), mock.patch.object(
+        core, "model_provider_requires_network", return_value=True
+    ), mock.patch.object(
+        core, "attempt_loading_model_with_auto_load_cache", return_value=None
+    ) as exact_cache_load, mock.patch.object(
+        core,
+        "attempt_loading_model_from_offline_cache",
+        return_value=None,
+    ) as raw_cache_load:
+        for acquisition_options in (
+            first_acquisition_options,
+            second_acquisition_options,
+        ):
+            with pytest.raises(ModelRetrievalError):
+                core.AutoModel.from_pretrained(
+                    "workspace/model/1",
+                    auto_resolution_cache=auto_resolution_cache,
+                    **acquisition_options,
+                )
+
+    exact_hashes = [
+        call.kwargs["auto_negotiation_hash"] for call in exact_cache_load.call_args_list
+    ]
+    compatibility_hashes = [
+        call.kwargs["offline_compatibility_hash"]
+        for call in raw_cache_load.call_args_list
+    ]
+    assert len(set(exact_hashes)) == 2
+    assert len(set(compatibility_hashes)) == 1
 
 
 def test_from_pretrained_uses_effective_env_key_for_strict_exact_cache_hit() -> None:

--- a/inference_models/tests/unit_tests/models/auto_loaders/test_core.py
+++ b/inference_models/tests/unit_tests/models/auto_loaders/test_core.py
@@ -2432,6 +2432,9 @@ def test_auto_load_exact_cache_rejects_manifest_canonical_owner_mismatch(
 
     assert result is None
     model_access_manager.is_model_package_access_granted.assert_not_called()
+    auto_resolution_cache.invalidate.assert_called_once_with(
+        auto_negotiation_hash="a" * 64
+    )
 
 
 def test_auto_load_exact_cache_rejects_same_owner_manifest_rewrite(
@@ -2501,6 +2504,9 @@ def test_auto_load_exact_cache_rejects_same_owner_manifest_rewrite(
     assert result is None
     resolve_model_class.assert_not_called()
     model_access_manager.is_model_package_access_granted.assert_not_called()
+    auto_resolution_cache.invalidate.assert_called_once_with(
+        auto_negotiation_hash="a" * 64
+    )
 
 
 def test_auto_load_exact_keyed_cache_accepts_matching_canonical_manifest(
@@ -2615,7 +2621,97 @@ def test_auto_load_exact_cache_rejects_resolution_constraints_mismatch() -> None
     )
 
     assert result is None
+    auto_resolution_cache.invalidate.assert_not_called()
     model_access_manager.is_model_package_access_granted.assert_not_called()
+
+
+def test_auto_load_cache_preserves_entry_on_temporary_manifest_error() -> None:
+    cache_entry = AutoResolutionCacheEntry(
+        model_id="workspace/model/1",
+        cache_model_id="workspace/model/1",
+        canonical_model_id="workspace/model/1",
+        cache_attribution_version=core.CACHE_ATTRIBUTION_VERSION,
+        model_package_id="package",
+        resolved_files=[],
+        model_architecture="yolov8",
+        task_type="object-detection",
+        backend_type=BackendType.ONNX,
+        created_at=datetime.now(),
+        trusted_source=True,
+        package_manifest_hash=TEST_PACKAGE_MANIFEST_HASH,
+    )
+    on_invalid_cache_entry = MagicMock()
+
+    with mock.patch.object(
+        core,
+        "resolve_existing_model_package_cache_path",
+        side_effect=OSError("temporary mount failure"),
+    ):
+        result = core._verified_auto_cache_package_dir(
+            cache_entry=cache_entry,
+            on_invalid_cache_entry=on_invalid_cache_entry,
+        )
+
+    assert result is None
+    on_invalid_cache_entry.assert_not_called()
+
+
+def test_auto_load_cache_preserves_entry_after_transient_constructor_error() -> None:
+    cache_entry = AutoResolutionCacheEntry(
+        model_id="workspace/model/1",
+        cache_model_id="workspace/model/1",
+        canonical_model_id="workspace/model/1",
+        cache_attribution_version=core.CACHE_ATTRIBUTION_VERSION,
+        model_package_id="package",
+        resolved_files=[],
+        model_architecture="yolov8",
+        task_type="object-detection",
+        backend_type=BackendType.ONNX,
+        created_at=datetime.now(),
+        trusted_source=True,
+        package_manifest_hash=TEST_PACKAGE_MANIFEST_HASH,
+    )
+    auto_resolution_cache = MagicMock()
+    auto_resolution_cache.retrieve.return_value = cache_entry
+    model_access_manager = MagicMock()
+    model_access_manager.is_model_package_access_granted.return_value = True
+    package_config = InferenceModelConfig(
+        model_architecture="yolov8",
+        task_type="object-detection",
+        backend_type=BackendType.ONNX,
+        model_module=None,
+        model_class=None,
+        dependency_package_paths=[],
+    )
+    model_class = MagicMock()
+    model_class.from_pretrained.side_effect = RuntimeError("temporary GPU failure")
+
+    with mock.patch.object(
+        core, "_verified_auto_cache_package_dir", return_value="/cached/model"
+    ), mock.patch.object(
+        core, "parse_model_config", return_value=package_config
+    ), mock.patch.object(
+        core, "resolve_model_class", return_value=model_class
+    ):
+        result = attempt_loading_model_with_auto_load_cache(
+            use_auto_resolution_cache=True,
+            auto_resolution_cache=auto_resolution_cache,
+            auto_negotiation_hash="a" * 64,
+            model_access_manager=model_access_manager,
+            model_name_or_path="workspace/model/1",
+            model_init_kwargs={},
+            api_key="api-key",
+            allow_loading_dependency_models=True,
+            forwarded_kwargs_values={},
+        )
+
+    assert result is None
+    auto_resolution_cache.invalidate.assert_not_called()
+    model_access_manager.is_model_package_access_granted.assert_called_once_with(
+        model_id="workspace/model/1",
+        package_id="package",
+        api_key="api-key",
+    )
 
 
 def test_auto_load_exact_cache_rejects_constructor_artifact_mutation(
@@ -2696,6 +2792,9 @@ def test_auto_load_exact_cache_rejects_constructor_artifact_mutation(
             )
 
     assert result is None
+    auto_resolution_cache.invalidate.assert_called_once_with(
+        auto_negotiation_hash="a" * 64
+    )
 
 
 @pytest.mark.parametrize("trusted_source", [None, False])
@@ -2735,6 +2834,9 @@ def test_auto_load_cache_rejects_entry_without_trusted_provenance(
 def test_auto_load_cache_rejects_dependencies_when_disabled() -> None:
     cache_entry = AutoResolutionCacheEntry(
         model_id="workspace/model/1",
+        cache_model_id="workspace/model/1",
+        canonical_model_id="workspace/model/1",
+        cache_attribution_version=core.CACHE_ATTRIBUTION_VERSION,
         model_package_id="package",
         resolved_files=[],
         model_architecture="yolov8",
@@ -2742,6 +2844,7 @@ def test_auto_load_cache_rejects_dependencies_when_disabled() -> None:
         backend_type=BackendType.ONNX,
         created_at=datetime.now(),
         trusted_source=True,
+        package_manifest_hash=TEST_PACKAGE_MANIFEST_HASH,
         model_dependencies=[
             ModelDependency(
                 name="encoder",
@@ -2755,7 +2858,9 @@ def test_auto_load_cache_rejects_dependencies_when_disabled() -> None:
     model_access_manager = MagicMock()
     model_access_manager.is_model_package_access_granted.return_value = True
 
-    with mock.patch.object(core.AutoModel, "from_pretrained") as dependency_load:
+    with mock.patch.object(
+        core, "_verified_auto_cache_package_dir", return_value="/cached/model"
+    ), mock.patch.object(core.AutoModel, "from_pretrained") as dependency_load:
         result = attempt_loading_model_with_auto_load_cache(
             use_auto_resolution_cache=True,
             auto_resolution_cache=auto_resolution_cache,
@@ -2770,6 +2875,7 @@ def test_auto_load_cache_rejects_dependencies_when_disabled() -> None:
 
     assert result is None
     dependency_load.assert_not_called()
+    auto_resolution_cache.invalidate.assert_not_called()
 
 
 def test_auto_load_cache_does_not_mutate_dependency_model_parameters() -> None:
@@ -2942,6 +3048,9 @@ def test_exact_cache_rejects_dependency_resolved_to_unbound_package() -> None:
 
     assert result is None
     resolve_parent_model.assert_not_called()
+    auto_resolution_cache.invalidate.assert_called_once_with(
+        auto_negotiation_hash="a" * 64
+    )
 
 
 def test_dump_model_config_for_offline_use_rejects_symlink_target(

--- a/tests/inference/unit_tests/core/registries/test_roboflow.py
+++ b/tests/inference/unit_tests/core/registries/test_roboflow.py
@@ -175,6 +175,41 @@ def test_in_process_model_metadata_cache_is_scoped_by_api_key() -> None:
     assert load_metadata.call_count == 2
 
 
+def test_save_model_metadata_populates_credential_scoped_in_process_cache() -> None:
+    with mock.patch.object(roboflow, "LAMBDA", True), mock.patch.object(
+        roboflow, "_save_model_metadata_in_cache"
+    ), mock.patch.object(
+        roboflow,
+        "_get_model_metadata_from_cache",
+        return_value=("classification", "model-b"),
+    ) as load_metadata:
+        save_model_metadata_in_cache(
+            dataset_id="workspace/model",
+            version_id="1",
+            project_task_type="object-detection",
+            model_type="model-a",
+            api_key="credential-a",
+        )
+        same_credential = get_model_metadata_from_cache(
+            dataset_id="workspace/model",
+            version_id="1",
+            api_key="credential-a",
+        )
+        different_credential = get_model_metadata_from_cache(
+            dataset_id="workspace/model",
+            version_id="1",
+            api_key="credential-b",
+        )
+
+    assert same_credential == ("object-detection", "model-a")
+    assert different_credential == ("classification", "model-b")
+    load_metadata.assert_called_once_with(
+        dataset_id="workspace/model",
+        version_id="1",
+        api_key="credential-b",
+    )
+
+
 def test_model_metadata_content_is_invalid_when_content_is_empty() -> None:
     # when
     result = model_metadata_content_is_invalid(content=None)

--- a/tests/inference/unit_tests/core/test_offline_mode_configuration.py
+++ b/tests/inference/unit_tests/core/test_offline_mode_configuration.py
@@ -136,6 +136,29 @@ assert os.environ["_ROBOFLOW_INFERENCE_OFFLINE_MODE_AT_PROCESS_START"] == "False
     )
 
 
+def test_offline_mode_does_not_construct_configured_redis_cache() -> None:
+    _run_with_env(
+        """
+import importlib
+import redis
+
+def fail_if_redis_is_constructed(*args, **kwargs):
+    raise AssertionError("Redis client constructed in OFFLINE_MODE")
+
+redis.Redis = fail_if_redis_is_constructed
+
+cache_module = importlib.import_module("inference.core.cache")
+from inference.core.cache.memory import MemoryCache
+
+assert isinstance(cache_module.cache, MemoryCache)
+""",
+        {
+            "OFFLINE_MODE": "True",
+            "REDIS_HOST": "redis.internal",
+        },
+    )
+
+
 def test_top_level_import_rejects_offline_mode_without_dotenv_value() -> None:
     _run_with_env(
         """

--- a/tests/inference/unit_tests/core/test_roboflow_api.py
+++ b/tests/inference/unit_tests/core/test_roboflow_api.py
@@ -2943,6 +2943,35 @@ def test_get_workflow_specification_uses_online_cache_after_switching_offline(
     assert result == {"source": "online-cache", "id": None}
 
 
+def test_get_workflow_specification_does_not_use_ephemeral_cache_offline(
+    tmp_path: Path,
+) -> None:
+    cached_response = _workflow_cache_response("file-cache")
+    ephemeral_cache = MagicMock()
+
+    with (
+        mock.patch.object(roboflow_api, "MODEL_CACHE_DIR", str(tmp_path)),
+        mock.patch.object(roboflow_api, "OFFLINE_MODE", True),
+        mock.patch.object(roboflow_api, "SINGLE_TENANT_WORKFLOW_CACHE", True),
+    ):
+        roboflow_api.cache_workflow_response(
+            api_key=None,
+            workspace_id="my_workspace",
+            workflow_id="some_workflow",
+            response=cached_response,
+        )
+        result = get_workflow_specification(
+            api_key=None,
+            workspace_id="my_workspace",
+            workflow_id="some_workflow",
+            ephemeral_cache=ephemeral_cache,
+        )
+
+    assert result == {"source": "file-cache", "id": None}
+    ephemeral_cache.get.assert_not_called()
+    ephemeral_cache.set.assert_not_called()
+
+
 def test_get_pinned_workflow_uses_online_cache_after_switching_offline(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## What does this PR do?

This PR hardens the ONLINE and OFFLINE model-loading behavior introduced in [#2263](https://github.com/roboflow/inference/pull/2263). During review, we found several cases where cache fallback could weaken credential revalidation, preserve or remove the wrong cache entries, reject otherwise compatible offline packages, or perform network I/O despite `OFFLINE_MODE=True`.

ONLINE mode now treats a provider outage as an error instead of silently falling back to an expired or independently discovered package. This prevents outages from bypassing credential revalidation and stops stale packages from being served indefinitely through the default liberal access manager. OFFLINE mode retains its trusted-cache fallback, but its compatibility identity now describes whether an already-downloaded package can be loaded rather than how it was originally acquired. Cache validation distinguishes deterministic corruption from transient filesystem or initialization failures, invalidating only entries that are demonstrably unusable. Model metadata reads and writes now use the same credential-scoped in-process cache key. Finally, OFFLINE mode always uses an in-memory process cache and bypasses Workflow ephemeral caches, ensuring that a configured Redis or Dragonfly instance cannot cause built-in network traffic or become an offline Workflow-definition source.

**Main elements:**

- **Prevent online provider-outage fallback**
  - Previously, a `RetryError` from the online weights provider could trigger the same package fallback intended for air-gapped operation.
  - With the default access manager, that fallback had no independent authorization authority, so an outage could allow a previously cached package to load without successful credential revalidation.
  - Expired resolution metadata could also be bypassed by raw package discovery, allowing the same stale package to be served repeatedly during an extended outage.
  - ONLINE mode now propagates provider retry failures and never enters credential-independent offline fallback.

- **Selectively invalidate auto-resolution entries**
  - Previously, cache handling either removed entries too aggressively or preserved entries without distinguishing why validation failed.
  - Deterministic problems—malformed attribution, manifest mismatches, changed artifacts, invalid dependency identities, or undeclared package layout—now invalidate the associated resolution entry.
  - Transient `OSError` conditions and general model-initialization failures preserve the entry because a later request may succeed without re-negotiating or downloading the package.
  - Request-policy differences, such as disallowing dependency loading or untrusted packages, also preserve the entry because they do not indicate cache corruption.
  - OFFLINE cache trees remain immutable and are never modified during validation.

- **Fix the in-process model-metadata cache key mismatch**
  - Metadata reads were changed to use `(dataset_id, version_id, credential_cache_key)`, while writes continued using the old two-element key.
  - As a result, newly written entries could never be read, forcing subsequent requests through the distributed-cache lock and filesystem path.
  - Reads and writes now share one key builder and include the same API-key-derived credential scope.

- **Separate acquisition identity from offline load compatibility**
  - The previous compatibility hash included provider headers, query parameters, retry limits, hash-verification policy, and unhashed-download policy.
  - Those options affect online acquisition but do not determine whether an already-materialized and verified package can be loaded.
  - Small deployment changes—such as removing a service header or reordering query parameters—could therefore reject an otherwise identical package after an offline restart.
  - The exact online negotiation key still includes acquisition controls and credentials.
  - The offline compatibility key now retains only package selection, runtime, dependency, trust, backend, device, and model-initialization constraints.

- **Eliminate built-in Redis I/O from OFFLINE mode**
  - Previously, setting `REDIS_HOST` caused `RedisCache` to be constructed and immediately issue `PING`, even with `OFFLINE_MODE=True`.
  - Model metadata locks and Workflow ephemeral-cache operations could then continue using that network cache if it was reachable.
  - OFFLINE mode now selects `MemoryCache` before Redis construction, regardless of Redis configuration.
  - Workflow specification resolution also skips ephemeral cache reads and writes while offline, including explicitly supplied Redis or Dragonfly backends.
  - Trusted Workflow definitions continue to load from the mounted file cache.

- **Regression coverage**
  - Added coverage for strict ONLINE provider-failure behavior, credential-bound cache handling, selective invalidation, compatibility hashing, metadata cache keys, offline Redis initialization, and offline Workflow ephemeral-cache bypass.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other:

## Testing

### Unit tests

- ONLINE provider retry failures are propagated without compatible or raw package fallback.
- Credential-bound requests cannot enter credential-independent fallback.
- Deterministically malformed or mismatched cache entries are invalidated.
- Transient filesystem and model-initialization failures preserve resolution entries.
- Request-policy mismatches preserve otherwise valid cache entries.
- Exact negotiation hashes still include acquisition options, while offline compatibility hashes exclude download-only and provider-transport options.
- Reordered unordered request values produce stable compatibility identities.
- Model metadata reads and writes use the same credential-scoped in-process key.
- OFFLINE startup does not construct a Redis client when `REDIS_HOST` is configured.
- OFFLINE Workflow loading does not call `get` or `set` on an ephemeral cache backend.
- Existing online Workflow ephemeral-cache behavior remains covered.

### Integration tests

- Auto-resolution cache registration and retrieval using the filesystem-backed cache.
- Malformed, missing, invalid, and expired cache-entry handling.
- File creation/deletion callbacks and canonical model attribution.
- Concurrent auto-resolution cache access.
- Warm-online Workflow file cache followed by credential-free offline loading.
- Pinned and unversioned Workflow definitions remain isolated and load from the correct file-cache entry.

### Other

- `TMPDIR=/private/tmp .venv/bin/pytest -q inference_models/tests/unit_tests/models/auto_loaders/test_core.py inference_models/tests/unit_tests/models/auto_loaders/test_model_cache_paths.py inference_models/tests/integration_tests/basic_library_features/test_auto_resolution_cache.py inference_models/tests/unit_tests/utils/test_download.py inference_models/tests/unit_tests/weights_providers/test_core.py inference_models/tests/unit_tests/weights_providers/test_local_trt_packages.py inference_models/tests/unit_tests/weights_providers/test_roboflow.py`
  - Result: **360 passed, 1 skipped**.
- `PYTHONPATH=inference_models .venv/bin/pytest -q tests/inference/unit_tests/core/test_offline_mode_configuration.py tests/inference/unit_tests/core/test_roboflow_api.py tests/inference/unit_tests/core/cache/test_redis_cache.py tests/inference/unit_tests/core/registries/test_roboflow.py`
  - Result: **452 passed, 10 skipped**.
- Socket-instrumented offline startup with `REDIS_HOST` configured recorded **zero socket connection attempts** and selected `MemoryCache`.
- Black check passed for all changed files.
- isort check passed for all changed files.
- `git diff --check` passed.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)

## Additional Context

This branch is a hardening layer on top of the OFFLINE mode introduced in [#2263](https://github.com/roboflow/inference/pull/2263) and should be reviewed against that branch rather than as an independent implementation of OFFLINE mode.

The supported deployment flow remains:

1. Warm a mounted cache while ONLINE with network access and the required credentials.
2. Restart with the same cache, `OFFLINE_MODE=True`, and no API key.
3. Load trusted model packages and Workflow definitions exclusively from the mounted cache.

`REDIS_HOST` is now intentionally ignored in OFFLINE mode. Deployments that require Redis or Dragonfly over a local network should run without `OFFLINE_MODE` or introduce a separately reviewed, explicit network-capability policy rather than relying on the generic offline path.

The cache remains a trusted input. Integrity hashes detect accidental corruption and changes relative to the recorded manifest, but they are not a substitute for protecting the cache volume from unauthorized writes; production offline caches should be mounted read-only where possible.