### PR TITLE
Add reasoning config support to shared OpenRouter plumbing

### DIFF
--- a/inference/core/workflows/core_steps/common/openrouter.py
+++ b/inference/core/workflows/core_steps/common/openrouter.py
@@ -25,7 +25,7 @@ import json
 from functools import partial
 from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, Union
 
-from openai import OpenAI
+from openai import APIStatusError, OpenAI
 from pydantic import ConfigDict, Field
 
 from inference.core.env import WORKFLOWS_REMOTE_EXECUTION_MAX_STEP_CONCURRENT_REQUESTS
@@ -33,6 +33,7 @@ from inference.core.exceptions import (
     RoboflowAPIForbiddenError,
     RoboflowAPIUnsuccessfulRequestError,
 )
+from inference.core.logger import logger
 from inference.core.managers.base import ModelManager
 from inference.core.roboflow_api import post_to_roboflow_api
 from inference.core.utils.image_utils import encode_image_to_jpeg_bytes, load_image
@@ -184,17 +185,41 @@ class OpenRouterWorkflowBlockBase(WorkflowBlock):
         model: str,
         prompts: List[List[dict]],
         max_tokens: int,
-        temperature: float,
+        temperature: Optional[float],
         privacy_level: str,
         max_concurrent_requests: Optional[int],
+        reasoning: Optional[dict] = None,
     ) -> List[str]:
         """Run a batch of OpenRouter chat-completion calls in parallel.
 
         Routes through the Roboflow proxy when ``openrouter_api_key`` starts
         with ``rf_key:`` (managed/user-stored), otherwise calls the OpenRouter
         API directly using the OpenAI SDK with the provided key.
+
+        ``temperature`` set to ``None`` omits the parameter so the provider
+        default applies. ``reasoning`` is an optional OpenRouter reasoning
+        config object (e.g. ``{"effort": "low"}`` or ``{"enabled": False}``)
+        forwarded verbatim; when the target model rejects the config, the
+        request is retried once without it.
+
+        Known limitation: the Roboflow proxy does not currently forward the
+        ``reasoning`` key upstream (verified empirically - disabling reasoning
+        through the proxy still produced reasoning tokens), so on managed
+        ``rf_key:`` keys the config is silently ignored by the platform and
+        the model applies its provider-default reasoning behavior. The key is
+        still sent so behavior self-corrects once the proxy adds support.
         """
         is_managed = openrouter_api_key.startswith(("rf_key:account", "rf_key:user:"))
