### PR TITLE
Add Gemini 3.7 Flash to Google Gemini v3 and v4 blocks

### DIFF
--- a/inference/core/workflows/core_steps/models/foundation/google_gemini/v3.py
+++ b/inference/core/workflows/core_steps/models/foundation/google_gemini/v3.py
@@ -52,6 +52,12 @@ MODEL_ALIASES = {
 
 GEMINI_MODELS = [
     {
+        "id": "gemini-3.7-flash",
+        "name": "Gemini 3.7 Flash",
+        "supports_thinking_level": True,
+        "supports_native_code_execution": True,
+    },
+    {
         "id": "gemini-3.6-flash",
         "name": "Gemini 3.6 Flash",
         "supports_thinking_level": True,

--- a/inference/core/workflows/core_steps/models/foundation/google_gemini/v4.py
+++ b/inference/core/workflows/core_steps/models/foundation/google_gemini/v4.py
@@ -52,6 +52,12 @@ MODEL_ALIASES = {
 
 GEMINI_MODELS = [
     {
+        "id": "gemini-3.7-flash",
+        "name": "Gemini 3.7 Flash",
+        "supports_thinking_level": True,
+        "supports_native_code_execution": True,
+    },
+    {
         "id": "gemini-3.6-flash",
         "name": "Gemini 3.6 Flash",
         "supports_thinking_level": True,

--- a/tests/workflows/unit_tests/core_steps/models/foundation/test_google_gemini.py
+++ b/tests/workflows/unit_tests/core_steps/models/foundation/test_google_gemini.py
@@ -80,16 +80,6 @@ def test_gemini_model_catalog_uses_available_google_models(
     assert "gemini-3.1-flash-lite" in model_ids
 
 
-@pytest.mark.parametrize(
-    "model_ids",
-    [V3_MODEL_VERSION_IDS, V4_MODEL_VERSION_IDS],
-)
-def test_gemini_model_catalog_includes_latest_models(
-    model_ids: list[str],
-) -> None:
-    assert "gemini-3.7-flash" in model_ids
-
-
 @pytest.mark.parametrize("value", [None, 1, "a", True])
 def test_gemini_step_validation_when_image_is_invalid(value: Any) -> None:
     # given

--- a/tests/workflows/unit_tests/core_steps/models/foundation/test_google_gemini.py
+++ b/tests/workflows/unit_tests/core_steps/models/foundation/test_google_gemini.py
@@ -80,6 +80,16 @@ def test_gemini_model_catalog_uses_available_google_models(
     assert "gemini-3.1-flash-lite" in model_ids
 
 
+@pytest.mark.parametrize(
+    "model_ids",
+    [V3_MODEL_VERSION_IDS, V4_MODEL_VERSION_IDS],
+)
+def test_gemini_model_catalog_includes_latest_models(
+    model_ids: list[str],
+) -> None:
+    assert "gemini-3.7-flash" in model_ids
+
+
 @pytest.mark.parametrize("value", [None, 1, "a", True])
 def test_gemini_step_validation_when_image_is_invalid(value: Any) -> None:
     # given


### PR DESCRIPTION
## What does this PR do?

Google released Gemini 3.7 Flash on Aug 13, 2026 (model id `gemini-3.7-flash`), and the model was not yet selectable in the Google Gemini workflow blocks. This PR adds it to the model catalogs, following the same pattern used to add `gemini-3.6-flash` in #2734.

The new entry is inserted at the top of `GEMINI_MODELS` in `google_gemini@v3` and `google_gemini@v4`, with `supports_thinking_level` and `supports_native_code_execution` both enabled (confirmed by Google's Gemini API docs and by full-benchmark runs in [roboflow/vlm-exam#26](https://github.com/roboflow/vlm-exam/pull/26), which exercised the model at low and high effort across all 6 tasks with zero failures; detection mAP@50 69.4%). All derived lists (`MODEL_VERSION_IDS`, model metadata, thinking-level and code-execution gating) are computed from the catalog, so no other block changes are needed. The model uses the same Gemini-native `box_2d` yxyx 0-1000 detection convention as existing models, so `vlm_as_detector@v2` parsing works unchanged. The default `model_version` and the frozen v1/v2 catalogs are left untouched.

**Main elements:**
- `inference/core/workflows/core_steps/models/foundation/google_gemini/v3.py` — catalog entry
- `inference/core/workflows/core_steps/models/foundation/google_gemini/v4.py` — catalog entry

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other:

## Testing

### Unit tests

- Existing catalog and manifest validation tests cover the updated `GEMINI_MODELS` lists.
- `pytest tests/workflows/unit_tests/core_steps/models/foundation/test_google_gemini.py` — passed.

### Integration tests

- None for this PR.

### Other

- black, isort, and flake8 error-level checks clean on changed files.
- Live benchmark validation of the model id and detection format in [roboflow/vlm-exam#26](https://github.com/roboflow/vlm-exam/pull/26).

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [ ] I have updated the documentation accordingly (if applicable)