### PR TITLE
fix(secure-gateway): align weights proxy builder with wrap_url (#2662)

### DIFF
--- a/inference_models/inference_models/weights_providers/roboflow.py
+++ b/inference_models/inference_models/weights_providers/roboflow.py
@@ -215,11 +215,21 @@ def roboflow_secure_gateway_proxy_url_builder(
         url = _add_query_params_to_url(url=url, query=query)
     if not SECURE_GATEWAY:
         return url
-    parts = urllib.parse.urlsplit(
-        SECURE_GATEWAY if "://" in SECURE_GATEWAY else f"http://{SECURE_GATEWAY}"
-    )
-    gateway_base = f"{parts.scheme}://{parts.netloc}"
-    return f"{gateway_base}/proxy?url=" + urllib.parse.quote(url, safe="~()*!'")
+    # Kept behaviour-identical to inference.core.utils.url_utils.wrap_url: both
+    # implement the same /proxy?url= contract, and a divergence between them sends
+    # weights traffic somewhere the server traffic does not go.
+    gateway = SECURE_GATEWAY.rstrip("/")
+    if "://" in gateway:
+        gateway_base = gateway
+    else:
+        gateway_base = f"http://{gateway}"
+    gateway_prefix = f"{gateway_base}/proxy?url="
+    # Idempotent: values may already be wrapped (e.g. a download_url returned by an
+    # API that is itself reached through the gateway) - wrapping twice would proxy
+    # the proxy.
+    if url.startswith(gateway_prefix):
+        return url
+    return gateway_prefix + urllib.parse.quote(url, safe="~()*!'")
 
 
 def get_model_metadata(

--- a/inference_models/tests/unit_tests/weights_providers/test_roboflow.py
+++ b/inference_models/tests/unit_tests/weights_providers/test_roboflow.py
@@ -1971,6 +1971,75 @@ def test_scheme_qualified_gateway_keeps_port_and_strips_trailing_slash():
     assert outer.path == "/proxy"
 
 
+@patch.object(roboflow_module, "SECURE_GATEWAY", "https://gateway.local")
+def test_proxy_url_builder_is_idempotent():
+    # given - a download_url that already came back wrapped, which happens when the
+    # metadata API that returned it was itself reached through the gateway
+    original_url = "https://api.roboflow.com/weights"
+
+    # when
+    wrapped_once = roboflow_secure_gateway_proxy_url_builder(
+        url=original_url, query=None
+    )
+    wrapped_twice = roboflow_secure_gateway_proxy_url_builder(
+        url=wrapped_once, query=None
+    )
+
+    # then - wrapping twice must not proxy the proxy
+    assert wrapped_twice == wrapped_once
+    assert _extract_proxied_url(wrapped_twice) == original_url
+
+
+@patch.object(roboflow_module, "SECURE_GATEWAY", "https://gw.local/edge")
+def test_proxy_url_builder_preserves_gateway_base_path():
+    # given - a gateway published under a base path
+    # when
+    result = roboflow_secure_gateway_proxy_url_builder(
+        url="https://api.roboflow.com/weights",
+        query=None,
+    )
+
+    # then - the path must survive, otherwise weights traffic goes to gw.local/proxy
+    # while server traffic goes to gw.local/edge/proxy
+    outer = _parse_proxy_result(result)
+    assert outer.netloc == "gw.local"
+    assert outer.path == "/edge/proxy"
+    assert _extract_proxied_url(result) == "https://api.roboflow.com/weights"
+
+
+@patch.object(roboflow_module, "SECURE_GATEWAY", "https://gw.local/edge/")
+def test_proxy_url_builder_preserves_gateway_base_path_with_trailing_slash():
+    # when
+    result = roboflow_secure_gateway_proxy_url_builder(
+        url="https://api.roboflow.com/weights",
+        query=None,
+    )
+
+    # then
+    outer = _parse_proxy_result(result)
+    assert outer.path == "/edge/proxy"
+    assert "//proxy" not in result
+
+
+@patch.object(roboflow_module, "SECURE_GATEWAY", "https://gw.local/edge")
+def test_proxy_url_builder_is_idempotent_under_a_gateway_base_path():
+    # given - the two fixes interact: the guard has to compare against the prefix
+    # that includes the base path, or an already-wrapped url is wrapped again
+    original_url = "https://api.roboflow.com/weights"
+
+    # when
+    wrapped_once = roboflow_secure_gateway_proxy_url_builder(
+        url=original_url, query=None
+    )
+    wrapped_twice = roboflow_secure_gateway_proxy_url_builder(
+        url=wrapped_once, query=None
+    )
+
+    # then
+    assert wrapped_twice == wrapped_once
+    assert _extract_proxied_url(wrapped_twice) == original_url
+
+
 @patch.object(roboflow_module, "SECURE_GATEWAY", "proxy.internal")
 def test_roundtrip_preserves_query_with_special_characters():
     result = roboflow_secure_gateway_proxy_url_builder(

--- a/tests/inference/unit_tests/core/utils/test_url_utils.py
+++ b/tests/inference/unit_tests/core/utils/test_url_utils.py
@@ -1,6 +1,8 @@
 from unittest import mock
 from urllib.parse import parse_qs, urlparse
 
+import pytest
+
 from inference.core.utils import url_utils
 from inference.core.utils.url_utils import wrap_url
 
@@ -90,3 +92,45 @@ def test_wrap_url_when_bare_host_secure_gateway_has_trailing_slash() -> None:
     assert result.startswith("http://gateway.local:8080/proxy?url=")
     assert "//proxy" not in result
     assert wrap_url(url=result) == result
+
+
+# `inference_models.weights_providers.roboflow.roboflow_secure_gateway_proxy_url_builder`
+# implements the same `/proxy?url=` contract as `wrap_url`, for weights traffic rather
+# than server traffic. They are separate packages and cannot share an implementation
+# without a dependency between them, so parity is pinned here instead. A divergence is
+# invisible at runtime: weights simply get fetched from a different place than
+# everything else. See issue #2662.
+@pytest.mark.parametrize(
+    "gateway",
+    [
+        "gateway.local",
+        "gateway.local:8080",
+        "https://gateway.local",
+        "https://gateway.local:8443/",
+        "https://gw.local/edge",
+        "https://gw.local/edge/",
+    ],
+)
+def test_weights_proxy_builder_matches_wrap_url(gateway: str) -> None:
+    # given
+    roboflow_module = pytest.importorskip("inference_models.weights_providers.roboflow")
+    original_url = "https://api.roboflow.com/models/v1/weights"
+
+    # when
+    with mock.patch.object(url_utils, "SECURE_GATEWAY", gateway), mock.patch.object(
+        roboflow_module, "SECURE_GATEWAY", gateway
+    ):
+        from_server = wrap_url(url=original_url)
+        from_weights = roboflow_module.roboflow_secure_gateway_proxy_url_builder(
+            url=original_url, query=None
+        )
+
+        # then - identical output, and both idempotent
+        assert from_weights == from_server
+        assert wrap_url(url=from_server) == from_server
+        assert (
+            roboflow_module.roboflow_secure_gateway_proxy_url_builder(
+                url=from_weights, query=None
+            )
+            == from_weights
+        )


### PR DESCRIPTION
Closes the first half of #2662.

`roboflow_secure_gateway_proxy_url_builder` and `wrap_url` implement the same
`/proxy?url=` contract, one for weights traffic and one for server traffic. They had
drifted apart in two ways, both exactly as @alexnorell described:

**1. No idempotence guard.** An already-wrapped `download_url` was wrapped again. On `main`:

```
https://gw.local/proxy?url=https%3A%2F%2Fgw.local%2Fproxy%3Furl%3Dhttps%253A%252F%252Fapi.roboflow.com%252Fweights
```

`wrap_url` gained this guard in #2658; the weights builder did not.

**2. The gateway base path was dropped.** The builder took `urlsplit` scheme and netloc
only, so `SECURE_GATEWAY=https://gw.local/edge` sent weights traffic to `gw.local/proxy`
while server traffic went to `gw.local/edge/proxy`.

Neither one raises. The weights are simply fetched from somewhere other than the gateway
you configured, which is the failure mode a secure gateway exists to prevent.

## The fix

The builder now mirrors `wrap_url` line for line: `rstrip("/")` on the configured value so
the base path survives, then the same `gateway_prefix` construction and the same
`startswith` guard.

The two fixes interact, which is worth stating because it is the part that is easy to get
wrong. The idempotence guard has to compare against a prefix that already includes the base
path, otherwise fixing the path reintroduces double-wrapping under `/edge`. There is a test
for that case specifically.

## Tests

Four in `inference_models/tests/unit_tests/weights_providers/test_roboflow.py`:
idempotence, base path preserved, base path with a trailing slash, and idempotence under a
base path. All four fail on `main`.

One parametrized cross-package test in `tests/inference/unit_tests/core/utils/test_url_utils.py`
asserting the two wrappers produce byte-identical output across six gateway spellings, and
that both are idempotent. Six cases, all failing on `main`, including the plain
`gateway.local` case because the idempotence half diverged for every spelling.

The issue suggested either sharing one implementation or keeping them behaviour-identical
with cross-package tests. Sharing would mean a dependency between the two packages, so this
takes the second option. The parity test lives in the `inference` unit suite rather than the
`inference_models` one because that workflow already does `pip install --no-deps
./inference_models`, so both are importable there, whereas the `inference_models` suite runs
with `working-directory: inference_models`. It is guarded with `importorskip` regardless.

## Not in scope

Part 2 of #2662, the per-run `step_execution_mode` bypass, is untouched. That one needs
gateway support in `inference_sdk`'s `InferenceHTTPClient` or a guard at the
`StepExecutionMode` consumption point, and it is a design decision rather than a divergence
between two functions.

## Verification

`test_url_utils.py`: 12 passed with the fix, 6 failed and 6 passed without it.
`test_roboflow.py` (weights providers): 72 passed with the fix, 68 passed without it plus
the 4 new failures. `test_roboflow_api.py` is byte-identical before and after, so nothing
that routes through these wrappers changed behaviour. `black` and `isort` clean per the
`style` target.
