### PR TITLE
fix(deps): pin supervision<0.30.0 to unblock CI

### DIFF
--- a/requirements/_requirements.txt
+++ b/requirements/_requirements.txt
@@ -16,7 +16,7 @@ psutil>=7.0.0
 redis~=5.0.0
 requests>=2.33.0,<3.0.0
 rich>=13.0.0,<15.0.0
-supervision>=0.27.0
+supervision>=0.27.0,<0.30.0
 pybase64~=1.0.0
 scikit-image>=0.19.0,<=0.25.2
 requests-toolbelt~=1.0.0


### PR DESCRIPTION
## What

Pins `supervision>=0.27.0,<0.30.0` in `requirements/_requirements.txt`.

## Why

`supervision 0.30.0` (released 2026-08-04) turns every PR's `build-dev-test` matrix red — 5 workflow unit-test failures, e.g. [this run](https://github.com/roboflow/inference/actions/runs/30996128876/job/92273538999) on a docs-only PR (#2708). Two behavior changes:

1. `sv.Detections.from_inference` no longer skips predictions with invalid (<3 point) polygons. The detections-alignment behavior encoded in `tests/workflows/unit_tests/core_steps/common/test_detections_mismatch.py` now sees 2 detections where 1 is expected (3 failures).
2. `Detections.data` now validates that array values' first dimension equals the number of detections. The semantic segmentation blocks store a full-size `confidence_mask` in `data`, which now raises `ValueError: First dimension of np.ndarray for key 'confidence_mask' must have size 1` (2 failures, production code path in `semantic_segmentation` v1/v2).

Point 2 is a real runtime break, not just stale test expectations, so pinning is the safe unblock. Follow-up should adapt the code to 0.30.0 and lift the pin.

## Verification

Failing jobs installed `supervision-0.30.0` (visible in the pip install log); the same suites passed everywhere before the 0.30.0 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)