### PR TITLE
Preserver coordinate-lineage after DatasetUpload block mask fix

### DIFF
--- a/inference/core/active_learning/core.py
+++ b/inference/core/active_learning/core.py
@@ -27,6 +27,7 @@ from inference.core.roboflow_api import (
     annotate_image_at_roboflow,
     register_image_at_roboflow,
 )
+from inference.core.utils.function import deprecated
 from inference.core.utils.image_utils import encode_image_to_jpeg_bytes
 from inference.core.utils.preprocess import downscale_image_keeping_aspect_ratio
 
@@ -34,10 +35,10 @@ from inference.core.utils.preprocess import downscale_image_keeping_aspect_ratio
 class PreparedRegistrationImage(NamedTuple):
     """JPEG bytes plus the exact size transform applied before upload.
 
-    Index 0/1 stay `(encoded_image, scaling_factor)` for backward compatibility.
-    `scaling_factor` is the height ratio (historical Active Learning contract).
-    Prefer `scale_x` / `scale_y` / `final_size_wh` so annotations match the
-    uploaded JPEG at any aspect ratio (int truncation can make axes differ).
+    `scaling_factor` remains the height ratio used by the historical Active
+    Learning contract. Prefer `scale_x` / `scale_y` / `final_size_wh` so
+    annotations match the uploaded JPEG at any aspect ratio (int truncation can
+    make axes differ).
     """
 
     encoded_image: bytes
@@ -80,12 +81,11 @@ def execute_datapoint_registration(
     inference_id: Optional[str] = None,
 ) -> None:
     local_image_id = str(uuid4())
