### PR TITLE
Add SpaceXAI Grok workflow block (Grok 4.6 / 4.5)

### DIFF
--- a/inference/core/env.py
+++ b/inference/core/env.py
@@ -944,6 +944,12 @@ WORKFLOWS_REMOTE_EXECUTION_MAX_STEP_BATCH_SIZE = int(
 WORKFLOWS_REMOTE_EXECUTION_MAX_STEP_CONCURRENT_REQUESTS = int(
     os.getenv("WORKFLOWS_REMOTE_EXECUTION_MAX_STEP_CONCURRENT_REQUESTS", "8")
 )
+# Enables the Roboflow-managed (rf_key) API key option in the SpaceXAI block.
+# Off by default until the platform-side xAI proxy (apiproxy/xai) is deployed;
+# with the flag off users must provide their own xAI API key.
+WORKFLOWS_SPACEXAI_MANAGED_KEY_ENABLED = str2bool(
+    os.getenv("WORKFLOWS_SPACEXAI_MANAGED_KEY_ENABLED", False)
+)
 ALLOW_CUSTOM_PYTHON_EXECUTION_IN_WORKFLOWS = str2bool(
     os.getenv("ALLOW_CUSTOM_PYTHON_EXECUTION_IN_WORKFLOWS", True)
 )

--- a/inference/core/workflows/core_steps/formatters/vlm_as_detector/spacexai_detection_parsing.py
+++ b/inference/core/workflows/core_steps/formatters/vlm_as_detector/spacexai_detection_parsing.py
@@ -1,0 +1,147 @@
+from typing import List, Union
+from uuid import uuid4
+
+import numpy as np
+import supervision as sv
+from supervision.config import CLASS_NAME_DATA_FIELD
+
+from inference.core.workflows.core_steps.common.utils import (
+    attach_parents_coordinates_to_sv_detections,
+)
+from inference.core.workflows.core_steps.formatters.vlm_as_detector.gemini_detection_parsing import (
+    create_classes_index,
+    get_gemini_detection_class_name,
+    scale_confidence,
+)
+from inference.core.workflows.execution_engine.constants import (
+    DETECTION_ID_KEY,
+    IMAGE_DIMENSIONS_KEY,
+    INFERENCE_ID_KEY,
+    PREDICTION_TYPE_KEY,
+)
+from inference.core.workflows.execution_engine.entities.base import WorkflowImageData
+
+SPACEXAI_BOX_COORDINATE_SCALE = 100.0
+
+
+def extract_spacexai_detection_entries(
+    parsed_data: Union[dict, list],
+) -> List[dict]:
+    """Extract detection entries from SpaceXAI object-detection JSON.
+
+    Args:
+        parsed_data: JSON payload extracted from the VLM output.
+
+    Returns:
+        List of detection dictionaries.
+
+    Raises:
+        ValueError: If the response is not a JSON list or a
+            ``{"detections": [...]}`` wrapper.
+    """
+    if isinstance(parsed_data, list):
+        return parsed_data
+    if isinstance(parsed_data, dict) and "detections" in parsed_data:
+        return parsed_data["detections"]
+    raise ValueError("Unexpected SpaceXAI object detection response format")
+
+
+def convert_spacexai_detection_to_pixel_xyxy(
+    detection: dict,
+    image_height: int,
+    image_width: int,
+) -> List[float]:
+    """Convert a percent ``box_2d`` entry into original-image pixel coordinates.
+
+    SpaceXAI Grok detection prompts ask for ``[x_min, y_min, x_max, y_max]`` as
+    percentages of image width and height (floats 0-100). Coordinates are
+    clamped to ``[0, 100]`` before scaling.
+
+    Args:
+        detection: Detection entry with a ``box_2d`` field.
+        image_height: Original image height in pixels.
+        image_width: Original image width in pixels.
+
+    Returns:
+        ``[x_min, y_min, x_max, y_max]`` in pixel coordinates of the original
+        image.
+    """
+    x_min, y_min, x_max, y_max = detection["box_2d"]
+    scale = SPACEXAI_BOX_COORDINATE_SCALE
+    x_min = min(max(float(x_min), 0.0), scale)
+    x_max = min(max(float(x_max), 0.0), scale)
+    y_min = min(max(float(y_min), 0.0), scale)
+    y_max = min(max(float(y_max), 0.0), scale)
+    return [
+        x_min / scale * image_width,
+        y_min / scale * image_height,
+        x_max / scale * image_width,
+        y_max / scale * image_height,
+    ]
+
+
+def parse_spacexai_object_detection_response(
+    image: WorkflowImageData,
+    parsed_data: Union[dict, list],
+    classes: List[str],
+    inference_id: str,
+) -> sv.Detections:
+    """Parse SpaceXAI Grok object-detection output into detections.
+
+    Args:
+        image: Workflow image the detections refer to.
+        parsed_data: JSON list of detection entries produced by the model.
+        classes: Class names used to map labels onto class ids.
+        inference_id: Identifier attached to every parsed detection.
+
+    Returns:
+        Parsed detections in the original image's coordinate space.
+    """
+    detections = extract_spacexai_detection_entries(parsed_data=parsed_data)
+    if len(detections) == 0:
+        return sv.Detections.empty()
+
+    class_name2id = create_classes_index(classes=classes)
+    image_height, image_width = image.numpy_image.shape[:2]
+
+    xyxy, class_id, class_name, confidence = [], [], [], []
+    for detection in detections:
+        xyxy.append(
+            convert_spacexai_detection_to_pixel_xyxy(
+                detection=detection,
+                image_height=image_height,
+                image_width=image_width,
+            )
+        )
+        label = get_gemini_detection_class_name(detection=detection)
+        class_id.append(class_name2id.get(label, -1))
+        class_name.append(label)
+        confidence.append(scale_confidence(detection.get("confidence", 1.0)))
+
+    xyxy = np.array(xyxy).round(0) if len(xyxy) > 0 else np.empty((0, 4))
+    confidence = np.array(confidence) if len(confidence) > 0 else np.empty(0)
+    class_id = np.array(class_id).astype(int) if len(class_id) > 0 else np.empty(0)
+    class_name = np.array(class_name) if len(class_name) > 0 else np.empty(0)
+    detection_ids = np.array([str(uuid4()) for _ in range(len(xyxy))])
+    dimensions = np.array([[image_height, image_width]] * len(xyxy))
+    inference_ids = np.array([inference_id] * len(xyxy))
+    prediction_type = np.array(["object-detection"] * len(xyxy))
+    data = {
+        CLASS_NAME_DATA_FIELD: class_name,
+        IMAGE_DIMENSIONS_KEY: dimensions,
+        INFERENCE_ID_KEY: inference_ids,
+        DETECTION_ID_KEY: detection_ids,
+        PREDICTION_TYPE_KEY: prediction_type,
+    }
+    detections_result = sv.Detections(
+        xyxy=xyxy,
+        confidence=confidence,
+        class_id=class_id,
+        mask=None,
+        tracker_id=None,
+        data=data,
+    )
+    return attach_parents_coordinates_to_sv_detections(
+        detections=detections_result,
+        image=image,
+    )

--- a/inference/core/workflows/core_steps/formatters/vlm_as_detector/v2.py
+++ b/inference/core/workflows/core_steps/formatters/vlm_as_detector/v2.py
@@ -21,6 +21,9 @@ from inference.core.workflows.core_steps.formatters.vlm_as_detector.gemini_detec
 from inference.core.workflows.core_steps.formatters.vlm_as_detector.openai_detection_parsing import (
     parse_openai_object_detection_response,
 )
+from inference.core.workflows.core_steps.formatters.vlm_as_detector.spacexai_detection_parsing import (
+    parse_spacexai_object_detection_response,
+)
 from inference.core.workflows.execution_engine.constants import (
     DETECTION_ID_KEY,
     IMAGE_DIMENSIONS_KEY,
@@ -145,7 +148,7 @@ This version (v2) includes the following enhancements over v1:
 
 ## Requirements
 
-This block requires an image input (for metadata and dimensions) and a VLM output string containing JSON detection data. The JSON can be raw JSON or wrapped in Markdown code blocks (```json ... ```). The block supports four model types: "openai", "google-gemini", "anthropic-claude", and "florence-2". It supports multiple task types: "object-detection", "open-vocabulary-object-detection", "object-detection-and-caption", "phrase-grounded-object-detection", "region-proposal", and "ocr-with-text-detection". The `classes` parameter is required for OpenAI, Gemini, and Claude models (to map class names to IDs) but optional for Florence-2 (some tasks don't require it). Classes are mapped to IDs by index (first class = 0, second = 1, etc.). Classes not in the list get class_id = -1. The block outputs object detection predictions in standard format (compatible with detection blocks), error_status (boolean), and inference_id (INFERENCE_ID_KIND) for tracking.
+This block requires an image input (for metadata and dimensions) and a VLM output string containing JSON detection data. The JSON can be raw JSON or wrapped in Markdown code blocks (```json ... ```). The block supports five model types: "openai", "google-gemini", "anthropic-claude", "spacexai", and "florence-2". It supports multiple task types: "object-detection", "open-vocabulary-object-detection", "object-detection-and-caption", "phrase-grounded-object-detection", "region-proposal", and "ocr-with-text-detection". The `classes` parameter is required for OpenAI, Gemini, Claude, and SpaceXAI models (to map class names to IDs) but optional for Florence-2 (some tasks don't require it). Classes are mapped to IDs by index (first class = 0, second = 1, etc.). Classes not in the list get class_id = -1. The block outputs object detection predictions in standard format (compatible with detection blocks), error_status (boolean), and inference_id (INFERENCE_ID_KIND) for tracking.
 """
 
 SHORT_DESCRIPTION = "Parses raw string into object-detection prediction."
@@ -213,22 +216,28 @@ class BlockManifest(WorkflowBlockManifest):
         json_schema_extra={
             "relevant_for": {
                 "model_type": {
-                    "values": ["openai", "google-gemini", "anthropic-claude"],
+                    "values": [
+                        "openai",
+                        "google-gemini",
+                        "anthropic-claude",
+                        "spacexai",
+                    ],
                     "required": True,
                 },
             }
         },
     )
-    model_type: Literal["openai", "google-gemini", "anthropic-claude", "florence-2"] = (
-        Field(
-            description="Type of the VLM/LLM model that generated the prediction. Determines which parser is used to extract detection data from the JSON output. Supported models: 'openai' (GPT-4V), 'google-gemini' (Gemini Vision), 'anthropic-claude' (Claude Vision), 'florence-2' (Microsoft Florence-2). Each model type has different JSON output formats, so the correct model type must be specified for proper parsing.",
-            examples=[
-                ["openai"],
-                ["google-gemini"],
-                ["anthropic-claude"],
-                ["florence-2"],
-            ],
-        )
+    model_type: Literal[
+        "openai", "google-gemini", "anthropic-claude", "spacexai", "florence-2"
+    ] = Field(
+        description="Type of the VLM/LLM model that generated the prediction. Determines which parser is used to extract detection data from the JSON output. Supported models: 'openai' (GPT-4V), 'google-gemini' (Gemini Vision), 'anthropic-claude' (Claude Vision), 'spacexai' (Grok), 'florence-2' (Microsoft Florence-2). Each model type has different JSON output formats, so the correct model type must be specified for proper parsing.",
+        examples=[
+            ["openai"],
+            ["google-gemini"],
+            ["anthropic-claude"],
+            ["spacexai"],
+            ["florence-2"],
+        ],
     )
     task_type: Literal[tuple(SUPPORTED_TASKS)] = Field(
         description="Task type performed by the VLM/LLM model. Determines which parser and format handler is used. Supported task types: 'object-detection' (standard object detection), 'open-vocabulary-object-detection' (detect objects with custom classes), 'object-detection-and-caption' (detection with captions), 'phrase-grounded-object-detection' (ground phrases to detections), 'region-proposal' (propose regions of interest), 'ocr-with-text-detection' (OCR with text region detection). The task type must match what the VLM/LLM was asked to perform.",
@@ -517,6 +526,7 @@ REGISTERED_PARSERS = {
     ("openai", "object-detection"): parse_openai_detection_response,
     ("google-gemini", "object-detection"): parse_gemini_object_detection_response,
     ("anthropic-claude", "object-detection"): parse_llm_object_detection_response,
+    ("spacexai", "object-detection"): parse_spacexai_object_detection_response,
     # Florence 2
     ("florence-2", "object-detection"): partial(
         parse_florence2_object_detection_response, florence_task_type="<OD>"

--- a/inference/core/workflows/core_steps/formatters/vlm_as_detector/v2_tensor.py
+++ b/inference/core/workflows/core_steps/formatters/vlm_as_detector/v2_tensor.py
@@ -23,6 +23,10 @@ from inference.core.workflows.core_steps.formatters.vlm_as_detector.gemini_detec
 from inference.core.workflows.core_steps.formatters.vlm_as_detector.openai_detection_parsing import (
     convert_openai_detection_to_pixel_xyxy,
 )
+from inference.core.workflows.core_steps.formatters.vlm_as_detector.spacexai_detection_parsing import (
+    convert_spacexai_detection_to_pixel_xyxy,
+    extract_spacexai_detection_entries,
+)
 from inference.core.workflows.execution_engine.constants import (
     CLASS_NAME_KEY,
     CLASS_NAMES_KEY,
@@ -158,7 +162,7 @@ This version (v2) includes the following enhancements over v1:
 
 ## Requirements
 
-This block requires an image input (for metadata and dimensions) and a VLM output string containing JSON detection data. The JSON can be raw JSON or wrapped in Markdown code blocks (```json ... ```). The block supports four model types: "openai", "google-gemini", "anthropic-claude", and "florence-2". It supports multiple task types: "object-detection", "open-vocabulary-object-detection", "object-detection-and-caption", "phrase-grounded-object-detection", "region-proposal", and "ocr-with-text-detection". The `classes` parameter is required for OpenAI, Gemini, and Claude models (to map class names to IDs) but optional for Florence-2 (some tasks don't require it). Classes are mapped to IDs by index (first class = 0, second = 1, etc.). Classes not in the list get class_id = -1. The block outputs object detection predictions in standard format (compatible with detection blocks), error_status (boolean), and inference_id (INFERENCE_ID_KIND) for tracking.
+This block requires an image input (for metadata and dimensions) and a VLM output string containing JSON detection data. The JSON can be raw JSON or wrapped in Markdown code blocks (```json ... ```). The block supports five model types: "openai", "google-gemini", "anthropic-claude", "spacexai", and "florence-2". It supports multiple task types: "object-detection", "open-vocabulary-object-detection", "object-detection-and-caption", "phrase-grounded-object-detection", "region-proposal", and "ocr-with-text-detection". The `classes` parameter is required for OpenAI, Gemini, Claude, and SpaceXAI models (to map class names to IDs) but optional for Florence-2 (some tasks don't require it). Classes are mapped to IDs by index (first class = 0, second = 1, etc.). Classes not in the list get class_id = -1. The block outputs object detection predictions in standard format (compatible with detection blocks), error_status (boolean), and inference_id (INFERENCE_ID_KIND) for tracking.
 """
 
 SHORT_DESCRIPTION = "Parses raw string into object-detection prediction."
@@ -226,22 +230,28 @@ class BlockManifest(WorkflowBlockManifest):
         json_schema_extra={
             "relevant_for": {
                 "model_type": {
-                    "values": ["openai", "google-gemini", "anthropic-claude"],
+                    "values": [
+                        "openai",
+                        "google-gemini",
+                        "anthropic-claude",
+                        "spacexai",
+                    ],
                     "required": True,
                 },
             }
         },
     )
-    model_type: Literal["openai", "google-gemini", "anthropic-claude", "florence-2"] = (
-        Field(
-            description="Type of the VLM/LLM model that generated the prediction. Determines which parser is used to extract detection data from the JSON output. Supported models: 'openai' (GPT-4V), 'google-gemini' (Gemini Vision), 'anthropic-claude' (Claude Vision), 'florence-2' (Microsoft Florence-2). Each model type has different JSON output formats, so the correct model type must be specified for proper parsing.",
-            examples=[
-                ["openai"],
-                ["google-gemini"],
-                ["anthropic-claude"],
-                ["florence-2"],
-            ],
-        )
+    model_type: Literal[
+        "openai", "google-gemini", "anthropic-claude", "spacexai", "florence-2"
+    ] = Field(
+        description="Type of the VLM/LLM model that generated the prediction. Determines which parser is used to extract detection data from the JSON output. Supported models: 'openai' (GPT-4V), 'google-gemini' (Gemini Vision), 'anthropic-claude' (Claude Vision), 'spacexai' (Grok), 'florence-2' (Microsoft Florence-2). Each model type has different JSON output formats, so the correct model type must be specified for proper parsing.",
+        examples=[
+            ["openai"],
+            ["google-gemini"],
+            ["anthropic-claude"],
+            ["spacexai"],
+            ["florence-2"],
+        ],
     )
     task_type: Literal[tuple(SUPPORTED_TASKS)] = Field(
         description="Task type performed by the VLM/LLM model. Determines which parser and format handler is used. Supported task types: 'object-detection' (standard object detection), 'open-vocabulary-object-detection' (detect objects with custom classes), 'object-detection-and-caption' (detection with captions), 'phrase-grounded-object-detection' (ground phrases to detections), 'region-proposal' (propose regions of interest), 'ocr-with-text-detection' (OCR with text region detection). The task type must match what the VLM/LLM was asked to perform.",
@@ -699,6 +709,59 @@ def parse_openai_object_detection_response(
     )
 
 
+def parse_spacexai_object_detection_response(
+    image: WorkflowImageData,
+    parsed_data: Union[dict, list],
+    classes: List[str],
+    inference_id: str,
+) -> Detections:
+    """Parse SpaceXAI Grok object-detection output into native detections.
+
+    Coordinates are percentages of image width/height (floats 0-100) in
+    ``[x_min, y_min, x_max, y_max]`` order. Tensor-native sibling of the
+    numpy ``spacexai_detection_parsing.parse_spacexai_object_detection_response``.
+    """
+    class_name2id = create_classes_index(classes=classes)
+    image_height, image_width = image._read_shape_without_materialization()
+    detections = extract_spacexai_detection_entries(parsed_data=parsed_data)
+    if len(detections) == 0:
+        return empty_native_detections(
+            image=image,
+            image_height=image_height,
+            image_width=image_width,
+            inference_id=inference_id,
+            class_names={idx: class_name for class_name, idx in class_name2id.items()},
+        )
+
+    xyxy, class_id, class_name, confidence = [], [], [], []
+    for detection in detections:
+        xyxy.append(
+            convert_spacexai_detection_to_pixel_xyxy(
+                detection=detection,
+                image_height=image_height,
+                image_width=image_width,
+            )
+        )
+        label = get_gemini_detection_class_name(detection=detection)
+        class_id.append(class_name2id.get(label, -1))
+        class_name.append(label)
+        confidence.append(scale_confidence(detection.get("confidence", 1.0)))
+
+    xyxy = np.array(xyxy).round(0) if len(xyxy) > 0 else np.empty((0, 4))
+    confidence = np.array(confidence) if len(confidence) > 0 else np.empty(0)
+    class_id = np.array(class_id).astype(int) if len(class_id) > 0 else np.empty(0)
+    return native_detections_from_parsed(
+        image=image,
+        image_height=image_height,
+        image_width=image_width,
+        inference_id=inference_id,
+        xyxy=xyxy,
+        class_id=class_id,
+        class_name=class_name,
+        confidence=confidence,
+    )
+
+
 def parse_openai_detection_response(
     image: WorkflowImageData,
     parsed_data: Union[dict, list],
@@ -748,6 +811,7 @@ REGISTERED_PARSERS = {
     ("openai", "object-detection"): parse_openai_detection_response,
     ("google-gemini", "object-detection"): parse_gemini_object_detection_response,
     ("anthropic-claude", "object-detection"): parse_llm_object_detection_response,
+    ("spacexai", "object-detection"): parse_spacexai_object_detection_response,
     # Florence 2
     ("florence-2", "object-detection"): partial(
         parse_florence2_object_detection_response, florence_task_type="<OD>"

--- a/inference/core/workflows/core_steps/loader.py
+++ b/inference/core/workflows/core_steps/loader.py
@@ -627,6 +627,9 @@ from inference.core.workflows.core_steps.models.foundation.openai_compatible.v1 
 from inference.core.workflows.core_steps.models.foundation.openrouter.v1 import (
     OpenRouterBlockV1,
 )
+from inference.core.workflows.core_steps.models.foundation.spacexai.v1 import (
+    SpaceXAIBlockV1,
+)
 
 if not ENABLE_TENSOR_DATA_REPRESENTATION:
     from inference.core.workflows.core_steps.models.foundation.perception_encoder.v1 import (
@@ -1723,6 +1726,7 @@ def load_blocks() -> List[Type[WorkflowBlock]]:
         AnthropicClaudeBlockV1,
         AnthropicClaudeBlockV2,
         AnthropicClaudeBlockV3,
+        SpaceXAIBlockV1,
         CosineSimilarityBlockV1,
         BackgroundColorVisualizationBlockV1,
         BarcodeDetectorBlockV1,

--- a/inference/core/workflows/core_steps/models/foundation/spacexai/v1.py
+++ b/inference/core/workflows/core_steps/models/foundation/spacexai/v1.py
@@ -2,8 +2,12 @@
 
 Calls Grok vision models via xAI's OpenAI-compatible Responses API, either
 directly with a user-provided xAI key or through Roboflow's ``apiproxy/xai``
-managed-key proxy. Object-detection prompting uses the percent-of-image
-``box_2d`` contract validated in the vlm-exam benchmark for Grok 4.5/4.6.
+managed-key proxy. The managed-key (``rf_key``) option is gated behind the
+``WORKFLOWS_SPACEXAI_MANAGED_KEY_ENABLED`` env flag (off by default) until the
+platform-side proxy is deployed; with the flag off users must provide their
+own xAI API key and the block never contacts the proxy. Object-detection
+prompting uses the percent-of-image ``box_2d`` contract validated in the
+vlm-exam benchmark for Grok 4.5/4.6.
 """
 
 import base64
@@ -17,15 +21,14 @@ import requests
 from openai import OpenAI
 from pydantic import ConfigDict, Field, model_validator
 
-from inference.core.env import WORKFLOWS_REMOTE_EXECUTION_MAX_STEP_CONCURRENT_REQUESTS
+from inference.core.env import (
+    WORKFLOWS_REMOTE_EXECUTION_MAX_STEP_CONCURRENT_REQUESTS,
+    WORKFLOWS_SPACEXAI_MANAGED_KEY_ENABLED,
+)
 from inference.core.managers.base import ModelManager
 from inference.core.roboflow_api import post_to_roboflow_api
 from inference.core.utils.image_utils import encode_image_to_jpeg_bytes, load_image
-from inference.core.workflows.core_steps.common.utils import (
-    DETECTION_MAX_EDGE_PIXELS,
-    run_in_parallel,
-    scale_dimensions_to_max_edge,
-)
+from inference.core.workflows.core_steps.common.utils import run_in_parallel
 from inference.core.workflows.core_steps.common.vlms import VLM_TASKS_METADATA
 from inference.core.workflows.execution_engine.entities.base import (
     Batch,
@@ -100,6 +103,20 @@ RELEVANT_TASKS_DOCS_DESCRIPTION = "\n\n".join(
     for k, v in RELEVANT_TASKS_METADATA.items()
 )
 
+if WORKFLOWS_SPACEXAI_MANAGED_KEY_ENABLED:
+    API_KEY_OPTIONS_DOCS = """### API Key Options
+
+1. **Roboflow Managed API Key (Default)** - Use `rf_key:account` to proxy
+   requests through Roboflow's API. Usage is billed against Roboflow credits.
+2. **Custom xAI API Key** - Provide your own xAI API key and pay xAI directly.
+"""
+else:
+    API_KEY_OPTIONS_DOCS = """### API Key
+
+Provide your own xAI API key (created at https://console.x.ai). Requests are
+sent directly to xAI and billed to your xAI account.
+"""
+
 LONG_DESCRIPTION = f"""
 Ask a question to SpaceXAI Grok models with vision capabilities.
 
@@ -115,16 +132,10 @@ coordinates are percentages of image width and height (floats 0-100). Use
 output into predictions. Confidence scores are optional; when absent the
 parser assigns `1.0`.
 
-Images for object detection are downscaled so that their longest edge does not
-exceed {DETECTION_MAX_EDGE_PIXELS}px and are sent as lossless PNG with
-`detail: "high"`.
+Images for object detection are sent at original resolution as lossless PNG
+with `detail: "high"`, matching the vlm-exam benchmark setup for Grok 4.5/4.6.
 
-### API Key Options
-
-1. **Roboflow Managed API Key (Default)** - Use `rf_key:account` to proxy
-   requests through Roboflow's API. Usage is billed against Roboflow credits.
-2. **Custom xAI API Key** - Provide your own xAI API key and pay xAI directly.
-"""
+{API_KEY_OPTIONS_DOCS}"""
 
 TaskType = Literal[tuple(SUPPORTED_TASK_TYPES_LIST)]
 
@@ -142,6 +153,26 @@ TASKS_REQUIRING_CLASSES = {
 TASKS_REQUIRING_OUTPUT_STRUCTURE = {
     "structured-answering",
 }
+
+if WORKFLOWS_SPACEXAI_MANAGED_KEY_ENABLED:
+    ApiKeyType = Union[
+        Selector(kind=[STRING_KIND, SECRET_KIND, ROBOFLOW_MANAGED_KEY]), str
+    ]
+    API_KEY_FIELD = Field(
+        default="rf_key:account",
+        description=(
+            "Your xAI API key or 'rf_key:account' to use Roboflow's managed API key"
+        ),
+        examples=["rf_key:account", "xxx-xxx", "$inputs.xai_api_key"],
+        private=True,
+    )
+else:
+    ApiKeyType = Union[Selector(kind=[STRING_KIND, SECRET_KIND]), str]
+    API_KEY_FIELD = Field(
+        description="Your xAI API key",
+        examples=["xxx-xxx", "$inputs.xai_api_key"],
+        private=True,
+    )
 
 
 class BlockManifest(WorkflowBlockManifest):
@@ -220,16 +251,7 @@ class BlockManifest(WorkflowBlockManifest):
             },
         },
     )
-    api_key: Union[
-        Selector(kind=[STRING_KIND, SECRET_KIND, ROBOFLOW_MANAGED_KEY]), str
-    ] = Field(
-        default="rf_key:account",
-        description=(
-            "Your xAI API key or 'rf_key:account' to use Roboflow's managed API key"
-        ),
-        examples=["rf_key:account", "xxx-xxx", "$inputs.xai_api_key"],
-        private=True,
-    )
+    api_key: ApiKeyType = API_KEY_FIELD
     model_version: Union[
         Selector(kind=[STRING_KIND]),
         Literal[tuple(MODEL_VERSION_IDS)],
@@ -361,7 +383,7 @@ class SpaceXAIBlockV1(WorkflowBlock):
         max_tokens: Optional[int],
         temperature: Optional[float],
         max_concurrent_requests: Optional[int],
-        api_key: str = "rf_key:account",
+        api_key: str,
     ) -> BlockResult:
         inference_images = [i.to_inference_format() for i in images]
         raw_outputs = run_spacexai_prompting(
@@ -453,44 +475,28 @@ def encode_image_for_task(
 ) -> Tuple[str, int, int]:
     """Encode an image as base64 using task-appropriate preprocessing.
 
-    The ``object-detection`` task downscales so the longest edge does not
-    exceed ``DETECTION_MAX_EDGE_PIXELS`` and encodes as lossless PNG. All
-    other tasks send the image unchanged as JPEG.
+    The ``object-detection`` task sends the image unchanged, at original
+    resolution, as lossless PNG — matching the vlm-exam benchmark setup the
+    percent-coordinate contract was validated with. All other tasks send the
+    image unchanged as JPEG.
 
     Args:
         image: BGR image to be encoded.
-        task_type: Task type determining the preprocessing applied.
+        task_type: Task type determining the encoding applied.
 
     Returns:
         Tuple of the base64-encoded image payload (without a data URL prefix)
         and the ``(width, height)`` of the encoded image.
     """
     if task_type == "object-detection":
-        encoded_image = _downscale_image_to_max_edge(
-            image, max_edge=DETECTION_MAX_EDGE_PIXELS
-        )
-        image_bytes = _encode_image_to_png_bytes(encoded_image)
+        image_bytes = _encode_image_to_png_bytes(image)
     else:
-        encoded_image = image
-        image_bytes = encode_image_to_jpeg_bytes(encoded_image)
+        image_bytes = encode_image_to_jpeg_bytes(image)
 
     base64_image = base64.b64encode(image_bytes).decode("ascii")
-    encoded_height, encoded_width = encoded_image.shape[:2]
-
-    return base64_image, encoded_width, encoded_height
-
-
-def _downscale_image_to_max_edge(image: np.ndarray, *, max_edge: int) -> np.ndarray:
     height, width = image.shape[:2]
-    target_width, target_height = scale_dimensions_to_max_edge(width, height, max_edge)
-    if (target_width, target_height) == (width, height):
-        return image
 
-    resized_image = cv2.resize(
-        image, (target_width, target_height), interpolation=cv2.INTER_LANCZOS4
-    )
-
-    return resized_image
+    return base64_image, width, height
 
 
 def _encode_image_to_png_bytes(image: np.ndarray) -> bytes:
@@ -574,6 +580,12 @@ def execute_spacexai_request(
         Raw text output of the model.
     """
     if xai_api_key.startswith(("rf_key:account", "rf_key:user:")):
+        if not WORKFLOWS_SPACEXAI_MANAGED_KEY_ENABLED:
+            raise ValueError(
+                "Roboflow-managed xAI API keys are not enabled on this "
+                "installation. Provide your own xAI API key in the SpaceXAI "
+                "block's `api_key` field."
+            )
         if not roboflow_api_key:
             raise ValueError(
                 "Roboflow API key is required when using a Roboflow-managed xAI API key."

--- a/inference/core/workflows/core_steps/models/foundation/spacexai/v1.py
+++ b/inference/core/workflows/core_steps/models/foundation/spacexai/v1.py
@@ -6,8 +6,6 @@ managed-key proxy. Object-detection prompting uses the percent-of-image
 ``box_2d`` contract validated in the vlm-exam benchmark for Grok 4.5/4.6.
 """
 
-from __future__ import annotations
-
 import base64
 import json
 from functools import partial
@@ -69,9 +67,7 @@ GROK_MODELS = [
 
 MODEL_VERSION_IDS = [model["id"] for model in GROK_MODELS]
 
-MODEL_VERSION_METADATA = {
-    model["id"]: {"name": model["name"]} for model in GROK_MODELS
-}
+MODEL_VERSION_METADATA = {model["id"]: {"name": model["name"]} for model in GROK_MODELS}
 
 OBJECT_DETECTION_PROMPT_TEMPLATE = (
     "Detect all objects in this image. "
@@ -254,8 +250,9 @@ class BlockManifest(WorkflowBlockManifest):
         default=None,
         description=(
             "Optional reasoning effort passed to xAI as "
-            '`reasoning: {"effort": ...}`. When the model rejects the parameter, '
-            "the request is retried without reasoning."
+            '`reasoning: {"effort": ...}`. For requests with a direct xAI key, '
+            "the request is retried without reasoning when the model rejects "
+            "the parameter."
         ),
         examples=["low", "high"],
     )
@@ -772,9 +769,7 @@ def _extract_output_text(response_data: dict) -> str:
     return output_text
 
 
-def _image_content(
-    base64_image: str, *, media_type: str, detail: str = "auto"
-) -> dict:
+def _image_content(base64_image: str, *, media_type: str, detail: str = "auto") -> dict:
     return {
         "type": "input_image",
         "image_url": f"data:{media_type};base64,{base64_image}",
@@ -987,11 +982,7 @@ def prepare_object_detection_prompt(
             {
                 "role": "user",
                 "content": [
-                    {
-                        "type": "input_image",
-                        "image_url": f"data:image/png;base64,{base64_image}",
-                        "detail": "high",
-                    },
+                    _image_content(base64_image, media_type="image/png", detail="high"),
                     {"type": "input_text", "text": prompt_text},
                 ],
             }

--- a/inference/core/workflows/core_steps/models/foundation/spacexai/v1.py
+++ b/inference/core/workflows/core_steps/models/foundation/spacexai/v1.py
@@ -1,0 +1,1012 @@
+"""SpaceXAI (Grok) workflow block.
+
+Calls Grok vision models via xAI's OpenAI-compatible Responses API, either
+directly with a user-provided xAI key or through Roboflow's ``apiproxy/xai``
+managed-key proxy. Object-detection prompting uses the percent-of-image
+``box_2d`` contract validated in the vlm-exam benchmark for Grok 4.5/4.6.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from functools import partial
+from typing import Any, Dict, List, Literal, Optional, Tuple, Type, Union
+
+import cv2
+import numpy as np
+import requests
+from openai import OpenAI
+from pydantic import ConfigDict, Field, model_validator
+
+from inference.core.env import WORKFLOWS_REMOTE_EXECUTION_MAX_STEP_CONCURRENT_REQUESTS
+from inference.core.managers.base import ModelManager
+from inference.core.roboflow_api import post_to_roboflow_api
+from inference.core.utils.image_utils import encode_image_to_jpeg_bytes, load_image
+from inference.core.workflows.core_steps.common.utils import (
+    DETECTION_MAX_EDGE_PIXELS,
+    run_in_parallel,
+    scale_dimensions_to_max_edge,
+)
+from inference.core.workflows.core_steps.common.vlms import VLM_TASKS_METADATA
+from inference.core.workflows.execution_engine.entities.base import (
+    Batch,
+    OutputDefinition,
+    WorkflowImageData,
+)
+from inference.core.workflows.execution_engine.entities.types import (
+    FLOAT_KIND,
+    IMAGE_KIND,
+    LANGUAGE_MODEL_OUTPUT_KIND,
+    LIST_OF_VALUES_KIND,
+    ROBOFLOW_MANAGED_KEY,
+    SECRET_KIND,
+    STRING_KIND,
+    ImageInputField,
+    Selector,
+)
+from inference.core.workflows.prototypes.block import (
+    AirGappedAvailability,
+    BlockResult,
+    DependentResource,
+    WorkflowBlock,
+    WorkflowBlockManifest,
+    third_party_model,
+)
+
+XAI_BASE_URL = "https://api.x.ai/v1"
+
+GROK_MODELS = [
+    {
+        "id": "grok-4.6",
+        "name": "Grok 4.6",
+    },
+    {
+        "id": "grok-4.5",
+        "name": "Grok 4.5",
+    },
+]
+
+MODEL_VERSION_IDS = [model["id"] for model in GROK_MODELS]
+
+MODEL_VERSION_METADATA = {
+    model["id"]: {"name": model["name"]} for model in GROK_MODELS
+}
+
+OBJECT_DETECTION_PROMPT_TEMPLATE = (
+    "Detect all objects in this image. "
+    "Output a JSON list where each entry contains the text label in the key "
+    '"label" and the 2D bounding box in the key "box_2d". '
+    'The "box_2d" value must be [x_min, y_min, x_max, y_max] as percentages '
+    "of image width and height (floats between 0 and 100). "
+    "Return only the JSON list, with no extra text. "
+    "Only use these labels: {class_list}"
+)
+
+SUPPORTED_TASK_TYPES_LIST = [
+    "unconstrained",
+    "ocr",
+    "structured-answering",
+    "classification",
+    "multi-label-classification",
+    "visual-question-answering",
+    "caption",
+    "detailed-caption",
+    "object-detection",
+]
+SUPPORTED_TASK_TYPES = set(SUPPORTED_TASK_TYPES_LIST)
+
+RELEVANT_TASKS_METADATA = {
+    k: v for k, v in VLM_TASKS_METADATA.items() if k in SUPPORTED_TASK_TYPES
+}
+RELEVANT_TASKS_DOCS_DESCRIPTION = "\n\n".join(
+    f"* **{v['name']}** (`{k}`) - {v['description']}"
+    for k, v in RELEVANT_TASKS_METADATA.items()
+)
+
+LONG_DESCRIPTION = f"""
+Ask a question to SpaceXAI Grok models with vision capabilities.
+
+You can specify arbitrary text prompts or predefined ones, the block supports
+the following types of prompt:
+
+{RELEVANT_TASKS_DOCS_DESCRIPTION}
+
+The `object-detection` task asks Grok for a JSON list of
+`{{"label": ..., "box_2d": [x_min, y_min, x_max, y_max]}}` entries where
+coordinates are percentages of image width and height (floats 0-100). Use
+`roboflow_core/vlm_as_detector@v2` with `model_type="spacexai"` to convert the
+output into predictions. Confidence scores are optional; when absent the
+parser assigns `1.0`.
+
+Images for object detection are downscaled so that their longest edge does not
+exceed {DETECTION_MAX_EDGE_PIXELS}px and are sent as lossless PNG with
+`detail: "high"`.
+
+### API Key Options
+
+1. **Roboflow Managed API Key (Default)** - Use `rf_key:account` to proxy
+   requests through Roboflow's API. Usage is billed against Roboflow credits.
+2. **Custom xAI API Key** - Provide your own xAI API key and pay xAI directly.
+"""
+
+TaskType = Literal[tuple(SUPPORTED_TASK_TYPES_LIST)]
+
+TASKS_REQUIRING_PROMPT = {
+    "unconstrained",
+    "visual-question-answering",
+}
+
+TASKS_REQUIRING_CLASSES = {
+    "classification",
+    "multi-label-classification",
+    "object-detection",
+}
+
+TASKS_REQUIRING_OUTPUT_STRUCTURE = {
+    "structured-answering",
+}
+
+
+class BlockManifest(WorkflowBlockManifest):
+    model_config = ConfigDict(
+        json_schema_extra={
+            "name": "SpaceXAI",
+            "version": "v1",
+            "short_description": "Run SpaceXAI Grok models with vision capabilities.",
+            "long_description": LONG_DESCRIPTION,
+            "license": "Apache-2.0",
+            "block_type": "model",
+            "search_keywords": ["LMM", "VLM", "Grok", "xAI", "SpaceXAI"],
+            "is_vlm_block": True,
+            "task_type_property": "task_type",
+            "ui_manifest": {
+                "section": "model",
+                "icon": "fal fa-rocket",
+                "blockPriority": 5.1,
+            },
+        },
+        protected_namespaces=(),
+    )
+    type: Literal["roboflow_core/spacexai@v1"]
+    images: Selector(kind=[IMAGE_KIND]) = ImageInputField
+    task_type: TaskType = Field(
+        default="unconstrained",
+        description=(
+            "Task type to be performed by model. Value determines required "
+            "parameters and output response."
+        ),
+        json_schema_extra={
+            "values_metadata": RELEVANT_TASKS_METADATA,
+            "recommended_parsers": {
+                "structured-answering": "roboflow_core/json_parser@v1",
+                "classification": "roboflow_core/vlm_as_classifier@v2",
+                "multi-label-classification": "roboflow_core/vlm_as_classifier@v2",
+                "object-detection": "roboflow_core/vlm_as_detector@v2",
+            },
+            "always_visible": True,
+        },
+    )
+    prompt: Optional[Union[Selector(kind=[STRING_KIND]), str]] = Field(
+        default=None,
+        description="Text prompt to the Grok model",
+        examples=["my prompt", "$inputs.prompt"],
+        json_schema_extra={
+            "relevant_for": {
+                "task_type": {"values": TASKS_REQUIRING_PROMPT, "required": True},
+            },
+            "multiline": True,
+        },
+    )
+    output_structure: Optional[Dict[str, str]] = Field(
+        default=None,
+        description="Dictionary with structure of expected JSON response",
+        examples=[{"my_key": "description"}, "$inputs.output_structure"],
+        json_schema_extra={
+            "relevant_for": {
+                "task_type": {
+                    "values": TASKS_REQUIRING_OUTPUT_STRUCTURE,
+                    "required": True,
+                },
+            },
+        },
+    )
+    classes: Optional[Union[Selector(kind=[LIST_OF_VALUES_KIND]), List[str]]] = Field(
+        default=None,
+        description="List of classes to be used",
+        examples=[["class-a", "class-b"], "$inputs.classes"],
+        json_schema_extra={
+            "relevant_for": {
+                "task_type": {
+                    "values": TASKS_REQUIRING_CLASSES,
+                    "required": True,
+                },
+            },
+        },
+    )
+    api_key: Union[
+        Selector(kind=[STRING_KIND, SECRET_KIND, ROBOFLOW_MANAGED_KEY]), str
+    ] = Field(
+        default="rf_key:account",
+        description=(
+            "Your xAI API key or 'rf_key:account' to use Roboflow's managed API key"
+        ),
+        examples=["rf_key:account", "xxx-xxx", "$inputs.xai_api_key"],
+        private=True,
+    )
+    model_version: Union[
+        Selector(kind=[STRING_KIND]),
+        Literal[tuple(MODEL_VERSION_IDS)],
+    ] = Field(
+        default="grok-4.6",
+        description="Model to be used",
+        examples=["grok-4.6", "grok-4.5", "$inputs.grok_model"],
+        json_schema_extra={
+            "values_metadata": MODEL_VERSION_METADATA,
+        },
+    )
+    reasoning_effort: Optional[
+        Union[
+            Selector(kind=[STRING_KIND]),
+            Literal["low", "high"],
+        ]
+    ] = Field(
+        default=None,
+        description=(
+            "Optional reasoning effort passed to xAI as "
+            '`reasoning: {"effort": ...}`. When the model rejects the parameter, '
+            "the request is retried without reasoning."
+        ),
+        examples=["low", "high"],
+    )
+    max_tokens: Optional[int] = Field(
+        default=None,
+        description=(
+            "Maximum number of tokens the model can generate in its response. "
+            "If not specified, the model will use its default limit. Minimum value is 16."
+        ),
+        ge=16,
+    )
+    temperature: Optional[Union[float, Selector(kind=[FLOAT_KIND])]] = Field(
+        default=None,
+        description=(
+            "Temperature to sample from the model - value in range 0.0-2.0, the "
+            'higher - the more random / "creative" the generations are.'
+        ),
+        ge=0.0,
+        le=2.0,
+    )
+    max_concurrent_requests: Optional[int] = Field(
+        default=None,
+        description=(
+            "Number of concurrent requests that can be executed by block when "
+            "batch of input images provided. If not given - block defaults to "
+            "value configured globally in Workflows Execution Engine. Please "
+            "restrict if you hit xAI limits."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def validate(self) -> "BlockManifest":
+        if self.task_type in TASKS_REQUIRING_PROMPT and self.prompt is None:
+            raise ValueError(
+                f"`prompt` parameter required to be set for task `{self.task_type}`"
+            )
+        if self.task_type in TASKS_REQUIRING_CLASSES and self.classes is None:
+            raise ValueError(
+                f"`classes` parameter required to be set for task `{self.task_type}`"
+            )
+        if (
+            self.task_type in TASKS_REQUIRING_OUTPUT_STRUCTURE
+            and self.output_structure is None
+        ):
+            raise ValueError(
+                f"`output_structure` parameter required to be set for task `{self.task_type}`"
+            )
+        return self
+
+    @classmethod
+    def get_air_gapped_availability(cls) -> AirGappedAvailability:
+        return AirGappedAvailability(available=False, reason="requires_internet")
+
+    @classmethod
+    def get_parameters_accepting_batches(cls) -> List[str]:
+        return ["images"]
+
+    @classmethod
+    def describe_outputs(cls) -> List[OutputDefinition]:
+        return [
+            OutputDefinition(
+                name="output", kind=[STRING_KIND, LANGUAGE_MODEL_OUTPUT_KIND]
+            ),
+            OutputDefinition(name="classes", kind=[LIST_OF_VALUES_KIND]),
+        ]
+
+    @classmethod
+    def get_execution_engine_compatibility(cls) -> Optional[str]:
+        return ">=1.4.0,<2.0.0"
+
+    def discover_dependent_resources(self) -> Optional[List[DependentResource]]:
+        return [third_party_model(provider="xai", model_id=self.model_version)]
+
+
+class SpaceXAIBlockV1(WorkflowBlock):
+
+    def __init__(
+        self,
+        model_manager: ModelManager,
+        api_key: Optional[str],
+    ):
+        self._model_manager = model_manager
+        self._api_key = api_key
+
+    @classmethod
+    def get_init_parameters(cls) -> List[str]:
+        return ["model_manager", "api_key"]
+
+    @classmethod
+    def get_manifest(cls) -> Type[WorkflowBlockManifest]:
+        return BlockManifest
+
+    @classmethod
+    def get_execution_engine_compatibility(cls) -> Optional[str]:
+        return ">=1.3.0,<2.0.0"
+
+    def run(
+        self,
+        images: Batch[WorkflowImageData],
+        task_type: TaskType,
+        prompt: Optional[str],
+        output_structure: Optional[Dict[str, str]],
+        classes: Optional[List[str]],
+        model_version: str,
+        reasoning_effort: Optional[str],
+        max_tokens: Optional[int],
+        temperature: Optional[float],
+        max_concurrent_requests: Optional[int],
+        api_key: str = "rf_key:account",
+    ) -> BlockResult:
+        inference_images = [i.to_inference_format() for i in images]
+        raw_outputs = run_spacexai_prompting(
+            roboflow_api_key=self._api_key,
+            images=inference_images,
+            task_type=task_type,
+            prompt=prompt,
+            output_structure=output_structure,
+            classes=classes,
+            xai_api_key=api_key,
+            model_version=model_version,
+            reasoning_effort=reasoning_effort,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            max_concurrent_requests=max_concurrent_requests,
+        )
+        return [
+            {"output": raw_output, "classes": classes} for raw_output in raw_outputs
+        ]
+
+
+def run_spacexai_prompting(
+    roboflow_api_key: Optional[str],
+    images: List[Dict[str, Any]],
+    task_type: TaskType,
+    prompt: Optional[str],
+    output_structure: Optional[Dict[str, str]],
+    classes: Optional[List[str]],
+    xai_api_key: str,
+    model_version: str,
+    reasoning_effort: Optional[str],
+    max_tokens: Optional[int],
+    temperature: Optional[float],
+    max_concurrent_requests: Optional[int],
+) -> List[str]:
+    """Encode images, build per-task prompts and execute xAI requests.
+
+    Args:
+        roboflow_api_key: Roboflow API key for proxied execution.
+        images: Input images in loadable form.
+        task_type: Task determining preprocessing and prompt construction.
+        prompt: Free-form text prompt for tasks that accept one.
+        output_structure: Field descriptions for structured answering.
+        classes: Class names for classification and detection tasks.
+        xai_api_key: xAI API key or Roboflow-proxied ``rf_key:`` key.
+        model_version: Grok model identifier.
+        reasoning_effort: Optional reasoning effort.
+        max_tokens: Maximum number of output tokens.
+        temperature: Sampling temperature.
+        max_concurrent_requests: Cap on concurrent xAI requests.
+
+    Returns:
+        Raw text outputs, one per input image.
+
+    Raises:
+        ValueError: If the task type has no registered prompt builder.
+    """
+    if task_type not in PROMPT_BUILDERS:
+        raise ValueError(f"Task type: {task_type} not supported.")
+    spacexai_prompts = []
+    for image in images:
+        loaded_image, _ = load_image(image)
+        base64_image, image_width, image_height = encode_image_for_task(
+            loaded_image, task_type=task_type
+        )
+        generated_prompt = PROMPT_BUILDERS[task_type](
+            base64_image=base64_image,
+            prompt=prompt,
+            output_structure=output_structure,
+            classes=classes,
+            image_width=image_width,
+            image_height=image_height,
+        )
+        spacexai_prompts.append(generated_prompt)
+    return execute_spacexai_requests(
+        roboflow_api_key=roboflow_api_key,
+        xai_api_key=xai_api_key,
+        spacexai_prompts=spacexai_prompts,
+        model_version=model_version,
+        reasoning_effort=reasoning_effort,
+        max_tokens=max_tokens,
+        temperature=temperature,
+        max_concurrent_requests=max_concurrent_requests,
+    )
+
+
+def encode_image_for_task(
+    image: np.ndarray, *, task_type: TaskType
+) -> Tuple[str, int, int]:
+    """Encode an image as base64 using task-appropriate preprocessing.
+
+    The ``object-detection`` task downscales so the longest edge does not
+    exceed ``DETECTION_MAX_EDGE_PIXELS`` and encodes as lossless PNG. All
+    other tasks send the image unchanged as JPEG.
+
+    Args:
+        image: BGR image to be encoded.
+        task_type: Task type determining the preprocessing applied.
+
+    Returns:
+        Tuple of the base64-encoded image payload (without a data URL prefix)
+        and the ``(width, height)`` of the encoded image.
+    """
+    if task_type == "object-detection":
+        encoded_image = _downscale_image_to_max_edge(
+            image, max_edge=DETECTION_MAX_EDGE_PIXELS
+        )
+        image_bytes = _encode_image_to_png_bytes(encoded_image)
+    else:
+        encoded_image = image
+        image_bytes = encode_image_to_jpeg_bytes(encoded_image)
+
+    base64_image = base64.b64encode(image_bytes).decode("ascii")
+    encoded_height, encoded_width = encoded_image.shape[:2]
+
+    return base64_image, encoded_width, encoded_height
+
+
+def _downscale_image_to_max_edge(image: np.ndarray, *, max_edge: int) -> np.ndarray:
+    height, width = image.shape[:2]
+    target_width, target_height = scale_dimensions_to_max_edge(width, height, max_edge)
+    if (target_width, target_height) == (width, height):
+        return image
+
+    resized_image = cv2.resize(
+        image, (target_width, target_height), interpolation=cv2.INTER_LANCZOS4
+    )
+
+    return resized_image
+
+
+def _encode_image_to_png_bytes(image: np.ndarray) -> bytes:
+    _, encoded_image = cv2.imencode(".png", image)
+    return encoded_image.tobytes()
+
+
+def execute_spacexai_requests(
+    roboflow_api_key: Optional[str],
+    xai_api_key: str,
+    spacexai_prompts: List[dict],
+    model_version: str,
+    reasoning_effort: Optional[str],
+    max_tokens: Optional[int],
+    temperature: Optional[float],
+    max_concurrent_requests: Optional[int],
+) -> List[str]:
+    """Execute prepared xAI request payloads in parallel.
+
+    Args:
+        roboflow_api_key: Roboflow API key for proxied execution.
+        xai_api_key: xAI API key or Roboflow-proxied ``rf_key:`` key.
+        spacexai_prompts: Prompt payloads with ``input`` and optionally
+            ``instructions`` keys.
+        model_version: Grok model identifier.
+        reasoning_effort: Optional reasoning effort.
+        max_tokens: Maximum number of output tokens.
+        temperature: Sampling temperature.
+        max_concurrent_requests: Cap on concurrent requests.
+
+    Returns:
+        Raw text outputs in the order of the input prompts.
+    """
+    tasks = [
+        partial(
+            execute_spacexai_request,
+            roboflow_api_key=roboflow_api_key,
+            xai_api_key=xai_api_key,
+            instructions=prompt.get("instructions"),
+            input_content=prompt["input"],
+            model_version=model_version,
+            reasoning_effort=reasoning_effort,
+            max_tokens=max_tokens,
+            temperature=temperature,
+        )
+        for prompt in spacexai_prompts
+    ]
+    max_workers = (
+        max_concurrent_requests
+        or WORKFLOWS_REMOTE_EXECUTION_MAX_STEP_CONCURRENT_REQUESTS
+    )
+    return run_in_parallel(
+        tasks=tasks,
+        max_workers=max_workers,
+    )
+
+
+def execute_spacexai_request(
+    roboflow_api_key: Optional[str],
+    xai_api_key: str,
+    instructions: Optional[str],
+    input_content: List[dict],
+    model_version: str,
+    reasoning_effort: Optional[str],
+    max_tokens: Optional[int],
+    temperature: Optional[float],
+) -> str:
+    """Execute a single xAI request, routing to direct or proxied mode.
+
+    Args:
+        roboflow_api_key: Roboflow API key, required for proxied execution.
+        xai_api_key: xAI API key or Roboflow-proxied ``rf_key:`` key.
+        instructions: Optional system instructions.
+        input_content: ``input`` entries of the Responses API payload.
+        model_version: Grok model identifier.
+        reasoning_effort: Optional reasoning effort.
+        max_tokens: Maximum number of output tokens.
+        temperature: Sampling temperature.
+
+    Returns:
+        Raw text output of the model.
+    """
+    if xai_api_key.startswith(("rf_key:account", "rf_key:user:")):
+        if not roboflow_api_key:
+            raise ValueError(
+                "Roboflow API key is required when using a Roboflow-managed xAI API key."
+            )
+
+        return _execute_proxied_spacexai_request(
+            roboflow_api_key=roboflow_api_key,
+            xai_api_key=xai_api_key,
+            instructions=instructions,
+            input_content=input_content,
+            model_version=model_version,
+            reasoning_effort=reasoning_effort,
+            max_tokens=max_tokens,
+            temperature=temperature,
+        )
+
+    return _execute_direct_spacexai_request(
+        xai_api_key=xai_api_key,
+        instructions=instructions,
+        input_content=input_content,
+        model_version=model_version,
+        reasoning_effort=reasoning_effort,
+        max_tokens=max_tokens,
+        temperature=temperature,
+    )
+
+
+def _execute_proxied_spacexai_request(
+    roboflow_api_key: str,
+    xai_api_key: str,
+    instructions: Optional[str],
+    input_content: List[dict],
+    model_version: str,
+    reasoning_effort: Optional[str],
+    max_tokens: Optional[int],
+    temperature: Optional[float],
+) -> str:
+    """Execute xAI request via Roboflow proxy."""
+    payload = {
+        "model": model_version,
+        "input": input_content,
+        "xai_api_key": xai_api_key,
+        "store": False,
+    }
+
+    if instructions is not None:
+        payload["instructions"] = instructions
+
+    if max_tokens is not None:
+        payload["max_output_tokens"] = max_tokens
+
+    if temperature is not None:
+        payload["temperature"] = temperature
+
+    if reasoning_effort is not None:
+        payload["reasoning"] = {"effort": reasoning_effort}
+
+    try:
+        response_data = post_to_roboflow_api(
+            endpoint="apiproxy/xai",
+            api_key=roboflow_api_key,
+            payload=payload,
+        )
+        return _extract_output_text(response_data)
+    except requests.exceptions.RequestException as e:
+        raise RuntimeError(f"Failed to connect to Roboflow proxy: {e}") from e
+    except (KeyError, IndexError) as e:
+        raise RuntimeError(
+            f"Invalid response structure from Roboflow proxy: {e}"
+        ) from e
+
+
+def _is_unsupported_reasoning_error(error: Exception) -> bool:
+    message = str(error).lower()
+    return "reasoning" in message and (
+        "unsupported" in message
+        or "not supported" in message
+        or "unknown" in message
+        or "invalid" in message
+    )
+
+
+def _execute_direct_spacexai_request(
+    xai_api_key: str,
+    instructions: Optional[str],
+    input_content: List[dict],
+    model_version: str,
+    reasoning_effort: Optional[str],
+    max_tokens: Optional[int],
+    temperature: Optional[float],
+) -> str:
+    """Execute xAI request directly against api.x.ai."""
+    client = OpenAI(base_url=XAI_BASE_URL, api_key=xai_api_key)
+
+    request_params: Dict[str, Any] = {
+        "model": model_version,
+        "input": input_content,
+        # xAI rejects responses exceeding its server-side storage limit;
+        # we never retrieve stored responses, so disable storage entirely.
+        "store": False,
+    }
+
+    if instructions is not None:
+        request_params["instructions"] = instructions
+
+    if max_tokens is not None:
+        request_params["max_output_tokens"] = max_tokens
+
+    if temperature is not None:
+        request_params["temperature"] = temperature
+
+    if reasoning_effort is not None:
+        request_params["reasoning"] = {"effort": reasoning_effort}
+
+    try:
+        response = client.responses.create(**request_params)
+    except Exception as error:
+        if reasoning_effort is None or not _is_unsupported_reasoning_error(error):
+            raise
+        request_params.pop("reasoning", None)
+        response = client.responses.create(**request_params)
+
+    status = response.status
+    if status == "failed":
+        error_message = "Unknown error"
+        if response.error:
+            error_message = f"{response.error.code}: {response.error.message}"
+        raise ValueError(f"xAI API request failed: {error_message}")
+
+    if status == "cancelled":
+        raise ValueError("xAI API request was cancelled.")
+
+    if status == "incomplete":
+        reason = "Unknown reason"
+        if response.incomplete_details:
+            reason = response.incomplete_details.reason
+        if reason == "max_output_tokens":
+            raise ValueError(
+                "xAI API stopped generation because the max_tokens limit was reached. "
+                "Please increase the max_tokens parameter to allow for a complete response."
+            )
+        raise ValueError(f"xAI API returned an incomplete response. Reason: {reason}")
+
+    if status not in ["completed", "in_progress", "queued"]:
+        raise ValueError(f"xAI API returned unexpected status: {status}")
+
+    output_text = response.output_text
+    if not output_text:
+        raise ValueError("xAI API returned no text content in response.")
+
+    return output_text
+
+
+def _extract_output_text(response_data: dict) -> str:
+    """Extract output text from xAI / OpenAI Responses API response."""
+    status = response_data.get("status")
+
+    if status == "failed":
+        error = response_data.get("error", {})
+        error_message = (
+            f"{error.get('code', 'Unknown')}: {error.get('message', 'Unknown error')}"
+        )
+        raise ValueError(f"xAI API request failed: {error_message}")
+
+    if status == "cancelled":
+        raise ValueError("xAI API request was cancelled.")
+
+    if status == "incomplete":
+        incomplete_details = response_data.get("incomplete_details", {})
+        reason = incomplete_details.get("reason", "Unknown reason")
+        if reason == "max_output_tokens":
+            raise ValueError(
+                "xAI API stopped generation because the max_tokens limit was reached. "
+                "Please increase the max_tokens parameter to allow for a complete response."
+            )
+        raise ValueError(f"xAI API returned an incomplete response. Reason: {reason}")
+
+    if status not in ["completed", "in_progress", "queued", None]:
+        raise ValueError(f"xAI API returned unexpected status: {status}")
+
+    output_items = response_data.get("output", [])
+    texts = []
+    for item in output_items:
+        if item.get("type") == "message":
+            for content in item.get("content", []):
+                if content.get("type") == "output_text":
+                    texts.append(content.get("text", ""))
+
+    output_text = "".join(texts)
+    if not output_text:
+        raise ValueError("xAI API returned no text content in response.")
+
+    return output_text
+
+
+def _image_content(
+    base64_image: str, *, media_type: str, detail: str = "auto"
+) -> dict:
+    return {
+        "type": "input_image",
+        "image_url": f"data:{media_type};base64,{base64_image}",
+        "detail": detail,
+    }
+
+
+def prepare_unconstrained_prompt(
+    base64_image: str,
+    prompt: str,
+    **kwargs,
+) -> dict:
+    """Build a request forwarding the user's prompt without instructions."""
+    return {
+        "input": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "input_text", "text": prompt},
+                    _image_content(base64_image, media_type="image/jpeg"),
+                ],
+            }
+        ],
+    }
+
+
+def prepare_classification_prompt(
+    base64_image: str,
+    classes: List[str],
+    **kwargs,
+) -> dict:
+    """Build a single-label classification request."""
+    serialised_classes = ", ".join(classes)
+    return {
+        "instructions": (
+            "You act as single-class classification model. You must provide reasonable predictions. "
+            "You are only allowed to produce JSON document in Markdown ```json [...]``` markers. "
+            'Expected structure of json: {"class_name": "class-name", "confidence": 0.4}. '
+            "`class-name` must be one of the class names defined by user. You are only allowed to return "
+            "single JSON document, even if there are potentially multiple classes. You are not allowed to return list."
+        ),
+        "input": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "input_text",
+                        "text": f"List of all classes to be recognised by model: {serialised_classes}",
+                    },
+                    _image_content(base64_image, media_type="image/jpeg"),
+                ],
+            }
+        ],
+    }
+
+
+def prepare_multi_label_classification_prompt(
+    base64_image: str,
+    classes: List[str],
+    **kwargs,
+) -> dict:
+    """Build a multi-label classification request."""
+    serialised_classes = ", ".join(classes)
+    return {
+        "instructions": (
+            "You act as multi-label classification model. You must provide reasonable predictions. "
+            "You are only allowed to produce JSON document in Markdown ```json``` markers. "
+            'Expected structure of json: {"predicted_classes": [{"class": "class-name-1", "confidence": 0.9}, '
+            '{"class": "class-name-2", "confidence": 0.7}]}. '
+            "`class-name-X` must be one of the class names defined by user and `confidence` is a float value in range "
+            "0.0-1.0 that represent how sure you are that the class is present in the image. Only return class names "
+            "that are visible."
+        ),
+        "input": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "input_text",
+                        "text": f"List of all classes to be recognised by model: {serialised_classes}",
+                    },
+                    _image_content(base64_image, media_type="image/jpeg"),
+                ],
+            }
+        ],
+    }
+
+
+def prepare_vqa_prompt(
+    base64_image: str,
+    prompt: str,
+    **kwargs,
+) -> dict:
+    """Build a visual-question-answering request."""
+    return {
+        "instructions": (
+            "You act as Visual Question Answering model. Your task is to provide answer to question "
+            "submitted by user. If this is open-question - answer with few sentences, for ABCD question, "
+            "return only the indicator of the answer."
+        ),
+        "input": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "input_text", "text": f"Question: {prompt}"},
+                    _image_content(base64_image, media_type="image/jpeg"),
+                ],
+            }
+        ],
+    }
+
+
+def prepare_ocr_prompt(
+    base64_image: str,
+    **kwargs,
+) -> dict:
+    """Build an OCR request returning recognised text as paragraphs."""
+    return {
+        "instructions": (
+            "You act as OCR model. Your task is to read text from the image and return it in "
+            "paragraphs representing the structure of texts in the image. You should only return "
+            "recognised text, nothing else."
+        ),
+        "input": [
+            {
+                "role": "user",
+                "content": [
+                    _image_content(base64_image, media_type="image/jpeg"),
+                ],
+            }
+        ],
+    }
+
+
+def prepare_caption_prompt(
+    base64_image: str,
+    short_description: bool,
+    **kwargs,
+) -> dict:
+    """Build an image captioning request."""
+    caption_detail_level = "Caption should be short."
+    if not short_description:
+        caption_detail_level = "Caption should be extensive."
+    return {
+        "instructions": (
+            f"You act as image caption model. Your task is to provide description of the image. "
+            f"{caption_detail_level}"
+        ),
+        "input": [
+            {
+                "role": "user",
+                "content": [
+                    _image_content(base64_image, media_type="image/jpeg"),
+                ],
+            }
+        ],
+    }
+
+
+def prepare_structured_answering_prompt(
+    base64_image: str,
+    output_structure: Dict[str, str],
+    **kwargs,
+) -> dict:
+    """Build a structured-answering request producing user-defined JSON."""
+    output_structure_serialised = json.dumps(output_structure, indent=4)
+    return {
+        "instructions": (
+            "You are supposed to produce responses in JSON wrapped in Markdown markers: "
+            "```json\nyour-response\n```. User is to provide you dictionary with keys and values. "
+            "Each key must be present in your response. Values in user dictionary represent "
+            "descriptions for JSON fields to be generated. Provide only JSON Markdown in response."
+        ),
+        "input": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "input_text",
+                        "text": f"Specification of requirements regarding output fields: \n"
+                        f"{output_structure_serialised}",
+                    },
+                    _image_content(base64_image, media_type="image/jpeg"),
+                ],
+            }
+        ],
+    }
+
+
+def prepare_object_detection_prompt(
+    base64_image: str,
+    classes: List[str],
+    **kwargs,
+) -> dict:
+    """Build the percent-format detection request used by Grok 4.5/4.6.
+
+    Args:
+        base64_image: Base64-encoded PNG image.
+        classes: Class names the model may predict.
+        **kwargs: Ignored builder arguments shared across task types.
+
+    Returns:
+        Request payload with an ``input`` key containing the detection prompt
+        and a high-detail PNG image.
+    """
+    class_list = ", ".join(classes)
+    prompt_text = OBJECT_DETECTION_PROMPT_TEMPLATE.format(class_list=class_list)
+    return {
+        "input": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "input_image",
+                        "image_url": f"data:image/png;base64,{base64_image}",
+                        "detail": "high",
+                    },
+                    {"type": "input_text", "text": prompt_text},
+                ],
+            }
+        ],
+    }
+
+
+PROMPT_BUILDERS = {
+    "unconstrained": prepare_unconstrained_prompt,
+    "ocr": prepare_ocr_prompt,
+    "visual-question-answering": prepare_vqa_prompt,
+    "caption": partial(prepare_caption_prompt, short_description=True),
+    "detailed-caption": partial(prepare_caption_prompt, short_description=False),
+    "classification": prepare_classification_prompt,
+    "multi-label-classification": prepare_multi_label_classification_prompt,
+    "structured-answering": prepare_structured_answering_prompt,
+    "object-detection": prepare_object_detection_prompt,
+}

