### PR TITLE
Default Qwen v2 max_tokens to 2048 and expand the OpenRouter VL roster

### DIFF
--- a/inference/core/version.py
+++ b/inference/core/version.py
@@ -1,4 +1,4 @@
-__version__ = "1.4.1.post1"
+__version__ = "1.4.1.post2"
 
 
 if __name__ == "__main__":

--- a/inference/core/workflows/core_steps/models/foundation/qwen_vlm/v2.py
+++ b/inference/core/workflows/core_steps/models/foundation/qwen_vlm/v2.py
@@ -17,18 +17,20 @@ that performed best for Qwen models in the vlm-exam benchmarks:
 * requests carry an explicit OpenRouter ``reasoning`` config: disabled by
   default (Qwen models default to extended reasoning, which bloats latency
   and can truncate answers), always-on for models that require it
-  (Qwen 3.8 Max rejects ``enabled: false``).
+  (Qwen 3.8 Max and the Qwen 3 VL Thinking variants reject
+  ``enabled: false``).
 * uploads are JPEG-encoded with iterative downscaling so the base64
   payload stays under Alibaba DashScope's data-URI limit.
-* ``max_tokens`` is unset by default; the OpenRouter path substitutes
-  16384 (benchmark parity — detection output on busy images easily
-  exceeds the old 500-token default) while the native path sends
-  nothing, so the inference server default (512) applies.
+* ``max_tokens`` defaults to 2048 on both backends so the UI always
+  sends a valid integer (an unset field fails Workflows validation).
+  Raise it explicitly (e.g. 8192) when a task needs a longer answer.
   ``temperature`` is not sent unless the user sets it.
 
