### PR TITLE
Add Qwen VLM v2 workflow block with Qwen-tuned OpenRouter plumbing (fast-track)

### DIFF
--- a/inference/core/version.py
+++ b/inference/core/version.py
@@ -1,4 +1,4 @@
-__version__ = "1.4.1"
+__version__ = "1.4.1.post1"
 
 
 if __name__ == "__main__":

--- a/inference/core/workflows/core_steps/common/openrouter.py
+++ b/inference/core/workflows/core_steps/common/openrouter.py
@@ -25,7 +25,7 @@ import json
 from functools import partial
 from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, Union
 
-from openai import OpenAI
+from openai import APIStatusError, OpenAI
 from pydantic import ConfigDict, Field
 
 from inference.core.env import WORKFLOWS_REMOTE_EXECUTION_MAX_STEP_CONCURRENT_REQUESTS
@@ -33,6 +33,7 @@ from inference.core.exceptions import (
     RoboflowAPIForbiddenError,
     RoboflowAPIUnsuccessfulRequestError,
 )
+from inference.core.logger import logger
 from inference.core.managers.base import ModelManager
 from inference.core.roboflow_api import post_to_roboflow_api
 from inference.core.utils.image_utils import encode_image_to_jpeg_bytes, load_image
@@ -184,15 +185,34 @@ class OpenRouterWorkflowBlockBase(WorkflowBlock):
         model: str,
         prompts: List[List[dict]],
         max_tokens: int,
-        temperature: float,
+        temperature: Optional[float],
         privacy_level: str,
         max_concurrent_requests: Optional[int],
-    ) -> List[str]:
+        reasoning: Optional[dict] = None,
+        include_reasoning: bool = False,
+    ) -> Union[List[str], List[Tuple[str, str]]]:
         """Run a batch of OpenRouter chat-completion calls in parallel.
 
         Routes through the Roboflow proxy when ``openrouter_api_key`` starts
         with ``rf_key:`` (managed/user-stored), otherwise calls the OpenRouter
         API directly using the OpenAI SDK with the provided key.
+
+        ``temperature`` set to ``None`` omits the parameter so the provider
+        default applies. ``reasoning`` is an optional OpenRouter reasoning
+        config object (e.g. ``{"effort": "low"}`` or ``{"enabled": False}``)
+        forwarded verbatim; when the target model rejects the config, the
+        request is retried once without it.
+
+        With ``include_reasoning=True`` each result is a
+        ``(content, reasoning_trace)`` tuple, where the trace is the
+        ``message.reasoning`` string OpenRouter returns for reasoning models
+        (empty string when absent). Default returns bare content strings for
+        backward compatibility.
+
+        Note: honoring ``reasoning`` on managed ``rf_key:`` keys requires a
+        Roboflow platform proxy version that forwards the key upstream
+        (older proxy versions strip it and the model applies its
+        provider-default reasoning behavior).
         """
         is_managed = openrouter_api_key.startswith(("rf_key:account", "rf_key:user:"))
         if is_managed:
@@ -202,6 +222,8 @@ class OpenRouterWorkflowBlockBase(WorkflowBlock):
                 openrouter_api_key=openrouter_api_key,
                 model=model,
                 privacy_level=privacy_level,