--- a/tests/workflows/unit_tests/core_steps/formatters/vlm_as_detector/test_v2.py
+++ b/tests/workflows/unit_tests/core_steps/formatters/vlm_as_detector/test_v2.py
@@ -296,6 +296,86 @@ def test_run_method_for_openai_legacy_detections_output() -> None:
     assert np.allclose(result["predictions"].confidence, np.array([0.98, 0.97]))
 
 
+def test_run_method_for_spacexai_percent_box_2d_output() -> None:
+    # given - SpaceXAI Grok returns [x_min, y_min, x_max, y_max] as percentages 0-100
+    block = VLMAsDetectorBlockV2()
+    image = WorkflowImageData(
+        numpy_image=np.zeros((200, 100, 3), dtype=np.uint8),
+        parent_metadata=ImageParentMetadata(parent_id="parent"),
+    )
+    vlm_output = """
+[
+  {"box_2d": [10.0, 20.0, 50.0, 80.0], "label": "cat", "confidence": 0.9},
+  {"box_2d": [60.0, 10.0, 110.0, 40.0], "label": "dog"}
+]
+    """
+
+    # when
+    result = block.run(
+        image=image,
+        vlm_output=vlm_output,
+        classes=["cat", "dog"],
+        model_type="spacexai",
+        task_type="object-detection",
+    )
+
+    # then - second box x_max clamped to 100 before scaling to width=100
+    assert result["error_status"] is False
+    assert isinstance(result["predictions"], sv.Detections)
+    assert result["predictions"].data["class_name"].tolist() == ["cat", "dog"]
+    assert np.allclose(result["predictions"].class_id, np.array([0, 1]))
+    assert np.allclose(
+        result["predictions"].xyxy,
+        np.array(
+            [
+                [10, 40, 50, 160],
+                [60, 20, 100, 80],
+            ]
+        ),
+        atol=1.0,
+    )
+    assert np.allclose(result["predictions"].confidence, np.array([0.9, 1.0]))
+
+
+def test_run_method_for_spacexai_unknown_label_gets_class_id_minus_one() -> None:
+    block = VLMAsDetectorBlockV2()
+    image = WorkflowImageData(
+        numpy_image=np.zeros((100, 100, 3), dtype=np.uint8),
+        parent_metadata=ImageParentMetadata(parent_id="parent"),
+    )
+    vlm_output = '[{"box_2d": [0, 0, 50, 50], "label": "bird"}]'
+
+    result = block.run(
+        image=image,
+        vlm_output=vlm_output,
+        classes=["cat", "dog"],
+        model_type="spacexai",
+        task_type="object-detection",
+    )
+
+    assert result["error_status"] is False
+    assert np.allclose(result["predictions"].class_id, np.array([-1]))
+
+
+def test_run_method_for_spacexai_malformed_json() -> None:
+    block = VLMAsDetectorBlockV2()
+    image = WorkflowImageData(
+        numpy_image=np.zeros((100, 100, 3), dtype=np.uint8),
+        parent_metadata=ImageParentMetadata(parent_id="parent"),
+    )
+
+    result = block.run(
+        image=image,
+        vlm_output="not json",
+        classes=["cat"],
+        model_type="spacexai",
+        task_type="object-detection",
+    )
+
+    assert result["error_status"] is True
+    assert result["predictions"] is None
+
+
 def test_run_method_for_invalid_claude_and_gemini_output() -> None:
     # given
     block = VLMAsDetectorBlockV2()