-The OpenRouter model roster is restricted to the vlm-exam-benchmarked
-models. The native backend is carried over from v1 except for the
-object-detection prompt, which is unified on the benchmarked template.
+The OpenRouter roster is every current image-capable Qwen chat model
+except Qwen 2.5 VL (that family does not follow the shared
+``box_2d`` / 0-1000 detection contract). The native backend is
+carried over from v1 except for the object-detection prompt, which
+is unified on the benchmarked template.
 """
 
 import base64
@@ -97,8 +99,8 @@ from inference_sdk import InferenceHTTPClient
 #
 # - Native model_ids are Roboflow inference model IDs (e.g. ``qwen3_5-2b``).
 # - OpenRouter model_ids are OpenRouter slugs (e.g. ``qwen/qwen3.7-plus``).
-#   The OpenRouter roster is restricted to the models benchmarked in
-#   vlm-exam; ``reasoning_required`` marks models that reject
+#   The OpenRouter roster is every current image-capable Qwen chat model
+#   except Qwen 2.5 VL. ``reasoning_required`` marks models that reject
 #   ``reasoning: {"enabled": false}`` and must always receive an effort.
 
 MODEL_VARIANTS: Dict[str, Dict[str, Any]] = {
@@ -119,7 +121,7 @@ MODEL_VARIANTS: Dict[str, Dict[str, Any]] = {
         "backend": "native",
         "model_id": "qwen3_5-2b",
     },
-    # OpenRouter — vlm-exam-benchmarked hosted Qwen models.
+    # OpenRouter — image-capable hosted Qwen chat models.
     "Qwen 3.8 Max": {
         "backend": "openrouter",
         "model_id": "qwen/qwen3.8-max",
@@ -137,13 +139,84 @@ MODEL_VARIANTS: Dict[str, Dict[str, Any]] = {
         "backend": "openrouter",
         "model_id": "qwen/qwen3.8-27b",
     },
+    "Qwen 3.6 Plus": {
+        "backend": "openrouter",
+        "model_id": "qwen/qwen3.6-plus",
+    },
+    "Qwen 3.6 Flash": {
+        "backend": "openrouter",
+        "model_id": "qwen/qwen3.6-flash",
+    },
+    "Qwen 3.6 27B": {
+        "backend": "openrouter",
+        "model_id": "qwen/qwen3.6-27b",
+    },
+    "Qwen 3.6 35B A3B": {
+        "backend": "openrouter",
+        "model_id": "qwen/qwen3.6-35b-a3b",
+    },
+    "Qwen 3.5 Plus": {
+        "backend": "openrouter",
+        "model_id": "qwen/qwen3.5-plus-20260420",
+    },
+    "Qwen 3.5 Plus 02-15": {
+        "backend": "openrouter",
+        "model_id": "qwen/qwen3.5-plus-02-15",
+    },
+    "Qwen 3.5 Flash": {
+        "backend": "openrouter",
+        "model_id": "qwen/qwen3.5-flash-02-23",
+    },
+    "Qwen 3.5 9B": {
+        "backend": "openrouter",
+        "model_id": "qwen/qwen3.5-9b",
+    },
     "Qwen 3.5 27B": {
         "backend": "openrouter",
         "model_id": "qwen/qwen3.5-27b",
     },
+    "Qwen 3.5 35B A3B": {
+        "backend": "openrouter",
+        "model_id": "qwen/qwen3.5-35b-a3b",
+    },
+    "Qwen 3.5 122B A10B": {
+        "backend": "openrouter",
+        "model_id": "qwen/qwen3.5-122b-a10b",
+    },
+    "Qwen 3.5 397B A17B": {
+        "backend": "openrouter",
+        "model_id": "qwen/qwen3.5-397b-a17b",
+    },
+    "Qwen 3 VL 8B Instruct": {
+        "backend": "openrouter",
+        "model_id": "qwen/qwen3-vl-8b-instruct",
+    },
+    "Qwen 3 VL 8B Thinking": {
+        "backend": "openrouter",
+        "model_id": "qwen/qwen3-vl-8b-thinking",
+        "reasoning_required": True,
+    },
+    "Qwen 3 VL 30B A3B Instruct": {
+        "backend": "openrouter",
+        "model_id": "qwen/qwen3-vl-30b-a3b-instruct",
+    },
+    "Qwen 3 VL 30B A3B Thinking": {
+        "backend": "openrouter",
+        "model_id": "qwen/qwen3-vl-30b-a3b-thinking",
+        "reasoning_required": True,
+    },
+    "Qwen 3 VL 32B Instruct": {
+        "backend": "openrouter",
+        "model_id": "qwen/qwen3-vl-32b-instruct",
+    },
     "Qwen 3 VL 235B A22B": {
         "backend": "openrouter",
         "model_id": "qwen/qwen3-vl-235b-a22b-instruct",
+    },
+    "Qwen 3 VL 235B A22B Thinking": {
+        "backend": "openrouter",
+        "model_id": "qwen/qwen3-vl-235b-a22b-thinking",
+        "reasoning_required": True,
     },
 }
 
@@ -199,8 +272,8 @@ REASONING_EFFORT_METADATA = {
             "Turns extended reasoning off. Qwen models default to extended "
             "reasoning on OpenRouter, which bloats latency and can consume "
             "the whole token budget before a visible answer is produced. "
-            "Models that require reasoning (Qwen 3.8 Max) fall back to low "
-            "effort instead."
+            "Models that require reasoning (Qwen 3.8 Max and the Qwen 3 VL "
+            "Thinking variants) fall back to low effort instead."
         ),
     },
     "low": {
@@ -224,14 +297,10 @@ REASONING_EFFORT_METADATA = {
 # selected model rejects `reasoning: {"enabled": false}`.
 REASONING_REQUIRED_FALLBACK_EFFORT = "low"
 
-# Default OpenRouter completion budget when the user leaves `max_tokens`
-# unset. Benchmark parity: detection output on busy images easily exceeds
-# the older 500-token default, and reasoning models need headroom to think
-# and still emit a visible answer. The native path deliberately has no
-# block-side default: nothing is sent, so the inference server's own
-# default (512) applies. (v1 sends the mixin default of 500 instead;
-# effectively the same budget, but not the identical mechanism.)
-QWEN_OPENROUTER_DEFAULT_MAX_TOKENS = 16384
+# Default completion budget when the user leaves `max_tokens` unset.
+# 2048 is a valid integer in the Workflows UI range [1, 8192]; raise it
+# explicitly when a task needs a longer answer.
+QWEN_OPENROUTER_DEFAULT_MAX_TOKENS = 2048
 
 
 def build_reasoning_config(
@@ -661,12 +730,12 @@ The block uses Qwen-tuned inference plumbing validated by benchmarks:
   message, matching how Qwen models are trained.
 * **Reasoning control**: Qwen models default to extended reasoning on OpenRouter,
   which bloats latency and can consume the whole token budget. v2 disables it by
-  default and exposes a `reasoning_effort` knob. Qwen 3.8 Max requires reasoning
-  and falls back to low effort when disabled.
+  default and exposes a `reasoning_effort` knob. Qwen 3.8 Max and the Qwen 3 VL
+  Thinking variants require reasoning and fall back to low effort when disabled.
 * Uploads are downscaled automatically when they would exceed the Qwen provider
-  payload limit, and OpenRouter requests default to `max_tokens=16384` so
-  detection output is not truncated (the native backend keeps the server
-  default unless you set `max_tokens` explicitly).
+  payload limit. `max_tokens` defaults to 2048 on both backends so the UI
+  always has a valid integer; raise it explicitly (e.g. 8192) when you need
+  a longer answer.
 
 #### 🛠️ Backend selection
 
@@ -674,7 +743,7 @@ The block uses Qwen-tuned inference plumbing validated by benchmarks:
   your other Roboflow models. Lower latency. Recommended for tasks
   like OCR, captioning, and visual question answering.
 
-* **OpenRouter** — benchmark-validated hosted Qwen models reached via
+* **OpenRouter** — hosted Qwen vision models reached via
   [OpenRouter](https://openrouter.ai/). Defaults to a Roboflow-managed API key and
   bills your Roboflow credits. Paste your own `sk-or-...` key in the `api_key`
   field to bypass Roboflow billing. Recommended for structured tasks that benefit
@@ -797,15 +866,14 @@ class BlockManifest(OpenRouterBlockManifestMixin):
         },
     )
 
-    # OpenRouter model picker: friendly-name dropdown bound to OpenRouter
-    # slugs, restricted to the vlm-exam-benchmarked models.
+    # OpenRouter model picker: friendly-name dropdown bound to OpenRouter slugs.
     openrouter_model_version: Union[
         Selector(kind=[STRING_KIND]), OpenRouterModelVersion
     ] = Field(
         default=DEFAULT_OPENROUTER_MODEL_VERSION,
         description=(
-            "OpenRouter-hosted Qwen variant. The roster is restricted to "
-            "benchmark-validated models."
+            "OpenRouter-hosted Qwen vision variant. The roster is every "
+            "current image-capable Qwen chat model except Qwen 2.5 VL."
         ),
         examples=[DEFAULT_OPENROUTER_MODEL_VERSION, "Qwen 3.8 Max"],
         json_schema_extra={
@@ -929,14 +997,13 @@ class BlockManifest(OpenRouterBlockManifestMixin):
         },
     )
     max_tokens: Optional[int] = Field(
-        default=None,
+        default=QWEN_OPENROUTER_DEFAULT_MAX_TOKENS,
         description=(
             "Maximum number of tokens the model can generate in its response. "
-            "When unset, each backend applies its own default: OpenRouter "
-            f"requests use {QWEN_OPENROUTER_DEFAULT_MAX_TOKENS} (headroom for "
-            "detection output and reasoning models; billing is based on "
-            "tokens actually generated, not on this limit), while the native "
-            "backend defers to the inference server default (512)."
+            f"Defaults to {QWEN_OPENROUTER_DEFAULT_MAX_TOKENS} on both backends "
+            "so the UI always sends a valid integer. Raise it explicitly "
+            "(e.g. 8192) when a task needs a longer answer. Billing is based "
+            "on tokens actually generated, not on this limit."
         ),
         gt=1,
     )

--- a/inference/core/workflows/core_steps/models/foundation/qwen_vlm/v2.py
+++ b/inference/core/workflows/core_steps/models/foundation/qwen_vlm/v2.py
@@ -16,21 +16,13 @@ that performed best for Qwen models in the vlm-exam benchmarks:
   text** and no system role, matching how the benchmarks prompt Qwen.
 * requests carry an explicit OpenRouter ``reasoning`` config: disabled by
   default (Qwen models default to extended reasoning, which bloats latency
-  and can truncate answers), always-on for models that require it
-  (Qwen 3.8 Max and the Qwen 3 VL Thinking variants reject
-  ``enabled: false``).
+  and can truncate answers), always-on for models that require it.
 * uploads are JPEG-encoded with iterative downscaling so the base64
   payload stays under Alibaba DashScope's data-URI limit.
-* ``max_tokens`` defaults to 2048 on both backends so the UI always
-  sends a valid integer (an unset field fails Workflows validation).
-  Raise it explicitly (e.g. 8192) when a task needs a longer answer.
-  ``temperature`` is not sent unless the user sets it.
+* ``temperature`` is not sent unless the user sets it.
 
-The OpenRouter roster is every current image-capable Qwen chat model
-except Qwen 2.5 VL (that family does not follow the shared
-``box_2d`` / 0-1000 detection contract). The native backend is
-carried over from v1 except for the object-detection prompt, which
-is unified on the benchmarked template.
+The native backend is carried over from v1 except for the
+object-detection prompt, which is unified on the benchmarked template.
 """
 
 import base64
