### PR TITLE
Fix optional CUDA stream contexts on non-CUDA devices

### DIFF
--- a/inference_models/docs/changelog.md
+++ b/inference_models/docs/changelog.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Fixed
+
+- ONNX models no longer invoke CUDA stream context management on non-CUDA devices,
+  preventing native inference failures on Apple Silicon.
+
 ## `0.34.5`
 
 ### Fixed

--- a/inference_models/inference_models/models/clip/clip_onnx.py
+++ b/inference_models/inference_models/models/clip/clip_onnx.py
@@ -19,7 +19,7 @@ from inference_models.models.common.onnx import (
     run_onnx_session_with_batch_size_limit,
     set_onnx_execution_provider_defaults,
 )
-from inference_models.models.common.streams import get_cuda_stream
+from inference_models.models.common.streams import get_cuda_stream, use_cuda_stream
 from inference_models.utils.onnx_introspection import (
     get_selected_onnx_execution_providers,
 )
@@ -131,7 +131,7 @@ class ClipOnnx(TextImageEmbeddingModel):
         **kwargs,
     ) -> torch.Tensor:
         pre_process_stream = self._pre_process_stream
-        with torch.cuda.stream(pre_process_stream):
+        with use_cuda_stream(pre_process_stream):
             pre_processed_images = self._preprocessor(
                 images, input_color_format, self._device
             )
@@ -149,7 +149,7 @@ class ClipOnnx(TextImageEmbeddingModel):
         if not isinstance(texts, list):
             texts = [texts]
         pre_process_stream = self._pre_process_stream
-        with torch.cuda.stream(pre_process_stream):
+        with use_cuda_stream(pre_process_stream):
             tokenized_batch = clip.tokenize(texts).to(self._device)
         if pre_process_stream is not None:
             pre_process_stream.synchronize()

--- a/inference_models/inference_models/models/common/streams.py
+++ b/inference_models/inference_models/models/common/streams.py
@@ -1,9 +1,24 @@
 import threading
-from typing import Dict, Optional, Tuple
+from contextlib import nullcontext
+from typing import ContextManager, Dict, Optional, Tuple
 
 import torch
 
 _THREAD_LOCAL_STREAMS = threading.local()
+
+
+def use_cuda_stream(
+    stream: Optional[torch.cuda.Stream],
+) -> ContextManager[None]:
+    """Activate a CUDA stream, or do nothing when no stream is available.
+
+    Args:
+        stream: CUDA stream to activate, or None for non-CUDA devices.
+
+    Returns:
+        Context manager that activates the CUDA stream when available.
+    """
+    return torch.cuda.stream(stream) if stream is not None else nullcontext()
 
 
 def get_cuda_stream(device: torch.device, purpose: str) -> Optional[torch.cuda.Stream]:
@@ -37,12 +52,15 @@ def get_cuda_stream(device: torch.device, purpose: str) -> Optional[torch.cuda.S
 
     Examples:
         >>> import torch
-        >>> from inference_models.models.common.streams import get_cuda_stream
+        >>> from inference_models.models.common.streams import (
+        ...     get_cuda_stream,
+        ...     use_cuda_stream,
+        ... )
         >>>
         >>> stream = get_cuda_stream(
         ...     device=torch.device("cuda:0"), purpose="pre-processing"
         ... )
-        >>> with torch.cuda.stream(stream):
+        >>> with use_cuda_stream(stream):
         ...     pass  # enqueue torch work
         >>> if stream is not None:
         ...     stream.synchronize()

--- a/inference_models/inference_models/models/deep_lab_v3_plus/deep_lab_v3_plus_segmentation_onnx.py
+++ b/inference_models/inference_models/models/deep_lab_v3_plus/deep_lab_v3_plus_segmentation_onnx.py
@@ -42,7 +42,7 @@ from inference_models.models.common.roboflow.semantic_segmentation import (
     resolve_background_class_id,
     validate_class_names,
 )
-from inference_models.models.common.streams import get_cuda_stream
+from inference_models.models.common.streams import get_cuda_stream, use_cuda_stream
 from inference_models.utils.onnx_introspection import (
     get_selected_onnx_execution_providers,
 )
@@ -174,7 +174,7 @@ class DeepLabV3PlusForSemanticSegmentationOnnx(
         **kwargs,
     ) -> Tuple[PreprocessedInputs, PreprocessingMetadata]:
         pre_process_stream = self._pre_process_stream
-        with torch.cuda.stream(pre_process_stream):
+        with use_cuda_stream(pre_process_stream):
             pre_processed_images, pre_processing_meta = pre_process_network_input(
                 images=images,
                 image_pre_processing=self._inference_config.image_pre_processing,
@@ -207,7 +207,7 @@ class DeepLabV3PlusForSemanticSegmentationOnnx(
         **kwargs,
     ) -> List[SemanticSegmentationResult]:
         post_process_stream = self._post_process_stream
-        with torch.cuda.stream(post_process_stream):
+        with use_cuda_stream(post_process_stream):
             if post_process_stream is not None:
                 model_results.record_stream(post_process_stream)
             results = post_process_semantic_segmentation_logits(

--- a/inference_models/inference_models/models/dinov3/dinov3_classification_onnx.py
+++ b/inference_models/inference_models/models/dinov3/dinov3_classification_onnx.py
@@ -38,7 +38,7 @@ from inference_models.models.common.roboflow.post_processing import ConfidenceFi
 from inference_models.models.common.roboflow.pre_processing import (
     pre_process_network_input,
 )
-from inference_models.models.common.streams import get_cuda_stream
+from inference_models.models.common.streams import get_cuda_stream, use_cuda_stream
 from inference_models.utils.onnx_introspection import (
     get_selected_onnx_execution_providers,
 )
@@ -178,7 +178,7 @@ class DinoV3ForClassificationOnnx(ClassificationModel[torch.Tensor, torch.Tensor
         **kwargs,
     ) -> torch.Tensor:
         pre_process_stream = self._pre_process_stream
-        with torch.cuda.stream(pre_process_stream):
+        with use_cuda_stream(pre_process_stream):
             pre_processed_images = pre_process_network_input(
                 images=images,
                 image_pre_processing=self._inference_config.image_pre_processing,
@@ -210,7 +210,7 @@ class DinoV3ForClassificationOnnx(ClassificationModel[torch.Tensor, torch.Tensor
         **kwargs,
     ) -> ClassificationPrediction:
         post_process_stream = self._post_process_stream
-        with torch.cuda.stream(post_process_stream):
+        with use_cuda_stream(post_process_stream):
             if post_process_stream is not None:
                 model_results.record_stream(post_process_stream)
             if (
@@ -364,7 +364,7 @@ class DinoV3ForMultiLabelClassificationOnnx(
         **kwargs,
     ) -> torch.Tensor:
         pre_process_stream = self._pre_process_stream
-        with torch.cuda.stream(pre_process_stream):
+        with use_cuda_stream(pre_process_stream):
             pre_processed_images = pre_process_network_input(
                 images=images,
                 image_pre_processing=self._inference_config.image_pre_processing,
@@ -406,7 +406,7 @@ class DinoV3ForMultiLabelClassificationOnnx(
                 dtype=model_results.dtype, device=model_results.device
             )
         post_process_stream = self._post_process_stream
-        with torch.cuda.stream(post_process_stream):
+        with use_cuda_stream(post_process_stream):
             if post_process_stream is not None:
                 model_results.record_stream(post_process_stream)
             if (

--- a/inference_models/inference_models/models/l2cs/l2cs_onnx.py
+++ b/inference_models/inference_models/models/l2cs/l2cs_onnx.py
@@ -21,7 +21,7 @@ from inference_models.models.common.onnx import (
     run_onnx_session_with_batch_size_limit,
     set_onnx_execution_provider_defaults,
 )
-from inference_models.models.common.streams import get_cuda_stream
+from inference_models.models.common.streams import get_cuda_stream, use_cuda_stream
 from inference_models.utils.onnx_introspection import (
     get_selected_onnx_execution_providers,
 )
@@ -147,7 +147,7 @@ class L2CSNetOnnx:
         **kwargs,
     ) -> torch.Tensor:
         pre_process_stream = self._pre_process_stream
-        with torch.cuda.stream(pre_process_stream):
+        with use_cuda_stream(pre_process_stream):
             pre_processed_images = self._pre_process(
                 images=images,
                 input_color_format=input_color_format,

--- a/inference_models/inference_models/models/resnet/resnet_classification_onnx.py
+++ b/inference_models/inference_models/models/resnet/resnet_classification_onnx.py
@@ -38,7 +38,7 @@ from inference_models.models.common.roboflow.post_processing import ConfidenceFi
 from inference_models.models.common.roboflow.pre_processing import (
     pre_process_network_input,
 )
-from inference_models.models.common.streams import get_cuda_stream
+from inference_models.models.common.streams import get_cuda_stream, use_cuda_stream
 from inference_models.utils.onnx_introspection import (
     get_selected_onnx_execution_providers,
 )
@@ -172,7 +172,7 @@ class ResNetForClassificationOnnx(ClassificationModel[torch.Tensor, torch.Tensor
         **kwargs,
     ) -> torch.Tensor:
         pre_process_stream = self._pre_process_stream
-        with torch.cuda.stream(pre_process_stream):
+        with use_cuda_stream(pre_process_stream):
             pre_processed_images = pre_process_network_input(
                 images=images,
                 image_pre_processing=self._inference_config.image_pre_processing,
@@ -204,7 +204,7 @@ class ResNetForClassificationOnnx(ClassificationModel[torch.Tensor, torch.Tensor
         **kwargs,
     ) -> ClassificationPrediction:
         post_process_stream = self._post_process_stream
-        with torch.cuda.stream(post_process_stream):
+        with use_cuda_stream(post_process_stream):
             if post_process_stream is not None:
                 model_results.record_stream(post_process_stream)
             if self._inference_config.post_processing.fused:
@@ -349,7 +349,7 @@ class ResNetForMultiLabelClassificationOnnx(
         **kwargs,
     ) -> torch.Tensor:
         pre_process_stream = self._pre_process_stream
-        with torch.cuda.stream(pre_process_stream):
+        with use_cuda_stream(pre_process_stream):
             pre_processed_images = pre_process_network_input(
                 images=images,
                 image_pre_processing=self._inference_config.image_pre_processing,
@@ -392,7 +392,7 @@ class ResNetForMultiLabelClassificationOnnx(
                 dtype=model_results.dtype, device=model_results.device
             )
         post_process_stream = self._post_process_stream
-        with torch.cuda.stream(post_process_stream):
+        with use_cuda_stream(post_process_stream):
             if post_process_stream is not None:
                 model_results.record_stream(post_process_stream)
             if self._inference_config.post_processing.fused:

--- a/inference_models/inference_models/models/rfdetr/rfdetr_instance_segmentation_onnx.py
+++ b/inference_models/inference_models/models/rfdetr/rfdetr_instance_segmentation_onnx.py
@@ -35,7 +35,7 @@ from inference_models.models.common.roboflow.model_packages import (
     parse_inference_config,
 )
 from inference_models.models.common.roboflow.post_processing import ConfidenceFilter
-from inference_models.models.common.streams import get_cuda_stream
+from inference_models.models.common.streams import get_cuda_stream, use_cuda_stream
 from inference_models.models.rfdetr.class_remapping import (
     ClassesReMapping,
     prepare_class_remapping,
@@ -203,7 +203,7 @@ class RFDetrForInstanceSegmentationOnnx(
         **kwargs,
     ) -> Tuple[torch.Tensor, List[PreProcessingMetadata]]:
         pre_process_stream = self._pre_process_stream
-        with torch.cuda.stream(pre_process_stream):
+        with use_cuda_stream(pre_process_stream):
             pre_processed_images, pre_processing_meta = pre_process_network_input(
                 images=images,
                 image_pre_processing=self._inference_config.image_pre_processing,
@@ -255,7 +255,7 @@ class RFDetrForInstanceSegmentationOnnx(
             default_confidence=INFERENCE_MODELS_RFDETR_DEFAULT_CONFIDENCE,
         )
         post_process_stream = self._post_process_stream
-        with torch.cuda.stream(post_process_stream):
+        with use_cuda_stream(post_process_stream):
             if post_process_stream is not None:
                 for result_element in model_results:
                     result_element.record_stream(post_process_stream)

--- a/inference_models/inference_models/models/rfdetr/rfdetr_key_points_detection_onnx.py
+++ b/inference_models/inference_models/models/rfdetr/rfdetr_key_points_detection_onnx.py
@@ -35,7 +35,7 @@ from inference_models.models.common.roboflow.model_packages import (
     parse_key_points_metadata,
 )
 from inference_models.models.common.roboflow.post_processing import ConfidenceFilter
-from inference_models.models.common.streams import get_cuda_stream
+from inference_models.models.common.streams import get_cuda_stream, use_cuda_stream
 from inference_models.models.rfdetr.class_remapping import (
     ClassesReMapping,
     prepare_class_remapping,
@@ -226,7 +226,7 @@ class RFDetrForKeyPointsONNX(
         **kwargs,
     ) -> Tuple[torch.Tensor, List[PreProcessingMetadata]]:
         pre_process_stream = self._pre_process_stream
-        with torch.cuda.stream(pre_process_stream):
+        with use_cuda_stream(pre_process_stream):
             pre_processed_images, pre_processing_meta = pre_process_network_input(
                 images=images,
                 image_pre_processing=self._inference_config.image_pre_processing,
@@ -266,7 +266,7 @@ class RFDetrForKeyPointsONNX(
             default_confidence=INFERENCE_MODELS_RFDETR_DEFAULT_CONFIDENCE,
         )
         post_process_stream = self._post_process_stream
-        with torch.cuda.stream(post_process_stream):
+        with use_cuda_stream(post_process_stream):
             if post_process_stream is not None:
                 for result_element in model_results:
                     result_element.record_stream(post_process_stream)

--- a/inference_models/inference_models/models/rfdetr/rfdetr_object_detection_onnx.py
+++ b/inference_models/inference_models/models/rfdetr/rfdetr_object_detection_onnx.py
@@ -28,7 +28,7 @@ from inference_models.models.common.roboflow.model_packages import (
     parse_inference_config,
 )
 from inference_models.models.common.roboflow.post_processing import ConfidenceFilter
-from inference_models.models.common.streams import get_cuda_stream
+from inference_models.models.common.streams import get_cuda_stream, use_cuda_stream
 from inference_models.models.rfdetr.class_remapping import (
     ClassesReMapping,
     prepare_class_remapping,
@@ -188,7 +188,7 @@ class RFDetrForObjectDetectionONNX(
         **kwargs,
     ) -> Tuple[torch.Tensor, List[PreProcessingMetadata]]:
         pre_process_stream = self._pre_process_stream
-        with torch.cuda.stream(pre_process_stream):
+        with use_cuda_stream(pre_process_stream):
             pre_processed_images, pre_processing_meta = pre_process_network_input(
                 images=images,
                 image_pre_processing=self._inference_config.image_pre_processing,
@@ -227,7 +227,7 @@ class RFDetrForObjectDetectionONNX(
             default_confidence=INFERENCE_MODELS_RFDETR_DEFAULT_CONFIDENCE,
         )
         post_process_stream = self._post_process_stream
-        with torch.cuda.stream(post_process_stream):
+        with use_cuda_stream(post_process_stream):
             if post_process_stream is not None:
                 for result_element in model_results:
                     result_element.record_stream(post_process_stream)

--- a/inference_models/inference_models/models/vit/vit_classification_onnx.py
+++ b/inference_models/inference_models/models/vit/vit_classification_onnx.py
@@ -38,7 +38,7 @@ from inference_models.models.common.roboflow.post_processing import ConfidenceFi
 from inference_models.models.common.roboflow.pre_processing import (
     pre_process_network_input,
 )
-from inference_models.models.common.streams import get_cuda_stream
+from inference_models.models.common.streams import get_cuda_stream, use_cuda_stream
 from inference_models.utils.onnx_introspection import (
     get_selected_onnx_execution_providers,
 )
@@ -171,7 +171,7 @@ class VITForClassificationOnnx(ClassificationModel[torch.Tensor, torch.Tensor]):
         **kwargs,
     ) -> torch.Tensor:
         pre_process_stream = self._pre_process_stream
-        with torch.cuda.stream(pre_process_stream):
+        with use_cuda_stream(pre_process_stream):
             pre_processed_images = pre_process_network_input(
                 images=images,
                 image_pre_processing=self._inference_config.image_pre_processing,
@@ -202,7 +202,7 @@ class VITForClassificationOnnx(ClassificationModel[torch.Tensor, torch.Tensor]):
         **kwargs,
     ) -> ClassificationPrediction:
         post_process_stream = self._post_process_stream
-        with torch.cuda.stream(post_process_stream):
+        with use_cuda_stream(post_process_stream):
             if post_process_stream is not None:
                 model_results.record_stream(post_process_stream)
             if self._inference_config.post_processing.fused:
@@ -347,7 +347,7 @@ class VITForMultiLabelClassificationOnnx(
         **kwargs,
     ) -> torch.Tensor:
         pre_process_stream = self._pre_process_stream
-        with torch.cuda.stream(pre_process_stream):
+        with use_cuda_stream(pre_process_stream):
             pre_processed_images = pre_process_network_input(
                 images=images,
                 image_pre_processing=self._inference_config.image_pre_processing,
@@ -389,7 +389,7 @@ class VITForMultiLabelClassificationOnnx(
                 dtype=model_results.dtype, device=model_results.device
             )
         post_process_stream = self._post_process_stream
-        with torch.cuda.stream(post_process_stream):
+        with use_cuda_stream(post_process_stream):
             if post_process_stream is not None:
                 model_results.record_stream(post_process_stream)
             if self._inference_config.post_processing.fused:

--- a/inference_models/inference_models/models/yolact/yolact_instance_segmentation_onnx.py
+++ b/inference_models/inference_models/models/yolact/yolact_instance_segmentation_onnx.py
@@ -42,7 +42,7 @@ from inference_models.models.common.roboflow.post_processing import ConfidenceFi
 from inference_models.models.common.roboflow.pre_processing import (
     pre_process_network_input,
 )
-from inference_models.models.common.streams import get_cuda_stream
+from inference_models.models.common.streams import get_cuda_stream, use_cuda_stream
 from inference_models.models.yolact.common import prepare_dense_masks, prepare_rle_masks
 from inference_models.utils.onnx_introspection import (
     get_selected_onnx_execution_providers,
@@ -187,7 +187,7 @@ class YOLOACTForInstanceSegmentationOnnx(
         **kwargs,
     ) -> Tuple[torch.Tensor, List[PreProcessingMetadata]]:
         pre_process_stream = self._pre_process_stream
-        with torch.cuda.stream(pre_process_stream):
+        with use_cuda_stream(pre_process_stream):
             pre_processed_images, pre_processing_meta = pre_process_network_input(
                 images=images,
                 image_pre_processing=self._inference_config.image_pre_processing,
@@ -265,7 +265,7 @@ class YOLOACTForInstanceSegmentationOnnx(
         )
         confidence = confidence_filter.get_threshold(self.class_names)
         post_process_stream = self._post_process_stream
-        with torch.cuda.stream(post_process_stream):
+        with use_cuda_stream(post_process_stream):
             if post_process_stream is not None:
                 for result_element in model_results:
                     result_element.record_stream(post_process_stream)

--- a/inference_models/inference_models/models/yolo26/yolo26_depth_estimation_onnx.py
+++ b/inference_models/inference_models/models/yolo26/yolo26_depth_estimation_onnx.py
@@ -30,7 +30,7 @@ from inference_models.models.common.roboflow.post_processing import (
 from inference_models.models.common.roboflow.pre_processing import (
     pre_process_network_input,
 )
-from inference_models.models.common.streams import get_cuda_stream
+from inference_models.models.common.streams import get_cuda_stream, use_cuda_stream
 from inference_models.utils.onnx_introspection import (
     get_selected_onnx_execution_providers,
 )
@@ -153,7 +153,7 @@ class YOLO26ForDepthEstimationOnnx(
         **kwargs,
     ) -> Tuple[torch.Tensor, List[PreProcessingMetadata]]:
         pre_process_stream = self._pre_process_stream
-        with torch.cuda.stream(pre_process_stream):
+        with use_cuda_stream(pre_process_stream):
             pre_processed_images, pre_processing_meta = pre_process_network_input(
                 images=images,
                 image_pre_processing=self._inference_config.image_pre_processing,
@@ -184,7 +184,7 @@ class YOLO26ForDepthEstimationOnnx(
         **kwargs,
     ) -> List[torch.Tensor]:
         post_process_stream = self._post_process_stream
-        with torch.cuda.stream(post_process_stream):
+        with use_cuda_stream(post_process_stream):
             if post_process_stream is not None:
                 model_results.record_stream(post_process_stream)
             results = post_process_depth_estimation_map(

--- a/inference_models/inference_models/models/yolo26/yolo26_instance_segmentation_onnx.py
+++ b/inference_models/inference_models/models/yolo26/yolo26_instance_segmentation_onnx.py
@@ -40,7 +40,7 @@ from inference_models.models.common.roboflow.post_processing import (
 from inference_models.models.common.roboflow.pre_processing import (
     pre_process_network_input,
 )
-from inference_models.models.common.streams import get_cuda_stream
+from inference_models.models.common.streams import get_cuda_stream, use_cuda_stream
 from inference_models.models.yolo26.common import prepare_dense_masks, prepare_rle_masks
 from inference_models.utils.onnx_introspection import (
     get_selected_onnx_execution_providers,
@@ -181,7 +181,7 @@ class YOLO26ForInstanceSegmentationOnnx(
         **kwargs,
     ) -> Tuple[torch.Tensor, List[PreProcessingMetadata]]:
         pre_process_stream = self._pre_process_stream
-        with torch.cuda.stream(pre_process_stream):
+        with use_cuda_stream(pre_process_stream):
             pre_processed_images, pre_processing_meta = pre_process_network_input(
                 images=images,
                 image_pre_processing=self._inference_config.image_pre_processing,
@@ -233,7 +233,7 @@ class YOLO26ForInstanceSegmentationOnnx(
         )
         confidence = confidence_filter.get_threshold(self.class_names)
         post_process_stream = self._post_process_stream
-        with torch.cuda.stream(post_process_stream):
+        with use_cuda_stream(post_process_stream):
             if post_process_stream is not None:
                 for result_element in model_results:
                     result_element.record_stream(post_process_stream)

--- a/inference_models/inference_models/models/yolo26/yolo26_key_points_detection_onnx.py
+++ b/inference_models/inference_models/models/yolo26/yolo26_key_points_detection_onnx.py
@@ -42,7 +42,7 @@ from inference_models.models.common.roboflow.post_processing import (
 from inference_models.models.common.roboflow.pre_processing import (
     pre_process_network_input,
 )
-from inference_models.models.common.streams import get_cuda_stream
+from inference_models.models.common.streams import get_cuda_stream, use_cuda_stream
 from inference_models.utils.onnx_introspection import (
     get_selected_onnx_execution_providers,
 )
@@ -200,7 +200,7 @@ class YOLO26ForKeyPointsDetectionOnnx(
         **kwargs,
     ) -> Tuple[torch.Tensor, List[PreProcessingMetadata]]:
         pre_process_stream = self._pre_process_stream
-        with torch.cuda.stream(pre_process_stream):
+        with use_cuda_stream(pre_process_stream):
             pre_processed_images, pre_processing_meta = pre_process_network_input(
                 images=images,
                 image_pre_processing=self._inference_config.image_pre_processing,
@@ -239,7 +239,7 @@ class YOLO26ForKeyPointsDetectionOnnx(
         )
         confidence = confidence_filter.get_threshold(self.class_names)
         post_process_stream = self._post_process_stream
-        with torch.cuda.stream(post_process_stream):
+        with use_cuda_stream(post_process_stream):
             if post_process_stream is not None:
                 model_results.record_stream(post_process_stream)
             filtered_results = post_process_nms_fused_model_output(

--- a/inference_models/inference_models/models/yolo26/yolo26_object_detection_onnx.py
+++ b/inference_models/inference_models/models/yolo26/yolo26_object_detection_onnx.py
@@ -35,7 +35,7 @@ from inference_models.models.common.roboflow.post_processing import (
 from inference_models.models.common.roboflow.pre_processing import (
     pre_process_network_input,
 )
-from inference_models.models.common.streams import get_cuda_stream
+from inference_models.models.common.streams import get_cuda_stream, use_cuda_stream
 from inference_models.utils.onnx_introspection import (
     get_selected_onnx_execution_providers,
 )
@@ -174,7 +174,7 @@ class YOLO26ForObjectDetectionOnnx(
         **kwargs,
     ) -> Tuple[torch.Tensor, List[PreProcessingMetadata]]:
         pre_process_stream = self._pre_process_stream
-        with torch.cuda.stream(pre_process_stream):
+        with use_cuda_stream(pre_process_stream):
             pre_processed_images, pre_processing_meta = pre_process_network_input(
                 images=images,
                 image_pre_processing=self._inference_config.image_pre_processing,
@@ -212,7 +212,7 @@ class YOLO26ForObjectDetectionOnnx(
         )
         confidence = confidence_filter.get_threshold(self.class_names)
         post_process_stream = self._post_process_stream
-        with torch.cuda.stream(post_process_stream):
+        with use_cuda_stream(post_process_stream):
             if post_process_stream is not None:
                 model_results.record_stream(post_process_stream)
             filtered_results = post_process_nms_fused_model_output(

--- a/inference_models/inference_models/models/yolo26/yolo26_semantic_segmentation_onnx.py
+++ b/inference_models/inference_models/models/yolo26/yolo26_semantic_segmentation_onnx.py
@@ -41,7 +41,7 @@ from inference_models.models.common.roboflow.semantic_segmentation import (
     resolve_background_class_id,
     validate_class_names,
 )
-from inference_models.models.common.streams import get_cuda_stream
+from inference_models.models.common.streams import get_cuda_stream, use_cuda_stream
 from inference_models.utils.onnx_introspection import (
     get_selected_onnx_execution_providers,
 )
@@ -180,7 +180,7 @@ class YOLO26ForSemanticSegmentationOnnx(
         **kwargs,
     ) -> Tuple[torch.Tensor, List[PreProcessingMetadata]]:
         pre_process_stream = self._pre_process_stream
-        with torch.cuda.stream(pre_process_stream):
+        with use_cuda_stream(pre_process_stream):
             pre_processed_images, pre_processing_meta = pre_process_network_input(
                 images=images,
                 image_pre_processing=self._inference_config.image_pre_processing,
@@ -212,7 +212,7 @@ class YOLO26ForSemanticSegmentationOnnx(
         **kwargs,
     ) -> List[SemanticSegmentationResult]:
         post_process_stream = self._post_process_stream
-        with torch.cuda.stream(post_process_stream):
+        with use_cuda_stream(post_process_stream):
             if post_process_stream is not None:
                 model_results.record_stream(post_process_stream)
             results = post_process_semantic_segmentation_logits(

--- a/inference_models/inference_models/models/yololite/yololite_object_detection_onnx.py
+++ b/inference_models/inference_models/models/yololite/yololite_object_detection_onnx.py
@@ -39,7 +39,7 @@ from inference_models.models.common.roboflow.post_processing import (
 from inference_models.models.common.roboflow.pre_processing import (
     pre_process_network_input,
 )
-from inference_models.models.common.streams import get_cuda_stream
+from inference_models.models.common.streams import get_cuda_stream, use_cuda_stream
 from inference_models.utils.onnx_introspection import (
     get_selected_onnx_execution_providers,
 )
@@ -177,7 +177,7 @@ class YOLOLiteForObjectDetectionOnnx(
         **kwargs,
     ) -> Tuple[torch.Tensor, List[PreProcessingMetadata]]:
         pre_process_stream = self._pre_process_stream
-        with torch.cuda.stream(pre_process_stream):
+        with use_cuda_stream(pre_process_stream):
             pre_processed_images, pre_processing_meta = pre_process_network_input(
                 images=images,
                 image_pre_processing=self._inference_config.image_pre_processing,
@@ -221,7 +221,7 @@ class YOLOLiteForObjectDetectionOnnx(
         )
         confidence = confidence_filter.get_threshold(self.class_names)
         post_process_stream = self._post_process_stream
-        with torch.cuda.stream(post_process_stream):
+        with use_cuda_stream(post_process_stream):
             if post_process_stream is not None:
                 for result_element in model_results:
                     result_element.record_stream(post_process_stream)

--- a/inference_models/inference_models/models/yolonas/yolonas_object_detection_onnx.py
+++ b/inference_models/inference_models/models/yolonas/yolonas_object_detection_onnx.py
@@ -38,7 +38,7 @@ from inference_models.models.common.roboflow.post_processing import (
 from inference_models.models.common.roboflow.pre_processing import (
     pre_process_network_input,
 )
-from inference_models.models.common.streams import get_cuda_stream
+from inference_models.models.common.streams import get_cuda_stream, use_cuda_stream
 from inference_models.models.yolonas.nms import run_yolonas_nms_for_object_detection
 from inference_models.utils.onnx_introspection import (
     get_selected_onnx_execution_providers,
@@ -182,7 +182,7 @@ class YOLONasForObjectDetectionOnnx(
         **kwargs,
     ) -> Tuple[torch.Tensor, List[PreProcessingMetadata]]:
         pre_process_stream = self._pre_process_stream
-        with torch.cuda.stream(pre_process_stream):
+        with use_cuda_stream(pre_process_stream):
             pre_processed_images, pre_processing_meta = pre_process_network_input(
                 images=images,
                 image_pre_processing=self._inference_config.image_pre_processing,
@@ -226,7 +226,7 @@ class YOLONasForObjectDetectionOnnx(
         )
         confidence = confidence_filter.get_threshold(self.class_names)
         post_process_stream = self._post_process_stream
-        with torch.cuda.stream(post_process_stream):
+        with use_cuda_stream(post_process_stream):
             if post_process_stream is not None:
                 model_results.record_stream(post_process_stream)
             nms_results = run_yolonas_nms_for_object_detection(

--- a/inference_models/inference_models/models/yolov10/yolov10_object_detection_onnx.py
+++ b/inference_models/inference_models/models/yolov10/yolov10_object_detection_onnx.py
@@ -36,7 +36,7 @@ from inference_models.models.common.roboflow.post_processing import (
 from inference_models.models.common.roboflow.pre_processing import (
     pre_process_network_input,
 )
-from inference_models.models.common.streams import get_cuda_stream
+from inference_models.models.common.streams import get_cuda_stream, use_cuda_stream
 from inference_models.utils.onnx_introspection import (
     get_selected_onnx_execution_providers,
 )
@@ -169,7 +169,7 @@ class YOLOv10ForObjectDetectionOnnx(
         **kwargs,
     ) -> Tuple[torch.Tensor, List[PreProcessingMetadata]]:
         pre_process_stream = self._pre_process_stream
-        with torch.cuda.stream(pre_process_stream):
+        with use_cuda_stream(pre_process_stream):
             pre_processed_images, pre_processing_meta = pre_process_network_input(
                 images=images,
                 image_pre_processing=self._inference_config.image_pre_processing,
@@ -211,7 +211,7 @@ class YOLOv10ForObjectDetectionOnnx(
                 dtype=model_results.dtype, device=model_results.device
             )
         post_process_stream = self._post_process_stream
-        with torch.cuda.stream(post_process_stream):
+        with use_cuda_stream(post_process_stream):
             if post_process_stream is not None:
                 model_results.record_stream(post_process_stream)
             results = []

--- a/inference_models/inference_models/models/yolov5/yolov5_instance_segmentation_onnx.py
+++ b/inference_models/inference_models/models/yolov5/yolov5_instance_segmentation_onnx.py
@@ -45,7 +45,7 @@ from inference_models.models.common.roboflow.post_processing import (
 from inference_models.models.common.roboflow.pre_processing import (
     pre_process_network_input,
 )
-from inference_models.models.common.streams import get_cuda_stream
+from inference_models.models.common.streams import get_cuda_stream, use_cuda_stream
 from inference_models.models.yolov5.common import prepare_dense_masks, prepare_rle_masks
 from inference_models.models.yolov5.nms import run_yolov5_nms_for_instance_segmentation
 from inference_models.utils.onnx_introspection import (
@@ -186,7 +186,7 @@ class YOLOv5ForInstanceSegmentationOnnx(
         **kwargs,
     ) -> Tuple[torch.Tensor, List[PreProcessingMetadata]]:
         pre_process_stream = self._pre_process_stream
-        with torch.cuda.stream(pre_process_stream):
+        with use_cuda_stream(pre_process_stream):
             pre_processed_images, pre_processing_meta = pre_process_network_input(
                 images=images,
                 image_pre_processing=self._inference_config.image_pre_processing,
@@ -240,7 +240,7 @@ class YOLOv5ForInstanceSegmentationOnnx(
         )
         confidence = confidence_filter.get_threshold(self.class_names)
         post_process_stream = self._post_process_stream
-        with torch.cuda.stream(post_process_stream):
+        with use_cuda_stream(post_process_stream):
             if post_process_stream is not None:
                 for result_element in model_results:
                     result_element.record_stream(post_process_stream)

--- a/inference_models/inference_models/models/yolov5/yolov5_object_detection_onnx.py
+++ b/inference_models/inference_models/models/yolov5/yolov5_object_detection_onnx.py
@@ -37,7 +37,7 @@ from inference_models.models.common.roboflow.post_processing import (
 from inference_models.models.common.roboflow.pre_processing import (
     pre_process_network_input,
 )
-from inference_models.models.common.streams import get_cuda_stream
+from inference_models.models.common.streams import get_cuda_stream, use_cuda_stream
 from inference_models.models.yolov5.nms import run_nms_yolov5
 from inference_models.utils.onnx_introspection import (
     get_selected_onnx_execution_providers,
@@ -171,7 +171,7 @@ class YOLOv5ForObjectDetectionOnnx(
         **kwargs,
     ) -> Tuple[torch.Tensor, List[PreProcessingMetadata]]:
         pre_process_stream = self._pre_process_stream
-        with torch.cuda.stream(pre_process_stream):
+        with use_cuda_stream(pre_process_stream):
             pre_processed_images, pre_processing_meta = pre_process_network_input(
                 images=images,
                 image_pre_processing=self._inference_config.image_pre_processing,
@@ -211,7 +211,7 @@ class YOLOv5ForObjectDetectionOnnx(
         )
         confidence = confidence_filter.get_threshold(self.class_names)
         post_process_stream = self._post_process_stream
-        with torch.cuda.stream(post_process_stream):
+        with use_cuda_stream(post_process_stream):
             if post_process_stream is not None:
                 model_results.record_stream(post_process_stream)
             nms_results = run_nms_yolov5(

--- a/inference_models/inference_models/models/yolov7/yolov7_instance_segmentation_onnx.py
+++ b/inference_models/inference_models/models/yolov7/yolov7_instance_segmentation_onnx.py
@@ -43,7 +43,7 @@ from inference_models.models.common.roboflow.post_processing import (
 from inference_models.models.common.roboflow.pre_processing import (
     pre_process_network_input,
 )
-from inference_models.models.common.streams import get_cuda_stream
+from inference_models.models.common.streams import get_cuda_stream, use_cuda_stream
 from inference_models.models.yolov7.common import prepare_dense_masks, prepare_rle_masks
 from inference_models.utils.onnx_introspection import (
     get_selected_onnx_execution_providers,
@@ -183,7 +183,7 @@ class YOLOv7ForInstanceSegmentationOnnx(
         **kwargs,
     ) -> Tuple[torch.Tensor, List[PreProcessingMetadata]]:
         pre_process_stream = self._pre_process_stream
-        with torch.cuda.stream(pre_process_stream):
+        with use_cuda_stream(pre_process_stream):
             pre_processed_images, pre_processing_meta = pre_process_network_input(
                 images=images,
                 image_pre_processing=self._inference_config.image_pre_processing,
@@ -245,7 +245,7 @@ class YOLOv7ForInstanceSegmentationOnnx(
             ["__objectness_slot__", *self.class_names]
         )
         post_process_stream = self._post_process_stream
-        with torch.cuda.stream(post_process_stream):
+        with use_cuda_stream(post_process_stream):
             if post_process_stream is not None:
                 for result_element in model_results:
                     result_element.record_stream(post_process_stream)

--- a/inference_models/inference_models/models/yolov8/yolov8_classification_onnx.py
+++ b/inference_models/inference_models/models/yolov8/yolov8_classification_onnx.py
@@ -32,7 +32,7 @@ from inference_models.models.common.roboflow.model_packages import (
 from inference_models.models.common.roboflow.pre_processing import (
     pre_process_network_input,
 )
-from inference_models.models.common.streams import get_cuda_stream
+from inference_models.models.common.streams import get_cuda_stream, use_cuda_stream
 from inference_models.utils.onnx_introspection import (
     get_selected_onnx_execution_providers,
 )
@@ -165,7 +165,7 @@ class YOLOv8ForClassificationOnnx(ClassificationModel[torch.Tensor, torch.Tensor
         **kwargs,
     ) -> torch.Tensor:
         pre_process_stream = self._pre_process_stream
-        with torch.cuda.stream(pre_process_stream):
+        with use_cuda_stream(pre_process_stream):
             pre_processed_images = pre_process_network_input(
                 images=images,
                 image_pre_processing=self._inference_config.image_pre_processing,
@@ -197,7 +197,7 @@ class YOLOv8ForClassificationOnnx(ClassificationModel[torch.Tensor, torch.Tensor
         **kwargs,
     ) -> ClassificationPrediction:
         post_process_stream = self._post_process_stream
-        with torch.cuda.stream(post_process_stream):
+        with use_cuda_stream(post_process_stream):
             if post_process_stream is not None:
                 model_results.record_stream(post_process_stream)
             if self._inference_config.post_processing.fused:

--- a/inference_models/inference_models/models/yolov8/yolov8_instance_segmentation_onnx.py
+++ b/inference_models/inference_models/models/yolov8/yolov8_instance_segmentation_onnx.py
@@ -47,7 +47,7 @@ from inference_models.models.common.roboflow.post_processing import (
 from inference_models.models.common.roboflow.pre_processing import (
     pre_process_network_input,
 )
-from inference_models.models.common.streams import get_cuda_stream
+from inference_models.models.common.streams import get_cuda_stream, use_cuda_stream
 from inference_models.models.yolov8.common import prepare_dense_masks, prepare_rle_masks
 from inference_models.utils.onnx_introspection import (
     get_selected_onnx_execution_providers,
@@ -193,7 +193,7 @@ class YOLOv8ForInstanceSegmentationOnnx(
         **kwargs,
     ) -> Tuple[torch.Tensor, List[PreProcessingMetadata]]:
         pre_process_stream = self._pre_process_stream
-        with torch.cuda.stream(pre_process_stream):
+        with use_cuda_stream(pre_process_stream):
             pre_processed_images, pre_processing_meta = pre_process_network_input(
                 images=images,
                 image_pre_processing=self._inference_config.image_pre_processing,
@@ -250,7 +250,7 @@ class YOLOv8ForInstanceSegmentationOnnx(
         )
         confidence = confidence_filter.get_threshold(self.class_names)
         post_process_stream = self._post_process_stream
-        with torch.cuda.stream(post_process_stream):
+        with use_cuda_stream(post_process_stream):
             if post_process_stream is not None:
                 for result_element in model_results:
                     result_element.record_stream(post_process_stream)

--- a/inference_models/inference_models/models/yolov8/yolov8_key_points_detection_onnx.py
+++ b/inference_models/inference_models/models/yolov8/yolov8_key_points_detection_onnx.py
@@ -47,7 +47,7 @@ from inference_models.models.common.roboflow.post_processing import (
 from inference_models.models.common.roboflow.pre_processing import (
     pre_process_network_input,
 )
-from inference_models.models.common.streams import get_cuda_stream
+from inference_models.models.common.streams import get_cuda_stream, use_cuda_stream
 from inference_models.utils.onnx_introspection import (
     get_selected_onnx_execution_providers,
 )
@@ -210,7 +210,7 @@ class YOLOv8ForKeyPointsDetectionOnnx(
         **kwargs,
     ) -> Tuple[torch.Tensor, List[PreProcessingMetadata]]:
         pre_process_stream = self._pre_process_stream
-        with torch.cuda.stream(pre_process_stream):
+        with use_cuda_stream(pre_process_stream):
             pre_processed_images, pre_processing_meta = pre_process_network_input(
                 images=images,
                 image_pre_processing=self._inference_config.image_pre_processing,
@@ -252,7 +252,7 @@ class YOLOv8ForKeyPointsDetectionOnnx(
         )
         confidence = confidence_filter.get_threshold(self.class_names)
         post_process_stream = self._post_process_stream
-        with torch.cuda.stream(post_process_stream):
+        with use_cuda_stream(post_process_stream):
             if post_process_stream is not None:
                 model_results.record_stream(post_process_stream)
             if self._inference_config.post_processing.fused:

--- a/inference_models/inference_models/models/yolov8/yolov8_object_detection_onnx.py
+++ b/inference_models/inference_models/models/yolov8/yolov8_object_detection_onnx.py
@@ -40,7 +40,7 @@ from inference_models.models.common.roboflow.post_processing import (
 from inference_models.models.common.roboflow.pre_processing import (
     pre_process_network_input,
 )
-from inference_models.models.common.streams import get_cuda_stream
+from inference_models.models.common.streams import get_cuda_stream, use_cuda_stream
 from inference_models.utils.onnx_introspection import (
     get_selected_onnx_execution_providers,
 )
@@ -184,7 +184,7 @@ class YOLOv8ForObjectDetectionOnnx(
         **kwargs,
     ) -> Tuple[torch.Tensor, List[PreProcessingMetadata]]:
         pre_process_stream = self._pre_process_stream
-        with torch.cuda.stream(pre_process_stream):
+        with use_cuda_stream(pre_process_stream):
             pre_processed_images, pre_processing_meta = pre_process_network_input(
                 images=images,
                 image_pre_processing=self._inference_config.image_pre_processing,
@@ -225,7 +225,7 @@ class YOLOv8ForObjectDetectionOnnx(
         )
         confidence = confidence_filter.get_threshold(self.class_names)
         post_process_stream = self._post_process_stream
-        with torch.cuda.stream(post_process_stream):
+        with use_cuda_stream(post_process_stream):
             if post_process_stream is not None:
                 model_results.record_stream(post_process_stream)
             if self._inference_config.post_processing.fused:

--- a/inference_models/tests/unit_tests/models/common/test_streams.py
+++ b/inference_models/tests/unit_tests/models/common/test_streams.py
@@ -1,0 +1,64 @@
+from contextlib import contextmanager
+from typing import Generator
+
+import pytest
+import torch
+
+from inference_models.models.common.streams import get_cuda_stream, use_cuda_stream
+
+
+@pytest.mark.parametrize("device", [torch.device("cpu"), torch.device("mps")])
+def test_get_cuda_stream_returns_none_for_non_cuda_device(
+    device: torch.device, monkeypatch
+) -> None:
+    # given
+    def raise_if_called(*args, **kwargs):
+        raise AssertionError("torch.cuda.Stream must not be used for non-CUDA devices")
+
+    monkeypatch.setattr(torch.cuda, "Stream", raise_if_called)
+
+    # when
+    result = get_cuda_stream(device=device, purpose="pre-processing")
+
+    # then
+    assert result is None
+
+
+def test_use_cuda_stream_is_no_op_when_stream_is_none(monkeypatch) -> None:
+    # given
+    def raise_if_called(*args, **kwargs):
+        raise AssertionError("torch.cuda.stream must not be used without a CUDA stream")
+
+    monkeypatch.setattr(torch.cuda, "stream", raise_if_called)
+
+    # when
+    with use_cuda_stream(None):
+        result = "processed"
+
+    # then
+    assert result == "processed"
+
+
+def test_use_cuda_stream_activates_provided_stream(monkeypatch) -> None:
+    # given
+    calls = []
+    cuda_stream = object()
+
+    @contextmanager
+    def track_cuda_stream(stream) -> Generator[None, None, None]:
+        calls.append(("enter", stream))
+        yield
+        calls.append(("exit", stream))
+
+    monkeypatch.setattr(torch.cuda, "stream", track_cuda_stream)
+
+    # when
+    with use_cuda_stream(cuda_stream):
+        calls.append(("body", cuda_stream))
+
+    # then
+    assert calls == [
+        ("enter", cuda_stream),
+        ("body", cuda_stream),
+        ("exit", cuda_stream),
+    ]


### PR DESCRIPTION
## Why

ONNX models in `inference-models` entered `torch.cuda.stream(...)` unconditionally around preprocessing and postprocessing. On non-CUDA devices, `get_cuda_stream(...)` returns `None`; with MPS active on Apple Silicon, passing that value to PyTorch's CUDA context resolves the current MPS accelerator and fails on the missing `torch.mps.current_device()` API before inference begins.

Fixes #2757

## What changed

- add a shared `use_cuda_stream(...)` context helper that becomes a no-op only when the optional stream is `None`
- apply the helper to all 25 ONNX implementations that use optional CUDA streams (55 production contexts)
- add CPU, MPS, no-op, and CUDA-delegation regression tests
- document the fix in the `inference-models` changelog

## Verification

- `cd inference_models && .venv/bin/python -m pytest tests/unit_tests/models/common/test_streams.py tests/unit_tests/models/rfdetr/test_base_execution_stages.py tests/unit_tests/models/rfdetr/test_pre_processing.py tests/unit_tests/models/rfdetr/test_common.py -q`
  - 36 passed
- `cd inference_models && .venv/bin/python -m pytest -n auto -m "not gpu_only" tests/unit_tests`
  - 1407 passed, 18 skipped
  - 10 existing macOS path-normalization failures compare `/var` with `/private/var`; the same failures reproduce on clean upstream and none touch files changed here
- Apple Silicon MPS smoke test
  - clean `main` reproduced the original `torch.mps.current_device` failure
  - this branch completed real RF-DETR ONNX inference
- NVIDIA RTX 4090 CUDA parity test
  - RF-DETR Nano ONNX ran on `cuda:0` with `CUDAExecutionProvider`
  - clean `main` and this branch both produced 10 detections and identical serialized output SHA-256: `85aa97e335585cf794622988f96cdba911c327732286c4d1351d87428ebdb92b`
- `git diff --check`, Black, isort, and `make check_code_quality` passed

## Not verified

- the full Docker, T4, and Jetson GPU matrix
- real CUDA end-to-end inference for every affected model family; RF-DETR object detection was used as the representative ONNX CUDA path

## Risks / rollback

The CUDA path still delegates to the existing `torch.cuda.stream(stream)` context whenever a stream is present. The behavior change is limited to replacing an invalid CUDA context with a no-op when no stream exists. Reverting commit `76641ba74` restores the previous behavior.

## Migrations / external effects

None.

## Screenshots / preview

Not applicable; this changes runtime device handling.