### PR TITLE
fix(workflows): skip steps disabled in the builder at compile time

### DIFF
--- a/inference/core/workflows/execution_engine/v1/compiler/core.py
+++ b/inference/core/workflows/execution_engine/v1/compiler/core.py
@@ -18,6 +18,9 @@ from inference.core.workflows.execution_engine.profiling.core import (
 from inference.core.workflows.execution_engine.v1.compiler.cache import (
     BasicWorkflowsCache,
 )
+from inference.core.workflows.execution_engine.v1.compiler.disabled_steps import (
+    strip_disabled_steps,
+)
 from inference.core.workflows.execution_engine.v1.compiler.entities import (
     CompiledWorkflow,
     GraphCompilationResult,
@@ -168,6 +171,10 @@ def compile_workflow_graph(
         raw_workflow_definition,
         available_blocks=available_blocks,
         profiler=profiler,
+    )
+    inlined_raw_workflow_definition = strip_disabled_steps(
+        workflow_definition=inlined_raw_workflow_definition,
+        available_blocks=available_blocks,
     )
     parsed_workflow_definition = parse_workflow_definition(
         raw_workflow_definition=inlined_raw_workflow_definition,

--- a/inference/core/workflows/execution_engine/v1/compiler/disabled_steps.py
+++ b/inference/core/workflows/execution_engine/v1/compiler/disabled_steps.py
@@ -1,0 +1,282 @@
+"""
+Honour steps disabled in the Workflow builder at runtime.
+
+The builder stores "disable block" as a UI-only flag at
+``metadata.ui.nodes["$steps.<name>"].disabled`` and strips such steps client-side
+before preview runs. The persisted specification still contains them, so any
+runtime that fetches the workflow by id (inference server, edge devices, Dedicated
+Deployments, serverless) would otherwise compile and execute every step - including
+loading model weights for disabled model blocks.
+
+This module mirrors the builder's ``stripDisabledForExecution`` logic:
+  * seed: every step manually flagged ``disabled: true``
+  * cascade (a): a step whose required (no-default) field would be emptied entirely
+    by removing references to disabled steps is itself disabled
+  * cascade (b): a step gated only by conditional-flow blocks (``next_steps``)
+    that are all disabled is itself disabled
+  * strip: drop disabled steps, remove references to them from surviving steps,
+    drop outputs whose selector points at a disabled step
+"""
+
+import re
+from typing import Any, Dict, Iterable, List, Optional, Set, Tuple, Type
+
+from pydantic.fields import FieldInfo
+from typing_extensions import get_args
+
+from inference.core.workflows.execution_engine.v1.compiler.entities import (
+    BlockSpecification,
+)
+from inference.core.workflows.prototypes.block import WorkflowBlockManifest
+
+STEP_REF_PATTERN = re.compile(r"\$steps\.([^.\s\]\[\"']+)")
+NEXT_STEPS_FIELD = "next_steps"
+RESERVED_STEP_KEYS = {"type", "name", "id"}
+
+
+def strip_disabled_steps(
+    workflow_definition: Dict[str, Any],
+    available_blocks: Iterable[BlockSpecification],
+) -> Dict[str, Any]:
+    """Return a copy of ``workflow_definition`` with disabled steps removed.
+
+    Returns the input object untouched when nothing is disabled, so the common
+    path is free of copies.
+    """
+    manually_disabled = _collect_manually_disabled_step_names(workflow_definition)
+    if not manually_disabled:
+        return workflow_definition
+    steps = workflow_definition.get("steps") or []
+    manifests_by_type = _index_manifests_by_type(available_blocks)
+    disabled = _compute_disabled_step_names(
+        steps=steps,
+        seed=manually_disabled,
+        manifests_by_type=manifests_by_type,
+    )
+    disabled_node_ids = {f"$steps.{name}" for name in disabled}
+    surviving_steps = []
+    for step in steps:
+        if _step_name(step) in disabled:
+            continue
+        surviving_steps.append(_strip_references(step, disabled_node_ids))
+    surviving_outputs = [
+        output
+        for output in workflow_definition.get("outputs") or []
+        if not (
+            isinstance(output, dict)
+            and isinstance(output.get("selector"), str)
+            and _selector_points_at_any(output["selector"], disabled_node_ids)
+        )
+    ]
+    result = dict(workflow_definition)
+    result["steps"] = surviving_steps
+    result["outputs"] = surviving_outputs
+    return result
+
+
+def _collect_manually_disabled_step_names(
+    workflow_definition: Dict[str, Any],
+) -> Set[str]:
+    metadata = workflow_definition.get("metadata")
+    if not isinstance(metadata, dict):
+        return set()
+    ui = metadata.get("ui")
+    if not isinstance(ui, dict):
+        return set()
+    nodes = ui.get("nodes")
+    if not isinstance(nodes, dict):
+        return set()
+    result = set()
+    for node_id, node_meta in nodes.items():
+        if not isinstance(node_meta, dict) or node_meta.get("disabled") is not True:
+            continue
+        if not isinstance(node_id, str) or not node_id.startswith("$steps."):
+            continue
+        result.add(node_id[len("$steps.") :])
+    return result
+
+
+def _compute_disabled_step_names(
+    steps: List[Dict[str, Any]],
+    seed: Set[str],
+    manifests_by_type: Dict[str, Type[WorkflowBlockManifest]],
+) -> Set[str]:
+    disabled = set(seed)
+    control_predecessors = _build_control_predecessor_map(steps)
+    changed = True
+    while changed:
+        changed = False
+        disabled_node_ids = {f"$steps.{name}" for name in disabled}
+        for step in steps:
+            name = _step_name(step)
+            if not name or name in disabled:
+                continue
+            if _has_fully_disabled_required_field(
+                step=step,
+                disabled_node_ids=disabled_node_ids,
+                manifests_by_type=manifests_by_type,
+            ) or _has_only_disabled_control_predecessors(
+                step_name=name,
+                control_predecessors=control_predecessors,
+                disabled=disabled,
+            ):
+                disabled.add(name)
+                changed = True
+    return disabled
+
+
+def _has_fully_disabled_required_field(
+    step: Dict[str, Any],
+    disabled_node_ids: Set[str],
+    manifests_by_type: Dict[str, Type[WorkflowBlockManifest]],
+) -> bool:
+    manifest_class = manifests_by_type.get(step.get("type"))
+    if manifest_class is None:
+        return False
+    for field_name, field_info in manifest_class.model_fields.items():
+        if field_name in RESERVED_STEP_KEYS or field_name == NEXT_STEPS_FIELD:
+            continue
+        if not _is_required(field_info):
+            continue
+        value = step.get(field_name)
+        if value is None and field_info.alias:
+            value = step.get(field_info.alias)
+        if value is None:
+            continue
+        if not _find_step_refs(value):
+            continue
+        cleaned, _ = _clean_value(value, disabled_node_ids)
+        if cleaned is _DELETE:
+            return True
+    return False
+
+
+def _is_required(field_info: FieldInfo) -> bool:
+    try:
+        return field_info.is_required()
+    except AttributeError:  # pragma: no cover - pydantic v1 fallback
+        return getattr(field_info, "required", False) is True
+
+
+def _build_control_predecessor_map(
+    steps: List[Dict[str, Any]],
+) -> Dict[str, Set[str]]:
+    result: Dict[str, Set[str]] = {}
+    for step in steps:
+        source = _step_name(step)
+        if not source or NEXT_STEPS_FIELD not in step:
+            continue
+        for target in _find_step_refs(step.get(NEXT_STEPS_FIELD)):
+            result.setdefault(target, set()).add(source)
+    return result
+
+
+def _has_only_disabled_control_predecessors(
+    step_name: str,
+    control_predecessors: Dict[str, Set[str]],
+    disabled: Set[str],
+) -> bool:
+    predecessors = control_predecessors.get(step_name)
+    if not predecessors:
+        return False
+    return all(predecessor in disabled for predecessor in predecessors)
+
+
+def _strip_references(
+    step: Dict[str, Any], disabled_node_ids: Set[str]
+) -> Dict[str, Any]:
+    result = {}
+    for key, value in step.items():
+        if key in RESERVED_STEP_KEYS:
+            result[key] = value
+            continue
+        cleaned, _ = _clean_value(value, disabled_node_ids)
+        if cleaned is _DELETE:
+            continue
+        result[key] = cleaned
+    return result
+
+
+class _Delete:
+    pass
+
+
+_DELETE = _Delete()
+
+
+def _clean_value(value: Any, disabled_node_ids: Set[str]) -> Tuple[Any, bool]:
+    """Return (cleaned_value, changed). ``_DELETE`` means drop the value."""
+    if isinstance(value, str):
+        if _string_references_disabled(value, disabled_node_ids):
+            return _DELETE, True
+        return value, False
+    if isinstance(value, list):
+        changed = False
+        filtered = []
+        for item in value:
+            cleaned, item_changed = _clean_value(item, disabled_node_ids)
+            if cleaned is _DELETE:
+                changed = True
+                continue
+            changed = changed or item_changed
+            filtered.append(cleaned)
+        if not filtered:
+            return _DELETE, True
+        return (filtered if changed else value), changed
+    if isinstance(value, dict):
+        changed = False
+        out = {}
+        for key, item in value.items():
+            cleaned, item_changed = _clean_value(item, disabled_node_ids)
+            if cleaned is _DELETE:
+                changed = True
+                continue
+            changed = changed or item_changed
+            out[key] = cleaned
+        if not out:
+            return _DELETE, True
+        return (out if changed else value), changed
+    return value, False
+
+
+def _string_references_disabled(value: str, disabled_node_ids: Set[str]) -> bool:
+    return any(
+        value == node_id or value.startswith(f"{node_id}.")
+        for node_id in disabled_node_ids
+    )
+
+
+def _selector_points_at_any(selector: str, disabled_node_ids: Set[str]) -> bool:
+    return _string_references_disabled(selector, disabled_node_ids)
+
+
+def _find_step_refs(value: Any) -> List[str]:
+    if isinstance(value, str):
+        return STEP_REF_PATTERN.findall(value)
+    if isinstance(value, list):
+        return [ref for item in value for ref in _find_step_refs(item)]
+    if isinstance(value, dict):
+        return [ref for item in value.values() for ref in _find_step_refs(item)]
+    return []
+
+
+def _step_name(step: Any) -> Optional[str]:
+    if not isinstance(step, dict):
+        return None
+    name = step.get("name") or step.get("id")
+    return name if isinstance(name, str) else None
+
+
+def _index_manifests_by_type(
+    available_blocks: Iterable[BlockSpecification],
+) -> Dict[str, Type[WorkflowBlockManifest]]:
+    result: Dict[str, Type[WorkflowBlockManifest]] = {}
+    for block in available_blocks:
+        manifest_class = block.manifest_class
+        type_field = manifest_class.model_fields.get("type")
+        if type_field is None:
+            continue
+        for type_identifier in get_args(type_field.annotation):
+            if isinstance(type_identifier, str):
+                result[type_identifier] = manifest_class
+    return result

--- a/tests/workflows/unit_tests/execution_engine/compiler/test_disabled_steps.py
+++ b/tests/workflows/unit_tests/execution_engine/compiler/test_disabled_steps.py
@@ -1,0 +1,188 @@
+from inference.core.workflows.execution_engine.introspection.blocks_loader import (
+    load_workflow_blocks,
+)
+from inference.core.workflows.execution_engine.v1.compiler.disabled_steps import (
+    strip_disabled_steps,
+)
+
+
+def _definition(disabled_nodes):
+    return {
+        "version": "1.0",
+        "inputs": [{"type": "WorkflowImage", "name": "image"}],
+        "steps": [
+            {
+                "type": "roboflow_core/roboflow_object_detection_model@v2",
+                "name": "crop_model",
+                "image": "$inputs.image",
+                "model_id": "some/1",
+            },
+            {
+                "type": "roboflow_core/dynamic_crop@v1",
+                "name": "crops",
+                "image": "$inputs.image",
+                "predictions": "$steps.crop_model.predictions",
+            },
+            {
+                "type": "roboflow_core/roboflow_object_detection_model@v2",
+                "name": "main_model",
+                "image": "$inputs.image",
+                "model_id": "other/1",
+            },
+        ],
+        "outputs": [
+            {"type": "JsonField", "name": "crops", "selector": "$steps.crops.crops"},
+            {
+                "type": "JsonField",
+                "name": "predictions",
+                "selector": "$steps.main_model.predictions",
+            },
+        ],
+        "metadata": {"ui": {"nodes": disabled_nodes}},
+    }
+
+
+def test_strip_disabled_steps_is_noop_when_nothing_disabled() -> None:
+    # given
+    definition = _definition(disabled_nodes={})
+
+    # when
+    result = strip_disabled_steps(definition, available_blocks=load_workflow_blocks())
+
+    # then
+    assert result is definition
+
+
+def test_strip_disabled_steps_removes_step_and_cascades_to_dependants() -> None:
+    # given
+    definition = _definition(disabled_nodes={"$steps.crop_model": {"disabled": True}})
+
+    # when
+    result = strip_disabled_steps(definition, available_blocks=load_workflow_blocks())
+
+    # then
+    assert [step["name"] for step in result["steps"]] == ["main_model"]
+    assert [output["name"] for output in result["outputs"]] == ["predictions"]
+    # input definition must not be mutated
+    assert len(definition["steps"]) == 3
+
+
+def test_strip_disabled_steps_ignores_non_step_nodes_and_false_flags() -> None:
+    # given
+    definition = _definition(
+        disabled_nodes={
+            "$inputs.image": {"disabled": True},
+            "$steps.crop_model": {"disabled": False},
+        }
+    )
+
+    # when
+    result = strip_disabled_steps(definition, available_blocks=load_workflow_blocks())
+
+    # then
+    assert result is definition
+
+
+def test_strip_disabled_steps_removes_reference_from_optional_list_without_cascade() -> (
+    None
+):
+    # given
+    definition = {
+        "version": "1.0",
+        "inputs": [{"type": "WorkflowImage", "name": "image"}],
+        "steps": [
+            {
+                "type": "roboflow_core/roboflow_object_detection_model@v2",
+                "name": "a",
+                "image": "$inputs.image",
+                "model_id": "some/1",
+            },
+            {
+                "type": "roboflow_core/roboflow_object_detection_model@v2",
+                "name": "b",
+                "image": "$inputs.image",
+                "model_id": "some/2",
+            },
+            {
+                "type": "roboflow_core/detections_consensus@v1",
+                "name": "consensus",
+                "predictions_batches": ["$steps.a.predictions", "$steps.b.predictions"],
+                "required_votes": 1,
+            },
+        ],
+        "outputs": [
+            {
+                "type": "JsonField",
+                "name": "result",
+                "selector": "$steps.consensus.predictions",
+            }
+        ],
+        "metadata": {"ui": {"nodes": {"$steps.a": {"disabled": True}}}},
+    }
+
+    # when
+    result = strip_disabled_steps(definition, available_blocks=load_workflow_blocks())
+
+    # then
+    assert [step["name"] for step in result["steps"]] == ["b", "consensus"]
+    assert result["steps"][1]["predictions_batches"] == ["$steps.b.predictions"]
+    assert len(result["outputs"]) == 1
+
+
+def test_strip_disabled_steps_cascades_to_steps_gated_only_by_disabled_conditional() -> (
+    None
+):
+    # given
+    definition = {
+        "version": "1.0",
+        "inputs": [{"type": "WorkflowImage", "name": "image"}],
+        "steps": [
+            {
+                "type": "roboflow_core/roboflow_object_detection_model@v2",
+                "name": "model",
+                "image": "$inputs.image",
+                "model_id": "some/1",
+            },
+            {
+                "type": "roboflow_core/continue_if@v1",
+                "name": "gate",
+                "condition_statement": {
+                    "type": "StatementGroup",
+                    "statements": [
+                        {
+                            "type": "BinaryStatement",
+                            "left_operand": {
+                                "type": "DynamicOperand",
+                                "operand_name": "predictions",
+                            },
+                            "comparator": {"type": "(Detections) not empty"},
+                            "right_operand": {"type": "StaticOperand", "value": None},
+                        }
+                    ],
+                },
+                "evaluation_parameters": {"predictions": "$steps.model.predictions"},
+                "next_steps": ["$steps.second_model"],
+            },
+            {
+                "type": "roboflow_core/roboflow_object_detection_model@v2",
+                "name": "second_model",
+                "image": "$inputs.image",
+                "model_id": "some/2",
+            },
+        ],
+        "outputs": [
+            {
+                "type": "JsonField",
+                "name": "second",
+                "selector": "$steps.second_model.predictions",
+            }
+        ],
+        "metadata": {"ui": {"nodes": {"$steps.gate": {"disabled": True}}}},
+    }
+
+    # when
+    result = strip_disabled_steps(definition, available_blocks=load_workflow_blocks())
+
+    # then
+    assert [step["name"] for step in result["steps"]] == ["model"]
+    assert result["outputs"] == []


### PR DESCRIPTION
## Problem

Reported by client: a model block toggled to **Disabled** in the Workflow builder still loads its weights onto the GPU at runtime. They have to manually evict it from the device.

Root cause: "Disable" is a UI-only flag stored at `metadata.ui.nodes["$steps.<name>"].disabled`. The builder strips disabled steps client-side (`stripDisabledForExecution` in `WorkflowBuilderV2/services/disabledBlocks.ts`) but only for preview/test-block runs. The persisted spec still contains the steps, and the execution engine has no concept of the flag, so every run by `workflow_id` (inference server, edge, Dedicated Deployments, serverless) compiles and executes disabled steps.

## Fix

New `compiler/disabled_steps.py`, called in `compile_workflow_graph` right before `parse_workflow_definition`. It mirrors the builder's logic:

- seed: steps flagged `disabled: true` under `metadata.ui.nodes`
- cascade (a): a step whose required (no-default) field would be emptied by removing disabled refs is itself disabled
- cascade (b): a step gated only by conditional-flow blocks (`next_steps`) that are all disabled is itself disabled
- strip: drop disabled steps, remove dangling refs from surviving steps, drop outputs pointing at disabled steps

No-op (returns the same object) when nothing is disabled.

## Tests

`tests/workflows/unit_tests/execution_engine/compiler/test_disabled_steps.py` (5 cases). Full `compiler/` unit dir passes (86) in a python:3.12 container.

## Open question

Alternative would be stripping server-side in the `GET /:workspace/workflows/:workflowUrl` API response. Went with the engine so it also covers inline specs posted to `/workflows/run` and doesn't change the public API's representation of a saved workflow. Happy to move it if the Workflows team prefers otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)