--- a/tests/workflows/unit_tests/core_steps/formatters/vlm_as_detector/test_v2.py
+++ b/tests/workflows/unit_tests/core_steps/formatters/vlm_as_detector/test_v2.py
@@ -357,25 +357,6 @@ def test_run_method_for_spacexai_unknown_label_gets_class_id_minus_one() -> None
     assert np.allclose(result["predictions"].class_id, np.array([-1]))
 
 
-def test_run_method_for_spacexai_malformed_json() -> None:
-    block = VLMAsDetectorBlockV2()
-    image = WorkflowImageData(
-        numpy_image=np.zeros((100, 100, 3), dtype=np.uint8),
-        parent_metadata=ImageParentMetadata(parent_id="parent"),
-    )
-
-    result = block.run(
-        image=image,
-        vlm_output="not json",
-        classes=["cat"],
-        model_type="spacexai",
-        task_type="object-detection",
-    )
-
-    assert result["error_status"] is True
-    assert result["predictions"] is None
-
-
 def test_run_method_for_invalid_claude_and_gemini_output() -> None:
     # given
     block = VLMAsDetectorBlockV2()

--- a/tests/workflows/unit_tests/core_steps/formatters/vlm_as_detector/test_v2_tensor.py
+++ b/tests/workflows/unit_tests/core_steps/formatters/vlm_as_detector/test_v2_tensor.py
@@ -179,3 +179,43 @@ def test_run_method_for_openai_legacy_detections_output_tensor_native() -> None:
     assert np.allclose(
         result["predictions"].confidence.cpu().numpy(), np.array([0.98, 0.97])
     )