+                reasoning=reasoning,
+                include_reasoning=include_reasoning,
             )
         else:
             single = partial(
@@ -209,6 +231,8 @@ class OpenRouterWorkflowBlockBase(WorkflowBlock):
                 api_key=openrouter_api_key,
                 model=model,
                 privacy_level=privacy_level,
+                reasoning=reasoning,
+                include_reasoning=include_reasoning,
             )
         tasks = [
             partial(
@@ -243,8 +267,14 @@ def _build_proxy_error_handler(
         except Exception:
             api_msg = str(http_error)
         if status_code == 403:
-            raise RoboflowAPIForbiddenError(api_msg) from http_error
-        raise RoboflowAPIUnsuccessfulRequestError(api_msg) from http_error
+            error = RoboflowAPIForbiddenError(api_msg)
+        else:
+            error = RoboflowAPIUnsuccessfulRequestError(api_msg)
+        # The exception types carry no HTTP status; attach it so callers (the
+        # retry-without-reasoning heuristic) can tell a client rejection from
+        # a relayed upstream 5xx.
+        error.status_code = status_code
+        raise error from http_error
 
     return _handler
 
@@ -263,29 +293,94 @@ _PROXY_ERROR_HANDLERS: Dict[int, Callable[[Exception], None]] = {
 }
 
 
+# Substrings observed in real OpenRouter rejections of a `reasoning` config.
+# Captured live against qwen/qwen3.8-max and qwen/qwen3.7-flash:
+#   "Reasoning is mandatory for this endpoint and cannot be disabled." (400)
+#   'reasoning.effort: Invalid option: expected one of "max"|"xhigh"|...' (400)
+_REASONING_REJECTION_MARKERS = (
+    "unsupported",
+    "not supported",
+    "unknown",
+    "invalid",
+    "mandatory",
+    "cannot be disabled",
+)
+
+
+def _is_unsupported_reasoning_error(error: Exception) -> bool:
+    """Whether the error is a client-error rejection of the reasoning config.
+
+    Only client (HTTP 4xx) errors qualify — connection/timeout failures and
+    relayed upstream 5xx must never trigger the retry-without-reasoning
+    fallback, as that would issue a duplicate billed request for a transient
+    problem. On the direct path the OpenAI SDK raises ``APIStatusError`` with
+    a status code; on the proxied path ``_PROXY_ERROR_HANDLERS`` attaches
+    ``status_code`` to the raised Roboflow exception. An exception without a
+    status (raised outside those handlers) is treated as not retryable.
+    """
+    if isinstance(error, APIStatusError):
+        status = error.status_code
+    elif isinstance(
+        error, (RoboflowAPIUnsuccessfulRequestError, RoboflowAPIForbiddenError)
+    ):
+        status = getattr(error, "status_code", None)
+    else:
+        return False
+    if status is None or not 400 <= status < 500:
+        return False
+    message = str(error).lower()
+    return "reasoning" in message and any(
+        marker in message for marker in _REASONING_REJECTION_MARKERS
+    )
+
+
 def _execute_proxied_openrouter_request(
     roboflow_api_key: Optional[str],
     openrouter_api_key: str,
     model: str,
     messages: List[dict],
     max_tokens: int,
-    temperature: float,
+    temperature: Optional[float],
     privacy_level: str,
-) -> str:
+    reasoning: Optional[dict] = None,
+    include_reasoning: bool = False,
+) -> Union[str, Tuple[str, str]]:
     payload = {
         "openrouter_api_key": openrouter_api_key,
         "model": model,
         "messages": messages,
         "max_tokens": max_tokens,
-        "temperature": temperature,
         "privacy_level": privacy_level,
     }
-    response_data = post_to_roboflow_api(
-        endpoint="apiproxy/openrouter",
-        api_key=roboflow_api_key,
-        payload=payload,
-        http_errors_handlers=_PROXY_ERROR_HANDLERS,
-    )
+    if temperature is not None:
+        payload["temperature"] = temperature
+    if reasoning is not None:
+        payload["reasoning"] = reasoning
+    try:
+        response_data = post_to_roboflow_api(
+            endpoint="apiproxy/openrouter",
+            api_key=roboflow_api_key,
+            payload=payload,
+            http_errors_handlers=_PROXY_ERROR_HANDLERS,
+        )
+    except Exception as error:
+        if reasoning is None or not _is_unsupported_reasoning_error(error):
+            raise
+        logger.warning(
+            "OpenRouter rejected the reasoning config %s for model %s "
+            "(details: %s). Retrying without it - the model will use its "
+            "provider-default reasoning behavior.",
+            reasoning,
+            model,
+            error,
+        )
+        retry_payload = {k: v for k, v in payload.items() if k != "reasoning"}
+        response_data = post_to_roboflow_api(
+            endpoint="apiproxy/openrouter",
+            api_key=roboflow_api_key,
+            payload=retry_payload,
+            http_errors_handlers=_PROXY_ERROR_HANDLERS,
+        )
     choices = response_data.get("choices") or []
     if not choices:
         err_msg = (
@@ -315,6 +410,9 @@ def _execute_proxied_openrouter_request(
         raise RuntimeError(
             "OpenRouter response missing message.content via Roboflow proxy." + hint
         )
+    if include_reasoning:
+        reasoning_trace = message.get("reasoning")
+        return content, reasoning_trace if isinstance(reasoning_trace, str) else ""
     return content
 
 
@@ -323,21 +421,46 @@ def _execute_direct_openrouter_request(
     model: str,
     messages: List[dict],
     max_tokens: int,
-    temperature: float,
+    temperature: Optional[float],
     privacy_level: str,
-) -> str:
+    reasoning: Optional[dict] = None,
+    include_reasoning: bool = False,
+) -> Union[str, Tuple[str, str]]:
     client = OpenAI(base_url="https://openrouter.ai/api/v1", api_key=api_key)
     extra_body: Dict[str, Any] = {}
     provider = build_provider_routing(privacy_level)
     if provider is not None:
         extra_body["provider"] = provider
-    response = client.chat.completions.create(
-        model=model,
-        messages=messages,
-        max_tokens=max_tokens,
-        temperature=temperature,
-        extra_body=extra_body,
-    )
+    if reasoning is not None:
+        extra_body["reasoning"] = reasoning
+    request_kwargs: Dict[str, Any] = {
+        "model": model,
+        "messages": messages,
+        "max_tokens": max_tokens,
+    }
+    if temperature is not None:
+        request_kwargs["temperature"] = temperature
+    try:
+        response = client.chat.completions.create(
+            **request_kwargs,
+            extra_body=extra_body,
+        )
+    except Exception as error:
+        if reasoning is None or not _is_unsupported_reasoning_error(error):
+            raise
+        logger.warning(
+            "OpenRouter rejected the reasoning config %s for model %s "
+            "(details: %s). Retrying without it - the model will use its "
+            "provider-default reasoning behavior.",
+            reasoning,
+            model,
+            error,
+        )
+        retry_extra_body = {k: v for k, v in extra_body.items() if k != "reasoning"}
+        response = client.chat.completions.create(
+            **request_kwargs,
+            extra_body=retry_extra_body,
+        )
     if not response.choices:
         error_detail = getattr(response, "error", {}) or {}
         if isinstance(error_detail, dict):
@@ -362,6 +485,12 @@ def _execute_direct_openrouter_request(
             "or reasoning tokens. Try a different prompt or model."
         )
         raise RuntimeError("OpenRouter response missing message.content." + hint)
+    if include_reasoning:
+        # OpenRouter returns the reasoning trace as an extra `reasoning`
+        # field on the message; the OpenAI SDK surfaces unknown fields as
+        # attributes on its pydantic models.
+        reasoning_trace = getattr(response.choices[0].message, "reasoning", None)
+        return content, reasoning_trace if isinstance(reasoning_trace, str) else ""
     return content
 
 

--- a/inference/core/workflows/core_steps/formatters/vlm_as_detector/qwen_detection_parsing.py
+++ b/inference/core/workflows/core_steps/formatters/vlm_as_detector/qwen_detection_parsing.py
@@ -1,0 +1,215 @@
+from typing import List, Optional, Union
+from uuid import uuid4
+
+import numpy as np
+import supervision as sv
+from supervision.config import CLASS_NAME_DATA_FIELD
+
+from inference.core.logger import logger
+from inference.core.workflows.core_steps.common.utils import (
+    attach_parents_coordinates_to_sv_detections,
+)
+from inference.core.workflows.core_steps.formatters.vlm_as_detector.gemini_detection_parsing import (
+    create_classes_index,
+)
+from inference.core.workflows.execution_engine.constants import (
+    DETECTION_ID_KEY,
+    IMAGE_DIMENSIONS_KEY,
+    INFERENCE_ID_KEY,
+    PREDICTION_TYPE_KEY,
+)
+from inference.core.workflows.execution_engine.entities.base import WorkflowImageData
+
+QWEN_BOX_COORDINATE_SCALE = 1000.0
+
+# Qwen models occasionally drift between the prompted keys and their native
+# grounding vocabulary; accept both, matching the vlm-exam parser.
+_BOX_KEYS = ("box_2d", "bbox_2d")
+_LABEL_KEYS = ("label", "description", "class_name", "class")
+
+
+def extract_qwen_detection_entries(
+    parsed_data: Union[dict, list],
+) -> List[dict]:
+    """Extract the list of detection entries from parsed Qwen JSON output.
+
+    The Qwen prompt asks for a bare JSON list, but some responses wrap the
+    entries in a ``{"detections": [...]}`` object; both shapes are accepted.
+
+    Args:
+        parsed_data: JSON payload extracted from the VLM output.
+
+    Returns:
+        List of raw detection entry dicts.
+
+    Raises:
+        ValueError: If the payload matches neither accepted shape.
+    """
+    if isinstance(parsed_data, list):
+        return parsed_data
+    if isinstance(parsed_data, dict) and isinstance(
+        parsed_data.get("detections"), list
+    ):
+        return parsed_data["detections"]
+    raise ValueError("Unexpected Qwen object detection response format")
+
+
+def get_qwen_detection_box(detection: dict) -> Optional[List[float]]:
+    """Read a valid bounding box from a Qwen detection entry.
+
+    Args:
+        detection: Raw detection entry.
+
+    Returns:
+        ``[x_min, y_min, x_max, y_max]`` floats in the 0-1000 normalized
+        space, or ``None`` when the entry carries no well-formed box.
+    """
+    for key in _BOX_KEYS:
+        box = detection.get(key)
+        if (
+            isinstance(box, list)
+            and len(box) == 4
+            and all(
+                isinstance(value, (int, float)) and not isinstance(value, bool)
+                for value in box
+            )
+        ):
+            return [float(value) for value in box]
+
+    return None
+
+
+def get_qwen_detection_class_name(detection: dict) -> str:
+    """Resolve the class label of a Qwen detection entry.
+
+    Args:
+        detection: Raw detection entry.
+
+    Returns:
+        First present label under the accepted key aliases, or ``"unknown"``.
+    """
+    for key in _LABEL_KEYS:
+        value = detection.get(key)
+        if value is not None:
+            return str(value)
+
+    return "unknown"
+
+
+def convert_qwen_detection_to_pixel_xyxy(
+    box: List[float],
+    image_height: int,
+    image_width: int,
+) -> List[float]:
+    """Convert a 0-1000-normalized ``box_2d`` into original-image pixels.
+
+    Coordinates are clamped to the 0-1000 range before scaling so slightly
+    out-of-range model output stays inside the image.
+
+    Args:
+        box: ``[x_min, y_min, x_max, y_max]`` normalized to 0-1000.
+        image_height: Original image height in pixels.
+        image_width: Original image width in pixels.
+
+    Returns:
+        ``[x_min, y_min, x_max, y_max]`` in pixel coordinates of the
+        original image.
+    """
+    x_min, y_min, x_max, y_max = (
+        min(max(value, 0.0), QWEN_BOX_COORDINATE_SCALE) for value in box
+    )
+    scale_x = image_width / QWEN_BOX_COORDINATE_SCALE
+    scale_y = image_height / QWEN_BOX_COORDINATE_SCALE
+
+    return [x_min * scale_x, y_min * scale_y, x_max * scale_x, y_max * scale_y]
+
+
+def parse_qwen_object_detection_response(
+    image: WorkflowImageData,
+    parsed_data: Union[dict, list],
+    classes: List[str],
+    inference_id: str,
+) -> sv.Detections:
+    """Parse Qwen block object-detection output into detections.
+
+    The Qwen block prompts for a JSON list of entries with a ``box_2d``
+    field holding ``[x_min, y_min, x_max, y_max]`` integers normalized to
+    0-1000 and a ``label`` field. Entries without a well-formed box are
+    skipped (with a debug log) rather than failing the whole response;
+    labels outside ``classes`` are kept with ``class_id == -1``.
+    Confidence is hardcoded to 1.0 — VLMs do not produce calibrated
+    detection confidences and the prompt does not ask for one.
+
+    Args:
+        image: Workflow image the detections refer to.
+        parsed_data: JSON payload extracted from the VLM output.
+        classes: Class names used to map labels onto class ids.
+        inference_id: Identifier attached to every parsed detection.
+
+    Returns:
+        Parsed detections in the original image's coordinate space.
+
+    Raises:
+        ValueError: If the response is neither a JSON list nor a
+            ``{"detections": [...]}`` object.
+    """
+    entries = extract_qwen_detection_entries(parsed_data=parsed_data)
+    class_name2id = create_classes_index(classes=classes)
+    image_height, image_width = image.numpy_image.shape[:2]
+
+    xyxy, class_id, class_name, confidence = [], [], [], []
+    for detection in entries:
+        if not isinstance(detection, dict):
+            logger.debug("Skipping non-dict Qwen detection entry: %r", detection)
+            continue
+        box = get_qwen_detection_box(detection=detection)
+        if box is None:
+            logger.debug(
+                "Skipping Qwen detection entry without a well-formed box: %r",
+                detection,
+            )
+            continue
+
+        xyxy.append(
+            convert_qwen_detection_to_pixel_xyxy(
+                box=box,
+                image_height=image_height,
+                image_width=image_width,
+            )
+        )
+        label = get_qwen_detection_class_name(detection=detection)
+        class_id.append(class_name2id.get(label, -1))
+        class_name.append(label)
+        confidence.append(1.0)
+
+    if not xyxy:
+        return sv.Detections.empty()
+
+    xyxy = np.array(xyxy).round(0)
+    confidence = np.array(confidence)
+    class_id = np.array(class_id).astype(int)
+    class_name = np.array(class_name)
+    detection_ids = np.array([str(uuid4()) for _ in range(len(xyxy))])
+    dimensions = np.array([[image_height, image_width]] * len(xyxy))
+    inference_ids = np.array([inference_id] * len(xyxy))
+    prediction_type = np.array(["object-detection"] * len(xyxy))
+    data = {
+        CLASS_NAME_DATA_FIELD: class_name,
+        IMAGE_DIMENSIONS_KEY: dimensions,
+        INFERENCE_ID_KEY: inference_ids,
+        DETECTION_ID_KEY: detection_ids,
+        PREDICTION_TYPE_KEY: prediction_type,
+    }
+    detections_result = sv.Detections(
+        xyxy=xyxy,
+        confidence=confidence,
+        class_id=class_id,
+        mask=None,
+        tracker_id=None,
+        data=data,
+    )
+
+    return attach_parents_coordinates_to_sv_detections(
+        detections=detections_result,
+        image=image,
+    )

--- a/inference/core/workflows/core_steps/formatters/vlm_as_detector/v2.py
+++ b/inference/core/workflows/core_steps/formatters/vlm_as_detector/v2.py
@@ -21,6 +21,9 @@ from inference.core.workflows.core_steps.formatters.vlm_as_detector.gemini_detec
 from inference.core.workflows.core_steps.formatters.vlm_as_detector.openai_detection_parsing import (
     parse_openai_object_detection_response,
 )
+from inference.core.workflows.core_steps.formatters.vlm_as_detector.qwen_detection_parsing import (
+    parse_qwen_object_detection_response,
+)
 from inference.core.workflows.core_steps.formatters.vlm_as_detector.spacexai_detection_parsing import (
     parse_spacexai_object_detection_response,
 )
@@ -148,7 +151,7 @@ This version (v2) includes the following enhancements over v1:
 
 ## Requirements
 
-This block requires an image input (for metadata and dimensions) and a VLM output string containing JSON detection data. The JSON can be raw JSON or wrapped in Markdown code blocks (```json ... ```). The block supports five model types: "openai", "google-gemini", "anthropic-claude", "spacexai", and "florence-2". It supports multiple task types: "object-detection", "open-vocabulary-object-detection", "object-detection-and-caption", "phrase-grounded-object-detection", "region-proposal", and "ocr-with-text-detection". The `classes` parameter is required for OpenAI, Gemini, Claude, and SpaceXAI models (to map class names to IDs) but optional for Florence-2 (some tasks don't require it). Classes are mapped to IDs by index (first class = 0, second = 1, etc.). Classes not in the list get class_id = -1. The block outputs object detection predictions in standard format (compatible with detection blocks), error_status (boolean), and inference_id (INFERENCE_ID_KIND) for tracking.
+This block requires an image input (for metadata and dimensions) and a VLM output string containing JSON detection data. The JSON can be raw JSON or wrapped in Markdown code blocks (```json ... ```). The block supports six model types: "openai", "google-gemini", "anthropic-claude", "spacexai", "qwen", and "florence-2". It supports multiple task types: "object-detection", "open-vocabulary-object-detection", "object-detection-and-caption", "phrase-grounded-object-detection", "region-proposal", and "ocr-with-text-detection". The `classes` parameter is required for OpenAI, Gemini, Claude, SpaceXAI, and Qwen models (to map class names to IDs) but optional for Florence-2 (some tasks don't require it). Classes are mapped to IDs by index (first class = 0, second = 1, etc.). Classes not in the list get class_id = -1. The block outputs object detection predictions in standard format (compatible with detection blocks), error_status (boolean), and inference_id (INFERENCE_ID_KIND) for tracking.
 """
 
 SHORT_DESCRIPTION = "Parses raw string into object-detection prediction."
@@ -221,6 +224,7 @@ class BlockManifest(WorkflowBlockManifest):
                         "google-gemini",
                         "anthropic-claude",
                         "spacexai",
+                        "qwen",
                     ],
                     "required": True,
                 },
@@ -228,14 +232,15 @@ class BlockManifest(WorkflowBlockManifest):
         },
     )
     model_type: Literal[
-        "openai", "google-gemini", "anthropic-claude", "spacexai", "florence-2"
+        "openai", "google-gemini", "anthropic-claude", "spacexai", "qwen", "florence-2"
     ] = Field(
-        description="Type of the VLM/LLM model that generated the prediction. Determines which parser is used to extract detection data from the JSON output. Supported models: 'openai' (GPT-4V), 'google-gemini' (Gemini Vision), 'anthropic-claude' (Claude Vision), 'spacexai' (Grok), 'florence-2' (Microsoft Florence-2). Each model type has different JSON output formats, so the correct model type must be specified for proper parsing.",
+        description="Type of the VLM/LLM model that generated the prediction. Determines which parser is used to extract detection data from the JSON output. Supported models: 'openai' (GPT-4V), 'google-gemini' (Gemini Vision), 'anthropic-claude' (Claude Vision), 'spacexai' (Grok), 'qwen' (Qwen-VL via OpenRouter), 'florence-2' (Microsoft Florence-2). Each model type has different JSON output formats, so the correct model type must be specified for proper parsing.",
         examples=[
             ["openai"],
             ["google-gemini"],
             ["anthropic-claude"],
             ["spacexai"],
+            ["qwen"],
             ["florence-2"],
         ],
     )
@@ -254,7 +259,8 @@ class BlockManifest(WorkflowBlockManifest):
             )
         if self.model_type != "florence-2" and self.classes is None:
             raise ValueError(
-                "Must pass list of classes to this block when using gemini or claude"
+                "Must pass list of classes to this block for every model type "
+                "except florence-2"
             )
 
         return self
@@ -527,6 +533,7 @@ REGISTERED_PARSERS = {
     ("google-gemini", "object-detection"): parse_gemini_object_detection_response,
     ("anthropic-claude", "object-detection"): parse_llm_object_detection_response,
     ("spacexai", "object-detection"): parse_spacexai_object_detection_response,
+    ("qwen", "object-detection"): parse_qwen_object_detection_response,
     # Florence 2
     ("florence-2", "object-detection"): partial(
         parse_florence2_object_detection_response, florence_task_type="<OD>"

--- a/inference/core/workflows/core_steps/formatters/vlm_as_detector/v2_tensor.py
+++ b/inference/core/workflows/core_steps/formatters/vlm_as_detector/v2_tensor.py
@@ -12,6 +12,7 @@ import torch
 from pydantic import ConfigDict, Field, model_validator
 
 from inference.core.env import WORKFLOWS_IMAGE_TENSOR_DEVICE
+from inference.core.logger import logger
 from inference.core.workflows.core_steps.common.vlms import VLM_TASKS_METADATA
 from inference.core.workflows.core_steps.formatters.vlm_as_detector.gemini_detection_parsing import (
     convert_gemini_detection_to_pixel_xyxy,
@@ -22,6 +23,12 @@ from inference.core.workflows.core_steps.formatters.vlm_as_detector.gemini_detec
 )
 from inference.core.workflows.core_steps.formatters.vlm_as_detector.openai_detection_parsing import (
     convert_openai_detection_to_pixel_xyxy,
+)
+from inference.core.workflows.core_steps.formatters.vlm_as_detector.qwen_detection_parsing import (
+    convert_qwen_detection_to_pixel_xyxy,
+    extract_qwen_detection_entries,
+    get_qwen_detection_box,
+    get_qwen_detection_class_name,
 )
 from inference.core.workflows.core_steps.formatters.vlm_as_detector.spacexai_detection_parsing import (
     convert_spacexai_detection_to_pixel_xyxy,
@@ -162,7 +169,7 @@ This version (v2) includes the following enhancements over v1:
 
 ## Requirements
 
-This block requires an image input (for metadata and dimensions) and a VLM output string containing JSON detection data. The JSON can be raw JSON or wrapped in Markdown code blocks (```json ... ```). The block supports five model types: "openai", "google-gemini", "anthropic-claude", "spacexai", and "florence-2". It supports multiple task types: "object-detection", "open-vocabulary-object-detection", "object-detection-and-caption", "phrase-grounded-object-detection", "region-proposal", and "ocr-with-text-detection". The `classes` parameter is required for OpenAI, Gemini, Claude, and SpaceXAI models (to map class names to IDs) but optional for Florence-2 (some tasks don't require it). Classes are mapped to IDs by index (first class = 0, second = 1, etc.). Classes not in the list get class_id = -1. The block outputs object detection predictions in standard format (compatible with detection blocks), error_status (boolean), and inference_id (INFERENCE_ID_KIND) for tracking.
+This block requires an image input (for metadata and dimensions) and a VLM output string containing JSON detection data. The JSON can be raw JSON or wrapped in Markdown code blocks (```json ... ```). The block supports six model types: "openai", "google-gemini", "anthropic-claude", "spacexai", "qwen", and "florence-2". It supports multiple task types: "object-detection", "open-vocabulary-object-detection", "object-detection-and-caption", "phrase-grounded-object-detection", "region-proposal", and "ocr-with-text-detection". The `classes` parameter is required for OpenAI, Gemini, Claude, SpaceXAI, and Qwen models (to map class names to IDs) but optional for Florence-2 (some tasks don't require it). Classes are mapped to IDs by index (first class = 0, second = 1, etc.). Classes not in the list get class_id = -1. The block outputs object detection predictions in standard format (compatible with detection blocks), error_status (boolean), and inference_id (INFERENCE_ID_KIND) for tracking.
 """
 
 SHORT_DESCRIPTION = "Parses raw string into object-detection prediction."
@@ -235,6 +242,7 @@ class BlockManifest(WorkflowBlockManifest):
                         "google-gemini",
                         "anthropic-claude",
                         "spacexai",
+                        "qwen",
                     ],
                     "required": True,
                 },
@@ -242,14 +250,15 @@ class BlockManifest(WorkflowBlockManifest):
         },
     )
     model_type: Literal[
-        "openai", "google-gemini", "anthropic-claude", "spacexai", "florence-2"
+        "openai", "google-gemini", "anthropic-claude", "spacexai", "qwen", "florence-2"
     ] = Field(
-        description="Type of the VLM/LLM model that generated the prediction. Determines which parser is used to extract detection data from the JSON output. Supported models: 'openai' (GPT-4V), 'google-gemini' (Gemini Vision), 'anthropic-claude' (Claude Vision), 'spacexai' (Grok), 'florence-2' (Microsoft Florence-2). Each model type has different JSON output formats, so the correct model type must be specified for proper parsing.",
+        description="Type of the VLM/LLM model that generated the prediction. Determines which parser is used to extract detection data from the JSON output. Supported models: 'openai' (GPT-4V), 'google-gemini' (Gemini Vision), 'anthropic-claude' (Claude Vision), 'spacexai' (Grok), 'qwen' (Qwen-VL via OpenRouter), 'florence-2' (Microsoft Florence-2). Each model type has different JSON output formats, so the correct model type must be specified for proper parsing.",
         examples=[
             ["openai"],
             ["google-gemini"],
             ["anthropic-claude"],
             ["spacexai"],
+            ["qwen"],
             ["florence-2"],
         ],
     )
@@ -268,7 +277,8 @@ class BlockManifest(WorkflowBlockManifest):
             )
         if self.model_type != "florence-2" and self.classes is None:
             raise ValueError(
-                "Must pass list of classes to this block when using gemini or claude"
+                "Must pass list of classes to this block for every model type "
+                "except florence-2"
             )
 
         return self
@@ -762,6 +772,79 @@ def parse_spacexai_object_detection_response(
     )
 
 
