### PR TITLE
ENT-1686/1687: Harden OpenCV RTSPS capture opens

### DIFF
--- a/inference/core/interfaces/camera/rtsp_opencv_tls.py
+++ b/inference/core/interfaces/camera/rtsp_opencv_tls.py
@@ -96,8 +96,13 @@ def opencv_rtsps_tls_env(video: Union[str, int]) -> Iterator[None]:
 
     OpenCV reads this env var at capture-open time. The lock spans set →
     VideoCapture open → restore so concurrent RTSPS sources cannot clobber each
-    other's TLS options. Isolation is RTSPS-vs-RTSPS only; concurrent non-RTSPS
-    opens do not take the lock and may briefly inherit these options.
+    other's TLS options.
+
+    Non-RTSPS opens (USB, V4L2, files, plain ``rtsp://``) do not take this lock
+    and are not serialized here. A process-wide lock around every VideoCapture
+    would stall those backends, which have no FFmpeg open timeout. Concurrent
+    non-RTSPS FFmpeg opens may briefly inherit these options; that window is
+    preferred over blocking every producer on one hung camera.
     """
     options = build_opencv_ffmpeg_capture_options(video)
     if options is None:

--- a/inference/core/interfaces/camera/rtsp_opencv_tls.py
+++ b/inference/core/interfaces/camera/rtsp_opencv_tls.py
@@ -99,9 +99,10 @@ def build_opencv_ffmpeg_capture_options(video: Union[str, int]) -> Optional[str]
     merged = _parse_opencv_ffmpeg_capture_options(existing or "")
     for key, value in overrides.items():
         merged[key] = value
-    if "stimeout" not in merged and "timeout" not in merged:
-        timeout_value = str(_RTSPS_OPEN_TIMEOUT_US)
+    timeout_value = str(_RTSPS_OPEN_TIMEOUT_US)
+    if "stimeout" not in merged:
         merged["stimeout"] = timeout_value
+    if "timeout" not in merged:
         merged["timeout"] = timeout_value
     return _format_opencv_ffmpeg_capture_options(merged)
 

--- a/inference/core/interfaces/camera/rtsp_opencv_tls.py
+++ b/inference/core/interfaces/camera/rtsp_opencv_tls.py
@@ -1,4 +1,15 @@
-"""OpenCV/FFmpeg RTSPS TLS option builder (ENT-1544 B3)."""
+"""OpenCV/FFmpeg RTSPS TLS option builder (ENT-1544 B3).
+
+Environment variables (also set by rfdm on Roboflow Edge devices):
+
+* ``ROBOFLOW_RTSP_TLS_VALIDATION_FLAGS`` — ``127`` strict (default when unset),
+  ``126`` or ``0`` to disable certificate verification (self-signed / custom CA).
+* ``GST_SSL_CA_CERTIFICATE`` or ``SSL_CERT_FILE`` — PEM bundle for ``cafile``.
+
+Self-hosted / OSS deployments without rfdm must set these explicitly on the
+inference container. Unmanaged ``rtsps://`` sources with self-signed certs need
+``ROBOFLOW_RTSP_TLS_VALIDATION_FLAGS=126`` or the open will fail after this wiring.
+"""
 
 from __future__ import annotations
 

--- a/inference/core/interfaces/camera/rtsp_opencv_tls.py
+++ b/inference/core/interfaces/camera/rtsp_opencv_tls.py
@@ -13,6 +13,7 @@ inference container. Unmanaged ``rtsps://`` sources with self-signed certs need
 
 from __future__ import annotations
 
+import logging
 import os
 import threading
 from contextlib import contextmanager
@@ -26,6 +27,11 @@ from inference.core.interfaces.camera.rtsp_tls import (
 
 OPENCV_FFMPEG_CAPTURE_OPTIONS_ENV_VAR = "OPENCV_FFMPEG_CAPTURE_OPTIONS"
 SSL_CERT_FILE_ENV_VAR = "SSL_CERT_FILE"
+# FFmpeg RTSP socket timeouts (microseconds). Bounds global-lock hold during capture open.
+# FFmpeg 5+ uses "timeout"; older builds use "stimeout" — set both (see webrtc/sources.py).
+_RTSPS_OPEN_TIMEOUT_US = 5_000_000
+
+logger = logging.getLogger(__name__)
 
 _opencv_rtsps_tls_lock = threading.Lock()
 
@@ -59,6 +65,11 @@ def _build_rtsps_tls_option_overrides() -> Dict[str, str]:
         # rfdm maps allow_self_signed to 126 (unknown-CA only). FFmpeg only
         # supports full verify on/off, so treat both 0 and 126 as tls_verify;0.
         if stripped in {"0", "126"}:
+            if stripped == "126":
+                logger.warning(
+                    "OpenCV/FFmpeg RTSPS cannot enforce partial TLS validation; "
+                    "tls_validation_flags=126 (allow_self_signed) maps to tls_verify=0"
+                )
             overrides["tls_verify"] = "0"
         else:
             overrides["tls_verify"] = "1"
@@ -84,10 +95,15 @@ def build_opencv_ffmpeg_capture_options(video: Union[str, int]) -> Optional[str]
         return None
 
     overrides = _build_rtsps_tls_option_overrides()
-    return merge_opencv_ffmpeg_capture_options(
-        os.environ.get(OPENCV_FFMPEG_CAPTURE_OPTIONS_ENV_VAR),
-        overrides,
-    )
+    existing = os.environ.get(OPENCV_FFMPEG_CAPTURE_OPTIONS_ENV_VAR)
+    merged = _parse_opencv_ffmpeg_capture_options(existing or "")
+    for key, value in overrides.items():
+        merged[key] = value
+    if "stimeout" not in merged and "timeout" not in merged:
+        timeout_value = str(_RTSPS_OPEN_TIMEOUT_US)
+        merged["stimeout"] = timeout_value
+        merged["timeout"] = timeout_value
+    return _format_opencv_ffmpeg_capture_options(merged)
 
 
 @contextmanager

--- a/inference/core/interfaces/camera/rtsp_opencv_tls.py
+++ b/inference/core/interfaces/camera/rtsp_opencv_tls.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import os
 import threading
 from contextlib import contextmanager
-from typing import Dict, Iterator, Optional
+from typing import Dict, Iterator, Optional, Union
 
 from inference.core.interfaces.camera.rtsp_tls import (
     GST_SSL_CA_CERTIFICATE_ENV_VAR,
@@ -67,7 +67,7 @@ def merge_opencv_ffmpeg_capture_options(
     return _format_opencv_ffmpeg_capture_options(merged)
 
 
-def build_opencv_ffmpeg_capture_options(video: str) -> Optional[str]:
+def build_opencv_ffmpeg_capture_options(video: Union[str, int]) -> Optional[str]:
     """Build OPENCV_FFMPEG_CAPTURE_OPTIONS for RTSPS sources."""
     if not is_rtsps_url(video):
         return None
@@ -80,12 +80,13 @@ def build_opencv_ffmpeg_capture_options(video: str) -> Optional[str]:
 
 
 @contextmanager
-def opencv_rtsps_tls_env(video: str) -> Iterator[None]:
+def opencv_rtsps_tls_env(video: Union[str, int]) -> Iterator[None]:
     """Hold OPENCV_FFMPEG_CAPTURE_OPTIONS for one VideoCapture open.
 
     OpenCV reads this env var at capture-open time. The lock spans set →
     VideoCapture open → restore so concurrent RTSPS sources cannot clobber each
-    other's TLS options.
+    other's TLS options. Isolation is RTSPS-vs-RTSPS only; concurrent non-RTSPS
+    opens do not take the lock and may briefly inherit these options.
     """
     options = build_opencv_ffmpeg_capture_options(video)
     if options is None:

--- a/inference/core/interfaces/camera/video_source.py
+++ b/inference/core/interfaces/camera/video_source.py
@@ -37,6 +37,7 @@ from inference.core.interfaces.camera.exceptions import (
     StreamOperationNotAllowedError,
 )
 from inference.core.interfaces.camera.rtsp_opencv_tls import opencv_rtsps_tls_env
+from inference.core.interfaces.camera.rtsp_tls import is_rtsps_url
 from inference.core.interfaces.camera.source_reference_sanitizer import (
     redact_credentials_in_text,
     sanitize_source_reference,
@@ -153,6 +154,8 @@ class CV2VideoFrameProducer(VideoFrameProducer):
         with opencv_rtsps_tls_env(video), capture_process_stderr() as captured_stderr:
             if _consumes_camera_on_jetson(video=video):
                 self.stream = cv2.VideoCapture(video, cv2.CAP_V4L2)
+            elif isinstance(video, str) and is_rtsps_url(video):
+                self.stream = cv2.VideoCapture(video, cv2.CAP_FFMPEG)
             else:
                 self.stream = cv2.VideoCapture(video)
         self._connection_error_message = extract_stream_open_error(

--- a/inference/core/interfaces/camera/video_source.py
+++ b/inference/core/interfaces/camera/video_source.py
@@ -36,6 +36,7 @@ from inference.core.interfaces.camera.exceptions import (
     EndOfStreamError,
     StreamOperationNotAllowedError,
 )
+from inference.core.interfaces.camera.rtsp_opencv_tls import opencv_rtsps_tls_env
 from inference.core.interfaces.camera.source_reference_sanitizer import (
     redact_credentials_in_text,
     sanitize_source_reference,
@@ -149,7 +150,7 @@ class CV2VideoFrameProducer(VideoFrameProducer):
     def __init__(self, video: Union[str, int]):
         self._source_ref = video
         self._connection_error_message = ""
-        with capture_process_stderr() as captured_stderr:
+        with opencv_rtsps_tls_env(video), capture_process_stderr() as captured_stderr:
             if _consumes_camera_on_jetson(video=video):
                 self.stream = cv2.VideoCapture(video, cv2.CAP_V4L2)
             else:

--- a/inference/core/interfaces/camera/video_source.py
+++ b/inference/core/interfaces/camera/video_source.py
@@ -146,11 +146,20 @@ def lock_state_transition(
     return locked_executor
 
 
+# VideoCapture open mutates process-global state (OPENCV_FFMPEG_CAPTURE_OPTIONS
+# and stderr fd 2). Serialize so concurrent cameras cannot clobber each other.
+_capture_open_lock = Lock()
+
+
 class CV2VideoFrameProducer(VideoFrameProducer):
     def __init__(self, video: Union[str, int]):
         self._source_ref = video
         self._connection_error_message = ""
-        with opencv_rtsps_tls_env(video), capture_process_stderr() as captured_stderr:
+        with (
+            _capture_open_lock,
+            opencv_rtsps_tls_env(video),
+            capture_process_stderr() as captured_stderr,
+        ):
             if _consumes_camera_on_jetson(video=video):
                 self.stream = cv2.VideoCapture(video, cv2.CAP_V4L2)
             else:

--- a/inference/core/interfaces/camera/video_source.py
+++ b/inference/core/interfaces/camera/video_source.py
@@ -146,20 +146,11 @@ def lock_state_transition(
     return locked_executor
 
 
-# VideoCapture open mutates process-global state (OPENCV_FFMPEG_CAPTURE_OPTIONS
-# and stderr fd 2). Serialize so concurrent cameras cannot clobber each other.
-_capture_open_lock = Lock()
-
-
 class CV2VideoFrameProducer(VideoFrameProducer):
     def __init__(self, video: Union[str, int]):
         self._source_ref = video
         self._connection_error_message = ""
-        with (
-            _capture_open_lock,
-            opencv_rtsps_tls_env(video),
-            capture_process_stderr() as captured_stderr,
-        ):
+        with opencv_rtsps_tls_env(video), capture_process_stderr() as captured_stderr:
             if _consumes_camera_on_jetson(video=video):
                 self.stream = cv2.VideoCapture(video, cv2.CAP_V4L2)
             else:

--- a/tests/inference/unit_tests/core/interfaces/camera/test_rtsp_opencv_tls.py
+++ b/tests/inference/unit_tests/core/interfaces/camera/test_rtsp_opencv_tls.py
@@ -30,6 +30,8 @@ def test_build_options_rtsps_default_strict_verify(
     assert got is not None
     assert "rtsp_transport;tcp" in got
     assert "tls_verify;1" in got
+    assert "stimeout;5000000" in got
+    assert "timeout;5000000" in got
 
 
 def test_build_options_rtsps_with_ca(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/inference/unit_tests/core/interfaces/camera/test_rtsp_opencv_tls.py
+++ b/tests/inference/unit_tests/core/interfaces/camera/test_rtsp_opencv_tls.py
@@ -96,8 +96,19 @@ def test_build_options_merges_existing_env(
     got = build_opencv_ffmpeg_capture_options("rtsps://cam/stream")
     assert got is not None
     assert "stimeout;5000000" in got
+    assert "timeout;5000000" in got
     assert "rtsp_transport;tcp" in got
     assert "tls_verify;1" in got
+
+
+def test_build_options_fills_stimeout_when_only_timeout_present(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(OPENCV_FFMPEG_CAPTURE_OPTIONS_ENV_VAR, "timeout;5000000")
+    got = build_opencv_ffmpeg_capture_options("rtsps://cam/stream")
+    assert got is not None
+    assert "stimeout;5000000" in got
+    assert "timeout;5000000" in got
 
 
 def test_rtsp_tls_validation_flags_gstreamer_suffix(

--- a/tests/inference/unit_tests/core/interfaces/camera/test_video_source.py
+++ b/tests/inference/unit_tests/core/interfaces/camera/test_video_source.py
@@ -1994,3 +1994,42 @@ def test_cv2_producer_leaves_ffmpeg_tls_env_unset_for_device_index(
     assert seen["video"] == 0
     assert seen["env"] is None
     assert OPENCV_FFMPEG_CAPTURE_OPTIONS_ENV_VAR not in os.environ
+
+
+def test_cv2_producer_non_rtsps_open_does_not_wait_on_stuck_rtsps(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(OPENCV_FFMPEG_CAPTURE_OPTIONS_ENV_VAR, raising=False)
+    monkeypatch.delenv(RTSP_TLS_VALIDATION_FLAGS_ENV_VAR, raising=False)
+    rtsps_entered = Event()
+    release_rtsps = Event()
+    non_rtsps_opened = Event()
+
+    def fake_video_capture(video, *args, **kwargs):
+        if isinstance(video, str) and video.startswith("rtsps://"):
+            rtsps_entered.set()
+            assert release_rtsps.wait(timeout=2.0)
+        else:
+            non_rtsps_opened.set()
+        return MagicMock()
+
+    with patch.object(video_source.cv2, "VideoCapture", fake_video_capture):
+        rtsps_thread = Thread(
+            target=lambda: CV2VideoFrameProducer("rtsps://camera.example/stream")
+        )
+        rtsps_thread.start()
+        assert rtsps_entered.wait(timeout=1.0)
+
+        non_rtsps_thread = Thread(target=lambda: CV2VideoFrameProducer(0))
+        non_rtsps_thread.start()
+        opened_without_waiting = non_rtsps_opened.wait(timeout=1.0)
+
+        release_rtsps.set()
+        rtsps_thread.join(timeout=2.0)
+        non_rtsps_thread.join(timeout=2.0)
+
+    assert opened_without_waiting, (
+        "USB/file/V4L2 opens must not wait on a stuck RTSPS VideoCapture"
+    )
+    assert not rtsps_thread.is_alive()
+    assert not non_rtsps_thread.is_alive()

--- a/tests/inference/unit_tests/core/interfaces/camera/test_video_source.py
+++ b/tests/inference/unit_tests/core/interfaces/camera/test_video_source.py
@@ -1,4 +1,5 @@
 import importlib
+import os
 import time
 from datetime import datetime
 from functools import partial
@@ -25,6 +26,10 @@ from inference.core.interfaces.camera.exceptions import (
     SourceConnectionError,
     StreamOperationNotAllowedError,
 )
+from inference.core.interfaces.camera.rtsp_opencv_tls import (
+    OPENCV_FFMPEG_CAPTURE_OPTIONS_ENV_VAR,
+)
+from inference.core.interfaces.camera.rtsp_tls import RTSP_TLS_VALIDATION_FLAGS_ENV_VAR
 from inference.core.interfaces.camera.stream_error_codes import StreamErrorCode
 from inference.core.interfaces.camera.video_source import (
     BufferConsumptionStrategy,
@@ -1917,3 +1922,26 @@ def test_consume_video_emits_poison_pill_on_consume_error() -> None:
     assert source._state is StreamState.ERROR
     with pytest.raises(EndOfStreamError):
         source.read_frame(timeout=0.0)
+
+
+def test_cv2_producer_sets_ffmpeg_tls_options_only_for_rtsps(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # given
+    monkeypatch.delenv(OPENCV_FFMPEG_CAPTURE_OPTIONS_ENV_VAR, raising=False)
+    monkeypatch.delenv(RTSP_TLS_VALIDATION_FLAGS_ENV_VAR, raising=False)
+    seen = {}
+
+    def fake_video_capture(video, *args, **kwargs):
+        seen[video] = os.environ.get(OPENCV_FFMPEG_CAPTURE_OPTIONS_ENV_VAR)
+        return MagicMock()
+
+    # when
+    with patch.object(video_source.cv2, "VideoCapture", fake_video_capture):
+        CV2VideoFrameProducer("rtsps://camera.example/stream")
+        CV2VideoFrameProducer("rtsp://camera.example/stream")
+
+    # then - OpenCV reads the env var at capture-open time, so it must be set
+    # while VideoCapture runs for RTSPS, and left alone for plain RTSP
+    assert "tls_verify;1" in seen["rtsps://camera.example/stream"]
+    assert seen["rtsp://camera.example/stream"] is None

--- a/tests/inference/unit_tests/core/interfaces/camera/test_video_source.py
+++ b/tests/inference/unit_tests/core/interfaces/camera/test_video_source.py
@@ -1945,3 +1945,52 @@ def test_cv2_producer_sets_ffmpeg_tls_options_only_for_rtsps(
     # while VideoCapture runs for RTSPS, and left alone for plain RTSP
     assert "tls_verify;1" in seen["rtsps://camera.example/stream"]
     assert seen["rtsp://camera.example/stream"] is None
+    assert OPENCV_FFMPEG_CAPTURE_OPTIONS_ENV_VAR not in os.environ
+
+
+def test_cv2_producer_restores_ffmpeg_tls_env_after_open(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(OPENCV_FFMPEG_CAPTURE_OPTIONS_ENV_VAR, raising=False)
+    monkeypatch.delenv(RTSP_TLS_VALIDATION_FLAGS_ENV_VAR, raising=False)
+
+    with patch.object(video_source.cv2, "VideoCapture", MagicMock()):
+        CV2VideoFrameProducer("rtsps://camera.example/stream")
+
+    assert OPENCV_FFMPEG_CAPTURE_OPTIONS_ENV_VAR not in os.environ
+
+
+def test_cv2_producer_restores_ffmpeg_tls_env_when_capture_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(OPENCV_FFMPEG_CAPTURE_OPTIONS_ENV_VAR, raising=False)
+    monkeypatch.delenv(RTSP_TLS_VALIDATION_FLAGS_ENV_VAR, raising=False)
+
+    def failing_video_capture(*args, **kwargs):
+        raise RuntimeError("simulated open failure")
+
+    with patch.object(
+        video_source.cv2, "VideoCapture", failing_video_capture
+    ), pytest.raises(RuntimeError):
+        CV2VideoFrameProducer("rtsps://camera.example/stream")
+
+    assert OPENCV_FFMPEG_CAPTURE_OPTIONS_ENV_VAR not in os.environ
+
+
+def test_cv2_producer_leaves_ffmpeg_tls_env_unset_for_device_index(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(OPENCV_FFMPEG_CAPTURE_OPTIONS_ENV_VAR, raising=False)
+    seen = {}
+
+    def fake_video_capture(video, *args, **kwargs):
+        seen["video"] = video
+        seen["env"] = os.environ.get(OPENCV_FFMPEG_CAPTURE_OPTIONS_ENV_VAR)
+        return MagicMock()
+
+    with patch.object(video_source.cv2, "VideoCapture", fake_video_capture):
+        CV2VideoFrameProducer(0)
+
+    assert seen["video"] == 0
+    assert seen["env"] is None
+    assert OPENCV_FFMPEG_CAPTURE_OPTIONS_ENV_VAR not in os.environ


### PR DESCRIPTION
# Description

Hardens the OpenCV/FFmpeg RTSPS path wired in inference#2776 (ENT-1677).

**Changes:**
1. **ENT-1686:** Default FFmpeg `stimeout` (5s) on RTSPS opens so one unreachable camera cannot hold the global TLS env lock for minutes.
2. **ENT-1687:** Pin `cv2.CAP_FFMPEG` for `rtsps://` URLs so `OPENCV_FFMPEG_CAPTURE_OPTIONS` cannot be silently ignored by another backend. Log a warning when `tls_validation_flags=126` (`allow_self_signed`) maps to full `tls_verify=0` on FFmpeg (weaker than GStreamer's partial mode — documented, permanent product choice).

**Depends on:** inference#2776 — merge that first, then this.

Linear: [ENT-1686](https://linear.app/roboflow/issue/ENT-1686), [ENT-1687](https://linear.app/roboflow/issue/ENT-1687)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Maintenance (non-breaking, non-user facing changing such as dependency update, adding test, modifying secrets, etc.)
- [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

- `test_build_options_rtsps_default_strict_verify` — asserts default options include `stimeout;5000000`.
- Inherits `test_cv2_producer_sets_ffmpeg_tls_options_only_for_rtsps` from #2776.
- CI unit/integration suites on rebased stack.

## Will the change affect Universe? If so was this change tested in universe?

No. Edge inference pipeline path only.

## Any specific deployment considerations

Ship in the same inference release as #2776 (or immediately after). No config migrations.

## Docs

- [ ] Docs updated? What were the changes: N/A