@@ -99,8 +91,7 @@ from inference_sdk import InferenceHTTPClient
 #
 # - Native model_ids are Roboflow inference model IDs (e.g. ``qwen3_5-2b``).
 # - OpenRouter model_ids are OpenRouter slugs (e.g. ``qwen/qwen3.7-plus``).
-#   The OpenRouter roster is every current image-capable Qwen chat model
-#   except Qwen 2.5 VL. ``reasoning_required`` marks models that reject
+#   ``reasoning_required`` marks models that reject
 #   ``reasoning: {"enabled": false}`` and must always receive an effort.
 
 MODEL_VARIANTS: Dict[str, Dict[str, Any]] = {
@@ -297,9 +288,7 @@ REASONING_EFFORT_METADATA = {
 # selected model rejects `reasoning: {"enabled": false}`.
 REASONING_REQUIRED_FALLBACK_EFFORT = "low"
 
-# Default completion budget when the user leaves `max_tokens` unset.
-# 2048 is a valid integer in the Workflows UI range [1, 8192]; raise it
-# explicitly when a task needs a longer answer.
+# Default completion budget when max_tokens is unset.
 QWEN_OPENROUTER_DEFAULT_MAX_TOKENS = 2048
 
 
@@ -733,9 +722,8 @@ The block uses Qwen-tuned inference plumbing validated by benchmarks:
   default and exposes a `reasoning_effort` knob. Qwen 3.8 Max and the Qwen 3 VL
   Thinking variants require reasoning and fall back to low effort when disabled.
 * Uploads are downscaled automatically when they would exceed the Qwen provider
-  payload limit. `max_tokens` defaults to 2048 on both backends so the UI
-  always has a valid integer; raise it explicitly (e.g. 8192) when you need
-  a longer answer.
+  payload limit. `max_tokens` defaults to 2048 on both backends; raise it
+  explicitly (e.g. 8192) when you need a longer answer.
 
 #### 🛠️ Backend selection
 
@@ -866,7 +854,6 @@ class BlockManifest(OpenRouterBlockManifestMixin):
         },
     )
 
