### PR TITLE
fix: exclude runtime_compatibility_hash from cache manifest identity …

### DIFF
--- a/inference/core/version.py
+++ b/inference/core/version.py
@@ -1,4 +1,4 @@
-__version__ = "1.4.1"
+__version__ = "1.4.2"
 
 
 if __name__ == "__main__":

--- a/inference_models/inference_models/models/auto_loaders/core.py
+++ b/inference_models/inference_models/models/auto_loaders/core.py
@@ -3506,6 +3506,13 @@ def attempt_loading_matching_model_packages(
     )
 
 
+# Manifest fields describing the runtime environment rather than the package
+# identity. A package materialized on one machine must remain loadable on
+# another (e.g. model caches shared between different GPU types), so these
+# fields must not participate in the cache-mutation guard below.
+MUTATION_GUARD_ENVIRONMENT_DEPENDENT_FIELDS = {"runtime_compatibility_hash"}
+
+
 def _validate_existing_cache_package_attribution(
     package_dir: str,
     cache_model_id: str,
@@ -3596,6 +3603,7 @@ def _validate_existing_cache_package_attribution(
         or any(
             content.get(field_name) != expected_value
             for field_name, expected_value in expected_manifest_fields.items()
+            if field_name not in MUTATION_GUARD_ENVIRONMENT_DEPENDENT_FIELDS
         )
         or _artifact_declarations_from_identities(
             identities=existing_artifact_identities
@@ -4271,6 +4279,7 @@ def dump_model_config_for_offline_use(
                 content.get(field_name) != field_value
                 for field_name, field_value in published_fields.items()
                 if field_name != "offline_compatibility_hash"
+                and field_name not in MUTATION_GUARD_ENVIRONMENT_DEPENDENT_FIELDS
             ):
                 raise CorruptedModelPackageError(
                     message=(
@@ -4287,6 +4296,13 @@ def dump_model_config_for_offline_use(
             # auto-resolution entry.
             published_fields["offline_compatibility_hash"] = (
                 existing_offline_compatibility_hash
+            )
+            # Likewise, the runtime compatibility hash describes the machine
+            # that first materialized the package, not the package itself.
+            # Keep the original manifest stable when another machine (e.g. a
+            # different GPU type sharing the model cache) republishes it.
+            published_fields["runtime_compatibility_hash"] = content.get(
+                "runtime_compatibility_hash"
             )
             # Every other current-manifest field was just proven identical.
             # Do not replace the file merely to publish another request alias:

--- a/inference_models/inference_models/models/auto_loaders/core.py
+++ b/inference_models/inference_models/models/auto_loaders/core.py
@@ -2496,8 +2496,12 @@ def _verified_auto_cache_package_dir(
             if cache_entry.recommended_parameters is not None
             else None
         )
-        or package_config.runtime_compatibility_hash
-        != _runtime_compatibility_hash(runtime_x_ray=x_ray_runtime_environment())
+        # The manifest's runtime_compatibility_hash identifies the machine
+        # that first materialized the package, not this one, so it is not
+        # compared here. Runtime applicability of the entry is already
+        # guaranteed by its lookup key: auto_negotiation_hash embeds the
+        # current runtime-compatibility content, and the entry was only
+        # written after a successful warm load under that exact runtime.
     ):
         LOGGER.warning(
             "Ignoring invalid auto-load cache entry because its resolution "

--- a/inference_models/pyproject.toml
+++ b/inference_models/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inference-models"
-version = "0.35.2"
+version = "0.35.3"
 description = "The new inference engine for Computer Vision models"
 readme = "README.md"
 requires-python = ">=3.10,<3.13"

--- a/inference_models/tests/unit_tests/models/auto_loaders/test_core.py
+++ b/inference_models/tests/unit_tests/models/auto_loaders/test_core.py
@@ -6361,3 +6361,70 @@ def test_dump_model_config_preserves_manifest_for_other_machine_runtime_hash(
     with open(config_path, "rb") as config_file:
         assert config_file.read() == original_bytes
     assert republished_hash == original_hash
+
+
+def test_verified_auto_cache_package_dir_accepts_manifest_from_other_machine(
+    empty_local_dir: str,
+) -> None:
+    """An auto-resolution entry must stay valid when the package manifest was
+    materialized by a machine with a different runtime-compatibility hash —
+    the entry's lookup key already scopes it to the current runtime."""
+    # given
+    model_id = "workspace/canonical/7"
+    package_id = "sharedPackage"
+    artifact_content = b"shared weights"
+    with mock.patch.object(model_cache_paths, "INFERENCE_HOME", empty_local_dir):
+        package_dir = generate_model_package_cache_path(
+            model_id=model_id,
+            package_id=package_id,
+        )
+        os.makedirs(package_dir)
+        with open(os.path.join(package_dir, "weights.bin"), "wb") as artifact_file:
+            artifact_file.write(artifact_content)
+        manifest_hash = dump_model_config_for_offline_use(
+            config_path=os.path.join(package_dir, MODEL_CONFIG_FILE_NAME),
+            model_architecture="yolov8",
+            task_type="object-detection",
+            backend_type=BackendType.ONNX,
+            file_lock_acquire_timeout=10,
+            model_id=model_id,
+            canonical_model_id=model_id,
+            trusted_source=True,
+            model_dependencies=[],
+            quantization="unknown",
+            dynamic_batch_size_supported=True,
+            runtime_compatibility_hash="a" * 64,  # not this machine's hash
+            offline_compatibility_hash="b" * 64,
+            package_artifacts=[
+                {
+                    "file_handle": "weights.bin",
+                    "md5_hash": hashlib.md5(artifact_content).hexdigest(),
+                    "unhashed": False,
+                    "sha256_hash": None,
+                    "source_hash": None,
+                    "storage": "package_file",
+                }
+            ],
+            dependency_package_paths=[],
+        )
+        cache_entry = AutoResolutionCacheEntry(
+            model_id=model_id,
+            cache_model_id=model_id,
+            canonical_model_id=model_id,
+            cache_attribution_version=core.CACHE_ATTRIBUTION_VERSION,
+            model_package_id=package_id,
+            resolved_files=[],
+            model_architecture="yolov8",
+            task_type="object-detection",
+            backend_type=BackendType.ONNX,
+            model_dependencies=None,
+            created_at=datetime.now(),
+            trusted_source=True,
+            package_manifest_hash=manifest_hash,
+        )
+
+        # when
+        result = core._verified_auto_cache_package_dir(cache_entry=cache_entry)
+
+    # then - entry accepted despite foreign runtime hash in the manifest
+    assert result == package_dir

--- a/inference_models/tests/unit_tests/models/auto_loaders/test_core.py
+++ b/inference_models/tests/unit_tests/models/auto_loaders/test_core.py
@@ -6230,3 +6230,134 @@ def test_auto_resolution_cache_entries_do_not_expire_in_offline_mode(
     assert result_offline is not None
     assert result_offline.model_id == "some/1"
     assert result_online is None
+
+
+def _current_manifest_content(runtime_compatibility_hash: str) -> dict:
+    return {
+        "offline_manifest_version": core.OFFLINE_CACHE_MANIFEST_VERSION,
+        "model_id": "workspace/project/3",
+        "canonical_model_id": "workspace/project/3",
+        "model_architecture": "yolov8",
+        "task_type": "object-detection",
+        "backend_type": "onnx",
+        "model_features": None,
+        "trusted_source": True,
+        "model_dependencies": [],
+        "recommended_parameters": None,
+        "quantization": "unknown",
+        "dynamic_batch_size_supported": True,
+        "static_batch_size": None,
+        "runtime_compatibility_hash": runtime_compatibility_hash,
+        "offline_compatibility_hash": "b" * 64,
+        "package_artifacts": [],
+        "dependency_package_paths": [],
+    }
+
+
+def _expected_manifest_fields_from_content(content: dict) -> dict:
+    return {
+        field_name: content[field_name]
+        for field_name in (
+            "model_id",
+            "canonical_model_id",
+            "model_architecture",
+            "task_type",
+            "backend_type",
+            "model_features",
+            "trusted_source",
+            "model_dependencies",
+            "recommended_parameters",
+            "quantization",
+            "dynamic_batch_size_supported",
+            "static_batch_size",
+            "runtime_compatibility_hash",
+        )
+    }
+
+
+def test_cache_attribution_accepts_package_materialized_on_another_machine(
+    empty_local_dir: str,
+) -> None:
+    """A package cached by one machine must stay loadable on another GPU type."""
+    # given - manifest written on a machine with a different runtime hash
+    content = _current_manifest_content(runtime_compatibility_hash="a" * 64)
+    config_path = os.path.join(empty_local_dir, "model_config.json")
+    with open(config_path, "w") as file:
+        json.dump(content, file)
+    expected_manifest_fields = _expected_manifest_fields_from_content(content)
+    expected_manifest_fields["runtime_compatibility_hash"] = "c" * 64
+
+    # when - no error expected
+    core._validate_existing_cache_package_attribution(
+        package_dir=empty_local_dir,
+        cache_model_id="workspace/project/3",
+        canonical_model_id="workspace/project/3",
+        expected_manifest_fields=expected_manifest_fields,
+        package_artifact_declarations=[],
+        dependency_package_paths=[],
+    )
+
+
+def test_cache_attribution_still_rejects_package_identity_change(
+    empty_local_dir: str,
+) -> None:
+    # given - manifest differing in a genuine package-identity field
+    content = _current_manifest_content(runtime_compatibility_hash="a" * 64)
+    config_path = os.path.join(empty_local_dir, "model_config.json")
+    with open(config_path, "w") as file:
+        json.dump(content, file)
+    expected_manifest_fields = _expected_manifest_fields_from_content(content)
+    expected_manifest_fields["backend_type"] = "torch"
+
+    # when / then
+    with pytest.raises(CorruptedModelPackageError, match="Refusing to mutate"):
+        core._validate_existing_cache_package_attribution(
+            package_dir=empty_local_dir,
+            cache_model_id="workspace/project/3",
+            canonical_model_id="workspace/project/3",
+            expected_manifest_fields=expected_manifest_fields,
+            package_artifact_declarations=[],
+            dependency_package_paths=[],
+        )
+
+
+def test_dump_model_config_preserves_manifest_for_other_machine_runtime_hash(
+    empty_local_dir: str,
+) -> None:
+    """Republishing an identical package from a different machine must keep the
+    original manifest byte-stable instead of raising or rewriting it."""
+    # given
+    config_path = os.path.join(empty_local_dir, "model_config.json")
+    original_hash = dump_model_config_for_offline_use(
+        config_path=config_path,
+        model_architecture="yolov8",
+        task_type="object-detection",
+        backend_type=BackendType.ONNX,
+        file_lock_acquire_timeout=10,
+        model_id="workspace/project/3",
+        canonical_model_id="workspace/project/3",
+        trusted_source=True,
+        model_dependencies=[],
+        runtime_compatibility_hash="a" * 64,
+    )
+    with open(config_path, "rb") as config_file:
+        original_bytes = config_file.read()
+
+    # when - same package republished from a machine with another runtime hash
+    republished_hash = dump_model_config_for_offline_use(
+        config_path=config_path,
+        model_architecture="yolov8",
+        task_type="object-detection",
+        backend_type=BackendType.ONNX,
+        file_lock_acquire_timeout=10,
+        model_id="workspace/project/3",
+        canonical_model_id="workspace/project/3",
+        trusted_source=True,
+        model_dependencies=[],
+        runtime_compatibility_hash="c" * 64,
+    )
+
+    # then
+    with open(config_path, "rb") as config_file:
+        assert config_file.read() == original_bytes
+    assert republished_hash == original_hash

--- a/inference_models/uv.lock
+++ b/inference_models/uv.lock
@@ -933,7 +933,7 @@ wheels = [
 
 [[package]]
 name = "inference-models"
-version = "0.35.2"
+version = "0.35.3"
 source = { virtual = "." }
 dependencies = [
     { name = "accelerate" },

--- a/requirements/requirements.cpu.txt
+++ b/requirements/requirements.cpu.txt
@@ -1,3 +1,3 @@
 onnxruntime>=1.15.1,<1.22.0
 nvidia-ml-py<13.0.0
-inference-models[torch-cpu,onnx-cpu]~=0.35.2  # keep in sync between requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt
+inference-models[torch-cpu,onnx-cpu]~=0.35.3  # keep in sync between requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt

--- a/requirements/requirements.gpu.txt
+++ b/requirements/requirements.gpu.txt
@@ -1,3 +1,3 @@
 onnxruntime-gpu>=1.15.1,<1.22.0
-inference-models[torch-cu124,onnx-cu12]~=0.35.2 # keep in sync between requirements.jetson requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt
+inference-models[torch-cu124,onnx-cu12]~=0.35.3 # keep in sync between requirements.jetson requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt
 pynvvideocodec~=2.1.0; platform_machine == "x86_64"

--- a/requirements/requirements.jetson.txt
+++ b/requirements/requirements.jetson.txt
@@ -1,3 +1,3 @@
 pypdfium2>=4.11.0,<5.0.0
 PyYAML~=6.0.0
-inference-models~=0.35.2  # keep in sync between requirements.jetson requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt
+inference-models~=0.35.3  # keep in sync between requirements.jetson requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt

--- a/requirements/requirements.vino.txt
+++ b/requirements/requirements.vino.txt
@@ -1,2 +1,2 @@
 onnxruntime-openvino>=1.15.0,<1.22.0
-inference-models[torch-cpu]~=0.35.2  # keep in sync between requirements.jetson requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt
+inference-models[torch-cpu]~=0.35.3  # keep in sync between requirements.jetson requirements.gpu.txt, requirements.cpu.txt, requirements.vino.txt


### PR DESCRIPTION
## What does this PR do?

Fixes model loading failures (`CorruptedModelPackageError: "Refusing to mutate a current cached package..."`) when a model cache is shared between machines with different GPU types.

For example here: https://roboflow.slack.com/archives/C08LJQRPDMZ/p1786723808777779

The cache-mutation guard and the manifest dump path compared `runtime_compatibility_hash` as part of the package's identity. That hash includes the GPU name, compute capability, and driver/CUDA versions — so a package materialized on one GPU type became permanently unloadable on any other machine sharing the cache. In production this broke sam3 workflows on `webrtc-gpu-small`/`medium` Modal workers, which share the `rfcache` volume with other GPU plans: whichever GPU type wrote `model_config.json` first "won", and every other GPU type failed with `ModelPackageAlternativesExhaustedError`.

The hash describes the runtime environment, not the package. This PR excludes it from both identity comparisons (new `MUTATION_GUARD_ENVIRONMENT_DEPENDENT_FIELDS` constant) and keeps the original manifest byte-stable when an identical package is republished from another machine — the same treatment `offline_compatibility_hash` already gets. It also stops `_verified_auto_cache_package_dir` from comparing the manifest's (writer's) hash against the current machine: runtime applicability of an auto-resolution entry is already enforced by its lookup key (`auto_negotiation_hash` embeds the runtime-compatibility content), so the removed check only caused cold-start cache misses and a misleading corruption warning on the non-writer GPU type. All other checks (model/canonical id, task type, backend, artifact MD5 identities, dependency paths) are unchanged. Out of scope: offline (`OFFLINE_MODE`) cross-GPU reuse — gated separately by the request-scoped `offline_compatibility_hash` and never worked before this PR.

**Related Issue(s):** none filed — found debugging prod webrtc workflow failures on 2026-08-17.

## Type of Change

- Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] I have tested this change locally
- [x] I have added/updated tests for this change

**Test details:**

- 4 new unit tests in `test_core.py`: guard accepts a manifest whose only difference is `runtime_compatibility_hash`; guard still rejects a genuine identity change (`backend_type`); `dump_model_config_for_offline_use` keeps the manifest byte-stable when republished with a different runtime hash; `_verified_auto_cache_package_dir` accepts an entry whose manifest was materialized on another machine. Existing provenance-rejection tests (including `test_attempt_loading_model_from_offline_cache_requires_matching_runtime`) unchanged and passing.
- **Reproduced the exact production failure and verified the fix end-to-end** on Modal GPUs (L40S + T4, shared volume): warm a torch package on L40S, then load it from T4 with `backend="torch"` pinned (single candidate — the same shape as sam3, which has exactly one package). Unpatched (`inference-models==0.35.2`, byte-identical to current `main` in the touched region) fails with the exact production error chain (`CorruptedModelPackageError: "Refusing to mutate a current cached package..."` → `ModelPackageAlternativesExhaustedError`); the patched build loads the same volume state successfully and leaves the manifest byte-identical (no hash ping-pong between GPU types). Same A/B reproduced locally by editing the manifest's `runtime_compatibility_hash`.
- Note: without a pinned backend the failure can be masked when negotiation offers an alternative package (e.g. onnx) — that escape hatch doesn't exist for single-package models like `sam3/sam3_final`, which is why production fails hard.
- Field-elimination check against the real production manifest and live API metadata: of everything the guard compares (13 manifest fields, artifact declarations, dependency paths), `runtime_compatibility_hash` is the only differing field.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [ ] I have updated the documentation accordingly (if applicable)

## Additional Context

Reviewer note: this guard is a write-conflict check, not a load-safety check — cross-GPU safety for device-specific packages (e.g. TRT engines) is enforced by package negotiation and the offline-compatibility check (`runtime_compatibility_hash` is still written to manifests and still used there). Prod evidence: failures started 2026-08-17 on the same image that loaded the same package successfully Aug 13–15; the deciding factor was which GPU type's hash was in the shared volume's manifest.
