### PR TITLE
ENT-1544 B2: OpenCV/FFmpeg RTSPS TLS fallback

### DIFF
--- a/inference/core/interfaces/camera/rtsp_opencv_tls.py
+++ b/inference/core/interfaces/camera/rtsp_opencv_tls.py
@@ -1,0 +1,42 @@
+"""OpenCV/FFmpeg RTSPS TLS option builder (ENT-1544 B2)."""
+
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+from inference.core.interfaces.camera.rtsp_tls import (
+    GST_SSL_CA_CERTIFICATE_ENV_VAR,
+    RTSP_TLS_VALIDATION_FLAGS_ENV_VAR,
+    SSL_CERT_FILE_ENV_VAR,
+    is_rtsps_url,
+)
+
+
+def build_opencv_ffmpeg_capture_options(video: str) -> Optional[str]:
+    """Build OPENCV_FFMPEG_CAPTURE_OPTIONS for RTSPS sources."""
+    if not is_rtsps_url(video):
+        return None
+
+    parts = ["rtsp_transport;tcp"]
+    ca_path = os.getenv(GST_SSL_CA_CERTIFICATE_ENV_VAR) or os.getenv(
+        SSL_CERT_FILE_ENV_VAR
+    )
+    if ca_path:
+        parts.append(f"cafile;{ca_path}")
+
+    raw_flags = os.getenv(RTSP_TLS_VALIDATION_FLAGS_ENV_VAR)
+    if raw_flags is not None and str(raw_flags).strip() == "0":
+        parts.append("tls_verify;0")
+
+    return "|".join(parts) if parts else None
+
+
+def apply_opencv_rtsps_tls_env(video: str) -> Optional[str]:
+    """Set OPENCV_FFMPEG_CAPTURE_OPTIONS when needed; returns previous value."""
+    options = build_opencv_ffmpeg_capture_options(video)
+    if options is None:
+        return os.environ.get("OPENCV_FFMPEG_CAPTURE_OPTIONS")
+    previous = os.environ.get("OPENCV_FFMPEG_CAPTURE_OPTIONS")
+    os.environ["OPENCV_FFMPEG_CAPTURE_OPTIONS"] = options
+    return previous

--- a/inference/core/interfaces/camera/rtsp_tls.py
+++ b/inference/core/interfaces/camera/rtsp_tls.py
@@ -1,0 +1,25 @@
+"""RTSPS TLS helpers shared by GStreamer and OpenCV ingest paths (ENT-1544 B1/B2)."""
+
+from __future__ import annotations
+
+import os
+
+RTSP_TLS_VALIDATION_FLAGS_ENV_VAR = "ROBOFLOW_RTSP_TLS_VALIDATION_FLAGS"
+GST_SSL_CA_CERTIFICATE_ENV_VAR = "GST_SSL_CA_CERTIFICATE"
+SSL_CERT_FILE_ENV_VAR = "SSL_CERT_FILE"
+
+
+def is_rtsps_url(url: str) -> bool:
+    return isinstance(url, str) and url.lower().startswith("rtsps://")
+
+
+def rtsp_tls_validation_flags_gstreamer_suffix() -> str:
+    raw = os.getenv(RTSP_TLS_VALIDATION_FLAGS_ENV_VAR)
+    if raw is None or not str(raw).strip():
+        return ""
+    flags = int(str(raw).strip())
+    if flags < 0:
+        raise ValueError(
+            f"{RTSP_TLS_VALIDATION_FLAGS_ENV_VAR} must be a non-negative integer"
+        )
+    return f" tls-validation-flags={flags}"

--- a/tests/inference/unit_tests/core/interfaces/camera/test_rtsp_opencv_tls.py
+++ b/tests/inference/unit_tests/core/interfaces/camera/test_rtsp_opencv_tls.py
@@ -1,0 +1,37 @@
+import os
+
+import pytest
+
+from inference.core.interfaces.camera.rtsp_opencv_tls import (
+    apply_opencv_rtsps_tls_env,
+    build_opencv_ffmpeg_capture_options,
+)
+from inference.core.interfaces.camera.rtsp_tls import (
+    GST_SSL_CA_CERTIFICATE_ENV_VAR,
+    RTSP_TLS_VALIDATION_FLAGS_ENV_VAR,
+)
+
+
+def test_build_options_non_rtsps() -> None:
+    assert build_opencv_ffmpeg_capture_options("rtsp://cam/stream") is None
+
+
+def test_build_options_rtsps_with_ca(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(GST_SSL_CA_CERTIFICATE_ENV_VAR, "/etc/ssl/certs/ca-certificates.crt")
+    got = build_opencv_ffmpeg_capture_options("rtsps://cam/stream")
+    assert got is not None
+    assert "cafile;/etc/ssl/certs/ca-certificates.crt" in got
+    assert "rtsp_transport;tcp" in got
+
+
+def test_build_options_self_signed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(RTSP_TLS_VALIDATION_FLAGS_ENV_VAR, "0")
+    got = build_opencv_ffmpeg_capture_options("rtsps://cam/stream")
+    assert got is not None
+    assert "tls_verify;0" in got
+
+
+def test_apply_sets_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OPENCV_FFMPEG_CAPTURE_OPTIONS", raising=False)
+    apply_opencv_rtsps_tls_env("rtsps://cam/stream")
+    assert "rtsp_transport;tcp" in os.environ["OPENCV_FFMPEG_CAPTURE_OPTIONS"]


### PR DESCRIPTION
## Summary
- Add `rtsp_opencv_tls` to build `OPENCV_FFMPEG_CAPTURE_OPTIONS` for `rtsps://` (CA file + optional `tls_verify;0`).
- Scaffold for `CV2VideoFrameProducer` and WebRTC `MediaPlayer` wiring.
- Plan: `cursor-cloud/features/ent-1544/plans/B2-inference.md`.

## ENT-1544
Phase B — RTSPS on x86/non-Jetson OpenCV fallback path.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?
- `test_rtsp_opencv_tls.py` unit tests.

## Dependencies
Shares `rtsp_tls` env vars with B1; B3 for CA bundle env on device.

## Test plan
- [ ] `pytest tests/inference/unit_tests/core/interfaces/camera/test_rtsp_opencv_tls.py`
- [ ] Follow-up: wire into `video_source.py` + manual x86 RTSPS test

Made with [Cursor](https://cursor.com)