-    # OpenRouter model picker: friendly-name dropdown bound to OpenRouter slugs.
     openrouter_model_version: Union[
         Selector(kind=[STRING_KIND]), OpenRouterModelVersion
     ] = Field(
@@ -1000,10 +987,9 @@ class BlockManifest(OpenRouterBlockManifestMixin):
         default=QWEN_OPENROUTER_DEFAULT_MAX_TOKENS,
         description=(
             "Maximum number of tokens the model can generate in its response. "
-            f"Defaults to {QWEN_OPENROUTER_DEFAULT_MAX_TOKENS} on both backends "
-            "so the UI always sends a valid integer. Raise it explicitly "
-            "(e.g. 8192) when a task needs a longer answer. Billing is based "
-            "on tokens actually generated, not on this limit."
+            f"Defaults to {QWEN_OPENROUTER_DEFAULT_MAX_TOKENS} on both backends. "
+            "Raise it explicitly (e.g. 8192) when a task needs a longer answer. "
+            "Billing is based on tokens actually generated, not on this limit."
         ),
         gt=1,
     )

--- a/tests/workflows/unit_tests/core_steps/models/foundation/test_qwen_vlm_v2.py
+++ b/tests/workflows/unit_tests/core_steps/models/foundation/test_qwen_vlm_v2.py
@@ -62,7 +62,7 @@ def _base_run_kwargs(**overrides):
         classes=None,
         api_key="rf_key:account",
         privacy_level="deny",
