### PR TITLE
Add staging MMP capacity experiment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -33,7 +33,9 @@ coverage.xml
 .mypy_cache
 .pytest_cache
 .hypothesis
-development
+development/*
+!development/mmp_staging_benchmark/
+!development/mmp_staging_benchmark/**
 .pytest_cache
 cache-test
 scratch

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ share/python-wheels/
 MANIFEST
 _classes.csv
 node_modules/
+development/mmp_staging_benchmark/results/
 
 
 # Build directories

--- a/development/mmp_staging_benchmark/Dockerfile
+++ b/development/mmp_staging_benchmark/Dockerfile
@@ -1,0 +1,116 @@
+# Staging-only MMP experiment image. Build for linux/amd64 from the repository
+# root. Base images are pinned to platform-specific manifest digests so the
+# runtime does not drift underneath an experiment.
+
+ARG CUDA_BUILDER_IMAGE=nvcr.io/nvidia/cuda@sha256:0a1cb6e7bd047a1067efe14efdf0276352d5ca643dfd77963dab1a4f05a003a4
+ARG CUDA_RUNTIME_IMAGE=nvcr.io/nvidia/cuda@sha256:0bb88834d973ca1b450fcc2a05333c6fe45510bee289912a5391274c351c4a4d
+ARG UV_IMAGE=ghcr.io/astral-sh/uv@sha256:dfd1e6972e100ca2fbf1f391effc3dd4aa57f319bf03c3e321e0a3f3341ed5af
+ARG BENCHMARK_PLATFORM=linux/amd64
+ARG PYTHON_VERSION=3.12
+ARG PYTHON_DEPENDENCY_CUTOFF=2026-08-12T00:00:00Z
+ARG SOURCE_REVISION=unknown
+
+FROM --platform=${BENCHMARK_PLATFORM} ${UV_IMAGE} AS uv
+
+FROM --platform=${BENCHMARK_PLATFORM} ${CUDA_BUILDER_IMAGE} AS builder
+ARG PYTHON_VERSION
+ARG PYTHON_DEPENDENCY_CUTOFF
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PYTHONUNBUFFERED=1 \
+    VIRTUAL_ENV=/opt/venv \
+    PATH=/opt/venv/bin:$PATH \
+    UV_LINK_MODE=copy
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        git curl ca-certificates build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=uv /uv /usr/local/bin/uv
+
+# Keep the expensive dependency layer independent of source edits. This
+# mirrors inference_server/docker/Dockerfile.gpu while fixing all image bases.
+WORKDIR /app
+COPY inference_models/pyproject.toml        inference_models/README.md        /app/inference_models/
+COPY inference_model_manager/pyproject.toml inference_model_manager/README.md /app/inference_model_manager/
+COPY inference_server/pyproject.toml        inference_server/README.md        /app/inference_server/
+RUN mkdir -p /app/inference_models/inference_models \
+             /app/inference_model_manager/inference_model_manager \
+             /app/inference_server/inference_server \
+    && touch /app/inference_models/inference_models/__init__.py \
+             /app/inference_model_manager/inference_model_manager/__init__.py \
+             /app/inference_server/inference_server/__init__.py
+
+WORKDIR /app/inference_models
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv python install ${PYTHON_VERSION} \
+    && uv venv --python ${PYTHON_VERSION} /opt/venv \
+    && uv pip install --exclude-newer ${PYTHON_DEPENDENCY_CUTOFF} \
+        -e ".[torch-cu124,onnx-cu12,trt10-runtime]" \
+        -e "../inference_model_manager[cuda]" \
+        -e "../inference_server"
+
+COPY inference_models        /app/inference_models
+COPY inference_model_manager /app/inference_model_manager
+COPY inference_server        /app/inference_server
+
+FROM --platform=${BENCHMARK_PLATFORM} ${CUDA_RUNTIME_IMAGE} AS runtime
+ARG SOURCE_REVISION
+
+LABEL org.opencontainers.image.title="Roboflow staging MMP benchmark" \
+      org.opencontainers.image.revision="${SOURCE_REVISION}" \
+      com.roboflow.environment="staging-only" \
+      com.roboflow.experiment="mmp-capacity" \
+      com.roboflow.cuda.builder.digest="sha256:0a1cb6e7bd047a1067efe14efdf0276352d5ca643dfd77963dab1a4f05a003a4" \
+      com.roboflow.cuda.runtime.digest="sha256:0bb88834d973ca1b450fcc2a05333c6fe45510bee289912a5391274c351c4a4d"
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PYTHONUNBUFFERED=1 \
+    VIRTUAL_ENV=/opt/venv \
+    PATH=/opt/venv/bin:$PATH \
+    API_BASE_URL=https://api.roboflow.one \
+    MODEL_CACHE_DIR=/models/cache \
+    NUM_WORKERS=4 \
+    INFERENCE_N_SLOTS=128 \
+    INFERENCE_INPUT_MB=20 \
+    INFERENCE_BATCH_MAX_SIZE=0 \
+    INFERENCE_BATCH_MAX_WAIT_MS=5 \
+    INFERENCE_DEPLOYMENT_MODE=mmp \
+    NVIDIA_MPS=0 \
+    NVIDIA_VISIBLE_DEVICES=all \
+    NVIDIA_DRIVER_CAPABILITIES=compute,utility \
+    MMP_BENCHMARK_SOURCE_REVISION=${SOURCE_REVISION}
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        git curl ca-certificates openssl \
+        libgl1 libglib2.0-0 libvips ffmpeg libgomp1 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /root/.local/share/uv/python /root/.local/share/uv/python
+COPY --from=builder /opt/venv /opt/venv
+COPY --from=builder /app /app
+
+# Register CUDA/cuDNN/TensorRT wheels with the dynamic loader. The system CUDA
+# runtime remains pinned above; the host driver is injected by the NVIDIA
+# container runtime.
+RUN { ls -d /opt/venv/lib/python*/site-packages/nvidia/*/lib \
+            /opt/venv/lib/python*/site-packages/tensorrt_libs 2>/dev/null || true; } \
+      > /etc/ld.so.conf.d/nvidia-pip.conf \
+    && ldconfig \
+    && mkdir -p /models/cache /opt/mmp-benchmark
+
+RUN python -m pip freeze | LC_ALL=C sort > /opt/mmp-benchmark/python-packages.txt
+
+COPY development/mmp_staging_benchmark/capability_probe.py /opt/mmp-benchmark/capability_probe.py
+COPY development/mmp_staging_benchmark/run_concurrent_clients.py /opt/mmp-benchmark/run_concurrent_clients.py
+COPY development/mmp_staging_benchmark/spec.same-model.example.json /opt/mmp-benchmark/spec.same-model.example.json
+COPY development/mmp_staging_benchmark/spec.same-model-isolated.example.json /opt/mmp-benchmark/spec.same-model-isolated.example.json
+COPY development/mmp_staging_benchmark/spec.mixed-model.example.json /opt/mmp-benchmark/spec.mixed-model.example.json
+
+WORKDIR /app/inference_server
+EXPOSE 8000
+
+HEALTHCHECK --interval=10s --timeout=3s --start-period=30s --retries=6 \
+    CMD curl -fsS http://127.0.0.1:8000/v2/server/health || exit 1
+
+CMD ["/bin/bash", "start_server.sh"]

--- a/development/mmp_staging_benchmark/Dockerfile
+++ b/development/mmp_staging_benchmark/Dockerfile
@@ -106,7 +106,6 @@ COPY development/mmp_staging_benchmark/run_concurrent_clients.py /opt/mmp-benchm
 COPY development/mmp_staging_benchmark/spec.same-model.example.json /opt/mmp-benchmark/spec.same-model.example.json
 COPY development/mmp_staging_benchmark/spec.same-model-isolated.example.json /opt/mmp-benchmark/spec.same-model-isolated.example.json
 COPY development/mmp_staging_benchmark/spec.mixed-model.example.json /opt/mmp-benchmark/spec.mixed-model.example.json
-
 WORKDIR /app/inference_server
 EXPOSE 8000
 

--- a/development/mmp_staging_benchmark/README.md
+++ b/development/mmp_staging_benchmark/README.md
@@ -1,7 +1,8 @@
 # Staging MMP capacity experiment
 
 This directory packages the `feat/new-model-manager` inference server into a
-staging-only GPU image and provides two tools:
+staging-only GPU image and provides a capability probe, local-only concurrent
+runner, immutable matrix/renderers, strict analyzer, and operator runbook:
 
 - `capability_probe.py` verifies the L40S/CUDA/MPS runtime and `/dev/shm`
   geometry before a test.
@@ -99,16 +100,19 @@ it does not modify the normal `video-proc` worker pool.
 python development/mmp_staging_benchmark/render_staging_deployment.py \
   --image "${IMAGE}@sha256:REGISTRY_DIGEST" \
   --source-revision "${REVISION}" \
+  --run-id mmp-capability-001-no-mps \
   --output /tmp/mmp-staging.json
 
 kubectl --context ck8s-stg apply -f /tmp/mmp-staging.json
 ```
 
-The renderer references `mmp-benchmark-api-keys` keys `tenant-a` and
-`tenant-b`; it never accepts secret values. Create that Secret out of band in
-the dedicated staging namespace. Run the capability probe and clients with
-`kubectl exec`, then copy `/results` before deleting the Deployment. Re-render
-with `--mps` only after the non-MPS capability run passes.
+The Deployment intentionally has no Service or Ingress, and the renderer no
+longer injects API keys into the server container. Keep workspace keys only in
+the local runner environment, connect with `kubectl port-forward`, and copy
+reports to a local ignored results directory. Re-render with `--mps` only after
+the non-MPS capability run passes. Never expose this API as a multi-tenant
+service: any valid key can currently see global MMP metrics/model identities and
+invoke global model lifecycle endpoints.
 
 ## Capability and MPS smoke
 
@@ -150,19 +154,38 @@ distinct staging workspaces is what creates a real cross-workspace test.
 export RF_BENCH_TENANT_A_KEY=...
 export RF_BENCH_TENANT_B_KEY=...
 
-python /opt/mmp-benchmark/run_concurrent_clients.py \
-  --spec /opt/mmp-benchmark/spec.same-model.example.json \
-  --image /data/dog.jpg \
-  --output /results/same-model.json
+kubectl --context ck8s-stg -n video-proc-bench-mmp port-forward \
+  deployment/mmp-benchmark-server 18000:8000
+
+python development/mmp_staging_benchmark/render_run_spec.py \
+  --matrix development/mmp_staging_benchmark/matrix.staging.json \
+  --total-concurrency 8 \
+  --run-id mmp-shared-no-mps-c08-r1 \
+  --phase mmp-shared-no-mps \
+  --server-pod "${SERVER_POD}" \
+  --server-node "${SERVER_NODE}" \
+  --output /tmp/mmp-point.json
+
+RF_BENCH_TENANT_A_KEY=... RF_BENCH_TENANT_B_KEY=... \
+python development/mmp_staging_benchmark/run_concurrent_clients.py \
+  --spec /tmp/mmp-point.json \
+  --image tests/workflows/integration_tests/execution/assets/dogs.jpg \
+  --output development/mmp_staging_benchmark/results/same-model.json \
+  --fail-on-errors
 ```
+
+The point renderer derives the harness revision itself and refuses a dirty
+checkout; it cannot be labeled with a caller-supplied SHA.
 
 For a mixed-model test, use `spec.mixed-model.example.json`. Every client has
 its own tenant ID, API-key environment variable, model, instance, concurrency,
 optional target FPS, and model parameters. `target_fps: 0` means closed-loop
 maximum throughput.
 
-The current MMP worker boundary is the routing key, not the tenant label or API
-key. Two clients with the same `model_id` and empty `instance` intentionally
+The current MMP worker boundary is the routing key, not the authenticated
+workspace, tenant label, or API key. The server validates the Bearer key and
+checks per-request model access, but workspace identity is not carried into the
+MMP scheduler. Two clients with the same `model_id` and empty `instance` intentionally
 share one model subprocess and can be auto-batched together; this is what
 `spec.same-model.example.json` measures. It is **not** cross-workspace process
 isolation. Use `spec.same-model-isolated.example.json` to give each tenant a
@@ -170,9 +193,17 @@ distinct `instance`. The MMP then creates separate routing keys and separate
 model subprocesses while loading the same weights. Comparing those two specs
 with and without MPS measures the real isolation/VRAM/throughput tradeoff.
 
-The runner refuses known production Roboflow hosts. Accepted targets are
-localhost/private addresses, Kubernetes service names, and
-`*.roboflow.one`/explicit staging hosts.
+The runner accepts only numeric loopback IPs over plain HTTP, refuses redirects,
+and rejects DNS names (including `localhost`), private addresses, Kubernetes
+service DNS, `*.roboflow.one`, and arbitrary public hosts. The campaign uses
+`127.0.0.1:18000` through the explicit port-forward above.
+
+This transport is JPEG bytes in a CPU-owned shared-memory slot. The model
+worker decodes those bytes and uploads model input to the GPU. CUDA IPC is not
+implemented in this path: `use_cuda_ipc` in `SubprocessBackend` is currently a
+reserved, unused argument. `INFERENCE_DECODER=imagecodecs` is the required
+first comparison; a separately labelled `nvjpeg` axis may follow, but it must
+not be mixed into the raw-MPS A/B.
 
 The JSON report includes:
 
@@ -186,22 +217,102 @@ The JSON report includes:
   MMP/NVML;
 - the source revision and image reference supplied by the image build/runtime.
 
+## Reproducible dry-run
+
+The checked-in matrix pins the already-built exact image digest, workload axes,
+and strict gates. Validate it and render the matched non-MPS/MPS Deployments
+without touching a cluster:
+
+```bash
+python development/mmp_staging_benchmark/validate_staging_plan.py \
+  --matrix development/mmp_staging_benchmark/matrix.staging.json \
+  --run-prefix mmp-capacity-001 \
+  --output /tmp/mmp-capacity-plan.json
+
+python development/mmp_staging_benchmark/render_staging_deployment.py \
+  --image us-central1-docker.pkg.dev/roboflow-staging/video-proc/mmp-benchmark@sha256:6a6592f77e0eb1d3bfc8b82d7add6a7206e946a437a072f7f3a58cf693b1716d \
+  --source-revision 5f02db12ebdda013ff92e6607f92f88c7f9582ec \
+  --run-id mmp-capacity-001-no-mps \
+  --output /tmp/mmp-no-mps.json
+```
+
+After separate staging authorization, server-side dry-run the exact output
+before applying it. The Deployment must remain Service/Ingress-free and own one
+exclusive L40S. Capture the namespace and Deployment before mutation; deleting
+the dedicated namespace is the complete rollback.
+
 ## First staging sequence
 
 1. Start one dedicated L40S pod with `NVIDIA_MPS=0` and the 4 GiB `/dev/shm`.
 2. Save the capability report, image digest, node, GPU UUID, driver, and cache
    state.
-3. Run same-model shared-worker `concurrency = 1, 2, 4, 8, 12, 16, 24, 32`
-   until the SLO knee, repeating each point after model warmup.
-4. Run the same-weight isolated-instance spec, then mixed public
-   detection/segmentation models and distinct private staging-workspace models.
-5. Repeat exactly with `NVIDIA_MPS=1`; compare throughput, tail latency,
-   fairness, worker failures, and VRAM.
+3. Keep the same image digest, node/GPU, decoder, JPEG digest, cache state,
+   batch window, duration, and warmup. Run the shared-backend points from
+   `matrix.staging.json`, twice each in ascending order.
+4. Run same-weight isolated routing keys, then the mixed detection/segmentation
+   points. `instance` is a benchmark routing convention—not an authenticated
+   workspace or security boundary.
+5. Repeat the exact shared/isolated/mixed sequence with `NVIDIA_MPS=1`.
+   MPS adds same-pod CUDA kernel concurrency; it provides neither memory
+   isolation nor tenant-aware fairness.
 6. Re-run the winning configurations as a long soak and inject one client
    cancellation/model-worker failure before considering video integration.
 
-The first L40S run is blocked until (a) the image is built/pushed after GCP
-auth is restored, (b) the dedicated pod has a memory-backed `/dev/shm`, (c)
-the container runtime exposes MPS binaries, (d) at least one staging model API
-key is available as a Secret, and (e) a test image is mounted or downloaded by
-an explicit setup step.
+Apply the strict analyzer to every report and preserve the matching server log:
+
+```bash
+python development/mmp_staging_benchmark/analyze_report.py \
+  development/mmp_staging_benchmark/results/shared-c08-r1.json \
+  --phase mmp-shared-no-mps \
+  --server-log development/mmp_staging_benchmark/results/shared-c08-r1.log \
+  --pod-evidence development/mmp_staging_benchmark/results/pod.json \
+  --capability-report development/mmp_staging_benchmark/results/capability-no-mps.json \
+  --expected-node "${BASELINE_NODE}" \
+  --expected-gpu-uuid "${BASELINE_GPU_UUID}"
+```
+
+A passing single-report analyzer result is not a capacity claim. After both
+repetitions at every point through the first failing boundary, certify the
+curve. This requires two passes at and below capacity plus two failures at the
+next allowed point; a split pair or right-censored curve fails:
+
+```bash
+python development/mmp_staging_benchmark/analyze_curve.py \
+  development/mmp_staging_benchmark/results/shared-*-analysis.json \
+  --matrix development/mmp_staging_benchmark/matrix.staging.json \
+  --phase mmp-shared-no-mps \
+  --output development/mmp_staging_benchmark/results/shared-curve.json
+```
+
+The exact head image is already built at the digest pinned by the matrix
+(Cloud Build `f0bd00b6-f0d1-410a-8ba6-bf9f8e8ccfd0`). Its provenance records
+the uploaded source tar rather than a Git URI, so use the in-image package
+manifest and revision label as evidence but do not overclaim a cryptographic
+Git-tree equivalence. The remaining first-run gates are: separate staging
+authorization, dedicated 4 GiB `/dev/shm`, runtime MPS binaries, two local-only
+staging workspace keys, and verification of the JPEG digest pinned by
+`matrix.staging.json`.
+
+The existing image predates the local matrix, renderers, analyzer, and runbook;
+those are deliberately executed from the clean checked-out harness. Do not
+claim they are embedded in that digest. The server code and original capability
+probe are embedded; a future rebuild would be a separately labeled artifact.
+
+## What this comparison does not answer
+
+Keep these three topologies separate in summaries:
+
+1. **MMP subprocess + auto-batching, MPS off**: this PR's shared/isolated/mixed
+   HTTP-image matrices.
+2. **The exact same MMP matrices + raw same-pod NVIDIA MPS**: changes only CUDA
+   process scheduling; no CUDA IPC and no tenant hard boundary.
+3. **Video POC D/E/F per-job process mode without MMP**: each video job owns
+   decode, workflow, model, CUDA context, and publisher. It is measured with
+   live MediaMTX streams and the video latency/continuity gates, not this JPEG
+   HTTP harness.
+
+The MMP image packages neither InferencePipeline nor the video processor. A
+result here cannot establish end-to-end video capacity, NVDEC behavior, frame
+freshness, watched-output latency, or failure containment of D/E/F. A later
+video integration must preserve the D/E/F source/workflow/FPS/output matrix and
+add MMP as its only changed dimension.

--- a/development/mmp_staging_benchmark/README.md
+++ b/development/mmp_staging_benchmark/README.md
@@ -1,0 +1,174 @@
+# Staging MMP capacity experiment
+
+This directory packages the `feat/new-model-manager` inference server into a
+staging-only GPU image and provides two tools:
+
+- `capability_probe.py` verifies the L40S/CUDA/MPS runtime and `/dev/shm`
+  geometry before a test.
+- `run_concurrent_clients.py` drives same-model or mixed-model clients and
+  records per-tenant throughput/latency/errors plus MMP batching, model-load,
+  slot, GPU-utilization, and VRAM evidence.
+
+The image is deliberately separate from the video POC image. It exercises the
+new `inference_server` -> MMP -> subprocess model worker path directly and is
+not a deployable production artifact.
+
+## Build
+
+Build from the repository root. The CUDA builder/runtime and `uv` images are
+pinned to amd64 manifest digests. Set `SOURCE_REVISION` to the exact git SHA;
+use that SHA in the image tag as well.
+
+```bash
+REVISION=$(git rev-parse HEAD)
+IMAGE=us-central1-docker.pkg.dev/roboflow-staging/video-proc/mmp-benchmark:${REVISION}
+
+docker buildx build --platform linux/amd64 \
+  --build-arg SOURCE_REVISION="${REVISION}" \
+  -f development/mmp_staging_benchmark/Dockerfile \
+  -t "${IMAGE}" \
+  --push .
+```
+
+Record the registry digest returned by `buildx`; deploy the resulting
+`IMAGE@sha256:...`, not the mutable tag.
+
+## Required pod shape
+
+This image must run in a dedicated staging pod that exclusively owns one GPU.
+It must not be placed beside the normal video processor in the same pod.
+
+The MMP pool consumes approximately:
+
+```text
+INFERENCE_N_SLOTS * (INFERENCE_INPUT_MB MiB + 64-byte slot header)
+```
+
+The experiment defaults are `128 * 20 MiB`, or about 2.5 GiB. Mount a
+memory-backed volume at `/dev/shm` with at least 4 GiB:
+
+```yaml
+volumeMounts:
+  - name: dshm
+    mountPath: /dev/shm
+volumes:
+  - name: dshm
+    emptyDir:
+      medium: Memory
+      sizeLimit: 4Gi
+```
+
+Docker's default 64 MiB `/dev/shm` is insufficient. The process may fail with
+`ENOSPC` during startup or `SIGBUS` when a mapped page is touched.
+
+Suggested environment for the first L40S smoke test:
+
+```yaml
+env:
+  - {name: API_BASE_URL, value: https://api.roboflow.one}
+  - {name: NUM_WORKERS, value: "4"}
+  - {name: INFERENCE_N_SLOTS, value: "128"}
+  - {name: INFERENCE_INPUT_MB, value: "20"}
+  - {name: INFERENCE_BATCH_MAX_SIZE, value: "0"}
+  - {name: INFERENCE_BATCH_MAX_WAIT_MS, value: "5"}
+  - {name: NVIDIA_MPS, value: "0"}
+```
+
+Mount model cache storage at `/models/cache` if cold-load results should be
+separated from repeated warm-cache capacity runs.
+
+## Capability and MPS smoke
+
+Run the non-mutating probe first:
+
+```bash
+python /opt/mmp-benchmark/capability_probe.py \
+  --require-gpu --require-shm --output /results/capability.json
+```
+
+The NVIDIA container runtime must inject both `nvidia-cuda-mps-control` and
+`nvidia-cuda-mps-server`. The image sets
+`NVIDIA_DRIVER_CAPABILITIES=compute,utility`, but the binaries ultimately come
+from the host driver/runtime integration, not the CUDA userspace image. If
+they are absent, fix the dedicated staging runtime before setting
+`NVIDIA_MPS=1`.
+
+Only in a dedicated, single-GPU experiment pod, exercise daemon startup and
+shutdown:
+
+```bash
+python /opt/mmp-benchmark/capability_probe.py \
+  --require-gpu --require-mps --require-shm --start-stop-mps \
+  --output /results/mps-capability.json
+```
+
+`NVIDIA_MPS=1` makes the existing `inference_server.server` launcher own the
+MPS daemon for the lifetime of the server. MPS must be compared with the same
+image, models, client matrix, batch settings, GPU, and cache state as the
+non-MPS run.
+
+## Benchmark clients
+
+API keys are read from environment variables and are never serialized into
+the report. A tenant label is only report metadata; using distinct keys from
+distinct staging workspaces is what creates a real cross-workspace test.
+
+```bash
+export RF_BENCH_TENANT_A_KEY=...
+export RF_BENCH_TENANT_B_KEY=...
+
+python /opt/mmp-benchmark/run_concurrent_clients.py \
+  --spec /opt/mmp-benchmark/spec.same-model.example.json \
+  --image /data/dog.jpg \
+  --output /results/same-model.json
+```
+
+For a mixed-model test, use `spec.mixed-model.example.json`. Every client has
+its own tenant ID, API-key environment variable, model, instance, concurrency,
+optional target FPS, and model parameters. `target_fps: 0` means closed-loop
+maximum throughput.
+
+The current MMP worker boundary is the routing key, not the tenant label or API
+key. Two clients with the same `model_id` and empty `instance` intentionally
+share one model subprocess and can be auto-batched together; this is what
+`spec.same-model.example.json` measures. It is **not** cross-workspace process
+isolation. Use `spec.same-model-isolated.example.json` to give each tenant a
+distinct `instance`. The MMP then creates separate routing keys and separate
+model subprocesses while loading the same weights. Comparing those two specs
+with and without MPS measures the real isolation/VRAM/throughput tradeoff.
+
+The runner refuses known production Roboflow hosts. Accepted targets are
+localhost/private addresses, Kubernetes service names, and
+`*.roboflow.one`/explicit staging hosts.
+
+The JSON report includes:
+
+- per-client and aggregate request counts, delivered FPS, p50/p95/p99/max
+  latency, status/error counts, and Jain fairness;
+- first-success/cold-load timing by model;
+- one-second client time buckets for degradation and recovery analysis;
+- initial/final and periodic `/v2/server/metrics` snapshots;
+- MMP slot pressure/rejects and per-model batching/worker-process fields;
+- GPU utilization, memory, power, and per-model VRAM attribution exposed by
+  MMP/NVML;
+- the source revision and image reference supplied by the image build/runtime.
+
+## First staging sequence
+
+1. Start one dedicated L40S pod with `NVIDIA_MPS=0` and the 4 GiB `/dev/shm`.
+2. Save the capability report, image digest, node, GPU UUID, driver, and cache
+   state.
+3. Run same-model shared-worker `concurrency = 1, 2, 4, 8, 12, 16, 24, 32`
+   until the SLO knee, repeating each point after model warmup.
+4. Run the same-weight isolated-instance spec, then mixed public
+   detection/segmentation models and distinct private staging-workspace models.
+5. Repeat exactly with `NVIDIA_MPS=1`; compare throughput, tail latency,
+   fairness, worker failures, and VRAM.
+6. Re-run the winning configurations as a long soak and inject one client
+   cancellation/model-worker failure before considering video integration.
+
+The first L40S run is blocked until (a) the image is built/pushed after GCP
+auth is restored, (b) the dedicated pod has a memory-backed `/dev/shm`, (c)
+the container runtime exposes MPS binaries, (d) at least one staging model API
+key is available as a Secret, and (e) a test image is mounted or downloaded by
+an explicit setup step.

--- a/development/mmp_staging_benchmark/README.md
+++ b/development/mmp_staging_benchmark/README.md
@@ -33,6 +33,18 @@ docker buildx build --platform linux/amd64 \
 Record the registry digest returned by `buildx`; deploy the resulting
 `IMAGE@sha256:...`, not the mutable tag.
 
+For Cloud Build, which avoids relying on a developer Docker Desktop disk, use
+the checked-in 200 GiB build configuration. Both substitutions are required:
+
+```bash
+gcloud builds submit \
+  --project roboflow-staging \
+  --config development/mmp_staging_benchmark/cloudbuild.yaml \
+  --substitutions \
+_SOURCE_REVISION="${REVISION}",_IMAGE="${IMAGE}" \
+  .
+```
+
 ## Required pod shape
 
 This image must run in a dedicated staging pod that exclusively owns one GPU.
@@ -76,6 +88,27 @@ env:
 
 Mount model cache storage at `/models/cache` if cold-load results should be
 separated from repeated warm-cache capacity runs.
+
+Render the dedicated Crusoe staging Deployment only after the pushed image has
+an immutable registry digest. The renderer refuses tags, production
+repositories, and malformed source revisions. It creates only the isolated
+`video-proc-bench-mmp` namespace and one Recreate Deployment pinned to an L40S;
+it does not modify the normal `video-proc` worker pool.
+
+```bash
+python development/mmp_staging_benchmark/render_staging_deployment.py \
+  --image "${IMAGE}@sha256:REGISTRY_DIGEST" \
+  --source-revision "${REVISION}" \
+  --output /tmp/mmp-staging.json
+
+kubectl --context ck8s-stg apply -f /tmp/mmp-staging.json
+```
+
+The renderer references `mmp-benchmark-api-keys` keys `tenant-a` and
+`tenant-b`; it never accepts secret values. Create that Secret out of band in
+the dedicated staging namespace. Run the capability probe and clients with
+`kubectl exec`, then copy `/results` before deleting the Deployment. Re-render
+with `--mps` only after the non-MPS capability run passes.
 
 ## Capability and MPS smoke
 