+def parse_qwen_object_detection_response(
+    image: WorkflowImageData,
+    parsed_data: Union[dict, list],
+    classes: List[str],
+    inference_id: str,
+) -> Detections:
+    """Parse Qwen block object-detection output into native detections.
+
+    The Qwen block prompts for a JSON list of ``box_2d``/``label`` entries
+    with ``[x_min, y_min, x_max, y_max]`` integers normalized to 0-1000.
+    Entries without a well-formed box are skipped (with a debug log) rather
+    than failing the whole response; confidence is hardcoded to 1.0 (VLMs do
+    not produce calibrated detection confidences). Tensor-native sibling of
+    the numpy ``qwen_detection_parsing.parse_qwen_object_detection_response``.
+
+    Raises:
+        ValueError: If the response is neither a JSON list nor a
+            ``{"detections": [...]}`` object.
+    """
+    entries = extract_qwen_detection_entries(parsed_data=parsed_data)
+    class_name2id = create_classes_index(classes=classes)
+    image_height, image_width = image._read_shape_without_materialization()
+
+    xyxy, class_id, class_name, confidence = [], [], [], []
+    for detection in entries:
+        if not isinstance(detection, dict):
+            logger.debug("Skipping non-dict Qwen detection entry: %r", detection)
+            continue
+        box = get_qwen_detection_box(detection=detection)
+        if box is None:
+            logger.debug(
+                "Skipping Qwen detection entry without a well-formed box: %r",
+                detection,
+            )
+            continue
+
+        xyxy.append(
+            convert_qwen_detection_to_pixel_xyxy(
+                box=box,
+                image_height=image_height,
+                image_width=image_width,
+            )
+        )
+        label = get_qwen_detection_class_name(detection=detection)
+        class_id.append(class_name2id.get(label, -1))
+        class_name.append(label)
+        confidence.append(1.0)
+
+    if not xyxy:
+        return empty_native_detections(
+            image=image,
+            image_height=image_height,
+            image_width=image_width,
+            inference_id=inference_id,
+            class_names={idx: class_name for class_name, idx in class_name2id.items()},
+        )
+
+    xyxy = np.array(xyxy).round(0)
+    confidence = np.array(confidence)
+    class_id = np.array(class_id).astype(int)
+
+    return native_detections_from_parsed(
+        image=image,
+        image_height=image_height,
+        image_width=image_width,
+        inference_id=inference_id,
+        xyxy=xyxy,
+        class_id=class_id,
+        class_name=class_name,
+        confidence=confidence,
+    )
+
+
 def parse_openai_detection_response(
     image: WorkflowImageData,
     parsed_data: Union[dict, list],
@@ -812,6 +895,7 @@ REGISTERED_PARSERS = {
     ("google-gemini", "object-detection"): parse_gemini_object_detection_response,
     ("anthropic-claude", "object-detection"): parse_llm_object_detection_response,
     ("spacexai", "object-detection"): parse_spacexai_object_detection_response,
+    ("qwen", "object-detection"): parse_qwen_object_detection_response,
     # Florence 2
     ("florence-2", "object-detection"): partial(
         parse_florence2_object_detection_response, florence_task_type="<OD>"

--- a/inference/core/workflows/core_steps/loader.py
+++ b/inference/core/workflows/core_steps/loader.py
@@ -688,6 +688,9 @@ from inference.core.workflows.core_steps.models.foundation.qwen.v1 import (
 from inference.core.workflows.core_steps.models.foundation.qwen_vlm.v1 import (
     QwenVlmBlockV1,
 )
+from inference.core.workflows.core_steps.models.foundation.qwen_vlm.v2 import (
+    QwenVlmBlockV2,
+)
 
 if not ENABLE_TENSOR_DATA_REPRESENTATION:
     from inference.core.workflows.core_steps.models.foundation.seg_preview.v1 import (
@@ -1895,6 +1898,7 @@ def load_blocks() -> List[Type[WorkflowBlock]]:
         Qwen35OpenRouterBlockV1,
         Qwen36OpenRouterBlockV1,
         QwenVlmBlockV1,
+        QwenVlmBlockV2,
         OpenAICompatibleBlockV1,
         KimiOpenRouterBlockV1,
         KimiOpenrouterBlockV2,

--- a/inference/core/workflows/core_steps/models/foundation/qwen_vlm/v2.py
+++ b/inference/core/workflows/core_steps/models/foundation/qwen_vlm/v2.py
@@ -1,30 +1,42 @@
-"""Unified Qwen-VL workflow block.
+"""Unified Qwen-VL workflow block, v2 — Qwen-specific OpenRouter plumbing.
 
-Subsumes the older per-version Qwen blocks (`qwen25vl@v1`, `qwen3vl@v1`,
-`qwen3_5vl@v1`, `qwen3_5_openrouter@v1`, `qwen3_6_openrouter@v1`) into a
-single block where the user picks:
+Same surface as ``qwen_vlm@v1`` (``backend`` = "Native (Roboflow)" or
+"OpenRouter", combined ``model_version`` pickers, the shared VLM
+``task_type`` set) but the OpenRouter path no longer relies on the generic
+prompt builders from ``common.openrouter``. Instead it uses the contract
+that performed best for Qwen models in the vlm-exam benchmarks:
 
-* a ``backend`` — "Native (Roboflow)" or "OpenRouter"
-* a ``model_version`` (combined version+size selector); each variant is bound
-  to one backend
-* the standard VLM ``task_type`` surface (unconstrained, OCR, classification,
-  detection, etc.) shared with the Gemma/Llama/Kimi blocks
+* **object-detection** asks for a bare JSON list of ``box_2d``/``label``
+  entries with ``[x_min, y_min, x_max, y_max]`` integer coordinates
+  normalized to 0-1000 — Qwen's native grounding convention — parsed by
+  ``vlm_as_detector@v2`` with ``model_type="qwen"``. Both backends emit
+  this same contract: the native path replaces v1's ad-hoc
+  ``x_min``/0.0-1.0 detection prompt with the benchmarked template.
+* every task sends a single user message with the **image before the
+  text** and no system role, matching how the benchmarks prompt Qwen.
+* requests carry an explicit OpenRouter ``reasoning`` config: disabled by
+  default (Qwen models default to extended reasoning, which bloats latency
+  and can truncate answers), always-on for models that require it
+  (Qwen 3.8 Max rejects ``enabled: false``).
+* uploads are JPEG-encoded with iterative downscaling so the base64
+  payload stays under Alibaba DashScope's data-URI limit.
+* ``max_tokens`` is unset by default; the OpenRouter path substitutes
+  16384 (benchmark parity — detection output on busy images easily
+  exceeds the old 500-token default) while the native path sends
+  nothing, so the inference server default (512) applies.
+  ``temperature`` is not sent unless the user sets it.
 
-For the OpenRouter backend, all the API Key Passthrough plumbing
-(``rf_key:account`` vs custom ``sk-or-...``, the ``privacy_level`` filter,
-the proxy/billing flow) is inherited from
-``common.openrouter.OpenRouterWorkflowBlockBase``.
-
-For the Native backend, the block dispatches via
-``StepExecutionMode.LOCAL``/``REMOTE`` to either ``model_manager`` (local
-process) or ``InferenceHTTPClient`` (Roboflow-hosted inference), exactly
-like the v1 native qwen blocks did.
+The OpenRouter model roster is restricted to the vlm-exam-benchmarked
+models. The native backend is carried over from v1 except for the
+object-detection prompt, which is unified on the benchmarked template.
 """
 
 import base64
 import json
 from typing import Any, Dict, List, Literal, Optional, Tuple, Type, Union
 
+import cv2
+import numpy as np
 from pydantic import ConfigDict, Field, field_validator, model_validator
 
 from inference.core.entities.requests.inference import LMMInferenceRequest
@@ -34,7 +46,7 @@ from inference.core.env import (
     WORKFLOWS_REMOTE_API_TARGET,
 )
 from inference.core.managers.base import ModelManager
-from inference.core.utils.image_utils import encode_image_to_jpeg_bytes, load_image
+from inference.core.utils.image_utils import encode_image_to_jpeg_bytes
 from inference.core.workflows.core_steps.common.entities import StepExecutionMode
 from inference.core.workflows.core_steps.common.openrouter import (
     PRIVACY_LEVEL_LITERAL,
@@ -44,8 +56,10 @@ from inference.core.workflows.core_steps.common.openrouter import (
     SUPPORTED_TASK_TYPES_LIST,
     OpenRouterBlockManifestMixin,
     OpenRouterWorkflowBlockBase,
-    build_prompts_from_images,
     validate_task_type_required_fields,
+)
+from inference.core.workflows.core_steps.common.utils import (
+    scale_dimensions_to_max_edge,
 )
 from inference.core.workflows.execution_engine.entities.base import (
     Batch,
@@ -79,12 +93,15 @@ from inference_sdk import InferenceHTTPClient
 # Model variants
 # ---------------------------------------------------------------------------
 # Each entry is ``"<friendly label>": {"backend": "native" | "openrouter",
-# "model_id": <id used by the chosen backend>}``.
+# "model_id": <id used by the chosen backend>, ...}``.
 #
-# model_ids are Roboflow inference model IDs (e.g. ``qwen3_5-2b``).
-# - OpenRouter model_ids are OpenRouter slugs (e.g. ``qwen/qwen3.6-27b``).
+# - Native model_ids are Roboflow inference model IDs (e.g. ``qwen3_5-2b``).
+# - OpenRouter model_ids are OpenRouter slugs (e.g. ``qwen/qwen3.7-plus``).
+#   The OpenRouter roster is restricted to the models benchmarked in
+#   vlm-exam; ``reasoning_required`` marks models that reject
+#   ``reasoning: {"enabled": false}`` and must always receive an effort.
 
-MODEL_VARIANTS: Dict[str, Dict[str, str]] = {
+MODEL_VARIANTS: Dict[str, Dict[str, Any]] = {
     # Native — small models that run on Roboflow infrastructure.
     "Qwen 2.5 VL 7B": {
         "backend": "native",
@@ -102,55 +119,32 @@ MODEL_VARIANTS: Dict[str, Dict[str, str]] = {
         "backend": "native",
         "model_id": "qwen3_5-2b",
     },
-    # OpenRouter — large hosted models reached via OpenRouter.
-    "Qwen 3.5 9B": {
+    # OpenRouter — vlm-exam-benchmarked hosted Qwen models.
+    "Qwen 3.8 Max": {
         "backend": "openrouter",
-        "model_id": "qwen/qwen3.5-9b",
+        "model_id": "qwen/qwen3.8-max",
+        "reasoning_required": True,
+    },
+    "Qwen 3.7 Plus": {
+        "backend": "openrouter",
+        "model_id": "qwen/qwen3.7-plus",
+    },
+    "Qwen 3.7 Flash": {
+        "backend": "openrouter",
+        "model_id": "qwen/qwen3.7-flash",
+    },
+    "Qwen 3.8 27B": {
+        "backend": "openrouter",
+        "model_id": "qwen/qwen3.8-27b",
     },
     "Qwen 3.5 27B": {
         "backend": "openrouter",
         "model_id": "qwen/qwen3.5-27b",
     },
-    "Qwen 3.5 122B A10B": {
+    "Qwen 3 VL 235B A22B": {
         "backend": "openrouter",
-        "model_id": "qwen/qwen3.5-122b-a10b",
+        "model_id": "qwen/qwen3-vl-235b-a22b-instruct",
     },
-    "Qwen 3.5 397B A17B": {
-        "backend": "openrouter",
-        "model_id": "qwen/qwen3.5-397b-a17b",
-    },
-    "Qwen 3.5 Flash 02-23": {
-        "backend": "openrouter",
-        "model_id": "qwen/qwen3.5-flash-02-23",
-    },
-    "Qwen 3.5 Plus": {
-        "backend": "openrouter",
-        "model_id": "qwen/qwen3.5-plus-20260420",
-    },
-    "Qwen 3.6 27B": {
-        "backend": "openrouter",
-        "model_id": "qwen/qwen3.6-27b",
-    },
-    "Qwen 3.6 35B A3B": {
-        "backend": "openrouter",
-        "model_id": "qwen/qwen3.6-35b-a3b",
-    },
-    "Qwen 3.6 Flash": {
-        "backend": "openrouter",
-        "model_id": "qwen/qwen3.6-flash",
-    },
-    "Qwen 3.6 Plus": {
-        "backend": "openrouter",
-        "model_id": "qwen/qwen3.6-plus",
-    },
-    "Qwen 3.8 Max": {
-        "backend": "openrouter",
-        "model_id": "qwen/qwen3.8-max",
-    },
-    # Note: Qwen 3.6 Max Preview is intentionally excluded — it's a text-only
-    # model on OpenRouter (no image-input endpoints), so it can't satisfy a
-    # VLM block. The Qwen 3.8 Max entry above is the vision-capable Max
-    # variant OpenRouter now ships (text + image + video input).
 }
 
 ModelVersion = Literal[tuple(MODEL_VARIANTS.keys())]
@@ -161,6 +155,7 @@ Backend = Literal["native", "openrouter"]
 # so the user can opt into picking a fine-tuned workspace model.
 FINE_TUNED_NATIVE_LABEL = "Fine-tuned model"
 DEFAULT_NATIVE_MODEL_VERSION = "Qwen 3.5 VL 2B"
+DEFAULT_OPENROUTER_MODEL_VERSION = "Qwen 3.7 Plus"
 
 # Per-backend variant lists, derived from MODEL_VARIANTS so the two stay in sync.
 NATIVE_VARIANT_LABELS = [
@@ -190,20 +185,155 @@ NATIVE_THINKING_MODEL_VERSIONS = [
     FINE_TUNED_NATIVE_LABEL,
 ]
 
+# ---------------------------------------------------------------------------
+# OpenRouter reasoning control
+# ---------------------------------------------------------------------------
+
+REASONING_EFFORT_OPTIONS = ["none", "low", "medium", "high"]
+ReasoningEffort = Literal[tuple(REASONING_EFFORT_OPTIONS)]
+
+REASONING_EFFORT_METADATA = {
+    "none": {
+        "name": "Disabled (recommended)",
+        "description": (
+            "Turns extended reasoning off. Qwen models default to extended "
+            "reasoning on OpenRouter, which bloats latency and can consume "
+            "the whole token budget before a visible answer is produced. "
+            "Models that require reasoning (Qwen 3.8 Max) fall back to low "
+            "effort instead."
+        ),
+    },
+    "low": {
+        "name": "Low",
+        "description": "Small reasoning budget before answering.",
+    },
+    "medium": {
+        "name": "Medium",
+        "description": "Moderate reasoning budget before answering.",
+    },
+    "high": {
+        "name": "High",
+        "description": (
+            "Large reasoning budget. Slowest and most expensive; consider "
+            "raising `max_tokens` so reasoning does not crowd out the answer."
+        ),
+    },
+}
+
+# Fallback effort applied when reasoning is disabled by the user but the
+# selected model rejects `reasoning: {"enabled": false}`.
+REASONING_REQUIRED_FALLBACK_EFFORT = "low"
+
+# Default OpenRouter completion budget when the user leaves `max_tokens`
+# unset. Benchmark parity: detection output on busy images easily exceeds
+# the older 500-token default, and reasoning models need headroom to think
+# and still emit a visible answer. The native path deliberately has no
+# block-side default: nothing is sent, so the inference server's own
+# default (512) applies. (v1 sends the mixin default of 500 instead;
+# effectively the same budget, but not the identical mechanism.)
+QWEN_OPENROUTER_DEFAULT_MAX_TOKENS = 16384
+
+
+def build_reasoning_config(
+    reasoning_effort: str,
+    *,
+    reasoning_required: bool,
+) -> dict:
+    """Translate the block's reasoning effort into OpenRouter's config object.
+
+    Mirrors the vlm-exam benchmark behavior: reasoning is explicitly
+    disabled unless an effort is requested, except for models that require
+    reasoning and reject ``enabled: false`` — those always receive an
+    effort (falling back to low when the user disabled reasoning).
+
+    Args:
+        reasoning_effort: One of ``REASONING_EFFORT_OPTIONS``.
+        reasoning_required: True when the target model rejects
+            ``reasoning: {"enabled": false}``.
+
+    Returns:
+        OpenRouter ``reasoning`` payload object.
+    """
+    if reasoning_required:
+        if reasoning_effort == "none":
+            return {"effort": REASONING_REQUIRED_FALLBACK_EFFORT}
+        return {"effort": reasoning_effort}
+    if reasoning_effort == "none":
+        return {"enabled": False}
+    return {"effort": reasoning_effort}
+
 
 # ---------------------------------------------------------------------------
-# Native prompt building
+# OpenRouter image encoding
 # ---------------------------------------------------------------------------
-# The native Qwen API takes a single ``prompt`` string and the image
-# separately (via LMMInferenceRequest). It uses the ``<system_prompt>``
-# separator convention from the legacy native qwen blocks.
-#
-# We map each task type to a (system, user-text-template) pair; the
-# combined prompt is ``user_text + "<system_prompt>" + system``. This
-# mirrors the system prompts used in the OpenRouter messages-array
-# builders in ``common.openrouter`` so behavior stays consistent.
 
-_SYSTEM_CLASSIFICATION = (
+# Safety cap below Alibaba DashScope's 10,485,760-byte data-URI limit —
+# DashScope backs the Qwen API-tier models on OpenRouter and rejects larger
+# payloads outright.
+OPENROUTER_MAX_BASE64_BYTES = 9_500_000
+OPENROUTER_JPEG_QUALITY = 90
+
+
+def encode_image_for_qwen_openrouter(numpy_image: np.ndarray) -> str:
+    """Encode a BGR image as base64 JPEG under the OpenRouter payload cap.
+
+    Encodes at fixed JPEG quality and, when the base64 payload exceeds
+    ``OPENROUTER_MAX_BASE64_BYTES``, iteratively downscales the longest
+    edge by 10% until it fits. Detection coordinates are normalized to
+    0-1000, so downscaling does not affect parsing.
+
+    Args:
+        numpy_image: Image in BGR channel order.
+
+    Returns:
+        Base64-encoded JPEG payload.
+    """
+    working = numpy_image
+    while True:
+        jpeg_bytes = encode_image_to_jpeg_bytes(
+            working, jpeg_quality=OPENROUTER_JPEG_QUALITY
+        )
+        base64_image = base64.b64encode(jpeg_bytes).decode("ascii")
+        if len(base64_image) <= OPENROUTER_MAX_BASE64_BYTES:
+            return base64_image
+
+        height, width = working.shape[:2]
+        if max(height, width) <= 1:
+            return base64_image
+
+        target_max_edge = max(int(max(height, width) * 0.9), 1)
+        target_width, target_height = scale_dimensions_to_max_edge(
+            width, height, target_max_edge
+        )
+        working = cv2.resize(
+            working, (target_width, target_height), interpolation=cv2.INTER_AREA
+        )
+
+
+# ---------------------------------------------------------------------------
+# OpenRouter prompt building (Qwen-specific)
+# ---------------------------------------------------------------------------
+# Every task sends a single user message with the image part FIRST and the
+# instruction text second, with no system role — the structure used for
+# Qwen models in the vlm-exam benchmarks. Output-format contracts for
+# non-detection tasks stay identical to the generic builders so downstream
+# parsers (`vlm_as_classifier@v2`, `json_parser@v1`) keep working.
+
+# Ported verbatim from vlm-exam's detection prompt for the
+# xyxy_normalized_0_to_1000 coordinate format — the format pinned for every
+# Qwen model in the benchmark configs.
+QWEN_OBJECT_DETECTION_PROMPT_TEMPLATE = (
+    "Detect all objects in this image. "
+    "Output a JSON list where each entry contains the 2D bounding box "
+    'in the key "box_2d" and the text label in the key "label". '
+    'The "box_2d" value must be [x_min, y_min, x_max, y_max]: the '
+    "top-left and bottom-right corners as integers between 0 and 1000, "
+    "normalized to the image width (x) and height (y). "
+    "Return only the JSON list, with no extra text. "
+    "Only use these labels: {class_list}"
+)
+
+_TASK_CLASSIFICATION = (
     "You act as single-class classification model. You must provide reasonable "
     "predictions. You are only allowed to produce JSON document in Markdown "
     "```json [...]``` markers. Expected structure of json: "
@@ -214,7 +344,7 @@ _SYSTEM_CLASSIFICATION = (
     "allowed to return JSON document."
 )
 
-_SYSTEM_MULTI_LABEL = (
+_TASK_MULTI_LABEL = (
     "You act as multi-label classification model. You must provide reasonable "
     "predictions. You are only allowed to produce JSON document in Markdown "
     '```json``` markers. Expected structure of json: {"predicted_classes": '
@@ -226,20 +356,20 @@ _SYSTEM_MULTI_LABEL = (
     "are only allowed to return JSON document."
 )
 
-_SYSTEM_VQA = (
+_TASK_VQA = (
     "You act as Visual Question Answering model. Your task is to provide "
     "answer to question submitted by user. If this is open-question - answer "
     "with few sentences, for ABCD question, return only the indicator of "
     "the answer."
 )
 
-_SYSTEM_OCR = (
+_TASK_OCR = (
     "You act as OCR model. Your task is to read text from the image and "
     "return it in paragraphs representing the structure of texts in the "
     "image. You should only return recognised text, nothing else."
 )
 
-_SYSTEM_STRUCTURED = (
+_TASK_STRUCTURED = (
     "You are supposed to produce responses in JSON wrapped in Markdown "
     "markers: ```json\nyour-response\n```. User is to provide you "
     "dictionary with keys and values. Each key must be present in your "
@@ -247,19 +377,167 @@ _SYSTEM_STRUCTURED = (
     "fields to be generated. Provide only JSON Markdown in response."
 )
 
-_SYSTEM_DETECTION = (
-    "You act as object-detection model. You must provide reasonable "
-    "predictions. You are only allowed to produce JSON document in "
-    'Markdown ```json``` markers. Expected structure of json: {"detections": '
-    '[{"x_min": 0.1, "y_min": 0.2, "x_max": 0.3, "y_max": 0.4, '
-    '"class_name": "my-class-X", "confidence": 0.7}]}. `my-class-X` must be '
-    "one of the class names defined by user. All coordinates must be in "
-    "range 0.0-1.0, representing percentage of image dimensions. "
-    "`confidence` is a value in range 0.0-1.0 representing your confidence "
-    "in prediction. You should detect all instances of classes provided by "
-    "user. You cannot discuss the result, you are only allowed to return "
-    "JSON document."
-)
+
+def _prepare_qwen_user_message(base64_image: str, text: str) -> List[dict]:
+    return [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image_url",
+                    "image_url": {
+                        "url": f"data:image/jpeg;base64,{base64_image}",
+                    },
+                },
+                {"type": "text", "text": text},
+            ],
+        }
+    ]
+
+
+def _prepare_unconstrained_prompt(base64_image: str, prompt: str, **_) -> List[dict]:
+    return _prepare_qwen_user_message(base64_image=base64_image, text=prompt)
+
+
+def _prepare_ocr_prompt(base64_image: str, **_) -> List[dict]:
+    return _prepare_qwen_user_message(base64_image=base64_image, text=_TASK_OCR)
+
+
+def _prepare_vqa_prompt(base64_image: str, prompt: str, **_) -> List[dict]:
+    text = f"{_TASK_VQA}\n\nQuestion: {prompt}"
+
+    return _prepare_qwen_user_message(base64_image=base64_image, text=text)
+
+
+def _prepare_caption_prompt(
+    base64_image: str, short_description: bool, **_
+) -> List[dict]:
+    caption_detail_level = (
+        "Caption should be short."
+        if short_description
+        else "Caption should be extensive."
+    )
+    text = (
+        "You act as image caption model. Your task is to provide "
+        f"description of the image. {caption_detail_level}"
+    )
+
+    return _prepare_qwen_user_message(base64_image=base64_image, text=text)
+
+
+def _prepare_classification_prompt(
+    base64_image: str, classes: List[str], **_
+) -> List[dict]:
+    serialised_classes = ", ".join(classes)
+    text = (
+        f"{_TASK_CLASSIFICATION}\n\n"
+        f"List of all classes to be recognised by model: {serialised_classes}"
+    )
+
+    return _prepare_qwen_user_message(base64_image=base64_image, text=text)
+
+
+def _prepare_multi_label_classification_prompt(
+    base64_image: str, classes: List[str], **_
+) -> List[dict]:
+    serialised_classes = ", ".join(classes)
+    text = (
+        f"{_TASK_MULTI_LABEL}\n\n"
+        f"List of all classes to be recognised by model: {serialised_classes}"
+    )
+
+    return _prepare_qwen_user_message(base64_image=base64_image, text=text)
+
+
+def _prepare_structured_answering_prompt(
+    base64_image: str, output_structure: Dict[str, str], **_
+) -> List[dict]:
+    output_structure_serialised = json.dumps(output_structure, indent=4)
+    text = (
+        f"{_TASK_STRUCTURED}\n\n"
+        "Specification of requirements regarding output fields: \n"
+        f"{output_structure_serialised}"
+    )
+
+    return _prepare_qwen_user_message(base64_image=base64_image, text=text)
+
+
+def _prepare_object_detection_prompt(
+    base64_image: str, classes: List[str], **_
+) -> List[dict]:
+    text = QWEN_OBJECT_DETECTION_PROMPT_TEMPLATE.format(
+        class_list=", ".join(classes),
+    )
+
+    return _prepare_qwen_user_message(base64_image=base64_image, text=text)
+
+
+QWEN_PROMPT_BUILDERS = {
+    "unconstrained": _prepare_unconstrained_prompt,
+    "ocr": _prepare_ocr_prompt,
+    "visual-question-answering": _prepare_vqa_prompt,
+    "caption": lambda **kwargs: _prepare_caption_prompt(
+        short_description=True, **kwargs
+    ),
+    "detailed-caption": lambda **kwargs: _prepare_caption_prompt(
+        short_description=False, **kwargs
+    ),
+    "classification": _prepare_classification_prompt,
+    "multi-label-classification": _prepare_multi_label_classification_prompt,
+    "structured-answering": _prepare_structured_answering_prompt,
+    "object-detection": _prepare_object_detection_prompt,
+}
+
+
+def build_qwen_openrouter_prompts(
+    images: List[np.ndarray],
+    task_type: str,
+    prompt: Optional[str],
+    output_structure: Optional[Dict[str, str]],
+    classes: Optional[List[str]],
+) -> List[List[dict]]:
+    """Build one OpenRouter ``messages`` array per input image, Qwen-style.
+
+    Args:
+        images: BGR numpy images.
+        task_type: One of the supported VLM task types.
+        prompt: User prompt for unconstrained / VQA tasks.
+        output_structure: Output spec for structured-answering.
+        classes: Class list for classification / detection tasks.
+
+    Returns:
+        List of ``messages`` arrays, one per image.
+
+    Raises:
+        ValueError: If the task type is not supported.
+    """
+    if task_type not in QWEN_PROMPT_BUILDERS:
+        raise ValueError(f"Task type: {task_type} not supported.")
+
+    builder = QWEN_PROMPT_BUILDERS[task_type]
+    built: List[List[dict]] = []
+    for image in images:
+        base64_image = encode_image_for_qwen_openrouter(numpy_image=image)
+        built.append(
+            builder(
+                base64_image=base64_image,
+                prompt=prompt,
+                output_structure=output_structure,
+                classes=classes,
+            )
+        )
+
+    return built
+
+
+# ---------------------------------------------------------------------------
+# Native prompt building (carried over from v1, except object-detection)
+# ---------------------------------------------------------------------------
+# The native Qwen API takes a single ``prompt`` string and the image
+# separately (via LMMInferenceRequest). It uses the ``<system_prompt>``
+# separator convention from the legacy native qwen blocks. Object detection
+# uses the same benchmarked box_2d/0-1000 template as the OpenRouter path so
+# both backends share one output contract.
 
 _DEFAULT_UNCONSTRAINED_SYSTEM_PROMPT = (
     "You are a Qwen vision-language model that can answer questions " "about any image."
@@ -313,10 +591,10 @@ def _build_native_prompt(
         system_text = _DEFAULT_UNCONSTRAINED_SYSTEM_PROMPT
     elif task_type == "ocr":
         user_text = "Extract the text from this image."
-        system_text = _SYSTEM_OCR
+        system_text = _TASK_OCR
     elif task_type == "visual-question-answering":
         user_text = f"Question: {prompt}" if prompt else "Describe this image."
-        system_text = _SYSTEM_VQA
+        system_text = _TASK_VQA
     elif task_type == "caption":
         user_text = "Caption this image."
         system_text = (
@@ -332,19 +610,24 @@ def _build_native_prompt(
     elif task_type == "classification":
         cls_str = ", ".join(classes or [])
         user_text = f"List of all classes to be recognised by model: {cls_str}"
-        system_text = _SYSTEM_CLASSIFICATION
+        system_text = _TASK_CLASSIFICATION
     elif task_type == "multi-label-classification":
         cls_str = ", ".join(classes or [])
         user_text = f"List of all classes to be recognised by model: {cls_str}"
-        system_text = _SYSTEM_MULTI_LABEL
+        system_text = _TASK_MULTI_LABEL
     elif task_type == "object-detection":
+        # Same benchmarked box_2d/0-1000 contract as the OpenRouter path, so
+        # both backends parse with vlm_as_detector@v2 model_type="qwen". Sent
+        # as user text with an empty system half — the model server falls
+        # back to its default system prompt, which is the closest native
+        # equivalent of the benchmark's single-user-message structure.
         cls_str = ", ".join(classes or [])
-        user_text = f"List of all classes to be recognised by model: {cls_str}"
-        system_text = _SYSTEM_DETECTION
+        user_text = QWEN_OBJECT_DETECTION_PROMPT_TEMPLATE.format(class_list=cls_str)
+        system_text = ""
     elif task_type == "structured-answering":
         spec = json.dumps(output_structure or {}, indent=4)
         user_text = f"Specification of requirements regarding output fields: \n{spec}"
-        system_text = _SYSTEM_STRUCTURED
+        system_text = _TASK_STRUCTURED
     else:
         raise ValueError(f"Task type: {task_type} not supported.")
     return user_text + "<system_prompt>" + system_text
@@ -366,17 +649,36 @@ You can specify arbitrary text prompts or predefined ones, the block supports th
 
 {RELEVANT_TASKS_DOCS_DESCRIPTION}
 
+#### 🆕 What's new in v2
+
+The block uses Qwen-tuned inference plumbing validated by benchmarks:
+
+* **Object detection** prompts for Qwen's native grounding format on **both backends**:
+  a JSON list of `box_2d`/`label` entries with `[x_min, y_min, x_max, y_max]` integer
+  coordinates normalized to 0-1000. Parse the output with `VLM as Detector`
+  (`vlm_as_detector@v2`) using `model_type="qwen"`.
+* Every request sends the image **before** the instruction text in a single user
+  message, matching how Qwen models are trained.
+* **Reasoning control**: Qwen models default to extended reasoning on OpenRouter,
+  which bloats latency and can consume the whole token budget. v2 disables it by
+  default and exposes a `reasoning_effort` knob. Qwen 3.8 Max requires reasoning
+  and falls back to low effort when disabled.
+* Uploads are downscaled automatically when they would exceed the Qwen provider
+  payload limit, and OpenRouter requests default to `max_tokens=16384` so
+  detection output is not truncated (the native backend keeps the server
+  default unless you set `max_tokens` explicitly).
+
 #### 🛠️ Backend selection
 
 * **Native (Roboflow)** — small Qwen-VL models (0.8B–7B) run on the same infrastructure as
   your other Roboflow models. Lower latency. Recommended for tasks
   like OCR, captioning, and visual question answering.
 
-* **OpenRouter** — large hosted Qwen models (9B–397B) reached via [OpenRouter](https://openrouter.ai/).
-  Defaults to a Roboflow-managed API key and bills your Roboflow credits. Paste your own
-  `sk-or-...` key in the `api_key` field to bypass Roboflow billing. Recommended for
-  structured tasks that benefit from larger models (classification, object-detection,
-  structured-answering).
+* **OpenRouter** — benchmark-validated hosted Qwen models reached via
+  [OpenRouter](https://openrouter.ai/). Defaults to a Roboflow-managed API key and
+  bills your Roboflow credits. Paste your own `sk-or-...` key in the `api_key`
+  field to bypass Roboflow billing. Recommended for structured tasks that benefit
+  from larger models (classification, object-detection, structured-answering).
 
 The `model_version` dropdown lists every supported variant; each is bound to one backend.
 A validator catches mismatches between your selected backend and model.
@@ -393,7 +695,7 @@ class BlockManifest(OpenRouterBlockManifestMixin):
     model_config = ConfigDict(
         json_schema_extra={
             "name": "Qwen",
-            "version": "v1",
+            "version": "v2",
             "short_description": "Run any Qwen vision model — natively or via OpenRouter.",
             "long_description": LONG_DESCRIPTION,
             "license": "Apache-2.0",
@@ -402,7 +704,7 @@ class BlockManifest(OpenRouterBlockManifestMixin):
                 "Qwen",
                 "qwen-vl",
                 "qwen3.5",
-                "qwen3.6",
+                "qwen3.7",
                 "qwen3.8",
                 "VLM",
                 "Alibaba",
@@ -418,7 +720,7 @@ class BlockManifest(OpenRouterBlockManifestMixin):
         },
         protected_namespaces=(),
     )
-    type: Literal["roboflow_core/qwen_vlm@v1"]
+    type: Literal["roboflow_core/qwen_vlm@v2"]
 
     images: Selector(kind=[IMAGE_KIND]) = ImageInputField
 
@@ -495,13 +797,17 @@ class BlockManifest(OpenRouterBlockManifestMixin):
         },
     )
 
-    # OpenRouter model picker: friendly-name dropdown bound to OpenRouter slugs.
+    # OpenRouter model picker: friendly-name dropdown bound to OpenRouter
+    # slugs, restricted to the vlm-exam-benchmarked models.
     openrouter_model_version: Union[
         Selector(kind=[STRING_KIND]), OpenRouterModelVersion
     ] = Field(
-        default="Qwen 3.6 27B",
-        description="OpenRouter-hosted Qwen variant.",
-        examples=["Qwen 3.6 27B", "Qwen 3.5 27B"],
+        default=DEFAULT_OPENROUTER_MODEL_VERSION,
+        description=(
+            "OpenRouter-hosted Qwen variant. The roster is restricted to "
+            "benchmark-validated models."
+        ),
+        examples=[DEFAULT_OPENROUTER_MODEL_VERSION, "Qwen 3.8 Max"],
         json_schema_extra={
             "relevant_for": {
                 "backend": {"values": ["openrouter"], "required": True},
@@ -549,6 +855,21 @@ class BlockManifest(OpenRouterBlockManifestMixin):
                     "required": False,
                 },
             },
+        },
+    )
+    reasoning_effort: ReasoningEffort = Field(
+        default="none",
+        description=(
+            "Extended-reasoning budget for OpenRouter-hosted Qwen models. "
+            "Disabled by default: Qwen models default to extended reasoning, "
+            "which bloats latency and can consume the whole token budget "
+            "before a visible answer is produced. Models that require "
+            "reasoning (Qwen 3.8 Max) fall back to low effort when disabled. "
+            "Only used when backend=openrouter."
+        ),
+        json_schema_extra={
+            "values_metadata": REASONING_EFFORT_METADATA,
+            "relevant_for": {"backend": {"values": ["openrouter"], "required": False}},
         },
     )
     output_structure: Optional[Dict[str, str]] = Field(
@@ -607,11 +928,24 @@ class BlockManifest(OpenRouterBlockManifestMixin):
             "relevant_for": {"backend": {"values": ["openrouter"], "required": False}},
         },
     )
-    temperature: Union[float, Selector(kind=[FLOAT_KIND])] = Field(
-        default=0.1,
+    max_tokens: Optional[int] = Field(
+        default=None,
+        description=(
+            "Maximum number of tokens the model can generate in its response. "
+            "When unset, each backend applies its own default: OpenRouter "
+            f"requests use {QWEN_OPENROUTER_DEFAULT_MAX_TOKENS} (headroom for "
+            "detection output and reasoning models; billing is based on "
+            "tokens actually generated, not on this limit), while the native "
+            "backend defers to the inference server default (512)."
+        ),
+        gt=1,
+    )
+    temperature: Optional[Union[float, Selector(kind=[FLOAT_KIND])]] = Field(
+        default=None,
         description=(
             "Sampling temperature (only used when backend=openrouter). "
-            "The native Qwen-VL runtime doesn't accept a temperature knob. "
+            "Left unset by default so the provider's per-model default "
+            "applies — this matches how the models were benchmarked. "
             'Range 0.0-2.0 — higher = more random / "creative" generations.'
         ),
         json_schema_extra={
@@ -667,8 +1001,10 @@ class BlockManifest(OpenRouterBlockManifestMixin):
 
     @field_validator("temperature")
     @classmethod
-    def validate_temperature(cls, value: Union[str, float]) -> Union[str, float]:
-        if isinstance(value, str):
+    def validate_temperature(
+        cls, value: Optional[Union[str, float]]
+    ) -> Optional[Union[str, float]]:
+        if value is None or isinstance(value, str):
             return value
         if value < 0.0 or value > 2.0:
             raise ValueError(
@@ -695,8 +1031,11 @@ class BlockManifest(OpenRouterBlockManifestMixin):
                 name="thinking",
                 kind=[STRING_KIND],
                 description=(
-                    "Reasoning trace from Qwen3.5-VL when `enable_thinking` "
-                    "is on. Empty string otherwise."
+                    "Reasoning trace emitted by the model: populated on the "
+                    "native backend when `enable_thinking` is on, and on the "
+                    "OpenRouter backend when the model performs extended "
+                    "reasoning (see `reasoning_effort`). Empty string "
+                    "otherwise."
                 ),
             ),
         ]
@@ -767,9 +1106,10 @@ class BlockManifest(OpenRouterBlockManifestMixin):
 # ---------------------------------------------------------------------------
 
 
-class QwenVlmBlockV1(OpenRouterWorkflowBlockBase):
-    """Unified Qwen-VL block. Inherits OpenRouter routing/execution from base
-    and adds the native local/remote dispatch on top.
+class QwenVlmBlockV2(OpenRouterWorkflowBlockBase):
+    """Unified Qwen-VL block v2. Inherits OpenRouter routing/execution from
+    base, uses Qwen-specific prompt building on the OpenRouter path, and
+    keeps the native local/remote dispatch from v1.
     """
 
     def __init__(
@@ -803,12 +1143,13 @@ class QwenVlmBlockV1(OpenRouterWorkflowBlockBase):
         task_type: str,
         prompt: Optional[str],
         enable_thinking: bool,
+        reasoning_effort: str,
         output_structure: Optional[Dict[str, str]],
         classes: Optional[List[str]],
         api_key: str,
         privacy_level: str,
-        max_tokens: int,
-        temperature: float,
+        max_tokens: Optional[int],
+        temperature: Optional[float],
         max_concurrent_requests: Optional[int],
     ) -> BlockResult:
         if backend == "native":
@@ -841,25 +1182,35 @@ class QwenVlmBlockV1(OpenRouterWorkflowBlockBase):
             raise ValueError(f"Unknown backend: {backend}")
 
         if backend == "openrouter":
-            inference_images = [i.to_inference_format() for i in images]
-            prompts = build_prompts_from_images(
-                images=inference_images,
+            prompts = build_qwen_openrouter_prompts(
+                images=[i.numpy_image for i in images],
                 task_type=task_type,
                 prompt=prompt,
                 output_structure=output_structure,
                 classes=classes,
             )
+            reasoning = build_reasoning_config(
+                reasoning_effort,
+                reasoning_required=variant.get("reasoning_required", False),
+            )
             raw_outputs = self.execute_openrouter_batch(
                 openrouter_api_key=api_key,
                 model=model_id,
                 prompts=prompts,
-                max_tokens=max_tokens,
+                max_tokens=(
+                    max_tokens
+                    if max_tokens is not None
+                    else QWEN_OPENROUTER_DEFAULT_MAX_TOKENS
+                ),
                 temperature=temperature,
                 privacy_level=privacy_level,
                 max_concurrent_requests=max_concurrent_requests,
+                reasoning=reasoning,
+                include_reasoning=True,
             )
             return [
-                {"output": o, "classes": classes, "thinking": ""} for o in raw_outputs
+                {"output": content, "classes": classes, "thinking": reasoning_trace}
+                for content, reasoning_trace in raw_outputs
             ]
 
         # `enable_thinking` is only meaningful on Qwen3.5-VL native variants

--- a/tests/workflows/integration_tests/execution/test_workflow_with_qwen_vlm_v2.py
+++ b/tests/workflows/integration_tests/execution/test_workflow_with_qwen_vlm_v2.py
@@ -1,0 +1,184 @@
+"""
+This test module requires an OpenRouter API key passed via env variable
+WORKFLOWS_TEST_OPEN_ROUTER_API_KEY. This is supposed to be used only locally,
+as that would be too much of a cost in CI.
+"""
+
+import os
+
+import numpy as np
+import pytest
+import supervision as sv
+
+from inference.core.env import WORKFLOWS_MAX_CONCURRENT_STEPS
+from inference.core.managers.base import ModelManager
+from inference.core.workflows.core_steps.common.entities import StepExecutionMode
+from inference.core.workflows.execution_engine.core import ExecutionEngine
+
+OPEN_ROUTER_API_KEY = os.getenv("WORKFLOWS_TEST_OPEN_ROUTER_API_KEY")
+
+OBJECT_DETECTION_WORKFLOW = {
+    "version": "1.0",
+    "inputs": [
+        {"type": "WorkflowImage", "name": "image"},
+        {"type": "WorkflowParameter", "name": "api_key"},
+        {"type": "WorkflowParameter", "name": "classes"},
+    ],
+    "steps": [
+        {
+            "type": "roboflow_core/qwen_vlm@v2",
+            "name": "qwen",
+            "images": "$inputs.image",
+            "backend": "openrouter",
+            "openrouter_model_version": "Qwen 3.7 Plus",
+            "task_type": "object-detection",
+            "classes": "$inputs.classes",
+            "api_key": "$inputs.api_key",
+        },
+        {
+            "type": "roboflow_core/vlm_as_detector@v2",
+            "name": "parser",
+            "vlm_output": "$steps.qwen.output",
+            "image": "$inputs.image",
+            "classes": "$steps.qwen.classes",
+            "model_type": "qwen",
+            "task_type": "object-detection",
+        },
+    ],
+    "outputs": [
+        {
+            "type": "JsonField",
+            "name": "qwen_result",
+            "selector": "$steps.qwen.output",
+        },
+        {
+            "type": "JsonField",
+            "name": "parsed_prediction",
+            "selector": "$steps.parser.predictions",
+        },
+    ],
+}
+
+
+def test_object_detection_workflow_compiles(model_manager: ModelManager) -> None:
+    """Ungated compile-only check: the live tests below are API-key-gated and
+    never run in CI, so without this nothing in CI would compile the
+    qwen_vlm@v2 -> vlm_as_detector@v2 block pair."""
+    workflow_init_parameters = {
+        "workflows_core.model_manager": model_manager,
+        "workflows_core.step_execution_mode": StepExecutionMode.LOCAL,
+    }
+
+    execution_engine = ExecutionEngine.init(
+        workflow_definition=OBJECT_DETECTION_WORKFLOW,
+        init_parameters=workflow_init_parameters,
+        max_concurrent_steps=WORKFLOWS_MAX_CONCURRENT_STEPS,
+    )
+
+    assert execution_engine is not None
+
+
+@pytest.mark.skipif(
+    condition=OPEN_ROUTER_API_KEY is None, reason="OpenRouter API key not provided"
+)
+def test_workflow_with_object_detection_prompt(
+    model_manager: ModelManager,
+    dogs_image: np.ndarray,
+) -> None:
+    # given
+    workflow_init_parameters = {
+        "workflows_core.model_manager": model_manager,
+        "workflows_core.step_execution_mode": StepExecutionMode.LOCAL,
+    }
+    execution_engine = ExecutionEngine.init(
+        workflow_definition=OBJECT_DETECTION_WORKFLOW,
+        init_parameters=workflow_init_parameters,
+        max_concurrent_steps=WORKFLOWS_MAX_CONCURRENT_STEPS,
+    )
+
+    # when
+    result = execution_engine.run(
+        runtime_parameters={
+            "image": [dogs_image],
+            "api_key": OPEN_ROUTER_API_KEY,
+            "classes": ["dog"],
+        }
+    )
+
+    # then
+    assert len(result) == 1, "Single image given, expected single output"
+    assert set(result[0].keys()) == {
+        "qwen_result",
+        "parsed_prediction",
+    }, "Expected all outputs to be delivered"
+    assert isinstance(
+        result[0]["parsed_prediction"], sv.Detections
+    ), "Expected parsed detections"
+    assert len(result[0]["parsed_prediction"]) > 0, "Expected dogs to be detected"
+    assert set(result[0]["parsed_prediction"]["class_name"].tolist()) == {
+        "dog"
+    }, "Expected only dogs to be detected"
+
+
+UNCONSTRAINED_WORKFLOW = {
+    "version": "1.0",
+    "inputs": [
+        {"type": "WorkflowImage", "name": "image"},
+        {"type": "WorkflowParameter", "name": "api_key"},
+        {"type": "WorkflowParameter", "name": "prompt"},
+    ],
+    "steps": [
+        {
+            "type": "roboflow_core/qwen_vlm@v2",
+            "name": "qwen",
+            "images": "$inputs.image",
+            "backend": "openrouter",
+            "openrouter_model_version": "Qwen 3.7 Flash",
+            "task_type": "unconstrained",
+            "prompt": "$inputs.prompt",
+            "api_key": "$inputs.api_key",
+        },
+    ],
+    "outputs": [
+        {
+            "type": "JsonField",
+            "name": "result",
+            "selector": "$steps.qwen.output",
+        },
+    ],
+}
+
+
+@pytest.mark.skipif(
+    condition=OPEN_ROUTER_API_KEY is None, reason="OpenRouter API key not provided"
+)
+def test_workflow_with_unconstrained_prompt(
+    model_manager: ModelManager,
+    dogs_image: np.ndarray,
+) -> None:
+    # given
+    workflow_init_parameters = {
+        "workflows_core.model_manager": model_manager,
+        "workflows_core.step_execution_mode": StepExecutionMode.LOCAL,
+    }
+    execution_engine = ExecutionEngine.init(
+        workflow_definition=UNCONSTRAINED_WORKFLOW,
+        init_parameters=workflow_init_parameters,
+        max_concurrent_steps=WORKFLOWS_MAX_CONCURRENT_STEPS,
+    )
+
+    # when
+    result = execution_engine.run(
+        runtime_parameters={
+            "image": [dogs_image],
+            "api_key": OPEN_ROUTER_API_KEY,
+            "prompt": "What animals are in this image?",
+        }
+    )
+
+    # then
+    assert len(result) == 1, "Single image given, expected single output"
+    assert set(result[0].keys()) == {"result"}, "Expected all outputs to be delivered"
+    assert (
+        isinstance(result[0]["result"], str) and len(result[0]["result"]) > 0
+    ), "Expected non-empty string generated"

--- a/tests/workflows/unit_tests/core_steps/common/test_openrouter.py
+++ b/tests/workflows/unit_tests/core_steps/common/test_openrouter.py
@@ -3,16 +3,48 @@
 from typing import Any
 from unittest.mock import MagicMock, patch
 
+import httpx
 import pytest
+from openai import APIStatusError
 
+from inference.core.exceptions import (
+    RoboflowAPIConnectionError,
+    RoboflowAPIUnsuccessfulRequestError,
+)
 from inference.core.workflows.core_steps.common.openrouter import (
     OpenRouterWorkflowBlockBase,
     _execute_direct_openrouter_request,
     _execute_proxied_openrouter_request,
+    _is_unsupported_reasoning_error,
     build_prompts_from_images,
     build_provider_routing,
     validate_task_type_required_fields,
 )
+
+# Real error strings captured live from OpenRouter (2026-08-19):
+# qwen/qwen3.8-max rejecting `reasoning: {"enabled": false}`:
+MANDATORY_REASONING_ERROR = (
+    "Reasoning is mandatory for this endpoint and cannot be disabled."
+)
+# qwen/qwen3.7-flash rejecting `reasoning: {"effort": "bogus"}`:
+INVALID_REASONING_OPTION_ERROR = (
+    "reasoning.effort: Invalid option: expected one of "
+    '"max"|"xhigh"|"high"|"medium"|"low"|"minimal"|"none"'
+)
+
+
+def _openai_status_error(message: str, status_code: int) -> APIStatusError:
+    request = httpx.Request("POST", "https://openrouter.ai/api/v1/chat/completions")
+    response = httpx.Response(status_code, request=request)
+    return APIStatusError(message, response=response, body=None)
+
+
+def _proxy_error(message: str, status_code: int) -> RoboflowAPIUnsuccessfulRequestError:
+    """Mirror _build_proxy_error_handler: Roboflow exception with status attached."""
+    error = RoboflowAPIUnsuccessfulRequestError(message)
+    error.status_code = status_code
+    return error
+
 
 # ---------------------------------------------------------------------------
 # build_provider_routing
@@ -208,6 +240,55 @@ def test_proxied_request_raises_when_choices_empty(mock_post):
 
 
 # ---------------------------------------------------------------------------
+# include_reasoning: reasoning-trace extraction
+# ---------------------------------------------------------------------------
+
+
+@patch("inference.core.workflows.core_steps.common.openrouter.post_to_roboflow_api")
+def test_proxied_request_returns_reasoning_trace_when_requested(mock_post):
+    mock_post.return_value = {
+        "choices": [{"message": {"content": "answer", "reasoning": "trace"}}]
+    }
+
+    out = _execute_proxied_openrouter_request(
+        roboflow_api_key="k",
+        openrouter_api_key="rf_key:account",
+        model="qwen/qwen3.7-plus",
+        messages=[{"role": "user", "content": "hi"}],
+        max_tokens=10,
+        temperature=None,
+        privacy_level="deny",
+        include_reasoning=True,
+    )
+
+    assert out == ("answer", "trace")
+
+
+@patch("inference.core.workflows.core_steps.common.openrouter.OpenAI")
+def test_direct_request_returns_empty_trace_when_reasoning_missing(mock_openai_cls):
+    client = MagicMock()
+    response = MagicMock()
+    choice = MagicMock()
+    choice.message.content = "answer"
+    # MagicMock auto-creates attributes; a non-str `reasoning` must map to "".
+    response.choices = [choice]
+    client.chat.completions.create.return_value = response
+    mock_openai_cls.return_value = client
+
+    out = _execute_direct_openrouter_request(
+        api_key="sk-or-v1-test",
+        model="qwen/qwen3.7-plus",
+        messages=[{"role": "user", "content": "hi"}],
+        max_tokens=10,
+        temperature=None,
+        privacy_level="deny",
+        include_reasoning=True,
+    )
+
+    assert out == ("answer", "")
+
+
+# ---------------------------------------------------------------------------
 # _execute_direct_openrouter_request: provider injection
 # ---------------------------------------------------------------------------
 
@@ -325,6 +406,224 @@ def test_direct_request_raises_when_message_content_is_none(mock_openai_cls):
             temperature=0.0,
             privacy_level="deny",
         )
+
+
+# ---------------------------------------------------------------------------
+# _is_unsupported_reasoning_error
+# ---------------------------------------------------------------------------
+
+
+def test_reasoning_error_matches_mandatory_reasoning_rejection_from_proxy():
+    error = _proxy_error(MANDATORY_REASONING_ERROR, status_code=400)
+    assert _is_unsupported_reasoning_error(error) is True
+
+
+def test_reasoning_error_ignores_proxied_5xx_even_with_matching_message():
+    # A transient upstream 502 relayed by the proxy carries the provider's
+    # message verbatim; it must never trigger a duplicate billed request.
+    error = _proxy_error(MANDATORY_REASONING_ERROR, status_code=502)
+    assert _is_unsupported_reasoning_error(error) is False
+
+
+def test_reasoning_error_ignores_proxy_exception_without_status():
+    # Raised outside _PROXY_ERROR_HANDLERS (no status attached): not retryable.
+    error = RoboflowAPIUnsuccessfulRequestError(MANDATORY_REASONING_ERROR)
+    assert _is_unsupported_reasoning_error(error) is False
+
+
+def test_reasoning_error_matches_invalid_option_rejection_from_direct_400():
+    error = _openai_status_error(INVALID_REASONING_OPTION_ERROR, status_code=400)
+    assert _is_unsupported_reasoning_error(error) is True
+
+
+def test_reasoning_error_ignores_5xx_even_with_matching_message():
+    error = _openai_status_error(MANDATORY_REASONING_ERROR, status_code=502)
+    assert _is_unsupported_reasoning_error(error) is False
+
+
+def test_reasoning_error_ignores_connection_errors_with_matching_message():
+    # A transient failure whose text happens to mention reasoning must NOT
+    # trigger a duplicate billed request.
+    error = RoboflowAPIConnectionError(MANDATORY_REASONING_ERROR)
+    assert _is_unsupported_reasoning_error(error) is False
+
+
+def test_reasoning_error_ignores_unrelated_client_errors():
+    error = _proxy_error("image exceeds maximum size", status_code=400)
+    assert _is_unsupported_reasoning_error(error) is False
+
+
+# ---------------------------------------------------------------------------
+# reasoning / temperature payload shape
+# ---------------------------------------------------------------------------
+
+
+@patch("inference.core.workflows.core_steps.common.openrouter.post_to_roboflow_api")
+def test_proxied_request_includes_reasoning_and_omits_none_temperature(mock_post):
+    mock_post.return_value = {"choices": [{"message": {"content": "ok"}}]}
+
+    _execute_proxied_openrouter_request(
+        roboflow_api_key="ws-key",
+        openrouter_api_key="rf_key:account",
+        model="qwen/qwen3.7-flash",
+        messages=[{"role": "user", "content": "hi"}],
+        max_tokens=100,
+        temperature=None,
+        privacy_level="deny",
+        reasoning={"enabled": False},
+    )
+
+    payload = mock_post.call_args.kwargs["payload"]
+    assert payload["reasoning"] == {"enabled": False}
+    assert "temperature" not in payload
+
+
+@patch("inference.core.workflows.core_steps.common.openrouter.OpenAI")
+def test_direct_request_includes_reasoning_and_omits_none_temperature(mock_openai_cls):
+    client = MagicMock()
+    client.chat.completions.create.return_value = _stub_openai_response("ok")
+    mock_openai_cls.return_value = client
+
+    _execute_direct_openrouter_request(
+        api_key="sk-or-v1-test",
+        model="qwen/qwen3.7-flash",
+        messages=[{"role": "user", "content": "hi"}],
+        max_tokens=100,
+        temperature=None,
+        privacy_level="deny",
+        reasoning={"effort": "low"},
+    )
+
+    create_kwargs = client.chat.completions.create.call_args.kwargs
+    assert create_kwargs["extra_body"]["reasoning"] == {"effort": "low"}
+    assert "temperature" not in create_kwargs
+
+
+# ---------------------------------------------------------------------------
+# retry-without-reasoning fallback
+# ---------------------------------------------------------------------------
+
+
+@patch("inference.core.workflows.core_steps.common.openrouter.logger")
+@patch("inference.core.workflows.core_steps.common.openrouter.post_to_roboflow_api")
+def test_proxied_request_retries_without_reasoning_on_rejection(mock_post, mock_logger):
+    mock_post.side_effect = [
+        _proxy_error(MANDATORY_REASONING_ERROR, status_code=400),
+        {"choices": [{"message": {"content": "ok"}}]},
+    ]
+
+    out = _execute_proxied_openrouter_request(
+        roboflow_api_key="ws-key",
+        openrouter_api_key="rf_key:account",
+        model="qwen/qwen3.8-max",
+        messages=[{"role": "user", "content": "hi"}],
+        max_tokens=100,
+        temperature=None,
+        privacy_level="deny",
+        reasoning={"enabled": False},
+    )
+
+    assert out == "ok"
+    assert mock_post.call_count == 2
+    assert "reasoning" in mock_post.call_args_list[0].kwargs["payload"]
+    assert "reasoning" not in mock_post.call_args_list[1].kwargs["payload"]
+    assert mock_logger.warning.call_count == 1
+
+
+@patch("inference.core.workflows.core_steps.common.openrouter.post_to_roboflow_api")
+def test_proxied_request_does_not_retry_on_relayed_502(mock_post):
+    # Regression: the proxy relays upstream 5xx with the provider message
+    # preserved; a reasoning-flavored 502 must not fire a duplicate request.
+    mock_post.side_effect = _proxy_error(MANDATORY_REASONING_ERROR, status_code=502)
+
+    with pytest.raises(RoboflowAPIUnsuccessfulRequestError):
+        _execute_proxied_openrouter_request(
+            roboflow_api_key="ws-key",
+            openrouter_api_key="rf_key:account",
+            model="qwen/qwen3.8-max",
+            messages=[],
+            max_tokens=1,
+            temperature=None,
+            privacy_level="deny",
+            reasoning={"enabled": False},
+        )
+
+    assert mock_post.call_count == 1
+
+
+@patch("inference.core.workflows.core_steps.common.openrouter.post_to_roboflow_api")
+def test_proxied_request_does_not_retry_when_no_reasoning_sent(mock_post):
+    mock_post.side_effect = _proxy_error(MANDATORY_REASONING_ERROR, status_code=400)
+
+    with pytest.raises(RoboflowAPIUnsuccessfulRequestError):
+        _execute_proxied_openrouter_request(
+            roboflow_api_key="ws-key",
+            openrouter_api_key="rf_key:account",
+            model="qwen/qwen3.8-max",
+            messages=[],
+            max_tokens=1,
+            temperature=None,
+            privacy_level="deny",
+        )
+
+    assert mock_post.call_count == 1
+
+
+@patch("inference.core.workflows.core_steps.common.openrouter.logger")
+@patch("inference.core.workflows.core_steps.common.openrouter.OpenAI")
+def test_direct_request_retries_without_reasoning_on_rejection(
+    mock_openai_cls, mock_logger
+):
+    client = MagicMock()
+    client.chat.completions.create.side_effect = [
+        _openai_status_error(INVALID_REASONING_OPTION_ERROR, status_code=400),
+        _stub_openai_response("ok"),
+    ]
+    mock_openai_cls.return_value = client
+
+    out = _execute_direct_openrouter_request(
+        api_key="sk-or-v1-test",
+        model="qwen/qwen3.7-flash",
+        messages=[{"role": "user", "content": "hi"}],
+        max_tokens=100,
+        temperature=None,
+        privacy_level="deny",
+        reasoning={"effort": "low"},
+    )
+
+    assert out == "ok"
+    assert client.chat.completions.create.call_count == 2
+    first_extra = client.chat.completions.create.call_args_list[0].kwargs["extra_body"]
+    second_extra = client.chat.completions.create.call_args_list[1].kwargs["extra_body"]
+    assert "reasoning" in first_extra
+    assert "reasoning" not in second_extra
+    assert mock_logger.warning.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# batch-level reasoning forwarding
+# ---------------------------------------------------------------------------
+
+
+@patch(
+    "inference.core.workflows.core_steps.common.openrouter._execute_proxied_openrouter_request"
+)
+def test_execute_openrouter_batch_forwards_reasoning_on_managed_key(mock_proxied):
+    mock_proxied.side_effect = ["resp"]
+    block = _FakeBlock(model_manager=MagicMock(), api_key="ws-key")
+
+    block.execute_openrouter_batch(
+        openrouter_api_key="rf_key:account",
+        model="qwen/qwen3.7-flash",
+        prompts=[[{"role": "user", "content": "hi"}]],
+        max_tokens=50,
+        temperature=None,
+        privacy_level="deny",
+        max_concurrent_requests=1,
+        reasoning={"enabled": False},
+    )
+
+    assert mock_proxied.call_args.kwargs["reasoning"] == {"enabled": False}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/workflows/unit_tests/core_steps/formatters/test_qwen_detection_parsing.py
+++ b/tests/workflows/unit_tests/core_steps/formatters/test_qwen_detection_parsing.py
@@ -1,0 +1,169 @@
+import numpy as np
+import pytest
+
+from inference.core.workflows.core_steps.formatters.vlm_as_detector.qwen_detection_parsing import (
+    convert_qwen_detection_to_pixel_xyxy,
+    get_qwen_detection_box,
+    get_qwen_detection_class_name,
+    parse_qwen_object_detection_response,
+)
+from inference.core.workflows.execution_engine.constants import (
+    DETECTION_ID_KEY,
+    IMAGE_DIMENSIONS_KEY,
+    INFERENCE_ID_KEY,
+    PARENT_COORDINATES_KEY,
+    PARENT_DIMENSIONS_KEY,
+    PARENT_ID_KEY,
+    PREDICTION_TYPE_KEY,
+    ROOT_PARENT_COORDINATES_KEY,
+    ROOT_PARENT_DIMENSIONS_KEY,
+    ROOT_PARENT_ID_KEY,
+)
+from inference.core.workflows.execution_engine.entities.base import (
+    ImageParentMetadata,
+    WorkflowImageData,
+)
+
+
+def _build_image(height: int, width: int) -> WorkflowImageData:
+    return WorkflowImageData(
+        parent_metadata=ImageParentMetadata(parent_id="parent"),
+        numpy_image=np.zeros((height, width, 3), dtype=np.uint8),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Box / label extraction
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "detection",
+    [
+        pytest.param({}, id="no-box-key"),
+        pytest.param({"box_2d": [1, 2, 3]}, id="too-few-coordinates"),
+        pytest.param({"box_2d": [1, 2, 3, 4, 5]}, id="too-many-coordinates"),
+        pytest.param({"box_2d": [1, 2, 3, "x"]}, id="non-numeric-coordinate"),
+        pytest.param({"box_2d": [1, 2, 3, True]}, id="boolean-coordinate"),
+        pytest.param({"box_2d": "1,2,3,4"}, id="box-not-a-list"),
+    ],
+)
+def test_get_box_returns_none_for_malformed_boxes(detection) -> None:
+    assert get_qwen_detection_box(detection) is None
+
+
+def test_get_class_name_reads_label_aliases_in_priority_order() -> None:
+    assert get_qwen_detection_class_name({"label": "cat"}) == "cat"
+    assert get_qwen_detection_class_name({"description": "dog"}) == "dog"
+    assert get_qwen_detection_class_name({"class_name": "bird"}) == "bird"
+    assert get_qwen_detection_class_name({"class": "fish"}) == "fish"
+    assert (
+        get_qwen_detection_class_name({"label": "cat", "description": "dog"}) == "cat"
+    )
+    assert get_qwen_detection_class_name({}) == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Coordinate conversion
+# ---------------------------------------------------------------------------
+
+
+def test_convert_box_clamps_out_of_range_coordinates() -> None:
+    result = convert_qwen_detection_to_pixel_xyxy(
+        box=[-50.0, 0.0, 1200.0, 1000.0],
+        image_height=480,
+        image_width=640,
+    )
+
+    assert result == pytest.approx([0.0, 0.0, 640.0, 480.0])
+
+
+# ---------------------------------------------------------------------------
+# Full parsing
+# ---------------------------------------------------------------------------
+
+
+def test_parse_response_assembles_detections() -> None:
+    parsed_data = [
+        {"box_2d": [100, 200, 500, 1000], "label": "cat", "confidence": 0.75},
+        {"bbox_2d": [0, 0, 500, 500], "description": "unicorn"},
+    ]
+
+    result = parse_qwen_object_detection_response(
+        image=_build_image(height=480, width=640),
+        parsed_data=parsed_data,
+        classes=["cat", "dog"],
+        inference_id="inference-id",
+    )
+
+    assert np.allclose(result.xyxy, [[64, 96, 320, 480], [0, 0, 320, 240]])
+    assert result.class_id.tolist() == [0, -1]
+    assert result["class_name"].tolist() == ["cat", "unicorn"]
+    # Confidence is hardcoded to 1.0; the model-provided value is ignored.
+    assert np.allclose(result.confidence, [1.0, 1.0])
+    assert result.mask is None
+    assert result.tracker_id is None
+    assert result[INFERENCE_ID_KEY].tolist() == ["inference-id"] * 2
+    assert result[PREDICTION_TYPE_KEY].tolist() == ["object-detection"] * 2
+    assert result[IMAGE_DIMENSIONS_KEY].tolist() == [[480, 640]] * 2
+    detection_ids = result[DETECTION_ID_KEY].tolist()
+    assert len(set(detection_ids)) == 2
+    assert all(detection_id for detection_id in detection_ids)
+    assert result[PARENT_ID_KEY].tolist() == ["parent"] * 2
+    assert result[PARENT_COORDINATES_KEY].tolist() == [[0, 0]] * 2
+    assert result[PARENT_DIMENSIONS_KEY].tolist() == [[480, 640]] * 2
+    assert result[ROOT_PARENT_ID_KEY].tolist() == ["parent"] * 2
+    assert result[ROOT_PARENT_COORDINATES_KEY].tolist() == [[0, 0]] * 2
+    assert result[ROOT_PARENT_DIMENSIONS_KEY].tolist() == [[480, 640]] * 2
+
+
+def test_parse_response_skips_malformed_entries() -> None:
+    parsed_data = [
+        "not-a-dict",
+        {"label": "cat"},
+        {"box_2d": [1, 2, 3], "label": "cat"},
+        {"box_2d": [100, 200, 500, 1000], "label": "cat"},
+    ]
+
+    result = parse_qwen_object_detection_response(
+        image=_build_image(height=480, width=640),
+        parsed_data=parsed_data,
+        classes=["cat", "dog"],
+        inference_id="inference-id",
+    )
+
+    assert len(result) == 1
+    assert result["class_name"].tolist() == ["cat"]
+
+
+def test_parse_response_for_empty_list() -> None:
+    result = parse_qwen_object_detection_response(
+        image=_build_image(height=480, width=640),
+        parsed_data=[],
+        classes=["cat", "dog"],
+        inference_id="inference-id",
+    )
+
+    assert len(result) == 0
+
+
+def test_parse_response_for_detections_wrapper() -> None:
+    result = parse_qwen_object_detection_response(
+        image=_build_image(height=480, width=640),
+        parsed_data={"detections": [{"box_2d": [0, 0, 1000, 1000], "label": "cat"}]},
+        classes=["cat"],
+        inference_id="inference-id",
+    )
+
+    assert len(result) == 1
+    assert np.allclose(result.xyxy, [[0, 0, 640, 480]])
+
+
+def test_parse_response_raises_on_unexpected_shape() -> None:
+    with pytest.raises(ValueError):
+        parse_qwen_object_detection_response(
+            image=_build_image(height=480, width=640),
+            parsed_data={"objects": []},
+            classes=["cat"],
+            inference_id="inference-id",
+        )

--- a/tests/workflows/unit_tests/core_steps/formatters/vlm_as_detector/test_v2_tensor.py
+++ b/tests/workflows/unit_tests/core_steps/formatters/vlm_as_detector/test_v2_tensor.py
@@ -219,3 +219,68 @@ def test_run_method_for_spacexai_percent_box_2d_output_tensor_native() -> None:
     assert np.allclose(
         result["predictions"].confidence.cpu().numpy(), np.array([0.9, 1.0])
     )
+
+
+def test_run_method_for_qwen_box_2d_output_tensor_native() -> None:
+    # given - qwen coordinates are normalized to 0-1000 on both axes; the
+    # bbox_2d alias and label alias keys are accepted, and model-provided
+    # confidence is ignored (hardcoded 1.0)
+    block = VLMAsDetectorBlockV2()
+    image = WorkflowImageData(
+        numpy_image=np.zeros((480, 640, 3), dtype=np.uint8),
+        parent_metadata=ImageParentMetadata(parent_id="parent"),
+    )
+    vlm_output = """
+[
+  {"box_2d": [100, 200, 500, 1000], "label": "cat", "confidence": 0.75},
+  {"bbox_2d": [0, 0, 500, 500], "description": "unicorn"}
+]
+    """
+
+    # when
+    result = block.run(
+        image=image,
+        vlm_output=vlm_output,
+        classes=["cat", "dog"],
+        model_type="qwen",
+        task_type="object-detection",
+    )
+
+    # then
+    assert result["error_status"] is False
+    assert isinstance(result["predictions"], Detections)
+    assert _class_names(result["predictions"]) == ["cat", "unicorn"]
+    assert np.allclose(result["predictions"].class_id.cpu().numpy(), np.array([0, -1]))
+    assert np.allclose(
+        result["predictions"].xyxy.cpu().numpy(),
+        np.array(
+            [
+                [64, 96, 320, 480],
+                [0, 0, 320, 240],
+            ]
+        ),
+        atol=1.0,
+    )
+    assert np.allclose(
+        result["predictions"].confidence.cpu().numpy(), np.array([1.0, 1.0])
+    )
+
+
+def test_run_method_for_qwen_unexpected_shape_sets_error_status_tensor_native() -> None:
+    # given - neither a JSON list nor a {"detections": [...]} object
+    block = VLMAsDetectorBlockV2()
+    image = WorkflowImageData(
+        numpy_image=np.zeros((480, 640, 3), dtype=np.uint8),
+        parent_metadata=ImageParentMetadata(parent_id="parent"),
+    )
+
+    result = block.run(
+        image=image,
+        vlm_output='{"objects": []}',
+        classes=["cat"],
+        model_type="qwen",
+        task_type="object-detection",
+    )
+
+    assert result["error_status"] is True
+    assert result["predictions"] is None

--- a/tests/workflows/unit_tests/core_steps/models/foundation/test_qwen_vlm_v2.py
+++ b/tests/workflows/unit_tests/core_steps/models/foundation/test_qwen_vlm_v2.py
@@ -1,0 +1,515 @@
+"""Tests for the unified Qwen-VL block v2 (Qwen-specific OpenRouter plumbing)."""
+
+import base64
+from unittest.mock import MagicMock, patch
+
+import cv2
+import numpy as np
+import pytest
+from pydantic import ValidationError
+
+from inference.core.workflows.core_steps.common.entities import StepExecutionMode
+from inference.core.workflows.core_steps.models.foundation.qwen_vlm import v2
+from inference.core.workflows.core_steps.models.foundation.qwen_vlm.v2 import (
+    DEFAULT_NATIVE_MODEL_VERSION,
+    DEFAULT_OPENROUTER_MODEL_VERSION,
+    FINE_TUNED_NATIVE_LABEL,
+    BlockManifest,
+    QwenVlmBlockV2,
+    build_qwen_openrouter_prompts,
+    build_reasoning_config,
+    encode_image_for_qwen_openrouter,
+)
+from inference.core.workflows.execution_engine.entities.base import WorkflowImageData
+
+# Copied literally from vlm-exam's `_NORMALIZED_XYXY_PROMPT_TEMPLATE`
+# (the benchmarked Qwen detection contract) so any accidental edit to the
+# block's template fails this exact-match test.
+EXPECTED_DETECTION_PROMPT_TEMPLATE = (
+    "Detect all objects in this image. "
+    "Output a JSON list where each entry contains the 2D bounding box "
+    'in the key "box_2d" and the text label in the key "label". '
+    'The "box_2d" value must be [x_min, y_min, x_max, y_max]: the '
+    "top-left and bottom-right corners as integers between 0 and 1000, "
+    "normalized to the image width (x) and height (y). "
+    "Return only the JSON list, with no extra text. "
+    "Only use these labels: {class_list}"
+)
+
+
+def _stub_image() -> WorkflowImageData:
+    return WorkflowImageData(
+        parent_metadata=MagicMock(
+            parent_id="root", workflow_root_ancestor_metadata=None
+        ),
+        numpy_image=np.zeros((10, 10, 3), dtype=np.uint8),
+    )
+
+
+def _base_run_kwargs(**overrides):
+    """Default kwargs for QwenVlmBlockV2.run; override specific keys per test."""
+    kwargs = dict(
+        images=[_stub_image()],
+        backend="native",
+        model_version="Qwen 3.5 VL 2B",
+        fine_tuned_model_id=None,
+        openrouter_model_version=DEFAULT_OPENROUTER_MODEL_VERSION,
+        task_type="caption",
+        prompt=None,
+        enable_thinking=False,
+        reasoning_effort="none",
+        output_structure=None,
+        classes=None,
+        api_key="rf_key:account",
+        privacy_level="deny",
+        max_tokens=None,
+        temperature=None,
+        max_concurrent_requests=None,
+    )
+    kwargs.update(overrides)
+    return kwargs
+
+
+# ---------------------------------------------------------------------------
+# Manifest validation
+# ---------------------------------------------------------------------------
+
+
+def test_manifest_defaults():
+    manifest = BlockManifest.model_validate(
+        {
+            "type": "roboflow_core/qwen_vlm@v2",
+            "name": "step",
+            "images": "$inputs.image",
+            "task_type": "caption",
+        }
+    )
+    assert manifest.backend == "native"
+    assert manifest.model_version == DEFAULT_NATIVE_MODEL_VERSION
+    assert manifest.openrouter_model_version == DEFAULT_OPENROUTER_MODEL_VERSION
+    # v2 benchmark-parity defaults: max_tokens unset (per-backend defaults
+    # apply at run time), provider-default temperature, reasoning off.
+    assert manifest.max_tokens is None
+    assert manifest.temperature is None
+    assert manifest.reasoning_effort == "none"
+
+
+def test_manifest_object_detection_requires_classes():
+    with pytest.raises(ValidationError):
+        BlockManifest.model_validate(
+            {
+                "type": "roboflow_core/qwen_vlm@v2",
+                "name": "step",
+                "images": "$inputs.image",
+                "task_type": "object-detection",
+                "backend": "openrouter",
+            }
+        )
+
+
+def test_manifest_native_fine_tuned_requires_model_id():
+    with pytest.raises(ValidationError, match="fine_tuned_model_id"):
+        BlockManifest.model_validate(
+            {
+                "type": "roboflow_core/qwen_vlm@v2",
+                "name": "step",
+                "images": "$inputs.image",
+                "task_type": "caption",
+                "backend": "native",
+                "model_version": FINE_TUNED_NATIVE_LABEL,
+            }
+        )
+
+
+def test_manifest_openrouter_resets_stale_fine_tuned_model_version():
+    manifest = BlockManifest.model_validate(
+        {
+            "type": "roboflow_core/qwen_vlm@v2",
+            "name": "step",
+            "images": "$inputs.image",
+            "task_type": "ocr",
+            "backend": "openrouter",
+            "model_version": FINE_TUNED_NATIVE_LABEL,
+        }
+    )
+    assert manifest.model_version == DEFAULT_NATIVE_MODEL_VERSION
+
+
+# ---------------------------------------------------------------------------
+# Reasoning config
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "effort,reasoning_required,expected",
+    [
+        ("none", False, {"enabled": False}),
+        ("none", True, {"effort": "low"}),
+        ("low", False, {"effort": "low"}),
+        ("low", True, {"effort": "low"}),
+        ("medium", False, {"effort": "medium"}),
+        ("high", False, {"effort": "high"}),
+        ("high", True, {"effort": "high"}),
+    ],
+)
+def test_build_reasoning_config(effort, reasoning_required, expected):
+    assert (
+        build_reasoning_config(effort, reasoning_required=reasoning_required)
+        == expected
+    )
+
+
+# ---------------------------------------------------------------------------
+# OpenRouter prompt builders
+# ---------------------------------------------------------------------------
+
+
+def test_detection_prompt_matches_benchmarked_template_exactly():
+    image = np.zeros((32, 32, 3), dtype=np.uint8)
+
+    prompts = build_qwen_openrouter_prompts(
+        images=[image],
+        task_type="object-detection",
+        prompt=None,
+        output_structure=None,
+        classes=["dog", "cat"],
+    )
+
+    text_part = prompts[0][0]["content"][1]
+    assert text_part["type"] == "text"
+    assert text_part["text"] == EXPECTED_DETECTION_PROMPT_TEMPLATE.format(
+        class_list="dog, cat"
+    )
+
+
+@pytest.mark.parametrize(
+    "task_type,kwargs",
+    [
+        ("unconstrained", {"prompt": "What is this?"}),
+        ("ocr", {}),
+        ("visual-question-answering", {"prompt": "How many dogs?"}),
+        ("caption", {}),
+        ("detailed-caption", {}),
+        ("classification", {"classes": ["a", "b"]}),
+        ("multi-label-classification", {"classes": ["a", "b"]}),
+        ("structured-answering", {"output_structure": {"field": "desc"}}),
+        ("object-detection", {"classes": ["a", "b"]}),
+    ],
+)
+def test_prompts_are_single_user_message_with_image_first(task_type, kwargs):
+    image = np.zeros((16, 16, 3), dtype=np.uint8)
+
+    prompts = build_qwen_openrouter_prompts(
+        images=[image],
+        task_type=task_type,
+        prompt=kwargs.get("prompt"),
+        output_structure=kwargs.get("output_structure"),
+        classes=kwargs.get("classes"),
+    )
+
+    assert len(prompts) == 1
+    messages = prompts[0]
+    # Qwen contract: single user message, no system role, image part first.
+    assert len(messages) == 1
+    assert messages[0]["role"] == "user"
+    content = messages[0]["content"]
+    assert len(content) == 2
+    assert content[0]["type"] == "image_url"
+    assert content[0]["image_url"]["url"].startswith("data:image/jpeg;base64,")
+    assert content[1]["type"] == "text"
+    assert len(content[1]["text"]) > 0
+
+
+def test_native_detection_prompt_uses_same_benchmarked_template():
+    # Both backends must emit one detection contract so the recommended
+    # parser (vlm_as_detector@v2, model_type="qwen") works regardless of
+    # backend. Regression guard for the v1-era x_min/0.0-1.0 prompt.
+    prompt = v2._build_native_prompt(
+        task_type="object-detection",
+        prompt=None,
+        output_structure=None,
+        classes=["dog", "cat"],
+    )
+
+    user_text, system_text = prompt.split("<system_prompt>")
+    assert user_text == EXPECTED_DETECTION_PROMPT_TEMPLATE.format(class_list="dog, cat")
+    # Empty system half: the model server substitutes its default system
+    # prompt, the closest native equivalent of the benchmark's
+    # single-user-message structure.
+    assert system_text == ""
+
+
+def test_classification_prompt_keeps_json_contract_and_classes():
+    image = np.zeros((16, 16, 3), dtype=np.uint8)
+
+    prompts = build_qwen_openrouter_prompts(
+        images=[image],
+        task_type="classification",
+        prompt=None,
+        output_structure=None,
+        classes=["dog", "cat"],
+    )
+
+    text = prompts[0][0]["content"][1]["text"]
+    # Output contract consumed by vlm_as_classifier@v2 must be preserved.
+    assert '{"class_name": "class-name", "confidence": 0.4}' in text
+    assert "List of all classes to be recognised by model: dog, cat" in text
+
+
+# ---------------------------------------------------------------------------
+# Payload-capped image encoding
+# ---------------------------------------------------------------------------
+
+
+def test_encode_image_under_cap_keeps_dimensions():
+    image = np.zeros((64, 128, 3), dtype=np.uint8)
+
+    encoded = encode_image_for_qwen_openrouter(image)
+
+    decoded = cv2.imdecode(
+        np.frombuffer(base64.b64decode(encoded), dtype=np.uint8), cv2.IMREAD_COLOR
+    )
+    assert decoded.shape[:2] == (64, 128)
+
+
+def test_encode_image_over_cap_downscales_until_it_fits():
+    rng = np.random.default_rng(42)
+    # Random noise compresses poorly, keeping the payload above a tiny cap
+    # until the image is downscaled substantially.
+    image = rng.integers(0, 256, size=(512, 1024, 3), dtype=np.uint8)
+
+    with patch.object(v2, "OPENROUTER_MAX_BASE64_BYTES", 50_000):
+        encoded = encode_image_for_qwen_openrouter(image)
+
+    assert len(encoded) <= 50_000
+    decoded = cv2.imdecode(
+        np.frombuffer(base64.b64decode(encoded), dtype=np.uint8), cv2.IMREAD_COLOR
+    )
+    assert decoded is not None
+    height, width = decoded.shape[:2]
+    assert height < 512 and width < 1024
+    # Aspect ratio is preserved through iterative downscaling.
+    assert width / height == pytest.approx(2.0, abs=0.1)
+
+
+# ---------------------------------------------------------------------------
+# Backend dispatch
+# ---------------------------------------------------------------------------
+
+
+@patch.object(QwenVlmBlockV2, "execute_openrouter_batch")
+def test_run_openrouter_passes_slug_reasoning_and_temperature(mock_or):
+    mock_or.return_value = [("resp", "")]
+    block = QwenVlmBlockV2(
+        model_manager=MagicMock(),
+        api_key="ws-key",
+        step_execution_mode=StepExecutionMode.LOCAL,
+    )
+
+    result = block.run(
+        **_base_run_kwargs(
+            backend="openrouter",
+            task_type="object-detection",
+            classes=["dog", "cat"],
+        )
+    )
+
+    assert mock_or.called
+    call_kwargs = mock_or.call_args.kwargs
+    assert call_kwargs["model"] == "qwen/qwen3.7-plus"
+    assert call_kwargs["reasoning"] == {"enabled": False}
+    assert call_kwargs["temperature"] is None
+    assert call_kwargs["max_tokens"] == 16384
+    assert call_kwargs["include_reasoning"] is True
+    assert result == [{"output": "resp", "classes": ["dog", "cat"], "thinking": ""}]
+
+
+@patch.object(QwenVlmBlockV2, "execute_openrouter_batch")
+def test_run_openrouter_populates_thinking_from_reasoning_trace(mock_or):
+    mock_or.return_value = [("the answer", "step-by-step trace")]
+    block = QwenVlmBlockV2(
+        model_manager=MagicMock(),
+        api_key="ws-key",
+        step_execution_mode=StepExecutionMode.LOCAL,
+    )
+
+    result = block.run(
+        **_base_run_kwargs(
+            backend="openrouter",
+            task_type="ocr",
+            reasoning_effort="low",
+        )
+    )
+
+    assert result == [
+        {"output": "the answer", "classes": None, "thinking": "step-by-step trace"}
+    ]
+
+
+@patch.object(QwenVlmBlockV2, "execute_openrouter_batch")
+def test_run_openrouter_reasoning_required_model_falls_back_to_low_effort(mock_or):
+    mock_or.return_value = [("resp", "")]
+    block = QwenVlmBlockV2(
+        model_manager=MagicMock(),
+        api_key="ws-key",
+        step_execution_mode=StepExecutionMode.LOCAL,
+    )
+
+    block.run(
+        **_base_run_kwargs(
+            backend="openrouter",
+            openrouter_model_version="Qwen 3.8 Max",
+            task_type="ocr",
+            reasoning_effort="none",
+        )
+    )
+
+    call_kwargs = mock_or.call_args.kwargs
+    assert call_kwargs["model"] == "qwen/qwen3.8-max"
+    # Qwen 3.8 Max rejects `enabled: false`; disabled maps to low effort.
+    assert call_kwargs["reasoning"] == {"effort": "low"}
+
+
+@patch.object(QwenVlmBlockV2, "execute_openrouter_batch")
+def test_run_openrouter_explicit_max_tokens_overrides_default(mock_or):
+    mock_or.return_value = [("resp", "")]
+    block = QwenVlmBlockV2(
+        model_manager=MagicMock(),
+        api_key="ws-key",
+        step_execution_mode=StepExecutionMode.LOCAL,
+    )
+
+    block.run(
+        **_base_run_kwargs(
+            backend="openrouter",
+            task_type="ocr",
+            max_tokens=2048,
+        )
+    )
+
+    assert mock_or.call_args.kwargs["max_tokens"] == 2048
+
+
+def test_run_native_default_max_tokens_defers_to_server_default():
+    model_manager = MagicMock()
+    fake_prediction = MagicMock()
+    fake_prediction.response = "answer"
+    model_manager.infer_from_request_sync.return_value = fake_prediction
+
+    block = QwenVlmBlockV2(
+        model_manager=model_manager,
+        api_key="ws-key",
+        step_execution_mode=StepExecutionMode.LOCAL,
+    )
+    block.run(**_base_run_kwargs())
+
+    request = model_manager.infer_from_request_sync.call_args.kwargs["request"]
+    # No block-side default: the request leaves max_new_tokens unset so the
+    # inference server default (512) applies.
+    assert request.max_new_tokens is None
+
+
+def test_run_native_explicit_max_tokens_is_forwarded_as_max_new_tokens():
+    model_manager = MagicMock()
+    fake_prediction = MagicMock()
+    fake_prediction.response = "answer"
+    model_manager.infer_from_request_sync.return_value = fake_prediction
+
+    block = QwenVlmBlockV2(
+        model_manager=model_manager,
+        api_key="ws-key",
+        step_execution_mode=StepExecutionMode.LOCAL,
+    )
+    block.run(**_base_run_kwargs(max_tokens=1024))
+
+    request = model_manager.infer_from_request_sync.call_args.kwargs["request"]
+    assert request.max_new_tokens == 1024
+
+
+def test_run_dispatches_to_local_native_when_step_mode_local():
+    model_manager = MagicMock()
+    fake_prediction = MagicMock()
+    fake_prediction.response = "native local answer"
+    model_manager.infer_from_request_sync.return_value = fake_prediction
+
+    block = QwenVlmBlockV2(
+        model_manager=model_manager,
+        api_key="ws-key",
+        step_execution_mode=StepExecutionMode.LOCAL,
+    )
+    result = block.run(**_base_run_kwargs())
+    assert result == [
+        {"output": "native local answer", "classes": None, "thinking": ""}
+    ]
+    model_manager.add_model.assert_called_once_with(
+        model_id="qwen3_5-2b", api_key="ws-key"
+    )
+
+
+def test_run_local_native_with_enable_thinking_splits_response():
+    model_manager = MagicMock()
+    fake_prediction = MagicMock()
+    fake_prediction.response = {"thinking": "reasoning...", "answer": "42"}
+    model_manager.infer_from_request_sync.return_value = fake_prediction
+
+    block = QwenVlmBlockV2(
+        model_manager=model_manager,
+        api_key="ws-key",
+        step_execution_mode=StepExecutionMode.LOCAL,
+    )
+    result = block.run(
+        **_base_run_kwargs(
+            task_type="unconstrained",
+            prompt="What is 6 times 7?",
+            enable_thinking=True,
+        )
+    )
+    assert result == [{"output": "42", "classes": None, "thinking": "reasoning..."}]
+    request = model_manager.infer_from_request_sync.call_args.kwargs["request"]
+    assert request.enable_thinking is True
+
+
+@patch(
+    "inference.core.workflows.core_steps.models.foundation.qwen_vlm.v2.InferenceHTTPClient"
+)
+def test_run_dispatches_to_remote_native_when_step_mode_remote(mock_client_cls):
+    fake_client = MagicMock()
+    fake_client.infer_lmm.return_value = {"response": "remote answer"}
+    mock_client_cls.return_value = fake_client
+
+    block = QwenVlmBlockV2(
+        model_manager=MagicMock(),
+        api_key="ws-key",
+        step_execution_mode=StepExecutionMode.REMOTE,
+    )
+    result = block.run(
+        **_base_run_kwargs(
+            model_version="Qwen 3.5 VL 0.8B",
+            task_type="ocr",
+        )
+    )
+    assert result == [{"output": "remote answer", "classes": None, "thinking": ""}]
+    assert fake_client.infer_lmm.call_args.kwargs["model_id"] == "qwen3_5-0.8b"
+
+
+def test_run_dispatches_to_local_native_with_fine_tuned_model_id():
+    model_manager = MagicMock()
+    fake_prediction = MagicMock()
+    fake_prediction.response = "finetune answer"
+    model_manager.infer_from_request_sync.return_value = fake_prediction
+
+    block = QwenVlmBlockV2(
+        model_manager=model_manager,
+        api_key="ws-key",
+        step_execution_mode=StepExecutionMode.LOCAL,
+    )
+    result = block.run(
+        **_base_run_kwargs(
+            model_version=FINE_TUNED_NATIVE_LABEL,
+            fine_tuned_model_id="your-workspace/3",
+        )
+    )
+    assert result == [{"output": "finetune answer", "classes": None, "thinking": ""}]
+    model_manager.add_model.assert_called_once_with(
+        model_id="your-workspace/3", api_key="ws-key"
+    )


### PR DESCRIPTION
## Summary

Fast-track version of #2825, squashed into a single commit on top of `fast-track/post-v1.4.1` for early deploy ahead of the Friday release cycle. Content is identical to `feat/qwen-vlm-v2` @ b2c39444d; only the base and history differ.

- New `qwen_vlm@v2` block: benchmarked OpenRouter roster, Qwen-native `box_2d`/0-1000 detection contract on both backends, reasoning control with retry fallback, payload-capped image encoding, `max_tokens=16384` OpenRouter default.
- `vlm_as_detector@v2` (numpy and tensor) gains `model_type="qwen"` with a dedicated parser.
- Shared `common/openrouter.py`: `reasoning` forwarding, reasoning-trace extraction, 4xx-gated retry-without-reasoning heuristic.

## Deploy dependency

Requires roboflow/roboflow#14563 (proxy: forward `reasoning`, raise `max_tokens` cap to 16384) on prod first; without it, managed-key OpenRouter calls 400 on the default `max_tokens`. Verified end-to-end against staging.

## Test plan

- [x] Unit tests: `test_openrouter.py` (34), `test_qwen_vlm_v2.py` (35), `test_qwen_detection_parsing.py`, `test_v2_tensor.py` — all passing locally
- [x] Ungated compile-only test for the `qwen_vlm@v2` -> `vlm_as_detector@v2` pair
- [x] Live staging probes: reasoning forwarding, 16384 cap, `reasoning_required` roster coverage, retry heuristic on relayed proxy errors
- [ ] Key-gated live integration tests (`WORKFLOWS_TEST_OPEN_ROUTER_API_KEY`) — run locally on demand

Full review history (two bot findings fixed, two blocking questions answered with staging probes) lives on #2825.