### PR TITLE
Increase 'INTEGRATION TESTS - workflows' github CI timeout to 25 minutes

### DIFF
--- a/.github/workflows/integration_tests_workflows_x86.yml
+++ b/.github/workflows/integration_tests_workflows_x86.yml
@@ -48,7 +48,7 @@ jobs:
       matrix:
         python-version: ${{ fromJSON((github.event.inputs.python-version || 'all') == 'all' && '["3.10","3.11","3.12"]' || format('["{0}"]', github.event.inputs.python-version)) }}
         use-inference-models: ${{ fromJSON((github.event.inputs.use-inference-models || 'all') == 'all'&& '["true","false"]'|| format('["{0}"]', github.event.inputs.use-inference-models)) }}
-    timeout-minutes: 15
+    timeout-minutes: 25
     steps:
       - name: 🛎️ Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
## What does this PR do?

Increase 'INTEGRATION TESTS - workflows' github CI timeout to 25 minutes

## Type of Change

- Other: maintenance

## Testing

 - [x] 'INTEGRATION TESTS - workflows' [passing](https://github.com/roboflow/inference/actions/runs/30286647318?pr=2719)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)

## Additional Context

N/A