### PR TITLE
docs(jetson): correct the kmod comment in the JP6.2 image

### DIFF
--- a/docker/dockerfiles/Dockerfile.onnx.jetson.6.2.0
+++ b/docker/dockerfiles/Dockerfile.onnx.jetson.6.2.0
@@ -639,9 +639,16 @@ WORKDIR /app
 # libgl1 (glvnd desktop-GL loader) provides libGL.so.1, linked by the Qt5 libs
 # bundled inside the opencv-python wheel (manylinux forbids vendoring libGL).
 # kmod (lsmod/modprobe) is shelled out to by the host-injected NV BSP
-# v4l2/GStreamer libs to check the codec kernel modules; without it every
-# nvv4l2decoder plugin load spams "sh: 1: lsmod: not found" and the module
-# check degrades. The media.jetson.7.2.0 image installs it for the same reason
+# v4l2/GStreamer libs to check the codec kernel modules. This is load-bearing,
+# not cosmetic: libnvtvmr.so runs `lsmod | grep nvgpu` while creating an
+# NVENC/NVDEC context, and with no lsmod on PATH that creation fails -- REQBUFS
+# returns 0 buffers and libtegrav4l2 reports "Error in initializing nvenc
+# context", leaving the image with no hardware encode or decode. VIC (nvvidconv)
+# and NVJPG (nvjpegenc) are unaffected, so it presents as engine-specific rather
+# than as a missing package; the only hint is "sh: 1: lsmod: not found" among the
+# GStreamer warnings. Measured on r36.5.0: with lsmod present, 1080p encodes and
+# NVENC moves suspended -> active; without it, neither encode nor decode runs.
+# The media.jetson.7.2.0 image installs it for the same reason
 # (verify_media_runtime.sh requires lsmod whenever BSP plugins are baked).
 # The dpkg path-exclude keeps docs/man/locale out of every package this layer installs.
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=apt-cache-jp62-runtime-${TARGETARCH} \


### PR DESCRIPTION
## What changed

One comment in `Dockerfile.onnx.jetson.6.2.0`. No behavior change, no package change.

## Why

The existing comment describes a missing `lsmod` as log spam plus a degraded module check:

> without it every nvv4l2decoder plugin load spams "sh: 1: lsmod: not found" and the module check degrades

It is not cosmetic. The host-injected `libnvtvmr.so` runs `lsmod | grep nvgpu` while creating an NVENC/NVDEC context, and without `lsmod` that creation **fails** — `REQBUFS` returns 0 buffers and `libtegrav4l2` reports `Error in initializing nvenc context`. The image gets no hardware encode *or* decode. VIC (`nvvidconv`) and NVJPG (`nvjpegenc`) keep working, so it presents as engine-specific rather than as a missing package.

This matters because that block documents which runtime packages were trimmed as "verified unreferenced on-device". A comment calling `kmod` cosmetic invites trimming a load-bearing package, and the failure mode it produces is genuinely hard to trace back — the only hint is one `sh: 1: lsmod: not found` line among GStreamer's warnings.

## Evidence

Measured on a Jetson Orin NX (JetPack 6.2 / L4T r36.5.0) using the shipped image with only an `lsmod` stand-in added:

| | Without `lsmod` | With `lsmod` |
| --- | --- | --- |
| 1080p encode, 120 frames | `ENC_CTX` error, 0 bytes | 2.2 MB, `NVMEDIA: Need to set EMC bandwidth : 846000` |
| `154c0000.nvenc` power state | `suspended` | **`active`** |
| NVDEC decode → NVJPG | fails | 9 JPEGs, `15480000.nvdec` **`active`** |

Upstream is [reported but unfixed](https://forums.developer.nvidia.com/t/bug-report-nvv4l2h264enc-fails-in-docker-on-jetson-orin-nx-jetpack-6-2-2-root-cause-is-missing-kmod-lsmod/364611) — NVIDIA staff initially disputed it and the reporter demonstrated it with logs — so the package stays load-bearing for now.

## Scope

`kmod` is already installed everywhere it is needed: `jetson.6.2.0` and `media.jetson.7.2.0` via #2357, and `jetson.7.2.0` inherits it (`FROM ${JETSON_MEDIA_IMAGE}`). `7.1.0` and `6.0.0` have no GStreamer/nvv4l2 path, and `5.1.1` is r35 where the check is not fatal — so no other target needs it. This supersedes #2816, where I proposed adding it to `6.0.0` before checking that.

## Testing

Comment-only, so nothing to run; the image builds unchanged. The behavior above was verified on-device as tabulated.

No changelog entry: `inference_models/docs/changelog.md` is scoped to that package, and this touches no version or pin.
