### PR TITLE
Fix/sam3 usage

### DIFF
--- a/inference/core/entities/requests/sam2.py
+++ b/inference/core/entities/requests/sam2.py
@@ -31,9 +31,9 @@ class Sam2InferenceRequest(BaseRequest):
     def validate_model_id(cls, value, values):
         if value is not None:
             return value
-        if values.get("sam_version_id") is None:
+        if values.get("sam2_version_id") is None:
             return None
-        return f"sam2/{values['sam_version_id']}"
+        return f"sam2/{values['sam2_version_id']}"
 
 
 class Sam2EmbeddingRequest(Sam2InferenceRequest):

--- a/inference/core/interfaces/http/http_api.py
+++ b/inference/core/interfaces/http/http_api.py
@@ -3525,6 +3525,8 @@ class HttpInterface(BaseInterface):
                 ):
                     logger.debug(f"Reached /sam3/embed_image")
 
+                    inference_request.model_id = "sam3/sam3_interactive"
+
                     if SAM3_EXEC_MODE == "remote":
                         raise HTTPException(
                             status_code=501,
@@ -3747,6 +3749,8 @@ class HttpInterface(BaseInterface):
                         inference_request.source = request_source
                     if request_source_info is not None:
                         inference_request.source_info = request_source_info
+
+                    inference_request.model_id = "sam3/sam3_interactive"
 
                     if SAM3_EXEC_MODE == "remote":
                         endpoint = f"{API_BASE_URL}/inferenceproxy/sam3-pvs"

--- a/inference/usage_tracking/collector.py
+++ b/inference/usage_tracking/collector.py
@@ -858,7 +858,7 @@ class UsageCollector:
             ):
                 usage_api_key = func_kwargs["kwargs"]["api_key"]
 
-        roboflow_service_name = func_kwargs.get("source_info")
+        roboflow_service_name = func_kwargs.get("source_info") or source_info
         roboflow_internal_secret = func_kwargs.get("service_secret")
 
         return {

--- a/inference/usage_tracking/decorator_helpers.py
+++ b/inference/usage_tracking/decorator_helpers.py
@@ -1,5 +1,6 @@
 from typing import Any, Dict, List, Optional
 
+from inference.core.env import SAM3_EXEC_MODE
 from inference.core.logger import logger
 from inference.core.workflows.execution_engine.v1.compiler.entities import (
     CompiledWorkflow,
@@ -173,6 +174,9 @@ def get_request_resource_details_from_kwargs(
             resource_details["steps"] = get_resource_details_from_workflow_json(
                 workflow_json=workflow_request.specification,
             )
-    if "countinference" in func_kwargs:
+    if func_kwargs.get("countinference") is not None:
         resource_details["billable"] = func_kwargs["countinference"]
+    model_id = getattr(func_kwargs.get("inference_request"), "model_id", None)
+    if isinstance(model_id, str) and model_id.startswith("sam3/"):
+        resource_details["execution_mode"] = SAM3_EXEC_MODE
     return resource_details

--- a/tests/inference/unit_tests/usage_tracking/test_decorator_helpers.py
+++ b/tests/inference/unit_tests/usage_tracking/test_decorator_helpers.py
@@ -1,0 +1,93 @@
+from types import SimpleNamespace
+
+from inference.core.entities.requests.sam2 import Sam2InferenceRequest
+from inference.core.env import SAM2_VERSION_ID, SAM3_EXEC_MODE
+from inference.usage_tracking import decorator_helpers
+from inference.usage_tracking.decorator_helpers import (
+    get_request_resource_details_from_kwargs,
+)
+
+
+def test_get_request_resource_details_ignores_default_countinference():
+    result = get_request_resource_details_from_kwargs({"countinference": None})
+
+    assert "billable" not in result
+
+
+def test_get_request_resource_details_respects_explicit_countinference():
+    result = get_request_resource_details_from_kwargs({"countinference": False})
+
+    assert result["billable"] is False
+
+
+def test_get_request_resource_details_tags_sam3_execution_mode(monkeypatch):
+    monkeypatch.setattr(decorator_helpers, "SAM3_EXEC_MODE", "remote", raising=False)
+
+    result = get_request_resource_details_from_kwargs(
+        {"inference_request": SimpleNamespace(model_id="sam3/sam3_interactive")}
+    )
+
+    assert result["execution_mode"] == "remote"
+
+
+def test_get_request_resource_details_skips_execution_mode_for_non_sam3_model():
+    result = get_request_resource_details_from_kwargs(
+        {"inference_request": SimpleNamespace(model_id="some-project/1")}
+    )
+
+    assert "execution_mode" not in result
+
+
+def test_sam2_inference_request_model_id_defaults_to_sam2_version():
+    request = Sam2InferenceRequest(api_key="key")
+
+    assert request.model_id == f"sam2/{SAM2_VERSION_ID}"
+
+
+def test_extract_usage_params_for_sam3_request(usage_collector_with_mocked_threads):
+    def handler(
+        inference_request,
+        request,
+        api_key=None,
+        countinference=None,
+        service_secret=None,
+        request_source=None,
+        request_source_info=None,
+    ): ...
+
+    usage_params = (
+        usage_collector_with_mocked_threads._extract_usage_params_from_func_kwargs(
+            usage_fps=0,
+            usage_api_key="",
+            usage_workflow_id="",
+            usage_workflow_preview=False,
+            usage_inference_test_run=False,
+            usage_billable=True,
+            execution_duration=0.1,
+            func=handler,
+            category="request",
+            error_details=None,
+            args=(
+                SimpleNamespace(
+                    api_key=None,
+                    model_id="sam3/sam3_interactive",
+                    source="app",
+                    source_info="async-serverless-gpu",
+                ),
+                SimpleNamespace(),
+            ),
+            kwargs={
+                "api_key": "query-api-key",
+                "service_secret": "internal-secret",
+                "request_source_info": "async-serverless-gpu",
+            },
+        )
+    )
+
+    assert usage_params["api_key"] == "query-api-key"
+    assert usage_params["resource_id"] == "sam3/sam3_interactive"
+    assert usage_params["roboflow_service_name"] == "async-serverless-gpu"
+    assert usage_params["roboflow_internal_secret"] == "internal-secret"
+    assert usage_params["resource_details"]["billable"] is True
+    assert usage_params["resource_details"]["source_info"] == "async-serverless-gpu"
+    assert usage_params["resource_details"]["execution_mode"] == SAM3_EXEC_MODE


### PR DESCRIPTION
## What does this PR do?

Fix sam2_version_id typo in Sam2InferenceRequest model_id validator - Sam2InferenceRequest declares field sam2_version_id, sam_version_id never existed here

Set model_id in sam3 embed_image and visual_segment handlers - those endpoints reuse (Sam2EmbeddingRequest/Sam2SegmentationRequest so model_id defaulted to sam2)

Fall back to request source_info for roboflow_service_name

Fix countinference default overwriting usage flag, tag sam3 exec mode; collect_func_params fills unpassed params with defaults, so countinference arrived as None on every request and overwrote the flag that marks usage as counted; now applied only when caller passed it explicitly

## Type of Change

- Bug fix (non-breaking change that fixes an issue)

## Testing

All tests passing

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)

## Additional Context

N/A