--- a/development/mmp_staging_benchmark/README.md
+++ b/development/mmp_staging_benchmark/README.md
@@ -162,6 +162,7 @@ python development/mmp_staging_benchmark/render_run_spec.py \
   --total-concurrency 8 \
   --run-id mmp-shared-no-mps-c08-r1 \
   --phase mmp-shared-no-mps \
+  --cache-state warm \
   --server-pod "${SERVER_POD}" \
   --server-node "${SERVER_NODE}" \
   --output /tmp/mmp-point.json
@@ -260,16 +261,50 @@ the dedicated namespace is the complete rollback.
 
 Apply the strict analyzer to every report and preserve the matching server log:
 
+Immediately before starting each run, capture the actual MMP route table and
+model-cache contents through the local port-forward. The API key remains in the
+named environment variable and is never serialized:
+
+```bash
+python development/mmp_staging_benchmark/capture_cache_evidence.py \
+  --pod "${SERVER_POD}" \
+  --api-key-env TENANT_A_KEY \
+  --output development/mmp_staging_benchmark/results/shared-c08-r1-cache.json
+```
+
+`cold` means the pre-run route table and `/models/cache` are both empty. `warm`
+means the cache is nonempty and the pre-run route table contains exactly the
+workload's expected routing keys, each with a live PID and positive inference
+and batch counters. The analyzer requires the snapshot within 60 seconds before
+the run on the same staging pod UID.
+
 ```bash
 python development/mmp_staging_benchmark/analyze_report.py \
   development/mmp_staging_benchmark/results/shared-c08-r1.json \
   --phase mmp-shared-no-mps \
+  --matrix development/mmp_staging_benchmark/matrix.staging.json \
   --server-log development/mmp_staging_benchmark/results/shared-c08-r1.log \
   --pod-evidence development/mmp_staging_benchmark/results/pod.json \
   --capability-report development/mmp_staging_benchmark/results/capability-no-mps.json \
   --expected-node "${BASELINE_NODE}" \
-  --expected-gpu-uuid "${BASELINE_GPU_UUID}"
+  --expected-gpu-uuid "${BASELINE_GPU_UUID}" \
+  --cache-evidence development/mmp_staging_benchmark/results/shared-c08-r1-cache.json
 ```
+
+For an MPS phase, capture a live MPS control observation during the measurement
+window. The helper binds it to `ck8s-stg`, the dedicated namespace, pod UID,
+and GPU UUID, then captures `get_client_list` for every live MPS server:
+
+```bash
+python development/mmp_staging_benchmark/capture_mps_evidence.py \
+  --pod "${SERVER_POD}" \
+  --output development/mmp_staging_benchmark/results/mps-live.json
+```
+
+Pass that JSON as `--mps-evidence`. The analyzer requires successful numeric
+server/client lists captured after warmup and before the report's finish
+timestamp, and every stable measured model-worker PID must be an MPS client;
+environment flags or an idle MPS server do not certify the MPS leg.
 
 A passing single-report analyzer result is not a capacity claim. After both
 repetitions at every point through the first failing boundary, certify the
