### PR TITLE
Make MemoryCache.acquire_lock actually serialise on one key

### DIFF
--- a/inference/core/cache/memory.py
+++ b/inference/core/cache/memory.py
@@ -25,6 +25,11 @@ class MemoryCache(BaseCache):
         self.cache = dict()
         self.expires = dict()
         self.zexpires = dict()
+        # Guards the lookup-and-create in acquire_lock so that two callers racing
+        # on the same missing key end up with one lock object rather than two.
+        # Held only around that bookkeeping, never while waiting on the lock
+        # itself, so callers holding different keys are not serialised.
+        self._acquire_lock_guard = Lock()
 
         self._expire_thread = threading.Thread(target=self._expire)
         self._expire_thread.daemon = True
@@ -152,13 +157,19 @@ class MemoryCache(BaseCache):
         return len(keys_to_delete)
 
     def acquire_lock(self, key: str, expire=None) -> Any:
-        lock: Optional[Lock] = self.get(key)
-        if lock is None:
-            lock = Lock()
-            self.set(key, lock, expire=expire)
-        if expire is None:
-            expire = -1
-        acquired = lock.acquire(timeout=expire)
+        with self._acquire_lock_guard:
+            lock: Optional[Lock] = self.get(key)
+            if lock is None:
+                lock = Lock()
+                self.set(key, lock, expire=expire)
+        # -1 is Lock.acquire's "block forever" sentinel, and it must not reach
+        # set(): as a cache expiry it stores an entry one second in the past, so
+        # the very next get() deletes it and the following caller builds a fresh
+        # lock. With the default expire=None that left acquire_lock handing out a
+        # different lock to every caller, so the protected section was never
+        # actually serialised.
+        timeout = -1 if expire is None else expire
+        acquired = lock.acquire(timeout=timeout)
         if not acquired:
             raise TimeoutError()
         # refresh the lock

--- a/tests/inference/unit_tests/core/cache/test_memory_cache.py
+++ b/tests/inference/unit_tests/core/cache/test_memory_cache.py
@@ -53,15 +53,20 @@ def test_acquire_lock_with_expire_still_records_the_expiry():
 
 def test_concurrent_first_acquisition_shares_one_lock():
     # given - a barrier that holds both callers past their first read, so the
-    # two would build separate locks if the lookup-and-create were not guarded
+    # two would build separate locks if the lookup-and-create were not guarded.
+    #
+    # Once it is guarded the second caller cannot reach the barrier while the
+    # first holds the guard, so the barrier is expected to time out rather than
+    # trip. That timeout is the whole wait in this test, hence a short one.
     cache = _build_cache()
     barrier = threading.Barrier(2)
+    barrier_timeout = 0.5
     original_get = cache.get
 
     def get_with_scheduling_gap(key):
         value = original_get(key)
         try:
-            barrier.wait(timeout=5)
+            barrier.wait(timeout=barrier_timeout)
         except threading.BrokenBarrierError:
             pass
         return value

