### PR TITLE
Add Meta Muse VLM v1 workflow block

### DIFF
--- a/inference/core/version.py
+++ b/inference/core/version.py
@@ -1,4 +1,4 @@
-__version__ = "1.4.1.post2"
+__version__ = "1.4.1.post3"
 
 
 if __name__ == "__main__":

--- a/inference/core/workflows/core_steps/formatters/vlm_as_detector/muse_detection_parsing.py
+++ b/inference/core/workflows/core_steps/formatters/vlm_as_detector/muse_detection_parsing.py
@@ -1,4 +1,5 @@
 import json
+import math
 from typing import List, Optional, Union
 from uuid import uuid4
 
@@ -26,6 +27,21 @@ _BOX_FIELDS = ("x_min", "y_min", "x_max", "y_max")
 
 
 def extract_flat_object_entries(prediction: str) -> List[dict]:
+    """Recover detection dicts from loose, non-JSON Muse output.
+
+    Muse Glimmer sometimes emits ``{...}, {...}`` objects without the
+    surrounding array brackets, which ``json.loads`` rejects. Scan the raw
+    string and decode each top-level ``{...}`` object individually. Only
+    dicts carrying all four named box fields are kept, so unrelated JSON
+    fragments in garbage output do not turn a parse failure into an
+    empty success.
+
+    Args:
+        prediction: Raw VLM output that failed regular JSON parsing.
+
+    Returns:
+        List of detection entry dicts; empty when nothing recoverable.
+    """
     decoder = json.JSONDecoder()
     entries: List[dict] = []
     index = 0
@@ -38,7 +54,7 @@ def extract_flat_object_entries(prediction: str) -> List[dict]:
         except json.JSONDecodeError:
             index = start + 1
             continue
-        if isinstance(entry, dict):
+        if isinstance(entry, dict) and all(field in entry for field in _BOX_FIELDS):
             entries.append(entry)
         index = end
     return entries
@@ -47,6 +63,21 @@ def extract_flat_object_entries(prediction: str) -> List[dict]:
 def extract_muse_detection_entries(
     parsed_data: Union[dict, list],
 ) -> List[dict]:
+    """Extract the list of detection entries from parsed Muse JSON output.
+
+    The Muse prompt asks for a bare JSON array, but responses may wrap the
+    entries in a ``{"detections": [...]}`` object or return a single bare
+    entry; all three shapes are accepted.
+
+    Args:
+        parsed_data: JSON payload extracted from the VLM output.
+
+    Returns:
+        List of raw detection entry dicts.
+
+    Raises:
+        ValueError: If the payload matches none of the accepted shapes.
+    """
     if isinstance(parsed_data, list):
         return [entry for entry in parsed_data if isinstance(entry, dict)]
     if isinstance(parsed_data, dict):