@@ -283,6 +318,10 @@ python development/mmp_staging_benchmark/analyze_curve.py \
   --phase mmp-shared-no-mps \
   --output development/mmp_staging_benchmark/results/shared-curve.json
 ```
+
+Use `--compare-with` on the second curve to certify a no-MPS/MPS A/B. The
+comparison fails unless image, source, clean harness, fixture, matrix, template,
+cache state, node, and GPU UUID are identical.
 
 The exact head image is already built at the digest pinned by the matrix
 (Cloud Build `f0bd00b6-f0d1-410a-8ba6-bf9f8e8ccfd0`). Its provenance records

--- a/development/mmp_staging_benchmark/STAGING_RUNBOOK.md
+++ b/development/mmp_staging_benchmark/STAGING_RUNBOOK.md
@@ -155,10 +155,12 @@ For each phase and allowed concurrency in `matrix.staging.json`:
 
 1. capture the exact ready pod and node;
 2. render one point with `render_run_spec.py`;
-3. run it twice in ascending concurrency order;
-4. save the server log for the exact measurement interval;
-5. apply `analyze_report.py`;
-6. stop after two consecutive points fail the same strict gate.
+3. immediately before each run, capture `capture_cache_evidence.py` output and
+   require the operational cold/warm state declared in the rendered spec;
+4. run it twice in ascending concurrency order;
+5. save the server log for the exact measurement interval;
+6. apply `analyze_report.py` with the matching cache evidence;
+7. stop after two consecutive points fail the same strict gate.
 
 The strict capacity gate is 100% success, per-client p95 <= 50 ms, Jain >=
 0.95 for equal-work same-model runs, zero pool-full rejects, one stable worker
@@ -195,6 +197,13 @@ private pipe/log volumes. It does not use Kubernetes device-plugin MPS sharing;
 the L40S node advertises that feature as unavailable. It also does not use CUDA
 IPC—the current subprocess argument is reserved and unused.
 
+After warmup during every MPS measurement window, run
+`capture_mps_evidence.py` against the
+exact server pod and retain its JSON beside the report. The analyzer rejects a
+different context, namespace, pod UID, GPU UUID, failed control query, empty
+server list, a measured worker absent from every MPS server's client list, or a
+timestamp outside the measured interval.
+
 ## Gate 4: fairness and failure sensitivity
 
 Only after both capacity curves:
@@ -222,6 +231,7 @@ kubectl --context ck8s-stg -n video-proc-bench-mmp get pod "${SERVER_POD}" \
   -o json > development/mmp_staging_benchmark/results/pod.json
 python development/mmp_staging_benchmark/analyze_report.py REPORT.json \
   --phase mmp-shared-no-mps \
+  --matrix development/mmp_staging_benchmark/matrix.staging.json \
   --server-log SERVER.log \
   --pod-evidence development/mmp_staging_benchmark/results/pod.json \
   --capability-report development/mmp_staging_benchmark/results/capability-no-mps.json \

--- a/development/mmp_staging_benchmark/STAGING_RUNBOOK.md
+++ b/development/mmp_staging_benchmark/STAGING_RUNBOOK.md
@@ -1,0 +1,239 @@
+# Staging-only MMP and raw-MPS runbook
+
+This runbook is for the isolated `video-proc-bench-mmp` namespace on
+`ck8s-stg`. Every `apply`, `exec` that starts/stops MPS, model-worker kill, and
+delete requires separate staging-write authorization. Nothing here authorizes
+production or changes the normal `video-proc` pool.
+
+## Experiment boundaries
+
+Do not merge these results:
+
+| Phase | Process topology | Input path | MPS | CUDA IPC |
+|---|---|---|---|---|
+| MMP baseline | 4 HTTP workers -> one MMP -> one model subprocess per routing key | local JPEG -> HTTP -> CPU SHM -> worker decode/upload | off | no |
+| MMP raw MPS | exact baseline topology and image | exact same JPEG path | raw, same pod | no |
+| Video D/E/F | supervisor -> one full decoder/workflow/model/publisher process per job | live MediaMTX stream | off | not applicable |
+
+The MMP artifact contains no InferencePipeline or video processor. It cannot
+answer live-stream freshness, NVDEC, output, or per-job failure-containment
+questions. Conversely, D/E/F has no shared MMP or cross-process batching.
+
+## Known immutable inputs
+
+- PR head: `5f02db12ebdda013ff92e6607f92f88c7f9582ec`
+- image: `us-central1-docker.pkg.dev/roboflow-staging/video-proc/mmp-benchmark@sha256:6a6592f77e0eb1d3bfc8b82d7add6a7206e946a437a072f7f3a58cf693b1716d`
+- Cloud Build: `f0bd00b6-f0d1-410a-8ba6-bf9f8e8ccfd0`
+- target: one exclusively allocated L40S GPU in Crusoe staging
+- SHM: `128 * (20 MiB + 64 B) + 64 B = 2,684,362,816 B`; the 1.25
+  reserve gate is `3,355,453,520 B`, so the 4 GiB memory-backed `/dev/shm`
+  passes. This tmpfs consumes pod memory and is covered by the 32 GiB limit.
+- first decoder axis: `imagecodecs`; `nvjpeg` is a separate later axis.
+- fixture: `tests/workflows/integration_tests/execution/assets/dogs.jpg`, SHA-256
+  `83bfa4e706f274ce1da7309cec6374d542f9938b3538481035588681cdaff139`.
+- initial MPS mode: no active-thread percentage cap. A later 50/25-percent
+  isolated-process sensitivity is not part of the matched baseline.
+
+The registry provenance binds the digest to the uploaded Cloud Build source
+tar and revision build argument, but not to a Git source URI. Preserve the
+in-image `python-packages.txt` hash and do not call it cryptographic Git-tree
+equivalence.
+
+## Safety and tenancy boundary
+
+The renderer emits only a Namespace and Deployment—no Service or Ingress. API
+keys stay in the local shell and reach the pod only as Bearer request headers
+over an explicit loopback port-forward. Never create an API-key Secret for the
+server container.
+
+The HTTP layer validates the key and checks model access, but discards the
+returned workspace before MMP scheduling. MMP routing is
+`model_id[:instance]`; `instance` is caller supplied. The scheduler, SHM pool,
+and model queue are not workspace-aware. Any valid key can currently view
+global metrics/model identities and invoke global unload endpoints. Therefore:
+
+- this pod is a trusted, operator-only experiment;
+- tenant labels are pseudonymous report labels, not security boundaries;
+- shared-backend runs prove cross-key batching behavior, not tenant isolation;
+- isolated `instance` runs prove process separation by routing key, not an
+  authenticated workspace boundary;
+- raw MPS is a throughput/scheduling experiment, not memory isolation or
+  fairness enforcement.
+
+## Gate 0: local render only
+
+These commands do not contact Kubernetes:
+
+```bash
+python development/mmp_staging_benchmark/validate_staging_plan.py \
+  --matrix development/mmp_staging_benchmark/matrix.staging.json \
+  --run-prefix mmp-capacity-001 \
+  --output /tmp/mmp-capacity-plan.json
+
+python development/mmp_staging_benchmark/render_staging_deployment.py \
+  --image us-central1-docker.pkg.dev/roboflow-staging/video-proc/mmp-benchmark@sha256:6a6592f77e0eb1d3bfc8b82d7add6a7206e946a437a072f7f3a58cf693b1716d \
+  --source-revision 5f02db12ebdda013ff92e6607f92f88c7f9582ec \
+  --run-id mmp-capacity-001-no-mps \
+  --output /tmp/mmp-no-mps.json
+```
+
+Verify locally that the render has one GPU, `Recreate`, `gpu_type=L40S`, 4 GiB
+memory-backed `/dev/shm`, `NVIDIA_MPS=0`, no Secret refs, and no Service or
+Ingress. After staging-write authorization, run server-side dry-run and inspect
+the entire diff before apply:
+
+```bash
+kubectl --context ck8s-stg apply --server-side --dry-run=server \
+  -f /tmp/mmp-no-mps.json -o yaml
+```
+
+## Gate 1: non-MPS capability and one-request smoke
+
+After the separately authorized apply, save exact workload identity:
+
+```bash
+kubectl --context ck8s-stg -n video-proc-bench-mmp rollout status \
+  deployment/mmp-benchmark-server --timeout=15m
+kubectl --context ck8s-stg -n video-proc-bench-mmp get deployment,pod -o yaml \
+  > development/mmp_staging_benchmark/results/mmp-capability-001-workload.yaml
+```
+
+Run the read-only capability probe in the ready pod and copy its report before
+any load. Require: one L40S, expected digest/source label, CUDA available,
+compute mode `Default`, both MPS binaries, MIG `N/A`, writable SHM, and
+`satisfies_recommended=true`.
+
+```bash
+kubectl --context ck8s-stg -n video-proc-bench-mmp exec \
+  deployment/mmp-benchmark-server -- \
+  python /opt/mmp-benchmark/capability_probe.py \
+    --require-gpu --require-mps --require-shm \
+    --output /results/capability-no-mps.json
+kubectl --context ck8s-stg -n video-proc-bench-mmp cp \
+  deployment/mmp-benchmark-server:/results/capability-no-mps.json \
+  development/mmp_staging_benchmark/results/capability-no-mps.json
+```
+
+The prior read-only staging probe observed driver `570.133.20`, CUDA `12.4`,
+Torch `2.6.0+cu124`, both MPS binaries, MIG `N/A`, and Kubernetes sharing
+strategy `none`. Treat that only as prerequisite evidence; repeat it on the
+actual benchmark pod.
+
+Capture the pod as JSON (not only YAML), record the exact `spec.nodeName` and
+single GPU UUID from the capability report, then re-render every measured
+Deployment with `--node-name SPEC_NODE_NAME`. The non-MPS/MPS comparison is
+invalid if either the node or GPU UUID differs from this capability baseline.
+
+```bash
+python development/mmp_staging_benchmark/render_staging_deployment.py \
+  --image IMAGE_AT_EXACT_DIGEST \
+  --source-revision 5f02db12ebdda013ff92e6607f92f88c7f9582ec \
+  --run-id mmp-capacity-001-no-mps \
+  --node-name "${BASELINE_NODE}" \
+  --output /tmp/mmp-no-mps-pinned.json
+```
+
+With separate authorization for the state-changing MPS smoke, run
+`--start-stop-mps` only while the server deployment itself has
+`NVIDIA_MPS=0`. Require start, server-list query, and stop success. Do not run a
+second MPS daemon inside the MPS-enabled deployment.
+
+Start an explicit local port-forward. No server port may be published:
+
+```bash
+kubectl --context ck8s-stg -n video-proc-bench-mmp port-forward \
+  deployment/mmp-benchmark-server 18000:8000
+```
+
+Use two distinct staging-workspace keys only in the local environment. Run c1,
+then c2, before any larger point. The report hashes the fixture; every later
+point must match that SHA-256.
+
+## Gate 2: matched non-MPS matrix
+
+For each phase and allowed concurrency in `matrix.staging.json`:
+
+1. capture the exact ready pod and node;
+2. render one point with `render_run_spec.py`;
+3. run it twice in ascending concurrency order;
+4. save the server log for the exact measurement interval;
+5. apply `analyze_report.py`;
+6. stop after two consecutive points fail the same strict gate.
+
+The strict capacity gate is 100% success, per-client p95 <= 50 ms, Jain >=
+0.95 for equal-work same-model runs, zero pool-full rejects, one stable worker
+PID per expected routing key, no CUDA/Xid error, and >= 90% metrics coverage.
+Capacity is the highest point passing twice with the next point failing twice.
+Mixed-model Jain is descriptive only because model costs differ.
+
+Do not report capacity from an individual `analyze_report.py` result. Feed all
+paired analyzer outputs for a phase to `analyze_curve.py`; it rejects missing,
+split, duplicate-run, and right-censored boundaries.
+
+Run order:
+
+1. `mmp-shared-no-mps`: one routing key, one model subprocess, cross-key
+   requests eligible for auto-batching;
+2. `mmp-isolated-no-mps`: two routing keys and two model subprocesses loading
+   the same weights;
+3. `mmp-mixed-no-mps`: independent detection and segmentation subprocesses.
+
+Preserve cold and warm runs separately. Restarting the disposable Deployment
+clears model processes and its `emptyDir` cache; keeping it alive preserves
+both. Never silently compare a cold point with a warm point.
+
+## Gate 3: matched raw-MPS matrix
+
+Copy all reports and logs, then render a new run ID with `--mps`. Server-side
+dry-run and apply again require staging-write authorization. Require the same
+image digest, node class, decoder, fixture digest, cache classification, slots,
+batch window, durations, and concurrency points. Then repeat the three phases
+in the same order.
+
+Raw MPS uses the host-injected `nvidia-cuda-mps-control/server` binaries and
+private pipe/log volumes. It does not use Kubernetes device-plugin MPS sharing;
+the L40S node advertises that feature as unavailable. It also does not use CUDA
+IPC—the current subprocess argument is reserved and unused.
+
+## Gate 4: fairness and failure sensitivity
+
+Only after both capacity curves:
+
+- equal-work cross-key comparison at the selected knee;
+- asymmetric 1:N noisy-neighbor load, reported per client without treating raw
+  Jain as equal-work fairness;
+- cancel one local client and verify the peer continues;
+- terminate one model worker by its observed PID and require one bounded reload,
+  stable peer progress, no server restart, and no leaked SHM slot;
+- optional isolated-backend MPS active-thread 50/25-percent sensitivity,
+  labelled separately from the uncapped MPS comparison;
+- 15-minute winning non-MPS and MPS soaks before longer campaign soaks.
+
+MPS has no tenant scheduler. Any fairness improvement is observational and
+must not be described as enforcement.
+
+The analyzer requires the interval server log, exact pod JSON, capability
+report, baseline node, and baseline GPU UUID. It rejects container/model-worker
+restarts, a runtime image digest mismatch, changed runtime flags, or mismatched
+pod annotations:
+
+```bash
+kubectl --context ck8s-stg -n video-proc-bench-mmp get pod "${SERVER_POD}" \
+  -o json > development/mmp_staging_benchmark/results/pod.json
+python development/mmp_staging_benchmark/analyze_report.py REPORT.json \
+  --phase mmp-shared-no-mps \
+  --server-log SERVER.log \
+  --pod-evidence development/mmp_staging_benchmark/results/pod.json \
+  --capability-report development/mmp_staging_benchmark/results/capability-no-mps.json \
+  --expected-node "${BASELINE_NODE}" \
+  --expected-gpu-uuid "${BASELINE_GPU_UUID}"
+```
+
+## Cleanup and rollback
+
+First stop the local runner and port-forward, copy `/results`, workload YAML,
+logs, reports, and analyzer output, and verify no process still writes a report.
+The exact rollback is deletion of the dedicated Deployment and namespace; it
+does not touch `video-proc`. This deletion is a staging write and requires
+authorization. Verify the namespace is gone and that the normal staging video
+pool image, ready/working counts, and configuration never changed.

--- a/development/mmp_staging_benchmark/__init__.py
+++ b/development/mmp_staging_benchmark/__init__.py
@@ -1,0 +1,1 @@
+"""Staging-only tools for MMP capacity experiments."""

--- a/development/mmp_staging_benchmark/analyze_curve.py
+++ b/development/mmp_staging_benchmark/analyze_curve.py
@@ -5,9 +5,61 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 from collections import defaultdict
 from pathlib import Path
 from typing import Any, Mapping, Sequence
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from development.mmp_staging_benchmark.validate_staging_plan import (  # noqa: E402
+    load_and_validate,
+)
+
+COHORT_FIELDS = (
+    "server_image_ref",
+    "server_source_revision",
+    "harness_revision",
+    "fixture_sha256",
+    "matrix_sha256",
+    "template_sha256",
+    "cache_state",
+    "server_node",
+    "gpu_uuid",
+)
+
+CAPACITY_FAILURE_PATTERNS = {
+    "latency": ("latency p95 failed",),
+    "throughput": (
+        "success rate below 100%",
+        "request errors recorded",
+        "no positive MMP inference/batch delta",
+    ),
+    "fairness": ("Jain fairness failed",),
+    "pool_admission": (
+        "pool-full rejects",
+        "pool-reject evidence missing or nonzero",
+    ),
+    "model_errors": ("model worker errors recorded",),
+}
+
+
+def _capacity_failures(result: Mapping[str, Any]) -> tuple[set[str], list[str]]:
+    failures = result.get("failures") or []
+    categories = set()
+    invalid = []
+    for failure in failures:
+        matched = {
+            category
+            for category, patterns in CAPACITY_FAILURE_PATTERNS.items()
+            if any(pattern in str(failure) for pattern in patterns)
+        }
+        if matched:
+            categories.update(matched)
+        else:
+            invalid.append(str(failure))
+    return categories, invalid
 
 
 def analyze_curve(
@@ -20,6 +72,7 @@ def analyze_curve(
     failures: list[str] = []
     grouped: dict[int, list[Mapping[str, Any]]] = defaultdict(list)
     run_ids: set[str] = set()
+    cohorts: set[tuple[Any, ...]] = set()
     for result in results:
         if result.get("phase") != phase:
             failures.append("single-report analyzer phase mismatch")
@@ -33,7 +86,13 @@ def analyze_curve(
         if not run_id or run_id in run_ids:
             failures.append("run IDs must be nonempty and unique")
         run_ids.add(run_id)
+        cohort = tuple(evidence.get(field) for field in COHORT_FIELDS)
+        if any(value in {None, "", "unknown"} for value in cohort):
+            failures.append("single-report cohort identity is incomplete")
+        cohorts.add(cohort)
         grouped[point].append(result)
+    if len(cohorts) != 1:
+        failures.append("single-report results do not form one exact cohort")
 
     outcomes: dict[int, str] = {}
     for point in allowed_points:
@@ -43,10 +102,39 @@ def analyze_curve(
         if len(point_results) != repetitions:
             failures.append(f"concurrency {point}: expected {repetitions} repetitions")
             outcomes[point] = "incomplete"
+        elif (
+            len(
+                {
+                    item.get("evidence", {}).get("workload_sha256")
+                    for item in point_results
+                }
+            )
+            != 1
+        ):
+            outcomes[point] = "split"
+            failures.append(f"concurrency {point}: workload identities differ")
         elif all(bool(item.get("success")) for item in point_results):
             outcomes[point] = "pass"
         elif all(not bool(item.get("success")) for item in point_results):
-            outcomes[point] = "fail"
+            classified = [_capacity_failures(item) for item in point_results]
+            shared_failures = set.intersection(
+                *(categories for categories, _invalid in classified)
+            )
+            invalid_failures = [
+                failure for _categories, invalid in classified for failure in invalid
+            ]
+            if invalid_failures:
+                outcomes[point] = "invalid"
+                failures.append(
+                    f"concurrency {point}: failed repetition contains non-capacity failure"
+                )
+            elif shared_failures:
+                outcomes[point] = "fail"
+            else:
+                outcomes[point] = "split"
+                failures.append(
+                    f"concurrency {point}: repetitions lack one shared capacity failure"
+                )
         else:
             outcomes[point] = "split"
             failures.append(f"concurrency {point}: repetitions disagree")
@@ -78,10 +166,33 @@ def analyze_curve(
         "capacity_total_concurrency": capacity if not failures else None,
         "next_failed_total_concurrency": next_point if not failures else None,
         "repetitions": repetitions,
+        "allowed_points": list(allowed_points),
         "outcomes": {
             str(point): outcomes[point] for point in allowed_points if point in outcomes
         },
+        "cohort": (
+            dict(zip(COHORT_FIELDS, next(iter(cohorts)))) if len(cohorts) == 1 else None
+        ),
     }
+
+
+def compare_mps_pair(
+    no_mps: Mapping[str, Any], mps: Mapping[str, Any]
+) -> dict[str, Any]:
+    failures = []
+    if not no_mps.get("success") or not mps.get("success"):
+        failures.append("both curves must be certified before A/B comparison")
+    no_phase = str(no_mps.get("phase", ""))
+    mps_phase = str(mps.get("phase", ""))
+    if no_phase.removesuffix("-no-mps") != mps_phase.removesuffix("-mps"):
+        failures.append("curves are not the matched no-MPS/MPS phase pair")
+    if no_mps.get("cohort") != mps.get("cohort"):
+        failures.append("no-MPS/MPS curves do not share one exact cohort")
+    if no_mps.get("allowed_points") != mps.get("allowed_points"):
+        failures.append("no-MPS/MPS curves do not use the same concurrency points")
+    if no_mps.get("repetitions") != mps.get("repetitions"):
+        failures.append("no-MPS/MPS curves do not use the same repetitions")
+    return {"success": not failures, "failures": failures}
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -90,8 +201,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument("--matrix", required=True, type=Path)
     parser.add_argument("--phase", required=True)
     parser.add_argument("--output", type=Path)
+    parser.add_argument("--compare-with", type=Path)
     args = parser.parse_args(argv)
-    matrix = json.loads(args.matrix.read_text())
+    matrix = load_and_validate(args.matrix)
     phase = next((item for item in matrix["phases"] if item["id"] == args.phase), None)
     if phase is None:
         raise SystemExit(f"unknown phase {args.phase!r}")
@@ -102,6 +214,15 @@ def main(argv: Sequence[str] | None = None) -> int:
         allowed_points=phase["total_concurrency"],
         repetitions=int(matrix["fixed_runtime"]["repetitions"]),
     )
+    if args.compare_with:
+        paired = json.loads(args.compare_with.read_text())
+        result["mps_pair"] = (
+            compare_mps_pair(paired, result)
+            if args.phase.endswith("-mps")
+            else compare_mps_pair(result, paired)
+        )
+        if not result["mps_pair"]["success"]:
+            result["success"] = False
     rendered = json.dumps(result, indent=2, sort_keys=True) + "\n"
     if args.output:
         args.output.write_text(rendered)

--- a/development/mmp_staging_benchmark/analyze_curve.py
+++ b/development/mmp_staging_benchmark/analyze_curve.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Certify a capacity boundary from paired single-report analyzer results."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+
+def analyze_curve(
+    results: Sequence[Mapping[str, Any]],
+    *,
+    phase: str,
+    allowed_points: Sequence[int],
+    repetitions: int = 2,
+) -> dict[str, Any]:
+    failures: list[str] = []
+    grouped: dict[int, list[Mapping[str, Any]]] = defaultdict(list)
+    run_ids: set[str] = set()
+    for result in results:
+        if result.get("phase") != phase:
+            failures.append("single-report analyzer phase mismatch")
+            continue
+        evidence = result.get("evidence", {})
+        point = int(evidence.get("total_concurrency", 0))
+        run_id = str(evidence.get("run_id", ""))
+        if point not in allowed_points:
+            failures.append(f"unexpected concurrency point {point}")
+            continue
+        if not run_id or run_id in run_ids:
+            failures.append("run IDs must be nonempty and unique")
+        run_ids.add(run_id)
+        grouped[point].append(result)
+
+    outcomes: dict[int, str] = {}
+    for point in allowed_points:
+        point_results = grouped.get(point, [])
+        if not point_results:
+            continue
+        if len(point_results) != repetitions:
+            failures.append(f"concurrency {point}: expected {repetitions} repetitions")
+            outcomes[point] = "incomplete"
+        elif all(bool(item.get("success")) for item in point_results):
+            outcomes[point] = "pass"
+        elif all(not bool(item.get("success")) for item in point_results):
+            outcomes[point] = "fail"
+        else:
+            outcomes[point] = "split"
+            failures.append(f"concurrency {point}: repetitions disagree")
+
+    passing = [point for point, outcome in outcomes.items() if outcome == "pass"]
+    capacity = max(passing) if passing else None
+    next_point = None
+    if capacity is None:
+        failures.append("no concurrency point passed twice")
+    else:
+        capacity_index = list(allowed_points).index(capacity)
+        if capacity_index + 1 >= len(allowed_points):
+            failures.append("capacity is right-censored; test the next higher point")
+        else:
+            next_point = allowed_points[capacity_index + 1]
+            if outcomes.get(next_point) != "fail":
+                failures.append("next higher concurrency did not fail twice")
+        if any(
+            outcomes.get(point) != "pass"
+            for point in allowed_points[: capacity_index + 1]
+        ):
+            failures.append("all tested points through capacity must pass twice")
+
+    return {
+        "schema_version": 1,
+        "phase": phase,
+        "success": not failures,
+        "failures": failures,
+        "capacity_total_concurrency": capacity if not failures else None,
+        "next_failed_total_concurrency": next_point if not failures else None,
+        "repetitions": repetitions,
+        "outcomes": {
+            str(point): outcomes[point] for point in allowed_points if point in outcomes
+        },
+    }
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("results", nargs="+", type=Path)
+    parser.add_argument("--matrix", required=True, type=Path)
+    parser.add_argument("--phase", required=True)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args(argv)
+    matrix = json.loads(args.matrix.read_text())
+    phase = next((item for item in matrix["phases"] if item["id"] == args.phase), None)
+    if phase is None:
+        raise SystemExit(f"unknown phase {args.phase!r}")
+    analyzed = [json.loads(path.read_text()) for path in args.results]
+    result = analyze_curve(
+        analyzed,
+        phase=args.phase,
+        allowed_points=phase["total_concurrency"],
+        repetitions=int(matrix["fixed_runtime"]["repetitions"]),
+    )
+    rendered = json.dumps(result, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.write_text(rendered)
+    else:
+        print(rendered, end="")
+    return 0 if result["success"] else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/development/mmp_staging_benchmark/analyze_report.py
+++ b/development/mmp_staging_benchmark/analyze_report.py
@@ -7,8 +7,24 @@ import argparse
 import hashlib
 import json
 import re
+import sys
 from pathlib import Path
 from typing import Any, Mapping, Sequence
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from development.mmp_staging_benchmark.render_run_spec import (  # noqa: E402
+    current_clean_revision,
+    render_point,
+)
+from development.mmp_staging_benchmark.run_concurrent_clients import (  # noqa: E402
+    ClientSpec,
+)
+from development.mmp_staging_benchmark.validate_staging_plan import (  # noqa: E402
+    canonical_sha256,
+    load_and_validate,
+)
 
 CUDA_FAILURE = re.compile(
     r"cuda (?:error|out of memory)|illegal memory access|nvrm:\s*xid",
@@ -61,6 +77,8 @@ def _pod_evidence(
     name, uuid = _gpu_identity(capability)
     return {
         "pod": pod.get("metadata", {}).get("name"),
+        "pod_uid": pod.get("metadata", {}).get("uid"),
+        "namespace": pod.get("metadata", {}).get("namespace"),
         "node": pod.get("spec", {}).get("nodeName"),
         "annotations": pod.get("metadata", {}).get("annotations", {}),
         "desired_image": server.get("image"),
@@ -70,6 +88,80 @@ def _pod_evidence(
         "env": _environment(server),
         "gpu_name": name,
         "gpu_uuid": uuid,
+    }
+
+
+def _raw_metrics(report: Mapping[str, Any], routes: set[str]) -> dict[str, Any]:
+    samples = [
+        sample
+        for sample in report.get("metrics_samples", [])
+        if sample.get("status") == 200 and isinstance(sample.get("metrics"), dict)
+    ]
+    rejects = []
+    route_samples: dict[str, list[tuple[float, Mapping[str, Any]]]] = {
+        route: [] for route in routes
+    }
+    for sample in samples:
+        offset = float(sample.get("offset_s", 0))
+        metrics = sample["metrics"]
+        if metrics.get("mmp_rejects_pool_full") is not None:
+            rejects.append(int(metrics["mmp_rejects_pool_full"]))
+        models = metrics.get("mmp_models") or {}
+        for route in routes:
+            if isinstance(models.get(route), dict):
+                route_samples[route].append((offset, models[route]))
+    deltas = {}
+    route_evidence = {}
+    counter_fields = ("inference_count", "batch_count", "error_count")
+    first_global_models = (
+        samples[0]["metrics"].get("mmp_models") or {} if samples else {}
+    )
+    for route, timed_models in route_samples.items():
+        models = [model for _offset, model in timed_models]
+        offsets = [offset for offset, _model in timed_models]
+        complete = all(
+            all(field in model for field in (*counter_fields, "worker_pid"))
+            for model in models
+        )
+        monotonic = complete and all(
+            int(later[field]) >= int(earlier[field])
+            for earlier, later in zip(models, models[1:])
+            for field in counter_fields
+        )
+        route_evidence[route] = {
+            "sample_count": len(models),
+            "span_s": max(offsets) - min(offsets) if len(offsets) >= 2 else 0.0,
+            "complete": complete,
+            "monotonic": monotonic,
+        }
+        if len(models) < 2:
+            continue
+        first = first_global_models.get(route) or {}
+        last = models[-1]
+        if not complete:
+            continue
+        deltas[route] = {
+            "inference_count_delta": int(last["inference_count"])
+            - int(first.get("inference_count", 0)),
+            "batch_count_delta": int(last["batch_count"])
+            - int(first.get("batch_count", 0)),
+            "error_count_delta": int(last["error_count"])
+            - int(first.get("error_count", 0)),
+        }
+    offsets = [float(sample.get("offset_s", 0)) for sample in samples]
+    return {
+        "sample_count": len(samples),
+        "span_s": max(offsets) - min(offsets) if len(offsets) >= 2 else 0.0,
+        "rejects_complete": len(rejects) == len(samples) and len(rejects) >= 2,
+        "rejects_monotonic": all(
+            later >= earlier for earlier, later in zip(rejects, rejects[1:])
+        ),
+        "rejects_delta": rejects[-1] - rejects[0] if len(rejects) >= 2 else None,
+        "model_deltas": deltas,
+        "route_evidence": route_evidence,
+        "offsets_monotonic": all(
+            later > earlier for earlier, later in zip(offsets, offsets[1:])
+        ),
     }
 
 
@@ -86,6 +178,11 @@ def analyze(
     capability: Mapping[str, Any] | None = None,
     expected_node: str | None = None,
     expected_gpu_uuid: str | None = None,
+    matrix: Mapping[str, Any] | None = None,
+    matrix_dir: Path | None = None,
+    mps_evidence: Mapping[str, Any] | None = None,
+    cache_evidence: Mapping[str, Any] | None = None,
+    expected_harness_revision: str | None = None,
 ) -> dict[str, Any]:
     failures: list[str] = []
     clients = report.get("clients", [])
@@ -93,6 +190,18 @@ def analyze(
     run = report.get("run", {})
     experiment = report.get("experiment", {})
     expected_mps = phase.endswith("-mps") and not phase.endswith("-no-mps")
+    phase_config = next(
+        (item for item in (matrix or {}).get("phases", []) if item.get("id") == phase),
+        None,
+    )
+    if phase_config is None or matrix_dir is None:
+        failures.append("checked-in matrix evidence is required")
+    else:
+        gates = matrix["strict_gates"]
+        latency_p95_ms_max = float(gates["latency_p95_ms_max"])
+        jain_fairness_min = float(gates["jain_fairness_min"])
+        minimum_metrics_coverage = float(gates["minimum_metrics_coverage"])
+        worker_restarts_max = int(gates["worker_restarts_max"])
     if pod is None or capability is None:
         failures.append("Kubernetes pod and capability evidence are required")
         identity: dict[str, Any] = {}
@@ -126,6 +235,22 @@ def analyze(
         failures.append("MMP pool-full rejects recorded")
     pids = _worker_pids(report)
     expected_routes = {client.get("routing_key") for client in clients}
+    raw = _raw_metrics(report, expected_routes)
+    raw_coverage = raw["sample_count"] / expected_samples
+    if raw_coverage < minimum_metrics_coverage:
+        failures.append("raw metrics coverage failed")
+    if raw["span_s"] < max(0.0, elapsed - sample_interval) * minimum_metrics_coverage:
+        failures.append("raw metrics interval span failed")
+    if sample_count != raw["sample_count"]:
+        failures.append("derived metrics sample count differs from raw samples")
+    if (
+        not raw["rejects_complete"]
+        or not raw["rejects_monotonic"]
+        or raw["rejects_delta"] != 0
+    ):
+        failures.append("raw MMP pool-reject evidence missing or nonzero")
+    if not raw["offsets_monotonic"]:
+        failures.append("raw metrics sample offsets are not strictly increasing")
     worker_restarts = sum(
         max(0, len(pids.get(route, set())) - 1) for route in expected_routes
     )
@@ -133,10 +258,74 @@ def analyze(
         failures.append("model worker PID missing or changed")
     if not expected_routes.issubset(pids):
         failures.append("expected model worker routing key is missing")
+    cache_state = experiment.get("cache_state")
+    if not cache_evidence:
+        failures.append("pre-run MMP/cache evidence is required")
+    else:
+        captured = float(cache_evidence.get("captured_unix_s", 0))
+        run_started = float(run.get("started_unix_s", 0))
+        if not 0 <= run_started - captured <= 60:
+            failures.append("cache evidence was not captured immediately before run")
+        if (
+            cache_evidence.get("context") != "ck8s-stg"
+            or cache_evidence.get("namespace") != "video-proc-bench-mmp"
+            or cache_evidence.get("pod") != run.get("pod_name")
+            or cache_evidence.get("pod_uid") != identity.get("pod_uid")
+        ):
+            failures.append("cache evidence staging pod UID mismatch")
+        cache_routes = cache_evidence.get("routes") or {}
+        cache_count = cache_evidence.get("cache_file_count")
+        cache_digest = str(cache_evidence.get("cache_paths_sha256", ""))
+        if not isinstance(cache_routes, dict) or not re.fullmatch(
+            r"[0-9a-f]{64}", cache_digest
+        ):
+            failures.append("cache evidence schema is invalid")
+        elif cache_state == "cold":
+            if (
+                cache_routes
+                or cache_count != 0
+                or cache_digest != hashlib.sha256(b"").hexdigest()
+            ):
+                failures.append("cold run did not start with empty routes/cache")
+        elif cache_state == "warm":
+            if (
+                set(cache_routes) != expected_routes
+                or not isinstance(cache_count, int)
+                or cache_count <= 0
+            ):
+                failures.append("warm run did not start with exact loaded routes/cache")
+            for route in expected_routes:
+                model = cache_routes.get(route) or {}
+                if (
+                    not isinstance(model.get("worker_pid"), int)
+                    or int(model.get("inference_count") or 0) <= 0
+                    or int(model.get("batch_count") or 0) <= 0
+                    or int(model.get("error_count") or 0) != 0
+                ):
+                    failures.append(f"{route}: warm pre-run route evidence is invalid")
+                if model.get("worker_pid") not in pids.get(route, set()):
+                    failures.append(
+                        f"{route}: warm pre-run worker PID differs from measured worker"
+                    )
     model_deltas = report.get("metrics_evidence", {}).get("model_deltas", {})
     run_batch_sizes: dict[str, float | None] = {}
     for route in expected_routes:
+        route_raw = raw["route_evidence"].get(route, {})
+        if (
+            not route_raw.get("complete")
+            or not route_raw.get("monotonic")
+            or route_raw.get("sample_count", 0) / expected_samples
+            < minimum_metrics_coverage
+            or route_raw.get("span_s", 0)
+            < max(0.0, elapsed - sample_interval) * minimum_metrics_coverage
+        ):
+            failures.append(f"{route}: raw model metric coverage/continuity failed")
         delta = model_deltas.get(route, {})
+        raw_delta = raw["model_deltas"].get(route)
+        if raw_delta is None or any(
+            int(delta.get(field, 0)) != value for field, value in raw_delta.items()
+        ):
+            failures.append(f"{route}: derived model deltas differ from raw samples")
         inference_count = int(delta.get("inference_count_delta", 0))
         batch_count = int(delta.get("batch_count_delta", 0))
         if inference_count <= 0 or batch_count <= 0:
@@ -151,14 +340,75 @@ def analyze(
         shared_route = next(iter(expected_routes), None)
         if shared_route is None or (run_batch_sizes.get(shared_route) or 0) <= 1.0:
             failures.append("shared backend did not produce a multi-request batch")
+    if ("isolated" in phase or "mixed" in phase) and len(expected_routes) > 1:
+        if len(expected_routes) != len(clients):
+            failures.append("isolated/mixed clients do not have distinct routing keys")
+        stable = [next(iter(pids.get(route, set())), None) for route in expected_routes]
+        if None in stable or len(set(stable)) != len(stable):
+            failures.append("isolated/mixed routes do not have distinct worker PIDs")
     if str(experiment.get("mps_enabled")) != ("1" if expected_mps else "0"):
         failures.append("report MPS identity does not match phase")
     if experiment.get("mode") != phase:
         failures.append("report phase identity does not match analyzer phase")
+    if phase_config is not None and matrix_dir is not None:
+        fixed = matrix["fixed_runtime"]
+        artifact = matrix["artifact"]
+        template = matrix_dir / phase_config["spec"]
+        if total_concurrency not in phase_config["total_concurrency"]:
+            failures.append("concurrency is absent from matrix phase")
+        expected_workload = render_point(
+            template,
+            total_concurrency,
+            fixed["duration_s"],
+            fixed["warmup_s"],
+        )
+        expected_clients = [
+            ClientSpec(**client).__dict__ for client in expected_workload["clients"]
+        ]
+        if run.get("clients") != expected_clients:
+            failures.append("report clients differ from matrix workload")
+        expected_runtime_fields = {
+            "server_url": expected_workload["server_url"],
+            "duration_s": float(expected_workload["duration_s"]),
+            "warmup_s": float(expected_workload["warmup_s"]),
+            "sample_interval_s": float(expected_workload.get("sample_interval_s", 1)),
+            "request_timeout_s": float(expected_workload.get("request_timeout_s", 60)),
+            "max_latency_samples_per_client": int(
+                expected_workload.get("max_latency_samples_per_client", 250_000)
+            ),
+        }
+        if any(
+            run.get(field) != expected
+            for field, expected in expected_runtime_fields.items()
+        ):
+            failures.append("report timing differs from matrix workload")
+        if experiment.get("matrix_sha256") != canonical_sha256(matrix):
+            failures.append("matrix digest identity mismatch")
+        if (
+            experiment.get("template_sha256")
+            != hashlib.sha256(template.read_bytes()).hexdigest()
+        ):
+            failures.append("template digest identity mismatch")
+        if experiment.get("workload_sha256") != canonical_sha256(expected_workload):
+            failures.append("workload digest identity mismatch")
+        if (
+            experiment.get("server_image_ref") != artifact["image"]
+            or experiment.get("server_source_revision") != artifact["source_revision"]
+        ):
+            failures.append("server artifact differs from checked-in matrix")
+        if experiment.get("fixture_sha256") != fixed["fixture_sha256"]:
+            failures.append("fixture identity differs from checked-in matrix")
+    if cache_state not in {"cold", "warm"}:
+        failures.append("cache state identity missing")
     if not experiment.get("run_id") or experiment.get("run_id") == "unknown":
         failures.append("run identity missing")
     if not re.fullmatch(r"[0-9a-f]{40}", str(experiment.get("harness_revision", ""))):
         failures.append("harness revision identity missing")
+    if (
+        expected_harness_revision is None
+        or experiment.get("harness_revision") != expected_harness_revision
+    ):
+        failures.append("harness revision differs from clean analyzer checkout")
     if experiment.get("decoder") != "imagecodecs":
         failures.append("initial matrix must use imagecodecs decoder")
     expected_runtime = {
@@ -200,6 +450,8 @@ def analyze(
             failures.append("server container restart recorded")
         if identity["pod"] != run.get("pod_name"):
             failures.append("pod evidence identity mismatch")
+        if identity["namespace"] != "video-proc-bench-mmp" or not identity["pod_uid"]:
+            failures.append("pod evidence namespace/UID mismatch")
         if identity["node"] != run.get("node_name"):
             failures.append("node evidence identity mismatch")
         if expected_node is None or identity["node"] != expected_node:
@@ -241,6 +493,54 @@ def analyze(
         }
         if any(env.get(key) != value for key, value in expected_env.items()):
             failures.append("pod runtime environment does not match matrix")
+    if expected_mps:
+        if not mps_evidence:
+            failures.append("live measured-interval MPS evidence is required")
+        else:
+            captured = float(mps_evidence.get("captured_unix_s", 0))
+            if not (
+                float(run.get("started_unix_s", 0)) + float(run.get("warmup_s", 0))
+                <= captured
+                <= float(run.get("finished_unix_s", 0))
+            ):
+                failures.append("MPS evidence was not captured during the run")
+            if mps_evidence.get("pod") != run.get("pod_name"):
+                failures.append("MPS evidence pod identity mismatch")
+            if (
+                mps_evidence.get("context") != "ck8s-stg"
+                or mps_evidence.get("namespace") != "video-proc-bench-mmp"
+                or mps_evidence.get("pod_uid") != identity.get("pod_uid")
+            ):
+                failures.append("MPS evidence staging pod UID mismatch")
+            if mps_evidence.get("gpu_uuid") != identity.get("gpu_uuid"):
+                failures.append("MPS evidence GPU identity mismatch")
+            server_list = str(mps_evidence.get("server_list", "")).strip()
+            if (
+                mps_evidence.get("command") != "get_server_list"
+                or mps_evidence.get("exit_code") != 0
+            ):
+                failures.append("MPS control query did not succeed")
+            if not server_list or not all(
+                line.strip().isdigit() for line in server_list.splitlines()
+            ):
+                failures.append("MPS server list is empty")
+            server_pids = {line.strip() for line in server_list.splitlines()}
+            clients_by_server = mps_evidence.get("clients_by_server") or {}
+            if set(clients_by_server) != server_pids or not all(
+                isinstance(clients, list)
+                and all(isinstance(pid, int) and pid > 0 for pid in clients)
+                for clients in clients_by_server.values()
+            ):
+                failures.append("MPS client-list evidence is incomplete")
+            else:
+                mps_clients = {
+                    pid for clients in clients_by_server.values() for pid in clients
+                }
+                measured_workers = {
+                    pid for route in expected_routes for pid in pids.get(route, set())
+                }
+                if not measured_workers.issubset(mps_clients):
+                    failures.append("measured model workers are not all MPS clients")
     if CUDA_FAILURE.search(server_log):
         failures.append("CUDA failure found in server log")
     if not server_log.strip():
@@ -259,6 +559,8 @@ def analyze(
             },
             "jain_fairness_delivered_fps": aggregate.get("jain_fairness_delivered_fps"),
             "metrics_coverage": coverage,
+            "raw_metrics_coverage": raw_coverage,
+            "raw_metrics_span_s": raw["span_s"],
             "mmp_pool_full_rejects_delta": rejects,
             "worker_pids": {
                 model_id: sorted(values) for model_id, values in pids.items()
@@ -271,6 +573,18 @@ def analyze(
             "extra_loaded_routes": sorted(set(pids) - expected_routes),
             "mps_enabled": experiment.get("mps_enabled"),
             "fixture_sha256": fixture_sha256,
+            "matrix_sha256": experiment.get("matrix_sha256"),
+            "template_sha256": experiment.get("template_sha256"),
+            "workload_sha256": experiment.get("workload_sha256"),
+            "cache_state": experiment.get("cache_state"),
+            "cache_evidence_sha256": (
+                canonical_sha256(cache_evidence) if cache_evidence else None
+            ),
+            "server_image_ref": experiment.get("server_image_ref"),
+            "server_source_revision": experiment.get("server_source_revision"),
+            "harness_revision": experiment.get("harness_revision"),
+            "server_node": run.get("node_name"),
+            "gpu_uuid": identity.get("gpu_uuid"),
             "pod_evidence": identity,
         },
     }
@@ -285,9 +599,14 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument("--capability-report", type=Path, required=True)
     parser.add_argument("--expected-node", required=True)
     parser.add_argument("--expected-gpu-uuid", required=True)
+    parser.add_argument("--matrix", required=True, type=Path)
+    parser.add_argument("--mps-evidence", type=Path)
+    parser.add_argument("--cache-evidence", required=True, type=Path)
     parser.add_argument("--output", type=Path)
     args = parser.parse_args(argv)
     report = json.loads(args.report.read_text())
+    matrix = load_and_validate(args.matrix)
+    harness_revision = current_clean_revision(Path(__file__).resolve().parents[2])
     result = analyze(
         report,
         phase=args.phase,
@@ -296,6 +615,13 @@ def main(argv: Sequence[str] | None = None) -> int:
         capability=json.loads(args.capability_report.read_text()),
         expected_node=args.expected_node,
         expected_gpu_uuid=args.expected_gpu_uuid,
+        matrix=matrix,
+        matrix_dir=args.matrix.parent,
+        mps_evidence=(
+            json.loads(args.mps_evidence.read_text()) if args.mps_evidence else None
+        ),
+        cache_evidence=json.loads(args.cache_evidence.read_text()),
+        expected_harness_revision=harness_revision,
     )
     rendered = json.dumps(result, indent=2, sort_keys=True) + "\n"
     if args.output:

--- a/development/mmp_staging_benchmark/analyze_report.py
+++ b/development/mmp_staging_benchmark/analyze_report.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+"""Apply the strict MMP staging capacity gates to one completed JSON report."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+CUDA_FAILURE = re.compile(
+    r"cuda (?:error|out of memory)|illegal memory access|nvrm:\s*xid",
+    re.IGNORECASE,
+)
+
+
+def _worker_pids(report: Mapping[str, Any]) -> dict[str, set[int]]:
+    pids: dict[str, set[int]] = {}
+    for sample in report.get("metrics_samples", []):
+        if sample.get("status") != 200:
+            continue
+        for model_id, model in sample.get("metrics", {}).get("mmp_models", {}).items():
+            pid = model.get("worker_pid")
+            if pid is not None:
+                pids.setdefault(model_id, set()).add(int(pid))
+    return pids
+
+
+def _environment(container: Mapping[str, Any]) -> dict[str, str]:
+    return {
+        item["name"]: str(item["value"])
+        for item in container.get("env", [])
+        if "name" in item and "value" in item
+    }
+
+
+def _gpu_identity(capability: Mapping[str, Any]) -> tuple[str | None, str | None]:
+    query = capability.get("nvidia_runtime", {}).get("gpu_query", {})
+    if query.get("exit_code") != 0:
+        return None, None
+    rows = [row.strip() for row in str(query.get("stdout", "")).splitlines() if row]
+    if len(rows) != 1:
+        return None, None
+    fields = [field.strip() for field in rows[0].split(",")]
+    if len(fields) < 6:
+        return None, None
+    return fields[1], fields[2]
+
+
+def _pod_evidence(
+    pod: Mapping[str, Any], capability: Mapping[str, Any]
+) -> dict[str, Any]:
+    containers = pod.get("spec", {}).get("containers", [])
+    statuses = pod.get("status", {}).get("containerStatuses", [])
+    server = next((item for item in containers if item.get("name") == "server"), {})
+    server_status = next(
+        (item for item in statuses if item.get("name") == "server"), {}
+    )
+    name, uuid = _gpu_identity(capability)
+    return {
+        "pod": pod.get("metadata", {}).get("name"),
+        "node": pod.get("spec", {}).get("nodeName"),
+        "annotations": pod.get("metadata", {}).get("annotations", {}),
+        "desired_image": server.get("image"),
+        "runtime_image_id": server_status.get("imageID"),
+        "restart_count": server_status.get("restartCount"),
+        "ready": server_status.get("ready"),
+        "env": _environment(server),
+        "gpu_name": name,
+        "gpu_uuid": uuid,
+    }
+
+
+def analyze(
+    report: Mapping[str, Any],
+    *,
+    phase: str,
+    latency_p95_ms_max: float = 50,
+    jain_fairness_min: float = 0.95,
+    minimum_metrics_coverage: float = 0.9,
+    worker_restarts_max: int = 0,
+    server_log: str = "",
+    pod: Mapping[str, Any] | None = None,
+    capability: Mapping[str, Any] | None = None,
+    expected_node: str | None = None,
+    expected_gpu_uuid: str | None = None,
+) -> dict[str, Any]:
+    failures: list[str] = []
+    clients = report.get("clients", [])
+    aggregate = report.get("aggregate", {})
+    run = report.get("run", {})
+    experiment = report.get("experiment", {})
+    expected_mps = phase.endswith("-mps") and not phase.endswith("-no-mps")
+    if pod is None or capability is None:
+        failures.append("Kubernetes pod and capability evidence are required")
+        identity: dict[str, Any] = {}
+    else:
+        identity = _pod_evidence(pod, capability)
+    if not clients:
+        failures.append("no client reports")
+    if int(aggregate.get("errors", 0)) != 0:
+        failures.append("request errors recorded")
+    if int(aggregate.get("successes", 0)) != int(aggregate.get("requests", -1)):
+        failures.append("success rate below 100%")
+    for client in clients:
+        p95 = client.get("latency_ms", {}).get("p95")
+        if p95 is None or float(p95) > latency_p95_ms_max:
+            failures.append(f"{client.get('client_id')}: latency p95 failed")
+    if "mixed" not in phase and len(clients) > 1:
+        fairness = aggregate.get("jain_fairness_delivered_fps")
+        if fairness is None or float(fairness) < jain_fairness_min:
+            failures.append("same-model Jain fairness failed")
+    elapsed = float(run.get("warmup_s", 0)) + float(run.get("duration_s", 0))
+    sample_count = int(report.get("metrics_evidence", {}).get("sample_count", 0))
+    sample_interval = float(run.get("sample_interval_s", 1))
+    expected_samples = max(1.0, elapsed / sample_interval)
+    coverage = sample_count / expected_samples
+    if coverage < minimum_metrics_coverage:
+        failures.append("metrics coverage failed")
+    rejects = int(
+        report.get("metrics_evidence", {}).get("mmp_pool_full_rejects_delta", 0)
+    )
+    if rejects:
+        failures.append("MMP pool-full rejects recorded")
+    pids = _worker_pids(report)
+    expected_routes = {client.get("routing_key") for client in clients}
+    worker_restarts = sum(
+        max(0, len(pids.get(route, set())) - 1) for route in expected_routes
+    )
+    if worker_restarts > worker_restarts_max:
+        failures.append("model worker PID missing or changed")
+    if not expected_routes.issubset(pids):
+        failures.append("expected model worker routing key is missing")
+    model_deltas = report.get("metrics_evidence", {}).get("model_deltas", {})
+    run_batch_sizes: dict[str, float | None] = {}
+    for route in expected_routes:
+        delta = model_deltas.get(route, {})
+        inference_count = int(delta.get("inference_count_delta", 0))
+        batch_count = int(delta.get("batch_count_delta", 0))
+        if inference_count <= 0 or batch_count <= 0:
+            failures.append(f"{route}: no positive MMP inference/batch delta")
+            run_batch_sizes[route] = None
+        else:
+            run_batch_sizes[route] = inference_count / batch_count
+        if int(delta.get("error_count_delta", 0)) != 0:
+            failures.append(f"{route}: model worker errors recorded")
+    total_concurrency = sum(int(client.get("concurrency", 0)) for client in clients)
+    if "shared" in phase and total_concurrency > 1:
+        shared_route = next(iter(expected_routes), None)
+        if shared_route is None or (run_batch_sizes.get(shared_route) or 0) <= 1.0:
+            failures.append("shared backend did not produce a multi-request batch")
+    if str(experiment.get("mps_enabled")) != ("1" if expected_mps else "0"):
+        failures.append("report MPS identity does not match phase")
+    if experiment.get("mode") != phase:
+        failures.append("report phase identity does not match analyzer phase")
+    if not experiment.get("run_id") or experiment.get("run_id") == "unknown":
+        failures.append("run identity missing")
+    if not re.fullmatch(r"[0-9a-f]{40}", str(experiment.get("harness_revision", ""))):
+        failures.append("harness revision identity missing")
+    if experiment.get("decoder") != "imagecodecs":
+        failures.append("initial matrix must use imagecodecs decoder")
+    expected_runtime = {
+        "slots": 128,
+        "input_mb_per_slot": 20,
+        "batch_max_size": 0,
+        "batch_max_wait_ms": 5,
+    }
+    for field, expected in expected_runtime.items():
+        try:
+            actual = int(experiment.get(field))
+        except (TypeError, ValueError):
+            actual = None
+        if actual != expected:
+            failures.append(f"runtime identity mismatch: {field}")
+    if run.get("image_ref") != experiment.get("server_image_ref"):
+        failures.append("server image identity mismatch")
+    if run.get("source_revision") != experiment.get("server_source_revision"):
+        failures.append("server source identity mismatch")
+    if run.get("pod_name") in {None, "", "unknown"}:
+        failures.append("server pod identity missing")
+    if run.get("node_name") in {None, "", "unknown"}:
+        failures.append("server node identity missing")
+    elif run.get("node_name") != experiment.get("server_node"):
+        failures.append("server node identity mismatch")
+    if run.get("pod_name") != experiment.get("server_pod"):
+        failures.append("server pod identity mismatch")
+    fixture_sha256 = experiment.get("fixture_sha256")
+    if not fixture_sha256 or fixture_sha256 == "unknown":
+        failures.append("fixture digest identity missing")
+    elif run.get("image_sha256") != fixture_sha256:
+        failures.append("fixture digest does not match report image")
+    if identity:
+        annotations = identity["annotations"]
+        env = identity["env"]
+        if identity["ready"] is not True:
+            failures.append("server container was not ready in pod evidence")
+        if int(identity["restart_count"] or 0) != 0:
+            failures.append("server container restart recorded")
+        if identity["pod"] != run.get("pod_name"):
+            failures.append("pod evidence identity mismatch")
+        if identity["node"] != run.get("node_name"):
+            failures.append("node evidence identity mismatch")
+        if expected_node is None or identity["node"] != expected_node:
+            failures.append("pod is not pinned to the expected capability node")
+        if expected_gpu_uuid is None or identity["gpu_uuid"] != expected_gpu_uuid:
+            failures.append("GPU UUID does not match capability baseline")
+        if identity["gpu_name"] != "NVIDIA L40S":
+            failures.append("capability evidence is not one L40S")
+        if capability.get("checks", {}).get("passed") is not True:
+            failures.append("capability checks did not pass")
+        if capability.get("source_revision") != experiment.get(
+            "server_source_revision"
+        ):
+            failures.append("capability source revision mismatch")
+        if capability.get("image_ref") != experiment.get("server_image_ref"):
+            failures.append("capability image reference mismatch")
+        if identity["desired_image"] != experiment.get("server_image_ref"):
+            failures.append("pod desired image mismatch")
+        digest = str(experiment.get("server_image_ref", "")).split("@", 1)[-1]
+        if digest not in str(identity["runtime_image_id"]):
+            failures.append("pod runtime image digest mismatch")
+        expected_annotations = {
+            "roboflow.com/source-revision": experiment.get("server_source_revision"),
+            "roboflow.com/run-id": experiment.get("run_id"),
+            "roboflow.com/mps": "enabled" if expected_mps else "disabled",
+            "roboflow.com/decoder": experiment.get("decoder"),
+        }
+        if any(
+            annotations.get(key) != value for key, value in expected_annotations.items()
+        ):
+            failures.append("pod annotations do not match report identity")
+        expected_env = {
+            "NVIDIA_MPS": "1" if expected_mps else "0",
+            "INFERENCE_DECODER": "imagecodecs",
+            "INFERENCE_N_SLOTS": "128",
+            "INFERENCE_INPUT_MB": "20",
+            "INFERENCE_BATCH_MAX_SIZE": "0",
+            "INFERENCE_BATCH_MAX_WAIT_MS": "5",
+        }
+        if any(env.get(key) != value for key, value in expected_env.items()):
+            failures.append("pod runtime environment does not match matrix")
+    if CUDA_FAILURE.search(server_log):
+        failures.append("CUDA failure found in server log")
+    if not server_log.strip():
+        failures.append("server log evidence is empty")
+    return {
+        "schema_version": 1,
+        "phase": phase,
+        "success": not failures,
+        "failures": failures,
+        "evidence": {
+            "requests": aggregate.get("requests"),
+            "successes": aggregate.get("successes"),
+            "latency_p95_ms_by_client": {
+                client.get("client_id"): client.get("latency_ms", {}).get("p95")
+                for client in clients
+            },
+            "jain_fairness_delivered_fps": aggregate.get("jain_fairness_delivered_fps"),
+            "metrics_coverage": coverage,
+            "mmp_pool_full_rejects_delta": rejects,
+            "worker_pids": {
+                model_id: sorted(values) for model_id, values in pids.items()
+            },
+            "worker_restarts": worker_restarts,
+            "run_average_batch_size": run_batch_sizes,
+            "total_concurrency": total_concurrency,
+            "run_id": experiment.get("run_id"),
+            "log_sha256": hashlib.sha256(server_log.encode()).hexdigest(),
+            "extra_loaded_routes": sorted(set(pids) - expected_routes),
+            "mps_enabled": experiment.get("mps_enabled"),
+            "fixture_sha256": fixture_sha256,
+            "pod_evidence": identity,
+        },
+    }
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("report", type=Path)
+    parser.add_argument("--phase", required=True)
+    parser.add_argument("--server-log", type=Path, required=True)
+    parser.add_argument("--pod-evidence", type=Path, required=True)
+    parser.add_argument("--capability-report", type=Path, required=True)
+    parser.add_argument("--expected-node", required=True)
+    parser.add_argument("--expected-gpu-uuid", required=True)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args(argv)
+    report = json.loads(args.report.read_text())
+    result = analyze(
+        report,
+        phase=args.phase,
+        server_log=args.server_log.read_text(),
+        pod=json.loads(args.pod_evidence.read_text()),
+        capability=json.loads(args.capability_report.read_text()),
+        expected_node=args.expected_node,
+        expected_gpu_uuid=args.expected_gpu_uuid,
+    )
+    rendered = json.dumps(result, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.write_text(rendered)
+    else:
+        print(rendered, end="")
+    return 0 if result["success"] else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/development/mmp_staging_benchmark/capability_probe.py
+++ b/development/mmp_staging_benchmark/capability_probe.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python3
+"""Emit a JSON CUDA/MPS and shared-memory capability report.
+
+The default probe is read-only. ``--start-stop-mps`` is intentionally explicit
+and must only be used in a dedicated pod that exclusively owns the GPU.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import platform
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Any, Sequence
+
+SLOT_HEADER_BYTES = 64
+MIB = 1024 * 1024
+
+
+def _run(command: Sequence[str], *, timeout_s: float = 10.0) -> dict[str, Any]:
+    started = time.monotonic()
+    try:
+        result = subprocess.run(
+            command,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout_s,
+        )
+        return {
+            "command": list(command),
+            "exit_code": result.returncode,
+            "stdout": result.stdout.strip(),
+            "stderr": result.stderr.strip(),
+            "duration_ms": round((time.monotonic() - started) * 1000, 3),
+        }
+    except FileNotFoundError:
+        return {
+            "command": list(command),
+            "exit_code": None,
+            "error": "not found",
+            "duration_ms": round((time.monotonic() - started) * 1000, 3),
+        }
+    except subprocess.TimeoutExpired as exc:
+        return {
+            "command": list(command),
+            "exit_code": None,
+            "error": "timeout",
+            "stdout": (exc.stdout or "").strip(),
+            "stderr": (exc.stderr or "").strip(),
+            "duration_ms": round((time.monotonic() - started) * 1000, 3),
+        }
+
+
+def _int_env(name: str, default: int) -> int:
+    try:
+        return int(os.environ.get(name, str(default)))
+    except ValueError as exc:
+        raise SystemExit(f"{name} must be an integer") from exc
+
+
+def _float_env(name: str, default: float) -> float:
+    try:
+        return float(os.environ.get(name, str(default)))
+    except ValueError as exc:
+        raise SystemExit(f"{name} must be numeric") from exc
+
+
+def shared_memory_report(path: str = "/dev/shm") -> dict[str, Any]:
+    slots = _int_env("INFERENCE_N_SLOTS", 32)
+    input_mb = _float_env("INFERENCE_INPUT_MB", 25.0)
+    required = int(slots * (input_mb * MIB + SLOT_HEADER_BYTES))
+    reserve_factor = _float_env("MMP_SHM_RESERVE_FACTOR", 1.25)
+    recommended = int(required * reserve_factor)
+
+    target = Path(path)
+    exists = target.exists()
+    report: dict[str, Any] = {
+        "path": path,
+        "exists": exists,
+        "writable": os.access(path, os.W_OK) if exists else False,
+        "slots": slots,
+        "input_mb_per_slot": input_mb,
+        "slot_header_bytes": SLOT_HEADER_BYTES,
+        "required_bytes": required,
+        "recommended_bytes": recommended,
+        "reserve_factor": reserve_factor,
+    }
+    if exists:
+        usage = shutil.disk_usage(path)
+        report.update(
+            {
+                "total_bytes": usage.total,
+                "free_bytes": usage.free,
+                "satisfies_required": usage.free >= required,
+                "satisfies_recommended": usage.free >= recommended,
+            }
+        )
+    else:
+        report.update({"satisfies_required": False, "satisfies_recommended": False})
+    return report
+
+
+def _torch_report() -> dict[str, Any]:
+    try:
+        import torch
+
+        available = torch.cuda.is_available()
+        result: dict[str, Any] = {
+            "installed": True,
+            "version": torch.__version__,
+            "compiled_cuda": torch.version.cuda,
+            "cuda_available": available,
+            "device_count": torch.cuda.device_count() if available else 0,
+        }
+        if available:
+            result["devices"] = [
+                {
+                    "index": index,
+                    "name": torch.cuda.get_device_name(index),
+                    "capability": list(torch.cuda.get_device_capability(index)),
+                }
+                for index in range(torch.cuda.device_count())
+            ]
+        return result
+    except Exception as exc:  # probe must report import/driver failures
+        return {
+            "installed": False,
+            "error_type": type(exc).__name__,
+            "error": str(exc),
+        }
+
+
+def _mps_start_stop() -> dict[str, Any]:
+    control = shutil.which("nvidia-cuda-mps-control")
+    server = shutil.which("nvidia-cuda-mps-server")
+    if not control or not server:
+        return {
+            "attempted": False,
+            "success": False,
+            "error": "MPS control/server binary missing",
+        }
+
+    with tempfile.TemporaryDirectory(prefix="mmp-mps-") as root:
+        pipe_dir = Path(root) / "pipe"
+        log_dir = Path(root) / "log"
+        pipe_dir.mkdir()
+        log_dir.mkdir()
+        env = dict(os.environ)
+        env["CUDA_MPS_PIPE_DIRECTORY"] = str(pipe_dir)
+        env["CUDA_MPS_LOG_DIRECTORY"] = str(log_dir)
+
+        started = time.monotonic()
+        start = subprocess.run(
+            [control, "-d"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=15,
+            env=env,
+        )
+        query: dict[str, Any] | None = None
+        stop: dict[str, Any] | None = None
+        try:
+            if start.returncode == 0:
+                query_proc = subprocess.run(
+                    [control],
+                    input="get_server_list\n",
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                    env=env,
+                )
+                query = {
+                    "exit_code": query_proc.returncode,
+                    "stdout": query_proc.stdout.strip(),
+                    "stderr": query_proc.stderr.strip(),
+                }
+        finally:
+            if start.returncode == 0:
+                stop_proc = subprocess.run(
+                    [control],
+                    input="quit\n",
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                    env=env,
+                )
+                stop = {
+                    "exit_code": stop_proc.returncode,
+                    "stdout": stop_proc.stdout.strip(),
+                    "stderr": stop_proc.stderr.strip(),
+                }
+
+        logs = {}
+        for log_file in sorted(log_dir.glob("*")):
+            try:
+                logs[log_file.name] = log_file.read_text(errors="replace")[-4000:]
+            except OSError as exc:
+                logs[log_file.name] = f"unreadable: {exc}"
+        return {
+            "attempted": True,
+            "success": start.returncode == 0
+            and stop is not None
+            and stop["exit_code"] == 0,
+            "duration_ms": round((time.monotonic() - started) * 1000, 3),
+            "pipe_directory": str(pipe_dir),
+            "log_directory": str(log_dir),
+            "start": {
+                "exit_code": start.returncode,
+                "stdout": start.stdout.strip(),
+                "stderr": start.stderr.strip(),
+            },
+            "query": query,
+            "stop": stop,
+            "logs": logs,
+        }
+
+
+def build_report(start_stop_mps: bool = False) -> dict[str, Any]:
+    mps_control = shutil.which("nvidia-cuda-mps-control")
+    mps_server = shutil.which("nvidia-cuda-mps-server")
+    nvidia_smi = shutil.which("nvidia-smi")
+    report: dict[str, Any] = {
+        "schema_version": 1,
+        "timestamp_unix_s": time.time(),
+        "source_revision": os.environ.get("MMP_BENCHMARK_SOURCE_REVISION", "unknown"),
+        "image_ref": os.environ.get("MMP_BENCHMARK_IMAGE_REF", "unknown"),
+        "platform": {
+            "system": platform.system(),
+            "release": platform.release(),
+            "machine": platform.machine(),
+            "python": platform.python_version(),
+        },
+        "nvidia_runtime": {
+            "visible_devices": os.environ.get("NVIDIA_VISIBLE_DEVICES"),
+            "driver_capabilities": os.environ.get("NVIDIA_DRIVER_CAPABILITIES"),
+            "device_nodes": sorted(str(p) for p in Path("/dev").glob("nvidia*")),
+            "nvidia_smi_path": nvidia_smi,
+            "mps_control_path": mps_control,
+            "mps_server_path": mps_server,
+            "mps_binaries_available": bool(mps_control and mps_server),
+            "cuda_mps_pipe_directory": os.environ.get("CUDA_MPS_PIPE_DIRECTORY"),
+            "cuda_mps_log_directory": os.environ.get("CUDA_MPS_LOG_DIRECTORY"),
+            "cuda_mps_active_thread_percentage": os.environ.get(
+                "CUDA_MPS_ACTIVE_THREAD_PERCENTAGE"
+            ),
+        },
+        "shared_memory": shared_memory_report(),
+        "torch": _torch_report(),
+    }
+
+    package_manifest = Path("/opt/mmp-benchmark/python-packages.txt")
+    if package_manifest.is_file():
+        manifest_bytes = package_manifest.read_bytes()
+        report["python_packages"] = {
+            "path": str(package_manifest),
+            "sha256": hashlib.sha256(manifest_bytes).hexdigest(),
+            "line_count": len(manifest_bytes.splitlines()),
+        }
+
+    if nvidia_smi:
+        report["nvidia_runtime"]["gpu_query"] = _run(
+            [
+                nvidia_smi,
+                "--query-gpu=index,name,uuid,driver_version,memory.total,compute_mode",
+                "--format=csv,noheader,nounits",
+            ]
+        )
+        report["nvidia_runtime"]["mig_query"] = _run(
+            [nvidia_smi, "--query-gpu=index,mig.mode.current", "--format=csv,noheader"]
+        )
+    if start_stop_mps:
+        report["mps_start_stop"] = _mps_start_stop()
+    return report
+
+
+def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", help="write JSON report to this path")
+    parser.add_argument("--require-gpu", action="store_true")
+    parser.add_argument("--require-mps", action="store_true")
+    parser.add_argument("--require-shm", action="store_true")
+    parser.add_argument(
+        "--start-stop-mps",
+        action="store_true",
+        help="start and stop MPS; dedicated single-GPU experiment pod only",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(argv)
+    report = build_report(start_stop_mps=args.start_stop_mps)
+    failures: list[str] = []
+    runtime = report["nvidia_runtime"]
+    if args.require_gpu:
+        if not runtime["nvidia_smi_path"]:
+            failures.append("nvidia-smi missing")
+        if not report["torch"].get("cuda_available", False):
+            failures.append("torch CUDA unavailable")
+    if args.require_mps and not runtime["mps_binaries_available"]:
+        failures.append("MPS control/server binaries missing")
+    if args.start_stop_mps and not report.get("mps_start_stop", {}).get(
+        "success", False
+    ):
+        failures.append("MPS start/stop smoke failed")
+    if args.require_shm and not report["shared_memory"]["satisfies_recommended"]:
+        failures.append("/dev/shm below recommended capacity")
+
+    report["checks"] = {"passed": not failures, "failures": failures}
+    rendered = json.dumps(report, indent=2, sort_keys=True)
+    if args.output:
+        path = Path(args.output)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(rendered + "\n")
+    print(rendered)
+    return 0 if not failures else 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/development/mmp_staging_benchmark/capture_cache_evidence.py
+++ b/development/mmp_staging_benchmark/capture_cache_evidence.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Capture read-only pre-run MMP route and model-cache evidence."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+import sys
+import time
+import urllib.request
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from development.mmp_staging_benchmark.run_concurrent_clients import (  # noqa: E402
+    validate_staging_url,
+)
+
+CONTEXT = "ck8s-stg"
+NAMESPACE = "video-proc-bench-mmp"
+
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, request, fp, code, msg, headers, newurl):
+        return None
+
+
+def _run(command: list[str]) -> str:
+    return subprocess.run(
+        command, check=True, capture_output=True, text=True
+    ).stdout.strip()
+
+
+def _metrics(server_url: str, api_key: str) -> Mapping[str, Any]:
+    request = urllib.request.Request(
+        f"{validate_staging_url(server_url)}/v2/server/metrics",
+        headers={"Authorization": f"Bearer {api_key}"},
+    )
+    opener = urllib.request.build_opener(_NoRedirect)
+    with opener.open(request, timeout=10) as response:
+        if response.status != 200:
+            raise ValueError(f"metrics endpoint returned HTTP {response.status}")
+        return json.loads(response.read())
+
+
+def capture(pod: str, server_url: str, api_key: str) -> dict[str, object]:
+    if _run(["kubectl", "config", "current-context"]) != CONTEXT:
+        raise ValueError(f"current context must be {CONTEXT!r}")
+    prefix = ["kubectl", "--context", CONTEXT, "-n", NAMESPACE]
+    pod_document = json.loads(_run([*prefix, "get", "pod", pod, "-o", "json"]))
+    if pod_document.get("metadata", {}).get("name") != pod:
+        raise ValueError("pod response identity mismatch")
+    cache_output = _run(
+        [
+            *prefix,
+            "exec",
+            pod,
+            "-c",
+            "server",
+            "--",
+            "find",
+            "/models/cache",
+            "-type",
+            "f",
+        ]
+    )
+    cache_files = sorted(
+        line.strip() for line in cache_output.splitlines() if line.strip()
+    )
+    metrics = _metrics(server_url, api_key)
+    raw_routes = metrics.get("mmp_models") or {}
+    routes = {
+        route: {
+            field: model.get(field)
+            for field in ("worker_pid", "inference_count", "batch_count", "error_count")
+        }
+        for route, model in sorted(raw_routes.items())
+        if isinstance(model, Mapping)
+    }
+    for route, model in routes.items():
+        pid = model.get("worker_pid")
+        if not isinstance(pid, int) or pid <= 0:
+            raise ValueError(f"route {route!r} does not report a positive worker PID")
+        _run([*prefix, "exec", pod, "-c", "server", "--", "kill", "-0", str(pid)])
+    return {
+        "schema_version": 1,
+        "context": CONTEXT,
+        "namespace": NAMESPACE,
+        "pod": pod,
+        "pod_uid": pod_document.get("metadata", {}).get("uid"),
+        "captured_unix_s": time.time(),
+        "cache_file_count": len(cache_files),
+        "cache_paths_sha256": hashlib.sha256(
+            "\n".join(cache_files).encode()
+        ).hexdigest(),
+        "routes": routes,
+    }
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--pod", required=True)
+    parser.add_argument("--server-url", default="http://127.0.0.1:18000")
+    parser.add_argument("--api-key-env", required=True)
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args(argv)
+    api_key = os.environ.get(args.api_key_env)
+    if not api_key:
+        raise ValueError(f"missing API key environment variable {args.api_key_env}")
+    evidence = capture(args.pod, args.server_url, api_key)
+    args.output.write_text(json.dumps(evidence, indent=2, sort_keys=True) + "\n")
+    print(args.output.resolve())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/development/mmp_staging_benchmark/capture_mps_evidence.py
+++ b/development/mmp_staging_benchmark/capture_mps_evidence.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Capture a live, read-only MPS server-list observation from the staging pod."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import time
+from pathlib import Path
+from typing import Sequence
+
+CONTEXT = "ck8s-stg"
+NAMESPACE = "video-proc-bench-mmp"
+
+
+def _run(command: list[str], *, stdin: str | None = None) -> str:
+    completed = subprocess.run(
+        command,
+        input=stdin,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return completed.stdout.strip()
+
+
+def _mps_control(prefix: list[str], pod: str, command: str) -> str:
+    return _run(
+        [
+            *prefix,
+            "exec",
+            "-i",
+            pod,
+            "-c",
+            "server",
+            "--",
+            "nvidia-cuda-mps-control",
+        ],
+        stdin=f"{command}\n",
+    )
+
+
+def capture(pod: str) -> dict[str, object]:
+    current = _run(["kubectl", "config", "current-context"])
+    if current != CONTEXT:
+        raise ValueError(f"refusing context {current!r}; expected {CONTEXT!r}")
+    prefix = ["kubectl", "--context", CONTEXT, "-n", NAMESPACE]
+    pod_document = json.loads(_run([*prefix, "get", "pod", pod, "-o", "json"]))
+    if pod_document.get("metadata", {}).get("name") != pod:
+        raise ValueError("pod response identity mismatch")
+    gpu_rows = _run(
+        [
+            *prefix,
+            "exec",
+            pod,
+            "-c",
+            "server",
+            "--",
+            "nvidia-smi",
+            "--query-gpu=uuid",
+            "--format=csv,noheader",
+        ]
+    ).splitlines()
+    if len(gpu_rows) != 1 or not gpu_rows[0].strip().startswith("GPU-"):
+        raise ValueError("expected exactly one GPU UUID")
+    server_list = _mps_control(prefix, pod, "get_server_list")
+    if not server_list or not all(
+        line.strip().isdigit() for line in server_list.splitlines()
+    ):
+        raise ValueError("MPS get_server_list returned no numeric server PIDs")
+    clients_by_server = {}
+    for server_pid in server_list.splitlines():
+        clients = _mps_control(prefix, pod, f"get_client_list {server_pid.strip()}")
+        if clients and not all(line.strip().isdigit() for line in clients.splitlines()):
+            raise ValueError("MPS get_client_list returned a nonnumeric client PID")
+        clients_by_server[server_pid.strip()] = [
+            int(line.strip()) for line in clients.splitlines() if line.strip()
+        ]
+    return {
+        "schema_version": 1,
+        "context": CONTEXT,
+        "namespace": NAMESPACE,
+        "pod": pod,
+        "pod_uid": pod_document.get("metadata", {}).get("uid"),
+        "gpu_uuid": gpu_rows[0].strip(),
+        "captured_unix_s": time.time(),
+        "command": "get_server_list",
+        "exit_code": 0,
+        "server_list": server_list,
+        "clients_by_server": clients_by_server,
+    }
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--pod", required=True)
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args(argv)
+    evidence = capture(args.pod)
+    args.output.write_text(json.dumps(evidence, indent=2, sort_keys=True) + "\n")
+    print(args.output.resolve())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/development/mmp_staging_benchmark/cloudbuild.yaml
+++ b/development/mmp_staging_benchmark/cloudbuild.yaml
@@ -1,0 +1,18 @@
+steps:
+  - name: gcr.io/cloud-builders/docker
+    id: build-mmp-benchmark
+    env:
+      - DOCKER_BUILDKIT=1
+    args:
+      - build
+      - --platform=linux/amd64
+      - --build-arg=SOURCE_REVISION=${_SOURCE_REVISION}
+      - --file=development/mmp_staging_benchmark/Dockerfile
+      - --tag=${_IMAGE}
+      - .
+images:
+  - ${_IMAGE}
+options:
+  machineType: E2_HIGHCPU_32
+  diskSizeGb: 200
+timeout: 3600s

--- a/development/mmp_staging_benchmark/matrix.staging.json
+++ b/development/mmp_staging_benchmark/matrix.staging.json
@@ -1,0 +1,79 @@
+{
+  "schema_version": 1,
+  "artifact": {
+    "source_revision": "5f02db12ebdda013ff92e6607f92f88c7f9582ec",
+    "image": "us-central1-docker.pkg.dev/roboflow-staging/video-proc/mmp-benchmark@sha256:6a6592f77e0eb1d3bfc8b82d7add6a7206e946a437a072f7f3a58cf693b1716d",
+    "cloud_build_id": "f0bd00b6-f0d1-410a-8ba6-bf9f8e8ccfd0"
+  },
+  "fixed_runtime": {
+    "gpu": "L40S",
+    "exclusive_gpu": true,
+    "http_workers": 4,
+    "shm_slots": 128,
+    "shm_input_mb_per_slot": 20,
+    "shm_size_limit": "4Gi",
+    "batch_max_size": 0,
+    "batch_max_wait_ms": 5,
+    "decoder": "imagecodecs",
+    "duration_s": 120,
+    "warmup_s": 15,
+    "sample_interval_s": 1,
+    "repetitions": 2,
+    "fixture_path": "tests/workflows/integration_tests/execution/assets/dogs.jpg",
+    "fixture_sha256": "83bfa4e706f274ce1da7309cec6374d542f9938b3538481035588681cdaff139"
+  },
+  "phases": [
+    {
+      "id": "mmp-shared-no-mps",
+      "execution": "MMP subprocess backend with cross-client auto-batching",
+      "mps": false,
+      "spec": "spec.same-model.example.json",
+      "total_concurrency": [1, 2, 4, 8, 12, 16, 24, 32]
+    },
+    {
+      "id": "mmp-isolated-no-mps",
+      "execution": "MMP with one routing-key subprocess per client",
+      "mps": false,
+      "spec": "spec.same-model-isolated.example.json",
+      "total_concurrency": [2, 4, 8, 12, 16, 24, 32]
+    },
+    {
+      "id": "mmp-mixed-no-mps",
+      "execution": "MMP with independent detection and segmentation subprocesses",
+      "mps": false,
+      "spec": "spec.mixed-model.example.json",
+      "total_concurrency": [2, 4, 8, 12]
+    },
+    {
+      "id": "mmp-shared-mps",
+      "execution": "same MMP shared-backend matrix with raw same-pod NVIDIA MPS",
+      "mps": true,
+      "spec": "spec.same-model.example.json",
+      "total_concurrency": [1, 2, 4, 8, 12, 16, 24, 32]
+    },
+    {
+      "id": "mmp-isolated-mps",
+      "execution": "same MMP isolated-backend matrix with raw same-pod NVIDIA MPS",
+      "mps": true,
+      "spec": "spec.same-model-isolated.example.json",
+      "total_concurrency": [2, 4, 8, 12, 16, 24, 32]
+    },
+    {
+      "id": "mmp-mixed-mps",
+      "execution": "same mixed-model matrix with raw same-pod NVIDIA MPS",
+      "mps": true,
+      "spec": "spec.mixed-model.example.json",
+      "total_concurrency": [2, 4, 8, 12]
+    }
+  ],
+  "strict_gates": {
+    "success_rate": 1.0,
+    "latency_p95_ms_max": 50,
+    "jain_fairness_min": 0.95,
+    "mmp_pool_full_rejects_delta_max": 0,
+    "worker_restarts_max": 0,
+    "cuda_errors_max": 0,
+    "minimum_metrics_coverage": 0.9,
+    "capacity_rule": "highest point passing twice with the next point failing twice"
+  }
+}

--- a/development/mmp_staging_benchmark/render_run_spec.py
+++ b/development/mmp_staging_benchmark/render_run_spec.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Render one exact, loopback-only MMP benchmark point from a checked-in spec."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Sequence
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from development.mmp_staging_benchmark.run_concurrent_clients import (  # noqa: E402
+    load_spec,
+)
+from development.mmp_staging_benchmark.validate_staging_plan import (  # noqa: E402
+    load_and_validate,
+)
+
+
+def render_point(
+    template: Path,
+    total_concurrency: int,
+    duration_s: float,
+    warmup_s: float,
+    experiment: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    if total_concurrency <= 0:
+        raise ValueError("total concurrency must be positive")
+    raw = json.loads(template.read_text())
+    clients = raw.get("clients", [])
+    if len(clients) != 2:
+        raise ValueError("point templates must contain exactly two clients")
+    if total_concurrency == 1:
+        clients = [clients[0]]
+        clients[0]["concurrency"] = 1
+    else:
+        if total_concurrency % 2:
+            raise ValueError("two-client points require even total concurrency")
+        per_client = total_concurrency // 2
+        for client in clients:
+            client["concurrency"] = per_client
+    raw["server_url"] = "http://127.0.0.1:18000"
+    raw["duration_s"] = duration_s
+    raw["warmup_s"] = warmup_s
+    raw["clients"] = clients
+    if experiment is not None:
+        raw["experiment"] = experiment
+    return raw
+
+
+def current_clean_revision(repo_root: Path) -> str:
+    status = subprocess.run(
+        ["git", "status", "--porcelain", "--untracked-files=normal"],
+        cwd=repo_root,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    if status.stdout.strip():
+        raise ValueError("benchmark harness checkout must be clean")
+    revision = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo_root,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    if len(revision) != 40:
+        raise ValueError("could not resolve exact harness revision")
+    return revision
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--matrix", required=True, type=Path)
+    parser.add_argument("--total-concurrency", required=True, type=int)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--run-id", required=True)
+    parser.add_argument("--phase", required=True)
+    parser.add_argument("--server-pod", required=True)
+    parser.add_argument("--server-node", required=True)
+    args = parser.parse_args(argv)
+    harness_revision = current_clean_revision(Path(__file__).resolve().parents[2])
+    matrix = load_and_validate(args.matrix)
+    phase = next((item for item in matrix["phases"] if item["id"] == args.phase), None)
+    if phase is None:
+        raise ValueError(f"unknown phase {args.phase!r}")
+    if args.total_concurrency not in phase["total_concurrency"]:
+        raise ValueError("concurrency point is not in the selected matrix phase")
+    fixed = matrix["fixed_runtime"]
+    artifact = matrix["artifact"]
+    template = args.matrix.parent / phase["spec"]
+    rendered = render_point(
+        template,
+        args.total_concurrency,
+        fixed["duration_s"],
+        fixed["warmup_s"],
+        experiment={
+            "run_id": args.run_id,
+            "phase": args.phase,
+            "server_image_ref": artifact["image"],
+            "server_source_revision": artifact["source_revision"],
+            "harness_revision": harness_revision,
+            "server_pod": args.server_pod,
+            "server_node": args.server_node,
+            "mps_enabled": "1" if phase["mps"] else "0",
+            "decoder": fixed["decoder"],
+            "slots": fixed["shm_slots"],
+            "input_mb_per_slot": fixed["shm_input_mb_per_slot"],
+            "batch_max_size": fixed["batch_max_size"],
+            "batch_max_wait_ms": fixed["batch_max_wait_ms"],
+            "fixture_sha256": fixed["fixture_sha256"],
+        },
+    )
+    args.output.write_text(json.dumps(rendered, indent=2, sort_keys=True) + "\n")
+    load_spec(args.output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/development/mmp_staging_benchmark/render_run_spec.py
+++ b/development/mmp_staging_benchmark/render_run_spec.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import subprocess
 import sys
@@ -17,6 +18,7 @@ from development.mmp_staging_benchmark.run_concurrent_clients import (  # noqa: 
     load_spec,
 )
 from development.mmp_staging_benchmark.validate_staging_plan import (  # noqa: E402
+    canonical_sha256,
     load_and_validate,
 )
 
@@ -83,6 +85,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument("--phase", required=True)
     parser.add_argument("--server-pod", required=True)
     parser.add_argument("--server-node", required=True)
+    parser.add_argument("--cache-state", choices=("cold", "warm"), required=True)
     args = parser.parse_args(argv)
     harness_revision = current_clean_revision(Path(__file__).resolve().parents[2])
     matrix = load_and_validate(args.matrix)
@@ -94,28 +97,33 @@ def main(argv: Sequence[str] | None = None) -> int:
     fixed = matrix["fixed_runtime"]
     artifact = matrix["artifact"]
     template = args.matrix.parent / phase["spec"]
-    rendered = render_point(
+    workload = render_point(
         template,
         args.total_concurrency,
         fixed["duration_s"],
         fixed["warmup_s"],
-        experiment={
-            "run_id": args.run_id,
-            "phase": args.phase,
-            "server_image_ref": artifact["image"],
-            "server_source_revision": artifact["source_revision"],
-            "harness_revision": harness_revision,
-            "server_pod": args.server_pod,
-            "server_node": args.server_node,
-            "mps_enabled": "1" if phase["mps"] else "0",
-            "decoder": fixed["decoder"],
-            "slots": fixed["shm_slots"],
-            "input_mb_per_slot": fixed["shm_input_mb_per_slot"],
-            "batch_max_size": fixed["batch_max_size"],
-            "batch_max_wait_ms": fixed["batch_max_wait_ms"],
-            "fixture_sha256": fixed["fixture_sha256"],
-        },
     )
+    experiment = {
+        "run_id": args.run_id,
+        "phase": args.phase,
+        "server_image_ref": artifact["image"],
+        "server_source_revision": artifact["source_revision"],
+        "harness_revision": harness_revision,
+        "server_pod": args.server_pod,
+        "server_node": args.server_node,
+        "mps_enabled": "1" if phase["mps"] else "0",
+        "decoder": fixed["decoder"],
+        "slots": fixed["shm_slots"],
+        "input_mb_per_slot": fixed["shm_input_mb_per_slot"],
+        "batch_max_size": fixed["batch_max_size"],
+        "batch_max_wait_ms": fixed["batch_max_wait_ms"],
+        "fixture_sha256": fixed["fixture_sha256"],
+        "matrix_sha256": canonical_sha256(matrix),
+        "template_sha256": hashlib.sha256(template.read_bytes()).hexdigest(),
+        "workload_sha256": canonical_sha256(workload),
+        "cache_state": args.cache_state,
+    }
+    rendered = {**workload, "experiment": experiment}
     args.output.write_text(json.dumps(rendered, indent=2, sort_keys=True) + "\n")
     load_spec(args.output)
     return 0

--- a/development/mmp_staging_benchmark/render_staging_deployment.py
+++ b/development/mmp_staging_benchmark/render_staging_deployment.py
@@ -6,24 +6,42 @@ import json
 import re
 from pathlib import Path
 
-
 STAGING_IMAGE = re.compile(
     r"^us-central1-docker\.pkg\.dev/roboflow-staging/video-proc/"
     r"mmp-benchmark@sha256:[0-9a-f]{64}$"
 )
 NAMESPACE = "video-proc-bench-mmp"
 NAME = "mmp-benchmark-server"
+RUN_ID = re.compile(r"^[a-z0-9](?:[-a-z0-9]{0,61}[a-z0-9])?$")
 
 
-def render(image, source_revision, api_key_secret, mps=False):
+def render(
+    image,
+    source_revision,
+    *,
+    run_id,
+    mps=False,
+    decoder="imagecodecs",
+    active_thread_percentage=None,
+    node_name=None,
+):
     if not STAGING_IMAGE.fullmatch(str(image or "")):
         raise ValueError(
             "image must be the staging mmp-benchmark repository at an exact digest"
         )
     if not re.fullmatch(r"[0-9a-f]{40}", str(source_revision or "")):
         raise ValueError("source revision must be an exact 40-character git SHA")
-    if not re.fullmatch(r"[a-z0-9](?:[-a-z0-9]*[a-z0-9])?", api_key_secret):
-        raise ValueError("API key Secret name must be a Kubernetes DNS label")
+    if not RUN_ID.fullmatch(str(run_id or "")):
+        raise ValueError("run ID must be a Kubernetes DNS label of at most 63 chars")
+    if decoder not in {"imagecodecs", "nvjpeg"}:
+        raise ValueError("decoder must be imagecodecs or nvjpeg")
+    if active_thread_percentage is not None:
+        if not mps:
+            raise ValueError("active thread percentage requires MPS")
+        if not 1 <= int(active_thread_percentage) <= 100:
+            raise ValueError("active thread percentage must be in [1, 100]")
+    if node_name is not None and not RUN_ID.fullmatch(str(node_name)):
+        raise ValueError("node name must be a Kubernetes DNS label")
 
     env = [
         {"name": "API_BASE_URL", "value": "https://api.roboflow.one"},
@@ -32,26 +50,42 @@ def render(image, source_revision, api_key_secret, mps=False):
         {"name": "INFERENCE_INPUT_MB", "value": "20"},
         {"name": "INFERENCE_BATCH_MAX_SIZE", "value": "0"},
         {"name": "INFERENCE_BATCH_MAX_WAIT_MS", "value": "5"},
+        {"name": "INFERENCE_DECODER", "value": decoder},
         {"name": "NVIDIA_MPS", "value": "1" if mps else "0"},
         {"name": "CUDA_MPS_PIPE_DIRECTORY", "value": "/var/run/nvidia-mps"},
         {"name": "CUDA_MPS_LOG_DIRECTORY", "value": "/var/log/nvidia-mps"},
         {"name": "MMP_BENCHMARK_IMAGE_REF", "value": image},
+        {"name": "MMP_BENCHMARK_RUN_ID", "value": run_id},
         {
-            "name": "RF_BENCH_TENANT_A_KEY",
-            "valueFrom": {
-                "secretKeyRef": {"name": api_key_secret, "key": "tenant-a"}
-            },
+            "name": "MMP_BENCHMARK_MODE",
+            "value": "mps" if mps else "non-mps",
         },
         {
-            "name": "RF_BENCH_TENANT_B_KEY",
-            "valueFrom": {
-                "secretKeyRef": {"name": api_key_secret, "key": "tenant-b"}
-            },
+            "name": "POD_NAME",
+            "valueFrom": {"fieldRef": {"fieldPath": "metadata.name"}},
+        },
+        {
+            "name": "NODE_NAME",
+            "valueFrom": {"fieldRef": {"fieldPath": "spec.nodeName"}},
         },
     ]
+    if active_thread_percentage is not None:
+        env.append(
+            {
+                "name": "CUDA_MPS_ACTIVE_THREAD_PERCENTAGE",
+                "value": str(active_thread_percentage),
+            }
+        )
     labels = {
         "app": NAME,
         "app.kubernetes.io/managed-by": "video-poc-benchmark",
+    }
+    annotations = {
+        "roboflow.com/environment": "staging-only",
+        "roboflow.com/source-revision": source_revision,
+        "roboflow.com/mps": "enabled" if mps else "disabled",
+        "roboflow.com/run-id": run_id,
+        "roboflow.com/decoder": decoder,
     }
     deployment = {
         "apiVersion": "apps/v1",
@@ -60,20 +94,23 @@ def render(image, source_revision, api_key_secret, mps=False):
             "name": NAME,
             "namespace": NAMESPACE,
             "labels": labels,
-            "annotations": {
-                "roboflow.com/environment": "staging-only",
-                "roboflow.com/source-revision": source_revision,
-                "roboflow.com/mps": "enabled" if mps else "disabled",
-            },
+            "annotations": annotations,
         },
         "spec": {
             "replicas": 1,
             "strategy": {"type": "Recreate"},
             "selector": {"matchLabels": {"app": NAME}},
             "template": {
-                "metadata": {"labels": labels},
+                "metadata": {
+                    "labels": labels,
+                    "annotations": annotations,
+                },
                 "spec": {
-                    "nodeSelector": {"gpu_type": "L40S"},
+                    "automountServiceAccountToken": False,
+                    "nodeSelector": {
+                        "gpu_type": "L40S",
+                        **({"kubernetes.io/hostname": node_name} if node_name else {}),
+                    },
                     "tolerations": [
                         {"key": "gpu", "value": "true", "effect": "NoSchedule"}
                     ],
@@ -109,6 +146,7 @@ def render(image, source_revision, api_key_secret, mps=False):
                             },
                             "securityContext": {
                                 "allowPrivilegeEscalation": False,
+                                "capabilities": {"drop": ["ALL"]},
                             },
                             "volumeMounts": [
                                 {"name": "dshm", "mountPath": "/dev/shm"},
@@ -160,12 +198,23 @@ def main(argv=None):
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--image", required=True)
     parser.add_argument("--source-revision", required=True)
-    parser.add_argument("--api-key-secret", default="mmp-benchmark-api-keys")
+    parser.add_argument("--run-id", required=True)
     parser.add_argument("--mps", action="store_true")
+    parser.add_argument(
+        "--decoder", choices=("imagecodecs", "nvjpeg"), default="imagecodecs"
+    )
+    parser.add_argument("--active-thread-percentage", type=int)
+    parser.add_argument("--node-name")
     parser.add_argument("--output")
     args = parser.parse_args(argv)
     document = render(
-        args.image, args.source_revision, args.api_key_secret, mps=args.mps
+        args.image,
+        args.source_revision,
+        run_id=args.run_id,
+        mps=args.mps,
+        decoder=args.decoder,
+        active_thread_percentage=args.active_thread_percentage,
+        node_name=args.node_name,
     )
     rendered = json.dumps(document, indent=2, sort_keys=True) + "\n"
     if args.output:

--- a/development/mmp_staging_benchmark/render_staging_deployment.py
+++ b/development/mmp_staging_benchmark/render_staging_deployment.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Render a digest-pinned, dedicated staging MMP experiment Deployment."""
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+
+STAGING_IMAGE = re.compile(
+    r"^us-central1-docker\.pkg\.dev/roboflow-staging/video-proc/"
+    r"mmp-benchmark@sha256:[0-9a-f]{64}$"
+)
+NAMESPACE = "video-proc-bench-mmp"
+NAME = "mmp-benchmark-server"
+
+
+def render(image, source_revision, api_key_secret, mps=False):
+    if not STAGING_IMAGE.fullmatch(str(image or "")):
+        raise ValueError(
+            "image must be the staging mmp-benchmark repository at an exact digest"
+        )
+    if not re.fullmatch(r"[0-9a-f]{40}", str(source_revision or "")):
+        raise ValueError("source revision must be an exact 40-character git SHA")
+    if not re.fullmatch(r"[a-z0-9](?:[-a-z0-9]*[a-z0-9])?", api_key_secret):
+        raise ValueError("API key Secret name must be a Kubernetes DNS label")
+
+    env = [
+        {"name": "API_BASE_URL", "value": "https://api.roboflow.one"},
+        {"name": "NUM_WORKERS", "value": "4"},
+        {"name": "INFERENCE_N_SLOTS", "value": "128"},
+        {"name": "INFERENCE_INPUT_MB", "value": "20"},
+        {"name": "INFERENCE_BATCH_MAX_SIZE", "value": "0"},
+        {"name": "INFERENCE_BATCH_MAX_WAIT_MS", "value": "5"},
+        {"name": "NVIDIA_MPS", "value": "1" if mps else "0"},
+        {"name": "CUDA_MPS_PIPE_DIRECTORY", "value": "/var/run/nvidia-mps"},
+        {"name": "CUDA_MPS_LOG_DIRECTORY", "value": "/var/log/nvidia-mps"},
+        {"name": "MMP_BENCHMARK_IMAGE_REF", "value": image},
+        {
+            "name": "RF_BENCH_TENANT_A_KEY",
+            "valueFrom": {
+                "secretKeyRef": {"name": api_key_secret, "key": "tenant-a"}
+            },
+        },
+        {
+            "name": "RF_BENCH_TENANT_B_KEY",
+            "valueFrom": {
+                "secretKeyRef": {"name": api_key_secret, "key": "tenant-b"}
+            },
+        },
+    ]
+    labels = {
+        "app": NAME,
+        "app.kubernetes.io/managed-by": "video-poc-benchmark",
+    }
+    deployment = {
+        "apiVersion": "apps/v1",
+        "kind": "Deployment",
+        "metadata": {
+            "name": NAME,
+            "namespace": NAMESPACE,
+            "labels": labels,
+            "annotations": {
+                "roboflow.com/environment": "staging-only",
+                "roboflow.com/source-revision": source_revision,
+                "roboflow.com/mps": "enabled" if mps else "disabled",
+            },
+        },
+        "spec": {
+            "replicas": 1,
+            "strategy": {"type": "Recreate"},
+            "selector": {"matchLabels": {"app": NAME}},
+            "template": {
+                "metadata": {"labels": labels},
+                "spec": {
+                    "nodeSelector": {"gpu_type": "L40S"},
+                    "tolerations": [
+                        {"key": "gpu", "value": "true", "effect": "NoSchedule"}
+                    ],
+                    "terminationGracePeriodSeconds": 60,
+                    "containers": [
+                        {
+                            "name": "server",
+                            "image": image,
+                            "imagePullPolicy": "IfNotPresent",
+                            "env": env,
+                            "ports": [{"name": "http", "containerPort": 8000}],
+                            "readinessProbe": {
+                                "httpGet": {
+                                    "path": "/v2/server/health",
+                                    "port": "http",
+                                },
+                                "initialDelaySeconds": 20,
+                                "periodSeconds": 10,
+                                "timeoutSeconds": 3,
+                                "failureThreshold": 12,
+                            },
+                            "resources": {
+                                "requests": {
+                                    "nvidia.com/gpu": 1,
+                                    "cpu": "4",
+                                    "memory": "16Gi",
+                                },
+                                "limits": {
+                                    "nvidia.com/gpu": 1,
+                                    "cpu": "8",
+                                    "memory": "32Gi",
+                                },
+                            },
+                            "securityContext": {
+                                "allowPrivilegeEscalation": False,
+                            },
+                            "volumeMounts": [
+                                {"name": "dshm", "mountPath": "/dev/shm"},
+                                {"name": "results", "mountPath": "/results"},
+                                {"name": "model-cache", "mountPath": "/models/cache"},
+                                {
+                                    "name": "mps-pipe",
+                                    "mountPath": "/var/run/nvidia-mps",
+                                },
+                                {"name": "mps-log", "mountPath": "/var/log/nvidia-mps"},
+                            ],
+                        }
+                    ],
+                    "volumes": [
+                        {
+                            "name": "dshm",
+                            "emptyDir": {"medium": "Memory", "sizeLimit": "4Gi"},
+                        },
+                        {"name": "results", "emptyDir": {}},
+                        {"name": "model-cache", "emptyDir": {}},
+                        {"name": "mps-pipe", "emptyDir": {"medium": "Memory"}},
+                        {"name": "mps-log", "emptyDir": {}},
+                    ],
+                },
+            },
+        },
+    }
+    return {
+        "apiVersion": "v1",
+        "kind": "List",
+        "items": [
+            {
+                "apiVersion": "v1",
+                "kind": "Namespace",
+                "metadata": {
+                    "name": NAMESPACE,
+                    "labels": {
+                        "roboflow.com/environment": "staging-only",
+                        "app.kubernetes.io/managed-by": "video-poc-benchmark",
+                    },
+                },
+            },
+            deployment,
+        ],
+    }
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--image", required=True)
+    parser.add_argument("--source-revision", required=True)
+    parser.add_argument("--api-key-secret", default="mmp-benchmark-api-keys")
+    parser.add_argument("--mps", action="store_true")
+    parser.add_argument("--output")
+    args = parser.parse_args(argv)
+    document = render(
+        args.image, args.source_revision, args.api_key_secret, mps=args.mps
+    )
+    rendered = json.dumps(document, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        Path(args.output).write_text(rendered)
+    else:
+        print(rendered, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/development/mmp_staging_benchmark/run_concurrent_clients.py
+++ b/development/mmp_staging_benchmark/run_concurrent_clients.py
@@ -21,6 +21,26 @@ from pathlib import Path
 from typing import Any, Iterable, Mapping, Sequence
 from urllib.parse import urlencode, urlparse
 
+EXPERIMENT_FIELDS = frozenset(
+    {
+        "run_id",
+        "phase",
+        "server_image_ref",
+        "server_source_revision",
+        "harness_revision",
+        "server_pod",
+        "server_node",
+        "mps_enabled",
+        "mps_active_thread_percentage",
+        "decoder",
+        "slots",
+        "input_mb_per_slot",
+        "batch_max_size",
+        "batch_max_wait_ms",
+        "fixture_sha256",
+    }
+)
+
 
 @dataclass(frozen=True)
 class ClientSpec:
@@ -44,6 +64,7 @@ class RunSpec:
     clients: tuple[ClientSpec, ...]
     request_timeout_s: float = 60.0
     max_latency_samples_per_client: int = 250_000
+    experiment: Mapping[str, Any] = field(default_factory=dict)
 
 
 @dataclass
@@ -202,32 +223,25 @@ def routing_key(client: ClientSpec) -> str:
 def _is_safe_staging_host(host: str | None) -> bool:
     if not host:
         return False
-    normalized = host.lower().rstrip(".")
-    if normalized in {"localhost", "host.docker.internal"}:
-        return True
     try:
-        address = ipaddress.ip_address(normalized)
-        return address.is_private or address.is_loopback or address.is_link_local
+        address = ipaddress.ip_address(host)
+        return address.is_loopback
     except ValueError:
-        pass
-    return (
-        normalized.endswith(".roboflow.one")
-        or normalized.endswith(".svc")
-        or normalized.endswith(".svc.cluster.local")
-        or "staging" in normalized
-    )
+        return False
 
 
 def validate_staging_url(server_url: str) -> str:
     parsed = urlparse(server_url)
-    if parsed.scheme not in {"http", "https"}:
-        raise ValueError("server_url must use http or https")
+    if parsed.scheme != "http":
+        raise ValueError("server_url must use plain HTTP over a local port-forward")
     if parsed.username or parsed.password or parsed.query or parsed.fragment:
         raise ValueError("server_url must not contain credentials, query, or fragment")
+    if parsed.path not in {"", "/"}:
+        raise ValueError("server_url must not contain a path")
     if not _is_safe_staging_host(parsed.hostname):
         raise ValueError(
-            f"refusing non-staging benchmark target {parsed.hostname!r}; "
-            "use localhost/private IP, Kubernetes service DNS, or a staging host"
+            f"refusing non-loopback benchmark target {parsed.hostname!r}; "
+            "use an explicit numeric loopback port-forward"
         )
     return server_url.rstrip("/")
 
@@ -245,6 +259,7 @@ def load_spec(path: Path) -> RunSpec:
         max_latency_samples_per_client=int(
             raw.get("max_latency_samples_per_client", 250_000)
         ),
+        experiment=raw.get("experiment", {}),
     )
     validate_spec(spec)
     return spec
@@ -259,6 +274,12 @@ def validate_spec(spec: RunSpec) -> None:
         )
     if spec.request_timeout_s <= 0 or spec.max_latency_samples_per_client <= 0:
         raise ValueError("request timeout and sample cap must be positive")
+    unknown_experiment_fields = set(spec.experiment) - EXPERIMENT_FIELDS
+    if unknown_experiment_fields:
+        raise ValueError(
+            "unknown experiment metadata fields: "
+            + ", ".join(sorted(unknown_experiment_fields))
+        )
     seen: set[str] = set()
     for client in spec.clients:
         name = client_name(client)
@@ -286,10 +307,41 @@ def _client_url(server_url: str, client: ClientSpec) -> str:
     return f"{server_url}/infer?{urlencode(query, doseq=True)}"
 
 
-def _safe_error(status: int | None, body: str | None, exc: Exception | None) -> str:
+def _redact_text(value: str, secrets: Sequence[str]) -> str:
+    redacted = value
+    for secret in secrets:
+        if secret:
+            redacted = redacted.replace(secret, "[REDACTED]")
+    return redacted
+
+
+def _redact_value(value: Any, secrets: Sequence[str]) -> Any:
+    """Remove key material from every string in a report before serialization."""
+    if isinstance(value, str):
+        return _redact_text(value, secrets)
+    if isinstance(value, list):
+        return [_redact_value(item, secrets) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_redact_value(item, secrets) for item in value)
+    if isinstance(value, dict):
+        return {
+            _redact_value(key, secrets): _redact_value(item, secrets)
+            for key, item in value.items()
+        }
+    return value
+
+
+def _safe_error(
+    status: int | None,
+    body: str | None,
+    exc: Exception | None,
+    *,
+    secrets: Sequence[str] = (),
+) -> str:
     if exc is not None:
-        return f"{type(exc).__name__}: {str(exc)[:160]}"
-    compact = " ".join((body or "").split())[:160]
+        detail = _redact_text(str(exc), secrets)[:160]
+        return f"{type(exc).__name__}: {detail}"
+    compact = _redact_text(" ".join((body or "").split()), secrets)[:160]
     return f"HTTP {status}: {compact}" if compact else f"HTTP {status}"
 
 
@@ -330,7 +382,9 @@ async def _run_worker(
         body: str | None = None
         caught: Exception | None = None
         try:
-            async with session.post(url, data=image, headers=headers) as response:
+            async with session.post(
+                url, data=image, headers=headers, allow_redirects=False
+            ) as response:
                 status = response.status
                 payload = await response.read()
                 if not 200 <= status < 300:
@@ -339,7 +393,7 @@ async def _run_worker(
             caught = exc
         finished = time.monotonic()
         if caught is not None or status is None or not 200 <= status < 300:
-            error = _safe_error(status, body, caught)
+            error = _safe_error(status, body, caught, secrets=(key,))
         recorder.record(
             offset_s=request_started - started,
             measured_offset_s=request_started - measure_started,
@@ -369,7 +423,9 @@ async def _metrics_sampler(
     while time.monotonic() < stop_at:
         sample_started = time.monotonic()
         try:
-            async with session.get(url, headers=headers) as response:
+            async with session.get(
+                url, headers=headers, allow_redirects=False
+            ) as response:
                 payload: Any
                 if response.status == 200:
                     payload = await response.json()
@@ -582,23 +638,75 @@ async def execute(spec: RunSpec, image: bytes) -> dict[str, Any]:
         )
         for report in client_reports
     ]
-    return {
+    report = {
         "schema_version": 1,
+        "experiment": {
+            "run_id": spec.experiment.get(
+                "run_id", os.environ.get("MMP_BENCHMARK_RUN_ID", "unknown")
+            ),
+            "mode": spec.experiment.get(
+                "phase", os.environ.get("MMP_BENCHMARK_MODE", "unknown")
+            ),
+            "harness_revision": spec.experiment.get(
+                "harness_revision",
+                os.environ.get("MMP_BENCHMARK_HARNESS_REVISION", "unknown"),
+            ),
+            "mps_enabled": spec.experiment.get(
+                "mps_enabled", os.environ.get("NVIDIA_MPS", "unknown")
+            ),
+            "mps_active_thread_percentage": spec.experiment.get(
+                "mps_active_thread_percentage",
+                os.environ.get("CUDA_MPS_ACTIVE_THREAD_PERCENTAGE"),
+            ),
+            "decoder": spec.experiment.get(
+                "decoder", os.environ.get("INFERENCE_DECODER", "unknown")
+            ),
+            "slots": spec.experiment.get(
+                "slots", os.environ.get("INFERENCE_N_SLOTS", "unknown")
+            ),
+            "input_mb_per_slot": spec.experiment.get(
+                "input_mb_per_slot", os.environ.get("INFERENCE_INPUT_MB", "unknown")
+            ),
+            "batch_max_size": spec.experiment.get(
+                "batch_max_size",
+                os.environ.get("INFERENCE_BATCH_MAX_SIZE", "unknown"),
+            ),
+            "batch_max_wait_ms": spec.experiment.get(
+                "batch_max_wait_ms",
+                os.environ.get("INFERENCE_BATCH_MAX_WAIT_MS", "unknown"),
+            ),
+            "server_image_ref": spec.experiment.get("server_image_ref", "unknown"),
+            "server_source_revision": spec.experiment.get(
+                "server_source_revision", "unknown"
+            ),
+            "server_pod": spec.experiment.get("server_pod", "unknown"),
+            "server_node": spec.experiment.get("server_node", "unknown"),
+            "fixture_sha256": spec.experiment.get("fixture_sha256", "unknown"),
+        },
         "run": {
             "server_url": spec.server_url,
             "duration_s": spec.duration_s,
             "warmup_s": spec.warmup_s,
+            "sample_interval_s": spec.sample_interval_s,
             "actual_elapsed_s": finished - started,
             "started_unix_s": time.time() - (finished - started),
             "finished_unix_s": time.time(),
             "image_bytes": len(image),
             "image_sha256": hashlib.sha256(image).hexdigest(),
-            "source_revision": os.environ.get(
-                "MMP_BENCHMARK_SOURCE_REVISION", "unknown"
+            "source_revision": spec.experiment.get(
+                "server_source_revision",
+                os.environ.get("MMP_BENCHMARK_SOURCE_REVISION", "unknown"),
             ),
-            "image_ref": os.environ.get("MMP_BENCHMARK_IMAGE_REF", "unknown"),
-            "node_name": os.environ.get("NODE_NAME", "unknown"),
-            "pod_name": os.environ.get("POD_NAME", "unknown"),
+            "image_ref": spec.experiment.get(
+                "server_image_ref",
+                os.environ.get("MMP_BENCHMARK_IMAGE_REF", "unknown"),
+            ),
+            "node_name": spec.experiment.get(
+                "server_node", os.environ.get("NODE_NAME", "unknown")
+            ),
+            "pod_name": spec.experiment.get(
+                "server_pod", os.environ.get("POD_NAME", "unknown")
+            ),
             "python": platform.python_version(),
             "clients": [asdict(client) for client in spec.clients],
         },
@@ -615,6 +723,7 @@ async def execute(spec: RunSpec, image: bytes) -> dict[str, Any]:
         "metrics_evidence": _metrics_evidence(metrics_samples),
         "metrics_samples": metrics_samples,
     }
+    return _redact_value(report, tuple(keys.values()))
 
 
 def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
@@ -642,6 +751,15 @@ def main(argv: Sequence[str] | None = None) -> int:
         image = args.image.read_bytes()
         if not image:
             raise ValueError("image file is empty")
+        image_sha256 = hashlib.sha256(image).hexdigest()
+        expected_fixture_sha256 = spec.experiment.get("fixture_sha256")
+        if (
+            expected_fixture_sha256 is not None
+            and image_sha256 != expected_fixture_sha256
+        ):
+            raise ValueError(
+                "fixture SHA256 does not match the selected benchmark matrix"
+            )
         if args.validate_only:
             print(
                 json.dumps(
@@ -650,6 +768,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                         "clients": len(spec.clients),
                         "total_concurrency": sum(c.concurrency for c in spec.clients),
                         "image_bytes": len(image),
+                        "image_sha256": image_sha256,
                     },
                     indent=2,
                 )

--- a/development/mmp_staging_benchmark/run_concurrent_clients.py
+++ b/development/mmp_staging_benchmark/run_concurrent_clients.py
@@ -38,6 +38,10 @@ EXPERIMENT_FIELDS = frozenset(
         "batch_max_size",
         "batch_max_wait_ms",
         "fixture_sha256",
+        "matrix_sha256",
+        "template_sha256",
+        "workload_sha256",
+        "cache_state",
     }
 )
 
@@ -682,12 +686,18 @@ async def execute(spec: RunSpec, image: bytes) -> dict[str, Any]:
             "server_pod": spec.experiment.get("server_pod", "unknown"),
             "server_node": spec.experiment.get("server_node", "unknown"),
             "fixture_sha256": spec.experiment.get("fixture_sha256", "unknown"),
+            "matrix_sha256": spec.experiment.get("matrix_sha256", "unknown"),
+            "template_sha256": spec.experiment.get("template_sha256", "unknown"),
+            "workload_sha256": spec.experiment.get("workload_sha256", "unknown"),
+            "cache_state": spec.experiment.get("cache_state", "unknown"),
         },
         "run": {
             "server_url": spec.server_url,
             "duration_s": spec.duration_s,
             "warmup_s": spec.warmup_s,
             "sample_interval_s": spec.sample_interval_s,
+            "request_timeout_s": spec.request_timeout_s,
+            "max_latency_samples_per_client": spec.max_latency_samples_per_client,
             "actual_elapsed_s": finished - started,
             "started_unix_s": time.time() - (finished - started),
             "finished_unix_s": time.time(),

--- a/development/mmp_staging_benchmark/run_concurrent_clients.py
+++ b/development/mmp_staging_benchmark/run_concurrent_clients.py
@@ -1,0 +1,671 @@
+#!/usr/bin/env python3
+"""Run tenant-aware concurrent HTTP clients against a staging MMP server."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import ipaddress
+import json
+import math
+import os
+import platform
+import random
+import statistics
+import sys
+import time
+from collections import Counter, defaultdict
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+from urllib.parse import urlencode, urlparse
+
+
+@dataclass(frozen=True)
+class ClientSpec:
+    tenant_id: str
+    api_key_env: str
+    model_id: str
+    client_id: str = ""
+    concurrency: int = 1
+    target_fps: float = 0.0
+    instance: str = ""
+    device: str = ""
+    params: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class RunSpec:
+    server_url: str
+    duration_s: float
+    warmup_s: float
+    sample_interval_s: float
+    clients: tuple[ClientSpec, ...]
+    request_timeout_s: float = 60.0
+    max_latency_samples_per_client: int = 250_000
+
+
+@dataclass
+class TimeBucket:
+    requests: int = 0
+    successes: int = 0
+    errors: int = 0
+    latency_sum_ms: float = 0.0
+    latency_max_ms: float = 0.0
+
+    def record(self, latency_ms: float, success: bool) -> None:
+        self.requests += 1
+        self.successes += int(success)
+        self.errors += int(not success)
+        self.latency_sum_ms += latency_ms
+        self.latency_max_ms = max(self.latency_max_ms, latency_ms)
+
+    def report(self, second: int) -> dict[str, Any]:
+        return {
+            "second": second,
+            "requests": self.requests,
+            "successes": self.successes,
+            "errors": self.errors,
+            "avg_latency_ms": (
+                self.latency_sum_ms / self.requests if self.requests else None
+            ),
+            "max_latency_ms": self.latency_max_ms if self.requests else None,
+        }
+
+
+class ClientRecorder:
+    def __init__(self, spec: ClientSpec, max_samples: int, seed: int) -> None:
+        self.spec = spec
+        self.max_samples = max_samples
+        self.random = random.Random(seed)
+        self.requests = 0
+        self.successes = 0
+        self.errors = 0
+        self.status_counts: Counter[str] = Counter()
+        self.error_counts: Counter[str] = Counter()
+        self.latencies_ms: list[float] = []
+        self.sampled_requests = 0
+        self.buckets: defaultdict[int, TimeBucket] = defaultdict(TimeBucket)
+        self.first_request_offset_s: float | None = None
+        self.first_success_offset_s: float | None = None
+        self.first_success_latency_ms: float | None = None
+
+    def record(
+        self,
+        *,
+        offset_s: float,
+        measured_offset_s: float,
+        latency_ms: float,
+        status: int | None,
+        error: str | None,
+        measured: bool,
+    ) -> None:
+        if self.first_request_offset_s is None:
+            self.first_request_offset_s = offset_s
+        success = status is not None and 200 <= status < 300 and error is None
+        if success and self.first_success_offset_s is None:
+            self.first_success_offset_s = offset_s + latency_ms / 1000.0
+            self.first_success_latency_ms = latency_ms
+        if not measured:
+            return
+
+        self.requests += 1
+        self.successes += int(success)
+        self.errors += int(not success)
+        self.status_counts[str(status) if status is not None else "transport"] += 1
+        if error:
+            self.error_counts[error] += 1
+        self.buckets[max(0, int(measured_offset_s))].record(latency_ms, success)
+        self.sampled_requests += 1
+        if len(self.latencies_ms) < self.max_samples:
+            self.latencies_ms.append(latency_ms)
+        else:
+            candidate = self.random.randrange(self.sampled_requests)
+            if candidate < self.max_samples:
+                self.latencies_ms[candidate] = latency_ms
+
+    def report(self, measured_duration_s: float) -> dict[str, Any]:
+        latencies = sorted(self.latencies_ms)
+        return {
+            "client_id": client_name(self.spec),
+            "tenant_id": self.spec.tenant_id,
+            "model_id": self.spec.model_id,
+            "routing_key": routing_key(self.spec),
+            "instance": self.spec.instance,
+            "device": self.spec.device,
+            "concurrency": self.spec.concurrency,
+            "target_fps": self.spec.target_fps,
+            "api_key_env": self.spec.api_key_env,
+            "requests": self.requests,
+            "successes": self.successes,
+            "errors": self.errors,
+            "success_rate": self.successes / self.requests if self.requests else 0.0,
+            "delivered_fps": self.successes / max(measured_duration_s, 1e-9),
+            "status_counts": dict(sorted(self.status_counts.items())),
+            "error_counts": dict(self.error_counts.most_common()),
+            "latency_sample_count": len(latencies),
+            "latency_population_count": self.sampled_requests,
+            "latency_ms": latency_summary(latencies),
+            "first_request_offset_s": self.first_request_offset_s,
+            "first_success_offset_s": self.first_success_offset_s,
+            "first_success_latency_ms": self.first_success_latency_ms,
+            "time_buckets": [
+                self.buckets[second].report(second) for second in sorted(self.buckets)
+            ],
+        }
+
+
+def percentile(sorted_values: Sequence[float], quantile: float) -> float | None:
+    if not sorted_values:
+        return None
+    if len(sorted_values) == 1:
+        return sorted_values[0]
+    position = (len(sorted_values) - 1) * quantile
+    lower = math.floor(position)
+    upper = math.ceil(position)
+    if lower == upper:
+        return sorted_values[lower]
+    fraction = position - lower
+    return sorted_values[lower] * (1 - fraction) + sorted_values[upper] * fraction
+
+
+def latency_summary(sorted_values: Sequence[float]) -> dict[str, float | None]:
+    if not sorted_values:
+        return {"p50": None, "p95": None, "p99": None, "max": None, "mean": None}
+    return {
+        "p50": percentile(sorted_values, 0.50),
+        "p95": percentile(sorted_values, 0.95),
+        "p99": percentile(sorted_values, 0.99),
+        "max": sorted_values[-1],
+        "mean": statistics.fmean(sorted_values),
+    }
+
+
+def jain_fairness(values: Iterable[float]) -> float | None:
+    usable = [max(0.0, value) for value in values]
+    if not usable or not any(usable):
+        return None
+    return sum(usable) ** 2 / (len(usable) * sum(v * v for v in usable))
+
+
+def client_name(client: ClientSpec) -> str:
+    return client.client_id or client.tenant_id
+
+
+def routing_key(client: ClientSpec) -> str:
+    return (
+        f"{client.model_id}:{client.instance}" if client.instance else client.model_id
+    )
+
+
+def _is_safe_staging_host(host: str | None) -> bool:
+    if not host:
+        return False
+    normalized = host.lower().rstrip(".")
+    if normalized in {"localhost", "host.docker.internal"}:
+        return True
+    try:
+        address = ipaddress.ip_address(normalized)
+        return address.is_private or address.is_loopback or address.is_link_local
+    except ValueError:
+        pass
+    return (
+        normalized.endswith(".roboflow.one")
+        or normalized.endswith(".svc")
+        or normalized.endswith(".svc.cluster.local")
+        or "staging" in normalized
+    )
+
+
+def validate_staging_url(server_url: str) -> str:
+    parsed = urlparse(server_url)
+    if parsed.scheme not in {"http", "https"}:
+        raise ValueError("server_url must use http or https")
+    if parsed.username or parsed.password or parsed.query or parsed.fragment:
+        raise ValueError("server_url must not contain credentials, query, or fragment")
+    if not _is_safe_staging_host(parsed.hostname):
+        raise ValueError(
+            f"refusing non-staging benchmark target {parsed.hostname!r}; "
+            "use localhost/private IP, Kubernetes service DNS, or a staging host"
+        )
+    return server_url.rstrip("/")
+
+
+def load_spec(path: Path) -> RunSpec:
+    raw = json.loads(path.read_text())
+    clients = tuple(ClientSpec(**client) for client in raw.get("clients", []))
+    spec = RunSpec(
+        server_url=validate_staging_url(raw["server_url"]),
+        duration_s=float(raw.get("duration_s", 120)),
+        warmup_s=float(raw.get("warmup_s", 15)),
+        sample_interval_s=float(raw.get("sample_interval_s", 1)),
+        clients=clients,
+        request_timeout_s=float(raw.get("request_timeout_s", 60)),
+        max_latency_samples_per_client=int(
+            raw.get("max_latency_samples_per_client", 250_000)
+        ),
+    )
+    validate_spec(spec)
+    return spec
+
+
+def validate_spec(spec: RunSpec) -> None:
+    if not spec.clients:
+        raise ValueError("at least one client is required")
+    if spec.duration_s <= 0 or spec.warmup_s < 0 or spec.sample_interval_s <= 0:
+        raise ValueError(
+            "duration/sample interval must be positive and warmup nonnegative"
+        )
+    if spec.request_timeout_s <= 0 or spec.max_latency_samples_per_client <= 0:
+        raise ValueError("request timeout and sample cap must be positive")
+    seen: set[str] = set()
+    for client in spec.clients:
+        name = client_name(client)
+        if not client.tenant_id or not name or name in seen:
+            raise ValueError(
+                "tenant_id must be non-empty and client_id (or tenant_id) must be unique"
+            )
+        seen.add(name)
+        if not client.api_key_env or not client.model_id:
+            raise ValueError(f"{client.tenant_id}: api_key_env and model_id required")
+        if client.concurrency <= 0 or client.target_fps < 0:
+            raise ValueError(f"{client.tenant_id}: invalid concurrency/target_fps")
+
+
+def _client_url(server_url: str, client: ClientSpec) -> str:
+    query: dict[str, Any] = {
+        "model_id": client.model_id,
+        "format": "json",
+    }
+    if client.instance:
+        query["instance"] = client.instance
+    if client.device:
+        query["device"] = client.device
+    query.update(client.params)
+    return f"{server_url}/infer?{urlencode(query, doseq=True)}"
+
+
+def _safe_error(status: int | None, body: str | None, exc: Exception | None) -> str:
+    if exc is not None:
+        return f"{type(exc).__name__}: {str(exc)[:160]}"
+    compact = " ".join((body or "").split())[:160]
+    return f"HTTP {status}: {compact}" if compact else f"HTTP {status}"
+
+
+async def _run_worker(
+    *,
+    session: Any,
+    server_url: str,
+    client: ClientSpec,
+    key: str,
+    image: bytes,
+    recorder: ClientRecorder,
+    started: float,
+    measure_started: float,
+    stop_at: float,
+    worker_index: int,
+) -> None:
+    url = _client_url(server_url, client)
+    headers = {"Authorization": f"Bearer {key}", "Content-Type": "image/jpeg"}
+    interval_s = (
+        client.concurrency / client.target_fps if client.target_fps > 0 else 0.0
+    )
+    next_start = started
+    if interval_s:
+        next_start += worker_index * interval_s / client.concurrency
+
+    while True:
+        now = time.monotonic()
+        if now >= stop_at:
+            return
+        if interval_s and now < next_start:
+            await asyncio.sleep(min(next_start - now, max(0.0, stop_at - now)))
+            now = time.monotonic()
+            if now >= stop_at:
+                return
+        request_started = time.monotonic()
+        status: int | None = None
+        error: str | None = None
+        body: str | None = None
+        caught: Exception | None = None
+        try:
+            async with session.post(url, data=image, headers=headers) as response:
+                status = response.status
+                payload = await response.read()
+                if not 200 <= status < 300:
+                    body = payload.decode("utf-8", errors="replace")
+        except Exception as exc:  # preserve all transport errors in evidence
+            caught = exc
+        finished = time.monotonic()
+        if caught is not None or status is None or not 200 <= status < 300:
+            error = _safe_error(status, body, caught)
+        recorder.record(
+            offset_s=request_started - started,
+            measured_offset_s=request_started - measure_started,
+            latency_ms=(finished - request_started) * 1000,
+            status=status,
+            error=error,
+            measured=request_started >= measure_started,
+        )
+        if interval_s:
+            next_start += interval_s
+            if next_start < finished - interval_s:
+                next_start = finished
+
+
+async def _metrics_sampler(
+    *,
+    session: Any,
+    server_url: str,
+    key: str,
+    started: float,
+    stop_at: float,
+    interval_s: float,
+) -> list[dict[str, Any]]:
+    samples: list[dict[str, Any]] = []
+    url = f"{server_url}/v2/server/metrics"
+    headers = {"Authorization": f"Bearer {key}"}
+    while time.monotonic() < stop_at:
+        sample_started = time.monotonic()
+        try:
+            async with session.get(url, headers=headers) as response:
+                payload: Any
+                if response.status == 200:
+                    payload = await response.json()
+                else:
+                    payload = {"error": f"HTTP {response.status}"}
+                samples.append(
+                    {
+                        "offset_s": sample_started - started,
+                        "status": response.status,
+                        "metrics": payload,
+                    }
+                )
+        except Exception as exc:
+            samples.append(
+                {
+                    "offset_s": sample_started - started,
+                    "status": None,
+                    "metrics": {"error": f"{type(exc).__name__}: {str(exc)[:160]}"},
+                }
+            )
+        await asyncio.sleep(max(0.0, interval_s - (time.monotonic() - sample_started)))
+    return samples
+
+
+def _model_load_evidence(client_reports: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    models: dict[str, dict[str, Any]] = {}
+    for report in client_reports:
+        model_id = str(report["routing_key"])
+        entry = models.setdefault(
+            model_id,
+            {"first_success_offset_s": None, "first_success_latency_ms": None},
+        )
+        offset = report.get("first_success_offset_s")
+        if offset is not None and (
+            entry["first_success_offset_s"] is None
+            or offset < entry["first_success_offset_s"]
+        ):
+            entry["first_success_offset_s"] = offset
+            entry["first_success_latency_ms"] = report.get("first_success_latency_ms")
+    return models
+
+
+def _metrics_evidence(samples: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    valid = [sample for sample in samples if sample.get("status") == 200]
+    if not valid:
+        return {"sample_count": 0}
+    gpu_utils: list[float] = []
+    gpu_memory: list[float] = []
+    gpu_power: list[float] = []
+    free_slots: list[int] = []
+    pending: list[int] = []
+    rejects: list[int] = []
+    per_model_peak_vram: dict[str, float] = {}
+    for sample in valid:
+        metrics = sample["metrics"]
+        for gpu in metrics.get("gpus", []):
+            if gpu.get("utilization_pct") is not None:
+                gpu_utils.append(float(gpu["utilization_pct"]))
+            if gpu.get("memory_used_mb") is not None:
+                gpu_memory.append(float(gpu["memory_used_mb"]))
+            if gpu.get("power_w") is not None:
+                gpu_power.append(float(gpu["power_w"]))
+        for model_id, value in metrics.get("per_model_gpu_mb", {}).items():
+            per_model_peak_vram[model_id] = max(
+                per_model_peak_vram.get(model_id, 0.0), float(value)
+            )
+        if metrics.get("mmp_free_slots") is not None:
+            free_slots.append(int(metrics["mmp_free_slots"]))
+        if metrics.get("mmp_pending") is not None:
+            pending.append(int(metrics["mmp_pending"]))
+        if metrics.get("mmp_rejects_pool_full") is not None:
+            rejects.append(int(metrics["mmp_rejects_pool_full"]))
+
+    first_metrics = valid[0]["metrics"]
+    last_metrics = valid[-1]["metrics"]
+    model_deltas: dict[str, dict[str, Any]] = {}
+    first_models = first_metrics.get("mmp_models", {})
+    last_models = last_metrics.get("mmp_models", {})
+    for model_id in sorted(set(first_models) | set(last_models)):
+        before = first_models.get(model_id, {})
+        after = last_models.get(model_id, {})
+        model_deltas[model_id] = {
+            "worker_pid": after.get("worker_pid"),
+            "backend_type": after.get("backend_type"),
+            "device": after.get("device"),
+            "max_batch_size": after.get("max_batch_size"),
+            "inference_count_delta": int(after.get("inference_count", 0))
+            - int(before.get("inference_count", 0)),
+            "batch_count_delta": int(after.get("batch_count", 0))
+            - int(before.get("batch_count", 0)),
+            "avg_batch_size_final": after.get("avg_batch_size"),
+            "throughput_fps_final": after.get("throughput_fps"),
+            "latency_p50_ms_final": after.get("latency_p50_ms"),
+            "latency_p95_ms_final": after.get("latency_p95_ms"),
+            "latency_p99_ms_final": after.get("latency_p99_ms"),
+            "avg_decode_ms_final": after.get("avg_decode_ms"),
+            "avg_infer_ms_final": after.get("avg_infer_ms"),
+            "avg_write_ms_final": after.get("avg_write_ms"),
+            "error_count_delta": int(after.get("error_count", 0))
+            - int(before.get("error_count", 0)),
+        }
+
+    return {
+        "sample_count": len(valid),
+        "first_offset_s": valid[0]["offset_s"],
+        "last_offset_s": valid[-1]["offset_s"],
+        "gpu_utilization_pct": _numeric_summary(gpu_utils),
+        "gpu_memory_used_mb": _numeric_summary(gpu_memory),
+        "gpu_power_w": _numeric_summary(gpu_power),
+        "mmp_free_slots": _numeric_summary(free_slots),
+        "mmp_pending": _numeric_summary(pending),
+        "mmp_pool_full_rejects_delta": (
+            rejects[-1] - rejects[0] if len(rejects) >= 2 else 0
+        ),
+        "per_model_peak_vram_mb": per_model_peak_vram,
+        "model_deltas": model_deltas,
+        "initial": first_metrics,
+        "final": last_metrics,
+    }
+
+
+def _numeric_summary(values: Sequence[float | int]) -> dict[str, float | None]:
+    if not values:
+        return {"min": None, "max": None, "mean": None}
+    return {
+        "min": min(values),
+        "max": max(values),
+        "mean": statistics.fmean(values),
+    }
+
+
+def _client_seed(client: ClientSpec) -> int:
+    digest = hashlib.sha256(
+        f"{client_name(client)}\0{client.tenant_id}\0{client.model_id}\0{client.instance}".encode()
+    ).digest()
+    return int.from_bytes(digest[:8], "big")
+
+
+async def execute(spec: RunSpec, image: bytes) -> dict[str, Any]:
+    try:
+        import aiohttp
+    except ImportError as exc:
+        raise RuntimeError("aiohttp is required to run the benchmark") from exc
+
+    keys: dict[str, str] = {}
+    for client in spec.clients:
+        key = os.environ.get(client.api_key_env, "")
+        if not key:
+            raise ValueError(
+                f"{client.tenant_id}: environment variable {client.api_key_env} is empty"
+            )
+        keys[client_name(client)] = key
+
+    timeout = aiohttp.ClientTimeout(total=spec.request_timeout_s)
+    connector = aiohttp.TCPConnector(limit=0, enable_cleanup_closed=True)
+    started = time.monotonic()
+    measure_started = started + spec.warmup_s
+    stop_at = measure_started + spec.duration_s
+    recorders = {
+        client_name(client): ClientRecorder(
+            client, spec.max_latency_samples_per_client, _client_seed(client)
+        )
+        for client in spec.clients
+    }
+
+    async with aiohttp.ClientSession(timeout=timeout, connector=connector) as session:
+        first_key = keys[client_name(spec.clients[0])]
+        sampler = asyncio.create_task(
+            _metrics_sampler(
+                session=session,
+                server_url=spec.server_url,
+                key=first_key,
+                started=started,
+                stop_at=stop_at,
+                interval_s=spec.sample_interval_s,
+            )
+        )
+        workers = [
+            asyncio.create_task(
+                _run_worker(
+                    session=session,
+                    server_url=spec.server_url,
+                    client=client,
+                    key=keys[client_name(client)],
+                    image=image,
+                    recorder=recorders[client_name(client)],
+                    started=started,
+                    measure_started=measure_started,
+                    stop_at=stop_at,
+                    worker_index=worker_index,
+                )
+            )
+            for client in spec.clients
+            for worker_index in range(client.concurrency)
+        ]
+        await asyncio.gather(*workers)
+        metrics_samples = await sampler
+    finished = time.monotonic()
+
+    client_reports = [
+        recorders[client_name(client)].report(spec.duration_s)
+        for client in spec.clients
+    ]
+    delivered = [float(report["delivered_fps"]) for report in client_reports]
+    normalized = [
+        (
+            float(report["delivered_fps"]) / float(report["target_fps"])
+            if float(report["target_fps"]) > 0
+            else float(report["delivered_fps"])
+        )
+        for report in client_reports
+    ]
+    return {
+        "schema_version": 1,
+        "run": {
+            "server_url": spec.server_url,
+            "duration_s": spec.duration_s,
+            "warmup_s": spec.warmup_s,
+            "actual_elapsed_s": finished - started,
+            "started_unix_s": time.time() - (finished - started),
+            "finished_unix_s": time.time(),
+            "image_bytes": len(image),
+            "image_sha256": hashlib.sha256(image).hexdigest(),
+            "source_revision": os.environ.get(
+                "MMP_BENCHMARK_SOURCE_REVISION", "unknown"
+            ),
+            "image_ref": os.environ.get("MMP_BENCHMARK_IMAGE_REF", "unknown"),
+            "node_name": os.environ.get("NODE_NAME", "unknown"),
+            "pod_name": os.environ.get("POD_NAME", "unknown"),
+            "python": platform.python_version(),
+            "clients": [asdict(client) for client in spec.clients],
+        },
+        "aggregate": {
+            "requests": sum(int(r["requests"]) for r in client_reports),
+            "successes": sum(int(r["successes"]) for r in client_reports),
+            "errors": sum(int(r["errors"]) for r in client_reports),
+            "delivered_fps": sum(delivered),
+            "jain_fairness_delivered_fps": jain_fairness(delivered),
+            "jain_fairness_normalized_to_target": jain_fairness(normalized),
+        },
+        "clients": client_reports,
+        "model_load_evidence": _model_load_evidence(client_reports),
+        "metrics_evidence": _metrics_evidence(metrics_samples),
+        "metrics_samples": metrics_samples,
+    }
+
+
+def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--spec", required=True, type=Path)
+    parser.add_argument("--image", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument(
+        "--validate-only",
+        action="store_true",
+        help="validate spec/image without sending requests or requiring API keys",
+    )
+    parser.add_argument(
+        "--fail-on-errors",
+        action="store_true",
+        help="return exit 2 when the completed run records any request errors",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(argv)
+    try:
+        spec = load_spec(args.spec)
+        image = args.image.read_bytes()
+        if not image:
+            raise ValueError("image file is empty")
+        if args.validate_only:
+            print(
+                json.dumps(
+                    {
+                        "valid": True,
+                        "clients": len(spec.clients),
+                        "total_concurrency": sum(c.concurrency for c in spec.clients),
+                        "image_bytes": len(image),
+                    },
+                    indent=2,
+                )
+            )
+            return 0
+        report = asyncio.run(execute(spec, image))
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
+        print(json.dumps(report["aggregate"], indent=2, sort_keys=True))
+        if args.fail_on_errors and report["aggregate"]["errors"]:
+            return 2
+        return 0
+    except (OSError, ValueError, RuntimeError, json.JSONDecodeError) as exc:
+        print(f"benchmark failed: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/development/mmp_staging_benchmark/spec.mixed-model.example.json
+++ b/development/mmp_staging_benchmark/spec.mixed-model.example.json
@@ -1,0 +1,22 @@
+{
+  "server_url": "http://127.0.0.1:8000",
+  "duration_s": 120,
+  "warmup_s": 15,
+  "sample_interval_s": 1,
+  "clients": [
+    {
+      "tenant_id": "workspace-a-detection",
+      "api_key_env": "RF_BENCH_TENANT_A_KEY",
+      "model_id": "yolov8n-640",
+      "concurrency": 4,
+      "target_fps": 0
+    },
+    {
+      "tenant_id": "workspace-b-segmentation",
+      "api_key_env": "RF_BENCH_TENANT_B_KEY",
+      "model_id": "yolov8n-seg-640",
+      "concurrency": 2,
+      "target_fps": 0
+    }
+  ]
+}

--- a/development/mmp_staging_benchmark/spec.same-model-isolated.example.json
+++ b/development/mmp_staging_benchmark/spec.same-model-isolated.example.json
@@ -1,0 +1,24 @@
+{
+  "server_url": "http://127.0.0.1:8000",
+  "duration_s": 120,
+  "warmup_s": 15,
+  "sample_interval_s": 1,
+  "clients": [
+    {
+      "tenant_id": "workspace-a",
+      "api_key_env": "RF_BENCH_TENANT_A_KEY",
+      "model_id": "yolov8n-640",
+      "instance": "workspace-a-process",
+      "concurrency": 4,
+      "target_fps": 0
+    },
+    {
+      "tenant_id": "workspace-b",
+      "api_key_env": "RF_BENCH_TENANT_B_KEY",
+      "model_id": "yolov8n-640",
+      "instance": "workspace-b-process",
+      "concurrency": 4,
+      "target_fps": 0
+    }
+  ]
+}

--- a/development/mmp_staging_benchmark/spec.same-model.example.json
+++ b/development/mmp_staging_benchmark/spec.same-model.example.json
@@ -1,0 +1,22 @@
+{
+  "server_url": "http://127.0.0.1:8000",
+  "duration_s": 120,
+  "warmup_s": 15,
+  "sample_interval_s": 1,
+  "clients": [
+    {
+      "tenant_id": "workspace-a",
+      "api_key_env": "RF_BENCH_TENANT_A_KEY",
+      "model_id": "yolov8n-640",
+      "concurrency": 4,
+      "target_fps": 0
+    },
+    {
+      "tenant_id": "workspace-b",
+      "api_key_env": "RF_BENCH_TENANT_B_KEY",
+      "model_id": "yolov8n-640",
+      "concurrency": 4,
+      "target_fps": 0
+    }
+  ]
+}

--- a/development/mmp_staging_benchmark/validate_staging_plan.py
+++ b/development/mmp_staging_benchmark/validate_staging_plan.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Validate and render the immutable, staging-only MMP/MPS experiment plan."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any, Sequence
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from development.mmp_staging_benchmark.render_staging_deployment import (  # noqa: E402
+    render,
+)
+
+EXPECTED_MODES = {
+    "mmp-shared-no-mps": False,
+    "mmp-isolated-no-mps": False,
+    "mmp-mixed-no-mps": False,
+    "mmp-shared-mps": True,
+    "mmp-isolated-mps": True,
+    "mmp-mixed-mps": True,
+}
+SHA256 = re.compile(r"^[0-9a-f]{64}$")
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def canonical_sha256(value: Any) -> str:
+    encoded = json.dumps(value, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def load_and_validate(path: Path) -> dict[str, Any]:
+    matrix = json.loads(path.read_text())
+    if matrix.get("schema_version") != 1:
+        raise ValueError("matrix schema_version must be 1")
+    artifact = matrix.get("artifact", {})
+    fixed = matrix.get("fixed_runtime", {})
+    phases = matrix.get("phases", [])
+    gates = matrix.get("strict_gates", {})
+    phase_map = {phase.get("id"): phase for phase in phases}
+    if set(phase_map) != set(EXPECTED_MODES) or len(phase_map) != len(phases):
+        raise ValueError("matrix must define each required phase exactly once")
+    if fixed.get("exclusive_gpu") is not True or fixed.get("gpu") != "L40S":
+        raise ValueError("matrix must reserve one exclusive L40S")
+    if fixed.get("shm_size_limit") != "4Gi":
+        raise ValueError("matrix must retain the certified 4Gi /dev/shm")
+    if fixed.get("decoder") not in {"imagecodecs", "nvjpeg"}:
+        raise ValueError("matrix decoder is invalid")
+    fixture_sha256 = fixed.get("fixture_sha256", "")
+    if not SHA256.fullmatch(fixture_sha256):
+        raise ValueError("matrix must pin a lowercase fixture SHA256")
+    fixture_path = fixed.get("fixture_path", "")
+    fixture = REPO_ROOT / fixture_path
+    if not fixture.is_file():
+        raise ValueError("matrix fixture_path must resolve to a checked-in file")
+    if hashlib.sha256(fixture.read_bytes()).hexdigest() != fixture_sha256:
+        raise ValueError("matrix fixture digest does not match fixture_path")
+    if int(fixed.get("repetitions", 0)) < 2:
+        raise ValueError("matrix requires at least two repetitions")
+    for phase_id, expected_mps in EXPECTED_MODES.items():
+        phase = phase_map[phase_id]
+        if phase.get("mps") is not expected_mps:
+            raise ValueError(f"{phase_id}: incorrect MPS mode")
+        points = phase.get("total_concurrency", [])
+        if not points or points != sorted(set(points)) or min(points) <= 0:
+            raise ValueError(f"{phase_id}: concurrency must be positive and ordered")
+    if gates.get("success_rate") != 1.0:
+        raise ValueError("strict capacity must require a 100% success rate")
+    if float(gates.get("latency_p95_ms_max", 0)) <= 0:
+        raise ValueError("strict latency gate must be positive")
+    return matrix
+
+
+def render_plan(matrix: dict[str, Any], run_prefix: str) -> dict[str, Any]:
+    artifact = matrix["artifact"]
+    fixed = matrix["fixed_runtime"]
+    deployments = {}
+    for mps in (False, True):
+        mode = "mps" if mps else "no-mps"
+        run_id = f"{run_prefix}-{mode}"
+        deployments[mode] = render(
+            artifact["image"],
+            artifact["source_revision"],
+            run_id=run_id,
+            mps=mps,
+            decoder=fixed["decoder"],
+        )
+    return {
+        "schema_version": 1,
+        "matrix_sha256": canonical_sha256(matrix),
+        "run_prefix": run_prefix,
+        "artifact": artifact,
+        "deployments": deployments,
+        "phases": matrix["phases"],
+        "strict_gates": matrix["strict_gates"],
+    }
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--matrix", required=True, type=Path)
+    parser.add_argument("--run-prefix", required=True)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args(argv)
+    plan = render_plan(load_and_validate(args.matrix), args.run_prefix)
+    rendered = json.dumps(plan, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.write_text(rendered)
+    else:
+        print(rendered, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/inference_server/inference_server/server.py
+++ b/inference_server/inference_server/server.py
@@ -32,9 +32,10 @@ Environment variables::
     INFERENCE_BATCH_MAX_SIZE    Max images per worker batch (default: 0 = use model's max).
     INFERENCE_BATCH_MAX_WAIT_MS Max ms to wait for a full batch (default: 5.0).
     NVIDIA_MPS              Set to "1" to start NVIDIA MPS before launching.
-                            MPS daemon is guaranteed to be stopped on exit
-                            (even on crash / SIGKILL of this process — via atexit
-                            + signal handlers).
+                            MPS is stopped on normal exit and handled signals.
+                            SIGKILL cannot run Python cleanup; only use this in
+                            an exclusive, disposable GPU pod whose container
+                            teardown removes the full process cgroup.
 
     LOG_LEVEL               uvicorn log level (default: warning)
 """

--- a/tests/development/mmp_staging_benchmark/test_benchmark_tools.py
+++ b/tests/development/mmp_staging_benchmark/test_benchmark_tools.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import os
 import tempfile
@@ -11,7 +12,10 @@ from development.mmp_staging_benchmark.run_concurrent_clients import (
     ClientRecorder,
     ClientSpec,
     _metrics_evidence,
+    _redact_value,
+    _safe_error,
     client_name,
+    execute,
     jain_fairness,
     latency_summary,
     load_spec,
@@ -22,14 +26,26 @@ from development.mmp_staging_benchmark.run_concurrent_clients import (
 DiskUsage = namedtuple("DiskUsage", "total used free")
 
 
+def load_spec_from_dict(raw):
+    with tempfile.TemporaryDirectory() as root:
+        path = Path(root) / "spec.json"
+        path.write_text(json.dumps(raw))
+        return load_spec(path)
+
+
+async def empty_async(**_kwargs):
+    return None
+
+
+async def empty_metrics(**_kwargs):
+    return []
+
+
 class StagingTargetTests(unittest.TestCase):
-    def test_accepts_local_private_kubernetes_and_staging(self) -> None:
+    def test_accepts_only_local_loopback(self) -> None:
         accepted = [
             "http://127.0.0.1:8000",
-            "http://10.1.2.3:8000",
-            "http://mmp.video-proc.svc:8000",
-            "https://mmp-benchmark.roboflow.one",
-            "https://inference-staging.example.net",
+            "http://[::1]:8000",
         ]
         for target in accepted:
             with self.subTest(target=target):
@@ -37,12 +53,25 @@ class StagingTargetTests(unittest.TestCase):
 
     def test_rejects_known_or_arbitrary_public_hosts(self) -> None:
         for target in [
-            "https://api.roboflow.com",
-            "https://video-processors.crusoe.roboflow.com",
-            "https://example.com",
+            "http://api.roboflow.com",
+            "http://video-processors.crusoe.roboflow.com",
+            "http://10.1.2.3:8000",
+            "http://mmp.video-proc.svc:8000",
+            "http://mmp-benchmark.roboflow.one",
+            "http://example.com",
         ]:
             with self.subTest(target=target):
-                with self.assertRaisesRegex(ValueError, "refusing non-staging"):
+                with self.assertRaisesRegex(ValueError, "refusing non-loopback"):
+                    validate_staging_url(target)
+
+    def test_rejects_dns_https_and_paths_even_on_loopback(self) -> None:
+        for target in [
+            "http://localhost:8000",
+            "https://127.0.0.1:8000",
+            "http://127.0.0.1:8000/proxy",
+        ]:
+            with self.subTest(target=target):
+                with self.assertRaises(ValueError):
                     validate_staging_url(target)
 
 
@@ -89,14 +118,49 @@ class SpecTests(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "client_id"):
                 load_spec(path)
 
+    def test_rejects_unknown_experiment_metadata(self) -> None:
+        raw = {
+            "server_url": "http://127.0.0.1:8000",
+            "experiment": {"api_key": "must-not-be-serialized"},
+            "clients": [
+                {"tenant_id": "a", "api_key_env": "A", "model_id": "m"},
+            ],
+        }
+        with tempfile.TemporaryDirectory() as root:
+            path = Path(root) / "spec.json"
+            path.write_text(json.dumps(raw))
+            with self.assertRaisesRegex(ValueError, "experiment metadata"):
+                load_spec(path)
+
     def test_instance_creates_distinct_mmp_routing_key(self) -> None:
         shared = ClientSpec("tenant-a", "KEY", "model")
         isolated = ClientSpec("tenant-a", "KEY", "model", instance="tenant-a")
         self.assertEqual(routing_key(shared), "model")
         self.assertEqual(routing_key(isolated), "model:tenant-a")
 
+    def test_rejects_hostname_that_only_contains_staging(self) -> None:
+        with self.assertRaisesRegex(ValueError, "refusing non-loopback"):
+            validate_staging_url("http://staging-attacker.invalid")
+
 
 class StatisticsTests(unittest.TestCase):
+    def test_recursive_report_redaction_removes_keys_from_values_and_keys(self) -> None:
+        secret = "super-secret-key"
+        value = {f"prefix-{secret}": [secret, {"nested": f"x-{secret}-y"}]}
+        rendered = json.dumps(_redact_value(value, (secret,)))
+        self.assertNotIn(secret, rendered)
+
+    def test_safe_error_redacts_api_key_from_body_and_exception(self) -> None:
+        secret = "super-secret-key"
+        self.assertNotIn(
+            secret,
+            _safe_error(500, f"reflected {secret}", None, secrets=(secret,)),
+        )
+        self.assertNotIn(
+            secret,
+            _safe_error(None, None, RuntimeError(secret), secrets=(secret,)),
+        )
+
     def test_latency_summary_interpolates_quantiles(self) -> None:
         summary = latency_summary([1.0, 2.0, 3.0, 4.0])
         self.assertEqual(summary["p50"], 2.5)
@@ -184,6 +248,45 @@ class StatisticsTests(unittest.TestCase):
         self.assertEqual(evidence["mmp_pool_full_rejects_delta"], 2)
         self.assertEqual(evidence["model_deltas"]["m"]["inference_count_delta"], 20)
         self.assertEqual(evidence["model_deltas"]["m"]["batch_count_delta"], 5)
+
+    def test_report_records_exact_experiment_configuration(self) -> None:
+        spec = load_spec_from_dict(
+            {
+                "server_url": "http://127.0.0.1:8000",
+                "duration_s": 0.001,
+                "warmup_s": 0,
+                "sample_interval_s": 0.001,
+                "clients": [
+                    {
+                        "tenant_id": "tenant-a",
+                        "api_key_env": "TENANT_A_KEY",
+                        "model_id": "model",
+                    }
+                ],
+            }
+        )
+        with patch.dict(
+            os.environ,
+            {
+                "TENANT_A_KEY": "secret",
+                "MMP_BENCHMARK_RUN_ID": "mmp-smoke-001",
+                "MMP_BENCHMARK_MODE": "mps",
+                "MMP_BENCHMARK_HARNESS_REVISION": "a" * 40,
+                "NVIDIA_MPS": "1",
+                "CUDA_MPS_ACTIVE_THREAD_PERCENTAGE": "50",
+            },
+            clear=False,
+        ), patch(
+            "development.mmp_staging_benchmark.run_concurrent_clients._run_worker",
+            new=empty_async,
+        ), patch(
+            "development.mmp_staging_benchmark.run_concurrent_clients._metrics_sampler",
+            new=empty_metrics,
+        ):
+            report = asyncio.run(execute(spec, b"image"))
+        self.assertEqual(report["experiment"]["run_id"], "mmp-smoke-001")
+        self.assertEqual(report["experiment"]["mps_enabled"], "1")
+        self.assertEqual(report["experiment"]["mps_active_thread_percentage"], "50")
 
 
 class CapabilityProbeTests(unittest.TestCase):

--- a/tests/development/mmp_staging_benchmark/test_benchmark_tools.py
+++ b/tests/development/mmp_staging_benchmark/test_benchmark_tools.py
@@ -1,0 +1,214 @@
+import json
+import os
+import tempfile
+import unittest
+from collections import namedtuple
+from pathlib import Path
+from unittest.mock import patch
+
+from development.mmp_staging_benchmark.capability_probe import shared_memory_report
+from development.mmp_staging_benchmark.run_concurrent_clients import (
+    ClientRecorder,
+    ClientSpec,
+    _metrics_evidence,
+    client_name,
+    jain_fairness,
+    latency_summary,
+    load_spec,
+    routing_key,
+    validate_staging_url,
+)
+
+DiskUsage = namedtuple("DiskUsage", "total used free")
+
+
+class StagingTargetTests(unittest.TestCase):
+    def test_accepts_local_private_kubernetes_and_staging(self) -> None:
+        accepted = [
+            "http://127.0.0.1:8000",
+            "http://10.1.2.3:8000",
+            "http://mmp.video-proc.svc:8000",
+            "https://mmp-benchmark.roboflow.one",
+            "https://inference-staging.example.net",
+        ]
+        for target in accepted:
+            with self.subTest(target=target):
+                self.assertEqual(validate_staging_url(target), target)
+
+    def test_rejects_known_or_arbitrary_public_hosts(self) -> None:
+        for target in [
+            "https://api.roboflow.com",
+            "https://video-processors.crusoe.roboflow.com",
+            "https://example.com",
+        ]:
+            with self.subTest(target=target):
+                with self.assertRaisesRegex(ValueError, "refusing non-staging"):
+                    validate_staging_url(target)
+
+
+class SpecTests(unittest.TestCase):
+    def test_same_tenant_can_drive_multiple_clients_with_client_ids(self) -> None:
+        raw = {
+            "server_url": "http://127.0.0.1:8000",
+            "duration_s": 10,
+            "clients": [
+                {
+                    "client_id": "tenant-a-det",
+                    "tenant_id": "tenant-a",
+                    "api_key_env": "TENANT_A_KEY",
+                    "model_id": "detector",
+                },
+                {
+                    "client_id": "tenant-a-seg",
+                    "tenant_id": "tenant-a",
+                    "api_key_env": "TENANT_A_KEY",
+                    "model_id": "segmenter",
+                },
+            ],
+        }
+        with tempfile.TemporaryDirectory() as root:
+            path = Path(root) / "spec.json"
+            path.write_text(json.dumps(raw))
+            spec = load_spec(path)
+        self.assertEqual(
+            [client_name(c) for c in spec.clients],
+            ["tenant-a-det", "tenant-a-seg"],
+        )
+
+    def test_duplicate_effective_client_ids_are_rejected(self) -> None:
+        raw = {
+            "server_url": "http://127.0.0.1:8000",
+            "clients": [
+                {"tenant_id": "a", "api_key_env": "A", "model_id": "m"},
+                {"tenant_id": "a", "api_key_env": "A", "model_id": "m2"},
+            ],
+        }
+        with tempfile.TemporaryDirectory() as root:
+            path = Path(root) / "spec.json"
+            path.write_text(json.dumps(raw))
+            with self.assertRaisesRegex(ValueError, "client_id"):
+                load_spec(path)
+
+    def test_instance_creates_distinct_mmp_routing_key(self) -> None:
+        shared = ClientSpec("tenant-a", "KEY", "model")
+        isolated = ClientSpec("tenant-a", "KEY", "model", instance="tenant-a")
+        self.assertEqual(routing_key(shared), "model")
+        self.assertEqual(routing_key(isolated), "model:tenant-a")
+
+
+class StatisticsTests(unittest.TestCase):
+    def test_latency_summary_interpolates_quantiles(self) -> None:
+        summary = latency_summary([1.0, 2.0, 3.0, 4.0])
+        self.assertEqual(summary["p50"], 2.5)
+        self.assertAlmostEqual(summary["p95"], 3.85)
+        self.assertEqual(summary["max"], 4.0)
+
+    def test_jain_fairness(self) -> None:
+        self.assertEqual(jain_fairness([10, 10, 10]), 1.0)
+        self.assertAlmostEqual(jain_fairness([10, 0]), 0.5)
+        self.assertIsNone(jain_fairness([0, 0]))
+
+    def test_recorder_excludes_warmup_from_capacity_counts(self) -> None:
+        client = ClientSpec("tenant", "KEY", "model")
+        recorder = ClientRecorder(client, max_samples=10, seed=1)
+        recorder.record(
+            offset_s=0.0,
+            measured_offset_s=-1.0,
+            latency_ms=100,
+            status=200,
+            error=None,
+            measured=False,
+        )
+        recorder.record(
+            offset_s=1.0,
+            measured_offset_s=0.0,
+            latency_ms=20,
+            status=200,
+            error=None,
+            measured=True,
+        )
+        report = recorder.report(measured_duration_s=2)
+        self.assertEqual(report["requests"], 1)
+        self.assertEqual(report["delivered_fps"], 0.5)
+        self.assertEqual(report["first_success_latency_ms"], 100)
+
+    def test_metrics_evidence_records_batch_and_vram_deltas(self) -> None:
+        samples = [
+            {
+                "offset_s": 0,
+                "status": 200,
+                "metrics": {
+                    "gpus": [
+                        {
+                            "utilization_pct": 10,
+                            "memory_used_mb": 1000,
+                            "power_w": 50,
+                        }
+                    ],
+                    "per_model_gpu_mb": {"m": 900},
+                    "mmp_free_slots": 10,
+                    "mmp_pending": 0,
+                    "mmp_rejects_pool_full": 1,
+                    "mmp_models": {"m": {"inference_count": 2, "batch_count": 1}},
+                },
+            },
+            {
+                "offset_s": 1,
+                "status": 200,
+                "metrics": {
+                    "gpus": [
+                        {
+                            "utilization_pct": 90,
+                            "memory_used_mb": 1500,
+                            "power_w": 150,
+                        }
+                    ],
+                    "per_model_gpu_mb": {"m": 1400},
+                    "mmp_free_slots": 2,
+                    "mmp_pending": 8,
+                    "mmp_rejects_pool_full": 3,
+                    "mmp_models": {
+                        "m": {
+                            "inference_count": 22,
+                            "batch_count": 6,
+                            "avg_batch_size": 4,
+                            "worker_pid": 42,
+                        }
+                    },
+                },
+            },
+        ]
+        evidence = _metrics_evidence(samples)
+        self.assertEqual(evidence["gpu_utilization_pct"]["max"], 90)
+        self.assertEqual(evidence["per_model_peak_vram_mb"]["m"], 1400)
+        self.assertEqual(evidence["mmp_pool_full_rejects_delta"], 2)
+        self.assertEqual(evidence["model_deltas"]["m"]["inference_count_delta"], 20)
+        self.assertEqual(evidence["model_deltas"]["m"]["batch_count_delta"], 5)
+
+
+class CapabilityProbeTests(unittest.TestCase):
+    def test_shared_memory_geometry_includes_reserve(self) -> None:
+        with patch.dict(
+            os.environ,
+            {
+                "INFERENCE_N_SLOTS": "2",
+                "INFERENCE_INPUT_MB": "1",
+                "MMP_SHM_RESERVE_FACTOR": "1.25",
+            },
+            clear=False,
+        ), patch("pathlib.Path.exists", return_value=True), patch(
+            "os.access", return_value=True
+        ), patch(
+            "shutil.disk_usage",
+            return_value=DiskUsage(total=4_000_000, used=0, free=4_000_000),
+        ):
+            report = shared_memory_report("/fake-shm")
+        self.assertEqual(report["required_bytes"], 2 * (1024 * 1024 + 64))
+        self.assertEqual(
+            report["recommended_bytes"], int(report["required_bytes"] * 1.25)
+        )
+        self.assertTrue(report["satisfies_recommended"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/development/mmp_staging_benchmark/test_staging_plan.py
+++ b/tests/development/mmp_staging_benchmark/test_staging_plan.py
@@ -1,0 +1,340 @@
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from development.mmp_staging_benchmark.analyze_curve import analyze_curve
+from development.mmp_staging_benchmark.analyze_report import analyze
+from development.mmp_staging_benchmark.render_run_spec import (
+    current_clean_revision,
+    render_point,
+)
+from development.mmp_staging_benchmark.validate_staging_plan import (
+    EXPECTED_MODES,
+    load_and_validate,
+    render_plan,
+)
+
+ROOT = Path(__file__).resolve().parents[3]
+MATRIX = ROOT / "development" / "mmp_staging_benchmark" / "matrix.staging.json"
+
+
+def test_checked_in_matrix_renders_matched_mps_pair():
+    matrix = load_and_validate(MATRIX)
+    plan = render_plan(matrix, "mmp-capacity-001")
+
+    assert {phase["id"] for phase in plan["phases"]} == set(EXPECTED_MODES)
+    no_mps = plan["deployments"]["no-mps"]
+    mps = plan["deployments"]["mps"]
+    assert (
+        no_mps["items"][1]["spec"]["template"]["spec"]["containers"][0]["image"]
+        == matrix["artifact"]["image"]
+    )
+    no_mps_env = {
+        item["name"]: item
+        for item in no_mps["items"][1]["spec"]["template"]["spec"]["containers"][0][
+            "env"
+        ]
+    }
+    mps_env = {
+        item["name"]: item
+        for item in mps["items"][1]["spec"]["template"]["spec"]["containers"][0]["env"]
+    }
+    differing = {
+        key
+        for key in set(no_mps_env) | set(mps_env)
+        if no_mps_env.get(key) != mps_env.get(key)
+    }
+    assert differing == {"NVIDIA_MPS", "MMP_BENCHMARK_MODE", "MMP_BENCHMARK_RUN_ID"}
+
+
+def test_rejects_missing_phase(tmp_path):
+    matrix = json.loads(MATRIX.read_text())
+    matrix["phases"].pop()
+    path = tmp_path / "matrix.json"
+    path.write_text(json.dumps(matrix))
+    with pytest.raises(ValueError, match="each required phase"):
+        load_and_validate(path)
+
+
+def test_rejects_nonexclusive_gpu(tmp_path):
+    matrix = json.loads(MATRIX.read_text())
+    matrix["fixed_runtime"]["exclusive_gpu"] = False
+    path = tmp_path / "matrix.json"
+    path.write_text(json.dumps(matrix))
+    with pytest.raises(ValueError, match="exclusive L40S"):
+        load_and_validate(path)
+
+
+def test_rejects_fixture_digest_mismatch(tmp_path):
+    matrix = json.loads(MATRIX.read_text())
+    matrix["fixed_runtime"]["fixture_sha256"] = "0" * 64
+    path = tmp_path / "matrix.json"
+    path.write_text(json.dumps(matrix))
+    with pytest.raises(ValueError, match="fixture digest"):
+        load_and_validate(path)
+
+
+def test_render_point_splits_equal_work_between_clients():
+    template = (
+        ROOT
+        / "development"
+        / "mmp_staging_benchmark"
+        / "spec.same-model-isolated.example.json"
+    )
+    point = render_point(template, 8, 120, 15)
+    assert point["server_url"] == "http://127.0.0.1:18000"
+    assert [client["concurrency"] for client in point["clients"]] == [4, 4]
+
+
+def test_render_point_c1_uses_one_client():
+    template = (
+        ROOT / "development" / "mmp_staging_benchmark" / "spec.same-model.example.json"
+    )
+    point = render_point(template, 1, 120, 15)
+    assert len(point["clients"]) == 1
+    assert point["clients"][0]["concurrency"] == 1
+
+
+def test_render_point_rejects_odd_two_client_point():
+    template = (
+        ROOT / "development" / "mmp_staging_benchmark" / "spec.same-model.example.json"
+    )
+    with pytest.raises(ValueError, match="even total concurrency"):
+        render_point(template, 3, 120, 15)
+
+
+def test_run_spec_renderer_rejects_dirty_harness_revision():
+    dirty = subprocess.CompletedProcess([], 0, stdout=" M file.py\n", stderr="")
+    with patch("subprocess.run", return_value=dirty):
+        with pytest.raises(ValueError, match="must be clean"):
+            current_clean_revision(ROOT)
+
+
+FIXTURE_SHA256 = "83bfa4e706f274ce1da7309cec6374d542f9938b3538481035588681cdaff139"
+
+
+def passing_report(mps="0"):
+    return {
+        "experiment": {
+            "run_id": "run-001",
+            "mode": "mmp-shared-mps" if mps == "1" else "mmp-shared-no-mps",
+            "mps_enabled": mps,
+            "fixture_sha256": FIXTURE_SHA256,
+            "harness_revision": "1" * 40,
+            "decoder": "imagecodecs",
+            "slots": 128,
+            "input_mb_per_slot": 20,
+            "batch_max_size": 0,
+            "batch_max_wait_ms": 5,
+            "server_image_ref": "example@sha256:" + "2" * 64,
+            "server_source_revision": "3" * 40,
+            "server_pod": "server-pod",
+            "server_node": "l40s-node",
+        },
+        "run": {
+            "duration_s": 10,
+            "warmup_s": 0,
+            "sample_interval_s": 1,
+            "pod_name": "server-pod",
+            "node_name": "l40s-node",
+            "image_sha256": FIXTURE_SHA256,
+            "image_ref": "example@sha256:" + "2" * 64,
+            "source_revision": "3" * 40,
+        },
+        "aggregate": {
+            "requests": 200,
+            "successes": 200,
+            "errors": 0,
+            "jain_fairness_delivered_fps": 1.0,
+        },
+        "clients": [
+            {
+                "client_id": "a",
+                "routing_key": "model",
+                "concurrency": 1,
+                "latency_ms": {"p95": 20},
+            },
+            {
+                "client_id": "b",
+                "routing_key": "model",
+                "concurrency": 1,
+                "latency_ms": {"p95": 21},
+            },
+        ],
+        "metrics_evidence": {
+            "sample_count": 10,
+            "mmp_pool_full_rejects_delta": 0,
+            "model_deltas": {
+                "model": {
+                    "inference_count_delta": 200,
+                    "batch_count_delta": 100,
+                    "error_count_delta": 0,
+                }
+            },
+        },
+        "metrics_samples": [
+            {
+                "status": 200,
+                "metrics": {"mmp_models": {"model": {"worker_pid": 42}}},
+            }
+        ],
+    }
+
+
+def passing_identity(report):
+    experiment = report["experiment"]
+    pod = {
+        "metadata": {
+            "name": "server-pod",
+            "annotations": {
+                "roboflow.com/source-revision": experiment["server_source_revision"],
+                "roboflow.com/run-id": experiment["run_id"],
+                "roboflow.com/mps": (
+                    "enabled" if experiment["mps_enabled"] == "1" else "disabled"
+                ),
+                "roboflow.com/decoder": "imagecodecs",
+            },
+        },
+        "spec": {
+            "nodeName": "l40s-node",
+            "containers": [
+                {
+                    "name": "server",
+                    "image": experiment["server_image_ref"],
+                    "env": [
+                        {"name": "NVIDIA_MPS", "value": experiment["mps_enabled"]},
+                        {"name": "INFERENCE_DECODER", "value": "imagecodecs"},
+                        {"name": "INFERENCE_N_SLOTS", "value": "128"},
+                        {"name": "INFERENCE_INPUT_MB", "value": "20"},
+                        {"name": "INFERENCE_BATCH_MAX_SIZE", "value": "0"},
+                        {"name": "INFERENCE_BATCH_MAX_WAIT_MS", "value": "5"},
+                    ],
+                }
+            ],
+        },
+        "status": {
+            "containerStatuses": [
+                {
+                    "name": "server",
+                    "imageID": "registry/thing@sha256:" + "2" * 64,
+                    "restartCount": 0,
+                    "ready": True,
+                }
+            ]
+        },
+    }
+    capability = {
+        "checks": {"passed": True},
+        "source_revision": experiment["server_source_revision"],
+        "image_ref": experiment["server_image_ref"],
+        "nvidia_runtime": {
+            "gpu_query": {
+                "exit_code": 0,
+                "stdout": "0, NVIDIA L40S, GPU-123, 570.1, 46068, Default",
+            }
+        },
+    }
+    return {
+        "pod": pod,
+        "capability": capability,
+        "expected_node": "l40s-node",
+        "expected_gpu_uuid": "GPU-123",
+    }
+
+
+def test_strict_analyzer_accepts_clean_shared_report():
+    report = passing_report()
+    result = analyze(
+        report,
+        phase="mmp-shared-no-mps",
+        server_log="server interval start run-001\n",
+        **passing_identity(report),
+    )
+    assert result["success"] is True
+
+
+def test_strict_analyzer_rejects_pid_change_and_cuda_error():
+    report = passing_report(mps="1")
+    report["metrics_samples"].append(
+        {
+            "status": 200,
+            "metrics": {"mmp_models": {"model": {"worker_pid": 99}}},
+        }
+    )
+    result = analyze(
+        report,
+        phase="mmp-shared-mps",
+        server_log="server interval start\nCUDA error: illegal memory access",
+        **passing_identity(report),
+    )
+    assert result["success"] is False
+    assert "model worker PID missing or changed" in result["failures"]
+    assert "CUDA failure found in server log" in result["failures"]
+
+
+def test_strict_analyzer_rejects_workload_identity_mismatch():
+    report = passing_report()
+    report["experiment"]["mode"] = "mmp-isolated-no-mps"
+    report["experiment"]["fixture_sha256"] = "4" * 64
+    report["experiment"]["slots"] = 64
+    result = analyze(
+        report,
+        phase="mmp-shared-no-mps",
+        server_log="server interval start run-001\n",
+        **passing_identity(report),
+    )
+    assert result["success"] is False
+    assert "report phase identity does not match analyzer phase" in result["failures"]
+    assert "fixture digest does not match report image" in result["failures"]
+    assert "runtime identity mismatch: slots" in result["failures"]
+
+
+def analyzed_point(point, repetition, success=True):
+    return {
+        "phase": "mmp-shared-no-mps",
+        "success": success,
+        "evidence": {
+            "total_concurrency": point,
+            "run_id": f"shared-c{point:02d}-r{repetition}",
+        },
+    }
+
+
+def test_curve_analyzer_certifies_highest_pass_twice_next_fail_twice():
+    results = [
+        analyzed_point(1, 1),
+        analyzed_point(1, 2),
+        analyzed_point(2, 1),
+        analyzed_point(2, 2),
+        analyzed_point(4, 1, False),
+        analyzed_point(4, 2, False),
+    ]
+    result = analyze_curve(
+        results,
+        phase="mmp-shared-no-mps",
+        allowed_points=[1, 2, 4, 8],
+    )
+    assert result["success"] is True
+    assert result["capacity_total_concurrency"] == 2
+    assert result["next_failed_total_concurrency"] == 4
+
+
+def test_curve_analyzer_rejects_single_repetition_and_right_censoring():
+    single = analyze_curve(
+        [analyzed_point(1, 1), analyzed_point(2, 1, False)],
+        phase="mmp-shared-no-mps",
+        allowed_points=[1, 2],
+    )
+    assert single["success"] is False
+    assert any("expected 2 repetitions" in item for item in single["failures"])
+
+    censored = analyze_curve(
+        [analyzed_point(1, 1), analyzed_point(1, 2)],
+        phase="mmp-shared-no-mps",
+        allowed_points=[1],
+    )
+    assert censored["success"] is False
+    assert any("right-censored" in item for item in censored["failures"])

--- a/tests/development/mmp_staging_benchmark/test_staging_plan.py
+++ b/tests/development/mmp_staging_benchmark/test_staging_plan.py
@@ -1,18 +1,29 @@
+import hashlib
 import json
 import subprocess
+from dataclasses import asdict
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
-from development.mmp_staging_benchmark.analyze_curve import analyze_curve
+from development.mmp_staging_benchmark.analyze_curve import (
+    analyze_curve,
+    compare_mps_pair,
+)
 from development.mmp_staging_benchmark.analyze_report import analyze
+from development.mmp_staging_benchmark.capture_cache_evidence import (
+    capture as capture_cache,
+)
+from development.mmp_staging_benchmark.capture_mps_evidence import capture
 from development.mmp_staging_benchmark.render_run_spec import (
     current_clean_revision,
     render_point,
 )
+from development.mmp_staging_benchmark.run_concurrent_clients import ClientSpec
 from development.mmp_staging_benchmark.validate_staging_plan import (
     EXPECTED_MODES,
+    canonical_sha256,
     load_and_validate,
     render_plan,
 )
@@ -113,14 +124,110 @@ def test_run_spec_renderer_rejects_dirty_harness_revision():
             current_clean_revision(ROOT)
 
 
+def test_mps_evidence_capture_binds_staging_pod_and_gpu():
+    responses = iter(
+        [
+            "ck8s-stg",
+            json.dumps({"metadata": {"name": "server-pod", "uid": "pod-uid-123"}}),
+            "GPU-123",
+            "101\n202",
+            "42",
+            "",
+        ]
+    )
+    with patch(
+        "development.mmp_staging_benchmark.capture_mps_evidence._run",
+        side_effect=lambda *_args, **_kwargs: next(responses),
+    ), patch(
+        "development.mmp_staging_benchmark.capture_mps_evidence.time.time",
+        return_value=1060,
+    ):
+        evidence = capture("server-pod")
+    assert evidence == {
+        "schema_version": 1,
+        "context": "ck8s-stg",
+        "namespace": "video-proc-bench-mmp",
+        "pod": "server-pod",
+        "pod_uid": "pod-uid-123",
+        "gpu_uuid": "GPU-123",
+        "captured_unix_s": 1060,
+        "command": "get_server_list",
+        "exit_code": 0,
+        "server_list": "101\n202",
+        "clients_by_server": {"101": [42], "202": []},
+    }
+
+
+def test_cache_evidence_capture_records_routes_without_api_key():
+    responses = iter(
+        [
+            "ck8s-stg",
+            json.dumps({"metadata": {"name": "server-pod", "uid": "pod-uid-123"}}),
+            "/models/cache/a\n/models/cache/b",
+            "",
+        ]
+    )
+    metrics = {
+        "mmp_models": {
+            "yolov8n-640": {
+                "worker_pid": 42,
+                "inference_count": 10,
+                "batch_count": 5,
+                "error_count": 0,
+            }
+        }
+    }
+    with patch(
+        "development.mmp_staging_benchmark.capture_cache_evidence._run",
+        side_effect=lambda *_args, **_kwargs: next(responses),
+    ), patch(
+        "development.mmp_staging_benchmark.capture_cache_evidence._metrics",
+        return_value=metrics,
+    ) as metrics_call, patch(
+        "development.mmp_staging_benchmark.capture_cache_evidence.time.time",
+        return_value=990,
+    ):
+        evidence = capture_cache("server-pod", "http://127.0.0.1:18000", "secret")
+    metrics_call.assert_called_once_with("http://127.0.0.1:18000", "secret")
+    assert "secret" not in json.dumps(evidence)
+    assert evidence["pod_uid"] == "pod-uid-123"
+    assert evidence["cache_file_count"] == 2
+    assert set(evidence["routes"]) == {"yolov8n-640"}
+
+
 FIXTURE_SHA256 = "83bfa4e706f274ce1da7309cec6374d542f9938b3538481035588681cdaff139"
 
 
 def passing_report(mps="0"):
+    matrix = load_and_validate(MATRIX)
+    phase = "mmp-shared-mps" if mps == "1" else "mmp-shared-no-mps"
+    phase_config = next(item for item in matrix["phases"] if item["id"] == phase)
+    template = MATRIX.parent / phase_config["spec"]
+    workload = render_point(template, 2, 120, 15)
+    workload_clients = [asdict(ClientSpec(**item)) for item in workload["clients"]]
+    samples = []
+    for index in range(135):
+        samples.append(
+            {
+                "offset_s": index,
+                "status": 200,
+                "metrics": {
+                    "mmp_rejects_pool_full": 0,
+                    "mmp_models": {
+                        "yolov8n-640": {
+                            "worker_pid": 42,
+                            "inference_count": 2 * index,
+                            "batch_count": index,
+                            "error_count": 0,
+                        }
+                    },
+                },
+            }
+        )
     return {
         "experiment": {
             "run_id": "run-001",
-            "mode": "mmp-shared-mps" if mps == "1" else "mmp-shared-no-mps",
+            "mode": phase,
             "mps_enabled": mps,
             "fixture_sha256": FIXTURE_SHA256,
             "harness_revision": "1" * 40,
@@ -129,20 +236,30 @@ def passing_report(mps="0"):
             "input_mb_per_slot": 20,
             "batch_max_size": 0,
             "batch_max_wait_ms": 5,
-            "server_image_ref": "example@sha256:" + "2" * 64,
-            "server_source_revision": "3" * 40,
+            "server_image_ref": matrix["artifact"]["image"],
+            "server_source_revision": matrix["artifact"]["source_revision"],
             "server_pod": "server-pod",
             "server_node": "l40s-node",
+            "matrix_sha256": canonical_sha256(matrix),
+            "template_sha256": hashlib.sha256(template.read_bytes()).hexdigest(),
+            "workload_sha256": canonical_sha256(workload),
+            "cache_state": "warm",
         },
         "run": {
-            "duration_s": 10,
-            "warmup_s": 0,
+            "server_url": "http://127.0.0.1:18000",
+            "duration_s": 120,
+            "warmup_s": 15,
             "sample_interval_s": 1,
+            "request_timeout_s": 60.0,
+            "max_latency_samples_per_client": 250_000,
+            "started_unix_s": 1000,
+            "finished_unix_s": 1135,
             "pod_name": "server-pod",
             "node_name": "l40s-node",
             "image_sha256": FIXTURE_SHA256,
-            "image_ref": "example@sha256:" + "2" * 64,
-            "source_revision": "3" * 40,
+            "image_ref": matrix["artifact"]["image"],
+            "source_revision": matrix["artifact"]["source_revision"],
+            "clients": workload_clients,
         },
         "aggregate": {
             "requests": 200,
@@ -153,34 +270,29 @@ def passing_report(mps="0"):
         "clients": [
             {
                 "client_id": "a",
-                "routing_key": "model",
+                "routing_key": "yolov8n-640",
                 "concurrency": 1,
                 "latency_ms": {"p95": 20},
             },
             {
                 "client_id": "b",
-                "routing_key": "model",
+                "routing_key": "yolov8n-640",
                 "concurrency": 1,
                 "latency_ms": {"p95": 21},
             },
         ],
         "metrics_evidence": {
-            "sample_count": 10,
+            "sample_count": 135,
             "mmp_pool_full_rejects_delta": 0,
             "model_deltas": {
-                "model": {
-                    "inference_count_delta": 200,
-                    "batch_count_delta": 100,
+                "yolov8n-640": {
+                    "inference_count_delta": 268,
+                    "batch_count_delta": 134,
                     "error_count_delta": 0,
                 }
             },
         },
-        "metrics_samples": [
-            {
-                "status": 200,
-                "metrics": {"mmp_models": {"model": {"worker_pid": 42}}},
-            }
-        ],
+        "metrics_samples": samples,
     }
 
 
@@ -189,6 +301,8 @@ def passing_identity(report):
     pod = {
         "metadata": {
             "name": "server-pod",
+            "namespace": "video-proc-bench-mmp",
+            "uid": "pod-uid-123",
             "annotations": {
                 "roboflow.com/source-revision": experiment["server_source_revision"],
                 "roboflow.com/run-id": experiment["run_id"],
@@ -219,7 +333,8 @@ def passing_identity(report):
             "containerStatuses": [
                 {
                     "name": "server",
-                    "imageID": "registry/thing@sha256:" + "2" * 64,
+                    "imageID": "registry/thing@"
+                    + experiment["server_image_ref"].split("@", 1)[1],
                     "restartCount": 0,
                     "ready": True,
                 }
@@ -237,12 +352,47 @@ def passing_identity(report):
             }
         },
     }
-    return {
+    identity = {
         "pod": pod,
         "capability": capability,
         "expected_node": "l40s-node",
         "expected_gpu_uuid": "GPU-123",
+        "matrix": load_and_validate(MATRIX),
+        "matrix_dir": MATRIX.parent,
+        "expected_harness_revision": "1" * 40,
+        "cache_evidence": {
+            "schema_version": 1,
+            "context": "ck8s-stg",
+            "namespace": "video-proc-bench-mmp",
+            "pod": "server-pod",
+            "pod_uid": "pod-uid-123",
+            "captured_unix_s": 990,
+            "cache_file_count": 1,
+            "cache_paths_sha256": "5" * 64,
+            "routes": {
+                "yolov8n-640": {
+                    "worker_pid": 42,
+                    "inference_count": 10,
+                    "batch_count": 5,
+                    "error_count": 0,
+                }
+            },
+        },
     }
+    if experiment["mps_enabled"] == "1":
+        identity["mps_evidence"] = {
+            "context": "ck8s-stg",
+            "namespace": "video-proc-bench-mmp",
+            "captured_unix_s": 1060,
+            "pod": "server-pod",
+            "pod_uid": "pod-uid-123",
+            "gpu_uuid": "GPU-123",
+            "command": "get_server_list",
+            "exit_code": 0,
+            "server_list": "12345",
+            "clients_by_server": {"12345": [42]},
+        }
+    return identity
 
 
 def test_strict_analyzer_accepts_clean_shared_report():
@@ -260,8 +410,19 @@ def test_strict_analyzer_rejects_pid_change_and_cuda_error():
     report = passing_report(mps="1")
     report["metrics_samples"].append(
         {
+            "offset_s": 135,
             "status": 200,
-            "metrics": {"mmp_models": {"model": {"worker_pid": 99}}},
+            "metrics": {
+                "mmp_rejects_pool_full": 0,
+                "mmp_models": {
+                    "yolov8n-640": {
+                        "worker_pid": 99,
+                        "inference_count": 270,
+                        "batch_count": 135,
+                        "error_count": 0,
+                    }
+                },
+            },
         }
     )
     result = analyze(
@@ -292,13 +453,150 @@ def test_strict_analyzer_rejects_workload_identity_mismatch():
     assert "runtime identity mismatch: slots" in result["failures"]
 
 
+def test_strict_analyzer_recomputes_raw_metrics_and_matrix_workload():
+    report = passing_report()
+    report["metrics_samples"] = report["metrics_samples"][:1]
+    report["run"]["clients"][0]["model_id"] = "wrong-model"
+    result = analyze(
+        report,
+        phase="mmp-shared-no-mps",
+        server_log="server interval start run-001\n",
+        **passing_identity(report),
+    )
+    assert result["success"] is False
+    assert "raw metrics coverage failed" in result["failures"]
+    assert "raw metrics interval span failed" in result["failures"]
+    assert "report clients differ from matrix workload" in result["failures"]
+
+
+def test_strict_analyzer_rejects_counter_reset_and_sparse_route_metrics():
+    report = passing_report()
+    report["metrics_samples"][100]["metrics"]["mmp_models"]["yolov8n-640"][
+        "inference_count"
+    ] = 1
+    for sample in report["metrics_samples"][:20]:
+        sample["metrics"]["mmp_models"] = {}
+    result = analyze(
+        report,
+        phase="mmp-shared-no-mps",
+        server_log="server interval start run-001\n",
+        **passing_identity(report),
+    )
+    assert result["success"] is False
+    assert any(
+        "raw model metric coverage/continuity failed" in failure
+        for failure in result["failures"]
+    )
+
+
+def test_strict_analyzer_rejects_self_attested_cold_cache_and_warmup_mps():
+    report = passing_report(mps="1")
+    report["experiment"]["cache_state"] = "cold"
+    identity = passing_identity(report)
+    identity["mps_evidence"]["captured_unix_s"] = 1005
+    result = analyze(
+        report,
+        phase="mmp-shared-mps",
+        server_log="server interval start run-001\n",
+        **identity,
+    )
+    assert result["success"] is False
+    assert "cold run did not start with empty routes/cache" in result["failures"]
+    assert "MPS evidence was not captured during the run" in result["failures"]
+
+
+def test_strict_analyzer_rejects_mps_server_without_measured_worker_client():
+    report = passing_report(mps="1")
+    identity = passing_identity(report)
+    identity["mps_evidence"]["clients_by_server"] = {"12345": [99999]}
+    result = analyze(
+        report,
+        phase="mmp-shared-mps",
+        server_log="server interval start run-001\n",
+        **identity,
+    )
+    assert result["success"] is False
+    assert "measured model workers are not all MPS clients" in result["failures"]
+
+
+def test_strict_analyzer_accepts_operationally_cold_pre_run_state():
+    report = passing_report()
+    report["experiment"]["cache_state"] = "cold"
+    identity = passing_identity(report)
+    identity["cache_evidence"].update(
+        {
+            "cache_file_count": 0,
+            "cache_paths_sha256": hashlib.sha256(b"").hexdigest(),
+            "routes": {},
+        }
+    )
+    result = analyze(
+        report,
+        phase="mmp-shared-no-mps",
+        server_log="server interval start run-001\n",
+        **identity,
+    )
+    assert result["success"] is True
+
+
+def test_strict_analyzer_accepts_cold_route_created_after_first_sample():
+    report = passing_report()
+    report["experiment"]["cache_state"] = "cold"
+    report["metrics_samples"][0]["metrics"]["mmp_models"] = {}
+    report["metrics_evidence"]["model_deltas"]["yolov8n-640"] = {
+        "inference_count_delta": 268,
+        "batch_count_delta": 134,
+        "error_count_delta": 0,
+    }
+    identity = passing_identity(report)
+    identity["cache_evidence"].update(
+        {
+            "cache_file_count": 0,
+            "cache_paths_sha256": hashlib.sha256(b"").hexdigest(),
+            "routes": {},
+        }
+    )
+    result = analyze(
+        report,
+        phase="mmp-shared-no-mps",
+        server_log="server interval start run-001\n",
+        **identity,
+    )
+    assert result["success"] is True
+
+
+def test_strict_analyzer_rejects_warm_worker_pid_mismatch():
+    report = passing_report()
+    identity = passing_identity(report)
+    identity["cache_evidence"]["routes"]["yolov8n-640"]["worker_pid"] = 99999
+    result = analyze(
+        report,
+        phase="mmp-shared-no-mps",
+        server_log="server interval start run-001\n",
+        **identity,
+    )
+    assert result["success"] is False
+    assert any("warm pre-run worker PID differs" in item for item in result["failures"])
+
+
 def analyzed_point(point, repetition, success=True):
     return {
         "phase": "mmp-shared-no-mps",
         "success": success,
+        "failures": [] if success else ["a: latency p95 failed"],
         "evidence": {
             "total_concurrency": point,
             "run_id": f"shared-c{point:02d}-r{repetition}",
+            "server_image_ref": "image@sha256:" + "1" * 64,
+            "server_source_revision": "2" * 40,
+            "harness_revision": "3" * 40,
+            "fixture_sha256": "4" * 64,
+            "matrix_sha256": "5" * 64,
+            "template_sha256": "6" * 64,
+            "workload_sha256": f"{point:064x}",
+            "cache_state": "warm",
+            "server_node": "l40s-node",
+            "gpu_uuid": "GPU-123",
         },
     }
 
@@ -338,3 +636,64 @@ def test_curve_analyzer_rejects_single_repetition_and_right_censoring():
     )
     assert censored["success"] is False
     assert any("right-censored" in item for item in censored["failures"])
+
+
+def test_curve_analyzer_rejects_cross_cohort_results():
+    results = [
+        analyzed_point(1, 1),
+        analyzed_point(1, 2),
+        analyzed_point(2, 1, False),
+        analyzed_point(2, 2, False),
+    ]
+    results[-1]["evidence"]["gpu_uuid"] = "GPU-other"
+    result = analyze_curve(
+        results,
+        phase="mmp-shared-no-mps",
+        allowed_points=[1, 2],
+    )
+    assert result["success"] is False
+    assert "single-report results do not form one exact cohort" in result["failures"]
+
+
+def test_curve_analyzer_requires_exact_matched_mps_pair():
+    no_mps = analyze_curve(
+        [
+            analyzed_point(1, 1),
+            analyzed_point(1, 2),
+            analyzed_point(2, 1, False),
+            analyzed_point(2, 2, False),
+        ],
+        phase="mmp-shared-no-mps",
+        allowed_points=[1, 2],
+    )
+    mps_results = [
+        {**analyzed_point(1, 1), "phase": "mmp-shared-mps"},
+        {**analyzed_point(1, 2), "phase": "mmp-shared-mps"},
+        {**analyzed_point(2, 1, False), "phase": "mmp-shared-mps"},
+        {**analyzed_point(2, 2, False), "phase": "mmp-shared-mps"},
+    ]
+    mps = analyze_curve(
+        mps_results,
+        phase="mmp-shared-mps",
+        allowed_points=[1, 2],
+    )
+    assert compare_mps_pair(no_mps, mps)["success"] is True
+    mps["cohort"]["gpu_uuid"] = "GPU-other"
+    assert compare_mps_pair(no_mps, mps)["success"] is False
+
+
+def test_curve_analyzer_rejects_disjoint_or_identity_only_failures():
+    results = [
+        analyzed_point(1, 1),
+        analyzed_point(1, 2),
+        analyzed_point(2, 1, False),
+        analyzed_point(2, 2, False),
+    ]
+    results[-2]["failures"].append("CUDA failure found in server log")
+    result = analyze_curve(
+        results,
+        phase="mmp-shared-no-mps",
+        allowed_points=[1, 2],
+    )
+    assert result["success"] is False
+    assert any("non-capacity failure" in item for item in result["failures"])

--- a/tests/development/test_mmp_staging_deployment.py
+++ b/tests/development/test_mmp_staging_deployment.py
@@ -3,7 +3,6 @@ from pathlib import Path
 
 import pytest
 
-
 MODULE = (
     Path(__file__).resolve().parents[2]
     / "development"
@@ -26,8 +25,17 @@ def deployment(document):
     return [item for item in document["items"] if item["kind"] == "Deployment"][0]
 
 
+def render(**kwargs):
+    return renderer.render(
+        IMAGE,
+        REVISION,
+        run_id="mmp-smoke-001",
+        **kwargs,
+    )
+
+
 def test_renders_dedicated_digest_pinned_l40s_deployment():
-    document = renderer.render(IMAGE, REVISION, "mmp-benchmark-api-keys")
+    document = render()
     workload = deployment(document)
     pod = workload["spec"]["template"]["spec"]
     container = pod["containers"][0]
@@ -35,27 +43,35 @@ def test_renders_dedicated_digest_pinned_l40s_deployment():
     assert document["items"][0]["metadata"]["name"] == "video-proc-bench-mmp"
     assert workload["spec"]["strategy"] == {"type": "Recreate"}
     assert pod["nodeSelector"] == {"gpu_type": "L40S"}
+    assert pod["automountServiceAccountToken"] is False
+    assert (
+        workload["spec"]["template"]["metadata"]["annotations"]
+        == workload["metadata"]["annotations"]
+    )
     assert container["image"] == IMAGE
     assert container["resources"]["limits"]["nvidia.com/gpu"] == 1
-    assert {item["name"]: item["emptyDir"] for item in pod["volumes"]}[
-        "dshm"
-    ] == {"medium": "Memory", "sizeLimit": "4Gi"}
+    assert {item["name"]: item["emptyDir"] for item in pod["volumes"]}["dshm"] == {
+        "medium": "Memory",
+        "sizeLimit": "4Gi",
+    }
     env = {item["name"]: item for item in container["env"]}
     assert env["NVIDIA_MPS"]["value"] == "0"
-    assert "value" not in env["RF_BENCH_TENANT_A_KEY"]
-    assert env["RF_BENCH_TENANT_A_KEY"]["valueFrom"]["secretKeyRef"] == {
-        "name": "mmp-benchmark-api-keys",
-        "key": "tenant-a",
-    }
+    assert env["INFERENCE_DECODER"]["value"] == "imagecodecs"
+    assert env["MMP_BENCHMARK_RUN_ID"]["value"] == "mmp-smoke-001"
+    assert env["POD_NAME"]["valueFrom"]["fieldRef"] == {"fieldPath": "metadata.name"}
+    assert env["NODE_NAME"]["valueFrom"]["fieldRef"] == {"fieldPath": "spec.nodeName"}
+    assert "RF_BENCH_TENANT_A_KEY" not in env
+    assert "RF_BENCH_TENANT_B_KEY" not in env
 
 
 def test_mps_changes_only_the_explicit_runtime_mode():
-    document = renderer.render(IMAGE, REVISION, "mmp-benchmark-api-keys", mps=True)
+    document = render(mps=True, active_thread_percentage=50)
     workload = deployment(document)
     container = workload["spec"]["template"]["spec"]["containers"][0]
     env = {item["name"]: item for item in container["env"]}
 
     assert env["NVIDIA_MPS"]["value"] == "1"
+    assert env["CUDA_MPS_ACTIVE_THREAD_PERCENTAGE"]["value"] == "50"
     assert workload["metadata"]["annotations"]["roboflow.com/mps"] == "enabled"
 
 
@@ -70,4 +86,31 @@ def test_mps_changes_only_the_explicit_runtime_mode():
 )
 def test_rejects_mutable_or_nonstaging_images(image):
     with pytest.raises(ValueError, match="staging mmp-benchmark"):
-        renderer.render(image, REVISION, "mmp-benchmark-api-keys")
+        renderer.render(
+            image,
+            REVISION,
+            run_id="mmp-smoke-001",
+        )
+
+
+@pytest.mark.parametrize("run_id", ["", "UPPER", "a" * 64])
+def test_rejects_invalid_run_id(run_id):
+    with pytest.raises(ValueError, match="run ID"):
+        renderer.render(
+            IMAGE,
+            REVISION,
+            run_id=run_id,
+        )
+
+
+def test_rejects_mps_partition_without_mps():
+    with pytest.raises(ValueError, match="requires MPS"):
+        render(active_thread_percentage=50)
+
+
+def test_pins_benchmark_to_capability_node_when_requested():
+    document = render(node_name="gpu-l40s-001")
+    assert deployment(document)["spec"]["template"]["spec"]["nodeSelector"] == {
+        "gpu_type": "L40S",
+        "kubernetes.io/hostname": "gpu-l40s-001",
+    }

--- a/tests/development/test_mmp_staging_deployment.py
+++ b/tests/development/test_mmp_staging_deployment.py
@@ -1,0 +1,73 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+MODULE = (
+    Path(__file__).resolve().parents[2]
+    / "development"
+    / "mmp_staging_benchmark"
+    / "render_staging_deployment.py"
+)
+SPEC = importlib.util.spec_from_file_location("mmp_deployment", MODULE)
+renderer = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(renderer)
+
+
+IMAGE = (
+    "us-central1-docker.pkg.dev/roboflow-staging/video-proc/"
+    "mmp-benchmark@sha256:" + "a" * 64
+)
+REVISION = "b" * 40
+
+
+def deployment(document):
+    return [item for item in document["items"] if item["kind"] == "Deployment"][0]
+
+
+def test_renders_dedicated_digest_pinned_l40s_deployment():
+    document = renderer.render(IMAGE, REVISION, "mmp-benchmark-api-keys")
+    workload = deployment(document)
+    pod = workload["spec"]["template"]["spec"]
+    container = pod["containers"][0]
+
+    assert document["items"][0]["metadata"]["name"] == "video-proc-bench-mmp"
+    assert workload["spec"]["strategy"] == {"type": "Recreate"}
+    assert pod["nodeSelector"] == {"gpu_type": "L40S"}
+    assert container["image"] == IMAGE
+    assert container["resources"]["limits"]["nvidia.com/gpu"] == 1
+    assert {item["name"]: item["emptyDir"] for item in pod["volumes"]}[
+        "dshm"
+    ] == {"medium": "Memory", "sizeLimit": "4Gi"}
+    env = {item["name"]: item for item in container["env"]}
+    assert env["NVIDIA_MPS"]["value"] == "0"
+    assert "value" not in env["RF_BENCH_TENANT_A_KEY"]
+    assert env["RF_BENCH_TENANT_A_KEY"]["valueFrom"]["secretKeyRef"] == {
+        "name": "mmp-benchmark-api-keys",
+        "key": "tenant-a",
+    }
+
+
+def test_mps_changes_only_the_explicit_runtime_mode():
+    document = renderer.render(IMAGE, REVISION, "mmp-benchmark-api-keys", mps=True)
+    workload = deployment(document)
+    container = workload["spec"]["template"]["spec"]["containers"][0]
+    env = {item["name"]: item for item in container["env"]}
+
+    assert env["NVIDIA_MPS"]["value"] == "1"
+    assert workload["metadata"]["annotations"]["roboflow.com/mps"] == "enabled"
+
+
+@pytest.mark.parametrize(
+    "image",
+    [
+        "us-central1-docker.pkg.dev/roboflow-staging/video-proc/mmp-benchmark:tag",
+        "us-central1-docker.pkg.dev/roboflow-platform/video-proc/"
+        "mmp-benchmark@sha256:" + "a" * 64,
+        "example.com/mmp-benchmark@sha256:" + "a" * 64,
+    ],
+)
+def test_rejects_mutable_or_nonstaging_images(image):
+    with pytest.raises(ValueError, match="staging mmp-benchmark"):
+        renderer.render(image, REVISION, "mmp-benchmark-api-keys")


### PR DESCRIPTION
## Summary

- add an amd64 staging-only MMP GPU image with pinned CUDA and uv base manifests
- add read-only CUDA, MPS, shared-memory, pre-run cache/route, and measured-window MPS client evidence
- add tenant-aware same-model shared-worker, same-weight isolated-process, and mixed-model load specs
- add an immutable six-phase matrix comparing MMP shared/isolated/mixed modes with raw same-pod MPS off and on
- add loopback-only local runners, strict per-report analysis, paired curve certification, and an authorization-gated staging runbook
- bind reports to the checked matrix/template/workload, clean harness commit, fixture, cache state, pod UID/node/GPU UUID, runtime flags, live stable worker PIDs, logs, and two-run capacity boundary
- keep API keys outside the pod and reports; render no Service or Ingress and disable service-account-token mounting

This PR is based on `feat/new-model-manager` and intentionally does not merge the MMP work into the video POC branch. The image exercises HTTP JPEG -> CPU shared memory -> MMP model subprocesses. It contains no video worker and does not use CUDA IPC. It does not deploy or mutate staging.

## Built artifact

- source revision label: `5f02db12ebdda013ff92e6607f92f88c7f9582ec`
- immutable image: `us-central1-docker.pkg.dev/roboflow-staging/video-proc/mmp-benchmark@sha256:6a6592f77e0eb1d3bfc8b82d7add6a7206e946a437a072f7f3a58cf693b1716d`
- Cloud Build: `f0bd00b6-f0d1-410a-8ba6-bf9f8e8ccfd0`

Artifact Registry reports SLSA level 3. The provenance binds the digest to the uploaded Cloud Build source tar and revision build argument, not a Git source URI, so the runbook does not overclaim cryptographic Git-tree equivalence. The checked-in matrix/analyzers/runbook were added after this image build and run locally from a clean checkout.

## Validation

- `51 passed` across staging MMP benchmark tools and deployment rendering
- Black and isort checks passed
- direct CLI imports, Python compilation, and `git diff --check` passed
- independent P0/P1 safety and experiment-validity review cleared

The analyzer rejects self-attested or mixed evidence: cold/warm state is verified immediately before each run; warm worker PIDs must be live and stable into measurement; MPS runs must prove every measured model worker is an MPS client; and a capacity boundary requires two failures sharing an allowed capacity reason with no CUDA/identity/evidence failure.

## Remaining staging gates

- separately authorize the dedicated staging Namespace/Deployment apply
- repeat the capability probe on the exact L40S pod and pin the comparison to its node and GPU UUID
- run one authenticated inference smoke through a local port-forward
- run paired non-MPS and raw-MPS curves, then certify each boundary with `analyze_curve.py`

No production or normal `video-proc` resources are in scope.