+
+
+def test_run_method_for_spacexai_percent_box_2d_output_tensor_native() -> None:
+    block = VLMAsDetectorBlockV2()
+    image = WorkflowImageData(
+        numpy_image=np.zeros((200, 100, 3), dtype=np.uint8),
+        parent_metadata=ImageParentMetadata(parent_id="parent"),
+    )
+    vlm_output = """
+[
+  {"box_2d": [10.0, 20.0, 50.0, 80.0], "label": "cat", "confidence": 0.9},
+  {"box_2d": [60.0, 10.0, 110.0, 40.0], "label": "dog"}
+]
+    """
+
+    result = block.run(
+        image=image,
+        vlm_output=vlm_output,
+        classes=["cat", "dog"],
+        model_type="spacexai",
+        task_type="object-detection",
+    )
+
+    assert result["error_status"] is False
+    assert isinstance(result["predictions"], Detections)
+    assert _class_names(result["predictions"]) == ["cat", "dog"]
+    assert np.allclose(result["predictions"].class_id.cpu().numpy(), np.array([0, 1]))
+    assert np.allclose(
+        result["predictions"].xyxy.cpu().numpy(),
+        np.array(
+            [
+                [10, 40, 50, 160],
+                [60, 20, 100, 80],
+            ]
+        ),
+        atol=1.0,
+    )
+    assert np.allclose(
+        result["predictions"].confidence.cpu().numpy(), np.array([0.9, 1.0])
+    )

