### PR TITLE
fix(stream manager): exit gracefully when another worker already bound the port

### DIFF
--- a/docker/config/cpu_http.py
+++ b/docker/config/cpu_http.py
@@ -1,6 +1,8 @@
+import os
 from functools import partial
 from multiprocessing import Process
 
+from inference.core import logger
 from inference.core.cache import cache
 from inference.core.env import (
     ACTIVE_LEARNING_ENABLED,
@@ -24,6 +26,11 @@ from inference.core.registries.roboflow import (
 from inference.models.utils import ROBOFLOW_MODEL_TYPES
 
 if ENABLE_STREAM_API:
+    if int(os.getenv("NUM_WORKERS", "1")) > 1:
+        logger.info(
+            "ENABLE_STREAM_API is set with NUM_WORKERS > 1. A single Stream Manager is shared by all "
+            "workers; it is started once per worker and only the first to bind the port survives."
+        )
     stream_manager_process = Process(
         target=partial(start, expected_warmed_up_pipelines=STREAM_API_PRELOADED_PROCESSES),
     )

--- a/docker/config/gpu_http.py
+++ b/docker/config/gpu_http.py
@@ -1,6 +1,8 @@
 import multiprocessing
+import os
 from functools import partial
 
+from inference.core import logger
 from inference.core.cache import cache
 from inference.core.env import (
     ACTIVE_LEARNING_ENABLED,
@@ -23,6 +25,11 @@ from inference.core.registries.roboflow import (
 from inference.models.utils import ROBOFLOW_MODEL_TYPES
 
 if ENABLE_STREAM_API:
+    if int(os.getenv("NUM_WORKERS", "1")) > 1:
+        logger.info(
+            "ENABLE_STREAM_API is set with NUM_WORKERS > 1. A single Stream Manager is shared by all "
+            "workers; it is started once per worker and only the first to bind the port survives."
+        )
     multiprocessing_context = multiprocessing.get_context(method="spawn")
     stream_manager_process = multiprocessing_context.Process(
         target=partial(start, expected_warmed_up_pipelines=STREAM_API_PRELOADED_PROCESSES),

--- a/docs/quickstart/docker_configuration_options.md
+++ b/docs/quickstart/docker_configuration_options.md
@@ -137,6 +137,18 @@ See [Model Weights Download](../using_inference/offline_weights_download.md) for
 
 Sets the number of workers used by HTTP interfaces. 
 
+!!! note "Interaction with `ENABLE_STREAM_API`"
+
+    The Stream Management API runs as a single Stream Manager process per container, bound to
+    `STREAM_MANAGER_HOST`:`STREAM_MANAGER_PORT` (`127.0.0.1:7070` by default), and every worker
+    connects to it as a client. When `NUM_WORKERS > 1`, each worker attempts to start a manager and
+    only the first one to bind the port keeps running - the rest exit and log that a manager is
+    already serving the container. This is expected and the shared manager serves all workers.
+
+    Note that some options are incompatible with multiple workers. `PRELOAD_HF_IDS`, for example,
+    causes every inference process to preload the models and requires `NUM_WORKERS=1` together with
+    `ENABLE_STREAM_API=False`.
+
 ## HTTPS / TLS
 
 **ENABLE_HTTPS**: Boolean (default = `False`)

--- a/inference/core/interfaces/stream_manager/manager_app/app.py
+++ b/inference/core/interfaces/stream_manager/manager_app/app.py
@@ -1,3 +1,4 @@
+import errno
 import os
 import signal
 import socket
@@ -557,25 +558,40 @@ def start(expected_warmed_up_pipelines: int = 0) -> None:
         signal.SIGTERM, partial(execute_termination, processes_table=PROCESSES_TABLE)
     )
 
-    # check process health in daemon thread
-    Thread(target=check_process_health, daemon=True).start()
+    # The manager is a single instance per container, shared by every HTTP worker, but it is
+    # started once per worker (see docker/config/{cpu,gpu}_http.py). Bind before doing any other
+    # work so that the instances which lose the race exit without warming up pipelines.
+    try:
+        tcp_server = RoboflowTCPServer(
+            server_address=(HOST, PORT),
+            handler_class=partial(
+                InferencePipelinesManagerHandler, processes_table=PROCESSES_TABLE
+            ),
+            socket_operations_timeout=SOCKET_TIMEOUT,
+        )
+    except OSError as error:
+        if error.errno != errno.EADDRINUSE:
+            raise
+        logger.info(
+            f"Inference Pipeline Processes Manager is already serving this container at {(HOST, PORT)} - "
+            f"this instance is exiting. This is expected when NUM_WORKERS > 1: the running manager is "
+            f"shared by all workers."
+        )
+        return
 
-    # keep expected number of processes ready for processing
-    Thread(
-        target=partial(
-            ensure_idle_pipelines_warmed_up,
-            expected_warmed_up_pipelines=expected_warmed_up_pipelines,
-        ),
-        daemon=True,
-    ).start()
+    with tcp_server:
+        # check process health in daemon thread
+        Thread(target=check_process_health, daemon=True).start()
 
-    with RoboflowTCPServer(
-        server_address=(HOST, PORT),
-        handler_class=partial(
-            InferencePipelinesManagerHandler, processes_table=PROCESSES_TABLE
-        ),
-        socket_operations_timeout=SOCKET_TIMEOUT,
-    ) as tcp_server:
+        # keep expected number of processes ready for processing
+        Thread(
+            target=partial(
+                ensure_idle_pipelines_warmed_up,
+                expected_warmed_up_pipelines=expected_warmed_up_pipelines,
+            ),
+            daemon=True,
+        ).start()
+
         logger.info(
             f"Inference Pipeline Processes Manager is ready to accept connections at {(HOST, PORT)}"
         )

--- a/inference/core/interfaces/stream_manager/manager_app/tcp_server.py
+++ b/inference/core/interfaces/stream_manager/manager_app/tcp_server.py
@@ -4,6 +4,11 @@ from typing import Any, Optional, Tuple, Type
 
 
 class RoboflowTCPServer(TCPServer):
+    # Matches `http.server.HTTPServer`: lets the manager rebind while a socket from a
+    # previous instance lingers in TIME_WAIT. This does not permit two live listeners
+    # on the same address, so a second manager still fails to bind, as intended.
+    allow_reuse_address = True
+
     def __init__(
         self,
         server_address: Tuple[str, int],

--- a/tests/inference/unit_tests/core/interfaces/stream_manager/manager_app/test_app.py
+++ b/tests/inference/unit_tests/core/interfaces/stream_manager/manager_app/test_app.py
@@ -1,0 +1,53 @@
+import errno
+import socket
+from unittest.mock import MagicMock
+
+import pytest
+
+from inference.core.interfaces.stream_manager.manager_app import app as manager_app
+
+
+def test_start_exits_gracefully_when_another_manager_already_bound_the_port() -> None:
+    # given - a manager started by another HTTP worker already owns the address
+    occupied_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    occupied_socket.bind(("127.0.0.1", 0))
+    occupied_socket.listen(1)
+    host, port = occupied_socket.getsockname()
+    warm_up_pipelines = MagicMock()
+    original_host, original_port = manager_app.HOST, manager_app.PORT
+    original_warm_up = manager_app.ensure_idle_pipelines_warmed_up
+    manager_app.HOST, manager_app.PORT = host, port
+    manager_app.ensure_idle_pipelines_warmed_up = warm_up_pipelines
+
+    # when
+    try:
+        manager_app.start(expected_warmed_up_pipelines=1)
+    finally:
+        manager_app.HOST, manager_app.PORT = original_host, original_port
+        manager_app.ensure_idle_pipelines_warmed_up = original_warm_up
+        occupied_socket.close()
+
+    # then - the instance that lost the race must exit before warming up pipelines,
+    # otherwise every worker would preload models
+    warm_up_pipelines.assert_not_called()
+
+
+def test_start_reraises_os_errors_other_than_address_in_use() -> None:
+    # given
+    def _raise_permission_denied(**kwargs) -> None:
+        raise OSError(errno.EACCES, "Permission denied")
+
+    original_server = manager_app.RoboflowTCPServer
+    manager_app.RoboflowTCPServer = _raise_permission_denied
+
+    # when
+    try:
+        with pytest.raises(OSError) as error:
+            manager_app.start()
+    finally:
+        manager_app.RoboflowTCPServer = original_server
+
+    # then
+    assert (
+        error.value.errno == errno.EACCES
+    ), "Only EADDRINUSE is expected to be handled, other socket errors must surface"

--- a/tests/inference/unit_tests/core/interfaces/stream_manager/manager_app/test_tcp_server.py
+++ b/tests/inference/unit_tests/core/interfaces/stream_manager/manager_app/test_tcp_server.py
@@ -5,6 +5,14 @@ from inference.core.interfaces.stream_manager.manager_app.tcp_server import (
 )
 
 
+def test_roboflow_server_allows_address_reuse() -> None:
+    # then - the manager must be able to rebind while a socket from a previous
+    # instance lingers in TIME_WAIT
+    assert (
+        RoboflowTCPServer.allow_reuse_address is True
+    ), "Server must set SO_REUSEADDR, as per http.server.HTTPServer"
+
+
 def test_roboflow_server_applies_connection_timeout() -> None:
     # given
     server = RoboflowTCPServer(


### PR DESCRIPTION
## Problem

The Stream Manager is started from the app module — `docker/config/gpu_http.py` and `docker/config/cpu_http.py` — which uvicorn imports **once per worker**. It binds a fixed `STREAM_MANAGER_HOST:STREAM_MANAGER_PORT` (`127.0.0.1:7070` by default, `manager_app/app.py`), through a `TCPServer` that never set `allow_reuse_address`.

So with `NUM_WORKERS > 1`, every worker starts a manager, one wins the bind, and the rest die with an unhandled:

```
OSError: [Errno 98] Address already in use
```

The GPU/CPU images ship `ENABLE_STREAM_API=True` with `NUM_WORKERS=1`, so the default config is safe — this is only reachable when a user raises `NUM_WORKERS`, which the docs did not flag as a hazard.

Reported by a customer running `roboflow-inference-server-gpu` with `NUM_WORKERS=4` on an A2, who sees the error at startup along with uvicorn workers dying and respawning, ending up with fewer workers serving than configured and reduced FPS. Their workaround is restarting the container, which just re-runs the same race.

## Why a single manager is the right end state

Not a regression, and not fixed by upgrading — `docker/config/gpu_http.py` is byte-identical from `v1.0.1` through `main`.

`inference/core/interfaces/http/http_api.py` builds a `StreamManagerClient` per worker pointing at the same `127.0.0.1:7070`. The design is already **one manager, many clients** — a single manager per container correctly serves all workers. Only the spawn location is wrong.

## Changes

- **`manager_app/app.py`** — `start()` catches `OSError` with `errno.EADDRINUSE` around the server construction, logs an explanatory line, and returns cleanly instead of raising. The bind now happens *before* the health-check and warm-up threads start, so an instance that loses the race exits without preloading pipelines (previously `STREAM_API_PRELOADED_PROCESSES` would have been honoured by all of them). Other `OSError`s still propagate.
- **`manager_app/tcp_server.py`** — `allow_reuse_address = True`, matching `http.server.HTTPServer`, so a restarted manager can rebind while the previous socket lingers in `TIME_WAIT`. Verified that this does **not** permit two live listeners, so the port remains an effective mutex and does not mask the condition above.
- **`docker/config/{cpu,gpu}_http.py`** — log once at startup when `ENABLE_STREAM_API` is set with `NUM_WORKERS > 1`, so the behaviour is greppable in exactly the logs users send us.
- **`docs/quickstart/docker_configuration_options.md`** — document the interaction under `NUM_WORKERS`. Also mentions the existing `PRELOAD_HF_IDS` constraint already noted in `inference/core/env.py`, which had never made it into the docs.
- **Tests** — `test_app.py` covers both the graceful-exit path (asserting pipelines are *not* warmed up) and that non-`EADDRINUSE` errors still surface; `test_tcp_server.py` covers `allow_reuse_address`.

## Reproduction

No GPU required — `cpu_http.py` has the identical defect:

```
docker run --rm -e NUM_WORKERS=4 -e ENABLE_STREAM_API=True roboflow/roboflow-inference-server-cpu
```

Before: `[Errno 98]` `NUM_WORKERS - 1` times. After: one manager log line, the rest exit quietly.

## Notes for reviewers

- **Scope:** both docker entrypoint configs, and `ENABLE_STREAM_API=True` ships in 8 images (CPU, CPU.dev, GPU, GPU.dev, GPU.3d, TRT, Jetson 5.1.1, Jetson 6.2.0).
- **What this PR does not claim.** The port conflict is proven from source. Whether it is *also* what terminates the uvicorn workers in the customer's logs is not proven — their excerpt is truncated above the `OSError`, so the traceback frames are missing. This removes the conflict either way; if worker deaths persist there is a second cause to chase.
- **Deliberately not included:** a file lock or entrypoint-level guard so losing workers never spawn a manager at all. It would save a few wasted `spawn` imports at startup, but adds stale-lock semantics and a worker-restart edge case — an orphaned manager keeps the port after its parent worker dies, so the lock and the port can disagree. The handling here covers that case correctly. Happy to add it if maintainers prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
