### PR TITLE
ENT-1544 B1: GStreamer RTSPS with CA bundle and TLS validation flags

### DIFF
--- a/inference/core/interfaces/camera/rtsp_tls.py
+++ b/inference/core/interfaces/camera/rtsp_tls.py
@@ -1,0 +1,38 @@
+"""RTSPS TLS helpers shared by GStreamer and OpenCV ingest paths (ENT-1544 B1/B2)."""
+
+from __future__ import annotations
+
+import os
+
+RTSP_TLS_VALIDATION_FLAGS_ENV_VAR = "ROBOFLOW_RTSP_TLS_VALIDATION_FLAGS"
+GST_SSL_CA_CERTIFICATE_ENV_VAR = "GST_SSL_CA_CERTIFICATE"
+
+
+def is_rtsps_url(url: str) -> bool:
+    return isinstance(url, str) and url.lower().startswith("rtsps://")
+
+
+def is_rtsp_url(url: str) -> bool:
+    return isinstance(url, str) and url.lower().startswith(("rtsp://", "rtsps://"))
+
+
+def rtsp_tls_validation_flags_gstreamer_suffix() -> str:
+    """Return an rtspsrc tls-validation-flags suffix when env requests it.
+
+    ``0`` disables certificate validation for cameras with private/self-signed
+    certificates. Keeping this unset avoids weakening RTSPS validation.
+    """
+    raw = os.getenv(RTSP_TLS_VALIDATION_FLAGS_ENV_VAR)
+    if raw is None or not str(raw).strip():
+        return ""
+    try:
+        flags = int(str(raw).strip())
+    except ValueError as error:
+        raise ValueError(
+            f"{RTSP_TLS_VALIDATION_FLAGS_ENV_VAR} must be a non-negative integer"
+        ) from error
+    if flags < 0:
+        raise ValueError(
+            f"{RTSP_TLS_VALIDATION_FLAGS_ENV_VAR} must be a non-negative integer"
+        )
+    return f" tls-validation-flags={flags}"

--- a/tests/inference/unit_tests/core/interfaces/camera/test_rtsp_tls.py
+++ b/tests/inference/unit_tests/core/interfaces/camera/test_rtsp_tls.py
@@ -1,0 +1,37 @@
+import os
+
+import pytest
+
+from inference.core.interfaces.camera.rtsp_tls import (
+    RTSP_TLS_VALIDATION_FLAGS_ENV_VAR,
+    is_rtsps_url,
+    is_rtsp_url,
+    rtsp_tls_validation_flags_gstreamer_suffix,
+)
+
+
+def test_is_rtsps_url() -> None:
+    assert is_rtsps_url("rtsps://cam.example/stream")
+    assert not is_rtsps_url("rtsp://cam.example/stream")
+
+
+def test_is_rtsp_url() -> None:
+    assert is_rtsp_url("rtsp://cam.example/stream")
+    assert is_rtsp_url("rtsps://cam.example/stream")
+    assert not is_rtsp_url("/dev/video0")
+
+
+def test_tls_suffix_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(RTSP_TLS_VALIDATION_FLAGS_ENV_VAR, raising=False)
+    assert rtsp_tls_validation_flags_gstreamer_suffix() == ""
+
+
+def test_tls_suffix_zero(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(RTSP_TLS_VALIDATION_FLAGS_ENV_VAR, "0")
+    assert rtsp_tls_validation_flags_gstreamer_suffix() == " tls-validation-flags=0"
+
+
+def test_tls_suffix_invalid(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(RTSP_TLS_VALIDATION_FLAGS_ENV_VAR, "nope")
+    with pytest.raises(ValueError):
+        rtsp_tls_validation_flags_gstreamer_suffix()


### PR DESCRIPTION
## Summary
- Add shared `rtsp_tls` helpers (`ROBOFLOW_RTSP_TLS_VALIDATION_FLAGS` → GStreamer `tls-validation-flags` suffix).
- Scaffold for Jetson `rtspsrc` pipeline wiring (reference: `agent/fix-jetson-nvjpeg-runtime` `jetson_producer.py`).
- Plan: `cursor-cloud/features/ent-1544/plans/B1-inference.md`.

## ENT-1544
Phase B — primary RTSPS decode path for edge Jetson devices.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?
- `test_rtsp_tls.py` unit tests for env parsing and rtsps URL detection.

## Dependencies
- B3 (rfdm) for fleet env injection; secure default works without B3.

## Test plan
- [ ] `pytest tests/inference/unit_tests/core/interfaces/camera/test_rtsp_tls.py`
- [ ] Follow-up: Jetson rtspsrc integration + manual RTSPS camera test

Made with [Cursor](https://cursor.com)