--- a/tests/workflows/unit_tests/core_steps/models/foundation/test_spacexai.py
+++ b/tests/workflows/unit_tests/core_steps/models/foundation/test_spacexai.py
@@ -9,9 +9,6 @@ from pydantic import ValidationError
 from inference.core.workflows.core_steps.models.foundation.spacexai.v1 import (
     OBJECT_DETECTION_PROMPT_TEMPLATE,
     BlockManifest,
-    _execute_proxied_spacexai_request,
-    _extract_output_text,
-    _is_unsupported_reasoning_error,
     encode_image_for_task,
     execute_spacexai_request,
     prepare_object_detection_prompt,
@@ -54,20 +51,6 @@ def test_spacexai_step_validation_requires_api_key_when_managed_key_disabled() -
 
     with pytest.raises(ValidationError):
         _ = BlockManifest.model_validate(specification)
-
-
-def test_spacexai_step_validation_applies_default_model_version() -> None:
-    specification = {
-        "type": "roboflow_core/spacexai@v1",
-        "name": "step_1",
-        "images": "$inputs.image",
-        "task_type": "caption",
-        "api_key": "xxx-xxx",
-    }
-
-    result = BlockManifest.model_validate(specification)
-
-    assert result.model_version == "grok-4.6"
 
 
 def test_spacexai_step_discovers_dependent_model() -> None:
@@ -157,8 +140,6 @@ def test_prepare_object_detection_prompt_uses_percent_contract() -> None:
     assert content[0]["image_url"].startswith("data:image/png;base64,")
     assert content[0]["detail"] == "high"
     assert content[1]["type"] == "input_text"
-    assert "floats between 0 and 100" in content[1]["text"]
-    assert "cat, dog" in content[1]["text"]
     assert (
         OBJECT_DETECTION_PROMPT_TEMPLATE.format(class_list="cat, dog")
         == content[1]["text"]
@@ -195,37 +176,6 @@ def test_encode_image_for_task_uses_jpeg_for_caption() -> None:
     raw = base64.b64decode(base64_image)
     assert raw.startswith(JPEG_MAGIC_BYTES)
     assert (width, height) == (200, 100)
-
-
-def test_extract_output_text_from_completed_response() -> None:
-    response_data = {
-        "status": "completed",
-        "output": [
-            {
-                "type": "message",
-                "content": [{"type": "output_text", "text": "hello world"}],
-            }
-        ],
-    }
-
-    assert _extract_output_text(response_data) == "hello world"
-
-
-def test_extract_output_text_raises_on_max_tokens() -> None:
-    response_data = {
-        "status": "incomplete",
-        "incomplete_details": {"reason": "max_output_tokens"},
-    }
-
-    with pytest.raises(ValueError, match="max_tokens"):
-        _extract_output_text(response_data)
-
-
-def test_is_unsupported_reasoning_error() -> None:
-    assert _is_unsupported_reasoning_error(
-        ValueError("reasoning is not supported for this model")
-    )
-    assert not _is_unsupported_reasoning_error(ValueError("rate limit exceeded"))
 
 
 def test_execute_spacexai_request_rejects_rf_key_when_managed_key_disabled() -> None:
@@ -291,42 +241,3 @@ def test_execute_spacexai_request_routes_direct_key(
     )
     assert result == "direct"
     direct_mock.assert_called_once()
-
-
-@patch(
-    "inference.core.workflows.core_steps.models.foundation.spacexai.v1."
-    "post_to_roboflow_api"
-)
-def test_execute_proxied_spacexai_request_payload(post_mock: MagicMock) -> None:
-    post_mock.return_value = {
-        "status": "completed",
-        "output": [
-            {
-                "type": "message",
-                "content": [{"type": "output_text", "text": "ok"}],
-            }
-        ],
-    }
-
-    result = _execute_proxied_spacexai_request(
-        roboflow_api_key="rf_abc",
-        xai_api_key="rf_key:account",
-        instructions="sys",
-        input_content=[{"role": "user", "content": []}],
-        model_version="grok-4.5",
-        reasoning_effort="high",
-        max_tokens=1024,
-        temperature=0.2,
-    )
-
-    assert result == "ok"
-    post_mock.assert_called_once()
-    _, kwargs = post_mock.call_args
-    assert kwargs["endpoint"] == "apiproxy/xai"
-    payload = kwargs["payload"]
-    assert payload["model"] == "grok-4.5"
-    assert payload["xai_api_key"] == "rf_key:account"
-    assert payload["store"] is False
-    assert payload["max_output_tokens"] == 1024
-    assert payload["reasoning"] == {"effort": "high"}
-    assert payload["instructions"] == "sys"

--- a/tests/workflows/unit_tests/core_steps/models/foundation/test_spacexai.py
+++ b/tests/workflows/unit_tests/core_steps/models/foundation/test_spacexai.py
@@ -42,7 +42,9 @@ def test_spacexai_step_validation_when_input_is_valid() -> None:
     assert result.api_key == "$inputs.xai_api_key"
 
 
-def test_spacexai_step_validation_with_default_api_key() -> None:
+def test_spacexai_step_validation_requires_api_key_when_managed_key_disabled() -> None:
+    # WORKFLOWS_SPACEXAI_MANAGED_KEY_ENABLED is off by default, so the block
+    # must demand a user-provided xAI key instead of defaulting to rf_key.
     specification = {
         "type": "roboflow_core/spacexai@v1",
         "name": "step_1",
@@ -50,9 +52,21 @@ def test_spacexai_step_validation_with_default_api_key() -> None:
         "task_type": "caption",
     }
 
+    with pytest.raises(ValidationError):
+        _ = BlockManifest.model_validate(specification)
+
+
+def test_spacexai_step_validation_applies_default_model_version() -> None:
+    specification = {
+        "type": "roboflow_core/spacexai@v1",
+        "name": "step_1",
+        "images": "$inputs.image",
+        "task_type": "caption",
+        "api_key": "xxx-xxx",
+    }
+
     result = BlockManifest.model_validate(specification)
 
-    assert result.api_key == "rf_key:account"
     assert result.model_version == "grok-4.6"
 
 
@@ -62,6 +76,7 @@ def test_spacexai_step_discovers_dependent_model() -> None:
         "name": "step_1",
         "images": "$inputs.image",
         "task_type": "caption",
+        "api_key": "xxx-xxx",
         "model_version": "grok-4.5",
     }
 
@@ -81,6 +96,7 @@ def test_spacexai_step_validation_when_model_version_valid(
         "name": "step_1",
         "images": "$inputs.image",
         "task_type": "caption",
+        "api_key": "xxx-xxx",
         "model_version": model_version,
     }
 
@@ -96,6 +112,7 @@ def test_spacexai_step_validation_when_model_version_invalid(value: Any) -> None
         "name": "step_1",
         "images": "$inputs.image",
         "task_type": "caption",
+        "api_key": "xxx-xxx",
         "model_version": value,
     }
 