@@ -59,12 +90,27 @@ def extract_muse_detection_entries(
 
 
 def get_muse_detection_box(detection: dict) -> Optional[List[float]]:
-    try:
-        box = [float(detection[field]) for field in _BOX_FIELDS]
-    except (KeyError, TypeError, ValueError):
-        return None
-    if any(isinstance(detection.get(field), bool) for field in _BOX_FIELDS):
-        return None
+    """Read a valid bounding box from a Muse detection entry.
+
+    Args:
+        detection: Raw detection entry.
+
+    Returns:
+        ``[x_min, y_min, x_max, y_max]`` floats in the 0-1000 normalized
+        space, or ``None`` when any field is missing or not a plain finite
+        number (bools, numeric strings, and NaN/inf are rejected —
+        ``json.loads`` accepts bare ``NaN`` and NaN would survive the
+        clamp into ``xyxy``).
+    """
+    box: List[float] = []
+    for field in _BOX_FIELDS:
+        value = detection.get(field)
+        if not isinstance(value, (int, float)) or isinstance(value, bool):
+            return None
+        value = float(value)
+        if not math.isfinite(value):
+            return None
+        box.append(value)
     return box
 
 
@@ -73,6 +119,20 @@ def convert_muse_detection_to_pixel_xyxy(
     image_height: int,
     image_width: int,
 ) -> List[float]:
+    """Convert 0-1000-normalized named fields into original-image pixels.
+
+    Coordinates are clamped to the 0-1000 range before scaling so slightly
+    out-of-range model output stays inside the image.
+
+    Args:
+        box: ``[x_min, y_min, x_max, y_max]`` normalized to 0-1000.
+        image_height: Original image height in pixels.
+        image_width: Original image width in pixels.
+
+    Returns:
+        ``[x_min, y_min, x_max, y_max]`` in pixel coordinates of the
+        original image.
+    """
     x_min, y_min, x_max, y_max = (
         min(max(value, 0.0), MUSE_BOX_COORDINATE_SCALE) for value in box
     )
@@ -87,6 +147,28 @@ def parse_muse_object_detection_response(
     classes: List[str],
     inference_id: str,
 ) -> sv.Detections:
+    """Parse Muse block object-detection output into detections.
+
+    The Muse block prompts for a JSON array of entries with named
+    ``x_min``/``y_min``/``x_max``/``y_max`` fields normalized to 0-1000 and
+    a ``label`` field. Entries without a well-formed box are skipped (with
+    a debug log) rather than failing the whole response; labels outside
+    ``classes`` are kept with ``class_id == -1``, and missing or empty
+    labels map to ``"unknown"``. Confidence is hardcoded to 1.0 because
+    VLMs do not produce calibrated detection confidences.
+
+    Args:
+        image: Workflow image the detections refer to.
+        parsed_data: JSON payload extracted from the VLM output.
+        classes: Class names used to map labels onto class ids.
+        inference_id: Identifier attached to every parsed detection.
+
+    Returns:
+        Parsed detections in the original image's coordinate space.
+
+    Raises:
+        ValueError: If the response matches no accepted Muse shape.
+    """
     entries = extract_muse_detection_entries(parsed_data=parsed_data)
     class_name2id = create_classes_index(classes=classes)
     image_height, image_width = image.numpy_image.shape[:2]

--- a/inference/core/workflows/core_steps/formatters/vlm_as_detector/muse_detection_parsing.py
+++ b/inference/core/workflows/core_steps/formatters/vlm_as_detector/muse_detection_parsing.py
@@ -1,0 +1,138 @@
+import json
+from typing import List, Optional, Union
+from uuid import uuid4
+
+import numpy as np
+import supervision as sv
+from supervision.config import CLASS_NAME_DATA_FIELD
+
+from inference.core.logger import logger
+from inference.core.workflows.core_steps.common.utils import (
+    attach_parents_coordinates_to_sv_detections,
+)
+from inference.core.workflows.core_steps.formatters.vlm_as_detector.gemini_detection_parsing import (
+    create_classes_index,
+)
+from inference.core.workflows.execution_engine.constants import (
+    DETECTION_ID_KEY,
+    IMAGE_DIMENSIONS_KEY,
+    INFERENCE_ID_KEY,
+    PREDICTION_TYPE_KEY,
+)
+from inference.core.workflows.execution_engine.entities.base import WorkflowImageData
+
+MUSE_BOX_COORDINATE_SCALE = 1000.0
+_BOX_FIELDS = ("x_min", "y_min", "x_max", "y_max")
+
+
+def extract_flat_object_entries(prediction: str) -> List[dict]:
+    decoder = json.JSONDecoder()
+    entries: List[dict] = []
+    index = 0
+    while True:
+        start = prediction.find("{", index)
+        if start == -1:
+            break
+        try:
+            entry, end = decoder.raw_decode(prediction, start)
+        except json.JSONDecodeError:
+            index = start + 1
+            continue
+        if isinstance(entry, dict):
+            entries.append(entry)
+        index = end
+    return entries
+
+
+def extract_muse_detection_entries(
+    parsed_data: Union[dict, list],
+) -> List[dict]:
+    if isinstance(parsed_data, list):
+        return [entry for entry in parsed_data if isinstance(entry, dict)]
+    if isinstance(parsed_data, dict):
+        detections = parsed_data.get("detections")
+        if isinstance(detections, list):
+            return [entry for entry in detections if isinstance(entry, dict)]
+        if all(field in parsed_data for field in _BOX_FIELDS):
+            return [parsed_data]
+    raise ValueError("Unexpected Muse object detection response format")
+
+
+def get_muse_detection_box(detection: dict) -> Optional[List[float]]:
+    try:
+        box = [float(detection[field]) for field in _BOX_FIELDS]
+    except (KeyError, TypeError, ValueError):
+        return None
+    if any(isinstance(detection.get(field), bool) for field in _BOX_FIELDS):
+        return None
+    return box
+
+
+def convert_muse_detection_to_pixel_xyxy(
+    box: List[float],
+    image_height: int,
+    image_width: int,
+) -> List[float]:
+    x_min, y_min, x_max, y_max = (
+        min(max(value, 0.0), MUSE_BOX_COORDINATE_SCALE) for value in box
+    )
+    scale_x = image_width / MUSE_BOX_COORDINATE_SCALE
+    scale_y = image_height / MUSE_BOX_COORDINATE_SCALE
+    return [x_min * scale_x, y_min * scale_y, x_max * scale_x, y_max * scale_y]
+
+
+def parse_muse_object_detection_response(
+    image: WorkflowImageData,
+    parsed_data: Union[dict, list],
+    classes: List[str],
+    inference_id: str,
+) -> sv.Detections:
+    entries = extract_muse_detection_entries(parsed_data=parsed_data)
+    class_name2id = create_classes_index(classes=classes)
+    image_height, image_width = image.numpy_image.shape[:2]
+
+    xyxy, class_id, class_name, confidence = [], [], [], []
+    for detection in entries:
+        box = get_muse_detection_box(detection=detection)
+        if box is None:
+            logger.debug(
+                "Skipping Muse detection entry without named 0-1000 fields: %r",
+                detection,
+            )
+            continue
+        xyxy.append(
+            convert_muse_detection_to_pixel_xyxy(
+                box=box,
+                image_height=image_height,
+                image_width=image_width,
+            )
+        )
+        label = str(detection.get("label") or "unknown")
+        class_id.append(class_name2id.get(label, -1))
+        class_name.append(label)
+        confidence.append(1.0)
+
+    if not xyxy:
+        return sv.Detections.empty()
+
+    xyxy = np.array(xyxy).round(0)
+    detection_ids = np.array([str(uuid4()) for _ in range(len(xyxy))])
+    dimensions = np.array([[image_height, image_width]] * len(xyxy))
+    detections_result = sv.Detections(
+        xyxy=xyxy,
+        confidence=np.array(confidence),
+        class_id=np.array(class_id).astype(int),
+        mask=None,
+        tracker_id=None,
+        data={
+            CLASS_NAME_DATA_FIELD: np.array(class_name),
+            IMAGE_DIMENSIONS_KEY: dimensions,
+            INFERENCE_ID_KEY: np.array([inference_id] * len(xyxy)),
+            DETECTION_ID_KEY: detection_ids,
+            PREDICTION_TYPE_KEY: np.array(["object-detection"] * len(xyxy)),
+        },
+    )
+    return attach_parents_coordinates_to_sv_detections(
+        detections=detections_result,
+        image=image,
+    )

--- a/inference/core/workflows/core_steps/formatters/vlm_as_detector/v2.py
+++ b/inference/core/workflows/core_steps/formatters/vlm_as_detector/v2.py
@@ -18,6 +18,10 @@ from inference.core.workflows.core_steps.common.vlms import VLM_TASKS_METADATA
 from inference.core.workflows.core_steps.formatters.vlm_as_detector.gemini_detection_parsing import (
     parse_gemini_object_detection_response,
 )
+from inference.core.workflows.core_steps.formatters.vlm_as_detector.muse_detection_parsing import (
+    extract_flat_object_entries,
+    parse_muse_object_detection_response,
+)
 from inference.core.workflows.core_steps.formatters.vlm_as_detector.openai_detection_parsing import (
     parse_openai_object_detection_response,
 )
@@ -151,7 +155,7 @@ This version (v2) includes the following enhancements over v1:
 
 ## Requirements
 
-This block requires an image input (for metadata and dimensions) and a VLM output string containing JSON detection data. The JSON can be raw JSON or wrapped in Markdown code blocks (```json ... ```). The block supports six model types: "openai", "google-gemini", "anthropic-claude", "spacexai", "qwen", and "florence-2". It supports multiple task types: "object-detection", "open-vocabulary-object-detection", "object-detection-and-caption", "phrase-grounded-object-detection", "region-proposal", and "ocr-with-text-detection". The `classes` parameter is required for OpenAI, Gemini, Claude, SpaceXAI, and Qwen models (to map class names to IDs) but optional for Florence-2 (some tasks don't require it). Classes are mapped to IDs by index (first class = 0, second = 1, etc.). Classes not in the list get class_id = -1. The block outputs object detection predictions in standard format (compatible with detection blocks), error_status (boolean), and inference_id (INFERENCE_ID_KIND) for tracking.
+This block requires an image input (for metadata and dimensions) and a VLM output string containing JSON detection data. The JSON can be raw JSON or wrapped in Markdown code blocks (```json ... ```). The block supports seven model types: "openai", "google-gemini", "anthropic-claude", "spacexai", "qwen", "muse", and "florence-2". It supports multiple task types: "object-detection", "open-vocabulary-object-detection", "object-detection-and-caption", "phrase-grounded-object-detection", "region-proposal", and "ocr-with-text-detection". The `classes` parameter is required for OpenAI, Gemini, Claude, SpaceXAI, Qwen, and Muse models (to map class names to IDs) but optional for Florence-2 (some tasks don't require it). Classes are mapped to IDs by index (first class = 0, second = 1, etc.). Classes not in the list get class_id = -1. The block outputs object detection predictions in standard format (compatible with detection blocks), error_status (boolean), and inference_id (INFERENCE_ID_KIND) for tracking.
 """
 
 SHORT_DESCRIPTION = "Parses raw string into object-detection prediction."
@@ -225,6 +229,7 @@ class BlockManifest(WorkflowBlockManifest):
                         "anthropic-claude",
                         "spacexai",
                         "qwen",
+                        "muse",
                     ],
                     "required": True,
                 },
@@ -232,15 +237,22 @@ class BlockManifest(WorkflowBlockManifest):
         },
     )
     model_type: Literal[
-        "openai", "google-gemini", "anthropic-claude", "spacexai", "qwen", "florence-2"
+        "openai",
+        "google-gemini",
+        "anthropic-claude",
+        "spacexai",
+        "qwen",
+        "muse",
+        "florence-2",
     ] = Field(
-        description="Type of the VLM/LLM model that generated the prediction. Determines which parser is used to extract detection data from the JSON output. Supported models: 'openai' (GPT-4V), 'google-gemini' (Gemini Vision), 'anthropic-claude' (Claude Vision), 'spacexai' (Grok), 'qwen' (Qwen-VL via OpenRouter), 'florence-2' (Microsoft Florence-2). Each model type has different JSON output formats, so the correct model type must be specified for proper parsing.",
+        description="Type of the VLM/LLM model that generated the prediction. Determines which parser is used to extract detection data from the JSON output. Supported models: 'openai' (GPT-4V), 'google-gemini' (Gemini Vision), 'anthropic-claude' (Claude Vision), 'spacexai' (Grok), 'qwen' (Qwen-VL via OpenRouter), 'muse' (Meta Muse via OpenRouter), 'florence-2' (Microsoft Florence-2). Each model type has different JSON output formats, so the correct model type must be specified for proper parsing.",
         examples=[
             ["openai"],
             ["google-gemini"],
             ["anthropic-claude"],
             ["spacexai"],
             ["qwen"],
+            ["muse"],
             ["florence-2"],
         ],
     )
@@ -298,6 +310,10 @@ class VLMAsDetectorBlockV2(WorkflowBlock):
         error_status, parsed_data = string2json(
             raw_json=vlm_output,
         )
+        if error_status and model_type == "muse":
+            loose_entries = extract_flat_object_entries(vlm_output)
+            if loose_entries:
+                error_status, parsed_data = False, loose_entries
         if error_status:
             return {
                 "error_status": True,
@@ -534,6 +550,7 @@ REGISTERED_PARSERS = {
     ("anthropic-claude", "object-detection"): parse_llm_object_detection_response,
     ("spacexai", "object-detection"): parse_spacexai_object_detection_response,
     ("qwen", "object-detection"): parse_qwen_object_detection_response,
+    ("muse", "object-detection"): parse_muse_object_detection_response,
     # Florence 2
     ("florence-2", "object-detection"): partial(
         parse_florence2_object_detection_response, florence_task_type="<OD>"

--- a/inference/core/workflows/core_steps/formatters/vlm_as_detector/v2_tensor.py
+++ b/inference/core/workflows/core_steps/formatters/vlm_as_detector/v2_tensor.py
@@ -21,6 +21,12 @@ from inference.core.workflows.core_steps.formatters.vlm_as_detector.gemini_detec
     get_gemini_detection_class_name,
     scale_confidence,
 )
+from inference.core.workflows.core_steps.formatters.vlm_as_detector.muse_detection_parsing import (
+    convert_muse_detection_to_pixel_xyxy,
+    extract_flat_object_entries,
+    extract_muse_detection_entries,
+    get_muse_detection_box,
+)
 from inference.core.workflows.core_steps.formatters.vlm_as_detector.openai_detection_parsing import (
     convert_openai_detection_to_pixel_xyxy,
 )
@@ -169,7 +175,7 @@ This version (v2) includes the following enhancements over v1:
 
 ## Requirements
 
-This block requires an image input (for metadata and dimensions) and a VLM output string containing JSON detection data. The JSON can be raw JSON or wrapped in Markdown code blocks (```json ... ```). The block supports six model types: "openai", "google-gemini", "anthropic-claude", "spacexai", "qwen", and "florence-2". It supports multiple task types: "object-detection", "open-vocabulary-object-detection", "object-detection-and-caption", "phrase-grounded-object-detection", "region-proposal", and "ocr-with-text-detection". The `classes` parameter is required for OpenAI, Gemini, Claude, SpaceXAI, and Qwen models (to map class names to IDs) but optional for Florence-2 (some tasks don't require it). Classes are mapped to IDs by index (first class = 0, second = 1, etc.). Classes not in the list get class_id = -1. The block outputs object detection predictions in standard format (compatible with detection blocks), error_status (boolean), and inference_id (INFERENCE_ID_KIND) for tracking.
+This block requires an image input (for metadata and dimensions) and a VLM output string containing JSON detection data. The JSON can be raw JSON or wrapped in Markdown code blocks (```json ... ```). The block supports seven model types: "openai", "google-gemini", "anthropic-claude", "spacexai", "qwen", "muse", and "florence-2". It supports multiple task types: "object-detection", "open-vocabulary-object-detection", "object-detection-and-caption", "phrase-grounded-object-detection", "region-proposal", and "ocr-with-text-detection". The `classes` parameter is required for OpenAI, Gemini, Claude, SpaceXAI, Qwen, and Muse models (to map class names to IDs) but optional for Florence-2 (some tasks don't require it). Classes are mapped to IDs by index (first class = 0, second = 1, etc.). Classes not in the list get class_id = -1. The block outputs object detection predictions in standard format (compatible with detection blocks), error_status (boolean), and inference_id (INFERENCE_ID_KIND) for tracking.
 """
 
 SHORT_DESCRIPTION = "Parses raw string into object-detection prediction."
@@ -243,6 +249,7 @@ class BlockManifest(WorkflowBlockManifest):
                         "anthropic-claude",
                         "spacexai",
                         "qwen",
+                        "muse",
                     ],
                     "required": True,
                 },
@@ -250,15 +257,22 @@ class BlockManifest(WorkflowBlockManifest):
         },
     )
     model_type: Literal[
-        "openai", "google-gemini", "anthropic-claude", "spacexai", "qwen", "florence-2"
+        "openai",
+        "google-gemini",
+        "anthropic-claude",
+        "spacexai",
+        "qwen",
+        "muse",
+        "florence-2",
     ] = Field(
-        description="Type of the VLM/LLM model that generated the prediction. Determines which parser is used to extract detection data from the JSON output. Supported models: 'openai' (GPT-4V), 'google-gemini' (Gemini Vision), 'anthropic-claude' (Claude Vision), 'spacexai' (Grok), 'qwen' (Qwen-VL via OpenRouter), 'florence-2' (Microsoft Florence-2). Each model type has different JSON output formats, so the correct model type must be specified for proper parsing.",
+        description="Type of the VLM/LLM model that generated the prediction. Determines which parser is used to extract detection data from the JSON output. Supported models: 'openai' (GPT-4V), 'google-gemini' (Gemini Vision), 'anthropic-claude' (Claude Vision), 'spacexai' (Grok), 'qwen' (Qwen-VL via OpenRouter), 'muse' (Meta Muse via OpenRouter), 'florence-2' (Microsoft Florence-2). Each model type has different JSON output formats, so the correct model type must be specified for proper parsing.",
         examples=[
             ["openai"],
             ["google-gemini"],
             ["anthropic-claude"],
             ["spacexai"],
             ["qwen"],
+            ["muse"],
             ["florence-2"],
         ],
     )
