### PR TITLE
feat: add OrcaRouter foundation block for workflow LLM steps

### DIFF
--- a/inference/core/workflows/core_steps/loader.py
+++ b/inference/core/workflows/core_steps/loader.py
@@ -624,6 +624,9 @@ from inference.core.workflows.core_steps.models.foundation.openai.v5 import (
 from inference.core.workflows.core_steps.models.foundation.openai_compatible.v1 import (
     OpenAICompatibleBlockV1,
 )
+from inference.core.workflows.core_steps.models.foundation.orcarouter.v1 import (
+    OrcaRouterBlockV1,
+)
 from inference.core.workflows.core_steps.models.foundation.openrouter.v1 import (
     OpenRouterBlockV1,
 )
@@ -1899,6 +1902,7 @@ def load_blocks() -> List[Type[WorkflowBlock]]:
         KimiOpenRouterBlockV1,
         KimiOpenrouterBlockV2,
         OpenRouterBlockV1,
+        OrcaRouterBlockV1,
         SmolVLM2BlockV1,
         Moondream2BlockV1,
         OverlapBlockV1,

--- a/inference/core/workflows/core_steps/models/foundation/orcarouter/v1.py
+++ b/inference/core/workflows/core_steps/models/foundation/orcarouter/v1.py
@@ -1,0 +1,442 @@
+import base64
+import re
+from collections import defaultdict
+from typing import Any, Dict, List, Literal, Optional, Set, Tuple, Type, Union
+
+from openai import OpenAI
+from pydantic import ConfigDict, Field
+
+from inference.core.logger import logger
+from inference.core.utils.image_utils import encode_image_to_jpeg_bytes
+from inference.core.workflows.core_steps.common.query_language.entities.operations import (
+    AllOperationsType,
+)
+from inference.core.workflows.core_steps.common.query_language.operations.core import (
+    build_operations_chain,
+)
+from inference.core.workflows.execution_engine.entities.base import (
+    OutputDefinition,
+    WorkflowImageData,
+)
+from inference.core.workflows.execution_engine.entities.types import (
+    FLOAT_KIND,
+    LANGUAGE_MODEL_OUTPUT_KIND,
+    SECRET_KIND,
+    STRING_KIND,
+    Selector,
+)
+from inference.core.workflows.prototypes.block import (
+    AirGappedAvailability,
+    BlockResult,
+    DependentResource,
+    WorkflowBlock,
+    WorkflowBlockManifest,
+    third_party_model,
+)
+
+PARAMETER_REGEX = re.compile(r"({{\s*\$parameters\.(\w+)\s*}})")
+
+DEFAULT_BASE_URL = "https://api.orcarouter.ai/v1"
+
+LONG_DESCRIPTION = """
+Send a prompt to OrcaRouter — an LLM routing and aggregation gateway that speaks the
+OpenAI chat completions API.
+
+## How this block works
+
+1. Use the **Model Name** to pick a route. `orcarouter/auto` asks OrcaRouter to pick
+   the best model for your prompt; namespaced IDs like `openai/gpt-5.5` or
+   `anthropic/claude-sonnet-4.6` pin a specific upstream model.
+2. Write an **Instruction** — the text the model receives.
+3. Add rows under **Inputs** to feed step outputs (images, detections, text) into
+   the request. Image inputs are base64-encoded and sent as vision content parts.
+   A list of images becomes one vision part per image.
+4. Non-image inputs are converted to strings. To splice them into the instruction
+   text, reference the input by name with the placeholder syntax shown in the
+   Instruction field's help text.
+5. Optionally apply **UQL operations** to transform input values before insertion.
+
+## Image handling
+
+- A `WorkflowImageData` value is JPEG-encoded and sent as an `image_url` part.
+- Raw JPEG `bytes` (e.g. from the Image Stack block) are sent directly.
+- A list of either is fanned out into multiple `image_url` parts.
+
+If an image input is also referenced in the instruction text by name, the
+placeholder is removed from the text — the image only travels as a vision part.
+"""
+
+
+class BlockManifest(WorkflowBlockManifest):
+    model_config = ConfigDict(
+        json_schema_extra={
+            "name": "OrcaRouter",
+            "version": "v1",
+            "short_description": "Send prompts to the OrcaRouter LLM routing gateway.",
+            "long_description": LONG_DESCRIPTION,
+            "license": "Apache-2.0",
+            "block_type": "model",
+            "search_keywords": [
+                "LLM",
+                "VLM",
+                "OrcaRouter",
+                "router",
+                "gateway",
+                "auto",
+                "multi-model",
+            ],
+            "ui_manifest": {
+                "section": "model",
+                "icon": "fal fa-route",
+            },
+        },
+        protected_namespaces=(),
+    )
+    type: Literal["roboflow_core/orcarouter@v1"]
+    base_url: Union[Selector(kind=[STRING_KIND]), str] = Field(
+        default=DEFAULT_BASE_URL,
+        title="Base URL",
+        description="OrcaRouter API endpoint, including /v1.",
+        examples=[DEFAULT_BASE_URL, "$inputs.base_url"],
+    )
+    model_name: Union[Selector(kind=[STRING_KIND]), str] = Field(
+        title="Model Name",
+        description=(
+            "Route to request from OrcaRouter — e.g. `orcarouter/auto` for smart "
+            "routing, or a namespaced model such as `openai/gpt-5.5`."
+        ),
+        examples=["orcarouter/auto", "openai/gpt-5.5", "$inputs.model_name"],
+    )
+    api_key: Optional[Union[Selector(kind=[STRING_KIND, SECRET_KIND]), str]] = Field(
+        default=None,
+        title="API Key",
+        description="OrcaRouter API key (sk-orca-...).",
+        examples=["sk-orca-xxx", "$inputs.api_key"],
+        private=True,
+    )
+    system_prompt: Optional[Union[Selector(kind=[STRING_KIND]), str]] = Field(
+        default=None,
+        title="System Prompt",
+        description="Optional system message that sets model behavior.",
+        examples=["You are a helpful assistant.", "$inputs.system_prompt"],
+        json_schema_extra={
+            "multiline": True,
+        },
+    )
+    prompt: Union[Selector(kind=[STRING_KIND]), str] = Field(
+        title="Instruction",
+        description="Text sent to the model.",
+        examples=[
+            "Describe what you see in the image.",
+            "Count the cars in the image.",
+        ],
+        json_schema_extra={
+            "multiline": True,
+            "always_visible": True,
+        },
+    )
+    prompt_parameters: Dict[
+        str,
+        Union[Selector(), Selector(), str, int, float, bool],
+    ] = Field(
+        title="Inputs",
+        description="Step outputs to include in the request (images or text).",
+        examples=[
+            {
+                "detections": "$steps.model.predictions",
+                "frames": "$steps.image_stack.frames",
+            }
+        ],
+        default_factory=dict,
+        json_schema_extra={
+            "always_visible": True,
+        },
+    )
+    prompt_parameters_operations: Dict[str, List[AllOperationsType]] = Field(
+        title="Input Transformations",
+        description="Optional UQL operations applied to inputs before use.",
+        examples=[
+            {
+                "detections": [
+                    {
+                        "type": "DetectionsPropertyExtract",
+                        "property_name": "class_name",
+                    }
+                ]
+            }
+        ],
+        default_factory=dict,
+    )
+    max_tokens: int = Field(
+        default=500,
+        title="Max Tokens",
+        description="Maximum tokens the model may generate.",
+        gt=1,
+    )
+    temperature: Optional[Union[float, Selector(kind=[FLOAT_KIND])]] = Field(
+        default=None,
+        title="Temperature",
+        description="Sampling temperature, 0.0 to 2.0.",
+        ge=0.0,
+        le=2.0,
+    )
+    extra_body: Optional[Dict[str, Any]] = Field(
+        default=None,
+        title="Advanced API Options",
+        description="Extra JSON forwarded as the OpenAI SDK extra_body argument.",
+        examples=[
+            {
+                "guided_choice": ["A", "B", "C", "D"],
+                "chat_template_kwargs": {"enable_thinking": False},
+            }
+        ],
+    )
+
+    @classmethod
+    def get_air_gapped_availability(cls) -> AirGappedAvailability:
+        return AirGappedAvailability(available=False, reason="requires_internet")
+
+    @classmethod
+    def describe_outputs(cls) -> List[OutputDefinition]:
+        return [
+            OutputDefinition(
+                name="output", kind=[STRING_KIND, LANGUAGE_MODEL_OUTPUT_KIND]
+            ),
+            OutputDefinition(name="error_status", kind=[STRING_KIND]),
+        ]
+
+    @classmethod
+    def get_execution_engine_compatibility(cls) -> Optional[str]:
+        return ">=1.4.0,<2.0.0"
+
+    def discover_dependent_resources(self) -> Optional[List[DependentResource]]:
+        # The provider is a named OrcaRouter integration (not a generic
+        # user-supplied endpoint), so every request here maps to the same
+        # third-party provider with the route as the model id.
+        return [
+            third_party_model(
+                provider="orcarouter",
+                model_id=self.model_name,
+            )
+        ]
+
+
+class OrcaRouterBlockV1(WorkflowBlock):
+
+    def __init__(self):
+        self._client_cache: Dict[Tuple[str, str], OpenAI] = {}
+
+    @classmethod
+    def get_init_parameters(cls) -> List[str]:
+        return []
+
+    @classmethod
+    def get_manifest(cls) -> Type[WorkflowBlockManifest]:
+        return BlockManifest
+
+    @classmethod
+    def get_execution_engine_compatibility(cls) -> Optional[str]:
+        return ">=1.4.0,<2.0.0"
+
+    def _get_client(self, base_url: str, api_key: str) -> OpenAI:
+        cache_key = (base_url, api_key)
+        client = self._client_cache.get(cache_key)
+        if client is None:
+            client = OpenAI(base_url=base_url, api_key=api_key, timeout=120.0)
+            self._client_cache[cache_key] = client
+        return client
+
+    def run(
+        self,
+        base_url: str,
+        model_name: str,
+        api_key: Optional[str],
+        system_prompt: Optional[str],
+        prompt: str,
+        prompt_parameters: Dict[str, Any],
+        prompt_parameters_operations: Dict[str, List[AllOperationsType]],
+        max_tokens: int,
+        temperature: Optional[float],
+        extra_body: Optional[Dict[str, Any]] = None,
+    ) -> BlockResult:
+        resolved_params = _resolve_parameters(
+            prompt_parameters=prompt_parameters,
+            prompt_parameters_operations=prompt_parameters_operations,
+        )
+        text_prompt, image_parts = _build_prompt_content(
+            prompt=prompt,
+            resolved_params=resolved_params,
+        )
+        messages = _build_messages(
+            system_prompt=system_prompt,
+            text_prompt=text_prompt,
+            image_parts=image_parts,
+        )
+        try:
+            output = _execute_request(
+                client=self._get_client(base_url, api_key or "no-key"),
+                model_name=model_name,
+                messages=messages,
+                max_tokens=max_tokens,
+                temperature=temperature,
+                extra_body=extra_body,
+            )
+            return {"output": output, "error_status": ""}
+        except Exception as e:
+            logger.warning(
+                f"OrcaRouter request to {base_url} failed: {e}",
+                exc_info=True,
+            )
+            return {"output": "", "error_status": str(e)}
+
+
+def _resolve_parameters(
+    prompt_parameters: Dict[str, Any],
+    prompt_parameters_operations: Dict[str, List[AllOperationsType]],
+) -> Dict[str, Any]:
+    resolved = {}
+    for name, value in prompt_parameters.items():
+        operations = prompt_parameters_operations.get(name)
+        if operations:
+            chain = build_operations_chain(operations=operations)
+            value = chain(value, global_parameters={})
+        resolved[name] = value
+    return resolved
+
+
+def _is_image_value(value: Any) -> bool:
+    if isinstance(value, (WorkflowImageData, bytes)):
+        return True
+    return False
+
+
+def _is_image_list(value: Any) -> bool:
+    if not isinstance(value, list) or not value:
+        return False
+    return any(_is_image_value(item) for item in value)
+
+
+def _encode_single_image(value: Any) -> str:
+    if isinstance(value, WorkflowImageData):
+        jpeg_bytes = encode_image_to_jpeg_bytes(value.numpy_image)
+        b64 = base64.b64encode(jpeg_bytes).decode("ascii")
+    elif isinstance(value, bytes):
+        b64 = base64.b64encode(value).decode("ascii")
+    else:
+        raise ValueError(f"Cannot encode value of type {type(value)} as image")
+    return f"data:image/jpeg;base64,{b64}"
+
+
+def _collect_image_data_urls(value: Any) -> List[str]:
+    if _is_image_value(value):
+        return [_encode_single_image(value)]
+    if _is_image_list(value):
+        return [_encode_single_image(item) for item in value if _is_image_value(item)]
+    return []
+
+
+def _build_prompt_content(
+    prompt: str,
+    resolved_params: Dict[str, Any],
+) -> Tuple[str, List[str]]:
+    """Build text prompt and image content parts from template + params.
+
+    Returns (text_prompt, image_parts) where image_parts is a list of
+    base64 data URLs for any image parameters found.
+    """
+    image_parts: List[str] = []
+    image_param_names: Set[str] = set()
+
+    matching_parameters = PARAMETER_REGEX.findall(prompt)
+    parameters_to_substitute = {
+        p[1] for p in matching_parameters if p[1] in resolved_params
+    }
+
+    # Collect images from params referenced in the template
+    for name in parameters_to_substitute:
+        value = resolved_params[name]
+        urls = _collect_image_data_urls(value)
+        if urls:
+            image_parts.extend(urls)
+            image_param_names.add(name)
+
+    # Collect images from params NOT referenced in the template
+    for name, value in resolved_params.items():
+        if name in image_param_names or name in parameters_to_substitute:
+            continue
+        urls = _collect_image_data_urls(value)
+        if urls:
+            image_parts.extend(urls)
+            image_param_names.add(name)
+
+    # Substitute non-image params into the prompt text
+    parameter_to_placeholders: Dict[str, List[str]] = defaultdict(list)
+    for placeholder, param_name in matching_parameters:
+        if param_name not in parameters_to_substitute:
+            continue
+        parameter_to_placeholders[param_name].append(placeholder)
+
+    for param_name, placeholders in parameter_to_placeholders.items():
+        for placeholder in placeholders:
+            if param_name in image_param_names:
+                prompt = prompt.replace(placeholder, "")
+            else:
+                prompt = prompt.replace(placeholder, str(resolved_params[param_name]))
+
+    return prompt.strip(), image_parts
+
+
+def _build_messages(
+    system_prompt: Optional[str],
+    text_prompt: str,
+    image_parts: List[str],
+) -> List[dict]:
+    messages = []
+    if system_prompt:
+        messages.append({"role": "system", "content": system_prompt})
+
+    content: List[dict] = []
+    if text_prompt:
+        content.append({"type": "text", "text": text_prompt})
+    for image_url in image_parts:
+        content.append(
+            {
+                "type": "image_url",
+                "image_url": {"url": image_url},
+            }
+        )
+
+    messages.append({"role": "user", "content": content})
+    return messages
+
+
+def _execute_request(
+    client: OpenAI,
+    model_name: str,
+    messages: List[dict],
+    max_tokens: int,
+    temperature: Optional[float],
+    extra_body: Optional[Dict[str, Any]],
+) -> str:
+    kwargs: Dict[str, Any] = {
+        "model": model_name,
+        "messages": messages,
+        "max_tokens": max_tokens,
+    }
+    if temperature is not None:
+        kwargs["temperature"] = temperature
+    if extra_body is not None:
+        kwargs["extra_body"] = extra_body
+    response = client.chat.completions.create(**kwargs)
+    if response.choices is None or len(response.choices) == 0:
+        error_detail = getattr(response, "error", {})
+        if isinstance(error_detail, dict):
+            error_detail = error_detail.get("message", "No response choices returned")
+        raise RuntimeError(f"API returned no choices. Details: {error_detail}")
+    content = response.choices[0].message.content
+    if content is None:
+        finish_reason = getattr(response.choices[0], "finish_reason", None)
+        raise RuntimeError(
+            f"API returned empty message content (finish_reason={finish_reason})."
+        )
+    return content

--- a/tests/workflows/unit_tests/core_steps/dependent_resources/test_orcarouter.py
+++ b/tests/workflows/unit_tests/core_steps/dependent_resources/test_orcarouter.py
@@ -1,0 +1,62 @@
+"""
+Dependent-resources discovery tests for the OrcaRouter block
+(``roboflow_core/orcarouter@v1``).
+
+The block is a named OrcaRouter integration: ``discover_dependent_resources()``
+reports every request as a third-party model with provider ``orcarouter`` and
+the route as the model id — both for literal routes like ``orcarouter/auto``
+and for selector-fed model names.
+"""
+
+from inference.core.workflows.core_steps.models.foundation.orcarouter.v1 import (
+    BlockManifest as OrcaRouterV1Manifest,
+)
+from inference.core.workflows.prototypes.block import third_party_model
+
+
+def test_orcarouter_v1_declares_named_provider_and_route() -> None:
+    manifest = OrcaRouterV1Manifest.model_validate(
+        {
+            "type": "roboflow_core/orcarouter@v1",
+            "name": "llm",
+            "model_name": "orcarouter/auto",
+            "prompt": "Summarize the detections.",
+        }
+    )
+
+    assert manifest.discover_dependent_resources() == [
+        third_party_model(
+            provider="orcarouter",
+            model_id="orcarouter/auto",
+        ),
+    ]
+
+
+def test_orcarouter_v1_defaults_to_orcarouter_endpoint() -> None:
+    manifest = OrcaRouterV1Manifest.model_validate(
+        {
+            "type": "roboflow_core/orcarouter@v1",
+            "name": "llm",
+            "model_name": "openai/gpt-5.5",
+            "prompt": "Hello.",
+        }
+    )
+
+    assert manifest.base_url == "https://api.orcarouter.ai/v1"
+
+
+def test_orcarouter_v1_returns_selector_fed_model_name_verbatim() -> None:
+    manifest = OrcaRouterV1Manifest.model_validate(
+        {
+            "type": "roboflow_core/orcarouter@v1",
+            "name": "llm",
+            "model_name": "$inputs.model_name",
+            "prompt": "Hello.",
+        }
+    )
+
+    assert manifest.discover_dependent_resources() == [
+        third_party_model(
+            provider="orcarouter", model_id="$inputs.model_name"
+        ),
+    ]

--- a/tests/workflows/unit_tests/core_steps/models/foundation/test_orcarouter.py
+++ b/tests/workflows/unit_tests/core_steps/models/foundation/test_orcarouter.py
@@ -1,0 +1,302 @@
+from unittest.mock import MagicMock, patch
+
+from inference.core.workflows.core_steps.models.foundation.orcarouter.v1 import (
+    BlockManifest,
+    OrcaRouterBlockV1,
+    _build_messages,
+    _build_prompt_content,
+    _collect_image_data_urls,
+    _encode_single_image,
+    _is_image_list,
+    _is_image_value,
+    _resolve_parameters,
+)
+from inference.core.workflows.execution_engine.entities.base import WorkflowImageData
+
+
+def test_manifest_validation_valid_input() -> None:
+    specification = {
+        "type": "roboflow_core/orcarouter@v1",
+        "name": "step_1",
+        "model_name": "orcarouter/auto",
+        "prompt": "Describe what you see.",
+    }
+    result = BlockManifest.model_validate(specification)
+    assert result.type == "roboflow_core/orcarouter@v1"
+    assert result.base_url == "https://api.orcarouter.ai/v1"
+    assert result.model_name == "orcarouter/auto"
+
+
+def test_manifest_validation_with_selectors() -> None:
+    specification = {
+        "type": "roboflow_core/orcarouter@v1",
+        "name": "step_1",
+        "model_name": "$inputs.model_name",
+        "prompt": "$inputs.prompt",
+        "api_key": "$inputs.api_key",
+    }
+    result = BlockManifest.model_validate(specification)
+    assert result.model_name == "$inputs.model_name"
+
+
+def test_manifest_validation_with_custom_base_url() -> None:
+    specification = {
+        "type": "roboflow_core/orcarouter@v1",
+        "name": "step_1",
+        "base_url": "$inputs.base_url",
+        "model_name": "orcarouter/auto",
+        "prompt": "Hello.",
+    }
+    result = BlockManifest.model_validate(specification)
+    assert result.base_url == "$inputs.base_url"
+
+
+def test_manifest_validation_missing_prompt() -> None:
+    import pytest
+    from pydantic import ValidationError
+
+    specification = {
+        "type": "roboflow_core/orcarouter@v1",
+        "name": "step_1",
+        "model_name": "orcarouter/auto",
+    }
+    with pytest.raises(ValidationError):
+        BlockManifest.model_validate(specification)
+
+
+def test_manifest_validation_with_parameters() -> None:
+    specification = {
+        "type": "roboflow_core/orcarouter@v1",
+        "name": "step_1",
+        "model_name": "orcarouter/auto",
+        "prompt": "Count {{ $parameters.obj_type }} objects",
+        "prompt_parameters": {
+            "obj_type": "$steps.classifier.class_name",
+        },
+    }
+    result = BlockManifest.model_validate(specification)
+    assert "obj_type" in result.prompt_parameters
+
+
+def test_is_image_value_with_bytes() -> None:
+    assert _is_image_value(b"\xff\xd8\xff") is True
+
+
+def test_is_image_value_with_workflow_image() -> None:
+    image = MagicMock(spec=WorkflowImageData)
+    assert _is_image_value(image) is True
+
+
+def test_is_image_value_with_string() -> None:
+    assert _is_image_value("hello") is False
+
+
+def test_is_image_list_with_bytes_list() -> None:
+    assert _is_image_list([b"\xff\xd8\xff", b"\xff\xd8\xff"]) is True
+
+
+def test_is_image_list_with_empty_list() -> None:
+    assert _is_image_list([]) is False
+
+
+def test_is_image_list_with_string_list() -> None:
+    assert _is_image_list(["a", "b"]) is False
+
+
+def test_encode_single_image_bytes() -> None:
+    jpeg_bytes = b"\xff\xd8\xff\xe0"
+    result = _encode_single_image(jpeg_bytes)
+    assert result.startswith("data:image/jpeg;base64,")
+
+
+def test_collect_image_data_urls_single_bytes() -> None:
+    result = _collect_image_data_urls(b"\xff\xd8\xff")
+    assert len(result) == 1
+    assert result[0].startswith("data:image/jpeg;base64,")
+
+
+def test_collect_image_data_urls_list_of_bytes() -> None:
+    result = _collect_image_data_urls([b"\xff\xd8", b"\xff\xd9"])
+    assert len(result) == 2
+
+
+def test_collect_image_data_urls_non_image() -> None:
+    result = _collect_image_data_urls("hello")
+    assert result == []
+
+
+def test_build_prompt_content_text_only() -> None:
+    text, images = _build_prompt_content(
+        prompt="Count {{ $parameters.obj_type }} in the scene",
+        resolved_params={"obj_type": "cars"},
+    )
+    assert text == "Count cars in the scene"
+    assert images == []
+
+
+def test_build_prompt_content_image_param_removed_from_text() -> None:
+    text, images = _build_prompt_content(
+        prompt="Describe {{ $parameters.frame }}",
+        resolved_params={"frame": b"\xff\xd8\xff"},
+    )
+    assert "frame" not in text
+    assert len(images) == 1
+
+
+def test_build_prompt_content_image_list() -> None:
+    text, images = _build_prompt_content(
+        prompt="What happens across these frames?",
+        resolved_params={"frames": [b"\xff\xd8", b"\xff\xd9", b"\xff\xda"]},
+    )
+    assert len(images) == 3
+
+
+def test_build_prompt_content_mixed_params() -> None:
+    text, images = _build_prompt_content(
+        prompt="Find {{ $parameters.object_type }} in the video",
+        resolved_params={
+            "object_type": "person",
+            "frames": [b"\xff\xd8", b"\xff\xd9"],
+        },
+    )
+    assert text == "Find person in the video"
+    assert len(images) == 2
+
+
+def test_build_messages_text_only() -> None:
+    messages = _build_messages(
+        system_prompt=None,
+        text_prompt="Hello",
+        image_parts=[],
+    )
+    assert len(messages) == 1
+    assert messages[0]["role"] == "user"
+    assert messages[0]["content"] == [{"type": "text", "text": "Hello"}]
+
+
+def test_build_messages_with_system_prompt() -> None:
+    messages = _build_messages(
+        system_prompt="You are helpful.",
+        text_prompt="Hello",
+        image_parts=[],
+    )
+    assert len(messages) == 2
+    assert messages[0]["role"] == "system"
+    assert messages[0]["content"] == "You are helpful."
+
+
+def test_build_messages_with_images() -> None:
+    messages = _build_messages(
+        system_prompt=None,
+        text_prompt="Describe",
+        image_parts=["data:image/jpeg;base64,abc", "data:image/jpeg;base64,def"],
+    )
+    content = messages[0]["content"]
+    assert len(content) == 3
+    assert content[0]["type"] == "text"
+    assert content[1]["type"] == "image_url"
+    assert content[2]["type"] == "image_url"
+
+
+def test_resolve_parameters_no_ops() -> None:
+    result = _resolve_parameters(
+        prompt_parameters={"a": "hello", "b": 42},
+        prompt_parameters_operations={},
+    )
+    assert result == {"a": "hello", "b": 42}
+
+
+@patch(
+    "inference.core.workflows.core_steps.models.foundation.orcarouter.v1._execute_request"
+)
+def test_block_run_success(mock_execute: MagicMock) -> None:
+    mock_execute.return_value = "The model response"
+    block = OrcaRouterBlockV1()
+    result = block.run(
+        base_url="https://api.orcarouter.ai/v1",
+        model_name="orcarouter/auto",
+        api_key="sk-orca-test",
+        system_prompt=None,
+        prompt="Hello",
+        prompt_parameters={},
+        prompt_parameters_operations={},
+        max_tokens=100,
+        temperature=None,
+        extra_body=None,
+    )
+    assert result["output"] == "The model response"
+    assert result["error_status"] == ""
+
+
+@patch(
+    "inference.core.workflows.core_steps.models.foundation.orcarouter.v1._execute_request"
+)
+def test_block_run_error(mock_execute: MagicMock) -> None:
+    mock_execute.side_effect = RuntimeError("Connection refused")
+    block = OrcaRouterBlockV1()
+    result = block.run(
+        base_url="https://api.orcarouter.ai/v1",
+        model_name="orcarouter/auto",
+        api_key=None,
+        system_prompt=None,
+        prompt="Hello",
+        prompt_parameters={},
+        prompt_parameters_operations={},
+        max_tokens=100,
+        temperature=None,
+        extra_body=None,
+    )
+    assert result["output"] == ""
+    assert "Connection refused" in result["error_status"]
+
+
+@patch(
+    "inference.core.workflows.core_steps.models.foundation.orcarouter.v1._execute_request"
+)
+def test_block_run_forwards_extra_body(mock_execute: MagicMock) -> None:
+    mock_execute.return_value = "A"
+    block = OrcaRouterBlockV1()
+    extra_body = {
+        "guided_choice": ["A", "B", "C", "D"],
+        "chat_template_kwargs": {"enable_thinking": False},
+    }
+    block.run(
+        base_url="https://api.orcarouter.ai/v1",
+        model_name="orcarouter/auto",
+        api_key="sk-orca-test",
+        system_prompt=None,
+        prompt="Pick one.",
+        prompt_parameters={},
+        prompt_parameters_operations={},
+        max_tokens=2,
+        temperature=0.0,
+        extra_body=extra_body,
+    )
+    assert mock_execute.call_args.kwargs["extra_body"] == extra_body
+
+
+def test_manifest_validation_with_extra_body() -> None:
+    specification = {
+        "type": "roboflow_core/orcarouter@v1",
+        "name": "step_1",
+        "model_name": "orcarouter/auto",
+        "prompt": "Pick one.",
+        "extra_body": {
+            "guided_choice": ["A", "B", "C"],
+            "chat_template_kwargs": {"enable_thinking": False},
+        },
+    }
+    result = BlockManifest.model_validate(specification)
+    assert result.extra_body["guided_choice"] == ["A", "B", "C"]
+    assert result.extra_body["chat_template_kwargs"] == {"enable_thinking": False}
+
+
+def test_manifest_extra_body_defaults_to_none() -> None:
+    specification = {
+        "type": "roboflow_core/orcarouter@v1",
+        "name": "step_1",
+        "model_name": "orcarouter/auto",
+        "prompt": "Hello.",
+    }
+    result = BlockManifest.model_validate(specification)
+    assert result.extra_body is None


### PR DESCRIPTION
## Summary

Adds a new `roboflow_core/orcarouter@v1` workflow block that sends prompts to **OrcaRouter** — an LLM routing and aggregation gateway (https://www.orcarouter.ai) that exposes an OpenAI-compatible chat completions API.

This is a **named provider integration**, not a generic passthrough: dependent-resource discovery reports `provider="orcarouter"` (with the route as `model_id`), so OrcaRouter traffic is distinguishable from user-supplied OpenAI-compatible endpoints and from other providers in workflows.

## What it does

- **Free-form model name** — use `orcarouter/auto` for OrcaRouter's smart routing, or a namespaced model such as `openai/gpt-5.5` / `anthropic/claude-sonnet-4.6`.
- **Default endpoint** `https://api.orcarouter.ai/v1` (overridable), **API key** field for `sk-orca-...` keys.
- **Full feature parity with the existing `openai_compatible` block**: system prompt, prompt parameters (`{{ $parameters.x }}`), image inputs (base64 JPEG vision parts), UQL input transformations, `max_tokens`, `temperature`, and `extra_body`.
- Mirrors the `openai_compatible`/`openrouter` block conventions throughout.

## Security

- The API key is declared as a `private` field (shown only as a reference in the UI, never rendered back), follows the exact pattern of the existing `openai_compatible` block, and is only ever sent in the request Authorization header.
- No new runtime dependencies; the block reuses the OpenAI SDK client the other blocks already use.

## Tests

- `tests/workflows/unit_tests/core_steps/models/foundation/test_orcarouter.py` — manifest validation (incl. default `base_url`, selectors, `extra_body`), image/prompt handling, run success/error, `extra_body` forwarding.
- `tests/workflows/unit_tests/core_steps/dependent_resources/test_orcarouter.py` — dependent-resource discovery reports `provider="orcarouter"`.
- All 31 tests pass locally. The request path was also verified live against `https://api.orcarouter.ai/v1` with `orcarouter/auto` (routed successfully).

## Disclosure

This PR was prepared with assistance from an AI coding assistant.