--- a/tests/inference/unit_tests/core/cache/test_memory_cache.py
+++ b/tests/inference/unit_tests/core/cache/test_memory_cache.py
@@ -1,0 +1,113 @@
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import patch
+
+from inference.core.cache.memory import MemoryCache
+
+
+def _build_cache() -> MemoryCache:
+    """Construct a MemoryCache without starting the background ``_expire`` thread."""
+    with patch("inference.core.cache.memory.threading.Thread"):
+        return MemoryCache()
+
+
+def test_acquire_lock_without_expire_keeps_the_lock_cached():
+    # given - the default expire=None, as used by the model-loading paths
+    cache = _build_cache()
+
+    # when
+    lock = cache.acquire_lock("some-key")
+    lock.release()
+
+    # then - no expiry is recorded, so the entry is not discarded on the next read
+    assert cache.expires.get("some-key") is None
+    assert cache.get("some-key") is lock
+
+
+def test_acquire_lock_without_expire_reuses_one_lock_across_calls():
+    # given
+    cache = _build_cache()
+
+    # when
+    first = cache.acquire_lock("some-key")
+    first.release()
+    second = cache.acquire_lock("some-key")
+    second.release()
+
+    # then - the whole point of a keyed lock: the same key means the same lock
+    assert first is second
+
+
+def test_acquire_lock_with_expire_still_records_the_expiry():
+    # given
+    cache = _build_cache()
+
+    # when
+    lock = cache.acquire_lock("some-key", expire=60)
+    lock.release()
+
+    # then - an explicit expiry is honoured, and is in the future
+    assert cache.expires["some-key"] > time.time()
+
+
+def test_concurrent_first_acquisition_shares_one_lock():
+    # given - a barrier that holds both callers past their first read, so the
+    # two would build separate locks if the lookup-and-create were not guarded
+    cache = _build_cache()
+    barrier = threading.Barrier(2)
+    original_get = cache.get
+
+    def get_with_scheduling_gap(key):
+        value = original_get(key)
+        try:
+            barrier.wait(timeout=5)
+        except threading.BrokenBarrierError:
+            pass
+        return value
+
+    cache.get = get_with_scheduling_gap
+    acquired = []
+
+    def worker():
+        lock = cache.acquire_lock("same-key")
+        acquired.append(lock)
+        lock.release()
+
+    # when
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        for future in [executor.submit(worker), executor.submit(worker)]:
+            future.result()
+
+    # then - one lock object, so the protected section is actually serialised
+    assert len(acquired) == 2
+    assert len({id(lock) for lock in acquired}) == 1
+
+
+def test_acquire_lock_serialises_the_protected_section():
+    # given - the behaviour the lock exists to provide, stated directly
+    cache = _build_cache()
+    concurrent = 0
+    peak = 0
+    peak_guard = threading.Lock()
+
+    def worker():
+        nonlocal concurrent, peak
+        lock = cache.acquire_lock("model-load")
+        try:
+            with peak_guard:
+                concurrent += 1
+                peak = max(peak, concurrent)
+            time.sleep(0.02)
+            with peak_guard:
+                concurrent -= 1
+        finally:
+            lock.release()
+
+    # when
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        for future in [executor.submit(worker) for _ in range(4)]:
+            future.result()
+
+    # then - never two callers inside at once
+    assert peak == 1


### PR DESCRIPTION
Fixes #2772.

@voropaevv's report is correct: `acquire_lock` did a check-then-act, so two callers racing on the same missing key each built their own `Lock` and both entered the protected section. Reproduced with the barrier from the issue before changing anything.

While fixing it I found a second problem in the same method, and it is the more serious of the two.

## The refresh was poisoning its own cache entry

```python
if expire is None:
    expire = -1
acquired = lock.acquire(timeout=expire)
...
self.set(key, lock, expire=expire)   # expire is now -1
```

`-1` is `Lock.acquire`'s "block forever" sentinel. Reusing it as a **cache expiry** stores an entry one second in the past, so the next `get()` sees it expired, deletes it, and the following caller builds a fresh lock.

With the default `expire=None` that means `acquire_lock` never shared a lock at all — not even between two sequential calls on one thread:

```
after first acquire_lock(expire=None):
  expires[k]:      1786678716.92
  now       :      1786678717.92
  already expired: True
second call reused the same lock: False
```

So on `main` the keyed lock provides no mutual exclusion under its default configuration. That is also why the reported race is so easy to hit: the entry is gone almost immediately, so nearly every call takes the create path.

## The fix

Two independent changes, both needed:

- a dedicated guard around the lookup-and-create, held **only** for that bookkeeping and never while waiting on the lock itself, so unrelated keys are not serialised against each other
- `-1` kept in a separate local so it reaches `Lock.acquire` but never `set()`

I checked they are independently load-bearing — with the expiry fix applied but the guard removed, the race still reproduces.

## Tests

`tests/inference/unit_tests/core/cache/test_memory_cache.py`, 5 cases: the entry survives with `expire=None`, sequential calls reuse one lock, an explicit `expire` is still recorded, concurrent first acquisition shares one lock, and the behaviour the whole thing exists for — never two callers inside the protected section at once.

4 of the 5 fail on the parent commit and all 5 pass here:

```
4 failed, 1 passed     # pre-fix source, tests kept
5 passed in 1.78s      # with the fix
```

The one that passes both ways is the regression guard for explicit expiries.

`make style` (black + isort) clean on both files. `test_model_artifacts.py` shows 15 failures in my environment, identical with and without this change — pre-existing and unrelated (Windows path/symlink cases).
