### PR TITLE
Validate parent_id alignment between images and predictions in Dynamic Crop

### DIFF
--- a/inference/core/workflows/core_steps/transformations/dynamic_crop/v1.py
+++ b/inference/core/workflows/core_steps/transformations/dynamic_crop/v1.py
@@ -10,6 +10,7 @@ from supervision.config import ORIENTED_BOX_COORDINATES
 from inference.core.workflows.execution_engine.constants import (
     DETECTION_ID_KEY,
     KEYPOINTS_XY_KEY_IN_SV_DETECTIONS,
+    PARENT_ID_KEY,
     POLYGON_KEY_IN_SV_DETECTIONS,
 )
 from inference.core.workflows.execution_engine.entities.base import (
@@ -209,6 +210,16 @@ def crop_image(
             f"sv.Detections object passed to crop step do not fulfill contract - lack of {detection_id_key} key "
             f"in data dictionary."
         )
+    if PARENT_ID_KEY in detections.data:
+        detection_parent_ids = set(detections[PARENT_ID_KEY].tolist())
+        image_parent_id = image.parent_metadata.parent_id
+        if detection_parent_ids != {image_parent_id}:
+            raise ValueError(
+                f"sv.Detections object passed to crop step do not fulfill contract - predictions "
+                f"parent_id(s) {sorted(detection_parent_ids)} do not match the image parent_id "
+                f"'{image_parent_id}'. Images and predictions are misaligned; this usually happens "
+                f"when they are produced by independent workflow branches."
+            )
     crops = []
     for idx, ((x_min, y_min, x_max, y_max), detection_id) in enumerate(
         zip(detections.xyxy.round().astype(dtype=int), detections[detection_id_key])

--- a/tests/workflows/unit_tests/core_steps/transformations/test_crop.py
+++ b/tests/workflows/unit_tests/core_steps/transformations/test_crop.py
@@ -12,6 +12,7 @@ from inference.core.workflows.core_steps.transformations.dynamic_crop.v1 import 
     convert_color_to_bgr_tuple,
     crop_image,
 )
+from inference.core.workflows.execution_engine.constants import PARENT_ID_KEY
 from inference.core.workflows.execution_engine.entities.base import (
     ImageParentMetadata,
     OriginCoordinatesSystem,
@@ -516,3 +517,60 @@ def test_crop_image_translates_oriented_bounding_box_corners(
     translated_corners = translated.data[ORIENTED_BOX_COORDINATES][0]
     assert translated_corners.min() >= 0.0
     assert translated_corners.max() <= side
+
+
+def test_crop_image_raises_when_predictions_parent_id_does_not_match_image() -> None:
+    # given
+    np_image = np.zeros((100, 100, 3), dtype=np.uint8)
+    image = WorkflowImageData(
+        parent_metadata=ImageParentMetadata(parent_id="origin_image"),
+        numpy_image=np_image,
+    )
+    detections = sv.Detections(
+        xyxy=np.array([[0, 0, 20, 20]], dtype=np.float64),
+        class_id=np.array([1]),
+        confidence=np.array([0.5], dtype=np.float64),
+        data={
+            "detection_id": np.array(["one"]),
+            PARENT_ID_KEY: np.array(["different_image"]),
+        },
+    )
+
+    # when / then
+    with pytest.raises(ValueError, match="do not match the image parent_id"):
+        crop_image(
+            image=image,
+            detections=detections,
+            mask_opacity=0.0,
+            background_color=(0, 0, 0),
+        )
+
+
+def test_crop_image_accepts_predictions_whose_parent_id_matches_image() -> None:
+    # given
+    np_image = np.zeros((100, 100, 3), dtype=np.uint8)
+    np_image[0:20, 0:20] = 39
+    image = WorkflowImageData(
+        parent_metadata=ImageParentMetadata(parent_id="origin_image"),
+        numpy_image=np_image,
+    )
+    detections = sv.Detections(
+        xyxy=np.array([[0, 0, 20, 20]], dtype=np.float64),
+        class_id=np.array([1]),
+        confidence=np.array([0.5], dtype=np.float64),
+        data={
+            "detection_id": np.array(["one"]),
+            PARENT_ID_KEY: np.array(["origin_image"]),
+        },
+    )
+
+    # when
+    result = crop_image(
+        image=image, detections=detections, mask_opacity=0.0, background_color=(0, 0, 0)
+    )
+
+    # then
+    assert len(result) == 1
+    assert (
+        result[0]["crops"].numpy_image == (np.ones((20, 20, 3), dtype=np.uint8) * 39)
+    ).all()


### PR DESCRIPTION
## What changed

`DynamicCropBlockV1.run` pairs `images` with `predictions` positionally via `zip(images, predictions)`. When those two inputs are produced by independent workflow branches they can be misaligned, so a crop gets taken from one image using another image's detections, producing silently incorrect results (the "nonsense results" described in the issue).

This adds a contract check in `crop_image`: when the predictions carry a `parent_id` (as model-produced `sv.Detections` do), it must match the image's `parent_metadata.parent_id`. On a mismatch the block now raises a clear `ValueError` explaining the misalignment instead of returning wrong crops. The check mirrors the block's existing `detection_id` contract validation and is skipped when predictions carry no `parent_id`, so behavior is unchanged for correctly aligned inputs.

Closes #390

## Design note

I implemented this as validation with an explicit error, consistent with the block's existing `detection_id` contract check, because a silent realignment would hide a genuinely misconfigured workflow rather than surface it. If you would instead prefer the block to match predictions to images by `parent_id`, I am happy to switch to that approach.

## Tests

Added two unit tests in `tests/workflows/unit_tests/core_steps/transformations/test_crop.py`:

- `test_crop_image_raises_when_predictions_parent_id_does_not_match_image` (fails on the pre-fix code, confirming the guard is effective)
- `test_crop_image_accepts_predictions_whose_parent_id_matches_image`

Command run:

```
pytest tests/workflows/unit_tests/core_steps/transformations/test_crop.py
```

Result: 47 passed. Files were formatted with `black` (26.3.1) and `isort` (5.13.2); both leave the changes unchanged.
