### PR TITLE
fix(tests): remove deadlock in RTSPS TLS serialization test (unblocks UNIT TESTS - inference)

### DIFF
--- a/tests/inference/unit_tests/core/interfaces/camera/test_rtsp_opencv_tls.py
+++ b/tests/inference/unit_tests/core/interfaces/camera/test_rtsp_opencv_tls.py
@@ -1,5 +1,6 @@
 import os
 import threading
+import time
 
 import pytest
 
@@ -124,30 +125,31 @@ def test_opencv_rtsps_tls_env_restores_previous(
 
 
 def test_opencv_rtsps_tls_env_serializes_concurrent_opens() -> None:
+    # The context manager holds its lock across the yield (set -> open ->
+    # restore), so no cross-thread rendezvous may happen INSIDE the `with`
+    # block - a barrier there deadlocks. Serialization is asserted instead by
+    # checking the two workers were never inside the context simultaneously.
     os.environ.pop(OPENCV_FFMPEG_CAPTURE_OPTIONS_ENV_VAR, None)
     observed: list[str] = []
-    barrier = threading.Barrier(2)
+    inside: list[str] = []
+    overlaps: list[int] = []
 
-    def worker(video: str, flag_value: str) -> None:
-        previous_flags = os.environ.get(RTSP_TLS_VALIDATION_FLAGS_ENV_VAR)
-        os.environ[RTSP_TLS_VALIDATION_FLAGS_ENV_VAR] = flag_value
-        try:
-            with opencv_rtsps_tls_env(video):
-                barrier.wait()
-                observed.append(os.environ[OPENCV_FFMPEG_CAPTURE_OPTIONS_ENV_VAR])
-        finally:
-            if previous_flags is None:
-                os.environ.pop(RTSP_TLS_VALIDATION_FLAGS_ENV_VAR, None)
-            else:
-                os.environ[RTSP_TLS_VALIDATION_FLAGS_ENV_VAR] = previous_flags
+    def worker(video: str) -> None:
+        with opencv_rtsps_tls_env(video):
+            inside.append(video)
+            overlaps.append(len(inside))
+            observed.append(os.environ[OPENCV_FFMPEG_CAPTURE_OPTIONS_ENV_VAR])
+            time.sleep(0.05)
+            inside.remove(video)
 
-    strict = threading.Thread(target=worker, args=("rtsps://strict/stream", "1"))
-    relaxed = threading.Thread(target=worker, args=("rtsps://relaxed/stream", "0"))
-    strict.start()
-    relaxed.start()
-    strict.join()
-    relaxed.join()
+    first = threading.Thread(target=worker, args=("rtsps://first/stream",))
+    second = threading.Thread(target=worker, args=("rtsps://second/stream",))
+    first.start()
+    second.start()
+    first.join()
+    second.join()
 
-    assert any("tls_verify;1" in value for value in observed)
-    assert any("tls_verify;0" in value for value in observed)
+    assert max(overlaps) == 1, "opens must be serialized, never concurrent"
+    assert len(observed) == 2
+    assert all("rtsp_transport;tcp" in value for value in observed)
     assert OPENCV_FFMPEG_CAPTURE_OPTIONS_ENV_VAR not in os.environ


### PR DESCRIPTION
## What does this PR do?

### Problem

`UNIT TESTS - inference` has been timing out at the 15-minute job limit on every run since #2727 merged (last green: `bdddff764`, first cancelled: `a34f929e0`). The job log goes silent the moment pytest enters `test_rtsp_opencv_tls.py` and the runner later kills an orphaned python process.

### Root cause

`test_opencv_rtsps_tls_env_serializes_concurrent_opens` deadlocks by construction:

- `opencv_rtsps_tls_env` **deliberately holds its lock across the yield** ("The lock spans set → VideoCapture open → restore", per its docstring) — that's the whole point of the serialization.
- The test rendezvouses two threads on a `threading.Barrier(2)` **inside** the `with` block: thread A waits at the barrier while holding the lock; thread B blocks entering the lock. The barrier never completes, the non-daemon threads never join, pytest hangs forever.

Secondary issue: the options string is computed from the global `RTSP_TLS_VALIDATION_FLAGS` env var *before* the lock is taken, so the two workers' strict-vs-relaxed assertions raced even conceptually.

### Fix

Rewrite the test to assert what "serializes" actually promises: the two workers are never inside the context simultaneously (overlap counter across a sleep window), both opens observe the TLS options, and the env var is restored afterwards. The strict/relaxed value coverage the old test claimed is already provided by the sequential `test_build_options_*` tests in the same file.

File now runs **13 passed in 0.2 s** (previously: hang until job timeout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Type of Change

<!-- Please select one and delete the others, or describe if Other -->

- Bug fix (non-breaking change that fixes an issue)

## Testing

<!-- Describe how you tested your changes -->
- ci
- [ ] I have tested this change locally
- [ ] I have added/updated tests for this change

**Test details:**
<!-- Describe what tests were added/updated and what they cover -->

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)

## Additional Context

<!-- Add any other context, screenshots, or notes about the PR here -->