-        max_tokens=None,
+        max_tokens=2048,
         temperature=None,
         max_concurrent_requests=None,
     )
@@ -87,9 +87,8 @@ def test_manifest_defaults():
     assert manifest.backend == "native"
     assert manifest.model_version == DEFAULT_NATIVE_MODEL_VERSION
     assert manifest.openrouter_model_version == DEFAULT_OPENROUTER_MODEL_VERSION
-    # v2 benchmark-parity defaults: max_tokens unset (per-backend defaults
-    # apply at run time), provider-default temperature, reasoning off.
-    assert manifest.max_tokens is None
+    # UI requires an integer in [1, 8192]; 2048 is the block default.
+    assert manifest.max_tokens == 2048
     assert manifest.temperature is None
     assert manifest.reasoning_effort == "none"
 
@@ -319,7 +318,7 @@ def test_run_openrouter_passes_slug_reasoning_and_temperature(mock_or):
     assert call_kwargs["model"] == "qwen/qwen3.7-plus"
     assert call_kwargs["reasoning"] == {"enabled": False}
     assert call_kwargs["temperature"] is None
-    assert call_kwargs["max_tokens"] == 16384
+    assert call_kwargs["max_tokens"] == 2048
     assert call_kwargs["include_reasoning"] is True
     assert result == [{"output": "resp", "classes": ["dog", "cat"], "thinking": ""}]
 
@@ -383,14 +382,14 @@ def test_run_openrouter_explicit_max_tokens_overrides_default(mock_or):
         **_base_run_kwargs(
             backend="openrouter",
             task_type="ocr",
-            max_tokens=2048,
+            max_tokens=8192,
         )
     )
 
-    assert mock_or.call_args.kwargs["max_tokens"] == 2048
+    assert mock_or.call_args.kwargs["max_tokens"] == 8192
 
 
-def test_run_native_default_max_tokens_defers_to_server_default():
+def test_run_native_default_max_tokens_is_forwarded():
     model_manager = MagicMock()
     fake_prediction = MagicMock()
     fake_prediction.response = "answer"
@@ -404,9 +403,7 @@ def test_run_native_default_max_tokens_defers_to_server_default():
     block.run(**_base_run_kwargs())
 
     request = model_manager.infer_from_request_sync.call_args.kwargs["request"]
-    # No block-side default: the request leaves max_new_tokens unset so the
-    # inference server default (512) applies.
-    assert request.max_new_tokens is None
+    assert request.max_new_tokens == 2048
 
 
 def test_run_native_explicit_max_tokens_is_forwarded_as_max_new_tokens():

--- a/tests/workflows/unit_tests/core_steps/models/foundation/test_qwen_vlm_v2.py
+++ b/tests/workflows/unit_tests/core_steps/models/foundation/test_qwen_vlm_v2.py
@@ -87,7 +87,6 @@ def test_manifest_defaults():
     assert manifest.backend == "native"
     assert manifest.model_version == DEFAULT_NATIVE_MODEL_VERSION
     assert manifest.openrouter_model_version == DEFAULT_OPENROUTER_MODEL_VERSION
-    # UI requires an integer in [1, 8192]; 2048 is the block default.
     assert manifest.max_tokens == 2048
     assert manifest.temperature is None
     assert manifest.reasoning_effort == "none"


### PR DESCRIPTION
The unset max_tokens field was failing in the Workflows UI because the form requires an integer between 1 and 8192. I set the default to 2048 on both the native and OpenRouter paths; raise it yourself (8192 is fine) if a task needs a longer answer. The OpenRouter dropdown now lists every current image-capable Qwen chat model except Qwen 2.5 VL, which does not speak the box_2d / 0-1000 detection format we parse. Qwen 3.8 Max and the three Qwen 3 VL Thinking variants reject disabled reasoning, so those four keep reasoning on at low effort when you leave the knob off. Version is 1.4.1.post2. I ran the unit tests and then hit prod with the same payload the block sends; all 23 slugs came back with a caption.