### PR TITLE
fix(jetson): install kmod in the JetPack 6.0 image

### DIFF
--- a/docker/dockerfiles/Dockerfile.onnx.jetson.6.0.0
+++ b/docker/dockerfiles/Dockerfile.onnx.jetson.6.0.0
@@ -268,6 +268,13 @@ WORKDIR /app
 RUN ln -sf /usr/bin/python3 /usr/bin/python
 
 # Install runtime dependencies
+# kmod (lsmod) is required, not cosmetic: the host-injected NV BSP libnvtvmr.so
+# shells out to `lsmod | grep nvgpu` while creating an NVENC/NVDEC context, and
+# without lsmod on PATH that context creation fails outright -- REQBUFS returns
+# 0 buffers and libtegrav4l2 reports "Error in initializing nvenc context", so
+# the image has no hardware encode or decode at all (VIC/NVJPG keep working,
+# which makes it look engine-specific). Verified on r36.5.0; jetson.6.2.0 and
+# media.jetson.7.2.0 install it for the same reason (#2357).
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
     file \
@@ -290,6 +297,7 @@ RUN apt-get update -y && \
     libexpat1 \
     ca-certificates \
     curl \
+    kmod \
     libv4l-0 \
     libavcodec58 \
     libavformat58 \

--- a/docker/dockerfiles/Dockerfile.onnx.jetson.6.2.0
+++ b/docker/dockerfiles/Dockerfile.onnx.jetson.6.2.0
@@ -639,9 +639,16 @@ WORKDIR /app
 # libgl1 (glvnd desktop-GL loader) provides libGL.so.1, linked by the Qt5 libs
 # bundled inside the opencv-python wheel (manylinux forbids vendoring libGL).
 # kmod (lsmod/modprobe) is shelled out to by the host-injected NV BSP
-# v4l2/GStreamer libs to check the codec kernel modules; without it every
-# nvv4l2decoder plugin load spams "sh: 1: lsmod: not found" and the module
-# check degrades. The media.jetson.7.2.0 image installs it for the same reason
+# v4l2/GStreamer libs to check the codec kernel modules. This is load-bearing,
+# not cosmetic: libnvtvmr.so runs `lsmod | grep nvgpu` while creating an
+# NVENC/NVDEC context, and with no lsmod on PATH that creation fails -- REQBUFS
+# returns 0 buffers and libtegrav4l2 reports "Error in initializing nvenc
+# context", leaving the image with no hardware encode or decode. VIC (nvvidconv)
+# and NVJPG (nvjpegenc) are unaffected, so it presents as engine-specific rather
+# than as a missing package; the only hint is "sh: 1: lsmod: not found" among the
+# GStreamer warnings. Measured on r36.5.0: with lsmod present, 1080p encodes and
+# NVENC moves suspended -> active; without it, neither encode nor decode runs.
+# The media.jetson.7.2.0 image installs it for the same reason
 # (verify_media_runtime.sh requires lsmod whenever BSP plugins are baked).
 # The dpkg path-exclude keeps docs/man/locale out of every package this layer installs.
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=apt-cache-jp62-runtime-${TARGETARCH} \


### PR DESCRIPTION
## What changed

- `Dockerfile.onnx.jetson.6.0.0`: add `kmod` to the runtime apt list.
- `Dockerfile.onnx.jetson.6.2.0`: correct the existing `kmod` comment, which described the failure as log spam / a degraded module check. It is not cosmetic.

## Why

The host-injected NV BSP `libnvtvmr.so` shells out to `lsmod | grep nvgpu` while creating an NVENC/NVDEC context. With no `lsmod` on `PATH` that context creation **fails**, so the image has no hardware encode or decode:

```
v4l2allocator  error requesting 2 buffers: Cannot allocate memory
v4l2bufferpool we received 0 buffer from device '/dev/v4l2-nvenc', we want at least 2
ENC_CTX(0xffff...) Error in initializing nvenc context
```

VIC (`nvvidconv`) and NVJPG (`nvjpegenc`) are unaffected and keep working, so it presents as engine-specific rather than as a missing package. The only hint is `sh: 1: lsmod: not found` among GStreamer's own warnings — easy to read as noise.

#2357 added `kmod` to `jetson.6.2.0` and `media.jetson.7.2.0`. `6.0.0` runs the same r36 BSP userspace and was missed.

### Why only 6.0.0

| Target | State |
| --- | --- |
| `onnx.jetson.6.0.0` | **gap** — r36 BSP, `libv4l-0`, no `kmod` |
| `onnx.jetson.6.2.0` | already has it (#2357) |
| `media.jetson.7.2.0` | already has it (#2357) |
| `onnx.jetson.7.2.0` | inherits it — runtime stage is `FROM ${JETSON_MEDIA_IMAGE}` |
| `onnx.jetson.7.1.0` | no GStreamer/nvv4l2 path at all |
| `onnx.jetson.5.1.1` | r35, where the check is not fatal — NVENC was measured working there without `kmod` |
| `wheels.jetson.7.2.0` | build-only |

## Evidence

Measured on a Jetson Orin NX, JetPack 6.2 / L4T r36.5.0, using the deployed image with only an `lsmod` stand-in added (`printf '#!/bin/sh\ncat /proc/modules\n' > /usr/bin/lsmod`):

| | Without `lsmod` | With `lsmod` |
| --- | --- | --- |
| 720p encode, 30 frames | `ENC_CTX` error, 0 bytes | 812 KB H.264 |
| 1080p encode, 120 frames | `ENC_CTX` error | 2.2 MB, `NVMEDIA: Need to set EMC bandwidth : 846000` |
| `154c0000.nvenc` power state | `suspended` | **`active`** |
| NVDEC decode → NVJPG | fails | 9 JPEGs, `15480000.nvdec` **`active`** |

So hardware **decode** is affected too, not just the encoder — it matters for RTSP ingest as well as live-view encoding.

The underlying defect is in NVIDIA's closed userspace and is [reported but unfixed](https://forums.developer.nvidia.com/t/bug-report-nvv4l2h264enc-fails-in-docker-on-jetson-orin-nx-jetpack-6-2-2-root-cause-is-missing-kmod-lsmod/364611) (NVIDIA staff initially disputed it; the reporter demonstrated it with logs). Until they change it, every image using the BSP codec path has to carry `kmod`.

## Testing

`docker/**` change only; no Python touched, so no unit suite applies. What I ran:

- Reproduced and fixed on-device with the shipped JP6.2 image, per the table above (the JP6.2 image is the one I had hardware for; 6.0.0 shares the r36 userspace and the same missing package).
- Verified the runtime apt list resolves — `kmod` is in Ubuntu main for the `l4t-cuda:12.6.11-runtime` base.

**Not covered by CI:** nothing asserts `lsmod` for the onnx Jetson images. `verify_media_runtime.sh` does exactly this (`command -v lsmod`) for the media image, but `6.0.0` runs no verification stage and `verify_gstreamer.sh` is shared with non-Jetson targets that legitimately lack `kmod`. Happy to add a guarded assertion in a follow-up if you'd like that protection — I kept this diff surgical.

No changelog entry: `inference_models/docs/changelog.md` is scoped to the `inference_models` package, and this touches neither it nor any version/pin.