@@ -109,6 +126,7 @@ def test_spacexai_step_validation_requires_prompt_for_unconstrained() -> None:
         "name": "step_1",
         "images": "$inputs.image",
         "task_type": "unconstrained",
+        "api_key": "xxx-xxx",
     }
 
     with pytest.raises(ValidationError):
@@ -121,6 +139,7 @@ def test_spacexai_step_validation_requires_classes_for_object_detection() -> Non
         "name": "step_1",
         "images": "$inputs.image",
         "task_type": "object-detection",
+        "api_key": "xxx-xxx",
     }
 
     with pytest.raises(ValidationError):
@@ -156,6 +175,16 @@ def test_encode_image_for_task_uses_png_for_detection() -> None:
     raw = base64.b64decode(base64_image)
     assert raw.startswith(PNG_MAGIC_BYTES)
     assert (width, height) == (200, 100)
+
+
+def test_encode_image_for_task_keeps_original_resolution_for_detection() -> None:
+    # vlm-exam sent original-resolution images to xAI; the block must not
+    # downscale large detection inputs.
+    image = np.zeros((2100, 3000, 3), dtype=np.uint8)
+
+    _, width, height = encode_image_for_task(image, task_type="object-detection")
+
+    assert (width, height) == (3000, 2100)
 
 
 def test_encode_image_for_task_uses_jpeg_for_caption() -> None:
@@ -199,6 +228,27 @@ def test_is_unsupported_reasoning_error() -> None:
     assert not _is_unsupported_reasoning_error(ValueError("rate limit exceeded"))
 
 
+def test_execute_spacexai_request_rejects_rf_key_when_managed_key_disabled() -> None:
+    # Default flag state: managed keys are off and the proxy must never be
+    # contacted; the block demands a user-provided xAI key.
+    with pytest.raises(ValueError, match="Provide your own xAI API key"):
+        execute_spacexai_request(
+            roboflow_api_key="rf_abc",
+            xai_api_key="rf_key:account",
+            instructions=None,
+            input_content=[{"role": "user", "content": []}],
+            model_version="grok-4.6",
+            reasoning_effort=None,
+            max_tokens=None,
+            temperature=None,
+        )
+
+
+@patch(
+    "inference.core.workflows.core_steps.models.foundation.spacexai.v1."
+    "WORKFLOWS_SPACEXAI_MANAGED_KEY_ENABLED",
+    True,
+)
 @patch(
     "inference.core.workflows.core_steps.models.foundation.spacexai.v1."
     "_execute_proxied_spacexai_request"

--- a/tests/workflows/unit_tests/core_steps/models/foundation/test_spacexai.py
+++ b/tests/workflows/unit_tests/core_steps/models/foundation/test_spacexai.py
@@ -1,0 +1,284 @@
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+from pydantic import ValidationError
+
+from inference.core.workflows.core_steps.models.foundation.spacexai.v1 import (
+    OBJECT_DETECTION_PROMPT_TEMPLATE,
+    BlockManifest,
+    _execute_proxied_spacexai_request,
+    _extract_output_text,
+    _is_unsupported_reasoning_error,
+    encode_image_for_task,
+    execute_spacexai_request,
+    prepare_object_detection_prompt,
+)
+from inference.core.workflows.prototypes.block import third_party_model
+
+PNG_MAGIC_BYTES = b"\x89PNG\r\n\x1a\n"
+JPEG_MAGIC_BYTES = b"\xff\xd8\xff"
+
+
+def test_spacexai_step_validation_when_input_is_valid() -> None:
+    specification = {
+        "type": "roboflow_core/spacexai@v1",
+        "name": "step_1",
+        "images": "$inputs.image",
+        "task_type": "unconstrained",
+        "prompt": "$inputs.prompt",
+        "api_key": "$inputs.xai_api_key",
+    }
+
+    result = BlockManifest.model_validate(specification)
+
+    assert result.type == "roboflow_core/spacexai@v1"
+    assert result.name == "step_1"
+    assert result.images == "$inputs.image"
+    assert result.task_type == "unconstrained"
+    assert result.prompt == "$inputs.prompt"
+    assert result.api_key == "$inputs.xai_api_key"
+
+
+def test_spacexai_step_validation_with_default_api_key() -> None:
+    specification = {
+        "type": "roboflow_core/spacexai@v1",
+        "name": "step_1",
+        "images": "$inputs.image",
+        "task_type": "caption",
+    }
+
+    result = BlockManifest.model_validate(specification)
+
+    assert result.api_key == "rf_key:account"
+    assert result.model_version == "grok-4.6"
+
+
+def test_spacexai_step_discovers_dependent_model() -> None:
+    specification = {
+        "type": "roboflow_core/spacexai@v1",
+        "name": "step_1",
+        "images": "$inputs.image",
+        "task_type": "caption",
+        "model_version": "grok-4.5",
+    }
+
+    manifest = BlockManifest.model_validate(specification)
+
+    result = manifest.discover_dependent_resources()
+
+    assert result == [third_party_model(provider="xai", model_id="grok-4.5")]
+
+
+@pytest.mark.parametrize("model_version", ["grok-4.6", "grok-4.5", "$inputs.model"])
+def test_spacexai_step_validation_when_model_version_valid(
+    model_version: str,
+) -> None:
+    specification = {
+        "type": "roboflow_core/spacexai@v1",
+        "name": "step_1",
+        "images": "$inputs.image",
+        "task_type": "caption",
+        "model_version": model_version,
+    }
+
+    result = BlockManifest.model_validate(specification)
+
+    assert result.model_version == model_version
+
+
+@pytest.mark.parametrize("value", ["invalid-model", 123])
+def test_spacexai_step_validation_when_model_version_invalid(value: Any) -> None:
+    specification = {
+        "type": "roboflow_core/spacexai@v1",
+        "name": "step_1",
+        "images": "$inputs.image",
+        "task_type": "caption",
+        "model_version": value,
+    }
+
+    with pytest.raises(ValidationError):
+        _ = BlockManifest.model_validate(specification)
+
+
+def test_spacexai_step_validation_requires_prompt_for_unconstrained() -> None:
+    specification = {
+        "type": "roboflow_core/spacexai@v1",
+        "name": "step_1",
+        "images": "$inputs.image",
+        "task_type": "unconstrained",
+    }
+
+    with pytest.raises(ValidationError):
+        _ = BlockManifest.model_validate(specification)
+
+
+def test_spacexai_step_validation_requires_classes_for_object_detection() -> None:
+    specification = {
+        "type": "roboflow_core/spacexai@v1",
+        "name": "step_1",
+        "images": "$inputs.image",
+        "task_type": "object-detection",
+    }
+
+    with pytest.raises(ValidationError):
+        _ = BlockManifest.model_validate(specification)
+
+
+def test_prepare_object_detection_prompt_uses_percent_contract() -> None:
+    prompt = prepare_object_detection_prompt(
+        base64_image="abc123",
+        classes=["cat", "dog"],
+    )
+
+    content = prompt["input"][0]["content"]
+    assert content[0]["type"] == "input_image"
+    assert content[0]["image_url"].startswith("data:image/png;base64,")
+    assert content[0]["detail"] == "high"
+    assert content[1]["type"] == "input_text"
+    assert "floats between 0 and 100" in content[1]["text"]
+    assert "cat, dog" in content[1]["text"]
+    assert OBJECT_DETECTION_PROMPT_TEMPLATE.format(class_list="cat, dog") == content[1][
+        "text"
+    ]
+
+
+def test_encode_image_for_task_uses_png_for_detection() -> None:
+    image = np.zeros((100, 200, 3), dtype=np.uint8)
+
+    base64_image, width, height = encode_image_for_task(
+        image, task_type="object-detection"
+    )
+
+    import base64
+
+    raw = base64.b64decode(base64_image)
+    assert raw.startswith(PNG_MAGIC_BYTES)
+    assert (width, height) == (200, 100)
+
+
+def test_encode_image_for_task_uses_jpeg_for_caption() -> None:
+    image = np.zeros((100, 200, 3), dtype=np.uint8)
+
+    base64_image, width, height = encode_image_for_task(image, task_type="caption")
+
+    import base64
+
+    raw = base64.b64decode(base64_image)
+    assert raw.startswith(JPEG_MAGIC_BYTES)
+    assert (width, height) == (200, 100)
+
+
+def test_extract_output_text_from_completed_response() -> None:
+    response_data = {
+        "status": "completed",
+        "output": [
+            {
+                "type": "message",
+                "content": [{"type": "output_text", "text": "hello world"}],
+            }
+        ],
+    }
+
+    assert _extract_output_text(response_data) == "hello world"
+
+
+def test_extract_output_text_raises_on_max_tokens() -> None:
+    response_data = {
+        "status": "incomplete",
+        "incomplete_details": {"reason": "max_output_tokens"},
+    }
+
+    with pytest.raises(ValueError, match="max_tokens"):
+        _extract_output_text(response_data)
+
+
+def test_is_unsupported_reasoning_error() -> None:
+    assert _is_unsupported_reasoning_error(
+        ValueError("reasoning is not supported for this model")
+    )
+    assert not _is_unsupported_reasoning_error(ValueError("rate limit exceeded"))
+
+
+@patch(
+    "inference.core.workflows.core_steps.models.foundation.spacexai.v1."
+    "_execute_proxied_spacexai_request"
+)
+def test_execute_spacexai_request_routes_rf_key_to_proxy(
+    proxied_mock: MagicMock,
+) -> None:
+    proxied_mock.return_value = "proxied"
+    result = execute_spacexai_request(
+        roboflow_api_key="rf_abc",
+        xai_api_key="rf_key:account",
+        instructions=None,
+        input_content=[{"role": "user", "content": []}],
+        model_version="grok-4.6",
+        reasoning_effort=None,
+        max_tokens=None,
+        temperature=None,
+    )
+    assert result == "proxied"
+    proxied_mock.assert_called_once()
+
+
+@patch(
+    "inference.core.workflows.core_steps.models.foundation.spacexai.v1."
+    "_execute_direct_spacexai_request"
+)
+def test_execute_spacexai_request_routes_direct_key(
+    direct_mock: MagicMock,
+) -> None:
+    direct_mock.return_value = "direct"
+    result = execute_spacexai_request(
+        roboflow_api_key="rf_abc",
+        xai_api_key="xai-secret",
+        instructions=None,
+        input_content=[{"role": "user", "content": []}],
+        model_version="grok-4.6",
+        reasoning_effort=None,
+        max_tokens=None,
+        temperature=None,
+    )
+    assert result == "direct"
+    direct_mock.assert_called_once()
+
+
+@patch(
+    "inference.core.workflows.core_steps.models.foundation.spacexai.v1."
+    "post_to_roboflow_api"
+)
+def test_execute_proxied_spacexai_request_payload(post_mock: MagicMock) -> None:
+    post_mock.return_value = {
+        "status": "completed",
+        "output": [
+            {
+                "type": "message",
+                "content": [{"type": "output_text", "text": "ok"}],
+            }
+        ],
+    }
+
+    result = _execute_proxied_spacexai_request(
+        roboflow_api_key="rf_abc",
+        xai_api_key="rf_key:account",
+        instructions="sys",
+        input_content=[{"role": "user", "content": []}],
+        model_version="grok-4.5",
+        reasoning_effort="high",
+        max_tokens=1024,
+        temperature=0.2,
+    )
+
+    assert result == "ok"
+    post_mock.assert_called_once()
+    _, kwargs = post_mock.call_args
+    assert kwargs["endpoint"] == "apiproxy/xai"
+    payload = kwargs["payload"]
+    assert payload["model"] == "grok-4.5"
+    assert payload["xai_api_key"] == "rf_key:account"
+    assert payload["store"] is False
+    assert payload["max_output_tokens"] == 1024
+    assert payload["reasoning"] == {"effort": "high"}
+    assert payload["instructions"] == "sys"

--- a/tests/workflows/unit_tests/core_steps/models/foundation/test_spacexai.py
+++ b/tests/workflows/unit_tests/core_steps/models/foundation/test_spacexai.py
@@ -1,3 +1,4 @@
+import base64
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -139,9 +140,10 @@ def test_prepare_object_detection_prompt_uses_percent_contract() -> None:
     assert content[1]["type"] == "input_text"
     assert "floats between 0 and 100" in content[1]["text"]
     assert "cat, dog" in content[1]["text"]
-    assert OBJECT_DETECTION_PROMPT_TEMPLATE.format(class_list="cat, dog") == content[1][
-        "text"
-    ]
+    assert (
+        OBJECT_DETECTION_PROMPT_TEMPLATE.format(class_list="cat, dog")
+        == content[1]["text"]
+    )
 
 
 def test_encode_image_for_task_uses_png_for_detection() -> None:
@@ -150,8 +152,6 @@ def test_encode_image_for_task_uses_png_for_detection() -> None:
     base64_image, width, height = encode_image_for_task(
         image, task_type="object-detection"
     )
-
-    import base64
 
     raw = base64.b64decode(base64_image)
     assert raw.startswith(PNG_MAGIC_BYTES)
@@ -162,8 +162,6 @@ def test_encode_image_for_task_uses_jpeg_for_caption() -> None:
     image = np.zeros((100, 200, 3), dtype=np.uint8)
 
     base64_image, width, height = encode_image_for_task(image, task_type="caption")
-
-    import base64
 
     raw = base64.b64decode(base64_image)
     assert raw.startswith(JPEG_MAGIC_BYTES)


### PR DESCRIPTION
## Summary
- Adds `roboflow_core/spacexai@v1` VLM block exposing Grok 4.6 (default) and Grok 4.5 via xAI's OpenAI-compatible Responses API. Users provide their own xAI API key; requests go directly to `api.x.ai`.
- The Roboflow-managed key option (`rf_key:account` routed through `apiproxy/xai`) is gated behind `WORKFLOWS_SPACEXAI_MANAGED_KEY_ENABLED` (default **off**). With the flag off the manifest requires a user key, the UI does not offer the managed option, and `rf_key:*` values are rejected at runtime before any proxy call — so this PR has **no dependency** on the platform proxy PR and cannot break if it never ships.
- Object-detection prompting uses the vlm-exam winning percent contract (`box_2d` as floats 0–100) with original-resolution PNG uploads, matching the benchmark setup exactly; registers `model_type="spacexai"` in `vlm_as_detector@v2` / `v2_tensor`.

## Test plan
- [x] `pytest tests/workflows/unit_tests/core_steps/models/foundation/test_spacexai.py`
- [x] `pytest tests/workflows/unit_tests/core_steps/formatters/vlm_as_detector/test_v2.py`
- [x] Manifest smoke-tested under both flag states (required key when off; `rf_key:account` default when on)
- [ ] Manual end-to-end with direct xAI key + `vlm_as_detector@v2` (model_type=spacexai)
- [ ] Managed-key path after platform `/apiproxy/xai` (roboflow `feature/apiproxy-xai`) deploys and the flag is enabled

## Review follow-ups
- Valid `reasoning_effort` values for Grok 4.5/4.6 and whether a non-default effort should be recommended for detection (vlm-exam always set an effort).
- Exact Responses API behavior on xAI (truncation signaling; whether `temperature` must be dropped with reasoning).
- Non-detection task prompt quality; structured-output support.
- Whether to port the exam's parse-recovery ladder into `spacexai_detection_parsing.py`.
- Naming freeze: block family `spacexai`, provider/billing `xai`, detector `model_type` `spacexai`.

## Ops note
Enabling managed keys later requires: the platform `/apiproxy/xai` PR deployed, `XAI_API_KEY` provisioned, and `WORKFLOWS_SPACEXAI_MANAGED_KEY_ENABLED=True` on inference servers.

Made with [Cursor](https://cursor.com)