### PR TITLE
Serialize concurrent MemoryCache lock initialization

### DIFF
--- a/inference/core/cache/memory.py
+++ b/inference/core/cache/memory.py
@@ -15,6 +15,7 @@ class MemoryCache(BaseCache):
         cache (dict): A dictionary to store the cache values.
         expires (dict): A dictionary to store the expiration times of the cache values.
         zexpires (dict): A dictionary to store the expiration times of the sorted set values.
+        _lock_creation_lock (threading.Lock): A lock serializing cache lock creation.
         _expire_thread (threading.Thread): A thread that runs the _expire method.
     """
 
@@ -25,6 +26,7 @@ class MemoryCache(BaseCache):
         self.cache = dict()
         self.expires = dict()
         self.zexpires = dict()
+        self._lock_creation_lock = Lock()
 
         self._expire_thread = threading.Thread(target=self._expire)
         self._expire_thread.daemon = True
@@ -154,8 +156,11 @@ class MemoryCache(BaseCache):
     def acquire_lock(self, key: str, expire=None) -> Any:
         lock: Optional[Lock] = self.get(key)
         if lock is None:
-            lock = Lock()
-            self.set(key, lock, expire=expire)
+            with self._lock_creation_lock:
+                lock = self.get(key)
+                if lock is None:
+                    lock = Lock()
+                    self.set(key, lock, expire=expire)
         if expire is None:
             expire = -1
         acquired = lock.acquire(timeout=expire)

--- a/tests/inference/unit_tests/core/cache/test_memory_cache.py
+++ b/tests/inference/unit_tests/core/cache/test_memory_cache.py
@@ -1,0 +1,35 @@
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+from inference.core.cache.memory import MemoryCache
+
+
+def test_acquire_lock_serializes_concurrent_initialization(monkeypatch) -> None:
+    cache = MemoryCache()
+    initial_reads_complete = threading.Barrier(2)
+    get_calls_lock = threading.Lock()
+    get_calls = 0
+    original_get = cache.get
+
+    def get_with_scheduling_gap(key: str):
+        nonlocal get_calls
+        value = original_get(key)
+        with get_calls_lock:
+            get_calls += 1
+            is_initial_read = get_calls <= 2
+        if is_initial_read:
+            initial_reads_complete.wait(timeout=5.0)
+        return value
+
+    monkeypatch.setattr(cache, "get", get_with_scheduling_gap)
+
+    def acquire_shared_lock():
+        lock = cache.acquire_lock("shared-key", expire=1.0)
+        lock.release()
+        return lock
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [executor.submit(acquire_shared_lock) for _ in range(2)]
+        locks = [future.result(timeout=10.0) for future in futures]
+
+    assert locks[0] is locks[1]


### PR DESCRIPTION
## Why

Two threads can concurrently observe a missing `MemoryCache` lock key, create different `threading.Lock` objects, and both enter work that should be serialized.

Fixes #2772.

## What changed

- add a short process-local guard around the missing-key lookup/create sequence
- double-check the cache after entering the guard so only one lock object is stored
- release the creation guard before the potentially blocking per-key acquisition
- add a deterministic barrier-based regression test for two concurrent first callers

Hot-key acquisition, lock timeout, and TTL refresh behavior are unchanged.

## Verification

- regression test against the unmodified parent: fails because the two callers receive distinct locks
- `.venv/bin/python -m pytest --confcutdir=tests/inference/unit_tests tests/inference/unit_tests/core/cache -q`
  - 87 passed
- `.venv/bin/python -m pytest --confcutdir=tests/inference/unit_tests tests/inference/unit_tests/core/active_learning/test_cache_operations.py -q`
  - 21 passed
- forced race regression: 250/250 iterations passed
- 16-thread cold-key smoke: one lock object, maximum one concurrent critical section
- `make check_code_quality`
- `git diff --check`

## Not verified

- the full repository test suite was not run locally because it requires optional model and platform dependencies
- the upstream Python 3.10/3.11/3.12 matrix remains to be run by CI
- this change is scoped to simultaneous initialization of a missing lock key; it does not change expiration-boundary behavior or make the complete cache implementation globally thread-safe

## Risks / rollback

The new guard briefly serializes first-time lock creation across different keys, but it is held only for in-memory lookups and one write, never while waiting on a per-key lock. Reverting the commit restores the previous behavior.

## Migrations / external effects

None.

## Screenshots / preview

Not applicable; this is an internal concurrency fix.