+        if is_managed and reasoning is not None:
+            logger.warning(
+                "A reasoning config %s was requested for model %s on a "
+                "Roboflow-managed OpenRouter key, but the Roboflow proxy does "
+                "not currently forward reasoning settings - the model will "
+                "use its provider-default reasoning behavior. Provide your "
+                "own OpenRouter API key (sk-or-...) to control reasoning.",
+                reasoning,
+                model,
+            )
         if is_managed:
             single = partial(
                 _execute_proxied_openrouter_request,
@@ -202,6 +227,7 @@ class OpenRouterWorkflowBlockBase(WorkflowBlock):
                 openrouter_api_key=openrouter_api_key,
                 model=model,
                 privacy_level=privacy_level,
+                reasoning=reasoning,
             )
         else:
             single = partial(
@@ -209,6 +235,7 @@ class OpenRouterWorkflowBlockBase(WorkflowBlock):
                 api_key=openrouter_api_key,
                 model=model,
                 privacy_level=privacy_level,
+                reasoning=reasoning,
             )
         tasks = [
             partial(
@@ -263,29 +290,90 @@ _PROXY_ERROR_HANDLERS: Dict[int, Callable[[Exception], None]] = {
 }
 
 
+# Substrings observed in real OpenRouter rejections of a `reasoning` config.
+# Captured live against qwen/qwen3.8-max and qwen/qwen3.7-flash:
+#   "Reasoning is mandatory for this endpoint and cannot be disabled." (400)
+#   'reasoning.effort: Invalid option: expected one of "max"|"xhigh"|...' (400)
+_REASONING_REJECTION_MARKERS = (
+    "unsupported",
+    "not supported",
+    "unknown",
+    "invalid",
+    "mandatory",
+    "cannot be disabled",
+)
+
+
+def _is_unsupported_reasoning_error(error: Exception) -> bool:
+    """Whether the error is a client-error rejection of the reasoning config.
+
+    Only client (HTTP 4xx-style) errors qualify — connection/timeout failures
+    must never trigger the retry-without-reasoning fallback, as that would
+    issue a duplicate billed request for a transient problem. On the direct
+    path the OpenAI SDK raises ``APIStatusError`` with a status code; on the
+    proxied path HTTP errors surface as ``RoboflowAPIUnsuccessfulRequestError``
+    / ``RoboflowAPIForbiddenError`` (network failures come through as distinct
+    connection/timeout exception types).
+    """
+    if isinstance(error, APIStatusError):
+        if not 400 <= error.status_code < 500:
+            return False
+    elif not isinstance(
+        error, (RoboflowAPIUnsuccessfulRequestError, RoboflowAPIForbiddenError)
+    ):
+        return False
+    message = str(error).lower()
+    return "reasoning" in message and any(
+        marker in message for marker in _REASONING_REJECTION_MARKERS
+    )
+
+
 def _execute_proxied_openrouter_request(
     roboflow_api_key: Optional[str],
     openrouter_api_key: str,
     model: str,
     messages: List[dict],
     max_tokens: int,
-    temperature: float,
+    temperature: Optional[float],
     privacy_level: str,
+    reasoning: Optional[dict] = None,
 ) -> str:
     payload = {
         "openrouter_api_key": openrouter_api_key,
         "model": model,
         "messages": messages,
         "max_tokens": max_tokens,
-        "temperature": temperature,
         "privacy_level": privacy_level,
     }
-    response_data = post_to_roboflow_api(
-        endpoint="apiproxy/openrouter",
-        api_key=roboflow_api_key,
-        payload=payload,
-        http_errors_handlers=_PROXY_ERROR_HANDLERS,
-    )
+    if temperature is not None:
+        payload["temperature"] = temperature
+    if reasoning is not None:
+        payload["reasoning"] = reasoning
+    try:
+        response_data = post_to_roboflow_api(
+            endpoint="apiproxy/openrouter",
+            api_key=roboflow_api_key,
+            payload=payload,
+            http_errors_handlers=_PROXY_ERROR_HANDLERS,
+        )
+    except Exception as error:
+        if reasoning is None or not _is_unsupported_reasoning_error(error):
+            raise
+        logger.warning(
+            "OpenRouter rejected the reasoning config %s for model %s "
+            "(details: %s). Retrying without it - the model will use its "
+            "provider-default reasoning behavior.",
+            reasoning,
+            model,
+            error,
+        )
+        retry_payload = {k: v for k, v in payload.items() if k != "reasoning"}
+        response_data = post_to_roboflow_api(
+            endpoint="apiproxy/openrouter",
+            api_key=roboflow_api_key,
+            payload=retry_payload,
+            http_errors_handlers=_PROXY_ERROR_HANDLERS,
+        )
     choices = response_data.get("choices") or []
     if not choices:
         err_msg = (
@@ -323,21 +411,45 @@ def _execute_direct_openrouter_request(
     model: str,
     messages: List[dict],
     max_tokens: int,
-    temperature: float,
+    temperature: Optional[float],
     privacy_level: str,
+    reasoning: Optional[dict] = None,
 ) -> str:
     client = OpenAI(base_url="https://openrouter.ai/api/v1", api_key=api_key)
     extra_body: Dict[str, Any] = {}
     provider = build_provider_routing(privacy_level)
     if provider is not None:
         extra_body["provider"] = provider
-    response = client.chat.completions.create(
-        model=model,
-        messages=messages,
-        max_tokens=max_tokens,
-        temperature=temperature,
-        extra_body=extra_body,
-    )
+    if reasoning is not None:
+        extra_body["reasoning"] = reasoning
+    request_kwargs: Dict[str, Any] = {
+        "model": model,
+        "messages": messages,
+        "max_tokens": max_tokens,
+    }
+    if temperature is not None:
+        request_kwargs["temperature"] = temperature
+    try:
+        response = client.chat.completions.create(
+            **request_kwargs,
+            extra_body=extra_body,
+        )
+    except Exception as error:
+        if reasoning is None or not _is_unsupported_reasoning_error(error):
+            raise
+        logger.warning(
+            "OpenRouter rejected the reasoning config %s for model %s "
+            "(details: %s). Retrying without it - the model will use its "
+            "provider-default reasoning behavior.",
+            reasoning,
+            model,
+            error,
+        )
+        retry_extra_body = {k: v for k, v in extra_body.items() if k != "reasoning"}
+        response = client.chat.completions.create(
+            **request_kwargs,
+            extra_body=retry_extra_body,
+        )
     if not response.choices:
         error_detail = getattr(response, "error", {}) or {}
         if isinstance(error_detail, dict):

--- a/tests/workflows/unit_tests/core_steps/common/test_openrouter.py
+++ b/tests/workflows/unit_tests/core_steps/common/test_openrouter.py
@@ -3,16 +3,41 @@
 from typing import Any
 from unittest.mock import MagicMock, patch
 
+import httpx
 import pytest
+from openai import APIStatusError
 
+from inference.core.exceptions import (
+    RoboflowAPIConnectionError,
+    RoboflowAPIUnsuccessfulRequestError,
+)
 from inference.core.workflows.core_steps.common.openrouter import (
     OpenRouterWorkflowBlockBase,
     _execute_direct_openrouter_request,
     _execute_proxied_openrouter_request,
+    _is_unsupported_reasoning_error,
     build_prompts_from_images,
     build_provider_routing,
     validate_task_type_required_fields,
 )
+
+# Real error strings captured live from OpenRouter (2026-08-19):
+# qwen/qwen3.8-max rejecting `reasoning: {"enabled": false}`:
+MANDATORY_REASONING_ERROR = (
+    "Reasoning is mandatory for this endpoint and cannot be disabled."
+)
+# qwen/qwen3.7-flash rejecting `reasoning: {"effort": "bogus"}`:
+INVALID_REASONING_OPTION_ERROR = (
+    "reasoning.effort: Invalid option: expected one of "
+    '"max"|"xhigh"|"high"|"medium"|"low"|"minimal"|"none"'
+)
+
+
+def _openai_status_error(message: str, status_code: int) -> APIStatusError:
+    request = httpx.Request("POST", "https://openrouter.ai/api/v1/chat/completions")
+    response = httpx.Response(status_code, request=request)
+    return APIStatusError(message, response=response, body=None)
+
 
 # ---------------------------------------------------------------------------
 # build_provider_routing
@@ -325,6 +350,293 @@ def test_direct_request_raises_when_message_content_is_none(mock_openai_cls):
             temperature=0.0,
             privacy_level="deny",
         )
+
+
+# ---------------------------------------------------------------------------
+# _is_unsupported_reasoning_error
+# ---------------------------------------------------------------------------
+
+
+def test_reasoning_error_matches_mandatory_reasoning_rejection_from_proxy():
+    error = RoboflowAPIUnsuccessfulRequestError(MANDATORY_REASONING_ERROR)
+    assert _is_unsupported_reasoning_error(error) is True
+
+
+def test_reasoning_error_matches_invalid_option_rejection_from_direct_400():
+    error = _openai_status_error(INVALID_REASONING_OPTION_ERROR, status_code=400)
+    assert _is_unsupported_reasoning_error(error) is True
+
+
+def test_reasoning_error_ignores_5xx_even_with_matching_message():
+    error = _openai_status_error(MANDATORY_REASONING_ERROR, status_code=502)
+    assert _is_unsupported_reasoning_error(error) is False
+
+
+def test_reasoning_error_ignores_connection_errors_with_matching_message():
+    # A transient failure whose text happens to mention reasoning must NOT
+    # trigger a duplicate billed request.
+    error = RoboflowAPIConnectionError(MANDATORY_REASONING_ERROR)
+    assert _is_unsupported_reasoning_error(error) is False
+
+
+def test_reasoning_error_ignores_plain_exceptions():
+    assert (
+        _is_unsupported_reasoning_error(Exception(MANDATORY_REASONING_ERROR)) is False
+    )
+
+
+def test_reasoning_error_ignores_unrelated_client_errors():
+    error = RoboflowAPIUnsuccessfulRequestError("image exceeds maximum size")
+    assert _is_unsupported_reasoning_error(error) is False
+
+
+# ---------------------------------------------------------------------------
+# reasoning / temperature payload shape
+# ---------------------------------------------------------------------------
+
+
+@patch("inference.core.workflows.core_steps.common.openrouter.post_to_roboflow_api")
+def test_proxied_request_includes_reasoning_and_omits_none_temperature(mock_post):
+    mock_post.return_value = {"choices": [{"message": {"content": "ok"}}]}
+
+    _execute_proxied_openrouter_request(
+        roboflow_api_key="ws-key",
+        openrouter_api_key="rf_key:account",
+        model="qwen/qwen3.7-flash",
+        messages=[{"role": "user", "content": "hi"}],
+        max_tokens=100,
+        temperature=None,
+        privacy_level="deny",
+        reasoning={"enabled": False},
+    )
+
+    payload = mock_post.call_args.kwargs["payload"]
+    assert payload["reasoning"] == {"enabled": False}
+    assert "temperature" not in payload
+
+
+@patch("inference.core.workflows.core_steps.common.openrouter.OpenAI")
+def test_direct_request_includes_reasoning_and_omits_none_temperature(mock_openai_cls):
+    client = MagicMock()
+    client.chat.completions.create.return_value = _stub_openai_response("ok")
+    mock_openai_cls.return_value = client
+
+    _execute_direct_openrouter_request(
+        api_key="sk-or-v1-test",
+        model="qwen/qwen3.7-flash",
+        messages=[{"role": "user", "content": "hi"}],
+        max_tokens=100,
+        temperature=None,
+        privacy_level="deny",
+        reasoning={"effort": "low"},
+    )
+
+    create_kwargs = client.chat.completions.create.call_args.kwargs
+    assert create_kwargs["extra_body"]["reasoning"] == {"effort": "low"}
+    assert "temperature" not in create_kwargs
+
+
+# ---------------------------------------------------------------------------
+# retry-without-reasoning fallback
+# ---------------------------------------------------------------------------
+
+
+@patch("inference.core.workflows.core_steps.common.openrouter.logger")
+@patch("inference.core.workflows.core_steps.common.openrouter.post_to_roboflow_api")
+def test_proxied_request_retries_without_reasoning_on_rejection(mock_post, mock_logger):
+    mock_post.side_effect = [
+        RoboflowAPIUnsuccessfulRequestError(MANDATORY_REASONING_ERROR),
+        {"choices": [{"message": {"content": "ok"}}]},
+    ]
+
+    out = _execute_proxied_openrouter_request(
+        roboflow_api_key="ws-key",
+        openrouter_api_key="rf_key:account",
+        model="qwen/qwen3.8-max",
+        messages=[{"role": "user", "content": "hi"}],
+        max_tokens=100,
+        temperature=None,
+        privacy_level="deny",
+        reasoning={"enabled": False},
+    )
+
+    assert out == "ok"
+    assert mock_post.call_count == 2
+    assert "reasoning" in mock_post.call_args_list[0].kwargs["payload"]
+    assert "reasoning" not in mock_post.call_args_list[1].kwargs["payload"]
+    assert mock_logger.warning.call_count == 1
+
+
+@patch("inference.core.workflows.core_steps.common.openrouter.post_to_roboflow_api")
+def test_proxied_request_does_not_retry_on_connection_error(mock_post):
+    mock_post.side_effect = RoboflowAPIConnectionError(MANDATORY_REASONING_ERROR)
+
+    with pytest.raises(RoboflowAPIConnectionError):
+        _execute_proxied_openrouter_request(
+            roboflow_api_key="ws-key",
+            openrouter_api_key="rf_key:account",
+            model="qwen/qwen3.8-max",
+            messages=[],
+            max_tokens=1,
+            temperature=None,
+            privacy_level="deny",
+            reasoning={"enabled": False},
+        )
+
+    assert mock_post.call_count == 1
+
+
+@patch("inference.core.workflows.core_steps.common.openrouter.post_to_roboflow_api")
+def test_proxied_request_does_not_retry_when_no_reasoning_sent(mock_post):
+    mock_post.side_effect = RoboflowAPIUnsuccessfulRequestError(
+        MANDATORY_REASONING_ERROR
+    )
+
+    with pytest.raises(RoboflowAPIUnsuccessfulRequestError):
+        _execute_proxied_openrouter_request(
+            roboflow_api_key="ws-key",
+            openrouter_api_key="rf_key:account",
+            model="qwen/qwen3.8-max",
+            messages=[],
+            max_tokens=1,
+            temperature=None,
+            privacy_level="deny",
+        )
+
+    assert mock_post.call_count == 1
+
+
+@patch("inference.core.workflows.core_steps.common.openrouter.logger")
+@patch("inference.core.workflows.core_steps.common.openrouter.OpenAI")
+def test_direct_request_retries_without_reasoning_on_rejection(
+    mock_openai_cls, mock_logger
+):
+    client = MagicMock()
+    client.chat.completions.create.side_effect = [
+        _openai_status_error(INVALID_REASONING_OPTION_ERROR, status_code=400),
+        _stub_openai_response("ok"),
+    ]
+    mock_openai_cls.return_value = client
+
+    out = _execute_direct_openrouter_request(
+        api_key="sk-or-v1-test",
+        model="qwen/qwen3.7-flash",
+        messages=[{"role": "user", "content": "hi"}],
+        max_tokens=100,
+        temperature=None,
+        privacy_level="deny",
+        reasoning={"effort": "low"},
+    )
+
+    assert out == "ok"
+    assert client.chat.completions.create.call_count == 2
+    first_extra = client.chat.completions.create.call_args_list[0].kwargs["extra_body"]
+    second_extra = client.chat.completions.create.call_args_list[1].kwargs["extra_body"]
+    assert "reasoning" in first_extra
+    assert "reasoning" not in second_extra
+    assert mock_logger.warning.call_count == 1
+
+
+@patch("inference.core.workflows.core_steps.common.openrouter.OpenAI")
+def test_direct_request_does_not_retry_on_server_error(mock_openai_cls):
+    client = MagicMock()
+    client.chat.completions.create.side_effect = _openai_status_error(
+        MANDATORY_REASONING_ERROR, status_code=502
+    )
+    mock_openai_cls.return_value = client
+
+    with pytest.raises(APIStatusError):
+        _execute_direct_openrouter_request(
+            api_key="sk-or-v1-test",
+            model="qwen/qwen3.8-max",
+            messages=[],
+            max_tokens=1,
+            temperature=None,
+            privacy_level="deny",
+            reasoning={"enabled": False},
+        )
+
+    assert client.chat.completions.create.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# managed-key reasoning warning (proxy does not forward `reasoning`)
+# ---------------------------------------------------------------------------
+
+
+@patch("inference.core.workflows.core_steps.common.openrouter.logger")
+@patch(
+    "inference.core.workflows.core_steps.common.openrouter._execute_proxied_openrouter_request"
+)
+def test_execute_openrouter_batch_warns_when_reasoning_sent_on_managed_key(
+    mock_proxied, mock_logger
+):
+    mock_proxied.side_effect = ["resp"]
+    block = _FakeBlock(model_manager=MagicMock(), api_key="ws-key")
+
+    block.execute_openrouter_batch(
+        openrouter_api_key="rf_key:account",
+        model="qwen/qwen3.7-flash",
+        prompts=[[{"role": "user", "content": "hi"}]],
+        max_tokens=50,
+        temperature=None,
+        privacy_level="deny",
+        max_concurrent_requests=1,
+        reasoning={"enabled": False},
+    )
+
+    assert mock_logger.warning.call_count == 1
+    # Reasoning is still forwarded so behavior self-corrects once the proxy
+    # adds support.
+    assert mock_proxied.call_args.kwargs["reasoning"] == {"enabled": False}
+
+
+@patch("inference.core.workflows.core_steps.common.openrouter.logger")
+@patch(
+    "inference.core.workflows.core_steps.common.openrouter._execute_proxied_openrouter_request"
+)
+def test_execute_openrouter_batch_does_not_warn_without_reasoning(
+    mock_proxied, mock_logger
+):
+    mock_proxied.side_effect = ["resp"]
+    block = _FakeBlock(model_manager=MagicMock(), api_key="ws-key")
+
+    block.execute_openrouter_batch(
+        openrouter_api_key="rf_key:account",
+        model="qwen/qwen3.7-flash",
+        prompts=[[{"role": "user", "content": "hi"}]],
+        max_tokens=50,
+        temperature=0.2,
+        privacy_level="deny",
+        max_concurrent_requests=1,
+    )
+
+    assert mock_logger.warning.call_count == 0
+
+
+@patch("inference.core.workflows.core_steps.common.openrouter.logger")
+@patch(
+    "inference.core.workflows.core_steps.common.openrouter._execute_direct_openrouter_request"
+)
+def test_execute_openrouter_batch_does_not_warn_on_direct_key_with_reasoning(
+    mock_direct, mock_logger
+):
+    mock_direct.side_effect = ["resp"]
+    block = _FakeBlock(model_manager=MagicMock(), api_key="ws-key")
+
+    block.execute_openrouter_batch(
+        openrouter_api_key="sk-or-v1-abcdef",
+        model="qwen/qwen3.7-flash",
+        prompts=[[{"role": "user", "content": "hi"}]],
+        max_tokens=50,
+        temperature=None,
+        privacy_level="deny",
+        max_concurrent_requests=1,
+        reasoning={"effort": "low"},
+    )
+
+    assert mock_logger.warning.call_count == 0
+    assert mock_direct.call_args.kwargs["reasoning"] == {"effort": "low"}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Linked issue: _none — internal follow-up from the unified Qwen VLM block work_

OpenRouter-hosted reasoning models (notably the Qwen 3.7/3.8 family) reason by default, burning 200-300 hidden tokens per call and inflating latency, with no way for Workflows blocks to control it. The shared OpenRouter plumbing also always sent `temperature`, preventing blocks from deferring to the provider's per-model default. This PR adds reasoning control to the shared layer so upcoming blocks (unified Qwen VLM v2) can expose a `reasoning_effort` knob.

`execute_openrouter_batch` and both request paths accept an optional `reasoning` config object (e.g. `{"effort": "low"}` or `{"enabled": false}`) forwarded verbatim to OpenRouter, and `temperature=None` now omits the parameter. When a model rejects the reasoning config with a client error - some models mandate reasoning and reject `enabled: false` - the request is retried once without the config and a warning is logged. The rejection heuristic matches error strings captured live from OpenRouter ("Reasoning is mandatory for this endpoint and cannot be disabled.", "reasoning.effort: Invalid option: ...") and only fires on 4xx-style error types, so connection failures and 5xx never trigger a duplicate billed request. Empirical probing showed the Roboflow proxy (`apiproxy/openrouter`) does not currently forward the `reasoning` key, so a warning is emitted when a reasoning config is sent on a managed `rf_key:` key; the key is still sent so behavior self-corrects once the proxy adds support. All changes are backward compatible - existing callers pass no reasoning and float temperatures, and their request payloads are unchanged.

**Main elements:**
- `inference/core/workflows/core_steps/common/openrouter.py` - `reasoning` parameter, optional `temperature`, retry-without-reasoning fallback with type-narrowed rejection heuristic, managed-key warning
- `tests/workflows/unit_tests/core_steps/common/test_openrouter.py` - heuristic, payload-shape, retry, and warning coverage

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other:

## Testing

### Unit tests

- `_is_unsupported_reasoning_error`: matches both real OpenRouter rejection strings; rejects 5xx, connection errors, plain exceptions, and unrelated client errors
- Payload shape: `reasoning` included and `temperature` omitted when `None`, on both proxied and direct paths
- Retry fallback: retries exactly once without `reasoning` on client-error rejection (warning logged); no retry on connection errors, server errors, or when no reasoning was sent
- Managed-key warning: emitted once per batch when reasoning is configured on an `rf_key:` key; absent on direct keys or without reasoning

### Integration tests

- None in this PR. Reasoning behavior was verified with live probes against `qwen/qwen3.7-flash` and `qwen/qwen3.8-max` on both the direct and proxied paths during development.

### Other

- `pytest tests/workflows/unit_tests/core_steps/common/test_openrouter.py` (34 passed)
- `pytest tests/workflows/unit_tests/core_steps/models/foundation/test_qwen_vlm.py test_qwen_vlm_v2.py test_google_gemma_v2.py test_kimi_openrouter_v2.py` (71 passed - blocks consuming the shared plumbing)
- black + isort on both files

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [ ] I have updated the documentation accordingly (if applicable)

## Additional Context

Follow-up for the platform team: `apiproxy/openrouter` should forward the `reasoning` payload key upstream. Verified empirically that it is currently stripped - disabling reasoning through the proxy still produced ~290 reasoning tokens, and an invalid reasoning config that OpenRouter rejects with 400 on the direct path passed through the proxy without error. Once forwarding lands, the managed-key warning in this PR can be removed. A follow-up PR adds the unified Qwen VLM v2 block that consumes this reasoning support.

Made with [Cursor](https://cursor.com)