@@ -317,6 +331,10 @@ class VLMAsDetectorBlockV2(WorkflowBlock):
         error_status, parsed_data = string2json(
             raw_json=vlm_output,
         )
+        if error_status and model_type == "muse":
+            loose_entries = extract_flat_object_entries(vlm_output)
+            if loose_entries:
+                error_status, parsed_data = False, loose_entries
         if error_status:
             return {
                 "error_status": True,
@@ -845,6 +863,58 @@ def parse_qwen_object_detection_response(
     )
 
 
+def parse_muse_object_detection_response(
+    image: WorkflowImageData,
+    parsed_data: Union[dict, list],
+    classes: List[str],
+    inference_id: str,
+) -> Detections:
+    entries = extract_muse_detection_entries(parsed_data=parsed_data)
+    class_name2id = create_classes_index(classes=classes)
+    image_height, image_width = image._read_shape_without_materialization()
+
+    xyxy, class_id, class_name, confidence = [], [], [], []
+    for detection in entries:
+        box = get_muse_detection_box(detection=detection)
+        if box is None:
+            logger.debug(
+                "Skipping Muse detection entry without named 0-1000 fields: %r",
+                detection,
+            )
+            continue
+        xyxy.append(
+            convert_muse_detection_to_pixel_xyxy(
+                box=box,
+                image_height=image_height,
+                image_width=image_width,
+            )
+        )
+        label = str(detection.get("label") or "unknown")
+        class_id.append(class_name2id.get(label, -1))
+        class_name.append(label)
+        confidence.append(1.0)
+
+    if not xyxy:
+        return empty_native_detections(
+            image=image,
+            image_height=image_height,
+            image_width=image_width,
+            inference_id=inference_id,
+            class_names={idx: class_name for class_name, idx in class_name2id.items()},
+        )
+
+    return native_detections_from_parsed(
+        image=image,
+        image_height=image_height,
+        image_width=image_width,
+        inference_id=inference_id,
+        xyxy=np.array(xyxy).round(0),
+        class_id=np.array(class_id).astype(int),
+        class_name=class_name,
+        confidence=np.array(confidence),
+    )
+
+
 def parse_openai_detection_response(
     image: WorkflowImageData,
     parsed_data: Union[dict, list],
@@ -896,6 +966,7 @@ REGISTERED_PARSERS = {
     ("anthropic-claude", "object-detection"): parse_llm_object_detection_response,
     ("spacexai", "object-detection"): parse_spacexai_object_detection_response,
     ("qwen", "object-detection"): parse_qwen_object_detection_response,
+    ("muse", "object-detection"): parse_muse_object_detection_response,
     # Florence 2
     ("florence-2", "object-detection"): partial(
         parse_florence2_object_detection_response, florence_task_type="<OD>"

--- a/inference/core/workflows/core_steps/loader.py
+++ b/inference/core/workflows/core_steps/loader.py
@@ -588,6 +588,9 @@ from inference.core.workflows.core_steps.models.foundation.lmm.v1 import LMMBloc
 from inference.core.workflows.core_steps.models.foundation.lmm_classifier.v1 import (
     LMMForClassificationBlockV1,
 )
+from inference.core.workflows.core_steps.models.foundation.meta_vlm.v1 import (
+    MetaVlmBlockV1,
+)
 
 if not ENABLE_TENSOR_DATA_REPRESENTATION:
     from inference.core.workflows.core_steps.models.foundation.moondream2.v1 import (
@@ -1887,6 +1890,7 @@ def load_blocks() -> List[Type[WorkflowBlock]]:
         GazeBlockV1,
         LlamaVisionBlockV1,
         LlamaVisionBlockV2,
+        MetaVlmBlockV1,
         GoogleGemmaBlockV1,
         GoogleGemmaBlockV2,
         ImageSlicerBlockV2,

--- a/inference/core/workflows/core_steps/models/foundation/meta_vlm/v1.py
+++ b/inference/core/workflows/core_steps/models/foundation/meta_vlm/v1.py
@@ -1,0 +1,591 @@
+"""Meta Muse vision-language block, v1.
+
+OpenRouter-only. Three Muse models, using the vlm-exam request contract:
+image-first user message, no system role, reasoning always on, meta-flat
+0-1000 detection prompt. Llama Vision stays on its own block.
+"""
+
+import base64
+import json
+from typing import Any, Dict, List, Literal, Optional, Type, Union
+
+import cv2
+import numpy as np
+from pydantic import ConfigDict, Field, field_validator, model_validator
+
+from inference.core.utils.image_utils import encode_image_to_jpeg_bytes
+from inference.core.workflows.core_steps.common.openrouter import (
+    PRIVACY_LEVEL_LITERAL,
+    PRIVACY_LEVEL_METADATA,
+    RECOMMENDED_PARSERS,
+    RELEVANT_TASKS_METADATA,
+    SUPPORTED_TASK_TYPES_LIST,
+    OpenRouterBlockManifestMixin,
+    OpenRouterWorkflowBlockBase,
+    validate_task_type_required_fields,
+)
+from inference.core.workflows.core_steps.common.utils import (
+    scale_dimensions_to_max_edge,
+)
+from inference.core.workflows.execution_engine.entities.base import (
+    Batch,
+    OutputDefinition,
+    WorkflowImageData,
+)
+from inference.core.workflows.execution_engine.entities.types import (
+    FLOAT_KIND,
+    IMAGE_KIND,
+    LANGUAGE_MODEL_OUTPUT_KIND,
+    LIST_OF_VALUES_KIND,
+    ROBOFLOW_MANAGED_KEY,
+    SECRET_KIND,
+    STRING_KIND,
+    ImageInputField,
+    Selector,
+)
+from inference.core.workflows.prototypes.block import (
+    AirGappedAvailability,
+    BlockResult,
+    DependentResource,
+    WorkflowBlockManifest,
+    is_workflow_selector,
+    third_party_model,
+)
+
+MODEL_VARIANTS: Dict[str, str] = {
+    "Muse Spark 1.1": "meta/muse-spark-1.1",
+    "Muse Spark 1.2": "meta/muse-spark-1.2",
+    "Muse Glimmer": "meta/muse-glimmer-30b",
+}
+
+ModelVersion = Literal[tuple(MODEL_VARIANTS.keys())]
+DEFAULT_MODEL_VERSION = "Muse Spark 1.2"
+
+TaskType = Literal[tuple(SUPPORTED_TASK_TYPES_LIST)]
+
+REASONING_EFFORT_OPTIONS = ["low", "medium", "high"]
+ReasoningEffort = Literal[tuple(REASONING_EFFORT_OPTIONS)]
+DEFAULT_REASONING_EFFORT = "low"
+
+REASONING_EFFORT_METADATA = {
+    "low": {
+        "name": "Low (recommended)",
+        "description": (
+            "Small reasoning budget. Muse models require reasoning; this is "
+            "the lowest effort they accept."
+        ),
+    },
+    "medium": {
+        "name": "Medium",
+        "description": "Moderate reasoning budget before answering.",
+    },
+    "high": {
+        "name": "High",
+        "description": (
+            "Large reasoning budget. Slowest and most expensive; consider "
+            "raising `max_tokens` so reasoning does not crowd out the answer."
+        ),
+    },
+}
+
+DEFAULT_MAX_TOKENS = 2048
+OPENROUTER_MAX_BASE64_BYTES = 9_500_000
+OPENROUTER_JPEG_QUALITY = 90
+
+# Ported verbatim from vlm-exam's `_META_FLAT_NORMALIZED_PROMPT_TEMPLATE`.
+MUSE_OBJECT_DETECTION_PROMPT_TEMPLATE = (
+    "You are an object grounding expert. Detect all objects in this image "
+    "matching these labels: {class_list}. Ensure the objects accurately "
+    "match the request and do not miss any objects. For each object, answer "
+    'in the format {{"label": "<name>", "x_min": <int>, "y_min": <int>, '
+    '"x_max": <int>, "y_max": <int>}}. The coordinates should be in the '
+    "0-1000 range. Return a JSON array of results. If you cannot find an "
+    "object, omit it from the results."
+)
+
+_TASK_CLASSIFICATION = (
+    "You act as single-class classification model. You must provide reasonable "
+    "predictions. You are only allowed to produce JSON document in Markdown "
+    "```json [...]``` markers. Expected structure of json: "
+    '{"class_name": "class-name", "confidence": 0.4}. `class-name` must be one '
+    "of the class names defined by user. You are only allowed to return single "
+    "JSON document, even if there are potentially multiple classes. You are not "
+    "allowed to return list. You cannot discuss the result, you are only "
+    "allowed to return JSON document."
+)
+
+_TASK_MULTI_LABEL = (
+    "You act as multi-label classification model. You must provide reasonable "
+    "predictions. You are only allowed to produce JSON document in Markdown "
+    '```json``` markers. Expected structure of json: {"predicted_classes": '
+    '[{"class": "class-name-1", "confidence": 0.9}, {"class": "class-name-2", '
+    '"confidence": 0.7}]}. `class-name-X` must be one of the class names '
+    "defined by user and `confidence` is a float value in range 0.0-1.0 that "
+    "represent how sure you are that the class is present in the image. Only "
+    "return class names that are visible. You cannot discuss the result, you "
+    "are only allowed to return JSON document."
+)
+
+_TASK_VQA = (
+    "You act as Visual Question Answering model. Your task is to provide "
+    "answer to question submitted by user. If this is open-question - answer "
+    "with few sentences, for ABCD question, return only the indicator of "
+    "the answer."
+)
+
+_TASK_OCR = (
+    "You act as OCR model. Your task is to read text from the image and "
+    "return it in paragraphs representing the structure of texts in the "
+    "image. You should only return recognised text, nothing else."
+)
+
+_TASK_STRUCTURED = (
+    "You are supposed to produce responses in JSON wrapped in Markdown "
+    "markers: ```json\nyour-response\n```. User is to provide you "
+    "dictionary with keys and values. Each key must be present in your "
+    "response. Values in user dictionary represent descriptions for JSON "
+    "fields to be generated. Provide only JSON Markdown in response."
+)
+
+
+def encode_image_for_muse_openrouter(numpy_image: np.ndarray) -> str:
+    working = numpy_image
+    while True:
+        jpeg_bytes = encode_image_to_jpeg_bytes(
+            working, jpeg_quality=OPENROUTER_JPEG_QUALITY
+        )
+        base64_image = base64.b64encode(jpeg_bytes).decode("ascii")
+        if len(base64_image) <= OPENROUTER_MAX_BASE64_BYTES:
+            return base64_image
+
+        height, width = working.shape[:2]
+        if max(height, width) <= 1:
+            return base64_image
+
+        target_max_edge = max(int(max(height, width) * 0.9), 1)
+        target_width, target_height = scale_dimensions_to_max_edge(
+            width, height, target_max_edge
+        )
+        working = cv2.resize(
+            working, (target_width, target_height), interpolation=cv2.INTER_AREA
+        )
+
+
+def _user_message(base64_image: str, text: str) -> List[dict]:
+    return [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image_url",
+                    "image_url": {
+                        "url": f"data:image/jpeg;base64,{base64_image}",
+                    },
+                },
+                {"type": "text", "text": text},
+            ],
+        }
+    ]
+
+
+def _prepare_unconstrained_prompt(base64_image: str, prompt: str, **_) -> List[dict]:
+    return _user_message(base64_image=base64_image, text=prompt)
+
+
+def _prepare_ocr_prompt(base64_image: str, **_) -> List[dict]:
+    return _user_message(base64_image=base64_image, text=_TASK_OCR)
+
+
+def _prepare_vqa_prompt(base64_image: str, prompt: str, **_) -> List[dict]:
+    return _user_message(
+        base64_image=base64_image, text=f"{_TASK_VQA}\n\nQuestion: {prompt}"
+    )
+
+
+def _prepare_caption_prompt(
+    base64_image: str, short_description: bool, **_
+) -> List[dict]:
+    detail = (
+        "Caption should be short."
+        if short_description
+        else "Caption should be extensive."
+    )
+    text = (
+        "You act as image caption model. Your task is to provide "
+        f"description of the image. {detail}"
+    )
+    return _user_message(base64_image=base64_image, text=text)
+
+
+def _prepare_classification_prompt(
+    base64_image: str, classes: List[str], **_
+) -> List[dict]:
+    text = (
+        f"{_TASK_CLASSIFICATION}\n\n"
+        f"List of all classes to be recognised by model: {', '.join(classes)}"
+    )
+    return _user_message(base64_image=base64_image, text=text)
+
+
+def _prepare_multi_label_classification_prompt(
+    base64_image: str, classes: List[str], **_
+) -> List[dict]:
+    text = (
+        f"{_TASK_MULTI_LABEL}\n\n"
+        f"List of all classes to be recognised by model: {', '.join(classes)}"
+    )
+    return _user_message(base64_image=base64_image, text=text)
+
+
+def _prepare_structured_answering_prompt(
+    base64_image: str, output_structure: Dict[str, str], **_
+) -> List[dict]:
+    text = (
+        f"{_TASK_STRUCTURED}\n\n"
+        "Specification of requirements regarding output fields: \n"
+        f"{json.dumps(output_structure, indent=4)}"
+    )
+    return _user_message(base64_image=base64_image, text=text)
+
+
+def _prepare_object_detection_prompt(
+    base64_image: str, classes: List[str], **_
+) -> List[dict]:
+    text = MUSE_OBJECT_DETECTION_PROMPT_TEMPLATE.format(class_list=", ".join(classes))
+    return _user_message(base64_image=base64_image, text=text)
+
+
+PROMPT_BUILDERS = {
+    "unconstrained": _prepare_unconstrained_prompt,
+    "ocr": _prepare_ocr_prompt,
+    "visual-question-answering": _prepare_vqa_prompt,
+    "caption": lambda **kwargs: _prepare_caption_prompt(
+        short_description=True, **kwargs
+    ),
+    "detailed-caption": lambda **kwargs: _prepare_caption_prompt(
+        short_description=False, **kwargs
+    ),
+    "classification": _prepare_classification_prompt,
+    "multi-label-classification": _prepare_multi_label_classification_prompt,
+    "structured-answering": _prepare_structured_answering_prompt,
+    "object-detection": _prepare_object_detection_prompt,
+}
+
+
+def build_muse_openrouter_prompts(
+    images: List[np.ndarray],
+    task_type: str,
+    prompt: Optional[str],
+    output_structure: Optional[Dict[str, str]],
+    classes: Optional[List[str]],
+) -> List[List[dict]]:
+    if task_type not in PROMPT_BUILDERS:
+        raise ValueError(f"Task type: {task_type} not supported.")
+    builder = PROMPT_BUILDERS[task_type]
+    built: List[List[dict]] = []
+    for image in images:
+        built.append(
+            builder(
+                base64_image=encode_image_for_muse_openrouter(numpy_image=image),
+                prompt=prompt,
+                output_structure=output_structure,
+                classes=classes,
+            )
+        )
+    return built
+
+
+def build_reasoning_config(reasoning_effort: str) -> Dict[str, Any]:
+    return {"effort": reasoning_effort}
+
+
+RELEVANT_TASKS_DOCS_DESCRIPTION = "\n\n".join(
+    f"* **{v['name']}** (`{k}`) - {v['description']}"
+    for k, v in RELEVANT_TASKS_METADATA.items()
+)
+
+LONG_DESCRIPTION = f"""
+Run Meta Muse vision-language models via [OpenRouter](https://openrouter.ai/).
+
+Supported models: Muse Spark 1.1, Muse Spark 1.2, and Muse Glimmer.
+Llama 3.2 Vision stays on its own block.
+
+You can specify arbitrary text prompts or predefined ones. The block supports:
+
+{RELEVANT_TASKS_DOCS_DESCRIPTION}
+
+Object detection uses Muse's native grounding format: a JSON array of
+`label` / `x_min` / `y_min` / `x_max` / `y_max` fields with coordinates
+normalized to 0-1000. Parse the output with `VLM as Detector`
+(`vlm_as_detector@v2`) using `model_type="muse"`.
+
+Every request sends the image before the instruction text in a single user
+message. Reasoning stays on; the `reasoning_effort` knob defaults to low.
+`max_tokens` defaults to 2048; raise it (e.g. 8192) when you need a longer
+answer.
+
+By default the block uses the Roboflow-managed OpenRouter key and bills
+your Roboflow credits. Paste your own `sk-or-...` key to call OpenRouter
+directly.
+"""
+
+
+class BlockManifest(OpenRouterBlockManifestMixin):
+    model_config = ConfigDict(
+        json_schema_extra={
+            "name": "Meta",
+            "version": "v1",
+            "short_description": "Run Meta Muse vision models via OpenRouter.",
+            "long_description": LONG_DESCRIPTION,
+            "license": "Apache-2.0",
+            "block_type": "model",
+            "search_keywords": [
+                "LMM",
+                "VLM",
+                "Meta",
+                "Muse",
+                "Spark",
+                "Glimmer",
+                "OpenRouter",
+            ],
+            "is_vlm_block": True,
+            "task_type_property": "task_type",
+            "ui_manifest": {
+                "section": "model",
+                "icon": "fa-brands fa-meta",
+                "blockPriority": 5.55,
+            },
+        },
+        protected_namespaces=(),
+    )
+    type: Literal["roboflow_core/meta_vlm@v1"]
+    images: Selector(kind=[IMAGE_KIND]) = ImageInputField
+    model_version: Union[Selector(kind=[STRING_KIND]), ModelVersion] = Field(
+        default=DEFAULT_MODEL_VERSION,
+        description=(
+            "Muse model to run. Spark 1.1, Spark 1.2, and Glimmer are the "
+            "current image-capable Muse chat models on OpenRouter."
+        ),
+        examples=[DEFAULT_MODEL_VERSION, "Muse Glimmer"],
+    )
+    task_type: TaskType = Field(
+        default="unconstrained",
+        description=(
+            "Task type to be performed by model. Value determines required "
+            "parameters and output response."
+        ),
+        json_schema_extra={
+            "values_metadata": RELEVANT_TASKS_METADATA,
+            "recommended_parsers": RECOMMENDED_PARSERS,
+            "always_visible": True,
+        },
+    )
+    prompt: Optional[Union[Selector(kind=[STRING_KIND]), str]] = Field(
+        default=None,
+        description="Text prompt to send to the model.",
+        examples=["my prompt", "$inputs.prompt"],
+        json_schema_extra={
+            "relevant_for": {
+                "task_type": {
+                    "values": ["unconstrained", "visual-question-answering"],
+                    "required": True,
+                },
+            },
+            "multiline": True,
+        },
+    )
+    output_structure: Optional[Dict[str, str]] = Field(
+        default=None,
+        description="Dictionary with structure of expected JSON response.",
+        examples=[{"my_key": "description"}, "$inputs.output_structure"],
+        json_schema_extra={
+            "relevant_for": {
+                "task_type": {"values": ["structured-answering"], "required": True},
+            },
+        },
+    )
+    classes: Optional[Union[Selector(kind=[LIST_OF_VALUES_KIND]), List[str]]] = Field(
+        default=None,
+        description="List of classes to be used.",
+        examples=[["class-a", "class-b"], "$inputs.classes"],
+        json_schema_extra={
+            "relevant_for": {
+                "task_type": {
+                    "values": [
+                        "classification",
+                        "multi-label-classification",
+                        "object-detection",
+                    ],
+                    "required": True,
+                },
+            },
+        },
+    )
+    reasoning_effort: ReasoningEffort = Field(
+        default=DEFAULT_REASONING_EFFORT,
+        description=(
+            "Reasoning budget. Muse models reject disabled reasoning, so this "
+            "is always sent as an effort. Low is the default used in the "
+            "vlm-exam benches."
+        ),
+        json_schema_extra={"values_metadata": REASONING_EFFORT_METADATA},
+    )
+    max_tokens: Optional[int] = Field(
+        default=DEFAULT_MAX_TOKENS,
+        description=(
+            "Maximum number of tokens the model can generate in its response. "
+            f"Defaults to {DEFAULT_MAX_TOKENS}. Raise it explicitly "
+            "(e.g. 8192) when a task needs a longer answer. Billing is based "
+            "on tokens actually generated, not on this limit."
+        ),
+        gt=1,
+    )
+    temperature: Optional[Union[float, Selector(kind=[FLOAT_KIND])]] = Field(
+        default=None,
+        description=(
+            "Sampling temperature. Left unset by default so the provider "
+            "default applies. Range 0.0-2.0."
+        ),
+    )
+    api_key: Union[
+        Selector(kind=[STRING_KIND, SECRET_KIND, ROBOFLOW_MANAGED_KEY]), str
+    ] = Field(
+        default="rf_key:account",
+        description=(
+            "OpenRouter API key. Defaults to Roboflow's managed key. Provide "
+            "your own `sk-or-...` key to call OpenRouter directly without "
+            "Roboflow billing."
+        ),
+        examples=["rf_key:account", "sk-or-...", "$inputs.openrouter_api_key"],
+        private=True,
+    )
+    privacy_level: PRIVACY_LEVEL_LITERAL = Field(
+        default="deny",
+        description=(
+            "Provider privacy filter. Stricter levels reduce the pool of "
+            "providers and may increase per-call cost on the managed key."
+        ),
+        json_schema_extra={"values_metadata": PRIVACY_LEVEL_METADATA},
+    )
+
+    @model_validator(mode="after")
+    def validate(self) -> "BlockManifest":
+        validate_task_type_required_fields(
+            task_type=self.task_type,
+            prompt=self.prompt,
+            classes=self.classes,
+            output_structure=self.output_structure,
+        )
+        return self
+
+    @field_validator("temperature")
+    @classmethod
+    def validate_temperature(
+        cls, value: Optional[Union[str, float]]
+    ) -> Optional[Union[str, float]]:
+        if value is None or isinstance(value, str):
+            return value
+        if value < 0.0 or value > 2.0:
+            raise ValueError(
+                "'temperature' parameter required to be in range [0.0, 2.0]"
+            )
+        return value
+
+    @classmethod
+    def get_air_gapped_availability(cls) -> AirGappedAvailability:
+        return AirGappedAvailability(available=False, reason="requires_internet")
+
+    @classmethod
+    def get_parameters_accepting_batches(cls) -> List[str]:
+        return ["images"]
+
+    @classmethod
+    def describe_outputs(cls) -> List[OutputDefinition]:
+        return [
+            OutputDefinition(
+                name="output", kind=[STRING_KIND, LANGUAGE_MODEL_OUTPUT_KIND]
+            ),
+            OutputDefinition(name="classes", kind=[LIST_OF_VALUES_KIND]),
+            OutputDefinition(
+                name="thinking",
+                kind=[STRING_KIND],
+                description=(
+                    "Reasoning trace from the model when OpenRouter returns "
+                    "one. Empty string otherwise."
+                ),
+            ),
+        ]
+
+    @classmethod
+    def get_execution_engine_compatibility(cls) -> Optional[str]:
+        return ">=1.3.0,<2.0.0"
+
+    def discover_dependent_resources(self) -> Optional[List[DependentResource]]:
+        if is_workflow_selector(self.model_version):
+            return [
+                third_party_model(
+                    provider="openrouter",
+                    model_id=self.model_version,
+                    model_id_resolver=lambda label: MODEL_VARIANTS.get(label),
+                )
+            ]
+        return [
+            third_party_model(
+                provider="openrouter",
+                model_id=MODEL_VARIANTS[self.model_version],
+            )
+        ]
+
+
+class MetaVlmBlockV1(OpenRouterWorkflowBlockBase):
+    @classmethod
+    def get_manifest(cls) -> Type[WorkflowBlockManifest]:
+        return BlockManifest
+
+    @classmethod
+    def get_execution_engine_compatibility(cls) -> Optional[str]:
+        return ">=1.3.0,<2.0.0"
+
+    def run(
+        self,
+        images: Batch[WorkflowImageData],
+        model_version: str,
+        task_type: str,
+        prompt: Optional[str],
+        output_structure: Optional[Dict[str, str]],
+        classes: Optional[List[str]],
+        reasoning_effort: str,
+        api_key: str,
+        privacy_level: str,
+        max_tokens: Optional[int],
+        temperature: Optional[float],
+        max_concurrent_requests: Optional[int],
+    ) -> BlockResult:
+        model_id = MODEL_VARIANTS.get(model_version)
+        if model_id is None:
+            raise ValueError(
+                f"Unknown Muse variant '{model_version}'. "
+                f"Pick one of: {list(MODEL_VARIANTS)}"
+            )
+        prompts = build_muse_openrouter_prompts(
+            images=[image.numpy_image for image in images],
+            task_type=task_type,
+            prompt=prompt,
+            output_structure=output_structure,
+            classes=classes,
+        )
+        raw_outputs = self.execute_openrouter_batch(
+            openrouter_api_key=api_key,
+            model=model_id,
+            prompts=prompts,
+            max_tokens=max_tokens if max_tokens is not None else DEFAULT_MAX_TOKENS,
+            temperature=temperature,
+            privacy_level=privacy_level,
+            max_concurrent_requests=max_concurrent_requests,
+            reasoning=build_reasoning_config(reasoning_effort),
+            include_reasoning=True,
+        )
+        return [
+            {"output": content, "classes": classes, "thinking": reasoning_trace}
+            for content, reasoning_trace in raw_outputs
+        ]

--- a/inference/core/workflows/core_steps/models/foundation/meta_vlm/v1.py
+++ b/inference/core/workflows/core_steps/models/foundation/meta_vlm/v1.py
@@ -149,6 +149,19 @@ _TASK_STRUCTURED = (
 
 
 def encode_image_for_muse_openrouter(numpy_image: np.ndarray) -> str:
+    """Encode a BGR image as base64 JPEG under the OpenRouter payload cap.
+
+    Encodes at fixed JPEG quality and, when the base64 payload exceeds
+    ``OPENROUTER_MAX_BASE64_BYTES``, iteratively downscales the longest
+    edge by 10% until it fits. Detection coordinates are normalized to
+    0-1000, so downscaling does not affect parsing.
+
+    Args:
+        numpy_image: Image in BGR channel order.
+
+    Returns:
+        Base64-encoded JPEG payload.
+    """
     working = numpy_image
     while True:
         jpeg_bytes = encode_image_to_jpeg_bytes(
@@ -279,6 +292,25 @@ def build_muse_openrouter_prompts(
     output_structure: Optional[Dict[str, str]],
     classes: Optional[List[str]],
 ) -> List[List[dict]]:
+    """Build one OpenRouter ``messages`` array per input image, Muse-style.
+
+    Every task sends a single user message with the image part first and
+    the instruction text second, with no system role, matching the
+    vlm-exam Muse request contract.
+
+    Args:
+        images: BGR numpy images.
+        task_type: One of the supported VLM task types.
+        prompt: User prompt for unconstrained / VQA tasks.
+        output_structure: Output spec for structured-answering.
+        classes: Class list for classification / detection tasks.
+
+    Returns:
+        List of ``messages`` arrays, one per image.
+
+    Raises:
+        ValueError: If the task type is not supported.
+    """
     if task_type not in PROMPT_BUILDERS:
         raise ValueError(f"Task type: {task_type} not supported.")
     builder = PROMPT_BUILDERS[task_type]
@@ -296,6 +328,16 @@ def build_muse_openrouter_prompts(
 
 
 def build_reasoning_config(reasoning_effort: str) -> Dict[str, Any]:
+    """Build the OpenRouter ``reasoning`` config for Muse models.
+
+    Muse models reject disabled reasoning, so an ``effort`` is always sent.
+
+    Args:
+        reasoning_effort: ``low``, ``medium``, or ``high``.
+
+    Returns:
+        Reasoning config to attach to the OpenRouter request.
+    """
     return {"effort": reasoning_effort}
 
 

--- a/tests/workflows/integration_tests/execution/test_workflow_with_meta_vlm_v1.py
+++ b/tests/workflows/integration_tests/execution/test_workflow_with_meta_vlm_v1.py
@@ -1,0 +1,57 @@
+from inference.core.env import WORKFLOWS_MAX_CONCURRENT_STEPS
+from inference.core.managers.base import ModelManager
+from inference.core.workflows.core_steps.common.entities import StepExecutionMode
+from inference.core.workflows.execution_engine.core import ExecutionEngine
+
+OBJECT_DETECTION_WORKFLOW = {
+    "version": "1.0",
+    "inputs": [
+        {"type": "WorkflowImage", "name": "image"},
+        {"type": "WorkflowParameter", "name": "api_key"},
+        {"type": "WorkflowParameter", "name": "classes"},
+    ],
+    "steps": [
+        {
+            "type": "roboflow_core/meta_vlm@v1",
+            "name": "muse",
+            "images": "$inputs.image",
+            "model_version": "Muse Spark 1.2",
+            "task_type": "object-detection",
+            "classes": "$inputs.classes",
+            "api_key": "$inputs.api_key",
+        },
+        {
+            "type": "roboflow_core/vlm_as_detector@v2",
+            "name": "parser",
+            "vlm_output": "$steps.muse.output",
+            "image": "$inputs.image",
+            "classes": "$steps.muse.classes",
+            "model_type": "muse",
+            "task_type": "object-detection",
+        },
+    ],
+    "outputs": [
+        {
+            "type": "JsonField",
+            "name": "muse_result",
+            "selector": "$steps.muse.output",
+        },
+        {
+            "type": "JsonField",
+            "name": "parsed_prediction",
+            "selector": "$steps.parser.predictions",
+        },
+    ],
+}
+
+
+def test_object_detection_workflow_compiles(model_manager: ModelManager) -> None:
+    execution_engine = ExecutionEngine.init(
+        workflow_definition=OBJECT_DETECTION_WORKFLOW,
+        init_parameters={
+            "workflows_core.model_manager": model_manager,
+            "workflows_core.step_execution_mode": StepExecutionMode.LOCAL,
+        },
+        max_concurrent_steps=WORKFLOWS_MAX_CONCURRENT_STEPS,
+    )
+    assert execution_engine is not None

--- a/tests/workflows/unit_tests/core_steps/formatters/test_muse_detection_parsing.py
+++ b/tests/workflows/unit_tests/core_steps/formatters/test_muse_detection_parsing.py
@@ -1,8 +1,6 @@
 import numpy as np
 
 from inference.core.workflows.core_steps.formatters.vlm_as_detector.muse_detection_parsing import (
-    convert_muse_detection_to_pixel_xyxy,
-    extract_flat_object_entries,
     parse_muse_object_detection_response,
 )
 from inference.core.workflows.core_steps.formatters.vlm_as_detector.v2 import (
@@ -34,32 +32,6 @@ def test_parse_named_0_to_1000_fields():
     np.testing.assert_allclose(result.xyxy[0], [100, 200, 300, 400])
 
 
-def test_parse_single_object_without_array():
-    result = parse_muse_object_detection_response(
-        image=_build_image(1000, 1000),
-        parsed_data={
-            "label": "dog",
-            "x_min": 10,
-            "y_min": 20,
-            "x_max": 30,
-            "y_max": 40,
-        },
-        classes=["cat", "dog"],
-        inference_id="inf",
-    )
-    assert len(result) == 1
-    assert result.data["class_name"][0] == "dog"
-
-
-def test_extract_loose_comma_separated_objects():
-    raw = (
-        '{"label": "cat", "x_min": 1, "y_min": 2, "x_max": 3, "y_max": 4}, '
-        '{"label": "dog", "x_min": 5, "y_min": 6, "x_max": 7, "y_max": 8}'
-    )
-    entries = extract_flat_object_entries(raw)
-    assert [entry["label"] for entry in entries] == ["cat", "dog"]
-
-
 def test_detector_run_recovers_glimmer_loose_objects():
     block = VLMAsDetectorBlockV2()
     result = block.run(
@@ -74,12 +46,3 @@ def test_detector_run_recovers_glimmer_loose_objects():
     )
     assert result["error_status"] is False
     assert len(result["predictions"]) == 2
-
-
-def test_convert_box_clamps_out_of_range_coordinates():
-    result = convert_muse_detection_to_pixel_xyxy(
-        box=[-50.0, 0.0, 1200.0, 1000.0],
-        image_height=480,
-        image_width=640,
-    )
-    assert result == [0.0, 0.0, 640.0, 480.0]

--- a/tests/workflows/unit_tests/core_steps/formatters/test_muse_detection_parsing.py
+++ b/tests/workflows/unit_tests/core_steps/formatters/test_muse_detection_parsing.py
@@ -1,6 +1,8 @@
 import numpy as np
+import pytest
 
 from inference.core.workflows.core_steps.formatters.vlm_as_detector.muse_detection_parsing import (
+    convert_muse_detection_to_pixel_xyxy,
     parse_muse_object_detection_response,
 )
 from inference.core.workflows.core_steps.formatters.vlm_as_detector.v2 import (
@@ -19,9 +21,9 @@ def _build_image(height: int, width: int) -> WorkflowImageData:
     )
 
 
-def test_parse_named_0_to_1000_fields():
+def test_parse_scales_0_to_1000_fields_onto_non_square_image():
     result = parse_muse_object_detection_response(
-        image=_build_image(1000, 1000),
+        image=_build_image(480, 640),
         parsed_data=[
             {"label": "cat", "x_min": 100, "y_min": 200, "x_max": 300, "y_max": 400}
         ],
@@ -29,7 +31,78 @@ def test_parse_named_0_to_1000_fields():
         inference_id="inf",
     )
     assert len(result) == 1
-    np.testing.assert_allclose(result.xyxy[0], [100, 200, 300, 400])
+    np.testing.assert_allclose(result.xyxy[0], [64, 96, 192, 192])
+
+
+def test_convert_box_clamps_out_of_range_coordinates():
+    result = convert_muse_detection_to_pixel_xyxy(
+        box=[-50.0, 0.0, 1200.0, 1000.0],
+        image_height=480,
+        image_width=640,
+    )
+    assert result == [0.0, 0.0, 640.0, 480.0]
+
+
+def test_parse_accepts_detections_wrapper_and_single_object():
+    wrapped = parse_muse_object_detection_response(
+        image=_build_image(1000, 1000),
+        parsed_data={
+            "detections": [
+                {"label": "cat", "x_min": 1, "y_min": 2, "x_max": 3, "y_max": 4}
+            ]
+        },
+        classes=["cat"],
+        inference_id="inf",
+    )
+    single = parse_muse_object_detection_response(
+        image=_build_image(1000, 1000),
+        parsed_data={
+            "label": "dog",
+            "x_min": 10,
+            "y_min": 20,
+            "x_max": 30,
+            "y_max": 40,
+        },
+        classes=["cat", "dog"],
+        inference_id="inf",
+    )
+    assert len(wrapped) == 1
+    assert len(single) == 1
+    assert single.data["class_name"][0] == "dog"
+
+
+def test_parse_skips_malformed_entries_but_keeps_valid_ones():
+    result = parse_muse_object_detection_response(
+        image=_build_image(1000, 1000),
+        parsed_data=[
+            {"label": "no-box"},
+            {"label": "bool", "x_min": True, "y_min": 2, "x_max": 3, "y_max": 4},
+            {"label": "str", "x_min": "1", "y_min": 2, "x_max": 3, "y_max": 4},
+            {
+                "label": "nan",
+                "x_min": float("nan"),
+                "y_min": 2,
+                "x_max": 3,
+                "y_max": 4,
+            },
+            "not-a-dict",
+            {"label": "cat", "x_min": 100, "y_min": 200, "x_max": 300, "y_max": 400},
+        ],
+        classes=["cat"],
+        inference_id="inf",
+    )
+    assert len(result) == 1
+    assert result.data["class_name"][0] == "cat"
+
+
+def test_parse_raises_on_unexpected_shape():
+    with pytest.raises(ValueError):
+        parse_muse_object_detection_response(
+            image=_build_image(1000, 1000),
+            parsed_data={"unrelated": "object"},
+            classes=["cat"],
+            inference_id="inf",
+        )
 
 
 def test_detector_run_recovers_glimmer_loose_objects():
@@ -46,3 +119,19 @@ def test_detector_run_recovers_glimmer_loose_objects():
     )
     assert result["error_status"] is False
     assert len(result["predictions"]) == 2
+    np.testing.assert_allclose(result["predictions"].xyxy[0], [100, 200, 300, 400])
+    np.testing.assert_allclose(result["predictions"].xyxy[1], [10, 20, 30, 40])
+    assert list(result["predictions"].data["class_name"]) == ["cat", "dog"]
+
+
+def test_detector_run_keeps_error_status_for_garbage_with_unrelated_json():
+    block = VLMAsDetectorBlockV2()
+    result = block.run(
+        image=_build_image(1000, 1000),
+        vlm_output='I could not detect anything {"note": "sorry"} in the image',
+        classes=["cat"],
+        model_type="muse",
+        task_type="object-detection",
+    )
+    assert result["error_status"] is True
+    assert result["predictions"] is None

--- a/tests/workflows/unit_tests/core_steps/formatters/test_muse_detection_parsing.py
+++ b/tests/workflows/unit_tests/core_steps/formatters/test_muse_detection_parsing.py
@@ -1,0 +1,85 @@
+import numpy as np
+
+from inference.core.workflows.core_steps.formatters.vlm_as_detector.muse_detection_parsing import (
+    convert_muse_detection_to_pixel_xyxy,
+    extract_flat_object_entries,
+    parse_muse_object_detection_response,
+)
+from inference.core.workflows.core_steps.formatters.vlm_as_detector.v2 import (
+    VLMAsDetectorBlockV2,
+)
+from inference.core.workflows.execution_engine.entities.base import (
+    ImageParentMetadata,
+    WorkflowImageData,
+)
+
+
+def _build_image(height: int, width: int) -> WorkflowImageData:
+    return WorkflowImageData(
+        parent_metadata=ImageParentMetadata(parent_id="parent"),
+        numpy_image=np.zeros((height, width, 3), dtype=np.uint8),
+    )
+
+
+def test_parse_named_0_to_1000_fields():
+    result = parse_muse_object_detection_response(
+        image=_build_image(1000, 1000),
+        parsed_data=[
+            {"label": "cat", "x_min": 100, "y_min": 200, "x_max": 300, "y_max": 400}
+        ],
+        classes=["cat", "dog"],
+        inference_id="inf",
+    )
+    assert len(result) == 1
+    np.testing.assert_allclose(result.xyxy[0], [100, 200, 300, 400])
+
+
+def test_parse_single_object_without_array():
+    result = parse_muse_object_detection_response(
+        image=_build_image(1000, 1000),
+        parsed_data={
+            "label": "dog",
+            "x_min": 10,
+            "y_min": 20,
+            "x_max": 30,
+            "y_max": 40,
+        },
+        classes=["cat", "dog"],
+        inference_id="inf",
+    )
+    assert len(result) == 1
+    assert result.data["class_name"][0] == "dog"
+
+
+def test_extract_loose_comma_separated_objects():
+    raw = (
+        '{"label": "cat", "x_min": 1, "y_min": 2, "x_max": 3, "y_max": 4}, '
+        '{"label": "dog", "x_min": 5, "y_min": 6, "x_max": 7, "y_max": 8}'
+    )
+    entries = extract_flat_object_entries(raw)
+    assert [entry["label"] for entry in entries] == ["cat", "dog"]
+
+
+def test_detector_run_recovers_glimmer_loose_objects():
+    block = VLMAsDetectorBlockV2()
+    result = block.run(
+        image=_build_image(1000, 1000),
+        vlm_output=(
+            '{"label": "cat", "x_min": 100, "y_min": 200, "x_max": 300, "y_max": 400}, '
+            '{"label": "dog", "x_min": 10, "y_min": 20, "x_max": 30, "y_max": 40}'
+        ),
+        classes=["cat", "dog"],
+        model_type="muse",
+        task_type="object-detection",
+    )
+    assert result["error_status"] is False
+    assert len(result["predictions"]) == 2
+
+
+def test_convert_box_clamps_out_of_range_coordinates():
+    result = convert_muse_detection_to_pixel_xyxy(
+        box=[-50.0, 0.0, 1200.0, 1000.0],
+        image_height=480,
+        image_width=640,
+    )
+    assert result == [0.0, 0.0, 640.0, 480.0]

--- a/tests/workflows/unit_tests/core_steps/formatters/vlm_as_detector/test_v2_tensor.py
+++ b/tests/workflows/unit_tests/core_steps/formatters/vlm_as_detector/test_v2_tensor.py
@@ -284,3 +284,85 @@ def test_run_method_for_qwen_unexpected_shape_sets_error_status_tensor_native() 
 
     assert result["error_status"] is True
     assert result["predictions"] is None
+
+
+def test_run_method_for_muse_named_fields_output_tensor_native() -> None:
+    # given - muse coordinates are named x_min/y_min/x_max/y_max fields
+    # normalized to 0-1000 on both axes; out-of-range values are clamped
+    block = VLMAsDetectorBlockV2()
+    image = WorkflowImageData(
+        numpy_image=np.zeros((480, 640, 3), dtype=np.uint8),
+        parent_metadata=ImageParentMetadata(parent_id="parent"),
+    )
+    vlm_output = """
+[
+  {"label": "cat", "x_min": 100, "y_min": 200, "x_max": 500, "y_max": 1000},
+  {"label": "unicorn", "x_min": -50, "y_min": 0, "x_max": 1200, "y_max": 500}
+]
+    """
+
+    # when
+    result = block.run(
+        image=image,
+        vlm_output=vlm_output,
+        classes=["cat", "dog"],
+        model_type="muse",
+        task_type="object-detection",
+    )
+
+    # then
+    assert result["error_status"] is False
+    assert isinstance(result["predictions"], Detections)
+    assert _class_names(result["predictions"]) == ["cat", "unicorn"]
+    assert np.allclose(result["predictions"].class_id.cpu().numpy(), np.array([0, -1]))
+    assert np.allclose(
+        result["predictions"].xyxy.cpu().numpy(),
+        np.array(
+            [
+                [64, 96, 320, 480],
+                [0, 0, 640, 240],
+            ]
+        ),
+        atol=1.0,
+    )
+    assert np.allclose(
+        result["predictions"].confidence.cpu().numpy(), np.array([1.0, 1.0])
+    )
+
+
+def test_run_method_for_muse_recovers_loose_objects_tensor_native() -> None:
+    # given - Glimmer-style `{...}, {...}` output without array brackets,
+    # which string2json rejects; the muse fallback must recover it
+    block = VLMAsDetectorBlockV2()
+    image = WorkflowImageData(
+        numpy_image=np.zeros((1000, 1000, 3), dtype=np.uint8),
+        parent_metadata=ImageParentMetadata(parent_id="parent"),
+    )
+    vlm_output = (
+        '{"label": "cat", "x_min": 100, "y_min": 200, "x_max": 300, "y_max": 400}, '
+        '{"label": "dog", "x_min": 10, "y_min": 20, "x_max": 30, "y_max": 40}'
+    )
+
+    # when
+    result = block.run(
+        image=image,
+        vlm_output=vlm_output,
+        classes=["cat", "dog"],
+        model_type="muse",
+        task_type="object-detection",
+    )
+
+    # then
+    assert result["error_status"] is False
+    assert isinstance(result["predictions"], Detections)
+    assert _class_names(result["predictions"]) == ["cat", "dog"]
+    assert np.allclose(
+        result["predictions"].xyxy.cpu().numpy(),
+        np.array(
+            [
+                [100, 200, 300, 400],
+                [10, 20, 30, 40],
+            ]
+        ),
+        atol=1.0,
+    )

--- a/tests/workflows/unit_tests/core_steps/models/foundation/test_meta_vlm_v1.py
+++ b/tests/workflows/unit_tests/core_steps/models/foundation/test_meta_vlm_v1.py
@@ -6,7 +6,6 @@ from inference.core.workflows.core_steps.models.foundation.meta_vlm.v1 import (
     DEFAULT_MAX_TOKENS,
     DEFAULT_MODEL_VERSION,
     DEFAULT_REASONING_EFFORT,
-    MODEL_VARIANTS,
     BlockManifest,
     MetaVlmBlockV1,
     build_muse_openrouter_prompts,
@@ -63,7 +62,7 @@ def test_manifest_defaults():
             "task_type": "caption",
         }
     )
-    assert manifest.model_version == DEFAULT_MODEL_VERSION
+    assert manifest.model_version == "Muse Spark 1.2"
     assert manifest.max_tokens == 2048
     assert manifest.temperature is None
     assert manifest.reasoning_effort == "low"
@@ -99,7 +98,7 @@ def test_run_openrouter_passes_slug_and_low_reasoning(mock_or):
             model_version="Muse Glimmer",
         )
     )
-    assert mock_or.call_args.kwargs["model"] == MODEL_VARIANTS["Muse Glimmer"]
+    assert mock_or.call_args.kwargs["model"] == "meta/muse-glimmer-30b"
     assert mock_or.call_args.kwargs["reasoning"] == {"effort": "low"}
     assert mock_or.call_args.kwargs["max_tokens"] == 2048
     assert mock_or.call_args.kwargs["temperature"] is None

--- a/tests/workflows/unit_tests/core_steps/models/foundation/test_meta_vlm_v1.py
+++ b/tests/workflows/unit_tests/core_steps/models/foundation/test_meta_vlm_v1.py
@@ -1,21 +1,29 @@
 from unittest.mock import MagicMock, patch
 
 import numpy as np
-import pytest
-from pydantic import ValidationError
 
 from inference.core.workflows.core_steps.models.foundation.meta_vlm.v1 import (
     DEFAULT_MAX_TOKENS,
     DEFAULT_MODEL_VERSION,
     DEFAULT_REASONING_EFFORT,
     MODEL_VARIANTS,
-    MUSE_OBJECT_DETECTION_PROMPT_TEMPLATE,
     BlockManifest,
     MetaVlmBlockV1,
     build_muse_openrouter_prompts,
-    build_reasoning_config,
 )
 from inference.core.workflows.execution_engine.entities.base import WorkflowImageData
+
+# Copied from vlm-exam `_META_FLAT_NORMALIZED_PROMPT_TEMPLATE` so an edit
+# to the block constant fails this test.
+EXPECTED_DETECTION_PROMPT = (
+    "You are an object grounding expert. Detect all objects in this image "
+    "matching these labels: cat, dog. Ensure the objects accurately "
+    "match the request and do not miss any objects. For each object, answer "
+    'in the format {"label": "<name>", "x_min": <int>, "y_min": <int>, '
+    '"x_max": <int>, "y_max": <int>}. The coordinates should be in the '
+    "0-1000 range. Return a JSON array of results. If you cannot find an "
+    "object, omit it from the results."
+)
 
 
 def _stub_image() -> WorkflowImageData:
@@ -62,23 +70,6 @@ def test_manifest_defaults():
     assert manifest.privacy_level == "deny"
 
 
-def test_manifest_rejects_none_reasoning_effort():
-    with pytest.raises(ValidationError):
-        BlockManifest.model_validate(
-            {
-                "type": "roboflow_core/meta_vlm@v1",
-                "name": "muse",
-                "images": "$inputs.image",
-                "reasoning_effort": "none",
-            }
-        )
-
-
-def test_reasoning_config_always_sends_effort():
-    assert build_reasoning_config("low") == {"effort": "low"}
-    assert build_reasoning_config("high") == {"effort": "high"}
-
-
 def test_detection_prompt_is_vlm_exam_meta_flat_template():
     messages = build_muse_openrouter_prompts(
         images=[np.zeros((8, 8, 3), dtype=np.uint8)],
@@ -87,26 +78,11 @@ def test_detection_prompt_is_vlm_exam_meta_flat_template():
         output_structure=None,
         classes=["cat", "dog"],
     )
-    user = messages[0][0]
-    assert user["role"] == "user"
-    content = user["content"]
+    assert [message["role"] for message in messages[0]] == ["user"]
+    content = messages[0][0]["content"]
     assert content[0]["type"] == "image_url"
     assert content[1]["type"] == "text"
-    assert content[1]["text"] == MUSE_OBJECT_DETECTION_PROMPT_TEMPLATE.format(
-        class_list="cat, dog"
-    )
-
-
-def test_caption_is_image_first_without_system_role():
-    messages = build_muse_openrouter_prompts(
-        images=[np.zeros((8, 8, 3), dtype=np.uint8)],
-        task_type="caption",
-        prompt=None,
-        output_structure=None,
-        classes=None,
-    )
-    assert [message["role"] for message in messages[0]] == ["user"]
-    assert messages[0][0]["content"][0]["type"] == "image_url"
+    assert content[1]["text"] == EXPECTED_DETECTION_PROMPT
 
 
 @patch(

--- a/tests/workflows/unit_tests/core_steps/models/foundation/test_meta_vlm_v1.py
+++ b/tests/workflows/unit_tests/core_steps/models/foundation/test_meta_vlm_v1.py
@@ -1,0 +1,130 @@
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+from pydantic import ValidationError
+
+from inference.core.workflows.core_steps.models.foundation.meta_vlm.v1 import (
+    DEFAULT_MAX_TOKENS,
+    DEFAULT_MODEL_VERSION,
+    DEFAULT_REASONING_EFFORT,
+    MODEL_VARIANTS,
+    MUSE_OBJECT_DETECTION_PROMPT_TEMPLATE,
+    BlockManifest,
+    MetaVlmBlockV1,
+    build_muse_openrouter_prompts,
+    build_reasoning_config,
+)
+from inference.core.workflows.execution_engine.entities.base import WorkflowImageData
+
+
+def _stub_image() -> WorkflowImageData:
+    return WorkflowImageData(
+        parent_metadata=MagicMock(
+            parent_id="root", workflow_root_ancestor_metadata=None
+        ),
+        numpy_image=np.zeros((10, 10, 3), dtype=np.uint8),
+    )
+
+
+def _base_run_kwargs(**overrides):
+    kwargs = dict(
+        images=[_stub_image()],
+        model_version=DEFAULT_MODEL_VERSION,
+        task_type="caption",
+        prompt=None,
+        output_structure=None,
+        classes=None,
+        reasoning_effort=DEFAULT_REASONING_EFFORT,
+        api_key="rf_key:account",
+        privacy_level="deny",
+        max_tokens=DEFAULT_MAX_TOKENS,
+        temperature=None,
+        max_concurrent_requests=None,
+    )
+    kwargs.update(overrides)
+    return kwargs
+
+
+def test_manifest_defaults():
+    manifest = BlockManifest.model_validate(
+        {
+            "type": "roboflow_core/meta_vlm@v1",
+            "name": "muse",
+            "images": "$inputs.image",
+            "task_type": "caption",
+        }
+    )
+    assert manifest.model_version == DEFAULT_MODEL_VERSION
+    assert manifest.max_tokens == 2048
+    assert manifest.temperature is None
+    assert manifest.reasoning_effort == "low"
+    assert manifest.privacy_level == "deny"
+
+
+def test_manifest_rejects_none_reasoning_effort():
+    with pytest.raises(ValidationError):
+        BlockManifest.model_validate(
+            {
+                "type": "roboflow_core/meta_vlm@v1",
+                "name": "muse",
+                "images": "$inputs.image",
+                "reasoning_effort": "none",
+            }
+        )
+
+
+def test_reasoning_config_always_sends_effort():
+    assert build_reasoning_config("low") == {"effort": "low"}
+    assert build_reasoning_config("high") == {"effort": "high"}
+
+
+def test_detection_prompt_is_vlm_exam_meta_flat_template():
+    messages = build_muse_openrouter_prompts(
+        images=[np.zeros((8, 8, 3), dtype=np.uint8)],
+        task_type="object-detection",
+        prompt=None,
+        output_structure=None,
+        classes=["cat", "dog"],
+    )
+    user = messages[0][0]
+    assert user["role"] == "user"
+    content = user["content"]
+    assert content[0]["type"] == "image_url"
+    assert content[1]["type"] == "text"
+    assert content[1]["text"] == MUSE_OBJECT_DETECTION_PROMPT_TEMPLATE.format(
+        class_list="cat, dog"
+    )
+
+
+def test_caption_is_image_first_without_system_role():
+    messages = build_muse_openrouter_prompts(
+        images=[np.zeros((8, 8, 3), dtype=np.uint8)],
+        task_type="caption",
+        prompt=None,
+        output_structure=None,
+        classes=None,
+    )
+    assert [message["role"] for message in messages[0]] == ["user"]
+    assert messages[0][0]["content"][0]["type"] == "image_url"
+
+
+@patch(
+    "inference.core.workflows.core_steps.models.foundation.meta_vlm.v1."
+    "OpenRouterWorkflowBlockBase.execute_openrouter_batch"
+)
+def test_run_openrouter_passes_slug_and_low_reasoning(mock_or):
+    mock_or.return_value = [("boxes", "trace")]
+    block = MetaVlmBlockV1(model_manager=MagicMock(), api_key="rf_key")
+    result = block.run(
+        **_base_run_kwargs(
+            task_type="object-detection",
+            classes=["cat"],
+            model_version="Muse Glimmer",
+        )
+    )
+    assert mock_or.call_args.kwargs["model"] == MODEL_VARIANTS["Muse Glimmer"]
+    assert mock_or.call_args.kwargs["reasoning"] == {"effort": "low"}
+    assert mock_or.call_args.kwargs["max_tokens"] == 2048
+    assert mock_or.call_args.kwargs["temperature"] is None
+    assert result == [{"output": "boxes", "classes": ["cat"], "thinking": "trace"}]


### PR DESCRIPTION
## Summary
- Add `roboflow_core/meta_vlm@v1` for Muse Spark 1.1, Spark 1.2, and Glimmer on OpenRouter. Llama Vision stays on its own block.
- Use the vlm-exam Muse contract: image-first user message, reasoning always on (`low` default), `max_tokens` 2048, temperature unset, and a named 0-1000 detection prompt.
- Add `vlm_as_detector@v2` `model_type=muse` (numpy and tensor) with a loose-object fallback for Glimmer `{...}, {...}` output. Bump version to `1.4.1.post3`.

## Test plan
- [x] `pytest` unit tests for prompts, reasoning, and the muse parser, plus a compile-only `meta_vlm@v1` -> `vlm_as_detector@v2` integration test
- [x] 250-image object-detection before/after on the vlm-exam set (managed key, 8-wide). Before is generic `openrouter@v1` + `model_type=openai` at shipped defaults. After is Meta v1 + `model_type=muse`.