### PR TITLE
Add rfdetr-keypoint-preview alias

### DIFF
--- a/inference/models/aliases.py
+++ b/inference/models/aliases.py
@@ -143,8 +143,6 @@ RFDETR_ALIASES = {
     "rfdetr-seg-large": "coco-dataset-vdnr1/38",
     "rfdetr-seg-xlarge": "coco-dataset-vdnr1/39",
     "rfdetr-seg-2xlarge": "coco-dataset-vdnr1/40",
-    # Registry model id, not {project}/{version}: alias resolution is single-hop,
-    # and this is what the models service resolves the alias to.
     "rfdetr-keypoint-preview": "microsoft/coco-pose-detection-17-rfdetr-keypoint-preview-t1",
 }
 

--- a/inference/models/aliases.py
+++ b/inference/models/aliases.py
@@ -143,6 +143,7 @@ RFDETR_ALIASES = {
     "rfdetr-seg-large": "coco-dataset-vdnr1/38",
     "rfdetr-seg-xlarge": "coco-dataset-vdnr1/39",
     "rfdetr-seg-2xlarge": "coco-dataset-vdnr1/40",
+    "rfdetr-keypoint-preview": "coco-pose-detection/17",
 }
 
 CLASSIFICATION_ALIASES = {

--- a/inference/models/aliases.py
+++ b/inference/models/aliases.py
@@ -143,7 +143,9 @@ RFDETR_ALIASES = {
     "rfdetr-seg-large": "coco-dataset-vdnr1/38",
     "rfdetr-seg-xlarge": "coco-dataset-vdnr1/39",
     "rfdetr-seg-2xlarge": "coco-dataset-vdnr1/40",
-    "rfdetr-keypoint-preview": "coco-pose-detection/17",
+    # Registry model id, not {project}/{version}: alias resolution is single-hop,
+    # and this is what the models service resolves the alias to.
+    "rfdetr-keypoint-preview": "microsoft/coco-pose-detection-17-rfdetr-keypoint-preview-t1",
 }
 
 CLASSIFICATION_ALIASES = {

--- a/inference_sdk/http/utils/aliases.py
+++ b/inference_sdk/http/utils/aliases.py
@@ -102,6 +102,7 @@ RFDETR_ALIASES = {
     "rfdetr-seg-large": "coco-dataset-vdnr1/38",
     "rfdetr-seg-xlarge": "coco-dataset-vdnr1/39",
     "rfdetr-seg-2xlarge": "coco-dataset-vdnr1/40",
+    "rfdetr-keypoint-preview": "coco-pose-detection/17",
 }
 
 QWEN_ALIASES = {

--- a/inference_sdk/http/utils/aliases.py
+++ b/inference_sdk/http/utils/aliases.py
@@ -102,8 +102,6 @@ RFDETR_ALIASES = {
     "rfdetr-seg-large": "coco-dataset-vdnr1/38",
     "rfdetr-seg-xlarge": "coco-dataset-vdnr1/39",
     "rfdetr-seg-2xlarge": "coco-dataset-vdnr1/40",
-    # Registry model id, not {project}/{version}: alias resolution is single-hop,
-    # and this is what the models service resolves the alias to.
     "rfdetr-keypoint-preview": "microsoft/coco-pose-detection-17-rfdetr-keypoint-preview-t1",
 }
 

--- a/inference_sdk/http/utils/aliases.py
+++ b/inference_sdk/http/utils/aliases.py
@@ -102,7 +102,9 @@ RFDETR_ALIASES = {
     "rfdetr-seg-large": "coco-dataset-vdnr1/38",
     "rfdetr-seg-xlarge": "coco-dataset-vdnr1/39",
     "rfdetr-seg-2xlarge": "coco-dataset-vdnr1/40",
-    "rfdetr-keypoint-preview": "coco-pose-detection/17",
+    # Registry model id, not {project}/{version}: alias resolution is single-hop,
+    # and this is what the models service resolves the alias to.
+    "rfdetr-keypoint-preview": "microsoft/coco-pose-detection-17-rfdetr-keypoint-preview-t1",
 }
 
 QWEN_ALIASES = {

--- a/uv.lock
+++ b/uv.lock
@@ -1,3 +1,7 @@
 version = 1
 revision = 3
-requires-python = ">=3.10"
+requires-python = ">=3.12"
+
+[options]
+exclude-newer = "2026-06-24T19:51:35.53173Z"
+exclude-newer-span = "P7D"

--- a/uv.lock
+++ b/uv.lock
@@ -1,7 +1,3 @@
 version = 1
 revision = 3
-requires-python = ">=3.12"
-
-[options]
-exclude-newer = "2026-06-24T19:51:35.53173Z"
-exclude-newer-span = "P7D"
+requires-python = ">=3.10"


### PR DESCRIPTION
> [!NOTE]
> _Code and PR description are LLM-written. If this PR has been marked Ready For Review, code has
> been reviewed and tested in staging by Kai_

### Diff breakdown

| Category | Lines |
|---|---|
| Genuinely new or altered logic | 6 |
| Moving/rearranging existing logic | 0 |
| Tests | 0 |

### What

Maps `rfdetr-keypoint-preview` to `microsoft/coco-pose-detection-17-rfdetr-keypoint-preview-t1` —
the registry model id of the COCO-pretrained RF-DETR keypoint model (registered from
`coco-pose-detection` v17 in the `microsoft` workspace) — so the model is addressable by name the
way the other pretrained models already are (`yolo26n-pose-640`, `rfdetr-seg-preview`, ...).

The target is deliberately the registry model id rather than the `{project}/{version}` form: it is
the exact id the platform's `models_aliases` table resolves the alias to, so the client-side and
server-side alias layers agree. There is precedent for registry-id targets in these maps — the
`yolo26*-sem-1024` aliases point at `yolo26-pretrains/*`. The id still splits into two
`/`-separated segments, so it passes the SDK's model-id shape validation.

Added to `RFDETR_ALIASES` in both `inference/models/aliases.py` and
`inference_sdk/http/utils/aliases.py`, per the header on both files requiring the duplicate maps
stay in sync.

### Why

RF-DETR Keypoint Preview shipped in `rfdetr` and has had a dispatch entry here since v1.3.0
(#2401), but no alias — so it could only be reached by its raw id and did not appear as a
pretrained option in Workflows. Requested in
[MODELS-958](https://linear.app/roboflow/issue/MODELS-958/rfdetr-keypoint-preview-available-as-foundational-model-in-workflows),
originally from a #p-playground thread about RF-DETR missing from the pose-estimation playground.

### Notes for review

- `rfdetr-keypoint-preview` is `inference_models`-only (`ROBOFLOW_MODEL_TYPES` entry is added under
  the `USE_INFERENCE_MODELS` branch in `models/utils.py`), so it will not load on images that pin
  `USE_INFERENCE_MODELS=False` — notably `Dockerfile.onnx.lambda` and `.lambda.slim`.
- The same model is separately registered in the platform's `models_aliases` table, which resolves
  server-side on `/models/v1/external/{stat,weights}` — to the same registry id this PR bakes in.
  That layer is what makes the name work before this release ships; this PR is what makes it work
  client-side, in `inference_sdk`, and in air-gapped deployments.
- The target id exists in **both** staging and production (staging's
  `microsoft/coco-pose-detection` mirrors prod for this model — same registry id, same sealed
  packages), so the baked-in mapping is environment-agnostic.

### Testing

Local testing works

🤖 Generated with [Claude Code](https://claude.com/claude-code)
