### PR TITLE
ENT-1677: Apply RTSPS TLS options to the OpenCV capture open

### DIFF
--- a/inference/core/interfaces/camera/rtsp_opencv_tls.py
+++ b/inference/core/interfaces/camera/rtsp_opencv_tls.py
@@ -96,8 +96,13 @@ def opencv_rtsps_tls_env(video: Union[str, int]) -> Iterator[None]:
 
     OpenCV reads this env var at capture-open time. The lock spans set →
     VideoCapture open → restore so concurrent RTSPS sources cannot clobber each
-    other's TLS options. Isolation is RTSPS-vs-RTSPS only; concurrent non-RTSPS
-    opens do not take the lock and may briefly inherit these options.
+    other's TLS options.
+
+    Non-RTSPS opens (USB, V4L2, files, plain ``rtsp://``) do not take this lock
+    and are not serialized here. A process-wide lock around every VideoCapture
+    would stall those backends, which have no FFmpeg open timeout. Concurrent
+    non-RTSPS FFmpeg opens may briefly inherit these options; that window is
+    preferred over blocking every producer on one hung camera.
     """
     options = build_opencv_ffmpeg_capture_options(video)
     if options is None:

--- a/inference/core/interfaces/camera/rtsp_opencv_tls.py
+++ b/inference/core/interfaces/camera/rtsp_opencv_tls.py
@@ -1,4 +1,15 @@
-"""OpenCV/FFmpeg RTSPS TLS option builder (ENT-1544 B3)."""
+"""OpenCV/FFmpeg RTSPS TLS option builder (ENT-1544 B3).
+
+Environment variables (also set by rfdm on Roboflow Edge devices):
+
+* ``ROBOFLOW_RTSP_TLS_VALIDATION_FLAGS`` — ``127`` strict (default when unset),
+  ``126`` or ``0`` to disable certificate verification (self-signed / custom CA).
+* ``GST_SSL_CA_CERTIFICATE`` or ``SSL_CERT_FILE`` — PEM bundle for ``cafile``.
+
+Self-hosted / OSS deployments without rfdm must set these explicitly on the
+inference container. Unmanaged ``rtsps://`` sources with self-signed certs need
+``ROBOFLOW_RTSP_TLS_VALIDATION_FLAGS=126`` or the open will fail after this wiring.
+"""
 
 from __future__ import annotations
 

--- a/inference/core/interfaces/camera/rtsp_opencv_tls.py
+++ b/inference/core/interfaces/camera/rtsp_opencv_tls.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import os
 import threading
 from contextlib import contextmanager
-from typing import Dict, Iterator, Optional
+from typing import Dict, Iterator, Optional, Union
 
 from inference.core.interfaces.camera.rtsp_tls import (
     GST_SSL_CA_CERTIFICATE_ENV_VAR,
@@ -67,7 +67,7 @@ def merge_opencv_ffmpeg_capture_options(
     return _format_opencv_ffmpeg_capture_options(merged)
 
 
-def build_opencv_ffmpeg_capture_options(video: str) -> Optional[str]:
+def build_opencv_ffmpeg_capture_options(video: Union[str, int]) -> Optional[str]:
     """Build OPENCV_FFMPEG_CAPTURE_OPTIONS for RTSPS sources."""
     if not is_rtsps_url(video):
         return None
@@ -80,12 +80,13 @@ def build_opencv_ffmpeg_capture_options(video: str) -> Optional[str]:
 
 
 @contextmanager
-def opencv_rtsps_tls_env(video: str) -> Iterator[None]:
+def opencv_rtsps_tls_env(video: Union[str, int]) -> Iterator[None]:
     """Hold OPENCV_FFMPEG_CAPTURE_OPTIONS for one VideoCapture open.
 
     OpenCV reads this env var at capture-open time. The lock spans set →
     VideoCapture open → restore so concurrent RTSPS sources cannot clobber each
-    other's TLS options.
+    other's TLS options. Isolation is RTSPS-vs-RTSPS only; concurrent non-RTSPS
+    opens do not take the lock and may briefly inherit these options.
     """
     options = build_opencv_ffmpeg_capture_options(video)
     if options is None:

--- a/inference/core/interfaces/camera/video_source.py
+++ b/inference/core/interfaces/camera/video_source.py
@@ -36,6 +36,7 @@ from inference.core.interfaces.camera.exceptions import (
     EndOfStreamError,
     StreamOperationNotAllowedError,
 )
+from inference.core.interfaces.camera.rtsp_opencv_tls import opencv_rtsps_tls_env
 from inference.core.interfaces.camera.source_reference_sanitizer import (
     redact_credentials_in_text,
     sanitize_source_reference,
@@ -149,7 +150,7 @@ class CV2VideoFrameProducer(VideoFrameProducer):
     def __init__(self, video: Union[str, int]):
         self._source_ref = video
         self._connection_error_message = ""
-        with capture_process_stderr() as captured_stderr:
+        with opencv_rtsps_tls_env(video), capture_process_stderr() as captured_stderr:
             if _consumes_camera_on_jetson(video=video):
                 self.stream = cv2.VideoCapture(video, cv2.CAP_V4L2)
             else:

--- a/inference/core/interfaces/camera/video_source.py
+++ b/inference/core/interfaces/camera/video_source.py
@@ -146,11 +146,20 @@ def lock_state_transition(
     return locked_executor
 
 
+# VideoCapture open mutates process-global state (OPENCV_FFMPEG_CAPTURE_OPTIONS
+# and stderr fd 2). Serialize so concurrent cameras cannot clobber each other.
+_capture_open_lock = Lock()
+
+
 class CV2VideoFrameProducer(VideoFrameProducer):
     def __init__(self, video: Union[str, int]):
         self._source_ref = video
         self._connection_error_message = ""
-        with opencv_rtsps_tls_env(video), capture_process_stderr() as captured_stderr:
+        with (
+            _capture_open_lock,
+            opencv_rtsps_tls_env(video),
+            capture_process_stderr() as captured_stderr,
+        ):
             if _consumes_camera_on_jetson(video=video):
                 self.stream = cv2.VideoCapture(video, cv2.CAP_V4L2)
             else:

--- a/inference/core/interfaces/camera/video_source.py
+++ b/inference/core/interfaces/camera/video_source.py
@@ -146,20 +146,11 @@ def lock_state_transition(
     return locked_executor
 
 
-# VideoCapture open mutates process-global state (OPENCV_FFMPEG_CAPTURE_OPTIONS
-# and stderr fd 2). Serialize so concurrent cameras cannot clobber each other.
-_capture_open_lock = Lock()
-
-
 class CV2VideoFrameProducer(VideoFrameProducer):
     def __init__(self, video: Union[str, int]):
         self._source_ref = video
         self._connection_error_message = ""
-        with (
-            _capture_open_lock,
-            opencv_rtsps_tls_env(video),
-            capture_process_stderr() as captured_stderr,
-        ):
+        with opencv_rtsps_tls_env(video), capture_process_stderr() as captured_stderr:
             if _consumes_camera_on_jetson(video=video):
                 self.stream = cv2.VideoCapture(video, cv2.CAP_V4L2)
             else:

--- a/tests/inference/unit_tests/core/interfaces/camera/test_video_source.py
+++ b/tests/inference/unit_tests/core/interfaces/camera/test_video_source.py
@@ -1994,3 +1994,42 @@ def test_cv2_producer_leaves_ffmpeg_tls_env_unset_for_device_index(
     assert seen["video"] == 0
     assert seen["env"] is None
     assert OPENCV_FFMPEG_CAPTURE_OPTIONS_ENV_VAR not in os.environ
+
+
+def test_cv2_producer_non_rtsps_open_does_not_wait_on_stuck_rtsps(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(OPENCV_FFMPEG_CAPTURE_OPTIONS_ENV_VAR, raising=False)
+    monkeypatch.delenv(RTSP_TLS_VALIDATION_FLAGS_ENV_VAR, raising=False)
+    rtsps_entered = Event()
+    release_rtsps = Event()
+    non_rtsps_opened = Event()
+
+    def fake_video_capture(video, *args, **kwargs):
+        if isinstance(video, str) and video.startswith("rtsps://"):
+            rtsps_entered.set()
+            assert release_rtsps.wait(timeout=2.0)
+        else:
+            non_rtsps_opened.set()
+        return MagicMock()
+
+    with patch.object(video_source.cv2, "VideoCapture", fake_video_capture):
+        rtsps_thread = Thread(
+            target=lambda: CV2VideoFrameProducer("rtsps://camera.example/stream")
+        )
+        rtsps_thread.start()
+        assert rtsps_entered.wait(timeout=1.0)
+
+        non_rtsps_thread = Thread(target=lambda: CV2VideoFrameProducer(0))
+        non_rtsps_thread.start()
+        opened_without_waiting = non_rtsps_opened.wait(timeout=1.0)
+
+        release_rtsps.set()
+        rtsps_thread.join(timeout=2.0)
+        non_rtsps_thread.join(timeout=2.0)
+
+    assert opened_without_waiting, (
+        "USB/file/V4L2 opens must not wait on a stuck RTSPS VideoCapture"
+    )
+    assert not rtsps_thread.is_alive()
+    assert not non_rtsps_thread.is_alive()

--- a/tests/inference/unit_tests/core/interfaces/camera/test_video_source.py
+++ b/tests/inference/unit_tests/core/interfaces/camera/test_video_source.py
@@ -1,4 +1,5 @@
 import importlib
+import os
 import time
 from datetime import datetime
 from functools import partial
@@ -25,6 +26,10 @@ from inference.core.interfaces.camera.exceptions import (
     SourceConnectionError,
     StreamOperationNotAllowedError,
 )
+from inference.core.interfaces.camera.rtsp_opencv_tls import (
+    OPENCV_FFMPEG_CAPTURE_OPTIONS_ENV_VAR,
+)
+from inference.core.interfaces.camera.rtsp_tls import RTSP_TLS_VALIDATION_FLAGS_ENV_VAR
 from inference.core.interfaces.camera.stream_error_codes import StreamErrorCode
 from inference.core.interfaces.camera.video_source import (
     BufferConsumptionStrategy,
@@ -1917,3 +1922,26 @@ def test_consume_video_emits_poison_pill_on_consume_error() -> None:
     assert source._state is StreamState.ERROR
     with pytest.raises(EndOfStreamError):
         source.read_frame(timeout=0.0)
+
+
+def test_cv2_producer_sets_ffmpeg_tls_options_only_for_rtsps(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # given
+    monkeypatch.delenv(OPENCV_FFMPEG_CAPTURE_OPTIONS_ENV_VAR, raising=False)
+    monkeypatch.delenv(RTSP_TLS_VALIDATION_FLAGS_ENV_VAR, raising=False)
+    seen = {}
+
+    def fake_video_capture(video, *args, **kwargs):
+        seen[video] = os.environ.get(OPENCV_FFMPEG_CAPTURE_OPTIONS_ENV_VAR)
+        return MagicMock()
+
+    # when
+    with patch.object(video_source.cv2, "VideoCapture", fake_video_capture):
+        CV2VideoFrameProducer("rtsps://camera.example/stream")
+        CV2VideoFrameProducer("rtsp://camera.example/stream")
+
+    # then - OpenCV reads the env var at capture-open time, so it must be set
+    # while VideoCapture runs for RTSPS, and left alone for plain RTSP
+    assert "tls_verify;1" in seen["rtsps://camera.example/stream"]
+    assert seen["rtsp://camera.example/stream"] is None

--- a/tests/inference/unit_tests/core/interfaces/camera/test_video_source.py
+++ b/tests/inference/unit_tests/core/interfaces/camera/test_video_source.py
@@ -1945,3 +1945,52 @@ def test_cv2_producer_sets_ffmpeg_tls_options_only_for_rtsps(
     # while VideoCapture runs for RTSPS, and left alone for plain RTSP
     assert "tls_verify;1" in seen["rtsps://camera.example/stream"]
     assert seen["rtsp://camera.example/stream"] is None
+    assert OPENCV_FFMPEG_CAPTURE_OPTIONS_ENV_VAR not in os.environ
+
+
+def test_cv2_producer_restores_ffmpeg_tls_env_after_open(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(OPENCV_FFMPEG_CAPTURE_OPTIONS_ENV_VAR, raising=False)
+    monkeypatch.delenv(RTSP_TLS_VALIDATION_FLAGS_ENV_VAR, raising=False)
+
+    with patch.object(video_source.cv2, "VideoCapture", MagicMock()):
+        CV2VideoFrameProducer("rtsps://camera.example/stream")
+
+    assert OPENCV_FFMPEG_CAPTURE_OPTIONS_ENV_VAR not in os.environ
+
+
+def test_cv2_producer_restores_ffmpeg_tls_env_when_capture_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(OPENCV_FFMPEG_CAPTURE_OPTIONS_ENV_VAR, raising=False)
+    monkeypatch.delenv(RTSP_TLS_VALIDATION_FLAGS_ENV_VAR, raising=False)
+
+    def failing_video_capture(*args, **kwargs):
+        raise RuntimeError("simulated open failure")
+
+    with patch.object(
+        video_source.cv2, "VideoCapture", failing_video_capture
+    ), pytest.raises(RuntimeError):
+        CV2VideoFrameProducer("rtsps://camera.example/stream")
+
+    assert OPENCV_FFMPEG_CAPTURE_OPTIONS_ENV_VAR not in os.environ
+
+
+def test_cv2_producer_leaves_ffmpeg_tls_env_unset_for_device_index(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(OPENCV_FFMPEG_CAPTURE_OPTIONS_ENV_VAR, raising=False)
+    seen = {}
+
+    def fake_video_capture(video, *args, **kwargs):
+        seen["video"] = video
+        seen["env"] = os.environ.get(OPENCV_FFMPEG_CAPTURE_OPTIONS_ENV_VAR)
+        return MagicMock()
+
+    with patch.object(video_source.cv2, "VideoCapture", fake_video_capture):
+        CV2VideoFrameProducer(0)
+
+    assert seen["video"] == 0
+    assert seen["env"] is None
+    assert OPENCV_FFMPEG_CAPTURE_OPTIONS_ENV_VAR not in os.environ


### PR DESCRIPTION
# Description

Wires the B3 `opencv_rtsps_tls_env` helper (inference#2727) into `CV2VideoFrameProducer` so non-Jetson OpenCV/FFmpeg RTSPS opens honor rfdm-injected TLS settings.

**Problem:** `opencv_rtsps_tls_env` was unit-tested but never called. `CV2VideoFrameProducer` opened `rtsps://` with bare `cv2.VideoCapture`, so FFmpeg got no `cafile` or `tls_verify`. RTSPS was encrypted but unauthenticated on every OpenCV fallback device.

**Change:**
- Wrap capture open with `opencv_rtsps_tls_env(video)` before `capture_process_stderr()` (TLS lock must sit outside the global stderr redirect).
- Widen helper signatures to `Union[str, int]` to match the producer call site.
- Document that env-var isolation is RTSPS-vs-RTSPS only (concurrent non-RTSPS opens do not take the lock).

**RTSPS TLS product model (permanent):**
- Default: validate against the device CA trust bundle (`tls_validation_flags=127` from rfdm).
- Self-signed / custom CA: operator enables **allow_self_signed** in Device Manager (B4) → rfdm sets `126` → FFmpeg maps to `tls_verify=0`.
- **ENT-1680 (remove bypass) is cancelled** — the toggle stays.

**Depends on:** nothing. **Blocks:** inference#2792 (hardening stacks on this branch).

Linear: [ENT-1677](https://linear.app/roboflow/issue/ENT-1677)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Maintenance (non-breaking, non-user facing changing such as dependency update, adding test, modifying secrets, etc.)
- [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

- `test_cv2_producer_sets_ffmpeg_tls_options_only_for_rtsps` — asserts `OPENCV_FFMPEG_CAPTURE_OPTIONS` is visible inside `cv2.VideoCapture` for `rtsps://` and absent for `rtsp://` (fails on `main`, passes here).
- Existing `test_rtsp_opencv_tls.py` — 13 passed.
- CI unit/integration suites on rebased branch.

## Will the change affect Universe? If so was this change tested in universe?

No. Edge inference pipeline path only.

## Any specific deployment considerations

Reaches devices via inference release → roboflow-edge pin bump. Behavior change limited to `rtsps://` on the OpenCV path. Jetson GStreamer path unchanged.

Merge **before** inference#2792.

## Docs

- [ ] Docs updated? What were the changes: N/A — operator docs for allow_self_signed shipped in B4.