### PR TITLE
Add cell-aware video processor contracts

### DIFF
--- a/development/video_poc/HANDOFF.md
+++ b/development/video_poc/HANDOFF.md
@@ -671,7 +671,10 @@ staging-only gates; none of these branches has been deployed:
   `c1a.16x` nodes, so it does not schedule onto or alter the active L40S capacity
   campaign. It requires observed connector, preview, claim, relay, pod/node,
   Prometheus, network, and bounded failure/recovery evidence rather than
-  accepting requested placement as proof.
+  accepting requested placement as proof. Stacked infra draft
+  [roboflow-infra#2461](https://github.com/roboflow/roboflow-infra/pull/2461)
+  prepares only the isolated East benchmark namespace/ServiceAccount; it does
+  not touch the live East video-processing release or active source.
 
 No second-cell resources, DNS, Kubernetes objects, functions, or test jobs had
 been applied when this status was written. The South stack, DNS, East identity

--- a/development/video_poc/HANDOFF.md
+++ b/development/video_poc/HANDOFF.md
@@ -627,6 +627,49 @@ Decisions and direction that came out of team review — this is current intent,
 yet all implemented. The detailed scaling plan, benchmarks, rollout gates, and open
 questions live in [MULTI_CELL_SCALING_RFC.md](MULTI_CELL_SCALING_RFC.md).
 
+### Multi-cell implementation status (2026-08-13)
+
+Phase 1 is implemented on isolated, not-yet-deployed branches and Phase 2 is
+prepared behind staging-only gates:
+
+- the Roboflow control plane has an explicit deployed-config cell registry,
+  per-workspace preferred/dedicated policy, transactional first activation,
+  persisted source/job placement and generations, cell-specific URLs,
+  cell-bound relay and fleet identities, cell+tier claim rechecks, explicit
+  idle reassignment/remote-experiment primitives, and a staging-only scheduled
+  orphan reaper. The first control-plane rollout registers only
+  `crusoe-use1`; missing placement remains a default-cell compatibility path;
+- the processor reads immutable `VIDEO_PROC_CELL` identity once at startup,
+  asserts it on platform calls, and rejects mismatched or implicit cross-cell
+  claims before registering a token, constructing a run, touching media, or
+  detaching a ready-pool pod. Health, runtime telemetry, and bounded Prometheus
+  identity expose the cell. Legacy unplaced jobs still run during migration;
+- connector draft
+  [rf-video-connector#2](https://github.com/roboflow/rf-video-connector/pull/2)
+  keeps selection server-side, reports cell/generation, fences stale route
+  commands, and redacts credentialed media URLs;
+- the infrastructure branch models `crusoe-ussc1` as a separate staging-only
+  South Central cell stack. It starts `unavailable`, with processors disabled,
+  cell-specific credentials/subscription, exact relay/gateway/processor node
+  classes, explicit `.one` endpoints, RTSPS for the opt-in WAN experiment,
+  and per-cell monitoring. Production renders are unchanged. The existing East
+  release changes only by injecting `VIDEO_PROC_CELL=crusoe-use1` when the
+  cell-aware processor rolls out;
+- the schema-v2 two-cell renderer in
+  [`benchmarks/networking/`](benchmarks/networking/) emits separate East/South
+  Job lists plus a redacted evidence/report contract. The example uses only
+  `c1a.16x` nodes, so it does not schedule onto or alter the active L40S capacity
+  campaign. It requires observed connector, preview, claim, relay, pod/node,
+  Prometheus, network, and bounded failure/recovery evidence rather than
+  accepting requested placement as proof.
+
+No second-cell resources, DNS, Kubernetes objects, functions, or test jobs had
+been applied when this status was written. The South stack, DNS, East identity
+rollout, processor activation, failure injection, and benchmark Jobs remain
+separate staging-write approval gates. The active connector source used by the
+L40S campaign must not be repointed; validation uses new short-lived test
+sources and Secret references.
+
 - **A live source gets a sticky home cell on first activation.** Registration remains
   metadata-only. The first preview or live job transactionally selects and persists a
   cell/relay shard; ordinary jobs inherit it so connector ingest, relay fan-out, and
@@ -706,14 +749,23 @@ questions live in [MULTI_CELL_SCALING_RFC.md](MULTI_CELL_SCALING_RFC.md).
    claim, ready pools, orphan requeue, per-job processor tokens, multiple workflows
    per source, up to four jobs per worker, GCS batch results, and relay-published
    watched outputs.
-3. Next: complete Phase 0 of
+3. The single-L40S capacity campaign remains a separate workstream. Do not
+   replace its image, configuration, source, or placement while advancing the
+   multi-cell branches.
+4. Review and merge the Phase 1 cell-aware control-plane and processor contracts,
+   deploy them with only East registered, and prove a wrong-cell synthetic worker
+   cannot claim East work. The Firestore index must precede the functions rollout;
+   the East worker identity follows the functions compatibility rollout.
+5. After staging-write approval, create the South relay-first cell while it is
+   unavailable and processor-disabled, add its three DNS records, and prove relay
+   auth/transport/monitoring with a new test source. Only then bind its cell secret,
+   register it, enable one CPU/GPU worker, and run the two-cell report contract.
+6. Continue Phase 0 capacity work from
    [MULTI_CELL_SCALING_RFC.md](MULTI_CELL_SCALING_RFC.md): agree on SLOs; review,
    merge the already-applied staging MediaMTX observability chart from infra
    [#2443](https://github.com/roboflow/roboflow-infra/pull/2443); deploy and
    validate the aggregate processor telemetry overlay; then run the controlled
    FPS, multi-workspace, MPS/MMP, recovery, mixed-workload, and soak matrices.
    A production apply remains a separate approval step.
-4. Then introduce cell-aware source/job contracts while only East is registered;
-   prove claim isolation before deploying a second non-production cell.
-5. Remaining adjacent hardening: job-addressed live events, connector-source polish,
+7. Remaining adjacent hardening: job-addressed live events, connector-source polish,
    recording/metering, and externalizable state for seamless stateful recovery.

--- a/development/video_poc/HANDOFF.md
+++ b/development/video_poc/HANDOFF.md
@@ -641,6 +641,10 @@ staging-only gates; none of these branches has been deployed:
   idle reassignment/remote-experiment primitives, and a staging-only scheduled
   orphan reaper. The first control-plane rollout registers only
   `crusoe-use1`; missing placement remains a default-cell compatibility path;
+- stacked staging-config draft
+  [roboflow#14445](https://github.com/roboflow/roboflow/pull/14445) adds the
+  explicit South registry entry as `unavailable` and binds its cell-specific
+  secret name only after the infra prerequisite exists;
 - processor/harness draft
   [inference#2793](https://github.com/roboflow/inference/pull/2793) reads
   immutable `VIDEO_PROC_CELL` identity once at startup,

--- a/development/video_poc/HANDOFF.md
+++ b/development/video_poc/HANDOFF.md
@@ -629,17 +629,21 @@ questions live in [MULTI_CELL_SCALING_RFC.md](MULTI_CELL_SCALING_RFC.md).
 
 ### Multi-cell implementation status (2026-08-13)
 
-Phase 1 is implemented on isolated, not-yet-deployed branches and Phase 2 is
-prepared behind staging-only gates:
+Phase 1 is implemented in review-only draft PRs and Phase 2 is prepared behind
+staging-only gates; none of these branches has been deployed:
 
-- the Roboflow control plane has an explicit deployed-config cell registry,
+- control-plane draft
+  [roboflow#14444](https://github.com/roboflow/roboflow/pull/14444) has an
+  explicit deployed-config cell registry,
   per-workspace preferred/dedicated policy, transactional first activation,
   persisted source/job placement and generations, cell-specific URLs,
   cell-bound relay and fleet identities, cell+tier claim rechecks, explicit
   idle reassignment/remote-experiment primitives, and a staging-only scheduled
   orphan reaper. The first control-plane rollout registers only
   `crusoe-use1`; missing placement remains a default-cell compatibility path;
-- the processor reads immutable `VIDEO_PROC_CELL` identity once at startup,
+- processor/harness draft
+  [inference#2793](https://github.com/roboflow/inference/pull/2793) reads
+  immutable `VIDEO_PROC_CELL` identity once at startup,
   asserts it on platform calls, and rejects mismatched or implicit cross-cell
   claims before registering a token, constructing a run, touching media, or
   detaching a ready-pool pod. Health, runtime telemetry, and bounded Prometheus
@@ -648,8 +652,10 @@ prepared behind staging-only gates:
   [rf-video-connector#2](https://github.com/roboflow/rf-video-connector/pull/2)
   keeps selection server-side, reports cell/generation, fences stale route
   commands, and redacts credentialed media URLs;
-- the infrastructure branch models `crusoe-ussc1` as a separate staging-only
-  South Central cell stack. It starts `unavailable`, with processors disabled,
+- infrastructure draft
+  [roboflow-infra#2460](https://github.com/roboflow/roboflow-infra/pull/2460)
+  models `crusoe-ussc1` as a separate staging-only South Central cell stack. It
+  starts `unavailable`, with processors disabled,
   cell-specific credentials/subscription, exact relay/gateway/processor node
   classes, explicit `.one` endpoints, RTSPS for the opt-in WAN experiment,
   and per-cell monitoring. Production renders are unchanged. The existing East

--- a/development/video_poc/MULTI_CELL_SCALING_RFC.md
+++ b/development/video_poc/MULTI_CELL_SCALING_RFC.md
@@ -537,6 +537,43 @@ not yet an approved target.
 
 ## Rollout plan
 
+### Implementation checkpoint (2026-08-13)
+
+The summary invariants above were checked against the current code rather than
+treated as an implementation specification. Registration was already
+metadata-only and the connector already consumed a complete server-issued ingest
+URL. The minimum safe change was therefore to make placement, identity, relay
+authorization, URL resolution, and claims explicit—not to add cell selection to
+the connector.
+
+Phase 1 code now exists on isolated review branches but is not deployed. It uses
+an East-only explicit registry first, transactional first activation, persisted
+placement metadata, generation-aware connector reports/commands, per-cell fleet
+credentials, a deployment-fixed relay auth cell, transactional cell+tier claim
+filters, wrong-cell processor rejection, legacy default-cell interpretation, and
+a bounded scheduled reaper. Emulator-backed tests exercise simultaneous preview
+and job activation against two eligible test cells and prove one committed source
+assignment; local execution still depends on the repository's current Node
+dependency overlay being available.
+
+Phase 2 infrastructure is prepared, not applied. The chosen cell is
+`crusoe-ussc1` on `ck8s-stg-us-southcentral1`. Its own stack begins
+`unavailable` with both processor pools disabled, non-runnable image placeholders,
+cell-specific credentials/subscription, fixed c1a.16x relay/gateway placement,
+fixed processor node classes, `.one` endpoints, metrics/dashboard coverage, and
+a default-off RTSPS listener for an explicitly authorized South-origin WAN read.
+The production Helm render is byte-for-byte unchanged. The East render changes
+only by adding immutable processor identity; the active L40S capacity settings
+and source are outside this workstream.
+
+The two-cell validation renderer is staging-only and offline. It emits separate
+East/South Job lists and requires actual pod/node/cluster/cell, connector route,
+preview, claim, MediaMTX session/reader, processor, latency/loss/bandwidth/egress,
+and failure/recovery evidence. Its cross-cell case is South origin to an East
+CPU reader; it never mutates the East relay or schedules onto L40S. Applying the
+cell, DNS, functions, benchmark prerequisites/Jobs, network impairment, or
+failure experiment still requires the documented staging approval.
+
 ### Phase 0: RFC, instrumentation, and baseline
 
 - agree on terminology, invariants, and SLOs;
@@ -564,6 +601,10 @@ bottlenecks.
 **Gate:** all existing behavior works with one registered cell, and a synthetic
 worker from another cell cannot claim East work.
 
+**Current status:** implemented and locally validated; review, Firestore index,
+East-only functions rollout, East processor identity rollout, and live synthetic
+claim-isolation evidence remain.
+
 ### Phase 2: Second non-production cell
 
 - deploy a second staging/performance cell;
@@ -574,6 +615,10 @@ worker from another cell cannot claim East work.
 
 **Gate:** deterministic two-cell operation with no cross-cell misclaims or missing
 local streams.
+
+**Current status:** repeatable South cell and deterministic validation contracts
+are prepared with processors default-off. No South resource/DNS/function binding
+or benchmark Job has been applied, and no two-cell validation result is claimed.
 
 ### Phase 3: Workload-aware admission and fairness
 
@@ -615,12 +660,16 @@ security, and cost envelope.
 
 1. What initial SLOs define acceptable preview startup, delivered FPS,
    decode-to-result latency, relay loss, and recovery time?
-2. Is the first second cell another Crusoe region, GCP, or a performance-only
-   environment?
-3. Where should the cell registry live initially: deployed configuration,
-   Firestore, or an existing infrastructure/service registry?
-4. What is the stable cell identity presented by a fleet worker, and how does the
-   platform verify it rather than trusting request data?
+2. ~~Is the first second cell another Crusoe region, GCP, or a performance-only
+   environment?~~ **Resolved for Phase 2:** Crusoe South Central staging,
+   `crusoe-ussc1`; this is not a production-region commitment.
+3. ~~Where should the cell registry live initially: deployed configuration,
+   Firestore, or an existing infrastructure/service registry?~~ **Resolved for
+   Phase 1:** validated deployed configuration behind one registry adapter.
+4. ~~What is the stable cell identity presented by a fleet worker, and how does the
+   platform verify it rather than trusting request data?~~ **Resolved for Phase
+   1:** immutable `VIDEO_PROC_CELL` plus a cell-scoped fleet secret; the body cell
+   is only a matching assertion and cannot grant placement.
 5. What workspace placement modes are product commitments versus internal testing
    controls?
 6. Which metrics are available from Crusoe LoadBalancers and GPU nodes, and what

--- a/development/video_poc/MULTI_CELL_SCALING_RFC.md
+++ b/development/video_poc/MULTI_CELL_SCALING_RFC.md
@@ -562,7 +562,10 @@ dependency overlay being available.
 
 Phase 2 infrastructure is prepared in draft
 [roboflow-infra#2460](https://github.com/roboflow/roboflow-infra/pull/2460), not
-applied. The chosen cell is `crusoe-ussc1` on
+applied. Stacked staging-config draft
+[roboflow#14445](https://github.com/roboflow/roboflow/pull/14445) registers the
+South cell as `unavailable` and binds only its cell-specific secret name after
+that infra prerequisite. The chosen cell is `crusoe-ussc1` on
 `ck8s-stg-us-southcentral1`. Its own stack begins
 `unavailable` with both processor pools disabled, non-runnable image placeholders,
 cell-specific credentials/subscription, fixed c1a.16x relay/gateway placement,

--- a/development/video_poc/MULTI_CELL_SCALING_RFC.md
+++ b/development/video_poc/MULTI_CELL_SCALING_RFC.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 
-**Last updated:** 2026-08-10
+**Last updated:** 2026-08-13
 
 **Scope:** Live connector sources, MediaMTX relay capacity, processor placement,
 multi-stream GPU allocation, dedicated cells, and remote execution experiments
@@ -546,7 +546,11 @@ URL. The minimum safe change was therefore to make placement, identity, relay
 authorization, URL resolution, and claims explicit—not to add cell selection to
 the connector.
 
-Phase 1 code now exists on isolated review branches but is not deployed. It uses
+Phase 1 code is in control-plane draft
+[roboflow#14444](https://github.com/roboflow/roboflow/pull/14444) and
+processor/harness draft
+[inference#2793](https://github.com/roboflow/inference/pull/2793), but is not
+deployed. It uses
 an East-only explicit registry first, transactional first activation, persisted
 placement metadata, generation-aware connector reports/commands, per-cell fleet
 credentials, a deployment-fixed relay auth cell, transactional cell+tier claim
@@ -556,8 +560,10 @@ and job activation against two eligible test cells and prove one committed sourc
 assignment; local execution still depends on the repository's current Node
 dependency overlay being available.
 
-Phase 2 infrastructure is prepared, not applied. The chosen cell is
-`crusoe-ussc1` on `ck8s-stg-us-southcentral1`. Its own stack begins
+Phase 2 infrastructure is prepared in draft
+[roboflow-infra#2460](https://github.com/roboflow/roboflow-infra/pull/2460), not
+applied. The chosen cell is `crusoe-ussc1` on
+`ck8s-stg-us-southcentral1`. Its own stack begins
 `unavailable` with both processor pools disabled, non-runnable image placeholders,
 cell-specific credentials/subscription, fixed c1a.16x relay/gateway placement,
 fixed processor node classes, `.one` endpoints, metrics/dashboard coverage, and

--- a/development/video_poc/MULTI_CELL_SCALING_RFC.md
+++ b/development/video_poc/MULTI_CELL_SCALING_RFC.md
@@ -582,6 +582,8 @@ and failure/recovery evidence. Its cross-cell case is South origin to an East
 CPU reader; it never mutates the East relay or schedules onto L40S. Applying the
 cell, DNS, functions, benchmark prerequisites/Jobs, network impairment, or
 failure experiment still requires the documented staging approval.
+The isolated East benchmark namespace prerequisite is review-only in
+[roboflow-infra#2461](https://github.com/roboflow/roboflow-infra/pull/2461).
 
 ### Phase 0: RFC, instrumentation, and baseline
 

--- a/development/video_poc/benchmarks/networking/README.md
+++ b/development/video_poc/benchmarks/networking/README.md
@@ -10,6 +10,16 @@ dedicated namespace containing `bench`. The renderer never invokes `kubectl`.
 It writes a Kubernetes JSON `List` for operator inspection plus a redacted run
 manifest. Kubernetes accepts the JSON list anywhere it accepts YAML.
 
+`render_two_cell_validation.py` adds the Phase 1/2 routing-validation contract.
+It remains render-only and writes one Job list per staging cell, a redacted
+collection manifest, and an initially empty validation-report template. The
+South+East example is `two-cell-south-east.staging.example.json`.
+It uses the canonical `crusoe-use1` / `crusoe-ussc1` cell IDs and
+`ck8s-stg` / `ck8s-stg-us-southcentral1` contexts. The explicit WAN case is
+South-origin to an East `c1a.16x` CPU reader through the South public RTSPS
+endpoint; it neither schedules on nor requires changes to the active East L40S
+capacity fleet.
+
 ## Contract
 
 The version 1 scenario declares:
@@ -59,6 +69,13 @@ node name against Kubernetes node inventory and add the actual instance type to
 the aggregate run report. Child maximum RSS is explicitly reported in KiB,
 matching the Linux load-agent contract.
 
+For two-cell runs the agent also records the expected cell, expected cluster
+context, media-path name, and whether the path is same-cell or explicitly
+cross-cell. These are requested assertions, not observed truth. The collection
+contract requires the controller to join each Pod UID and node name with the
+actual cluster, node labels, image ID, and cell release before marking placement
+as proven.
+
 `read-copy` keeps decode CPU out of capacity curves. Use a small
 `read-decode` group to enforce the fixture FPS and catch media corruption or
 continuity problems.
@@ -79,6 +96,42 @@ Inspect `run-manifest.json` and `jobs.json`. In particular, verify the current
 Kubernetes context independently, requested node placement, immutable image,
 fixture hash/FPS, job count, active deadline, resource bounds, and cleanup
 selector. Rendering makes no cluster changes.
+
+## Render a deterministic two-cell validation
+
+Copy the South+East example and replace every placeholder, including the agent
+digest, cell endpoint Secret references, fixture hash, cluster contexts,
+instance types, release/config hashes, and evidence artifact paths. Endpoint,
+fixture, monitoring, and control-plane values are accepted only through
+Kubernetes Secret name/key references.
+
+```bash
+python development/video_poc/benchmarks/networking/render_two_cell_validation.py \
+  --scenario /path/to/two-cell-south-east.staging.json \
+  --run-id south-east-routing-001 \
+  --output-dir development/video_poc/benchmarks/results/south-east-routing-001
+```
+
+Inspect `jobs-east.json`, `jobs-south.json`, `validation-manifest.json`, and
+`validation-report.template.json`. The scenario must explicitly declare:
+
+- exactly two recognizable staging contexts and dedicated benchmark namespaces;
+- cell-specific ingest, internal consume, public consume, preview, processor,
+  and Prometheus endpoint Secret references;
+- first-activation, reconnect-stickiness, and dedicated-workspace evidence
+  cases;
+- both local media paths and a separately authorized
+  `explicit-cross-cell`/`remoteExecution=true` experiment;
+- baseline and impaired latency/loss/bandwidth/egress profiles; and
+- an approval-gated failure experiment with recovery timeline and rollback
+  artifacts.
+
+The rendered manifest contains read-only placement collection argument vectors,
+required MediaMTX/processor/Prometheus/network evidence, per-cell cleanup
+commands, and the failure-event timeline schema. Rendering does not execute any
+of those commands. Applying either Job list, changing network impairment,
+running a failure experiment, or revoking credentials remains an operator-owned
+staging mutation requiring the normal approval and rollback review.
 
 Once the dedicated staging benchmark cell and short-lived media Secret exist,
 an operator can apply the inspected manifest:

--- a/development/video_poc/benchmarks/networking/relay_agent.py
+++ b/development/video_poc/benchmarks/networking/relay_agent.py
@@ -356,6 +356,10 @@ def _placement():
             "REQUESTED_NODE_INSTANCE_TYPE"
         ),
         "requestedImageReference": os.environ.get("AGENT_IMAGE_REFERENCE"),
+        "expectedCell": os.environ.get("EXPECTED_CELL_ID"),
+        "expectedClusterContext": os.environ.get("EXPECTED_CLUSTER_CONTEXT"),
+        "mediaPath": os.environ.get("MEDIA_PATH"),
+        "mediaPathKind": os.environ.get("MEDIA_PATH_KIND"),
     }
 
 

--- a/development/video_poc/benchmarks/networking/render_two_cell_validation.py
+++ b/development/video_poc/benchmarks/networking/render_two_cell_validation.py
@@ -1,0 +1,872 @@
+#!/usr/bin/env python3
+"""Render a staging-only, two-cell video-routing validation bundle.
+
+The renderer is deliberately offline. It creates one Kubernetes Job list per
+cell, a redacted evidence-collection manifest, and an empty report template. It
+never invokes Kubernetes, a control-plane API, Prometheus, or a credential
+issuer.
+"""
+
+import argparse
+import json
+import platform
+import sys
+import time
+from pathlib import Path, PurePosixPath
+
+from render_distributed_relay_benchmark import (
+    IMMUTABLE_IMAGE,
+    STAGING_CONTEXT,
+    _canonical_hash,
+    _limited_name,
+    _require_dns_label,
+    _secret_key_ref,
+    render_job,
+    resolve_run_id,
+)
+
+ENDPOINT_KEYS = (
+    "ingestTemplate",
+    "consumeInternalTemplate",
+    "consumePublicTemplate",
+    "previewBase",
+    "processorApiBase",
+    "prometheusBase",
+)
+ASSIGNMENT_CASE_KINDS = (
+    "first-activation",
+    "reconnect-stickiness",
+    "dedicated-workspace",
+    "preferred-workspace",
+    "cell-loss-recovery",
+)
+PATH_KINDS = ("same-cell", "explicit-cross-cell")
+FAILURE_TARGETS = ("mediamtx", "gateway", "processor-pool", "cell-network")
+CASE_ARTIFACT_KEYS = {
+    "first-activation": {
+        "registeredIdle",
+        "activated",
+        "connectorPublishEndpoint",
+        "previewProof",
+    },
+    "reconnect-stickiness": {
+        "beforeReconnect",
+        "afterReconnect",
+        "connectorPublishEndpoint",
+        "previewProof",
+    },
+    "dedicated-workspace": {
+        "policySnapshot",
+        "activated",
+        "connectorPublishEndpoint",
+        "previewProof",
+    },
+    "preferred-workspace": {"policySnapshot", "activated"},
+    "cell-loss-recovery": {
+        "cellLossStarted",
+        "unavailableObserved",
+        "reassignmentDecision",
+        "recovered",
+        "connectorPublishAfterRecovery",
+        "previewAfterRecovery",
+    },
+}
+PATH_EVIDENCE_KEYS = {
+    "processorClaimedCell",
+    "relaySessions",
+    "relayReaders",
+    "podPlacement",
+    "nodePlacement",
+    "metricsWindow",
+}
+
+
+def _positive(value, field, integer=False):
+    try:
+        normalized = int(value) if integer else float(value)
+    except (TypeError, ValueError) as error:
+        raise ValueError("%s must be numeric" % field) from error
+    if normalized <= 0:
+        raise ValueError("%s must be positive" % field)
+    return normalized
+
+
+def _non_negative(value, field):
+    try:
+        normalized = float(value)
+    except (TypeError, ValueError) as error:
+        raise ValueError("%s must be numeric" % field) from error
+    if normalized < 0:
+        raise ValueError("%s cannot be negative" % field)
+    return normalized
+
+
+def _artifact_ref(value, field):
+    """Accept only local, non-secret evidence paths in rendered reports."""
+
+    value = str(value or "")
+    path = PurePosixPath(value)
+    if (
+        not value
+        or path.is_absolute()
+        or ".." in path.parts
+        or "://" in value
+        or "?" in value
+        or "@" in value
+    ):
+        raise ValueError("%s must be a relative non-URL artifact path" % field)
+    return value
+
+
+def _resources(value, field):
+    value = value or {}
+    if not isinstance(value, dict):
+        raise ValueError("%s must be an object" % field)
+    return value
+
+
+def _strict_secret_ref(value, field):
+    if not isinstance(value, dict) or set(value) != {"name", "key"}:
+        raise ValueError(
+            "%s must contain only a Kubernetes Secret name and key" % field
+        )
+    return _secret_key_ref(value, field)
+
+
+def _load_cells(raw):
+    cells = {}
+    cell_ids = set()
+    for alias, value in (raw or {}).items():
+        alias = _require_dns_label(alias, "cell alias")
+        if not isinstance(value, dict):
+            raise ValueError("cell %s must be an object" % alias)
+        cell_id = _require_dns_label(value.get("cellId"), "cell.cellId")
+        if cell_id in cell_ids:
+            raise ValueError("cellId values must be unique")
+        context = str(value.get("clusterContext") or "")
+        if not STAGING_CONTEXT.search(context):
+            raise ValueError("every cell clusterContext must be recognizably staging")
+        namespace = _require_dns_label(value.get("namespace"), "cell.namespace")
+        if "bench" not in namespace:
+            raise ValueError(
+                "every cell namespace must be a dedicated benchmark namespace"
+            )
+        endpoints = value.get("endpoints") or {}
+        normalized_endpoints = {
+            key: _strict_secret_ref(endpoints.get(key), "cell.endpoints.%s" % key)
+            for key in ENDPOINT_KEYS
+        }
+        cells[alias] = {
+            "cellId": cell_id,
+            "provider": str(value.get("provider") or ""),
+            "region": str(value.get("region") or ""),
+            "clusterContext": context,
+            "namespace": namespace,
+            "serviceAccountName": _require_dns_label(
+                value.get("serviceAccountName", "video-relay-benchmark"),
+                "cell.serviceAccountName",
+            ),
+            "endpoints": normalized_endpoints,
+            "versions": value.get("versions") or {},
+        }
+        cell_ids.add(cell_id)
+    if len(cells) != 2:
+        raise ValueError("two-cell validation requires exactly two staging cells")
+    return cells
+
+
+def _load_locations(raw, cells):
+    locations = {}
+    for name, value in (raw or {}).items():
+        name = _require_dns_label(name, "location name")
+        if not isinstance(value, dict):
+            raise ValueError("location %s must be an object" % name)
+        cell = _require_dns_label(value.get("cell"), "location.cell")
+        if cell not in cells:
+            raise ValueError("location references unknown cell: %s" % cell)
+        node_selector = value.get("nodeSelector") or {}
+        node_name = value.get("nodeName")
+        if not node_selector and not node_name:
+            raise ValueError("location %s must declare nodeSelector or nodeName" % name)
+        locations[name] = {
+            "cell": cell,
+            "nodeSelector": node_selector,
+            "nodeName": node_name,
+            "tolerations": value.get("tolerations") or [],
+            "affinity": value.get("affinity"),
+            "annotations": value.get("annotations") or {},
+            "metadata": value.get("metadata") or {},
+        }
+    if not locations:
+        raise ValueError("scenario must define explicit locations")
+    return locations
+
+
+def _load_sources(raw, cells, locations):
+    sources = {}
+    for value in raw or []:
+        name = _require_dns_label(value.get("name"), "source.name")
+        if name in sources:
+            raise ValueError("source names must be unique")
+        home_cell = _require_dns_label(
+            value.get("expectedHomeCell"), "source.expectedHomeCell"
+        )
+        location = _require_dns_label(
+            value.get("publisherLocation"), "source.publisherLocation"
+        )
+        if home_cell not in cells:
+            raise ValueError("source references unknown expectedHomeCell")
+        if location not in locations or locations[location]["cell"] != home_cell:
+            raise ValueError(
+                "source publisherLocation must be in its expected home cell"
+            )
+        sources[name] = {
+            "name": name,
+            "expectedHomeCell": home_cell,
+            "publisherLocation": location,
+            "resources": _resources(value.get("resources"), "source.resources"),
+            "startAfterSeconds": _non_negative(
+                value.get("startAfterSeconds", 0), "source.startAfterSeconds"
+            ),
+        }
+    if len(sources) < 2:
+        raise ValueError("two-cell validation requires at least two sources")
+    return sources
+
+
+def _load_paths(raw, cells, locations, sources):
+    paths = []
+    names = set()
+    covered = set()
+    for value in raw or []:
+        name = _require_dns_label(value.get("name"), "mediaPath.name")
+        if name in names:
+            raise ValueError("mediaPath names must be unique")
+        kind = str(value.get("kind") or "")
+        if kind not in PATH_KINDS:
+            raise ValueError("mediaPath.kind must be same-cell or explicit-cross-cell")
+        source_name = _require_dns_label(value.get("source"), "mediaPath.source")
+        execution_cell = _require_dns_label(
+            value.get("executionCell"), "mediaPath.executionCell"
+        )
+        location = _require_dns_label(
+            value.get("readerLocation"), "mediaPath.readerLocation"
+        )
+        if source_name not in sources or execution_cell not in cells:
+            raise ValueError("mediaPath references an unknown source or cell")
+        if location not in locations or locations[location]["cell"] != execution_cell:
+            raise ValueError("mediaPath readerLocation must be in executionCell")
+        source_cell = sources[source_name]["expectedHomeCell"]
+        remote = value.get("remoteExecution") is True
+        endpoint = str(value.get("consumeEndpoint") or "")
+        if kind == "same-cell":
+            if execution_cell != source_cell or remote:
+                raise ValueError(
+                    "same-cell paths must be local and remoteExecution=false"
+                )
+            if endpoint != "consumeInternalTemplate":
+                raise ValueError("same-cell paths must use consumeInternalTemplate")
+        else:
+            if execution_cell == source_cell or not remote:
+                raise ValueError(
+                    "explicit-cross-cell paths require a different execution cell and remoteExecution=true"
+                )
+            if endpoint != "consumePublicTemplate":
+                raise ValueError("cross-cell paths must use consumePublicTemplate")
+        copies = _positive(
+            value.get("copyReaders", 1), "mediaPath.copyReaders", integer=True
+        )
+        decode = _positive(
+            value.get("decodeReaders", 1), "mediaPath.decodeReaders", integer=True
+        )
+        evidence_artifacts = {
+            str(key): _artifact_ref(path, "mediaPath evidence artifact")
+            for key, path in (value.get("evidenceArtifacts") or {}).items()
+        }
+        if not PATH_EVIDENCE_KEYS.issubset(evidence_artifacts):
+            raise ValueError(
+                "mediaPath evidence must include processor cell, relay sessions/readers, pod/node placement, and metrics window artifacts"
+            )
+        paths.append(
+            {
+                "name": name,
+                "kind": kind,
+                "source": source_name,
+                "sourceCell": source_cell,
+                "executionCell": execution_cell,
+                "remoteExecution": remote,
+                "consumeEndpoint": endpoint,
+                "readerLocation": location,
+                "copyReaders": copies,
+                "decodeReaders": decode,
+                "resources": _resources(value.get("resources"), "mediaPath.resources"),
+                "evidenceArtifacts": evidence_artifacts,
+                "startAfterSeconds": _non_negative(
+                    value.get("startAfterSeconds", 5), "mediaPath.startAfterSeconds"
+                ),
+            }
+        )
+        names.add(name)
+        covered.add(kind)
+    if covered != set(PATH_KINDS):
+        raise ValueError(
+            "scenario must include same-cell and explicit-cross-cell paths"
+        )
+    return paths
+
+
+def _load_control_plane_evidence(raw, cells, sources):
+    raw = raw or {}
+    endpoint = _strict_secret_ref(raw.get("endpoint"), "controlPlaneEvidence.endpoint")
+    auth = _strict_secret_ref(raw.get("auth"), "controlPlaneEvidence.auth")
+    registry = _artifact_ref(raw.get("cellRegistrySnapshot"), "cellRegistrySnapshot")
+    cases = []
+    covered = set()
+    for value in raw.get("cases") or []:
+        name = _require_dns_label(value.get("name"), "controlPlane case.name")
+        kind = str(value.get("kind") or "")
+        if kind not in ASSIGNMENT_CASE_KINDS:
+            raise ValueError("unknown control-plane evidence case kind")
+        source = _require_dns_label(value.get("source"), "controlPlane case.source")
+        expected_cell = _require_dns_label(
+            value.get("expectedCell"), "controlPlane case.expectedCell"
+        )
+        if source not in sources or expected_cell not in cells:
+            raise ValueError("control-plane case references unknown source or cell")
+        artifacts = {
+            str(key): _artifact_ref(path, "controlPlane case artifact")
+            for key, path in (value.get("artifacts") or {}).items()
+        }
+        if not CASE_ARTIFACT_KEYS[kind].issubset(artifacts):
+            raise ValueError(
+                "control-plane case is missing required connector, preview, policy, or recovery artifacts"
+            )
+        recovery_cell = value.get("recoveryCell")
+        if kind == "cell-loss-recovery":
+            recovery_cell = _require_dns_label(
+                recovery_cell, "controlPlane case.recoveryCell"
+            )
+            if recovery_cell not in cells:
+                raise ValueError("cell-loss recovery references unknown recoveryCell")
+        elif recovery_cell is not None:
+            raise ValueError("recoveryCell is valid only for cell-loss-recovery")
+        cases.append(
+            {
+                "name": name,
+                "kind": kind,
+                "source": source,
+                "workspaceAlias": _require_dns_label(
+                    value.get("workspaceAlias"), "controlPlane case.workspaceAlias"
+                ),
+                "expectedCell": expected_cell,
+                "recoveryCell": recovery_cell,
+                "artifacts": artifacts,
+            }
+        )
+        covered.add(kind)
+    required = {
+        "first-activation",
+        "reconnect-stickiness",
+        "dedicated-workspace",
+        "cell-loss-recovery",
+    }
+    if not required.issubset(covered):
+        raise ValueError(
+            "control-plane evidence must cover first activation, reconnect stickiness, dedicated workspace policy, and cell-loss recovery"
+        )
+    return {
+        "endpoint": endpoint,
+        "auth": auth,
+        "cellRegistrySnapshot": registry,
+        "cases": cases,
+    }
+
+
+def _load_measurement_plan(raw, cells):
+    raw = raw or {}
+    profiles = []
+    for value in raw.get("networkProfiles") or []:
+        name = _require_dns_label(value.get("name"), "networkProfile.name")
+        profiles.append(
+            {
+                "name": name,
+                "latencyMs": _non_negative(value.get("latencyMs", 0), "latencyMs"),
+                "lossPercent": _non_negative(
+                    value.get("lossPercent", 0), "lossPercent"
+                ),
+                "bandwidthBps": _positive(value.get("bandwidthBps"), "bandwidthBps"),
+                "egressAccounting": bool(value.get("egressAccounting", True)),
+                "application": "operator-approved",
+            }
+        )
+    if not profiles or not any(
+        profile["latencyMs"] == 0 and profile["lossPercent"] == 0
+        for profile in profiles
+    ):
+        raise ValueError("measurementPlan must include an unimpaired baseline profile")
+    failures = []
+    for value in raw.get("failureExperiments") or []:
+        target_cell = _require_dns_label(value.get("targetCell"), "failure.targetCell")
+        target = str(value.get("target") or "")
+        if target_cell not in cells or target not in FAILURE_TARGETS:
+            raise ValueError("failure experiment references an unknown target")
+        if value.get("requiresApproval") is not True:
+            raise ValueError("failure experiments must explicitly require approval")
+        failures.append(
+            {
+                "name": _require_dns_label(value.get("name"), "failure.name"),
+                "targetCell": target_cell,
+                "target": target,
+                "requiresApproval": True,
+                "maxUnavailableSeconds": _positive(
+                    value.get("maxUnavailableSeconds"),
+                    "failure.maxUnavailableSeconds",
+                ),
+                "reassignmentPolicy": str(value.get("reassignmentPolicy") or ""),
+                "timelineArtifact": _artifact_ref(
+                    value.get("timelineArtifact"), "failure.timelineArtifact"
+                ),
+                "rollbackArtifact": _artifact_ref(
+                    value.get("rollbackArtifact"), "failure.rollbackArtifact"
+                ),
+                "requiredEvents": [
+                    "baseline-healthy",
+                    "failure-started",
+                    "cell-marked-unavailable",
+                    "reassignment-decision",
+                    "recovery-started",
+                    "routing-recovered",
+                ],
+            }
+        )
+        if failures[-1]["reassignmentPolicy"] not in (
+            "retain-home-cell",
+            "explicit-migration",
+        ):
+            raise ValueError(
+                "failure.reassignmentPolicy must be retain-home-cell or explicit-migration"
+            )
+    if not failures:
+        raise ValueError("measurementPlan must define a failure/recovery experiment")
+    return {"networkProfiles": profiles, "failureExperiments": failures}
+
+
+def load_scenario(path):
+    scenario_path = Path(path).resolve()
+    with scenario_path.open() as source:
+        raw = json.load(source)
+    if raw.get("schemaVersion") != 2:
+        raise ValueError("two-cell scenario schemaVersion must be 2")
+    if raw.get("environment") != "staging" or raw.get("executionMode") != "render-only":
+        raise ValueError("two-cell validation is staging-only and render-only")
+    name = _require_dns_label(raw.get("name"), "name")
+    image = str(raw.get("agentImage") or "")
+    if not IMMUTABLE_IMAGE.fullmatch(image):
+        raise ValueError("agentImage must use an immutable sha256 digest")
+    fixture = raw.get("fixture") or {}
+    fixture_ref = _strict_secret_ref(
+        fixture.get("secretKeyRef"), "fixture.secretKeyRef"
+    )
+    fixture_metadata = fixture.get("metadata") or {}
+    expected_fps = _positive(fixture_metadata.get("fps"), "fixture.metadata.fps")
+    cells = _load_cells(raw.get("cells"))
+    locations = _load_locations(raw.get("locations"), cells)
+    sources = _load_sources(raw.get("sources"), cells, locations)
+    paths = _load_paths(raw.get("mediaPaths"), cells, locations, sources)
+    control_plane = _load_control_plane_evidence(
+        raw.get("controlPlaneEvidence"), cells, sources
+    )
+    measurement_plan = _load_measurement_plan(raw.get("measurementPlan"), cells)
+    timing = raw.get("timing") or {}
+    thresholds = raw.get("stopThresholds") or {}
+    return {
+        "schemaVersion": 2,
+        "scenarioPath": str(scenario_path),
+        "name": name,
+        "environment": "staging",
+        "executionMode": "render-only",
+        "agentImage": image,
+        "agentCommand": [
+            str(value)
+            for value in raw.get("agentCommand")
+            or ["python", "/opt/roboflow/relay_agent.py"]
+        ],
+        "maxAgents": _positive(raw.get("maxAgents", 100), "maxAgents", integer=True),
+        "fixture": {
+            "source": {"secretKeyRef": fixture_ref},
+            "metadata": fixture_metadata,
+            "expectedFps": expected_fps,
+        },
+        "cells": cells,
+        "locations": locations,
+        "sources": sources,
+        "mediaPaths": paths,
+        "controlPlaneEvidence": control_plane,
+        "measurementPlan": measurement_plan,
+        "timing": {
+            "durationSeconds": _positive(
+                timing.get("durationSeconds", 60), "durationSeconds"
+            ),
+            "startupGraceSeconds": _positive(
+                timing.get("startupGraceSeconds", 60), "startupGraceSeconds"
+            ),
+            "ttlSecondsAfterFinished": _positive(
+                timing.get("ttlSecondsAfterFinished", 600),
+                "ttlSecondsAfterFinished",
+                integer=True,
+            ),
+        },
+        "stopThresholds": {
+            "maxStartupSeconds": _positive(
+                thresholds.get("maxStartupSeconds", 30), "maxStartupSeconds"
+            ),
+            "maxProgressStallSeconds": _positive(
+                thresholds.get("maxProgressStallSeconds", 15), "maxProgressStallSeconds"
+            ),
+            "maxReconnects": int(thresholds.get("maxReconnects", 1)),
+            "minDeliveredFpsRatio": float(thresholds.get("minDeliveredFpsRatio", 0.95)),
+        },
+    }
+
+
+def _base_scenario(scenario, cell_alias, endpoint_key, location_name):
+    cell = scenario["cells"][cell_alias]
+    return {
+        "name": scenario["name"],
+        "namespace": cell["namespace"],
+        "serviceAccountName": cell["serviceAccountName"],
+        "agentImage": scenario["agentImage"],
+        "agentCommand": scenario["agentCommand"],
+        "fixture": scenario["fixture"],
+        "mediaUrlSecret": {
+            "publishTemplate": cell["endpoints"].get(endpoint_key),
+            "readTemplate": cell["endpoints"].get(endpoint_key),
+        },
+        "locations": {location_name: scenario["locations"][location_name]},
+        "timing": scenario["timing"],
+        "stopThresholds": scenario["stopThresholds"],
+    }
+
+
+def _annotate_job(job, scenario, cell_alias, source_cell, path_name, path_kind):
+    cell = scenario["cells"][cell_alias]
+    labels = job["metadata"]["labels"]
+    labels.update(
+        {
+            "benchmark.roboflow.com/expected-cell": cell["cellId"],
+            "benchmark.roboflow.com/source-cell": scenario["cells"][source_cell][
+                "cellId"
+            ],
+            "benchmark.roboflow.com/media-path": path_name,
+            "benchmark.roboflow.com/path-kind": path_kind,
+        }
+    )
+    job["spec"]["template"]["metadata"]["labels"] = dict(labels)
+    env = job["spec"]["template"]["spec"]["containers"][0]["env"]
+    env.extend(
+        [
+            {"name": "EXPECTED_CELL_ID", "value": cell["cellId"]},
+            {"name": "EXPECTED_CLUSTER_CONTEXT", "value": cell["clusterContext"]},
+            {"name": "MEDIA_PATH", "value": path_name},
+            {"name": "MEDIA_PATH_KIND", "value": path_kind},
+        ]
+    )
+
+
+def render(scenario, run_id):
+    scenario_hash = _canonical_hash(
+        {key: value for key, value in scenario.items() if key != "scenarioPath"}
+    )
+    bundles = {alias: [] for alias in scenario["cells"]}
+    agents = []
+    streams = {}
+    for source in scenario["sources"].values():
+        stream = _limited_name("bench", run_id, source["name"])
+        streams[source["name"]] = stream
+        agent = {
+            "name": _limited_name(run_id, source["name"], "publisher"),
+            "group": source["name"],
+            "role": "publish-copy",
+            "location": source["publisherLocation"],
+            "stream": stream,
+            "startAfterSeconds": source["startAfterSeconds"],
+            "resources": source["resources"],
+        }
+        base = _base_scenario(
+            scenario,
+            source["expectedHomeCell"],
+            "ingestTemplate",
+            source["publisherLocation"],
+        )
+        job = render_job(base, run_id, scenario_hash, agent)
+        _annotate_job(
+            job,
+            scenario,
+            source["expectedHomeCell"],
+            source["expectedHomeCell"],
+            _limited_name(source["name"], "ingest"),
+            "same-cell",
+        )
+        bundles[source["expectedHomeCell"]].append(job)
+        agents.append(
+            {**agent, "cell": source["expectedHomeCell"], "source": source["name"]}
+        )
+
+    for path in scenario["mediaPaths"]:
+        roles = (
+            ("read-copy", path["copyReaders"]),
+            ("read-decode", path["decodeReaders"]),
+        )
+        for role, count in roles:
+            for index in range(1, count + 1):
+                agent = {
+                    "name": _limited_name(run_id, path["name"], role, index),
+                    "group": path["name"],
+                    "role": role,
+                    "location": path["readerLocation"],
+                    "stream": streams[path["source"]],
+                    "startAfterSeconds": path["startAfterSeconds"],
+                    "resources": path["resources"],
+                }
+                base = _base_scenario(
+                    scenario,
+                    path["sourceCell"],
+                    path["consumeEndpoint"],
+                    path["readerLocation"],
+                )
+                # The Job runs in executionCell, while its read endpoint belongs
+                # to sourceCell. Keep namespace/service account local to the Job.
+                execution = scenario["cells"][path["executionCell"]]
+                base["namespace"] = execution["namespace"]
+                base["serviceAccountName"] = execution["serviceAccountName"]
+                job = render_job(base, run_id, scenario_hash, agent)
+                _annotate_job(
+                    job,
+                    scenario,
+                    path["executionCell"],
+                    path["sourceCell"],
+                    path["name"],
+                    path["kind"],
+                )
+                bundles[path["executionCell"]].append(job)
+                agents.append(
+                    {
+                        **agent,
+                        "cell": path["executionCell"],
+                        "source": path["source"],
+                        "mediaPath": path["name"],
+                        "pathKind": path["kind"],
+                    }
+                )
+    if len(agents) > scenario["maxAgents"] or scenario["maxAgents"] > 5000:
+        raise ValueError("scenario agent expansion exceeds its safety limit")
+
+    job_lists = {
+        alias: {"apiVersion": "v1", "kind": "List", "items": jobs}
+        for alias, jobs in bundles.items()
+    }
+    cleanup = {}
+    for alias, cell in scenario["cells"].items():
+        selector = "benchmark.roboflow.com/run-id=%s" % run_id
+        cleanup[alias] = {
+            "command": [
+                "kubectl",
+                "--context",
+                cell["clusterContext"],
+                "--namespace",
+                cell["namespace"],
+                "delete",
+                "jobs",
+                "--selector",
+                selector,
+                "--wait=false",
+            ],
+            "credentialRevocation": "operator-owned; no credential contents are rendered",
+        }
+
+    manifest = {
+        "schemaVersion": 2,
+        "runId": run_id,
+        "scenario": scenario["name"],
+        "scenarioSha256": scenario_hash,
+        "environment": "staging",
+        "executionMode": "render-only",
+        "agentImage": scenario["agentImage"],
+        "cells": scenario["cells"],
+        "sources": list(scenario["sources"].values()),
+        "mediaPaths": scenario["mediaPaths"],
+        "controlPlaneEvidence": scenario["controlPlaneEvidence"],
+        "measurementPlan": scenario["measurementPlan"],
+        "agents": agents,
+        "collectionContract": _collection_contract(scenario, run_id),
+        "cleanup": cleanup,
+        "rollback": {
+            "order": list(reversed(list(scenario["cells"]))),
+            "scope": "benchmark Jobs and separately issued run credentials only",
+            "cellResourcesChanged": False,
+            "failureExperimentRollbackRequiresApproval": True,
+        },
+        "renderedBy": {
+            "contractVersion": 2,
+            "renderedAt": time.time(),
+            "python": sys.version.split()[0],
+            "platform": platform.platform(),
+        },
+    }
+    report = _report_template(manifest)
+    return job_lists, manifest, report
+
+
+def _collection_contract(scenario, run_id):
+    placement = {}
+    for alias, cell in scenario["cells"].items():
+        selector = "benchmark.roboflow.com/run-id=%s" % run_id
+        placement[alias] = {
+            "command": [
+                "kubectl",
+                "--context",
+                cell["clusterContext"],
+                "--namespace",
+                cell["namespace"],
+                "get",
+                "pods",
+                "--selector",
+                selector,
+                "-o",
+                "json",
+            ],
+            "requiredObservedFields": [
+                "metadata.name",
+                "metadata.uid",
+                "spec.nodeName",
+                "status.podIP",
+                "status.containerStatuses[].imageID",
+                "node.metadata.labels.instance-type",
+                "clusterContext",
+                "expectedCell",
+                "observedCell",
+            ],
+        }
+    return {
+        "placement": placement,
+        "agentReports": {
+            "source": "termination message or BENCHMARK_FINAL_JSON log line",
+            "required": ["status", "progress", "attempts", "placement", "resources"],
+        },
+        "controlPlaneRouting": {
+            "requiredPerSource": [
+                "persisted home cell, assignment state/version, and lease/last-active metadata",
+                "actual connector publish endpoint resolved from the activation response",
+                "preview request and successful response from the assigned cell endpoint",
+                "job sourceCell/executionCell/remoteExecution placement fields",
+                "processor claim/status cell assertion",
+            ]
+        },
+        "prometheus": {
+            "window": "measured run start/end plus two scrape intervals",
+            "endpointSource": "each cell endpoints.prometheusBase secretKeyRef",
+            "requiredEvidence": [
+                "MediaMTX paths/readers/sessions/bytes/RTP loss/input errors",
+                "processor cell info/claims/rejections/jobs/CPU/memory/network",
+                "pod and node bytes/packets/drops/errors/retransmits",
+                "Cilium drops/map pressure/conntrack and connectivity latency",
+                "agent startup/frames/reconnects",
+            ],
+        },
+        "network": {
+            "requiredPerPath": [
+                "latency p50/p95/p99",
+                "packet or RTP loss and input errors",
+                "delivered and encoded bandwidth",
+                "source-cell egress bytes",
+                "execution-cell ingress bytes",
+                "documented and observed node/LB bandwidth limits",
+            ]
+        },
+        "failureTimeline": {
+            "clock": "UTC RFC3339 with monotonic offsets",
+            "requiredFields": [
+                "event",
+                "observedAt",
+                "offsetSeconds",
+                "cell",
+                "evidenceArtifact",
+            ],
+        },
+    }
+
+
+def _report_template(manifest):
+    return {
+        "schemaVersion": 2,
+        "runId": manifest["runId"],
+        "scenarioSha256": manifest["scenarioSha256"],
+        "status": "pending",
+        "secretsRecorded": False,
+        "assertions": {
+            "firstActivationAssignment": "pending",
+            "reconnectStickiness": "pending",
+            "dedicatedWorkspacePolicy": "pending",
+            "connectorUsesAssignedIngest": "pending",
+            "sameCellProcessing": "pending",
+            "noAccidentalCrossCellPath": "pending",
+            "explicitCrossCellExperiment": "pending",
+            "failureRecovery": "pending",
+            "cellLossUnavailableBounded": "pending",
+            "reassignmentDecisionHonored": "pending",
+            "previewFromAssignedCell": "pending",
+            "processorClaimedExpectedCell": "pending",
+            "relaySessionsAndReadersMatch": "pending",
+        },
+        "controlPlaneEvidence": [],
+        "observedPlacement": [],
+        "agentReports": [],
+        "mediaPathMeasurements": [],
+        "prometheusEvidence": [],
+        "failureRecoveryTimeline": [],
+        "cleanup": {"completed": False, "credentialRevoked": False, "evidence": []},
+        "remainingRisks": [],
+    }
+
+
+def write_rendered(output_dir, job_lists, manifest, report):
+    output_dir = Path(output_dir).resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    outputs = {
+        "validation-manifest.json": manifest,
+        "validation-report.template.json": report,
+    }
+    for alias, jobs in job_lists.items():
+        outputs["jobs-%s.json" % alias] = jobs
+    for filename in outputs:
+        if (output_dir / filename).exists():
+            raise ValueError("refusing to overwrite an existing rendered run")
+    paths = []
+    for filename, payload in outputs.items():
+        path = output_dir / filename
+        path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+        paths.append(path)
+    return paths
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--scenario", required=True)
+    parser.add_argument("--run-id")
+    parser.add_argument("--output-dir", required=True)
+    args = parser.parse_args(argv)
+    try:
+        scenario = load_scenario(args.scenario)
+        run_id = resolve_run_id(args.run_id)
+        job_lists, manifest, report = render(scenario, run_id)
+        paths = write_rendered(args.output_dir, job_lists, manifest, report)
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        parser.error(str(error))
+    for path in paths:
+        print(path)
+    print("No cluster, control-plane, DNS, or credential writes were performed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/development/video_poc/benchmarks/networking/two-cell-south-east.staging.example.json
+++ b/development/video_poc/benchmarks/networking/two-cell-south-east.staging.example.json
@@ -1,0 +1,400 @@
+{
+  "schemaVersion": 2,
+  "name": "south-east-cell-routing",
+  "environment": "staging",
+  "executionMode": "render-only",
+  "maxAgents": 20,
+  "agentImage": "us-central1-docker.pkg.dev/roboflow-staging/video-proc/relay-benchmark-agent@sha256:0000000000000000000000000000000000000000000000000000000000000000",
+  "agentCommand": [
+    "python",
+    "/opt/roboflow/relay_agent.py"
+  ],
+  "fixture": {
+    "secretKeyRef": {
+      "name": "replace-two-cell-benchmark-media",
+      "key": "fixture-url"
+    },
+    "metadata": {
+      "sha256": "replace-with-fixture-sha256",
+      "codec": "h264",
+      "width": 1920,
+      "height": 1080,
+      "fps": 15,
+      "bitrateBps": 5000000,
+      "gopFrames": 30
+    }
+  },
+  "cells": {
+    "east": {
+      "cellId": "crusoe-use1",
+      "provider": "crusoe",
+      "region": "us-east1",
+      "clusterContext": "ck8s-stg",
+      "namespace": "video-proc-bench",
+      "serviceAccountName": "video-relay-benchmark",
+      "endpoints": {
+        "ingestTemplate": {
+          "name": "replace-east-cell-endpoints",
+          "key": "ingest-template"
+        },
+        "consumeInternalTemplate": {
+          "name": "replace-east-cell-endpoints",
+          "key": "consume-internal-template"
+        },
+        "consumePublicTemplate": {
+          "name": "replace-east-cell-endpoints",
+          "key": "consume-public-template"
+        },
+        "previewBase": {
+          "name": "replace-east-cell-endpoints",
+          "key": "preview-base"
+        },
+        "processorApiBase": {
+          "name": "replace-east-cell-endpoints",
+          "key": "processor-api-base"
+        },
+        "prometheusBase": {
+          "name": "replace-east-cell-monitoring",
+          "key": "prometheus-base"
+        }
+      },
+      "versions": {
+        "mediaMtxImage": "replace-with-immutable-digest",
+        "mediaMtxConfigSha256": "replace-before-run",
+        "gatewayImage": "replace-with-immutable-digest",
+        "processorImage": "replace-with-immutable-digest",
+        "ciliumVersion": "1.17.16",
+        "loadBalancerId": "replace-before-run"
+      }
+    },
+    "south": {
+      "cellId": "crusoe-ussc1",
+      "provider": "crusoe",
+      "region": "us-southcentral1",
+      "clusterContext": "ck8s-stg-us-southcentral1",
+      "namespace": "video-proc-bench",
+      "serviceAccountName": "video-relay-benchmark",
+      "endpoints": {
+        "ingestTemplate": {
+          "name": "replace-south-cell-endpoints",
+          "key": "ingest-template"
+        },
+        "consumeInternalTemplate": {
+          "name": "replace-south-cell-endpoints",
+          "key": "consume-internal-template"
+        },
+        "consumePublicTemplate": {
+          "name": "replace-south-cell-endpoints",
+          "key": "consume-public-template"
+        },
+        "previewBase": {
+          "name": "replace-south-cell-endpoints",
+          "key": "preview-base"
+        },
+        "processorApiBase": {
+          "name": "replace-south-cell-endpoints",
+          "key": "processor-api-base"
+        },
+        "prometheusBase": {
+          "name": "replace-south-cell-monitoring",
+          "key": "prometheus-base"
+        }
+      },
+      "versions": {
+        "mediaMtxImage": "replace-with-immutable-digest",
+        "mediaMtxConfigSha256": "replace-before-run",
+        "gatewayImage": "replace-with-immutable-digest",
+        "processorImage": "replace-with-immutable-digest",
+        "ciliumVersion": "1.19.1",
+        "loadBalancerId": "replace-before-run"
+      }
+    }
+  },
+  "locations": {
+    "east-generator": {
+      "cell": "east",
+      "nodeSelector": {
+        "node.kubernetes.io/instance-type": "c1a.16x"
+      },
+      "metadata": {
+        "instanceType": "c1a.16x",
+        "documentedVpcBandwidthBps": 10000000000
+      }
+    },
+    "east-processor": {
+      "cell": "east",
+      "nodeSelector": {
+        "node.kubernetes.io/instance-type": "c1a.16x"
+      },
+      "metadata": {
+        "instanceType": "c1a.16x",
+        "documentedVpcBandwidthBps": 10000000000
+      }
+    },
+    "south-generator": {
+      "cell": "south",
+      "nodeSelector": {
+        "node.kubernetes.io/instance-type": "c1a.16x"
+      },
+      "metadata": {
+        "instanceType": "c1a.16x",
+        "documentedVpcBandwidthBps": 10000000000
+      }
+    },
+    "south-processor": {
+      "cell": "south",
+      "nodeSelector": {
+        "node.kubernetes.io/instance-type": "c1a.16x"
+      },
+      "metadata": {
+        "instanceType": "c1a.16x",
+        "documentedVpcBandwidthBps": 10000000000
+      }
+    }
+  },
+  "sources": [
+    {
+      "name": "default-source",
+      "expectedHomeCell": "east",
+      "publisherLocation": "east-generator",
+      "resources": {
+        "requests": {
+          "cpu": "250m",
+          "memory": "128Mi"
+        },
+        "limits": {
+          "cpu": "1",
+          "memory": "512Mi"
+        }
+      }
+    },
+    {
+      "name": "reconnect-source",
+      "expectedHomeCell": "east",
+      "publisherLocation": "east-generator",
+      "resources": {
+        "requests": {
+          "cpu": "250m",
+          "memory": "128Mi"
+        },
+        "limits": {
+          "cpu": "1",
+          "memory": "512Mi"
+        }
+      }
+    },
+    {
+      "name": "dedicated-source",
+      "expectedHomeCell": "south",
+      "publisherLocation": "south-generator",
+      "resources": {
+        "requests": {
+          "cpu": "250m",
+          "memory": "128Mi"
+        },
+        "limits": {
+          "cpu": "1",
+          "memory": "512Mi"
+        }
+      }
+    }
+  ],
+  "mediaPaths": [
+    {
+      "name": "east-local",
+      "kind": "same-cell",
+      "source": "default-source",
+      "executionCell": "east",
+      "readerLocation": "east-processor",
+      "remoteExecution": false,
+      "consumeEndpoint": "consumeInternalTemplate",
+      "copyReaders": 1,
+      "decodeReaders": 1,
+      "evidenceArtifacts": {
+        "processorClaimedCell": "evidence/paths/east-local-processor-cell.json",
+        "relaySessions": "evidence/paths/east-local-relay-sessions.json",
+        "relayReaders": "evidence/paths/east-local-relay-readers.json",
+        "podPlacement": "evidence/paths/east-local-pods.json",
+        "nodePlacement": "evidence/paths/east-local-nodes.json",
+        "metricsWindow": "evidence/paths/east-local-metrics.json"
+      },
+      "resources": {
+        "requests": {
+          "cpu": "250m",
+          "memory": "128Mi"
+        },
+        "limits": {
+          "cpu": "2",
+          "memory": "1Gi"
+        }
+      }
+    },
+    {
+      "name": "south-local",
+      "kind": "same-cell",
+      "source": "dedicated-source",
+      "executionCell": "south",
+      "readerLocation": "south-processor",
+      "remoteExecution": false,
+      "consumeEndpoint": "consumeInternalTemplate",
+      "copyReaders": 1,
+      "decodeReaders": 1,
+      "evidenceArtifacts": {
+        "processorClaimedCell": "evidence/paths/south-local-processor-cell.json",
+        "relaySessions": "evidence/paths/south-local-relay-sessions.json",
+        "relayReaders": "evidence/paths/south-local-relay-readers.json",
+        "podPlacement": "evidence/paths/south-local-pods.json",
+        "nodePlacement": "evidence/paths/south-local-nodes.json",
+        "metricsWindow": "evidence/paths/south-local-metrics.json"
+      },
+      "resources": {
+        "requests": {
+          "cpu": "250m",
+          "memory": "128Mi"
+        },
+        "limits": {
+          "cpu": "2",
+          "memory": "1Gi"
+        }
+      }
+    },
+    {
+      "name": "south-origin-east-processor",
+      "kind": "explicit-cross-cell",
+      "source": "dedicated-source",
+      "executionCell": "east",
+      "readerLocation": "east-processor",
+      "remoteExecution": true,
+      "consumeEndpoint": "consumePublicTemplate",
+      "copyReaders": 1,
+      "decodeReaders": 1,
+      "evidenceArtifacts": {
+        "processorClaimedCell": "evidence/paths/south-to-east-processor-cell.json",
+        "relaySessions": "evidence/paths/south-to-east-relay-sessions.json",
+        "relayReaders": "evidence/paths/south-to-east-relay-readers.json",
+        "podPlacement": "evidence/paths/south-to-east-pods.json",
+        "nodePlacement": "evidence/paths/south-to-east-nodes.json",
+        "metricsWindow": "evidence/paths/south-to-east-metrics.json"
+      },
+      "resources": {
+        "requests": {
+          "cpu": "250m",
+          "memory": "128Mi"
+        },
+        "limits": {
+          "cpu": "2",
+          "memory": "1Gi"
+        }
+      }
+    }
+  ],
+  "controlPlaneEvidence": {
+    "endpoint": {
+      "name": "replace-two-cell-control-plane",
+      "key": "endpoint"
+    },
+    "auth": {
+      "name": "replace-two-cell-control-plane",
+      "key": "benchmark-auth"
+    },
+    "cellRegistrySnapshot": "evidence/control-plane/cell-registry.json",
+    "cases": [
+      {
+        "name": "first-activation-default",
+        "kind": "first-activation",
+        "source": "default-source",
+        "workspaceAlias": "default-workspace",
+        "expectedCell": "east",
+        "artifacts": {
+          "registeredIdle": "evidence/control-plane/default-before.json",
+          "activated": "evidence/control-plane/default-activated.json",
+          "connectorPublishEndpoint": "evidence/control-plane/default-connector-publish.json",
+          "previewProof": "evidence/control-plane/default-preview.json"
+        }
+      },
+      {
+        "name": "reconnect-retains-cell",
+        "kind": "reconnect-stickiness",
+        "source": "reconnect-source",
+        "workspaceAlias": "default-workspace",
+        "expectedCell": "east",
+        "artifacts": {
+          "beforeReconnect": "evidence/control-plane/reconnect-before.json",
+          "afterReconnect": "evidence/control-plane/reconnect-after.json",
+          "connectorPublishEndpoint": "evidence/control-plane/reconnect-connector-publish.json",
+          "previewProof": "evidence/control-plane/reconnect-preview.json"
+        }
+      },
+      {
+        "name": "dedicated-workspace-south",
+        "kind": "dedicated-workspace",
+        "source": "dedicated-source",
+        "workspaceAlias": "dedicated-workspace",
+        "expectedCell": "south",
+        "artifacts": {
+          "policySnapshot": "evidence/control-plane/dedicated-policy.json",
+          "activated": "evidence/control-plane/dedicated-activated.json",
+          "connectorPublishEndpoint": "evidence/control-plane/dedicated-connector-publish.json",
+          "previewProof": "evidence/control-plane/dedicated-preview.json"
+        }
+      },
+      {
+        "name": "south-cell-loss-recovery",
+        "kind": "cell-loss-recovery",
+        "source": "dedicated-source",
+        "workspaceAlias": "dedicated-workspace",
+        "expectedCell": "south",
+        "recoveryCell": "south",
+        "artifacts": {
+          "cellLossStarted": "evidence/control-plane/cell-loss-started.json",
+          "unavailableObserved": "evidence/control-plane/cell-loss-unavailable.json",
+          "reassignmentDecision": "evidence/control-plane/cell-loss-reassignment.json",
+          "recovered": "evidence/control-plane/cell-loss-recovered.json",
+          "connectorPublishAfterRecovery": "evidence/control-plane/cell-loss-connector-publish.json",
+          "previewAfterRecovery": "evidence/control-plane/cell-loss-preview.json"
+        }
+      }
+    ]
+  },
+  "measurementPlan": {
+    "networkProfiles": [
+      {
+        "name": "baseline",
+        "latencyMs": 0,
+        "lossPercent": 0,
+        "bandwidthBps": 1000000000,
+        "egressAccounting": true
+      },
+      {
+        "name": "wan-50ms-loss-01",
+        "latencyMs": 50,
+        "lossPercent": 0.1,
+        "bandwidthBps": 100000000,
+        "egressAccounting": true
+      }
+    ],
+    "failureExperiments": [
+      {
+        "name": "south-mediamtx-recovery",
+        "targetCell": "south",
+        "target": "mediamtx",
+        "requiresApproval": true,
+        "maxUnavailableSeconds": 120,
+        "reassignmentPolicy": "retain-home-cell",
+        "timelineArtifact": "evidence/failures/south-mediamtx-timeline.json",
+        "rollbackArtifact": "evidence/failures/south-mediamtx-rollback.json"
+      }
+    ]
+  },
+  "timing": {
+    "durationSeconds": 300,
+    "startupGraceSeconds": 60,
+    "ttlSecondsAfterFinished": 900
+  },
+  "stopThresholds": {
+    "maxStartupSeconds": 30,
+    "maxProgressStallSeconds": 15,
+    "maxReconnects": 1,
+    "minDeliveredFpsRatio": 0.95
+  }
+}

--- a/development/video_poc/processor/job_process.py
+++ b/development/video_poc/processor/job_process.py
@@ -40,6 +40,7 @@ RUNTIME_KEYS = frozenset(
     {
         "schemaVersion",
         "processorId",
+        "cell",
         "hostname",
         "processId",
         "image",

--- a/development/video_poc/processor/job_telemetry.py
+++ b/development/video_poc/processor/job_telemetry.py
@@ -29,7 +29,7 @@ def _safe_env(*names):
     return None
 
 
-def build_runtime_identity(processor_id=None):
+def build_runtime_identity(processor_id=None, cell=None):
     """Build non-secret process/image identity once at worker startup.
 
     Container images cannot discover their own registry reference, so deployers
@@ -40,6 +40,7 @@ def build_runtime_identity(processor_id=None):
     identity = {
         "schemaVersion": 1,
         "processorId": str(processor_id)[:256] if processor_id else None,
+        "cell": str(cell)[:63] if cell else None,
         "hostname": socket.gethostname()[:256],
         "processId": os.getpid(),
         "image": _safe_env("VIDEO_PROC_IMAGE", "VIDEO_PROCESSOR_IMAGE", "IMAGE_URI"),

--- a/development/video_poc/processor/processor.py
+++ b/development/video_poc/processor/processor.py
@@ -112,12 +112,15 @@ from job_telemetry import JobTelemetry, build_runtime_identity
 from processor_metrics import ProcessorMetrics
 from security import (
     DiagnosticRing,
+    JobPlacementMismatch,
     JobSecurityRegistry,
     MissingJobAccessToken,
     env_flag,
     extract_access_token,
     format_inference_error,
     sanitize_diagnostic,
+    validate_cell_id,
+    validate_job_placement,
     validate_job_id,
 )
 from video_ingest import (
@@ -1297,7 +1300,7 @@ class JobRun:
             resp = self.worker.api(
                 "POST",
                 f"/video-jobs/{self.job_id}/results/upload-urls",
-                json={"processorId": self.worker.processor_id},
+                json=self.worker.platform_identity(),
             )
             uploads = resp.get("uploads", {})
             uploaded = []
@@ -1315,7 +1318,7 @@ class JobRun:
                 self.worker.api(
                     "POST",
                     f"/video-jobs/{self.job_id}/results/complete",
-                    json={"files": uploaded, "processorId": self.worker.processor_id},
+                    json={"files": uploaded, **self.worker.platform_identity()},
                 )
                 print(f"[processor] uploaded results for {self.job_id}: {', '.join(uploaded)}")
         except Exception as exc:
@@ -1547,6 +1550,7 @@ class _ChildWorker:
 
         self.args = SimpleNamespace(api_key=None, api_url=None)
         self.processor_id = str(config.get("processorId") or "process-child")[:256]
+        self.cell = config.get("cell")
         self.capture_env_lock = threading.Lock()
         self.execution_domains = _ChildExecutionDomains()
         self.metrics = _ChildMetrics()
@@ -1555,7 +1559,7 @@ class _ChildWorker:
         self.video_ingest_mode = resolve_video_ingest_mode(
             tensor_runtime_available=ENABLE_TENSOR_DATA_REPRESENTATION
         )
-        self.runtime_identity = build_runtime_identity(self.processor_id)
+        self.runtime_identity = build_runtime_identity(self.processor_id, self.cell)
         self.runtime_identity.update(
             process_runtime_identity(
                 self.video_ingest_mode,
@@ -1744,7 +1748,10 @@ class ProcessJobRun:
                 target=_isolated_job_child_main,
                 args=(
                     child_job,
-                    {"processorId": self.worker.processor_id},
+                    {
+                        "processorId": self.worker.processor_id,
+                        "cell": self.worker.cell,
+                    },
                     child,
                 ),
                 name=f"video-job-{self.job_id}",
@@ -1955,6 +1962,7 @@ class Worker:
     def __init__(self, args):
         self.args = args
         self.processor_id = args.processor_id or f"proc-{socket.gethostname()}-{uuid.uuid4().hex[:6]}"
+        self.cell = validate_cell_id(os.getenv("VIDEO_PROC_CELL"))
         self.pod = PodSelf()
         self.retiring = False
         # gpu/cpu: this worker only claims jobs created for its tier, so light
@@ -2012,7 +2020,7 @@ class Worker:
             if self.job_execution_mode == JOB_EXECUTION_PROCESS
             else None
         )
-        self.runtime_identity = build_runtime_identity(self.processor_id)
+        self.runtime_identity = build_runtime_identity(self.processor_id, self.cell)
         self.runtime_identity.update(
             process_runtime_identity(
                 self.video_ingest_mode,
@@ -2110,6 +2118,12 @@ class Worker:
 
     # ---------- job failure reporting ----------
 
+    def platform_identity(self):
+        identity = {"processorId": self.processor_id}
+        if self.cell is not None:
+            identity["cell"] = self.cell
+        return identity
+
     def report_job_failure(self, job, message, log_tail=None):
         """Best-effort: persist why this attempt died (message + recent log
         tail) on the job doc BEFORE the run is torn down. state="failing"
@@ -2131,7 +2145,7 @@ class Worker:
                     "state": "failing",
                     "error": sanitize_diagnostic(message)[:2000],
                     "logTail": diagnostics.tail(),
-                    "processorId": self.processor_id,
+                    **self.platform_identity(),
                 },
             )
         except Exception as exc:
@@ -2147,6 +2161,7 @@ class Worker:
         runs = self.snapshot_runs()
         doc = {
             "processorId": self.processor_id,
+            "cell": self.cell,
             "tier": self.tier,
             "capacity": self.capacity,
             "jobExecutionMode": self.job_execution_mode,
@@ -2168,6 +2183,7 @@ class Worker:
         """Non-sensitive readiness response for unauthenticated pool probes."""
         return {
             "state": "ready",
+            "cell": self.cell,
             "tier": self.tier,
             "capacity": self.capacity,
             "jobExecutionMode": self.job_execution_mode,
@@ -2272,17 +2288,34 @@ class Worker:
                 "POST",
                 "/video-jobs/claim",
                 json={
-                    "processorId": self.processor_id,
                     "processorUrl": self.public_url,
                     "tier": self.tier,
+                    **self.platform_identity(),
                 },
             )
             job = resp.get("job")
             if not job:
                 return None
+            # Validate placement before the access token is registered or any
+            # job-owned state is constructed.
+            job = dict(job)
+            try:
+                validate_job_placement(job, self.cell)
+            except JobPlacementMismatch as exc:
+                # The claim already committed server-side. Do not heartbeat it,
+                # register its token, detach the pod, spawn a child, or start a
+                # pipeline. Quarantine this worker so it cannot strand more jobs;
+                # the normal heartbeat reaper releases this claim after its
+                # bounded timeout.
+                self.metrics.claim_rejected(exc.reason)
+                self.retiring = True
+                print(
+                    f"[processor] rejected claimed job placement: {exc}",
+                    file=sys.stderr,
+                )
+                return job
             # The access token is transport authorization, not workflow input.
             # Remove it before the job dict is retained or surfaced by status.
-            job = dict(job)
             access_token = job.pop("processorAccessToken", None)
             # Shutdown may have started while the blocking claim request was in
             # flight. Do not create a run after stop_all() took its snapshot;
@@ -2409,7 +2442,7 @@ class Worker:
                                 "stats": run.stats.snapshot(
                                     runtime=run.runtime_identity()
                                 ),
-                                "processorId": self.processor_id,
+                                **self.platform_identity(),
                             },
                         )
                     except requests.RequestException as exc:
@@ -2697,6 +2730,7 @@ def make_handler(worker: Worker):
                     capacity=worker.capacity,
                     tier=worker.tier,
                     retiring=worker.retiring,
+                    cell=worker.cell,
                     active_publishers=publishers,
                 ).encode()
                 self.send_response(200)

--- a/development/video_poc/processor/processor_metrics.py
+++ b/development/video_poc/processor/processor_metrics.py
@@ -7,12 +7,20 @@ benchmark result manifest, not Prometheus labels.
 """
 
 import math
+import re
 import threading
 from collections import defaultdict
 
 VALID_MODES = ("stream", "batch", "unknown")
 VALID_OUTCOMES = ("completed", "error", "cancelled", "stopped")
 VALID_TRANSPORTS = ("whip", "rtsp")
+VALID_CLAIM_REJECTION_REASONS = (
+    "execution_cell_mismatch",
+    "implicit_cross_cell",
+    "invalid_placement",
+    "processor_cell_missing",
+)
+CELL_ID_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$")
 
 
 def _bounded(value, allowed, fallback):
@@ -90,6 +98,7 @@ class ProcessorMetrics:
         self._jobs_started = defaultdict(int)
         self._jobs_finished = defaultdict(int)
         self._frames_processed = defaultdict(int)
+        self._claim_rejections = defaultdict(int)
         self._job_start_duration = _Histogram((0.5, 1, 2, 5, 10, 30, 60, 120, 300))
         self._time_to_first_result = _Histogram((0.5, 1, 2, 5, 10, 30, 60, 120, 300))
         self._decode_to_result_latency = _Histogram(
@@ -120,6 +129,15 @@ class ProcessorMetrics:
             if first_result_seconds is not None:
                 self._time_to_first_result.observe(mode, first_result_seconds)
 
+    def claim_rejected(self, reason):
+        reason = _bounded(
+            reason,
+            VALID_CLAIM_REJECTION_REASONS,
+            "invalid_placement",
+        )
+        with self._lock:
+            self._claim_rejections[reason] += 1
+
     def render(
         self,
         *,
@@ -127,17 +145,22 @@ class ProcessorMetrics:
         capacity,
         tier,
         retiring,
+        cell=None,
         active_publishers=None,
     ):
         active_jobs = max(0, int(active_jobs))
         capacity = max(1, int(capacity))
         tier = _bounded(tier, ("gpu", "cpu"), "unknown")
+        cell = str(cell or "legacy")
+        if cell != "legacy" and not CELL_ID_RE.fullmatch(cell):
+            cell = "unknown"
         publishers = active_publishers or {}
 
         with self._lock:
             jobs_started = dict(self._jobs_started)
             jobs_finished = dict(self._jobs_finished)
             frames_processed = dict(self._frames_processed)
+            claim_rejections = dict(self._claim_rejections)
             job_start_duration = self._job_start_duration.render(
                 "video_processor_job_start_duration_seconds",
                 "Seconds from job receipt until the workflow pipeline is initialized",
@@ -157,7 +180,7 @@ class ProcessorMetrics:
         lines = [
             "# HELP video_processor_info Static video processor identity",
             "# TYPE video_processor_info gauge",
-            f"video_processor_info{_labels(tier=tier)} 1",
+            f"video_processor_info{_labels(cell=cell, tier=tier)} 1",
             "# HELP video_processor_busy Number of active jobs assigned to this worker",
             "# TYPE video_processor_busy gauge",
             f"video_processor_busy {active_jobs}",
@@ -206,6 +229,18 @@ class ProcessorMetrics:
             lines.append(
                 f"video_processor_frames_processed_total{_labels(mode=mode)} "
                 f"{frames_processed.get(mode, 0)}"
+            )
+
+        lines.extend(
+            [
+                "# HELP video_processor_claim_rejections_total Claims rejected before job execution by bounded reason",
+                "# TYPE video_processor_claim_rejections_total counter",
+            ]
+        )
+        for reason in VALID_CLAIM_REJECTION_REASONS:
+            lines.append(
+                "video_processor_claim_rejections_total"
+                f"{_labels(reason=reason)} {claim_rejections.get(reason, 0)}"
             )
 
         lines.extend(

--- a/development/video_poc/processor/security.py
+++ b/development/video_poc/processor/security.py
@@ -13,6 +13,7 @@ import threading
 from urllib.parse import parse_qs, urlsplit, urlunsplit
 
 JOB_ID_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+CELL_ID_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$")
 _BEARER_VALUE_RE = re.compile(r"(?i)\bBearer\s+[^\s,;]+")
 _SECRET_PARAM_RE = re.compile(
     r"(?i)(\b(?:api[_-]?key|token|access_token|signature|sig)=)[^\s&#]+"
@@ -22,6 +23,76 @@ _URL_RE = re.compile(r"(?P<url>(?:https?|rtsp)://[^\s\"'<>]+)", re.IGNORECASE)
 
 class MissingJobAccessToken(ValueError):
     """A managed-pool claim did not include its browser-facing job token."""
+
+
+class JobPlacementMismatch(ValueError):
+    """A server-issued job placement is unsafe for this worker."""
+
+    def __init__(self, reason: str, message: str):
+        super().__init__(message)
+        self.reason = reason
+
+
+def validate_cell_id(value, *, required=False):
+    """Normalize a bounded deployment cell identifier.
+
+    Cell identity is optional only for the single-cell migration path. Once a
+    worker is configured, this value is read once at startup and job payloads
+    cannot override it.
+    """
+
+    cell = str(value or "").strip()
+    if not cell:
+        if required:
+            raise ValueError("processor cell is required")
+        return None
+    if not CELL_ID_RE.fullmatch(cell):
+        raise ValueError("processor cell must be a lowercase DNS label")
+    return cell
+
+
+def validate_job_placement(job, processor_cell):
+    """Fail closed on wrong-cell or implicit cross-cell claim payloads.
+
+    Missing placement remains valid for legacy jobs during the one-cell
+    migration. A placed job, however, requires a configured worker cell. Remote
+    media consumption is accepted only when the control plane explicitly marks
+    it as such.
+    """
+
+    job = job if isinstance(job, dict) else {}
+    execution_cell = job.get("executionCell")
+    source_cell = job.get("sourceCell")
+    if execution_cell is None and source_cell is None:
+        return
+    try:
+        execution_cell = validate_cell_id(execution_cell, required=True)
+        source_cell = (
+            validate_cell_id(source_cell, required=True)
+            if source_cell is not None
+            else None
+        )
+    except ValueError as error:
+        raise JobPlacementMismatch("invalid_placement", str(error)) from error
+    if processor_cell is None:
+        raise JobPlacementMismatch(
+            "processor_cell_missing",
+            "placed job cannot run on a worker without cell identity",
+        )
+    if execution_cell != processor_cell:
+        raise JobPlacementMismatch(
+            "execution_cell_mismatch",
+            "job execution cell does not match processor cell",
+        )
+    if (
+        source_cell is not None
+        and source_cell != execution_cell
+        and job.get("remoteExecution") is not True
+    ):
+        raise JobPlacementMismatch(
+            "implicit_cross_cell",
+            "cross-cell media execution was not explicitly authorized",
+        )
 
 
 def env_flag(name: str, default: bool = False) -> bool:

--- a/development/video_poc/processor/test_job_process.py
+++ b/development/video_poc/processor/test_job_process.py
@@ -68,7 +68,7 @@ def test_child_protocol_does_not_accept_payload_or_credentials():
         "type": "status",
         "state": "running",
         "stats": {"frames": 7},
-        "runtime": {"processId": 42},
+        "runtime": {"processId": 42, "cell": "crusoe-use1"},
         "imageOutputs": ["visualization"],
         "defaultImageOutput": "visualization",
         "error": None,

--- a/tests/development/video_poc/test_job_telemetry.py
+++ b/tests/development/video_poc/test_job_telemetry.py
@@ -121,14 +121,19 @@ def test_runtime_identity_uses_only_allowlisted_bounded_environment(monkeypatch)
     monkeypatch.setenv("VIDEO_PROC_SERVICE_SECRET", "must-not-leak")
     monkeypatch.setenv("ROBOFLOW_API_KEY", "must-not-leak-either")
 
-    identity = build_runtime_identity("processor-a")
+    identity = build_runtime_identity("processor-a", "crusoe-use1")
 
     assert identity["processorId"] == "processor-a"
+    assert identity["cell"] == "crusoe-use1"
     assert identity["image"] == "registry/video-processor:benchmark"
     assert identity["revision"] == "deadbeef"
     assert identity["gpuVisibleDevices"] == "GPU-123"
     assert identity["processId"] > 0
     assert "must-not-leak" not in repr(identity)
+
+
+def test_runtime_identity_preserves_legacy_no_cell_mode():
+    assert "cell" not in build_runtime_identity("processor-a")
 
 
 def test_processor_wires_job_telemetry_without_job_labeled_prometheus():

--- a/tests/development/video_poc/test_processor_cell_contract.py
+++ b/tests/development/video_poc/test_processor_cell_contract.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+
+PROCESSOR_DIR = (
+    Path(__file__).resolve().parents[3] / "development" / "video_poc" / "processor"
+)
+
+
+def test_claim_validates_placement_before_any_execution_side_effect():
+    source = (PROCESSOR_DIR / "processor.py").read_text()
+    claim = source[
+        source.index("    def try_claim(self):") : source.index(
+            "    def _fresh_claim_holdoff"
+        )
+    ]
+
+    validation = claim.index("validate_job_placement(job, self.cell)")
+    assert validation < claim.index('job.pop("processorAccessToken", None)')
+    assert validation < claim.index("self.security.register_job")
+    assert validation < claim.index("run_type(self, job)")
+    assert validation < claim.index("self.pod.detach_from_pool")
+    assert (
+        "self.report_job_failure"
+        not in claim[validation : claim.index("access_token =")]
+    )
+    assert "self.retiring = True" in claim[validation : claim.index("access_token =")]
+
+
+def test_platform_calls_carry_the_immutable_worker_cell_assertion():
+    source = (PROCESSOR_DIR / "processor.py").read_text()
+
+    assert 'self.cell = validate_cell_id(os.getenv("VIDEO_PROC_CELL"))' in source
+    assert source.count("platform_identity()") >= 5
+    assert '"cell": self.cell' in source
+    assert "cell=worker.cell" in source

--- a/tests/development/video_poc/test_processor_metrics.py
+++ b/tests/development/video_poc/test_processor_metrics.py
@@ -64,16 +64,18 @@ def test_metrics_render_aggregate_worker_state_and_bounded_labels():
     metrics.frame_processed("stream", 0.042, first_result_seconds=1.5)
     metrics.frame_processed("stream", 0.055)
     metrics.job_finished("stream", "completed")
+    metrics.claim_rejected("execution_cell_mismatch")
 
     rendered = metrics.render(
         active_jobs=2,
         capacity=4,
         tier="gpu",
+        cell="crusoe-use1",
         retiring=False,
         active_publishers={"whip": 1},
     )
 
-    assert 'video_processor_info{tier="gpu"} 1' in rendered
+    assert 'video_processor_info{cell="crusoe-use1",tier="gpu"} 1' in rendered
     assert "video_processor_busy 2" in rendered
     assert "video_processor_active_jobs 2" in rendered
     assert "video_processor_capacity 4" in rendered
@@ -85,6 +87,10 @@ def test_metrics_render_aggregate_worker_state_and_bounded_labels():
     )
     assert 'video_processor_frames_processed_total{mode="stream"} 2' in rendered
     assert 'video_processor_output_publishers{transport="whip"} 1' in rendered
+    assert (
+        'video_processor_claim_rejections_total{reason="execution_cell_mismatch"} 1'
+        in rendered
+    )
     assert (
         'video_processor_decode_to_result_latency_seconds_count{mode="stream"} 2'
         in rendered
@@ -104,16 +110,28 @@ def test_metrics_normalize_untrusted_labels_and_never_include_job_identity():
         active_jobs=0,
         capacity=1,
         tier="unexpected-tier",
+        cell="workspace/job-123",
         retiring=True,
     )
 
     assert "workspace" not in rendered
     assert "job-123" not in rendered
     assert "unexpected" not in rendered
-    assert 'video_processor_info{tier="unknown"} 1' in rendered
+    assert 'video_processor_info{cell="unknown",tier="unknown"} 1' in rendered
     assert 'video_processor_jobs_started_total{mode="unknown"} 1' in rendered
     assert (
         'video_processor_jobs_finished_total{mode="unknown",outcome="error"} 1'
         in rendered
     )
     assert "video_processor_retiring 1" in rendered
+
+
+def test_metrics_use_a_bounded_legacy_cell_when_cell_is_not_configured():
+    rendered = ProcessorMetrics().render(
+        active_jobs=0,
+        capacity=1,
+        tier="cpu",
+        retiring=False,
+    )
+
+    assert 'video_processor_info{cell="legacy",tier="cpu"} 1' in rendered

--- a/tests/development/video_poc/test_processor_security.py
+++ b/tests/development/video_poc/test_processor_security.py
@@ -10,13 +10,70 @@ sys.path.insert(0, str(PROCESSOR_DIR))
 
 from security import (  # noqa: E402
     DiagnosticRing,
+    JobPlacementMismatch,
     JobSecurityRegistry,
     MissingJobAccessToken,
     extract_access_token,
     format_inference_error,
     sanitize_diagnostic,
+    validate_cell_id,
+    validate_job_placement,
     validate_job_id,
 )
+
+
+def test_cell_identity_is_optional_but_validated_as_a_bounded_dns_label():
+    assert validate_cell_id(None) is None
+    assert validate_cell_id("crusoe-use1") == "crusoe-use1"
+
+    for value in ("Crusoe-USE1", "cell.with.dots", "-cell", "cell-", "x" * 64):
+        with pytest.raises(ValueError, match="lowercase DNS label"):
+            validate_cell_id(value)
+
+
+def test_job_placement_accepts_matching_explicit_remote_and_legacy_jobs():
+    validate_job_placement({}, None)
+    validate_job_placement({}, "crusoe-use1")
+    validate_job_placement(
+        {"executionCell": "crusoe-use1", "sourceCell": "crusoe-use1"},
+        "crusoe-use1",
+    )
+    validate_job_placement(
+        {
+            "executionCell": "crusoe-ussc1",
+            "sourceCell": "crusoe-use1",
+            "remoteExecution": True,
+        },
+        "crusoe-ussc1",
+    )
+
+
+@pytest.mark.parametrize(
+    ("job", "cell", "reason"),
+    [
+        (
+            {"executionCell": "crusoe-use1", "sourceCell": "crusoe-use1"},
+            "crusoe-ussc1",
+            "execution_cell_mismatch",
+        ),
+        (
+            {"executionCell": "crusoe-use1", "sourceCell": "crusoe-ussc1"},
+            "crusoe-use1",
+            "implicit_cross_cell",
+        ),
+        (
+            {"executionCell": "crusoe-use1", "sourceCell": "crusoe-use1"},
+            None,
+            "processor_cell_missing",
+        ),
+        ({"sourceCell": "crusoe-use1"}, "crusoe-use1", "invalid_placement"),
+    ],
+)
+def test_job_placement_rejects_unsafe_assignments(job, cell, reason):
+    with pytest.raises(JobPlacementMismatch) as error:
+        validate_job_placement(job, cell)
+
+    assert error.value.reason == reason
 
 
 def test_required_registry_rejects_claim_without_access_token():

--- a/tests/development/video_poc/test_relay_benchmark_agent.py
+++ b/tests/development/video_poc/test_relay_benchmark_agent.py
@@ -123,7 +123,15 @@ def test_prometheus_contract_uses_only_bounded_role_location_labels():
 def test_placement_distinguishes_observed_node_from_requested_instance(monkeypatch):
     monkeypatch.setenv("NODE_NAME", "observed-node-1")
     monkeypatch.setenv("REQUESTED_NODE_INSTANCE_TYPE", "c1a.16x")
+    monkeypatch.setenv("EXPECTED_CELL_ID", "crusoe-use1")
+    monkeypatch.setenv("EXPECTED_CLUSTER_CONTEXT", "ck8s-stg")
+    monkeypatch.setenv("MEDIA_PATH", "south-to-east")
+    monkeypatch.setenv("MEDIA_PATH_KIND", "explicit-cross-cell")
     placement = _placement()
     assert placement["nodeName"] == "observed-node-1"
     assert placement["requestedNodeInstanceType"] == "c1a.16x"
+    assert placement["expectedCell"] == "crusoe-use1"
+    assert placement["expectedClusterContext"] == "ck8s-stg"
+    assert placement["mediaPath"] == "south-to-east"
+    assert placement["mediaPathKind"] == "explicit-cross-cell"
     assert "nodeInstanceType" not in placement

--- a/tests/development/video_poc/test_two_cell_validation.py
+++ b/tests/development/video_poc/test_two_cell_validation.py
@@ -1,0 +1,216 @@
+import copy
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+NETWORKING_DIR = (
+    Path(__file__).resolve().parents[3]
+    / "development"
+    / "video_poc"
+    / "benchmarks"
+    / "networking"
+)
+sys.path.insert(0, str(NETWORKING_DIR))
+
+from render_two_cell_validation import (  # noqa: E402
+    load_scenario,
+    render,
+    write_rendered,
+)
+
+EXAMPLE = NETWORKING_DIR / "two-cell-south-east.staging.example.json"
+
+
+def example_dict():
+    return json.loads(EXAMPLE.read_text())
+
+
+def load(tmp_path, raw=None):
+    path = tmp_path / "two-cell.json"
+    path.write_text(json.dumps(raw or example_dict()))
+    return load_scenario(path)
+
+
+def test_example_renders_separate_staging_bundles_with_explicit_cells(tmp_path):
+    scenario = load(tmp_path)
+    bundles, manifest, report = render(scenario, "two-cell-001")
+
+    assert set(bundles) == {"east", "south"}
+    assert len(bundles["east"]["items"]) == 6
+    assert len(bundles["south"]["items"]) == 3
+    assert manifest["environment"] == "staging"
+    assert manifest["executionMode"] == "render-only"
+    assert manifest["agentImage"].endswith("@sha256:" + "0" * 64)
+    assert manifest["cells"]["east"]["cellId"] == "crusoe-use1"
+    assert manifest["cells"]["south"]["cellId"] == "crusoe-ussc1"
+    assert manifest["cells"]["east"]["clusterContext"] == "ck8s-stg"
+    assert manifest["cells"]["south"]["clusterContext"] == ("ck8s-stg-us-southcentral1")
+    assert all(
+        location["nodeSelector"] == {"node.kubernetes.io/instance-type": "c1a.16x"}
+        for location in scenario["locations"].values()
+    )
+    assert "l40s" not in EXAMPLE.read_text().lower()
+    assert report["scenarioSha256"] == manifest["scenarioSha256"]
+    assert report["secretsRecorded"] is False
+
+
+def test_cross_cell_job_runs_on_east_cpu_but_reads_south_public_endpoint(tmp_path):
+    bundles, manifest, _report = render(load(tmp_path), "two-cell-001")
+    cross_job = next(
+        job
+        for job in bundles["east"]["items"]
+        if job["metadata"]["labels"]["benchmark.roboflow.com/media-path"]
+        == "south-origin-east-processor"
+    )
+    labels = cross_job["metadata"]["labels"]
+    assert labels["benchmark.roboflow.com/expected-cell"] == "crusoe-use1"
+    assert labels["benchmark.roboflow.com/source-cell"] == "crusoe-ussc1"
+    assert labels["benchmark.roboflow.com/path-kind"] == "explicit-cross-cell"
+    assert cross_job["metadata"]["namespace"] == "video-proc-bench"
+    assert cross_job["spec"]["template"]["spec"]["nodeSelector"] == {
+        "node.kubernetes.io/instance-type": "c1a.16x"
+    }
+    container = cross_job["spec"]["template"]["spec"]["containers"][0]
+    env = {value["name"]: value for value in container["env"]}
+    assert env["BENCH_INPUT_URL"]["valueFrom"]["secretKeyRef"] == {
+        "name": "replace-south-cell-endpoints",
+        "key": "consume-public-template",
+    }
+    assert env["EXPECTED_CELL_ID"]["value"] == "crusoe-use1"
+    assert env["EXPECTED_CLUSTER_CONTEXT"]["value"] == "ck8s-stg"
+    assert env["MEDIA_PATH_KIND"]["value"] == "explicit-cross-cell"
+    rendered = json.dumps({"bundles": bundles, "manifest": manifest})
+    assert "rtsp://" not in rendered
+    assert "https://" not in rendered
+
+
+def test_same_cell_path_requires_internal_endpoint_and_remote_false(tmp_path):
+    raw = example_dict()
+    raw["mediaPaths"][0]["remoteExecution"] = True
+    with pytest.raises(ValueError, match="same-cell paths must be local"):
+        load(tmp_path, raw)
+
+    raw = example_dict()
+    raw["mediaPaths"][0]["consumeEndpoint"] = "consumePublicTemplate"
+    with pytest.raises(ValueError, match="consumeInternalTemplate"):
+        load(tmp_path, raw)
+
+
+def test_cross_cell_path_must_be_explicit_and_use_public_endpoint(tmp_path):
+    raw = example_dict()
+    cross = raw["mediaPaths"][2]
+    cross["remoteExecution"] = False
+    with pytest.raises(ValueError, match="remoteExecution=true"):
+        load(tmp_path, raw)
+
+    raw = example_dict()
+    raw["mediaPaths"][2]["consumeEndpoint"] = "consumeInternalTemplate"
+    with pytest.raises(ValueError, match="consumePublicTemplate"):
+        load(tmp_path, raw)
+
+
+def test_staging_render_only_and_secret_reference_guards_are_hard(tmp_path):
+    raw = example_dict()
+    raw["environment"] = "production"
+    with pytest.raises(ValueError, match="staging-only"):
+        load(tmp_path, raw)
+
+    raw = example_dict()
+    raw["cells"]["south"]["clusterContext"] = "production"
+    with pytest.raises(ValueError, match="recognizably staging"):
+        load(tmp_path, raw)
+
+    raw = example_dict()
+    raw["executionMode"] = "apply"
+    with pytest.raises(ValueError, match="render-only"):
+        load(tmp_path, raw)
+
+    raw = example_dict()
+    raw["cells"]["east"]["endpoints"]["ingestTemplate"] = {
+        "value": "rtsp://credential@example.test/{stream}"
+    }
+    with pytest.raises(ValueError, match="Secret name and key"):
+        load(tmp_path, raw)
+
+
+def test_control_plane_evidence_requires_assignment_reconnect_and_policy(tmp_path):
+    raw = example_dict()
+    raw["controlPlaneEvidence"]["cases"] = raw["controlPlaneEvidence"]["cases"][:3]
+    with pytest.raises(ValueError, match="cell-loss recovery"):
+        load(tmp_path, raw)
+
+    raw = example_dict()
+    raw["controlPlaneEvidence"]["cases"][0]["artifacts"][
+        "activated"
+    ] = "https://signed.example/evidence?token=secret"
+    with pytest.raises(ValueError, match="relative non-URL artifact path"):
+        load(tmp_path, raw)
+
+
+def test_report_contract_covers_placement_metrics_network_and_recovery(tmp_path):
+    _bundles, manifest, report = render(load(tmp_path), "two-cell-001")
+    collection = manifest["collectionContract"]
+
+    assert set(collection["placement"]) == {"east", "south"}
+    assert "observedCell" in collection["placement"]["east"]["requiredObservedFields"]
+    assert any(
+        "MediaMTX" in item for item in collection["prometheus"]["requiredEvidence"]
+    )
+    assert any(
+        "processor cell" in item
+        for item in collection["prometheus"]["requiredEvidence"]
+    )
+    assert "source-cell egress bytes" in collection["network"]["requiredPerPath"]
+    assert collection["failureTimeline"]["clock"].startswith("UTC RFC3339")
+    assert "actual connector publish endpoint" in " ".join(
+        collection["controlPlaneRouting"]["requiredPerSource"]
+    )
+    assert "preview request" in " ".join(
+        collection["controlPlaneRouting"]["requiredPerSource"]
+    )
+    assert (
+        "processor claim/status cell assertion"
+        in collection["controlPlaneRouting"]["requiredPerSource"]
+    )
+    assert report["assertions"]["firstActivationAssignment"] == "pending"
+    assert report["assertions"]["explicitCrossCellExperiment"] == "pending"
+    assert report["assertions"]["failureRecovery"] == "pending"
+    assert report["assertions"]["cellLossUnavailableBounded"] == "pending"
+    assert report["assertions"]["previewFromAssignedCell"] == "pending"
+    assert report["assertions"]["processorClaimedExpectedCell"] == "pending"
+    assert report["assertions"]["relaySessionsAndReadersMatch"] == "pending"
+    failure = manifest["measurementPlan"]["failureExperiments"][0]
+    assert failure["targetCell"] == "south"
+    assert failure["maxUnavailableSeconds"] == 120
+    assert failure["reassignmentPolicy"] == "retain-home-cell"
+    assert "cell-marked-unavailable" in failure["requiredEvents"]
+    assert "reassignment-decision" in failure["requiredEvents"]
+    assert manifest["rollback"]["cellResourcesChanged"] is False
+    assert manifest["rollback"]["failureExperimentRollbackRequiresApproval"] is True
+
+
+def test_scenario_hash_is_stable_and_outputs_refuse_overwrite(tmp_path):
+    scenario = load(tmp_path)
+    first = render(scenario, "two-cell-001")
+    second = render(scenario, "two-cell-001")
+    assert first[1]["scenarioSha256"] == second[1]["scenarioSha256"]
+
+    output_dir = tmp_path / "rendered"
+    paths = write_rendered(output_dir, *first)
+    assert {path.name for path in paths} == {
+        "jobs-east.json",
+        "jobs-south.json",
+        "validation-manifest.json",
+        "validation-report.template.json",
+    }
+    with pytest.raises(ValueError, match="refusing to overwrite"):
+        write_rendered(output_dir, *first)
+
+
+def test_failure_experiment_requires_approval_and_recovery_artifacts(tmp_path):
+    raw = copy.deepcopy(example_dict())
+    raw["measurementPlan"]["failureExperiments"][0]["requiresApproval"] = False
+    with pytest.raises(ValueError, match="explicitly require approval"):
+        load(tmp_path, raw)


### PR DESCRIPTION
## Summary

Stacks on #2616 and adds the Phase-1 processor safety seam for multi-cell Video Sources plus an offline, deterministic two-cell staging validation harness.

- reads a bounded immutable `VIDEO_PROC_CELL` identity once per worker;
- asserts cell identity on claim/status/result calls;
- rejects wrong-cell and accidental cross-cell jobs before any execution side effect while preserving legacy jobs with no placement metadata;
- permits remote execution only when the job is explicitly marked `remoteExecution=true`;
- exposes bounded cell identity and rejection reasons in health/runtime/metrics;
- preserves cell identity through process-mode IPC;
- renders separate East/South benchmark Jobs and redacted evidence templates for assignment, connector, preview, placement, failure/recovery, and network proof;
- updates `HANDOFF.md` and the multi-cell RFC to reflect what is implemented versus still undeployed.

The harness is staging/render-only. It does not access Kubernetes, credentials, DNS, or the live capacity-test connector source.

## Compatibility and dependencies

- Base/dependency: #2616 (`hansent/video-poc`).
- Legacy worker + legacy job remains accepted.
- Configured worker + legacy job remains accepted during migration.
- A placed job on a worker with no cell identity fails closed.
- This intentionally does not change the active L40S capacity/runtime settings.
- Deployment depends on the matching control-plane and staging-infra PRs; do not deploy independently.

## Validation

- `pytest -q tests/development/video_poc` — 217 passed
- `PYTHONPATH=. pytest -q development/video_poc/processor/test_*.py` — 18 passed
- focused two-cell renderer dry run — 9 agents, separate East/South manifests, no inline secrets
- `git diff --check`

Whole-file Black checks for three touched POC files fail identically on the parent branch; this PR avoids unrelated formatter churn.

## Deployment safety

Draft only. No staging or production deployment is included. Any staged failure injection, benchmark Jobs, or cell rollout requires a separate owner approval checkpoint.