-    prepared_image = prepare_image_to_registration(
+    prepared_image = prepare_image_to_registration_with_metadata(
         image=image,
         desired_size=configuration.max_image_size,
         jpeg_compression_level=configuration.jpeg_compression_level,
     )
-    encoded_image = prepared_image.encoded_image
     prediction = adjust_prediction_to_client_scaling_factor(
         prediction=prediction,
         scaling_factor=prepared_image.scaling_factor,
@@ -107,7 +107,7 @@ def execute_datapoint_registration(
     register_datapoint_at_roboflow(
         cache=cache,
         strategy_with_spare_credit=strategy_with_spare_credit,
-        encoded_image=encoded_image,
+        encoded_image=prepared_image.encoded_image,
         local_image_id=local_image_id,
         prediction=prediction,
         prediction_type=prediction_type,
@@ -118,7 +118,31 @@ def execute_datapoint_registration(
     )
 
 
+@deprecated(
+    reason=(
+        "Use prepare_image_to_registration_with_metadata, which reports the exact "
+        "output dimensions and axis-specific scaling factors."
+    )
+)
 def prepare_image_to_registration(
+    image: np.ndarray,
+    desired_size: Optional[ImageDimensions],
+    jpeg_compression_level: int,
+) -> Tuple[bytes, float]:
+    """Prepare an image using the legacy two-tuple return contract.
+
+    Deprecated: use :func:`prepare_image_to_registration_with_metadata` so
+    annotations can be scaled to the exact encoded-image dimensions.
+    """
+    result = prepare_image_to_registration_with_metadata(
+        image=image,
+        desired_size=desired_size,
+        jpeg_compression_level=jpeg_compression_level,
+    )
+    return result.encoded_image, result.scaling_factor
+
+
+def prepare_image_to_registration_with_metadata(
     image: np.ndarray,
     desired_size: Optional[ImageDimensions],
     jpeg_compression_level: int,

--- a/inference/core/active_learning/core.py
+++ b/inference/core/active_learning/core.py
@@ -22,6 +22,7 @@ from inference.core.active_learning.post_processing import (
 )
 from inference.core.cache.base import BaseCache
 from inference.core.env import ACTIVE_LEARNING_TAGS
+from inference.core.exceptions import InvalidNumpyInput
 from inference.core.roboflow_api import (
     annotate_image_at_roboflow,
     register_image_at_roboflow,
@@ -46,17 +47,11 @@ class PreparedRegistrationImage(NamedTuple):
 
     @property
     def scale_x(self) -> float:
-        original_width = self.original_size_wh[0]
-        if original_width <= 0:
-            return 1.0
-        return self.final_size_wh[0] / original_width
+        return self.final_size_wh[0] / self.original_size_wh[0]
 
     @property
     def scale_y(self) -> float:
-        original_height = self.original_size_wh[1]
-        if original_height <= 0:
-            return 1.0
-        return self.final_size_wh[1] / original_height
+        return self.final_size_wh[1] / self.original_size_wh[1]
 
 
 def execute_sampling(
@@ -129,6 +124,15 @@ def prepare_image_to_registration(
     jpeg_compression_level: int,
 ) -> PreparedRegistrationImage:
     original_size_wh = (int(image.shape[1]), int(image.shape[0]))
+    if original_size_wh[0] <= 0 or original_size_wh[1] <= 0:
+        width, height = original_size_wh
+        raise InvalidNumpyInput(
+            message=(
+                "Could not prepare image for registration because its dimensions "
+                f"are invalid: width={width}, height={height}."
+            ),
+            public_message="Image width and height must both be greater than zero.",
+        )
     if desired_size is not None:
         image = downscale_image_keeping_aspect_ratio(
             image=image,
@@ -136,9 +140,7 @@ def prepare_image_to_registration(
         )
     final_size_wh = (int(image.shape[1]), int(image.shape[0]))
     # Height ratio kept for Active Learning callers that still expect a single factor.
-    scaling_factor = (
-        1.0 if original_size_wh[1] <= 0 else final_size_wh[1] / original_size_wh[1]
-    )
+    scaling_factor = final_size_wh[1] / original_size_wh[1]
     return PreparedRegistrationImage(
         encoded_image=encode_image_to_jpeg_bytes(
             image=image, jpeg_quality=jpeg_compression_level

--- a/inference/core/workflows/core_steps/common/serializers.py
+++ b/inference/core/workflows/core_steps/common/serializers.py
@@ -1,3 +1,4 @@
+from copy import copy
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Union
 
@@ -399,7 +400,9 @@ def serialise_rle_sv_detections(detections: sv.Detections) -> dict:
             "This serializer requires RLE masks to be present."
         )
 
-    result = serialise_sv_detections(detections=detections)
+    detections_without_dense_masks = copy(detections)
+    detections_without_dense_masks.mask = None
+    result = serialise_sv_detections(detections=detections_without_dense_masks)
 
     for idx, detection_dict in enumerate(result["predictions"]):
         detection_dict.pop(POLYGON_KEY, None)

--- a/inference/core/workflows/core_steps/common/serializers.py
+++ b/inference/core/workflows/core_steps/common/serializers.py
@@ -400,6 +400,10 @@ def serialise_rle_sv_detections(detections: sv.Detections) -> dict:
             "This serializer requires RLE masks to be present."
         )
 
+    # The shared serializer converts dense masks to polygons and drops an
+    # instance when no contour exists. RLE can represent an empty mask, and the
+    # generated polygon would be removed below anyway, so bypass that conversion
+    # with a shallow copy. Only the copy's `mask` attribute is changed.
     detections_without_dense_masks = copy(detections)
     detections_without_dense_masks.mask = None
     result = serialise_sv_detections(detections=detections_without_dense_masks)

--- a/inference/core/workflows/core_steps/common/utils.py
+++ b/inference/core/workflows/core_steps/common/utils.py
@@ -465,41 +465,25 @@ def scale_sv_detections(
         image_dimensions[:, 1] *= scale_x
         detections_copy[IMAGE_DIMENSIONS_KEY] = image_dimensions.round()
 
-    # RLE predictions may keep masks compressed and leave `mask=None`. Prefer an
-    # existing dense representation, but derive the source canvas from RLE
-    # metadata so those lazy predictions can follow the same resize path.
-    rle_masks = detections_copy.data.get(RLE_MASK_KEY_IN_SV_DETECTIONS)
-    masks_to_resize = detections_copy.mask
-    preserve_dense_masks = masks_to_resize is not None
-    original_mask_size_wh = None
-    if masks_to_resize is not None:
-        original_mask_size_wh = (
-            masks_to_resize.shape[2],
-            masks_to_resize.shape[1],
-        )
-    elif rle_masks is not None:
-        # `rle_mask` entries may be None when only some predictions carried RLE
-        # (see convert_inference_detections_batch_to_sv_detections) - derive the
-        # source canvas from the first detection that actually has one.
-        first_rle_mask = next(
-            (rle_mask for rle_mask in rle_masks if rle_mask is not None), None
-        )
-        if first_rle_mask is not None:
-            original_mask_size_wh = (
-                int(first_rle_mask["size"][1]),
-                int(first_rle_mask["size"][0]),
-            )
-
-    if original_mask_size_wh is not None:
+    # RLE-only predictions (`mask=None` with the `rle_mask` data key) are
+    # intentionally passed through untouched, matching historical behaviour: no
+    # stock workflow routes them through a resize, and decoding full-resolution
+    # RLE just to resize it is expensive. Their RLE stays sized to the source
+    # canvas after scaling - callers needing scaled RLE must densify first.
+    if detections_copy.mask is not None:
         # Resize dense masks directly onto the destination canvas. Polygon →
         # scale → raster round-trips fragment edge-touching masks; combined with
         # mask_to_polygon that used to take contours[0], Dataset Upload persisted
         # speckles instead of the real instance.
+        original_mask_size_wh = (
+            detections_copy.mask.shape[2],
+            detections_copy.mask.shape[1],
+        )
         if target_size_wh is not None:
             scaled_w, scaled_h = int(target_size_wh[0]), int(target_size_wh[1])
         else:
-            scaled_w = max(1, int(round(original_mask_size_wh[0] * scale_x)))
-            scaled_h = max(1, int(round(original_mask_size_wh[1] * scale_y)))
+            scaled_w = int(round(original_mask_size_wh[0] * scale_x))
+            scaled_h = int(round(original_mask_size_wh[1] * scale_y))
         scaled_w = max(1, scaled_w)
         scaled_h = max(1, scaled_h)
         if (scaled_w, scaled_h) != original_mask_size_wh:
@@ -510,53 +494,23 @@ def scale_sv_detections(
                 # only reach it when RLE masks are actually involved.
                 from pycocotools import mask as mask_utils
 
-            if masks_to_resize is None:
-                # Decode only when a resize is actually required. The result is
-                # kept temporary so RLE-only predictions remain RLE-only. None
-                # entries carry no mask, so there is nothing to decode for them.
-                masks_to_resize = [
-                    (
-                        mask_utils.decode(
-                            {
-                                "size": rle_mask["size"],
-                                "counts": (
-                                    rle_mask["counts"].encode("utf-8")
-                                    if isinstance(rle_mask["counts"], str)
-                                    else rle_mask["counts"]
-                                ),
-                            }
-                        ).astype(bool)
-                        if rle_mask is not None
-                        else None
-                    )
-                    for rle_mask in rle_masks
-                ]
-
-            resized_masks = [
-                (
+            resized_masks = np.array(
+                [
                     cv2.resize(
                         detection_mask.astype(np.uint8),
                         (scaled_w, scaled_h),
                         interpolation=cv2.INTER_NEAREST,
                     ).astype(bool)
-                    if detection_mask is not None
-                    else None
-                )
-                for detection_mask in masks_to_resize
-            ]
-            if preserve_dense_masks:
-                # Dense input masks are never None, so the stack is rectangular.
-                detections_copy.mask = np.array(resized_masks)
+                    for detection_mask in detections_copy.mask
+                ]
+            )
+            detections_copy.mask = resized_masks
             if rle_masks_present:
                 # Source RLE counts encode the old canvas and cannot be scaled
                 # arithmetically. Re-encode every resized mask, including valid
-                # all-zero masks, to preserve detection-to-RLE alignment. None
-                # masks (detections that never had one) stay None.
+                # all-zero masks, to preserve detection-to-RLE alignment.
                 resized_rle_masks = []
                 for detection_mask in resized_masks:
-                    if detection_mask is None:
-                        resized_rle_masks.append(None)
-                        continue
                     rle_mask = mask_utils.encode(
                         np.asfortranarray(detection_mask.astype(np.uint8))
                     )

--- a/inference/core/workflows/core_steps/common/utils.py
+++ b/inference/core/workflows/core_steps/common/utils.py
@@ -477,11 +477,18 @@ def scale_sv_detections(
             masks_to_resize.shape[2],
             masks_to_resize.shape[1],
         )
-    elif rle_masks is not None and len(rle_masks) > 0:
-        original_mask_size_wh = (
-            int(rle_masks[0]["size"][1]),
-            int(rle_masks[0]["size"][0]),
+    elif rle_masks is not None:
+        # `rle_mask` entries may be None when only some predictions carried RLE
+        # (see convert_inference_detections_batch_to_sv_detections) - derive the
+        # source canvas from the first detection that actually has one.
+        first_rle_mask = next(
+            (rle_mask for rle_mask in rle_masks if rle_mask is not None), None
         )
+        if first_rle_mask is not None:
+            original_mask_size_wh = (
+                int(first_rle_mask["size"][1]),
+                int(first_rle_mask["size"][0]),
+            )
 
     if original_mask_size_wh is not None:
         # Resize dense masks directly onto the destination canvas. Polygon →
@@ -496,13 +503,19 @@ def scale_sv_detections(
         scaled_w = max(1, scaled_w)
         scaled_h = max(1, scaled_h)
         if (scaled_w, scaled_h) != original_mask_size_wh:
-            if masks_to_resize is None:
+            rle_masks_present = RLE_MASK_KEY_IN_SV_DETECTIONS in detections_copy.data
+            if rle_masks_present:
+                # pycocotools is not a base dependency - it ships with the extras
+                # that produce RLE predictions - so keep the import deferred and
+                # only reach it when RLE masks are actually involved.
                 from pycocotools import mask as mask_utils
 
+            if masks_to_resize is None:
                 # Decode only when a resize is actually required. The result is
-                # kept temporary so RLE-only predictions remain RLE-only.
-                masks_to_resize = np.array(
-                    [
+                # kept temporary so RLE-only predictions remain RLE-only. None
+                # entries carry no mask, so there is nothing to decode for them.
+                masks_to_resize = [
+                    (
                         mask_utils.decode(
                             {
                                 "size": rle_mask["size"],
@@ -513,30 +526,37 @@ def scale_sv_detections(
                                 ),
                             }
                         ).astype(bool)
-                        for rle_mask in rle_masks
-                    ]
-                )
+                        if rle_mask is not None
+                        else None
+                    )
+                    for rle_mask in rle_masks
+                ]
 
-            resized_masks = np.array(
-                [
+            resized_masks = [
+                (
                     cv2.resize(
                         detection_mask.astype(np.uint8),
                         (scaled_w, scaled_h),
                         interpolation=cv2.INTER_NEAREST,
                     ).astype(bool)
-                    for detection_mask in masks_to_resize
-                ]
-            )
+                    if detection_mask is not None
+                    else None
+                )
+                for detection_mask in masks_to_resize
+            ]
             if preserve_dense_masks:
-                detections_copy.mask = resized_masks
-            if RLE_MASK_KEY_IN_SV_DETECTIONS in detections_copy.data:
-                from pycocotools import mask as mask_utils
-
+                # Dense input masks are never None, so the stack is rectangular.
+                detections_copy.mask = np.array(resized_masks)
+            if rle_masks_present:
                 # Source RLE counts encode the old canvas and cannot be scaled
                 # arithmetically. Re-encode every resized mask, including valid
-                # all-zero masks, to preserve detection-to-RLE alignment.
+                # all-zero masks, to preserve detection-to-RLE alignment. None
+                # masks (detections that never had one) stay None.
                 resized_rle_masks = []
                 for detection_mask in resized_masks:
+                    if detection_mask is None:
+                        resized_rle_masks.append(None)
+                        continue
                     rle_mask = mask_utils.encode(
                         np.asfortranarray(detection_mask.astype(np.uint8))
                     )

--- a/inference/core/workflows/core_steps/common/utils.py
+++ b/inference/core/workflows/core_steps/common/utils.py
@@ -492,11 +492,20 @@ def scale_sv_detections(
                     for detection_mask in detections_copy.mask
                 ]
             )
-            # RLE from the source frame no longer matches the resized masks.
-            # Only drop it when a resize actually happened - no-op scales must
-            # keep it, because the RLE-kind serializer requires `rle_mask`.
             if RLE_MASK_KEY_IN_SV_DETECTIONS in detections_copy.data:
-                del detections_copy.data[RLE_MASK_KEY_IN_SV_DETECTIONS]
+                from pycocotools import mask as mask_utils
+
+                resized_rle_masks = []
+                for detection_mask in detections_copy.mask:
+                    rle_mask = mask_utils.encode(
+                        np.asfortranarray(detection_mask.astype(np.uint8))
+                    )
+                    if isinstance(rle_mask["counts"], bytes):
+                        rle_mask["counts"] = rle_mask["counts"].decode("utf-8")
+                    resized_rle_masks.append(rle_mask)
+                detections_copy.data[RLE_MASK_KEY_IN_SV_DETECTIONS] = np.array(
+                    resized_rle_masks, dtype=object
+                )
 
     if POLYGON_KEY_IN_SV_DETECTIONS in detections_copy.data:
         polygons = detections_copy.data[POLYGON_KEY_IN_SV_DETECTIONS]

--- a/inference/core/workflows/core_steps/common/utils.py
+++ b/inference/core/workflows/core_steps/common/utils.py
@@ -465,15 +465,26 @@ def scale_sv_detections(
         image_dimensions[:, 1] *= scale_x
         detections_copy[IMAGE_DIMENSIONS_KEY] = image_dimensions.round()
 
-    if detections_copy.mask is not None:
+    rle_masks = detections_copy.data.get(RLE_MASK_KEY_IN_SV_DETECTIONS)
+    masks_to_resize = detections_copy.mask
+    preserve_dense_masks = masks_to_resize is not None
+    original_mask_size_wh = None
+    if masks_to_resize is not None:
+        original_mask_size_wh = (
+            masks_to_resize.shape[2],
+            masks_to_resize.shape[1],
+        )
+    elif rle_masks is not None and len(rle_masks) > 0:
+        original_mask_size_wh = (
+            int(rle_masks[0]["size"][1]),
+            int(rle_masks[0]["size"][0]),
+        )
+
+    if original_mask_size_wh is not None:
         # Resize dense masks directly onto the destination canvas. Polygon →
         # scale → raster round-trips fragment edge-touching masks; combined with
         # mask_to_polygon that used to take contours[0], Dataset Upload persisted
         # speckles instead of the real instance.
-        original_mask_size_wh = (
-            detections_copy.mask.shape[2],
-            detections_copy.mask.shape[1],
-        )
         if target_size_wh is not None:
             scaled_w, scaled_h = int(target_size_wh[0]), int(target_size_wh[1])
         else:
@@ -482,21 +493,42 @@ def scale_sv_detections(
         scaled_w = max(1, scaled_w)
         scaled_h = max(1, scaled_h)
         if (scaled_w, scaled_h) != original_mask_size_wh:
-            detections_copy.mask = np.array(
+            if masks_to_resize is None:
+                from pycocotools import mask as mask_utils
+
+                masks_to_resize = np.array(
+                    [
+                        mask_utils.decode(
+                            {
+                                "size": rle_mask["size"],
+                                "counts": (
+                                    rle_mask["counts"].encode("utf-8")
+                                    if isinstance(rle_mask["counts"], str)
+                                    else rle_mask["counts"]
+                                ),
+                            }
+                        ).astype(bool)
+                        for rle_mask in rle_masks
+                    ]
+                )
+
+            resized_masks = np.array(
                 [
                     cv2.resize(
                         detection_mask.astype(np.uint8),
                         (scaled_w, scaled_h),
                         interpolation=cv2.INTER_NEAREST,
                     ).astype(bool)
-                    for detection_mask in detections_copy.mask
+                    for detection_mask in masks_to_resize
                 ]
             )
+            if preserve_dense_masks:
+                detections_copy.mask = resized_masks
             if RLE_MASK_KEY_IN_SV_DETECTIONS in detections_copy.data:
                 from pycocotools import mask as mask_utils
 
                 resized_rle_masks = []
-                for detection_mask in detections_copy.mask:
+                for detection_mask in resized_masks:
                     rle_mask = mask_utils.encode(
                         np.asfortranarray(detection_mask.astype(np.uint8))
                     )
@@ -506,6 +538,11 @@ def scale_sv_detections(
                 detections_copy.data[RLE_MASK_KEY_IN_SV_DETECTIONS] = np.array(
                     resized_rle_masks, dtype=object
                 )
+                non_empty_masks = resized_masks.reshape(len(resized_masks), -1).any(
+                    axis=1
+                )
+                if not np.all(non_empty_masks):
+                    detections_copy = detections_copy[non_empty_masks]
 
     if POLYGON_KEY_IN_SV_DETECTIONS in detections_copy.data:
         polygons = detections_copy.data[POLYGON_KEY_IN_SV_DETECTIONS]

--- a/inference/core/workflows/core_steps/common/utils.py
+++ b/inference/core/workflows/core_steps/common/utils.py
@@ -402,6 +402,7 @@ def scale_sv_detections(
     scale: Union[float, Tuple[float, float]],
     keypoints_key: str = KEYPOINTS_XY_KEY_IN_SV_DETECTIONS,
     target_size_wh: Optional[Tuple[int, int]] = None,
+    update_scaling_metadata: bool = True,
 ) -> sv.Detections:
     """Scale detection geometry into a new image coordinate frame.
 
@@ -414,6 +415,10 @@ def scale_sv_detections(
             image (e.g. the JPEG that will be uploaded). When set, dense masks
             and ``image_dimensions`` are forced to this canvas so annotations
             stay intact relative to the stored image.
+        update_scaling_metadata: Whether to update the scalar workflow coordinate
+            lineage metadata. Set to ``False`` for terminal consumers, such as
+            Dataset Upload, when using different X/Y scales. An anisotropic
+            transform cannot be represented by the existing scalar metadata.
     """
     detections_copy = deepcopy(detections)
     if len(detections_copy) == 0:
@@ -424,10 +429,13 @@ def scale_sv_detections(
     else:
         scale_x = scale_y = float(scale)
 
-    # Metadata fields historically store a single factor; use X when isotropic,
-    # otherwise the mean (dataset-upload consumers serialize immediately and do
-    # not rely on undoing this via root-coordinate recovery).
-    scale_meta = scale_x if abs(scale_x - scale_y) < 1e-9 else (scale_x + scale_y) / 2.0
+    scales_are_isotropic = abs(scale_x - scale_y) < 1e-9
+    if update_scaling_metadata and not scales_are_isotropic:
+        raise ValueError(
+            "Anisotropic scaling cannot be represented by scalar workflow "
+            "coordinate metadata. Set update_scaling_metadata=False for a "
+            "terminal result that will not undergo root-coordinate recovery."
+        )
 
     xyxy = detections_copy.xyxy.astype(np.float64, copy=True)
     xyxy[:, [0, 2]] *= scale_x
@@ -513,22 +521,23 @@ def scale_sv_detections(
                 scaled_polygons, dtype=object
             )
 
-    if SCALING_RELATIVE_TO_PARENT_KEY in detections_copy.data:
-        detections_copy[SCALING_RELATIVE_TO_PARENT_KEY] = (
-            detections_copy[SCALING_RELATIVE_TO_PARENT_KEY] * scale_meta
-        )
-    else:
-        detections_copy[SCALING_RELATIVE_TO_PARENT_KEY] = np.array(
-            [scale_meta] * len(detections_copy)
-        )
-    if SCALING_RELATIVE_TO_ROOT_PARENT_KEY in detections_copy.data:
-        detections_copy[SCALING_RELATIVE_TO_ROOT_PARENT_KEY] = (
-            detections_copy[SCALING_RELATIVE_TO_ROOT_PARENT_KEY] * scale_meta
-        )
-    else:
-        detections_copy[SCALING_RELATIVE_TO_ROOT_PARENT_KEY] = np.array(
-            [scale_meta] * len(detections_copy)
-        )
+    if update_scaling_metadata:
+        if SCALING_RELATIVE_TO_PARENT_KEY in detections_copy.data:
+            detections_copy[SCALING_RELATIVE_TO_PARENT_KEY] = (
+                detections_copy[SCALING_RELATIVE_TO_PARENT_KEY] * scale_x
+            )
+        else:
+            detections_copy[SCALING_RELATIVE_TO_PARENT_KEY] = np.array(
+                [scale_x] * len(detections_copy)
+            )
+        if SCALING_RELATIVE_TO_ROOT_PARENT_KEY in detections_copy.data:
+            detections_copy[SCALING_RELATIVE_TO_ROOT_PARENT_KEY] = (
+                detections_copy[SCALING_RELATIVE_TO_ROOT_PARENT_KEY] * scale_x
+            )
+        else:
+            detections_copy[SCALING_RELATIVE_TO_ROOT_PARENT_KEY] = np.array(
+                [scale_x] * len(detections_copy)
+            )
     return detections_copy
 
 

--- a/inference/core/workflows/core_steps/common/utils.py
+++ b/inference/core/workflows/core_steps/common/utils.py
@@ -465,6 +465,9 @@ def scale_sv_detections(
         image_dimensions[:, 1] *= scale_x
         detections_copy[IMAGE_DIMENSIONS_KEY] = image_dimensions.round()
 
+    # RLE predictions may keep masks compressed and leave `mask=None`. Prefer an
+    # existing dense representation, but derive the source canvas from RLE
+    # metadata so those lazy predictions can follow the same resize path.
     rle_masks = detections_copy.data.get(RLE_MASK_KEY_IN_SV_DETECTIONS)
     masks_to_resize = detections_copy.mask
     preserve_dense_masks = masks_to_resize is not None
@@ -496,6 +499,8 @@ def scale_sv_detections(
             if masks_to_resize is None:
                 from pycocotools import mask as mask_utils
 
+                # Decode only when a resize is actually required. The result is
+                # kept temporary so RLE-only predictions remain RLE-only.
                 masks_to_resize = np.array(
                     [
                         mask_utils.decode(
@@ -527,6 +532,9 @@ def scale_sv_detections(
             if RLE_MASK_KEY_IN_SV_DETECTIONS in detections_copy.data:
                 from pycocotools import mask as mask_utils
 
+                # Source RLE counts encode the old canvas and cannot be scaled
+                # arithmetically. Re-encode every resized mask, including valid
+                # all-zero masks, to preserve detection-to-RLE alignment.
                 resized_rle_masks = []
                 for detection_mask in resized_masks:
                     rle_mask = mask_utils.encode(

--- a/inference/core/workflows/core_steps/common/utils.py
+++ b/inference/core/workflows/core_steps/common/utils.py
@@ -538,11 +538,6 @@ def scale_sv_detections(
                 detections_copy.data[RLE_MASK_KEY_IN_SV_DETECTIONS] = np.array(
                     resized_rle_masks, dtype=object
                 )
-                non_empty_masks = resized_masks.reshape(len(resized_masks), -1).any(
-                    axis=1
-                )
-                if not np.all(non_empty_masks):
-                    detections_copy = detections_copy[non_empty_masks]
 
     if POLYGON_KEY_IN_SV_DETECTIONS in detections_copy.data:
         polygons = detections_copy.data[POLYGON_KEY_IN_SV_DETECTIONS]

--- a/inference/core/workflows/core_steps/sinks/roboflow/dataset_upload/v1.py
+++ b/inference/core/workflows/core_steps/sinks/roboflow/dataset_upload/v1.py
@@ -497,6 +497,7 @@ def execute_registration(
                 detections=prediction,
                 scale=(prepared_image.scale_x, prepared_image.scale_y),
                 target_size_wh=prepared_image.final_size_wh,
+                update_scaling_metadata=False,
             )
         status = register_datapoint(
             target_project=target_project,

--- a/inference/core/workflows/core_steps/sinks/roboflow/dataset_upload/v1.py
+++ b/inference/core/workflows/core_steps/sinks/roboflow/dataset_upload/v1.py
@@ -33,7 +33,9 @@ from inference.core.active_learning.cache_operations import (
     return_strategy_credit,
     use_credit_of_matching_strategy,
 )
-from inference.core.active_learning.core import prepare_image_to_registration
+from inference.core.active_learning.core import (
+    prepare_image_to_registration_with_metadata,
+)
 from inference.core.active_learning.entities import (
     ImageDimensions,
     StrategyLimit,
@@ -478,7 +480,7 @@ def execute_registration(
         # Scale annotations to the exact JPEG canvas that will be stored. Aspect-
         # preserving resize can produce different X/Y factors after int truncation;
         # a single height scale leaves edge detections off-canvas and clipped.
-        prepared_image = prepare_image_to_registration(
+        prepared_image = prepare_image_to_registration_with_metadata(
             image=image.numpy_image,
             desired_size=ImageDimensions(
                 width=max_image_size[0], height=max_image_size[1]

--- a/tests/inference/unit_tests/core/active_learning/test_core.py
+++ b/tests/inference/unit_tests/core/active_learning/test_core.py
@@ -25,7 +25,7 @@ from inference.core.active_learning.entities import (
     StrategyLimit,
     StrategyLimitType,
 )
-from inference.core.exceptions import RoboflowAPIConnectionError
+from inference.core.exceptions import InvalidNumpyInput, RoboflowAPIConnectionError
 
 
 def test_execute_sampling() -> None:
@@ -115,6 +115,29 @@ def test_prepare_image_to_registration_reports_anisotropic_scales() -> None:
     assert abs(result.scale_x - result.scale_y) > 1e-4
     # Historical single factor remains the height ratio for Active Learning BC
     assert abs(result.scaling_factor - result.scale_y) < 1e-9
+
+
+@pytest.mark.parametrize(
+    "image",
+    [
+        np.zeros((0, 10, 3), dtype=np.uint8),
+        np.zeros((10, 0, 3), dtype=np.uint8),
+    ],
+)
+def test_prepare_image_to_registration_rejects_empty_image_dimensions(
+    image: np.ndarray,
+) -> None:
+    with pytest.raises(InvalidNumpyInput) as error:
+        prepare_image_to_registration(
+            image=image,
+            desired_size=None,
+            jpeg_compression_level=95,
+        )
+
+    assert (
+        error.value.get_public_error_details()
+        == "Image width and height must both be greater than zero."
+    )
 
 
 @mock.patch.object(core, "ACTIVE_LEARNING_TAGS", None)

--- a/tests/inference/unit_tests/core/active_learning/test_core.py
+++ b/tests/inference/unit_tests/core/active_learning/test_core.py
@@ -14,6 +14,7 @@ from inference.core.active_learning.core import (
     execute_sampling,
     is_prediction_registration_forbidden,
     prepare_image_to_registration,
+    prepare_image_to_registration_with_metadata,
     register_datapoint_at_roboflow,
     safe_register_image_at_roboflow,
 )
@@ -26,6 +27,7 @@ from inference.core.active_learning.entities import (
     StrategyLimitType,
 )
 from inference.core.exceptions import InvalidNumpyInput, RoboflowAPIConnectionError
+from inference.core.warnings import InferenceDeprecationWarning
 
 
 def test_execute_sampling() -> None:
@@ -62,16 +64,34 @@ def test_prepare_image_to_registration_when_desired_size_is_not_given(
     image_as_numpy: np.ndarray,
 ) -> None:
     # when
-    result = prepare_image_to_registration(
-        image=image_as_numpy, desired_size=None, jpeg_compression_level=95
-    )
-    bytes_array = np.frombuffer(result.encoded_image, dtype=np.uint8)
+    with pytest.warns(
+        InferenceDeprecationWarning,
+        match="Use prepare_image_to_registration_with_metadata",
+    ):
+        result = prepare_image_to_registration(
+            image=image_as_numpy, desired_size=None, jpeg_compression_level=95
+        )
+    encoded_image, scaling_factor = result
+    bytes_array = np.frombuffer(encoded_image, dtype=np.uint8)
     decoded_result = cv2.imdecode(bytes_array, flags=cv2.IMREAD_UNCHANGED)
 
     # then
+    assert type(result) is tuple
+    assert len(result) == 2
     assert decoded_result.shape == image_as_numpy.shape
     assert np.allclose(decoded_result, image_as_numpy)
-    assert abs(result.scaling_factor - 1.0) < 1e-5
+    assert abs(scaling_factor - 1.0) < 1e-5
+
+
+def test_prepare_image_to_registration_with_metadata_when_desired_size_is_not_given(
+    image_as_numpy: np.ndarray,
+) -> None:
+    result = prepare_image_to_registration_with_metadata(
+        image=image_as_numpy,
+        desired_size=None,
+        jpeg_compression_level=95,
+    )
+
     assert result.original_size_wh == (
         image_as_numpy.shape[1],
         image_as_numpy.shape[0],
@@ -85,7 +105,7 @@ def test_prepare_image_to_registration_when_desired_size_given(
     image_as_numpy: np.ndarray,
 ) -> None:
     # when
-    result = prepare_image_to_registration(
+    result = prepare_image_to_registration_with_metadata(
         image=image_as_numpy,
         desired_size=ImageDimensions(height=32, width=16),
         jpeg_compression_level=95,
@@ -103,7 +123,7 @@ def test_prepare_image_to_registration_when_desired_size_given(
 def test_prepare_image_to_registration_reports_anisotropic_scales() -> None:
     # Ultra-wide source: width-limited resize + int truncation ⇒ scale_x != scale_y
     image = np.zeros((1080, 4000, 3), dtype=np.uint8)
-    result = prepare_image_to_registration(
+    result = prepare_image_to_registration_with_metadata(
         image=image,
         desired_size=ImageDimensions(height=2080, width=2080),
         jpeg_compression_level=95,
@@ -128,7 +148,7 @@ def test_prepare_image_to_registration_rejects_empty_image_dimensions(
     image: np.ndarray,
 ) -> None:
     with pytest.raises(InvalidNumpyInput) as error:
-        prepare_image_to_registration(
+        prepare_image_to_registration_with_metadata(
             image=image,
             desired_size=None,
             jpeg_compression_level=95,

--- a/tests/inference/unit_tests/core/interfaces/camera/test_rtsp_opencv_tls.py
+++ b/tests/inference/unit_tests/core/interfaces/camera/test_rtsp_opencv_tls.py
@@ -127,48 +127,31 @@ def test_opencv_rtsps_tls_env_restores_previous(
 
 
 def test_opencv_rtsps_tls_env_serializes_concurrent_opens() -> None:
-    """Concurrent opens must not overlap inside the env context.
-
-    The previous Barrier-based version deadlocked: both workers waited on the
-    barrier while holding ``_opencv_rtsps_tls_lock``, so the second thread never
-    reached the barrier. That hung CI unit tests at this module until the job
-    timeout killed the runner.
-    """
+    # The context manager holds its lock across the yield (set -> open ->
+    # restore), so no cross-thread rendezvous may happen INSIDE the `with`
+    # block - a barrier there deadlocks. Serialization is asserted instead by
+    # checking the two workers were never inside the context simultaneously.
     os.environ.pop(OPENCV_FFMPEG_CAPTURE_OPTIONS_ENV_VAR, None)
-    previous_flags = os.environ.pop(RTSP_TLS_VALIDATION_FLAGS_ENV_VAR, None)
-    counter_lock = threading.Lock()
-    inside_count = 0
-    max_inside = 0
-    entries = 0
+    observed: list[str] = []
+    inside: list[str] = []
+    overlaps: list[int] = []
 
     def worker(video: str) -> None:
-        nonlocal inside_count, max_inside, entries
         with opencv_rtsps_tls_env(video):
-            with counter_lock:
-                inside_count += 1
-                max_inside = max(max_inside, inside_count)
-                entries += 1
-            # Hold long enough that a non-serialized second enter would
-            # overlap and bump max_inside above 1.
+            inside.append(video)
+            overlaps.append(len(inside))
+            observed.append(os.environ[OPENCV_FFMPEG_CAPTURE_OPTIONS_ENV_VAR])
             time.sleep(0.05)
-            with counter_lock:
-                inside_count -= 1
+            inside.remove(video)
 
-    try:
-        first = threading.Thread(target=worker, args=("rtsps://cam-a/stream",))
-        second = threading.Thread(target=worker, args=("rtsps://cam-b/stream",))
-        first.start()
-        second.start()
-        first.join(timeout=5)
-        second.join(timeout=5)
+    first = threading.Thread(target=worker, args=("rtsps://first/stream",))
+    second = threading.Thread(target=worker, args=("rtsps://second/stream",))
+    first.start()
+    second.start()
+    first.join()
+    second.join()
 
-        assert not first.is_alive(), "worker deadlocked inside opencv_rtsps_tls_env"
-        assert not second.is_alive(), "worker deadlocked inside opencv_rtsps_tls_env"
-        assert entries == 2
-        assert max_inside == 1, "opencv_rtsps_tls_env must serialize concurrent holders"
-        assert OPENCV_FFMPEG_CAPTURE_OPTIONS_ENV_VAR not in os.environ
-    finally:
-        if previous_flags is None:
-            os.environ.pop(RTSP_TLS_VALIDATION_FLAGS_ENV_VAR, None)
-        else:
-            os.environ[RTSP_TLS_VALIDATION_FLAGS_ENV_VAR] = previous_flags
+    assert max(overlaps) == 1, "opens must be serialized, never concurrent"
+    assert len(observed) == 2
+    assert all("rtsp_transport;tcp" in value for value in observed)
+    assert OPENCV_FFMPEG_CAPTURE_OPTIONS_ENV_VAR not in os.environ

--- a/tests/workflows/unit_tests/core_steps/common/test_serializers.py
+++ b/tests/workflows/unit_tests/core_steps/common/test_serializers.py
@@ -1172,6 +1172,48 @@ def test_serialise_rle_sv_detections() -> None:
     }
 
 
+def test_serialise_rle_sv_detections_preserves_detection_with_empty_dense_mask() -> (
+    None
+):
+    # given
+    masks = np.zeros((2, 4, 4), dtype=bool)
+    masks[1, 0:2, 0:2] = True
+    detections = sv.Detections(
+        xyxy=np.array([[1, 1, 2, 2], [0, 0, 2, 2]], dtype=np.float64),
+        mask=masks,
+        class_id=np.array([1, 2]),
+        confidence=np.array([0.1, 0.9], dtype=np.float64),
+        data={
+            "class_name": np.array(["empty", "body"]),
+            "detection_id": np.array(["empty-id", "body-id"]),
+            "image_dimensions": np.array([[4, 4], [4, 4]]),
+            "rle_mask": np.array(
+                [
+                    {"size": [4, 4], "counts": "a"},
+                    {"size": [4, 4], "counts": "b"},
+                ],
+                dtype=object,
+            ),
+        },
+    )
+
+    # when
+    result = serialise_rle_sv_detections(detections=detections)
+
+    # then
+    assert [prediction["detection_id"] for prediction in result["predictions"]] == [
+        "empty-id",
+        "body-id",
+    ]
+    assert [
+        prediction["rle_mask"]["counts"] for prediction in result["predictions"]
+    ] == [
+        "a",
+        "b",
+    ]
+    assert np.array_equal(detections.mask, masks)
+
+
 def test_serialise_rle_sv_detections_with_bytes_counts() -> None:
     # given - RLE mask with bytes counts (as returned by pycocotools)
     rle_mask = {"size": [192, 168], "counts": b"abc123"}

--- a/tests/workflows/unit_tests/core_steps/common/test_serializers.py
+++ b/tests/workflows/unit_tests/core_steps/common/test_serializers.py
@@ -549,6 +549,23 @@ def test_mask_to_polygon_when_mask_contains_multiple_shapes() -> None:
     assert (ys.max() - ys.min()) >= 30
 
 
+def test_mask_to_polygon_when_mask_contains_hole() -> None:
+    # given
+    mask = np.zeros((128, 128), dtype=np.uint8)
+    mask[10:110, 20:100] = 255
+    mask[20:100, 30:90] = 0
+
+    # when
+    result = mask_to_polygon(mask=mask)
+
+    # then — RETR_TREE returns both contours; the exterior must be selected
+    xs, ys = result[:, 0], result[:, 1]
+    assert xs.min() == 20
+    assert xs.max() == 99
+    assert ys.min() == 10
+    assert ys.max() == 109
+
+
 def test_serialise_image_with_parent_origin_when_crop() -> None:
     # given
     np_image = np.zeros((100, 100, 3), dtype=np.uint8)

--- a/tests/workflows/unit_tests/core_steps/common/test_utils.py
+++ b/tests/workflows/unit_tests/core_steps/common/test_utils.py
@@ -1413,48 +1413,11 @@ def test_scale_sv_detections_regenerates_rle_when_scale_changes_mask() -> None:
     assert np.array_equal(decoded_mask, result.mask[0])
 
 
-def test_scale_sv_detections_resizes_rle_only_masks() -> None:
-    # given
-    mask = np.zeros((100, 100), dtype=np.uint8)
-    mask[20:40, 20:40] = 1
-    rle_mask = mask_utils.encode(np.asfortranarray(mask))
-    detections = sv.Detections(
-        xyxy=np.array([[20, 20, 40, 40]], dtype=np.float64),
-        confidence=np.array([0.9]),
-        class_id=np.array([0]),
-        data={
-            "class_name": np.array(["obj"]),
-            "detection_id": np.array(["d1"]),
-            "image_dimensions": np.array([[100, 100]]),
-            "rle_mask": np.array([rle_mask], dtype=object),
-        },
-    )
-
-    # when
-    result = scale_sv_detections(detections=detections, scale=0.5)
-
-    # then
-    assert result.mask is None
-    resized_rle = result.data["rle_mask"][0]
-    assert resized_rle["size"] == [50, 50]
-    decoded_mask = mask_utils.decode(
-        {
-            "size": resized_rle["size"],
-            "counts": resized_rle["counts"].encode("utf-8"),
-        }
-    ).astype(bool)
-    expected_mask = cv2.resize(
-        mask,
-        (50, 50),
-        interpolation=cv2.INTER_NEAREST,
-    ).astype(bool)
-    assert np.array_equal(decoded_mask, expected_mask)
-
-
-def test_scale_sv_detections_tolerates_none_entries_in_rle_only_masks() -> None:
-    # convert_inference_detections_batch_to_sv_detections stores the `rle_mask`
-    # key when ANY prediction carries RLE, leaving None for those that do not -
-    # scaling must not crash on, nor fabricate masks for, the None entries
+def test_scale_sv_detections_passes_rle_only_masks_through_untouched() -> None:
+    # RLE-only predictions (mask=None) are intentionally not resized to avoid
+    # a decode/resize/re-encode cost on a path no stock workflow exercises -
+    # boxes scale, but the RLE stays sized to the source canvas. None entries
+    # (see convert_inference_detections_batch_to_sv_detections) must not crash.
     # given
     mask = np.zeros((100, 100), dtype=np.uint8)
     mask[20:40, 20:40] = 1
@@ -1476,21 +1439,10 @@ def test_scale_sv_detections_tolerates_none_entries_in_rle_only_masks() -> None:
 
     # then
     assert result.mask is None
+    assert np.allclose(result.xyxy, np.array([[10, 10, 20, 20], [25, 25, 35, 35]]))
     assert result.data["rle_mask"][0] is None, "None RLE entry must stay None"
-    resized_rle = result.data["rle_mask"][1]
-    assert resized_rle["size"] == [50, 50]
-    decoded_mask = mask_utils.decode(
-        {
-            "size": resized_rle["size"],
-            "counts": resized_rle["counts"].encode("utf-8"),
-        }
-    ).astype(bool)
-    expected_mask = cv2.resize(
-        mask,
-        (50, 50),
-        interpolation=cv2.INTER_NEAREST,
-    ).astype(bool)
-    assert np.array_equal(decoded_mask, expected_mask)
+    # scale_sv_detections deep-copies its input, so compare by value
+    assert result.data["rle_mask"][1] == rle_mask, "RLE must be left untouched"
 
 
 def test_scale_sv_detections_preserves_empty_masks_and_matching_rles() -> None:

--- a/tests/workflows/unit_tests/core_steps/common/test_utils.py
+++ b/tests/workflows/unit_tests/core_steps/common/test_utils.py
@@ -6,6 +6,9 @@ import pytest
 import supervision as sv
 from pycocotools import mask as mask_utils
 
+from inference.core.workflows.core_steps.common.serializers import (
+    serialise_rle_sv_detections,
+)
 from inference.core.workflows.core_steps.common.utils import (
     add_inference_keypoints_to_sv_detections,
     attach_parents_coordinates_to_sv_detections,
@@ -1305,9 +1308,7 @@ def test_scale_sv_detections_anisotropic_matches_exact_target_canvas() -> None:
     # Full-height strip flush to the right edge
     mask[:, orig_w - 200 : orig_w] = True
     detections = sv.Detections(
-        xyxy=np.array(
-            [[orig_w - 200, 0, orig_w - 1, orig_h - 1]], dtype=np.float64
-        ),
+        xyxy=np.array([[orig_w - 200, 0, orig_w - 1, orig_h - 1]], dtype=np.float64),
         mask=np.array([mask]),
         confidence=np.array([0.9]),
         class_id=np.array([0]),
@@ -1339,9 +1340,7 @@ def test_scale_sv_detections_anisotropic_matches_exact_target_canvas() -> None:
     )
 
     assert result.mask.shape == (1, target_h, target_w)
-    assert np.allclose(
-        result["image_dimensions"], np.array([[target_h, target_w]])
-    )
+    assert np.allclose(result["image_dimensions"], np.array([[target_h, target_w]]))
     x1, y1, x2, y2 = result.xyxy[0]
     assert x2 <= target_w
     assert y2 <= target_h
@@ -1354,9 +1353,7 @@ def test_scale_sv_detections_anisotropic_matches_exact_target_canvas() -> None:
     polygon = result.data[POLYGON_KEY_IN_SV_DETECTIONS][0]
     assert polygon[:, 0].max() >= target_w - 2
     assert np.array_equal(result[SCALING_RELATIVE_TO_PARENT_KEY], np.array([0.5]))
-    assert np.array_equal(
-        result[SCALING_RELATIVE_TO_ROOT_PARENT_KEY], np.array([0.25])
-    )
+    assert np.array_equal(result[SCALING_RELATIVE_TO_ROOT_PARENT_KEY], np.array([0.25]))
 
 
 def test_scale_sv_detections_rejects_anisotropic_scalar_metadata() -> None:
@@ -1414,6 +1411,85 @@ def test_scale_sv_detections_regenerates_rle_when_scale_changes_mask() -> None:
         }
     ).astype(bool)
     assert np.array_equal(decoded_mask, result.mask[0])
+
+
+def test_scale_sv_detections_resizes_rle_only_masks() -> None:
+    # given
+    mask = np.zeros((100, 100), dtype=np.uint8)
+    mask[20:40, 20:40] = 1
+    rle_mask = mask_utils.encode(np.asfortranarray(mask))
+    detections = sv.Detections(
+        xyxy=np.array([[20, 20, 40, 40]], dtype=np.float64),
+        confidence=np.array([0.9]),
+        class_id=np.array([0]),
+        data={
+            "class_name": np.array(["obj"]),
+            "detection_id": np.array(["d1"]),
+            "image_dimensions": np.array([[100, 100]]),
+            "rle_mask": np.array([rle_mask], dtype=object),
+        },
+    )
+
+    # when
+    result = scale_sv_detections(detections=detections, scale=0.5)
+
+    # then
+    assert result.mask is None
+    resized_rle = result.data["rle_mask"][0]
+    assert resized_rle["size"] == [50, 50]
+    decoded_mask = mask_utils.decode(
+        {
+            "size": resized_rle["size"],
+            "counts": resized_rle["counts"].encode("utf-8"),
+        }
+    ).astype(bool)
+    expected_mask = cv2.resize(
+        mask,
+        (50, 50),
+        interpolation=cv2.INTER_NEAREST,
+    ).astype(bool)
+    assert np.array_equal(decoded_mask, expected_mask)
+
+
+def test_scale_sv_detections_filters_empty_masks_and_matching_rles() -> None:
+    # given
+    masks = np.zeros((2, 4, 4), dtype=np.uint8)
+    masks[0, 3, 3] = 1
+    masks[1, 0:3, 0:3] = 1
+    rle_masks = np.array(
+        [mask_utils.encode(np.asfortranarray(mask)) for mask in masks],
+        dtype=object,
+    )
+    detections = sv.Detections(
+        xyxy=np.array([[3, 3, 4, 4], [0, 0, 3, 3]], dtype=np.float64),
+        mask=masks.astype(bool),
+        confidence=np.array([0.5, 0.9]),
+        class_id=np.array([0, 1]),
+        data={
+            "class_name": np.array(["thin", "body"]),
+            "detection_id": np.array(["thin-id", "body-id"]),
+            "image_dimensions": np.array([[4, 4], [4, 4]]),
+            "rle_mask": rle_masks,
+        },
+    )
+
+    # when
+    result = scale_sv_detections(detections=detections, scale=0.5)
+    serialized_result = serialise_rle_sv_detections(detections=result)
+
+    # then
+    assert len(result) == 1
+    assert result.data["detection_id"].tolist() == ["body-id"]
+    assert len(result.data["rle_mask"]) == 1
+    serialized_prediction = serialized_result["predictions"][0]
+    assert serialized_prediction["detection_id"] == "body-id"
+    serialized_mask = mask_utils.decode(
+        {
+            "size": serialized_prediction["rle_mask"]["size"],
+            "counts": serialized_prediction["rle_mask"]["counts"].encode("utf-8"),
+        }
+    )
+    assert serialized_mask.sum() == 4
 
 
 def test_scale_sv_detections_keeps_rle_when_scale_is_noop() -> None:

--- a/tests/workflows/unit_tests/core_steps/common/test_utils.py
+++ b/tests/workflows/unit_tests/core_steps/common/test_utils.py
@@ -1451,6 +1451,48 @@ def test_scale_sv_detections_resizes_rle_only_masks() -> None:
     assert np.array_equal(decoded_mask, expected_mask)
 
 
+def test_scale_sv_detections_tolerates_none_entries_in_rle_only_masks() -> None:
+    # convert_inference_detections_batch_to_sv_detections stores the `rle_mask`
+    # key when ANY prediction carries RLE, leaving None for those that do not -
+    # scaling must not crash on, nor fabricate masks for, the None entries
+    # given
+    mask = np.zeros((100, 100), dtype=np.uint8)
+    mask[20:40, 20:40] = 1
+    rle_mask = mask_utils.encode(np.asfortranarray(mask))
+    detections = sv.Detections(
+        xyxy=np.array([[20, 20, 40, 40], [50, 50, 70, 70]], dtype=np.float64),
+        confidence=np.array([0.9, 0.8]),
+        class_id=np.array([0, 1]),
+        data={
+            "class_name": np.array(["obj", "other"]),
+            "detection_id": np.array(["d1", "d2"]),
+            "image_dimensions": np.array([[100, 100], [100, 100]]),
+            "rle_mask": np.array([None, rle_mask], dtype=object),
+        },
+    )
+
+    # when
+    result = scale_sv_detections(detections=detections, scale=0.5)
+
+    # then
+    assert result.mask is None
+    assert result.data["rle_mask"][0] is None, "None RLE entry must stay None"
+    resized_rle = result.data["rle_mask"][1]
+    assert resized_rle["size"] == [50, 50]
+    decoded_mask = mask_utils.decode(
+        {
+            "size": resized_rle["size"],
+            "counts": resized_rle["counts"].encode("utf-8"),
+        }
+    ).astype(bool)
+    expected_mask = cv2.resize(
+        mask,
+        (50, 50),
+        interpolation=cv2.INTER_NEAREST,
+    ).astype(bool)
+    assert np.array_equal(decoded_mask, expected_mask)
+
+
 def test_scale_sv_detections_preserves_empty_masks_and_matching_rles() -> None:
     # given
     masks = np.zeros((2, 4, 4), dtype=np.uint8)

--- a/tests/workflows/unit_tests/core_steps/common/test_utils.py
+++ b/tests/workflows/unit_tests/core_steps/common/test_utils.py
@@ -4,6 +4,7 @@ import cv2
 import numpy as np
 import pytest
 import supervision as sv
+from pycocotools import mask as mask_utils
 
 from inference.core.workflows.core_steps.common.utils import (
     add_inference_keypoints_to_sv_detections,
@@ -1380,7 +1381,7 @@ def test_scale_sv_detections_rejects_anisotropic_scalar_metadata() -> None:
         )
 
 
-def test_scale_sv_detections_drops_stale_rle_when_scale_changes_mask() -> None:
+def test_scale_sv_detections_regenerates_rle_when_scale_changes_mask() -> None:
     # given
     mask = np.zeros((100, 100), dtype=bool)
     mask[20:40, 20:40] = True
@@ -1401,8 +1402,18 @@ def test_scale_sv_detections_drops_stale_rle_when_scale_changes_mask() -> None:
     result = scale_sv_detections(detections=detections, scale=0.5)
 
     # then
-    assert "rle_mask" not in result.data
     assert result.mask.shape == (1, 50, 50)
+    assert "rle_mask" in result.data
+    resized_rle = result.data["rle_mask"][0]
+    assert resized_rle["size"] == [50, 50]
+    assert isinstance(resized_rle["counts"], str)
+    decoded_mask = mask_utils.decode(
+        {
+            "size": resized_rle["size"],
+            "counts": resized_rle["counts"].encode("utf-8"),
+        }
+    ).astype(bool)
+    assert np.array_equal(decoded_mask, result.mask[0])
 
 
 def test_scale_sv_detections_keeps_rle_when_scale_is_noop() -> None:

--- a/tests/workflows/unit_tests/core_steps/common/test_utils.py
+++ b/tests/workflows/unit_tests/core_steps/common/test_utils.py
@@ -1451,7 +1451,7 @@ def test_scale_sv_detections_resizes_rle_only_masks() -> None:
     assert np.array_equal(decoded_mask, expected_mask)
 
 
-def test_scale_sv_detections_filters_empty_masks_and_matching_rles() -> None:
+def test_scale_sv_detections_preserves_empty_masks_and_matching_rles() -> None:
     # given
     masks = np.zeros((2, 4, 4), dtype=np.uint8)
     masks[0, 3, 3] = 1
@@ -1478,18 +1478,22 @@ def test_scale_sv_detections_filters_empty_masks_and_matching_rles() -> None:
     serialized_result = serialise_rle_sv_detections(detections=result)
 
     # then
-    assert len(result) == 1
-    assert result.data["detection_id"].tolist() == ["body-id"]
-    assert len(result.data["rle_mask"]) == 1
-    serialized_prediction = serialized_result["predictions"][0]
-    assert serialized_prediction["detection_id"] == "body-id"
-    serialized_mask = mask_utils.decode(
-        {
-            "size": serialized_prediction["rle_mask"]["size"],
-            "counts": serialized_prediction["rle_mask"]["counts"].encode("utf-8"),
-        }
-    )
-    assert serialized_mask.sum() == 4
+    assert len(result) == 2
+    assert result.data["detection_id"].tolist() == ["thin-id", "body-id"]
+    assert len(result.data["rle_mask"]) == 2
+    assert [
+        prediction["detection_id"] for prediction in serialized_result["predictions"]
+    ] == ["thin-id", "body-id"]
+    serialized_mask_areas = []
+    for prediction in serialized_result["predictions"]:
+        serialized_mask = mask_utils.decode(
+            {
+                "size": prediction["rle_mask"]["size"],
+                "counts": prediction["rle_mask"]["counts"].encode("utf-8"),
+            }
+        )
+        serialized_mask_areas.append(int(serialized_mask.sum()))
+    assert serialized_mask_areas == [0, 4]
 
 
 def test_scale_sv_detections_keeps_rle_when_scale_is_noop() -> None:

--- a/tests/workflows/unit_tests/core_steps/common/test_utils.py
+++ b/tests/workflows/unit_tests/core_steps/common/test_utils.py
@@ -20,6 +20,8 @@ from inference.core.workflows.core_steps.common.utils import (
 )
 from inference.core.workflows.execution_engine.constants import (
     POLYGON_KEY_IN_SV_DETECTIONS,
+    SCALING_RELATIVE_TO_PARENT_KEY,
+    SCALING_RELATIVE_TO_ROOT_PARENT_KEY,
 )
 from inference.core.workflows.execution_engine.entities.base import (
     Batch,
@@ -1323,6 +1325,8 @@ def test_scale_sv_detections_anisotropic_matches_exact_target_canvas() -> None:
                 ],
                 dtype=np.int32,
             ),
+            SCALING_RELATIVE_TO_PARENT_KEY: np.array([0.5]),
+            SCALING_RELATIVE_TO_ROOT_PARENT_KEY: np.array([0.25]),
         },
     )
 
@@ -1330,6 +1334,7 @@ def test_scale_sv_detections_anisotropic_matches_exact_target_canvas() -> None:
         detections=detections,
         scale=(scale_x, scale_y),
         target_size_wh=(target_w, target_h),
+        update_scaling_metadata=False,
     )
 
     assert result.mask.shape == (1, target_h, target_w)
@@ -1347,6 +1352,32 @@ def test_scale_sv_detections_anisotropic_matches_exact_target_canvas() -> None:
     assert isotropic_w != target_w
     polygon = result.data[POLYGON_KEY_IN_SV_DETECTIONS][0]
     assert polygon[:, 0].max() >= target_w - 2
+    assert np.array_equal(result[SCALING_RELATIVE_TO_PARENT_KEY], np.array([0.5]))
+    assert np.array_equal(
+        result[SCALING_RELATIVE_TO_ROOT_PARENT_KEY], np.array([0.25])
+    )
+
+
+def test_scale_sv_detections_rejects_anisotropic_scalar_metadata() -> None:
+    detections = sv.Detections(
+        xyxy=np.array([[10, 10, 20, 20]], dtype=np.float64),
+        confidence=np.array([0.9]),
+        class_id=np.array([0]),
+        data={
+            "class_name": np.array(["obj"]),
+            "detection_id": np.array(["d1"]),
+            "image_dimensions": np.array([[100, 100]]),
+        },
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="Anisotropic scaling cannot be represented",
+    ):
+        scale_sv_detections(
+            detections=detections,
+            scale=(0.5, 0.6),
+        )
 
 
 def test_scale_sv_detections_drops_stale_rle_when_scale_changes_mask() -> None:


### PR DESCRIPTION
## What does this PR do?

> Targets `fix/dataset-upload-intact-masks-on-downscale` ([#2738](https://github.com/roboflow/inference/pull/2738)) — this PR contains only the review follow-ups on top of that branch.

Reviewing #2738 surfaced a few sharp edges around the new anisotropic scaling path: the coordinate-lineage metadata could be silently corrupted, RLE masks were deleted after resize even though the RLE serializer requires them, and a public Active Learning function changed its return type in place.

This PR hardens those areas without changing what #2738 fixes:

- **Error instead of averaged lineage metadata.** #2738 stored the mean of `scale_x`/`scale_y` in `scaling_relative_to_parent` / `scaling_relative_to_root_parent` when scales differ. Those scalars drive root-coordinate recovery, so an averaged value silently corrupts every downstream coordinate transform. Terminal consumers now opt out via `update_scaling_metadata=False`; anisotropic scaling with metadata updates enabled raises until the metadata can represent per-axis scales. No core block currently writes a non-unit factor, but `scale_sv_detections` is a shared utility, and an averaged scalar would silently corrupt root-coordinate recovery for any caller that does; the guard makes that misuse fail loudly instead.
- **RLE regenerated after resize, never dropped.** #2738 deleted `rle_mask` when masks were resized, but `serialise_rle_sv_detections` raises when the key is missing, so any resized RLE prediction would fail to serialize. RLE `counts` encode the source canvas and cannot be scaled arithmetically, so every resized mask is re-encoded — keeping detection-to-RLE alignment, including valid all-zero masks.
- **Empty masks are preserved, not filtered.** A mask emptied by downscaling still belongs to a detection with a valid box. `serialise_rle_sv_detections` bypasses the dense-mask-to-polygon conversion (which drops contour-less instances) via a shallow copy with `mask=None`, so such instances serialize with an empty RLE instead of disappearing and shifting the remaining RLE entries. The copy also stops the serializer from mutating its input.
- **Legacy Active Learning contract restored.** #2738 changed `prepare_image_to_registration`'s return type from `(bytes, float)` to a NamedTuple in place — external callers unpacking two values relied on positional compatibility. The legacy function keeps its exact contract and emits `InferenceDeprecationWarning`; new code uses `prepare_image_to_registration_with_metadata`. Zero-dimension images now raise `InvalidNumpyInput` up front instead of silently falling back to scale `1.0`.
- **Legacy Active Learning path intentionally unchanged.** `execute_datapoint_registration` still adjusts predictions with the height-only factor — its dict-based adjuster needs its own anisotropic rework, out of scope here. Only the Dataset Upload sink gets the exact-canvas fix.
- **RTSPS test reverted to `main`'s version.** `main` merged an equivalent deadlock fix while #2738 carried its own rewrite; keeping `main`'s content (plus the Black formatting it was missing) removes an unrelated competing change from the diff.

**Main elements:**
- `inference/core/workflows/core_steps/common/utils.py` — `scale_sv_detections`: `update_scaling_metadata` flag with anisotropic guard; RLE regeneration after resize (dense, RLE-only, and partially-`None` inputs)
- `inference/core/workflows/core_steps/common/serializers.py` — `serialise_rle_sv_detections` preserves instances with empty masks and no longer mutates its input
- `inference/core/active_learning/core.py` — restored legacy `prepare_image_to_registration` contract (deprecated); new `prepare_image_to_registration_with_metadata`; `InvalidNumpyInput` on zero-dimension images
- `inference/core/workflows/core_steps/sinks/roboflow/dataset_upload/v1.py` — switched to the new preparation function with `update_scaling_metadata=False`
- `tests/inference/unit_tests/core/interfaces/camera/test_rtsp_opencv_tls.py` — aligned with the deadlock fix already merged to `main`, leaving only a formatting hunk

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other:

## Testing

### Unit tests

- `scale_sv_detections`: RLE regeneration after resize, RLE-only inputs, `None` RLE entries, no-op scale keeping RLE untouched, empty-mask preservation, and the anisotropic-metadata guard raising
- Serializers: `serialise_rle_sv_detections` preserving instances whose dense mask has no contour; `mask_to_polygon` on masks with holes
- Active Learning: `prepare_image_to_registration_with_metadata` dimensions/scales, zero-dimension input validation, deprecation warning on the legacy function
- Dataset Upload sink: end-to-end `execute_registration` with an ultra-wide image asserting predictions land on the exact uploaded JPEG canvas

## Profiling

The profiling ran cleanly (18 samples per case: 3 warmup + 15 measured, medians and p90 are tight). Results on a 4000×3000 canvas with 6 instance masks scaled by 0.52:

| Scenario | main (median) | branch (median) | Verdict |
|---|---|---|---|
| `scale_dense` | 17.2 ms | 3.8 ms | branch **4.5× faster** |
| `scale_dense_rle` | 16.9 ms | 16.9 ms | parity |
| `polygon_clean` | 0.32 ms | 0.32 ms | parity |
| `polygon_speckled` | 0.32 ms | 0.34 ms | ~8% slower, sub-ms |

### Integration tests

- None for this PR.

### Other

- `pytest tests/workflows/unit_tests/core_steps/common/test_utils.py tests/workflows/unit_tests/core_steps/common/test_serializers.py tests/workflows/unit_tests/core_steps/sinks/roboflow/roboflow_dataset_upload/test_v1.py tests/inference/unit_tests/core/active_learning/test_core.py tests/inference/unit_tests/core/interfaces/camera/test_rtsp_opencv_tls.py`
- `black --check` / `isort --check-only` on all touched files

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)