### PR TITLE
Replace WebRTC SAM3 tracking with an HTTP worker

### DIFF
--- a/inference/core/interfaces/http/handlers/sam3_video_sessions.py
+++ b/inference/core/interfaces/http/handlers/sam3_video_sessions.py
@@ -1,0 +1,214 @@
+import asyncio
+import json
+from typing import AsyncIterator, Optional
+
+from fastapi import FastAPI, HTTPException, Query, Request
+from fastapi.responses import StreamingResponse
+
+from inference.core.interfaces.http.api_key_resolution import (
+    api_key_fallback,
+    api_key_override,
+)
+from inference.core.interfaces.http.error_handlers import with_route_exceptions_async
+from inference.core.interfaces.sam3_video_session.entities import (
+    Sam3VideoInternalEventRequest,
+    Sam3VideoSessionCreated,
+    Sam3VideoSessionEndRequest,
+    Sam3VideoSessionRequest,
+    Sam3VideoSessionSnapshot,
+)
+from inference.core.interfaces.sam3_video_session.service import (
+    client_seen,
+    end_session,
+    publish_internal_event,
+    session_snapshot,
+    start_session,
+)
+from inference.core.interfaces.sam3_video_session.session_store import list_events
+from inference.core.interfaces.webrtc_worker.utils import (
+    deregister_webrtc_session,
+    refresh_webrtc_session,
+)
+from inference.core.logger import logger
+
+
+def _require_api_key(api_key: Optional[str]) -> str:
+    if api_key is None:
+        raise HTTPException(
+            status_code=401,
+            detail={"status": "error", "message": "unauthorized"},
+        )
+    return api_key
+
+
+def _public_event(event: dict) -> dict:
+    return {key: value for key, value in event.items() if key != "publish_token"}
+
+
+async def _sse_stream(session_id: str, after_seq: int, workspace_id: Optional[str]) -> AsyncIterator[str]:
+    last_seq = after_seq
+    while True:
+        client_seen(session_id)
+        if workspace_id:
+            refresh_webrtc_session(workspace_id=workspace_id, session_id=session_id)
+        snapshot = session_snapshot(session_id)
+        if snapshot is None:
+            error = {"seq": last_seq, "type": "error", "message": "session not found"}
+            yield f"event: error\ndata: {json.dumps(error)}\n\n"
+            return
+        events = list_events(session_id, after_seq=last_seq)
+        for event in events:
+            last_seq = int(event.get("seq") or last_seq)
+            public = _public_event(event)
+            yield f"event: {public.get('type', 'message')}\ndata: {json.dumps(public)}\n\n"
+            if public.get("type") in {"done", "error"}:
+                return
+        if snapshot.get("status") in {"completed", "failed", "cancelled"}:
+            return
+        await asyncio.sleep(0.2)
+
+
+def register_sam3_video_session_routes(app: FastAPI) -> None:
+    @app.post(
+        "/sam3/video/sessions",
+        response_model=Sam3VideoSessionCreated,
+        summary="Start a SAM3 video tracking session",
+        description=(
+            "Spawns a long-lived Modal (or local) SAM3 worker that downloads "
+            "video_url, writes track artifacts to GCS via Roboflow-signed "
+            "upload URLs, and publishes overlay events. Auth: Roboflow API key "
+            "via query, Authorization Bearer header, or JSON body. Reachable "
+            "on serverless."
+        ),
+    )
+    @with_route_exceptions_async
+    async def create_sam3_video_session(
+        request: Sam3VideoSessionRequest,
+        r: Request,
+    ) -> Sam3VideoSessionCreated:
+        api_key = api_key_override(request.api_key)
+        _require_api_key(api_key)
+        callback_base = str(request.events_callback_base or r.base_url)
+        session_id = start_session(
+            request,
+            api_key=api_key,
+            events_callback_base=callback_base,
+        )
+        return Sam3VideoSessionCreated(session_id=session_id)
+
+    @app.get(
+        "/sam3/video/sessions/{session_id}",
+        response_model=Sam3VideoSessionSnapshot,
+        summary="SAM3 video session snapshot",
+        description="Auth: Roboflow API key. Reachable on serverless.",
+    )
+    @with_route_exceptions_async
+    async def get_sam3_video_session(
+        session_id: str,
+        api_key: Optional[str] = Query(None),
+    ) -> Sam3VideoSessionSnapshot:
+        _require_api_key(api_key_fallback(api_key))
+        snap = session_snapshot(session_id)
+        if snap is None:
+            raise HTTPException(
+                status_code=404,
+                detail={"status": "error", "message": "session not found"},
+            )
+        return Sam3VideoSessionSnapshot.model_validate(snap)
+
+    @app.get(
+        "/sam3/video/sessions/{session_id}/events",
+        summary="SAM3 video session event stream",
+        description=(
+            "Server-sent events for live overlay. Auth: Roboflow API key via "
+            "query or Authorization Bearer header (EventSource cannot set "
+            "headers; prefer fetch). Reachable on serverless."
+        ),
+    )
+    @with_route_exceptions_async
+    async def stream_sam3_video_session_events(
+        session_id: str,
+        api_key: Optional[str] = Query(None),
+        after: int = Query(0, ge=0),
+    ) -> StreamingResponse:
+        resolved_key = _require_api_key(api_key_fallback(api_key))
+        snap = session_snapshot(session_id)
+        if snap is None:
+            raise HTTPException(
+                status_code=404,
+                detail={"status": "error", "message": "session not found"},
+            )
+        workspace_id = None
+        try:
+            from inference.core.roboflow_api import get_roboflow_workspace
+
+            workspace_id = get_roboflow_workspace(api_key=resolved_key)
+        except Exception:
+            logger.debug("Could not resolve workspace for SAM3 SSE heartbeat")
+        return StreamingResponse(
+            _sse_stream(session_id, after, workspace_id),
+            media_type="text/event-stream",
+            headers={
+                "Cache-Control": "no-cache",
+                "Connection": "keep-alive",
+                "X-Accel-Buffering": "no",
+            },
+        )
+
+    @app.post(
+        "/sam3/video/sessions/{session_id}/end",
+        summary="End a SAM3 video tracking session",
+        description="Auth: Roboflow API key. Reachable on serverless.",
+    )
+    @with_route_exceptions_async
+    async def end_sam3_video_session(
+        session_id: str,
+        request: Sam3VideoSessionEndRequest,
+    ) -> dict:
+        api_key = _require_api_key(api_key_override(request.api_key))
+        end_session(session_id)
+        try:
+            from inference.core.roboflow_api import get_roboflow_workspace
+
+            workspace_id = get_roboflow_workspace(api_key=api_key)
+            if workspace_id:
+                deregister_webrtc_session(
+                    workspace_id=workspace_id,
+                    session_id=session_id,
+                )
+        except Exception:
+            logger.debug("Could not deregister SAM3 session quota slot")
+        return {"status": "ok"}
+
+    @app.post(
+        "/sam3/video/sessions/{session_id}/internal/events",
+        summary="Worker event publish",
+        description=(
+            "Called by the SAM3 worker. Auth: Roboflow API key plus the "
+            "session publish_token. Reachable on serverless."
+        ),
+    )
+    @with_route_exceptions_async
+    async def publish_sam3_video_session_event(
+        session_id: str,
+        request: Sam3VideoInternalEventRequest,
+        api_key: Optional[str] = Query(None),
+    ) -> dict:
+        _require_api_key(api_key_override(api_key))
+        try:
+            stop_requested = publish_internal_event(
+                session_id,
+                publish_token=request.publish_token,
+                event=request.event,
+            )
+        except KeyError:
+            raise HTTPException(
+                status_code=404,
+                detail={"status": "error", "message": "session not found"},
+            )
+        except PermissionError:
+            raise HTTPException(
+                status_code=401,
+                detail={"status": "error", "message": "unauthorized"},
+            )
+        return {"stop_requested": stop_requested}

--- a/inference/core/interfaces/http/http_api.py
+++ b/inference/core/interfaces/http/http_api.py
@@ -238,6 +238,9 @@ from inference.core.interfaces.http.error_handlers import (
     with_route_exceptions,
     with_route_exceptions_async,
 )
+from inference.core.interfaces.http.handlers.sam3_video_sessions import (
+    register_sam3_video_session_routes,
+)
 from inference.core.interfaces.http.handlers.workflows import (
     filter_out_unwanted_workflow_outputs,
     handle_describe_workflows_blocks_request,
@@ -2636,6 +2639,8 @@ class HttpInterface(BaseInterface):
                     session_id=request.session_id,
                 )
                 return {"status": "ok"}
+
+            register_sam3_video_session_routes(app)
 
         if ENABLE_STREAM_API:
 

--- a/inference/core/interfaces/sam3_video_session/__init__.py
+++ b/inference/core/interfaces/sam3_video_session/__init__.py
@@ -1,0 +1,7 @@
+from inference.core.interfaces.sam3_video_session.service import (
+    end_session,
+    session_snapshot,
+    start_session,
+)
+
+__all__ = ["end_session", "session_snapshot", "start_session"]

--- a/inference/core/interfaces/sam3_video_session/artifacts.py
+++ b/inference/core/interfaces/sam3_video_session/artifacts.py
@@ -1,0 +1,193 @@
+import json
+from typing import Any, Dict, List, Optional
+from urllib.parse import urljoin
+
+import requests
+
+from inference.core.interfaces.sam3_video_session.entities import (
+    ARTIFACT_CHUNK_CONTENT_TYPE,
+    Sam3VideoTimeBase,
+    validated_app_base_url,
+)
+from inference.core.utils.requests import api_key_safe_raise_for_status
+
+
+class ArtifactWriter:
+    def __init__(
+        self,
+        *,
+        app_base_url: str,
+        video_id: str,
+        workspace_id: str,
+        dataset_id: str,
+        revision_id: str,
+        api_key: str,
+        timeout_seconds: float = 60.0,
+    ):
+        if not api_key:
+            raise ValueError("api_key is required to write SAM3 video artifacts")
+        self._app_base_url = validated_app_base_url(app_base_url)
+        self._video_id = video_id
+        self._workspace_id = workspace_id
+        self._dataset_id = dataset_id
+        self._revision_id = revision_id
+        self._api_key = api_key
+        self._timeout_seconds = timeout_seconds
+
+    def _auth_headers(self) -> Dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self._api_key}",
+            "Content-Type": "application/json",
+        }
+
+    def checkpoint_chunk(
+        self,
+        *,
+        track_id: str,
+        chunk_index: int,
+        total_chunks: int,
+        samples: List[Dict[str, Any]],
+    ) -> None:
+        mint_url = urljoin(
+            self._app_base_url,
+            f"query/video/{self._video_id}/tracks/{track_id}/artifact-chunks/upload-url",
+        )
+        mint_response = requests.post(
+            mint_url,
+            json={
+                "workspaceId": self._workspace_id,
+                "datasetId": self._dataset_id,
+                "revisionId": self._revision_id,
+                "chunkIndex": chunk_index,
+                "totalChunks": total_chunks,
+            },
+            headers=self._auth_headers(),
+            timeout=self._timeout_seconds,
+        )
+        api_key_safe_raise_for_status(response=mint_response)
+        upload_url = mint_response.json().get("uploadUrl")
+        if not upload_url:
+            raise RuntimeError("Roboflow did not return an artifact upload URL.")
+        put_response = requests.put(
+            upload_url,
+            data=json.dumps({"samples": samples}).encode("utf-8"),
+            headers={"Content-Type": ARTIFACT_CHUNK_CONTENT_TYPE},
+            timeout=self._timeout_seconds,
+        )
+        api_key_safe_raise_for_status(response=put_response)
+
+    def commit_revision(
+        self,
+        *,
+        track_id: str,
+        start_frame_index: int,
+        end_frame_index: int,
+        start_pts: int,
+        end_pts: int,
+        video_time_base: Sam3VideoTimeBase,
+        class_name: str,
+        tracker_id: int,
+        sample_count: int,
+        chunk_count: int,
+    ) -> None:
+        url = urljoin(
+            self._app_base_url,
+            f"query/video/{self._video_id}/tracks/{track_id}/artifact-revisions/{self._revision_id}/commit",
+        )
+        response = requests.post(
+            url,
+            json={
+                "workspaceId": self._workspace_id,
+                "datasetId": self._dataset_id,
+                "startFrameIndex": start_frame_index,
+                "endFrameIndex": end_frame_index,
+                "startPts": start_pts,
+                "endPts": end_pts,
+                "videoTimeBase": {
+                    "numerator": video_time_base.numerator,
+                    "denominator": video_time_base.denominator,
+                },
+                "className": class_name,
+                "trackerId": tracker_id,
+                "sampleCount": sample_count,
+                "chunkCount": chunk_count,
+            },
+            headers=self._auth_headers(),
+            timeout=self._timeout_seconds,
+        )
+        api_key_safe_raise_for_status(response=response)
+
+
+class TrackAccumulator:
+    def __init__(self, track_id: str, class_name: str, tracker_id: int):
+        self.track_id = track_id
+        self.class_name = class_name
+        self.tracker_id = tracker_id
+        self.start_frame_index: Optional[int] = None
+        self.end_frame_index: Optional[int] = None
+        self.start_pts: Optional[int] = None
+        self.end_pts: Optional[int] = None
+        self.pending_samples: List[Dict[str, Any]] = []
+        self.flushed_chunks = 0
+        self.sample_count = 0
+
+    def add_sample(self, sample: Dict[str, Any], frame_index: int, pts: int) -> None:
+        if self.start_frame_index is None:
+            self.start_frame_index = frame_index
+            self.start_pts = pts
+        self.end_frame_index = (
+            frame_index
+            if self.end_frame_index is None
+            else max(self.end_frame_index, frame_index)
+        )
+        self.end_pts = pts if self.end_pts is None else max(self.end_pts, pts)
+        self.class_name = str(sample.get("className") or self.class_name)
+        self.pending_samples.append(sample)
+        self.sample_count += 1
+
+    def flush_ready(
+        self,
+        writer: ArtifactWriter,
+        *,
+        chunk_sample_size: int,
+        is_final: bool,
+    ) -> int:
+        flushed = 0
+        while self.pending_samples and (
+            is_final or len(self.pending_samples) >= chunk_sample_size
+        ):
+            if is_final:
+                samples = self.pending_samples
+                self.pending_samples = []
+            else:
+                samples = self.pending_samples[:chunk_sample_size]
+                self.pending_samples = self.pending_samples[chunk_sample_size:]
+            if not samples:
+                break
+            writer.checkpoint_chunk(
+                track_id=self.track_id,
+                chunk_index=self.flushed_chunks,
+                total_chunks=self.flushed_chunks + 1,
+                samples=samples,
+            )
+            self.flushed_chunks += 1
+            flushed += 1
+        return flushed
+
+    def commit(
+        self, writer: ArtifactWriter, video_time_base: Sam3VideoTimeBase
+    ) -> None:
+        if self.sample_count == 0 or self.start_frame_index is None:
+            return
+        writer.commit_revision(
+            track_id=self.track_id,
+            start_frame_index=self.start_frame_index,
+            end_frame_index=self.end_frame_index or self.start_frame_index,
+            start_pts=self.start_pts or 0,
+            end_pts=self.end_pts or 0,
+            video_time_base=video_time_base,
+            class_name=self.class_name,
+            tracker_id=self.tracker_id,
+            sample_count=self.sample_count,
+            chunk_count=max(1, self.flushed_chunks),
+        )

--- a/inference/core/interfaces/sam3_video_session/entities.py
+++ b/inference/core/interfaces/sam3_video_session/entities.py
@@ -1,0 +1,136 @@
+from typing import Any, Dict, List, Literal, Optional, Union
+from urllib.parse import urlparse
+
+from pydantic import BaseModel, Field, field_validator
+
+SAM3_VIDEO_EVENT_DOWNLOADING = "downloading"
+SAM3_VIDEO_EVENT_FRAME = "frame"
+SAM3_VIDEO_EVENT_CHECKPOINTED = "checkpointed"
+SAM3_VIDEO_EVENT_DONE = "done"
+SAM3_VIDEO_EVENT_ERROR = "error"
+
+Sam3VideoEventType = Literal[
+    "downloading",
+    "frame",
+    "checkpointed",
+    "done",
+    "error",
+]
+
+Sam3VideoSessionStatus = Literal[
+    "starting",
+    "downloading",
+    "running",
+    "completed",
+    "failed",
+    "cancelled",
+]
+
+CHUNK_SAMPLE_SIZE = 500
+DEFAULT_THRESHOLD = 0.35
+DEFAULT_CLASS_NAME = "object"
+SESSION_EVENT_TTL_SECONDS = 600
+MAX_VIDEO_BYTES = 2 * 1024 * 1024 * 1024
+MODEL_ID = "sam3video"
+
+ALLOWED_APP_HOSTS = {
+    "app.roboflow.com",
+    "app.roboflow.one",
+    "localhost",
+    "127.0.0.1",
+}
+ALLOWED_APP_HOST_SUFFIXES = (".roboflow.com", ".roboflow.one")
+ARTIFACT_CHUNK_CONTENT_TYPE = "application/json"
+
+
+def is_allowed_app_base_url(url: str) -> bool:
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"}:
+        return False
+    host = (parsed.hostname or "").lower()
+    if not host:
+        return False
+    if host in ALLOWED_APP_HOSTS:
+        return True
+    return host.endswith(ALLOWED_APP_HOST_SUFFIXES)
+
+
+def validated_app_base_url(url: str) -> str:
+    if not is_allowed_app_base_url(url):
+        raise ValueError("app_base_url must be a Roboflow app host")
+    return url.rstrip("/") + "/"
+
+
+class Sam3VideoTimeBase(BaseModel):
+    numerator: int = Field(gt=0)
+    denominator: int = Field(gt=0)
+
+
+class Sam3VideoArtifactTarget(BaseModel):
+    app_base_url: str
+    video_id: str
+    workspace_id: str
+    dataset_id: str
+    revision_id: str
+    video_time_base: Optional[Sam3VideoTimeBase] = None
+
+    @field_validator("app_base_url")
+    @classmethod
+    def validate_app_base_url_field(cls, value: str) -> str:
+        return validated_app_base_url(value).rstrip("/")
+
+
+class Sam3VideoSessionRequest(BaseModel):
+    video_url: str
+    class_names: List[str]
+    artifact: Sam3VideoArtifactTarget
+    api_key: Optional[str] = None
+    requested_plan: Optional[str] = None
+    requested_region: Optional[str] = None
+    processing_timeout: Optional[int] = None
+    threshold: float = DEFAULT_THRESHOLD
+    events_callback_base: Optional[str] = None
+
+
+class Sam3VideoSessionCreated(BaseModel):
+    session_id: str
+
+
+class Sam3VideoSessionSnapshot(BaseModel):
+    session_id: str
+    status: Sam3VideoSessionStatus
+    last_seq: int = 0
+    last_frame_id: Optional[int] = None
+    error_message: Optional[str] = None
+    stop_requested: bool = False
+
+
+class Sam3VideoInternalEventRequest(BaseModel):
+    publish_token: str
+    event: Dict[str, Any]
+
+
+class Sam3VideoInternalEventResponse(BaseModel):
+    stop_requested: bool = False
+
+
+class Sam3VideoSessionEndRequest(BaseModel):
+    api_key: Optional[str] = None
+
+
+class Sam3VideoWorkerPayload(BaseModel):
+    session_id: str
+    video_url: str
+    class_names: List[str]
+    artifact: Sam3VideoArtifactTarget
+    api_key: Optional[str] = None
+    threshold: float = DEFAULT_THRESHOLD
+    events_callback_url: str
+    publish_token: str
+    requested_plan: Optional[str] = None
+    workspace_id: Optional[str] = None
+    processing_timeout: Optional[int] = None
+
+
+JsonDict = Dict[str, Any]
+JsonList = List[Union[JsonDict, Any]]

--- a/inference/core/interfaces/sam3_video_session/predictions.py
+++ b/inference/core/interfaces/sam3_video_session/predictions.py
@@ -1,0 +1,99 @@
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+import numpy as np
+
+from inference.core.interfaces.sam3_video_session.entities import DEFAULT_CLASS_NAME
+
+
+def mask_to_uncompressed_rle(mask: np.ndarray) -> Dict[str, Any]:
+    height, width = mask.shape[:2]
+    flat = np.asfortranarray(mask.astype(np.uint8)).ravel(order="F")
+    if flat.size == 0:
+        return {"counts": [0], "size": [int(height), int(width)]}
+    change_indices = np.flatnonzero(flat[1:] != flat[:-1]) + 1
+    boundaries = np.concatenate(([0], change_indices, [flat.size]))
+    counts = np.diff(boundaries).astype(int).tolist()
+    if int(flat[0]) == 1:
+        counts.insert(0, 0)
+    return {"counts": counts, "size": [int(height), int(width)]}
+
+
+def xyxy_to_center_bounds(box: Sequence[float]) -> Optional[Dict[str, float]]:
+    if len(box) < 4:
+        return None
+    x1, y1, x2, y2 = [float(value) for value in box[:4]]
+    width = abs(x2 - x1)
+    height = abs(y2 - y1)
+    if width <= 0 or height <= 0:
+        return None
+    return {
+        "x": (x1 + x2) / 2.0,
+        "y": (y1 + y2) / 2.0,
+        "width": width,
+        "height": height,
+    }
+
+
+def class_name_for_object(
+    object_id: int,
+    prompt_to_object_ids: Dict[str, List[int]],
+    fallback: str = DEFAULT_CLASS_NAME,
+) -> str:
+    for prompt, object_ids in prompt_to_object_ids.items():
+        if int(object_id) in {int(item) for item in object_ids}:
+            name = str(prompt).strip()
+            return name or fallback
+    return fallback
+
+
+def serialize_frame_predictions(
+    *,
+    masks: np.ndarray,
+    object_ids: np.ndarray,
+    scores: np.ndarray,
+    boxes: np.ndarray,
+    prompt_to_object_ids: Dict[str, List[int]],
+    threshold: float,
+    width: int,
+    height: int,
+) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    predictions: List[Dict[str, Any]] = []
+    samples: List[Dict[str, Any]] = []
+    if masks.size == 0:
+        return predictions, samples
+    for index, object_id in enumerate(object_ids.tolist()):
+        score = float(scores[index]) if index < len(scores) else 0.0
+        if score < threshold:
+            continue
+        mask = masks[index]
+        if not np.any(mask):
+            continue
+        box = boxes[index] if index < len(boxes) else (0, 0, 0, 0)
+        bounds = xyxy_to_center_bounds(box)
+        rle_mask = mask_to_uncompressed_rle(mask)
+        class_name = class_name_for_object(int(object_id), prompt_to_object_ids)
+        prediction: Dict[str, Any] = {
+            "tracker_id": int(object_id),
+            "class_name": class_name,
+            "confidence": score,
+            "rle_mask": rle_mask,
+        }
+        if bounds is not None:
+            prediction.update(bounds)
+        predictions.append(prediction)
+        geometry: Dict[str, Any] = {
+            "width": int(width),
+            "height": int(height),
+            "rleMask": rle_mask,
+        }
+        if bounds is not None:
+            geometry["bounds"] = bounds
+        samples.append(
+            {
+                "trackId": int(object_id),
+                "className": class_name,
+                "confidence": score,
+                "geometry": geometry,
+            }
+        )
+    return predictions, samples

--- a/inference/core/interfaces/sam3_video_session/service.py
+++ b/inference/core/interfaces/sam3_video_session/service.py
@@ -1,0 +1,179 @@
+import hashlib
+import multiprocessing
+import secrets
+import uuid
+from typing import Any, Dict, Optional
+from urllib.parse import urljoin
+
+from inference.core.env import (
+    WEBRTC_MODAL_TOKEN_ID,
+    WEBRTC_MODAL_TOKEN_SECRET,
+    WEBRTC_MODAL_USAGE_QUOTA_ENABLED,
+    WEBRTC_WORKSPACE_STREAM_QUOTA,
+    WEBRTC_WORKSPACE_STREAM_QUOTA_ENABLED,
+    WEBRTC_WORKSPACE_STREAM_TTL_SECONDS,
+)
+from inference.core.exceptions import CreditsExceededError, WorkspaceStreamQuotaError
+from inference.core.interfaces.sam3_video_session.entities import (
+    Sam3VideoSessionRequest,
+    Sam3VideoWorkerPayload,
+)
+from inference.core.interfaces.sam3_video_session.session_store import (
+    append_event,
+    create_session,
+    get_session,
+    is_stop_requested,
+    mark_client_seen,
+    request_stop,
+    snapshot,
+    update_session,
+)
+from inference.core.interfaces.sam3_video_session.worker import (
+    run_sam3_video_session_from_dict,
+)
+from inference.core.interfaces.webrtc_worker.utils import (
+    is_over_quota,
+    is_over_workspace_session_quota,
+    register_webrtc_session,
+)
+from inference.core.logger import logger
+from inference.core.roboflow_api import get_roboflow_workspace
+
+
+def _hash_api_key(api_key: Optional[str]) -> str:
+    if not api_key:
+        return ""
+    return hashlib.sha256(api_key.encode("utf-8")).hexdigest()
+
+
+def _events_callback_url(base: str, session_id: str) -> str:
+    return urljoin(
+        base.rstrip("/") + "/", f"sam3/video/sessions/{session_id}/internal/events"
+    )
+
+
+def _local_worker_process(payload: Dict[str, Any]) -> None:
+    run_sam3_video_session_from_dict(payload)
+
+
+def _spawn_local(payload: Sam3VideoWorkerPayload) -> None:
+    ctx = multiprocessing.get_context("spawn")
+    process = ctx.Process(
+        target=_local_worker_process,
+        args=(payload.model_dump(mode="json"),),
+        daemon=False,
+    )
+    process.start()
+
+
+def _spawn_modal(payload: Sam3VideoWorkerPayload) -> Optional[str]:
+    from inference.core.interfaces.webrtc_worker.modal import (
+        spawn_sam3_video_session_modal,
+    )
+
+    return spawn_sam3_video_session_modal(payload)
+
+
+def start_session(
+    request: Sam3VideoSessionRequest,
+    *,
+    api_key: Optional[str],
+    events_callback_base: str,
+) -> str:
+    if WEBRTC_MODAL_USAGE_QUOTA_ENABLED and api_key and is_over_quota(api_key):
+        raise CreditsExceededError("API key over quota")
+
+    workspace_id = None
+    if api_key:
+        workspace_id = get_roboflow_workspace(api_key=api_key)
+
+    session_id = str(uuid.uuid4())
+    if WEBRTC_WORKSPACE_STREAM_QUOTA_ENABLED and workspace_id:
+        if is_over_workspace_session_quota(
+            workspace_id=workspace_id,
+            quota=WEBRTC_WORKSPACE_STREAM_QUOTA,
+            ttl_seconds=WEBRTC_WORKSPACE_STREAM_TTL_SECONDS,
+        ):
+            raise WorkspaceStreamQuotaError(
+                f"You have reached the maximum of {WEBRTC_WORKSPACE_STREAM_QUOTA} "
+                f"concurrent streams."
+            )
+        register_webrtc_session(workspace_id=workspace_id, session_id=session_id)
+
+    publish_token = secrets.token_urlsafe(32)
+    create_session(
+        session_id,
+        workspace_id=workspace_id,
+        publish_token=publish_token,
+        owner_api_key_hash=_hash_api_key(api_key),
+    )
+
+    callback_base = request.events_callback_base or events_callback_base
+    payload = Sam3VideoWorkerPayload(
+        session_id=session_id,
+        video_url=request.video_url,
+        class_names=request.class_names,
+        artifact=request.artifact,
+        api_key=api_key,
+        threshold=request.threshold,
+        events_callback_url=_events_callback_url(callback_base, session_id),
+        publish_token=publish_token,
+        requested_plan=request.requested_plan,
+        workspace_id=workspace_id,
+        processing_timeout=request.processing_timeout,
+    )
+
+    if WEBRTC_MODAL_TOKEN_ID and WEBRTC_MODAL_TOKEN_SECRET:
+        try:
+            call_id = _spawn_modal(payload)
+            if call_id:
+                update_session(session_id, modal_call_id=call_id)
+        except Exception:
+            request_stop(session_id)
+            raise
+    else:
+        _spawn_local(payload)
+
+    logger.info("Started SAM3 video session %s", session_id)
+    return session_id
+
+
+def publish_internal_event(
+    session_id: str,
+    *,
+    publish_token: str,
+    event: Dict[str, Any],
+) -> bool:
+    meta = get_session(session_id)
+    if meta is None:
+        raise KeyError(f"Unknown SAM3 video session {session_id}")
+    stored = str(meta.get("publish_token") or "")
+    if len(stored) != len(publish_token) or not secrets.compare_digest(
+        stored, publish_token
+    ):
+        raise PermissionError("Invalid SAM3 video session publish token")
+    event_type = str(event.get("type") or "")
+    payload = {key: value for key, value in event.items() if key != "type"}
+    append_event(session_id, event_type, payload or None)
+    return is_stop_requested(session_id, WEBRTC_WORKSPACE_STREAM_TTL_SECONDS)
+
+
+def end_session(session_id: str) -> None:
+    meta = request_stop(session_id)
+    call_id = meta.get("modal_call_id") if meta else None
+    if call_id:
+        try:
+            import modal
+
+            modal.FunctionCall.from_id(call_id).cancel()
+        except Exception as error:
+            logger.warning("Failed to cancel SAM3 Modal call %s: %s", call_id, error)
+
+
+def session_snapshot(session_id: str) -> Optional[Dict[str, Any]]:
+    mark_client_seen(session_id)
+    return snapshot(session_id)
+
+
+def client_seen(session_id: str) -> None:
+    mark_client_seen(session_id)

--- a/inference/core/interfaces/sam3_video_session/session_store.py
+++ b/inference/core/interfaces/sam3_video_session/session_store.py
@@ -1,0 +1,174 @@
+import json
+import time
+from typing import Any, Dict, List, Optional
+
+from inference.core.cache import cache
+from inference.core.env import WEBRTC_WORKSPACE_STREAM_TTL_SECONDS
+from inference.core.interfaces.sam3_video_session.entities import (
+    SESSION_EVENT_TTL_SECONDS,
+    Sam3VideoSessionStatus,
+)
+
+META_KEY_PREFIX = "sam3_video_session:meta:"
+EVENTS_KEY_PREFIX = "sam3_video_session:events:"
+
+
+def _meta_key(session_id: str) -> str:
+    return f"{META_KEY_PREFIX}{session_id}"
+
+
+def _events_key(session_id: str) -> str:
+    return f"{EVENTS_KEY_PREFIX}{session_id}"
+
+
+def _event_ttl_seconds() -> int:
+    return max(SESSION_EVENT_TTL_SECONDS, WEBRTC_WORKSPACE_STREAM_TTL_SECONDS)
+
+
+def _decode_meta(raw: Any) -> Optional[Dict[str, Any]]:
+    if raw is None:
+        return None
+    if isinstance(raw, dict):
+        return raw
+    if isinstance(raw, (bytes, bytearray)):
+        raw = raw.decode("utf-8")
+    if isinstance(raw, str):
+        try:
+            parsed = json.loads(raw)
+        except (TypeError, ValueError):
+            return None
+        return parsed if isinstance(parsed, dict) else None
+    return None
+
+
+def create_session(
+    session_id: str,
+    *,
+    workspace_id: Optional[str],
+    publish_token: str,
+    owner_api_key_hash: str,
+) -> Dict[str, Any]:
+    now = time.time()
+    meta = {
+        "session_id": session_id,
+        "status": "starting",
+        "workspace_id": workspace_id,
+        "publish_token": publish_token,
+        "owner_api_key_hash": owner_api_key_hash,
+        "last_seq": 0,
+        "last_frame_id": None,
+        "error_message": None,
+        "stop_requested": False,
+        "last_client_seen_at": now,
+        "modal_call_id": None,
+        "created_at": now,
+    }
+    cache.set(_meta_key(session_id), meta, expire=_event_ttl_seconds())
+    return meta
+
+
+def get_session(session_id: str) -> Optional[Dict[str, Any]]:
+    return _decode_meta(cache.get(_meta_key(session_id)))
+
+
+def _touch_meta(meta: Dict[str, Any]) -> None:
+    cache.set(_meta_key(meta["session_id"]), meta, expire=_event_ttl_seconds())
+
+
+def update_session(session_id: str, **fields: Any) -> Optional[Dict[str, Any]]:
+    meta = get_session(session_id)
+    if meta is None:
+        return None
+    meta.update(fields)
+    _touch_meta(meta)
+    return meta
+
+
+def mark_client_seen(session_id: str) -> Optional[Dict[str, Any]]:
+    return update_session(session_id, last_client_seen_at=time.time())
+
+
+def request_stop(session_id: str) -> Optional[Dict[str, Any]]:
+    return update_session(session_id, stop_requested=True)
+
+
+def is_stop_requested(session_id: str, client_ttl_seconds: int) -> bool:
+    meta = get_session(session_id)
+    if meta is None:
+        return True
+    if meta.get("stop_requested"):
+        return True
+    last_seen = float(meta.get("last_client_seen_at") or 0)
+    return (time.time() - last_seen) > client_ttl_seconds
+
+
+def append_event(
+    session_id: str, event_type: str, payload: Optional[Dict[str, Any]] = None
+) -> Dict[str, Any]:
+    meta = get_session(session_id)
+    if meta is None:
+        raise KeyError(f"Unknown SAM3 video session {session_id}")
+    seq = int(meta.get("last_seq") or 0) + 1
+    event: Dict[str, Any] = {"seq": seq, "type": event_type}
+    if payload:
+        event.update(payload)
+    cache.zadd(
+        _events_key(session_id),
+        event,
+        float(seq),
+        expire=_event_ttl_seconds(),
+    )
+    fields: Dict[str, Any] = {"last_seq": seq}
+    if event_type == "frame":
+        frame_id = event.get("frame_id")
+        if frame_id is not None:
+            fields["last_frame_id"] = frame_id
+        fields["status"] = "running"
+    elif event_type == "downloading":
+        fields["status"] = "downloading"
+    elif event_type == "done":
+        fields["status"] = "cancelled" if event.get("cancelled") else "completed"
+    elif event_type == "error":
+        fields["status"] = "failed"
+        fields["error_message"] = event.get("message")
+    meta.update(fields)
+    _touch_meta(meta)
+    return event
+
+
+def list_events(session_id: str, after_seq: int = 0) -> List[Dict[str, Any]]:
+    raw_events = cache.zrangebyscore(
+        _events_key(session_id),
+        min=float(after_seq) + 0.5,
+        max=float("inf"),
+    )
+    events: List[Dict[str, Any]] = []
+    for item in raw_events:
+        if isinstance(item, dict):
+            events.append(item)
+            continue
+        if isinstance(item, (bytes, bytearray)):
+            item = item.decode("utf-8")
+        if isinstance(item, str):
+            try:
+                parsed = json.loads(item)
+            except (TypeError, ValueError):
+                continue
+            if isinstance(parsed, dict):
+                events.append(parsed)
+    return events
+
+
+def snapshot(session_id: str) -> Optional[Dict[str, Any]]:
+    meta = get_session(session_id)
+    if meta is None:
+        return None
+    status: Sam3VideoSessionStatus = meta.get("status") or "starting"
+    return {
+        "session_id": session_id,
+        "status": status,
+        "last_seq": int(meta.get("last_seq") or 0),
+        "last_frame_id": meta.get("last_frame_id"),
+        "error_message": meta.get("error_message"),
+        "stop_requested": bool(meta.get("stop_requested")),
+    }

--- a/inference/core/interfaces/sam3_video_session/worker.py
+++ b/inference/core/interfaces/sam3_video_session/worker.py
@@ -1,0 +1,356 @@
+from dataclasses import dataclass
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any, Dict, Iterable, List, Optional, Protocol
+
+import cv2
+import numpy as np
+import requests
+
+from inference.core.exceptions import InputImageLoadError
+from inference.core.interfaces.sam3_video_session.artifacts import (
+    ArtifactWriter,
+    TrackAccumulator,
+)
+from inference.core.interfaces.sam3_video_session.entities import (
+    CHUNK_SAMPLE_SIZE,
+    DEFAULT_CLASS_NAME,
+    DEFAULT_THRESHOLD,
+    MAX_VIDEO_BYTES,
+    MODEL_ID,
+    SAM3_VIDEO_EVENT_CHECKPOINTED,
+    SAM3_VIDEO_EVENT_DONE,
+    SAM3_VIDEO_EVENT_DOWNLOADING,
+    SAM3_VIDEO_EVENT_ERROR,
+    SAM3_VIDEO_EVENT_FRAME,
+    Sam3VideoTimeBase,
+    Sam3VideoWorkerPayload,
+)
+from inference.core.interfaces.sam3_video_session.predictions import (
+    serialize_frame_predictions,
+)
+from inference.core.logger import logger
+from inference.core.utils.image_utils import download_url_to_file
+from inference.core.utils.requests import api_key_safe_raise_for_status
+
+
+class EventPublisher(Protocol):
+    def publish(
+        self, event_type: str, payload: Optional[Dict[str, Any]] = None
+    ) -> bool:
+        """Return True when the worker should stop after the current checkpoint."""
+
+
+class HttpEventPublisher:
+    def __init__(
+        self,
+        *,
+        events_callback_url: str,
+        publish_token: str,
+        api_key: Optional[str],
+        timeout_seconds: float = 15.0,
+    ):
+        self._events_callback_url = events_callback_url
+        self._publish_token = publish_token
+        self._api_key = api_key
+        self._timeout_seconds = timeout_seconds
+
+    def publish(
+        self, event_type: str, payload: Optional[Dict[str, Any]] = None
+    ) -> bool:
+        event: Dict[str, Any] = {"type": event_type}
+        if payload:
+            event.update(payload)
+        headers = {"Content-Type": "application/json"}
+        if self._api_key:
+            headers["Authorization"] = f"Bearer {self._api_key}"
+        response = requests.post(
+            self._events_callback_url,
+            json={"publish_token": self._publish_token, "event": event},
+            headers=headers,
+            timeout=self._timeout_seconds,
+        )
+        api_key_safe_raise_for_status(response=response)
+        try:
+            body = response.json()
+        except ValueError:
+            return False
+        return bool(body.get("stop_requested"))
+
+
+@dataclass
+class FramePacket:
+    image_bgr: np.ndarray
+    frame_index: int
+    pts: int
+    time_base: float
+    source_time_seconds: float
+    width: int
+    height: int
+
+
+def time_base_from_fps(fps: float) -> Sam3VideoTimeBase:
+    if fps <= 0:
+        return Sam3VideoTimeBase(numerator=1, denominator=30)
+    return Sam3VideoTimeBase(numerator=1, denominator=max(1, int(round(fps))))
+
+
+def iter_frames_from_video(
+    video_path: str,
+    video_time_base: Optional[Sam3VideoTimeBase],
+) -> Iterable[FramePacket]:
+    capture = cv2.VideoCapture(video_path)
+    if not capture.isOpened():
+        raise RuntimeError("Could not open the downloaded video for SAM3 tracking.")
+    try:
+        fps = float(capture.get(cv2.CAP_PROP_FPS) or 0.0)
+        resolved = video_time_base or time_base_from_fps(fps)
+        time_base = resolved.numerator / resolved.denominator
+        frame_index = 0
+        while True:
+            ok, image_bgr = capture.read()
+            if not ok or image_bgr is None:
+                break
+            height, width = image_bgr.shape[:2]
+            source_time_seconds = (
+                frame_index / fps if fps > 0 else frame_index * time_base
+            )
+            pts = (
+                int(round(source_time_seconds / time_base))
+                if time_base
+                else frame_index
+            )
+            yield FramePacket(
+                image_bgr=image_bgr,
+                frame_index=frame_index,
+                pts=pts,
+                time_base=time_base,
+                source_time_seconds=source_time_seconds,
+                width=int(width),
+                height=int(height),
+            )
+            frame_index += 1
+    finally:
+        capture.release()
+
+
+def _load_sam3_model(api_key: Optional[str]):
+    from inference_models import AutoModel
+
+    return AutoModel.from_pretrained(model_id_or_path=MODEL_ID, api_key=api_key)
+
+
+def _bgr_to_model_image(image_bgr: np.ndarray) -> np.ndarray:
+    return cv2.cvtColor(image_bgr, cv2.COLOR_BGR2RGB)
+
+
+def process_frames(
+    *,
+    frames: Iterable[FramePacket],
+    model: Any,
+    class_names: List[str],
+    threshold: float,
+    revision_id: str,
+    publisher: EventPublisher,
+    writer: ArtifactWriter,
+    video_time_base: Sam3VideoTimeBase,
+    chunk_sample_size: int = CHUNK_SAMPLE_SIZE,
+) -> None:
+    accumulators: Dict[str, TrackAccumulator] = {}
+    state_dict = None
+    produced = 0
+    stop_requested = False
+
+    for packet in frames:
+        if state_dict is None:
+            result = model.prompt(
+                image=_bgr_to_model_image(packet.image_bgr),
+                text=class_names,
+                clear_old_prompts=True,
+            )
+        else:
+            result = model.track(
+                image=_bgr_to_model_image(packet.image_bgr),
+                state_dict=state_dict,
+            )
+        state_dict = result.state_dict
+        predictions, samples = serialize_frame_predictions(
+            masks=result.masks,
+            object_ids=result.object_ids,
+            scores=result.scores,
+            boxes=result.boxes,
+            prompt_to_object_ids=result.prompt_to_object_ids,
+            threshold=threshold,
+            width=packet.width,
+            height=packet.height,
+        )
+        for sample in samples:
+            sample["frameIndex"] = packet.frame_index
+            sample["pts"] = packet.pts
+            sample["timeBase"] = packet.time_base
+            sample["timestampUs"] = int(round(packet.source_time_seconds * 1_000_000))
+            track_id = str(sample["trackId"])
+            accumulator = accumulators.get(track_id)
+            if accumulator is None:
+                accumulator = TrackAccumulator(
+                    track_id=track_id,
+                    class_name=str(sample["className"]),
+                    tracker_id=int(sample["trackId"]),
+                )
+                accumulators[track_id] = accumulator
+            accumulator.add_sample(sample, packet.frame_index, packet.pts)
+        flushed = 0
+        for accumulator in accumulators.values():
+            flushed += accumulator.flush_ready(
+                writer,
+                chunk_sample_size=chunk_sample_size,
+                is_final=False,
+            )
+        if flushed:
+            publisher.publish(
+                SAM3_VIDEO_EVENT_CHECKPOINTED,
+                {"chunk_count": flushed},
+            )
+        stop_requested = publisher.publish(
+            SAM3_VIDEO_EVENT_FRAME,
+            {
+                "frame_id": packet.frame_index,
+                "revision_id": revision_id,
+                "serialized_output_data": {"predictions": {"predictions": predictions}},
+                "video_metadata": {
+                    "frame_id": packet.frame_index,
+                    "pts": packet.pts,
+                    "time_base": packet.time_base,
+                    "source_time_seconds": packet.source_time_seconds,
+                    "width": packet.width,
+                    "height": packet.height,
+                    "revision_id": revision_id,
+                },
+            },
+        )
+        produced += 1
+        if stop_requested:
+            break
+
+    for accumulator in accumulators.values():
+        accumulator.flush_ready(
+            writer,
+            chunk_sample_size=chunk_sample_size,
+            is_final=True,
+        )
+        accumulator.commit(writer, video_time_base)
+
+    if produced == 0:
+        publisher.publish(
+            SAM3_VIDEO_EVENT_ERROR,
+            {"message": "SAM3 produced no frames for this video."},
+        )
+        return
+    if not accumulators:
+        publisher.publish(
+            SAM3_VIDEO_EVENT_ERROR,
+            {"message": "SAM3 produced no predictions for this video."},
+        )
+        return
+    publisher.publish(
+        SAM3_VIDEO_EVENT_DONE,
+        {"cancelled": bool(stop_requested), "frame_count": produced},
+    )
+
+
+def run_sam3_video_session(
+    payload: Sam3VideoWorkerPayload,
+    *,
+    publisher: Optional[EventPublisher] = None,
+    writer: Optional[ArtifactWriter] = None,
+    model: Any = None,
+    frames: Optional[Iterable[FramePacket]] = None,
+    chunk_sample_size: int = CHUNK_SAMPLE_SIZE,
+) -> None:
+    class_names = [
+        name.strip() for name in payload.class_names if name and name.strip()
+    ]
+    if not class_names:
+        class_names = [DEFAULT_CLASS_NAME]
+    event_publisher = publisher or HttpEventPublisher(
+        events_callback_url=payload.events_callback_url,
+        publish_token=payload.publish_token,
+        api_key=payload.api_key,
+    )
+    artifact_writer = writer or ArtifactWriter(
+        app_base_url=payload.artifact.app_base_url,
+        video_id=payload.artifact.video_id,
+        workspace_id=payload.artifact.workspace_id,
+        dataset_id=payload.artifact.dataset_id,
+        revision_id=payload.artifact.revision_id,
+        api_key=payload.api_key or "",
+    )
+    try:
+        event_publisher.publish(SAM3_VIDEO_EVENT_DOWNLOADING)
+        if frames is None:
+            with TemporaryDirectory(prefix="sam3-video-") as temp_dir:
+                video_path = str(Path(temp_dir) / "video.mp4")
+                download_url_to_file(
+                    payload.video_url,
+                    video_path,
+                    max_bytes=MAX_VIDEO_BYTES,
+                )
+                loaded_model = model or _load_sam3_model(payload.api_key)
+                if payload.artifact.video_time_base is not None:
+                    resolved_time_base = payload.artifact.video_time_base
+                else:
+                    probe = cv2.VideoCapture(video_path)
+                    try:
+                        resolved_time_base = time_base_from_fps(
+                            float(probe.get(cv2.CAP_PROP_FPS) or 0.0)
+                        )
+                    finally:
+                        probe.release()
+                process_frames(
+                    frames=iter_frames_from_video(
+                        video_path,
+                        payload.artifact.video_time_base,
+                    ),
+                    model=loaded_model,
+                    class_names=class_names,
+                    threshold=(
+                        payload.threshold if payload.threshold else DEFAULT_THRESHOLD
+                    ),
+                    revision_id=payload.artifact.revision_id,
+                    publisher=event_publisher,
+                    writer=artifact_writer,
+                    video_time_base=resolved_time_base,
+                    chunk_sample_size=chunk_sample_size,
+                )
+            return
+        loaded_model = model or _load_sam3_model(payload.api_key)
+        resolved_time_base = payload.artifact.video_time_base or Sam3VideoTimeBase(
+            numerator=1, denominator=30
+        )
+        process_frames(
+            frames=frames,
+            model=loaded_model,
+            class_names=class_names,
+            threshold=payload.threshold if payload.threshold else DEFAULT_THRESHOLD,
+            revision_id=payload.artifact.revision_id,
+            publisher=event_publisher,
+            writer=artifact_writer,
+            video_time_base=resolved_time_base,
+            chunk_sample_size=chunk_sample_size,
+        )
+    except InputImageLoadError as error:
+        logger.warning("SAM3 video download failed: %s", error)
+        event_publisher.publish(
+            SAM3_VIDEO_EVENT_ERROR,
+            {"message": error.get_public_error_details()},
+        )
+    except Exception as error:
+        logger.exception("SAM3 video session failed")
+        event_publisher.publish(
+            SAM3_VIDEO_EVENT_ERROR,
+            {"message": str(error) or "SAM3 video tracking failed"},
+        )
+
+
+def run_sam3_video_session_from_dict(payload: Dict[str, Any]) -> None:
+    run_sam3_video_session(Sam3VideoWorkerPayload.model_validate(payload))

--- a/inference/core/interfaces/webrtc_worker/modal.py
+++ b/inference/core/interfaces/webrtc_worker/modal.py
@@ -503,6 +503,17 @@ if modal is not None:
                     )
             usage_collector.push_usage_payloads()
 
+        @modal.method()
+        def sam3_video_session_modal(self, payload: Dict[str, Any]):
+            from inference.core.interfaces.sam3_video_session.worker import (
+                run_sam3_video_session_from_dict,
+            )
+
+            self._function_call_number_on_container += 1
+            logger.info("Spawning SAM3 video session on %s", self._gpu)
+            run_sam3_video_session_from_dict(payload)
+            logger.info("SAM3 video session function completed")
+
         @modal.exit()
         def stop(self):
             logger.info("Stopping container")
@@ -753,3 +764,66 @@ if modal is not None:
                 logger.error(exc)
                 raise exc
             return answer
+
+
+def spawn_sam3_video_session_modal(payload) -> Optional[str]:
+    from inference.core.interfaces.sam3_video_session.entities import (
+        Sam3VideoWorkerPayload,
+    )
+
+    if not isinstance(payload, Sam3VideoWorkerPayload):
+        payload = Sam3VideoWorkerPayload.model_validate(payload)
+
+    requested_gpu: Optional[str] = None
+    requested_ram_mb: Optional[int] = None
+    requested_cpu_cores: Optional[int] = None
+    webrtc_plans: Optional[Dict[str, WebRTCPlan]] = (
+        usage_collector._plan_details.get_webrtc_plans(api_key=payload.api_key)
+        if payload.api_key
+        else None
+    )
+    if webrtc_plans and payload.requested_plan:
+        if payload.requested_plan not in webrtc_plans:
+            raise RoboflowAPIUnsuccessfulRequestError(
+                f"Unknown requested plan {payload.requested_plan}, available plans: {', '.join(webrtc_plans.keys())}"
+            )
+        requested_gpu = webrtc_plans[payload.requested_plan].gpu
+        requested_ram_mb = webrtc_plans[payload.requested_plan].ram_mb
+        requested_cpu_cores = webrtc_plans[payload.requested_plan].cpu_cores
+
+    client = modal.Client.from_credentials(
+        token_id=WEBRTC_MODAL_TOKEN_ID,
+        token_secret=WEBRTC_MODAL_TOKEN_SECRET,
+    )
+    try:
+        modal.App.lookup(
+            name=WEBRTC_MODAL_APP_NAME, client=client, create_if_missing=False
+        )
+    except modal.exception.NotFoundError:
+        logger.info("Deploying webrtc modal app %s", WEBRTC_MODAL_APP_NAME)
+        app.deploy(name=WEBRTC_MODAL_APP_NAME, client=client, tag=docker_tag)
+
+    modal_cls = RTCPeerConnectionModalGPU if requested_gpu else RTCPeerConnectionModalCPU
+    deployed_cls = modal.Cls.from_name(
+        app_name=app.name,
+        name=modal_cls.__name__,
+    )
+    deployed_cls.hydrate(client=client)
+    timeout = payload.processing_timeout or WEBRTC_MODAL_FUNCTION_MAX_TIME_LIMIT
+    cls_with_options = deployed_cls.with_options(timeout=timeout)
+    if requested_gpu is not None:
+        cls_with_options = cls_with_options.with_options(gpu=requested_gpu)
+    if requested_ram_mb is not None:
+        cls_with_options = cls_with_options.with_options(memory=requested_ram_mb)
+    if requested_cpu_cores is not None:
+        cls_with_options = cls_with_options.with_options(cpu=requested_cpu_cores)
+
+    modal_obj = cls_with_options(preload_hf_ids="", preload_models="")
+    function_call: modal.FunctionCall = modal_obj.sam3_video_session_modal.spawn(
+        payload=payload.model_dump(mode="json"),
+    )
+    call_id = getattr(function_call, "object_id", None) or getattr(
+        function_call, "call_id", None
+    )
+    logger.info("Spawned SAM3 video session Modal function")
+    return str(call_id) if call_id else None

--- a/inference/core/utils/image_utils.py
+++ b/inference/core/utils/image_utils.py
@@ -44,6 +44,8 @@ from inference.core.utils.url_input import (
     URLAddressNotAllowedError,
     fetch_url_content_legacy,
     fetch_url_content_validating_redirects,
+    fetch_url_to_file_legacy,
+    fetch_url_to_file_validating_redirects,
 )
 
 BASE64_DATA_TYPE_PATTERN = re.compile(r"^data:image\/[a-z]+;base64,")
@@ -427,6 +429,50 @@ def load_image_from_url(
     return load_image_from_encoded_bytes(
         value=image_bytes, cv_imread_flags=cv_imread_flags
     )
+
+
+def download_url_to_file(value: str, destination_path: str, max_bytes: int) -> None:
+    """Download a caller-supplied URL to disk using the same SSRF guards as
+    ``load_image_from_url``. The prepared URL is validated then fetched; the
+    body is streamed so a large video is not buffered in RAM.
+    """
+    if OFFLINE_MODE:
+        message = "Cannot load a URL while OFFLINE_MODE is enabled."
+        raise InputImageLoadError(
+            message=message,
+            public_message=message,
+        )
+    _ensure_url_input_allowed()
+    prepared_url = _validate_url_destination(value=value)
+    try:
+        if VALIDATE_IMAGE_URL_REDIRECTS:
+            fetch_url_to_file_validating_redirects(
+                url=prepared_url,
+                destination_path=destination_path,
+                allow_non_global_addresses=ALLOW_URL_TO_NON_GLOBAL_ADDRESSES,
+                max_redirects=MAX_IMAGE_URL_REDIRECTS,
+                max_bytes=max_bytes,
+                validate_redirect=_validate_url_destination,
+            )
+        else:
+            fetch_url_to_file_legacy(
+                url=prepared_url,
+                destination_path=destination_path,
+                allow_non_global_addresses=ALLOW_URL_TO_NON_GLOBAL_ADDRESSES,
+                max_redirects=MAX_IMAGE_URL_REDIRECTS,
+                max_bytes=max_bytes,
+            )
+    except URLAddressNotAllowedError as error:
+        message = "URL points to a network destination that is not allowed."
+        raise InputImageLoadError(
+            message=f"{message} Details: {error}",
+            public_message=message,
+        ) from error
+    except (RequestException, ConnectionError, OSError) as error:
+        raise InputImageLoadError(
+            message=f"Could not download URL: {value}. Details: {error}",
+            public_message="Data pointed by URL could not be downloaded.",
+        ) from error
 
 
 def _validate_url_destination(value: str) -> str:

--- a/inference/core/utils/url_input.py
+++ b/inference/core/utils/url_input.py
@@ -332,3 +332,91 @@ def fetch_url_content_validating_redirects(
         )
     finally:
         session.close()
+
+
+def _write_response_body_to_file(
+    response: requests.Response,
+    destination_path: str,
+    max_bytes: int,
+) -> None:
+    written = 0
+    with open(destination_path, "wb") as handle:
+        for chunk in response.iter_content(chunk_size=1024 * 1024):
+            if not chunk:
+                continue
+            written += len(chunk)
+            if written > max_bytes:
+                raise requests.exceptions.RequestException(
+                    f"URL content exceeded the maximum of {max_bytes} bytes."
+                )
+            handle.write(chunk)
+    if written == 0:
+        raise requests.exceptions.RequestException("URL returned an empty body.")
+
+
+def fetch_url_to_file_legacy(
+    url: str,
+    destination_path: str,
+    allow_non_global_addresses: bool,
+    max_redirects: int,
+    max_bytes: int,
+    request_timeout: Optional[float] = None,
+) -> None:
+    _warn_legacy_redirect_handling()
+    session = _build_ssrf_protected_session(allow_non_global_addresses)
+    session.max_redirects = max_redirects
+    try:
+        response = session.get(
+            url, stream=True, allow_redirects=True, timeout=request_timeout
+        )
+        api_key_safe_raise_for_status(response=response)
+        _write_response_body_to_file(
+            response=response,
+            destination_path=destination_path,
+            max_bytes=max_bytes,
+        )
+    finally:
+        session.close()
+
+
+def fetch_url_to_file_validating_redirects(
+    url: str,
+    destination_path: str,
+    allow_non_global_addresses: bool,
+    max_redirects: int,
+    max_bytes: int,
+    validate_redirect: Callable[[str], str],
+    request_timeout: Optional[float] = None,
+) -> None:
+    session = _build_ssrf_protected_session(allow_non_global_addresses)
+    current_url = url
+    try:
+        for _ in range(max_redirects + 1):
+            response = session.get(
+                current_url,
+                stream=True,
+                allow_redirects=False,
+                timeout=request_timeout,
+            )
+            if response.is_redirect:
+                location = response.headers.get("Location")
+                response.close()
+                if not location:
+                    raise requests.exceptions.RequestException(
+                        "Redirect response did not contain a Location header."
+                    )
+                next_url = urllib.parse.urljoin(current_url, location)
+                current_url = validate_redirect(next_url)
+                continue
+            api_key_safe_raise_for_status(response=response)
+            _write_response_body_to_file(
+                response=response,
+                destination_path=destination_path,
+                max_bytes=max_bytes,
+            )
+            return
+        raise requests.exceptions.TooManyRedirects(
+            f"Exceeded maximum of {max_redirects} redirects."
+        )
+    finally:
+        session.close()

--- a/tests/inference/unit_tests/core/interfaces/sam3_video_session/test_artifacts.py
+++ b/tests/inference/unit_tests/core/interfaces/sam3_video_session/test_artifacts.py
@@ -1,0 +1,104 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from inference.core.interfaces.sam3_video_session.artifacts import ArtifactWriter
+from inference.core.interfaces.sam3_video_session.entities import (
+    Sam3VideoArtifactTarget,
+    Sam3VideoTimeBase,
+)
+
+
+def test_artifact_writer_mints_signed_url_puts_gcs_and_posts_commit(monkeypatch) -> None:
+    calls = []
+
+    def fake_put(url, data=None, json=None, headers=None, timeout=None):
+        calls.append(("PUT", url, data, json, headers))
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = {}
+        return response
+
+    def fake_post(url, json=None, headers=None, timeout=None):
+        calls.append(("POST", url, json, headers))
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = {
+            "uploadUrl": "https://storage.googleapis.com/signed/chunk-000000.json"
+        }
+        return response
+
+    monkeypatch.setattr(
+        "inference.core.interfaces.sam3_video_session.artifacts.requests.put",
+        fake_put,
+    )
+    monkeypatch.setattr(
+        "inference.core.interfaces.sam3_video_session.artifacts.requests.post",
+        fake_post,
+    )
+
+    writer = ArtifactWriter(
+        app_base_url="https://app.roboflow.com",
+        video_id="video-1",
+        workspace_id="ws-1",
+        dataset_id="ds-1",
+        revision_id="rev-1",
+        api_key="rf_key",
+    )
+    writer.checkpoint_chunk(
+        track_id="7",
+        chunk_index=0,
+        total_chunks=1,
+        samples=[{"trackId": 7, "className": "forklift"}],
+    )
+    writer.commit_revision(
+        track_id="7",
+        start_frame_index=0,
+        end_frame_index=4,
+        start_pts=0,
+        end_pts=4,
+        video_time_base=Sam3VideoTimeBase(numerator=1, denominator=30),
+        class_name="forklift",
+        tracker_id=7,
+        sample_count=5,
+        chunk_count=1,
+    )
+
+    assert calls[0][0] == "POST"
+    assert calls[0][1].endswith(
+        "query/video/video-1/tracks/7/artifact-chunks/upload-url"
+    )
+    assert calls[0][2]["revisionId"] == "rev-1"
+    assert calls[0][3]["Authorization"] == "Bearer rf_key"
+    assert calls[1][0] == "PUT"
+    assert calls[1][1].startswith("https://storage.googleapis.com/signed/")
+    assert b'"samples"' in calls[1][2]
+    assert calls[1][4] == {"Content-Type": "application/json"}
+    assert "Authorization" not in (calls[1][4] or {})
+    assert calls[2][0] == "POST"
+    assert "artifact-revisions/rev-1/commit" in calls[2][1]
+    assert calls[2][2]["sampleCount"] == 5
+    assert calls[2][3]["Authorization"] == "Bearer rf_key"
+
+
+def test_artifact_writer_rejects_untrusted_app_host() -> None:
+    with pytest.raises(ValueError, match="Roboflow app host"):
+        ArtifactWriter(
+            app_base_url="https://evil.example",
+            video_id="video-1",
+            workspace_id="ws-1",
+            dataset_id="ds-1",
+            revision_id="rev-1",
+            api_key="rf_key",
+        )
+
+
+def test_session_request_rejects_untrusted_app_host() -> None:
+    with pytest.raises(ValueError, match="Roboflow app host"):
+        Sam3VideoArtifactTarget(
+            app_base_url="https://evil.example",
+            video_id="video-1",
+            workspace_id="ws-1",
+            dataset_id="ds-1",
+            revision_id="rev-1",
+        )

--- a/tests/inference/unit_tests/core/interfaces/sam3_video_session/test_predictions.py
+++ b/tests/inference/unit_tests/core/interfaces/sam3_video_session/test_predictions.py
@@ -1,0 +1,65 @@
+import numpy as np
+
+from inference.core.interfaces.sam3_video_session.predictions import (
+    class_name_for_object,
+    mask_to_uncompressed_rle,
+    serialize_frame_predictions,
+    xyxy_to_center_bounds,
+)
+
+
+def test_mask_to_uncompressed_rle_uses_fortran_order() -> None:
+    mask = np.zeros((4, 3), dtype=np.uint8)
+    mask[1:3, 1] = 1
+
+    encoded = mask_to_uncompressed_rle(mask)
+
+    assert encoded["size"] == [4, 3]
+    reconstructed = np.zeros(4 * 3, dtype=np.uint8)
+    offset = 0
+    foreground = False
+    for count in encoded["counts"]:
+        if foreground:
+            reconstructed[offset : offset + count] = 1
+        offset += count
+        foreground = not foreground
+    assert reconstructed.reshape((4, 3), order="F").tolist() == mask.tolist()
+
+
+def test_xyxy_to_center_bounds() -> None:
+    assert xyxy_to_center_bounds([10, 20, 30, 40]) == {
+        "x": 20.0,
+        "y": 30.0,
+        "width": 20.0,
+        "height": 20.0,
+    }
+    assert xyxy_to_center_bounds([1, 1, 1, 2]) is None
+
+
+def test_serialize_frame_predictions_skips_low_score_and_empty_masks() -> None:
+    masks = np.zeros((3, 8, 8), dtype=np.uint8)
+    masks[0, 2:6, 2:6] = 1
+    masks[2, 0:2, 0:2] = 1
+    predictions, samples = serialize_frame_predictions(
+        masks=masks,
+        object_ids=np.array([7, 8, 9]),
+        scores=np.array([0.9, 0.1, 0.8]),
+        boxes=np.array(
+            [
+                [2.0, 2.0, 6.0, 6.0],
+                [0.0, 0.0, 1.0, 1.0],
+                [0.0, 0.0, 2.0, 2.0],
+            ]
+        ),
+        prompt_to_object_ids={"forklift": [7], "pallet": [9]},
+        threshold=0.35,
+        width=8,
+        height=8,
+    )
+
+    assert [item["tracker_id"] for item in predictions] == [7, 9]
+    assert predictions[0]["class_name"] == "forklift"
+    assert predictions[0]["rle_mask"]["size"] == [8, 8]
+    assert samples[0]["trackId"] == 7
+    assert samples[0]["geometry"]["rleMask"]["size"] == [8, 8]
+    assert class_name_for_object(7, {"forklift": [7]}) == "forklift"

--- a/tests/inference/unit_tests/core/interfaces/sam3_video_session/test_service.py
+++ b/tests/inference/unit_tests/core/interfaces/sam3_video_session/test_service.py
@@ -1,0 +1,113 @@
+import uuid
+
+from inference.core.interfaces.sam3_video_session.entities import (
+    Sam3VideoArtifactTarget,
+    Sam3VideoSessionRequest,
+)
+from inference.core.interfaces.sam3_video_session.service import (
+    publish_internal_event,
+    start_session,
+)
+from inference.core.interfaces.sam3_video_session.session_store import (
+    create_session,
+    list_events,
+)
+
+
+def test_publish_internal_event_appends_and_replays_after_seq() -> None:
+    session_id = f"sam3-test-{uuid.uuid4()}"
+    create_session(
+        session_id,
+        workspace_id="ws-1",
+        publish_token="publish-me",
+        owner_api_key_hash="abc",
+    )
+
+    publish_internal_event(
+        session_id,
+        publish_token="publish-me",
+        event={"type": "downloading"},
+    )
+    publish_internal_event(
+        session_id,
+        publish_token="publish-me",
+        event={"type": "frame", "frame_id": 4},
+    )
+
+    replayed = list_events(session_id, after_seq=1)
+    assert [event["type"] for event in replayed] == ["frame"]
+    assert replayed[0]["frame_id"] == 4
+
+
+def test_publish_internal_event_rejects_bad_token() -> None:
+    session_id = f"sam3-test-{uuid.uuid4()}"
+    create_session(
+        session_id,
+        workspace_id="ws-1",
+        publish_token="publish-me",
+        owner_api_key_hash="abc",
+    )
+    try:
+        publish_internal_event(
+            session_id,
+            publish_token="wrong-token-value",
+            event={"type": "frame"},
+        )
+        raised = False
+    except PermissionError:
+        raised = True
+    assert raised is True
+
+
+def test_start_session_spawns_local_without_modal(monkeypatch) -> None:
+    spawned = {}
+    monkeypatch.setattr(
+        "inference.core.interfaces.sam3_video_session.service.WEBRTC_MODAL_TOKEN_ID",
+        "",
+    )
+    monkeypatch.setattr(
+        "inference.core.interfaces.sam3_video_session.service.WEBRTC_MODAL_TOKEN_SECRET",
+        "",
+    )
+    monkeypatch.setattr(
+        "inference.core.interfaces.sam3_video_session.service.WEBRTC_MODAL_USAGE_QUOTA_ENABLED",
+        False,
+    )
+    monkeypatch.setattr(
+        "inference.core.interfaces.sam3_video_session.service.WEBRTC_WORKSPACE_STREAM_QUOTA_ENABLED",
+        False,
+    )
+    monkeypatch.setattr(
+        "inference.core.interfaces.sam3_video_session.service.get_roboflow_workspace",
+        lambda api_key: "ws-1",
+    )
+
+    def fake_spawn(payload) -> None:
+        spawned["session_id"] = payload.session_id
+        spawned["video_url"] = payload.video_url
+        spawned["revision_id"] = payload.artifact.revision_id
+
+    monkeypatch.setattr(
+        "inference.core.interfaces.sam3_video_session.service._spawn_local",
+        fake_spawn,
+    )
+
+    session_id = start_session(
+        Sam3VideoSessionRequest(
+            video_url="https://storage.example/clip.mp4",
+            class_names=["forklift"],
+            artifact=Sam3VideoArtifactTarget(
+                app_base_url="https://app.roboflow.com",
+                video_id="video-1",
+                workspace_id="ws-1",
+                dataset_id="ds-1",
+                revision_id="rev-1",
+            ),
+        ),
+        api_key="rf_key",
+        events_callback_base="https://serverless.example",
+    )
+
+    assert spawned["session_id"] == session_id
+    assert spawned["video_url"] == "https://storage.example/clip.mp4"
+    assert spawned["revision_id"] == "rev-1"

--- a/tests/inference/unit_tests/core/interfaces/sam3_video_session/test_session_store.py
+++ b/tests/inference/unit_tests/core/interfaces/sam3_video_session/test_session_store.py
@@ -1,0 +1,49 @@
+import uuid
+
+from inference.core.interfaces.sam3_video_session.session_store import (
+    append_event,
+    create_session,
+    is_stop_requested,
+    list_events,
+    request_stop,
+    snapshot,
+)
+
+
+def test_list_events_replays_after_seq() -> None:
+    session_id = f"sam3-test-{uuid.uuid4()}"
+    create_session(
+        session_id,
+        workspace_id="ws-1",
+        publish_token="token",
+        owner_api_key_hash="abc",
+    )
+    append_event(session_id, "downloading")
+    append_event(session_id, "frame", {"frame_id": 0})
+    append_event(session_id, "frame", {"frame_id": 1})
+    append_event(session_id, "done", {"frame_count": 2})
+
+    replayed = list_events(session_id, after_seq=1)
+
+    assert [event["type"] for event in replayed] == ["frame", "frame", "done"]
+    assert replayed[0]["seq"] == 2
+    assert replayed[0]["frame_id"] == 0
+    snap = snapshot(session_id)
+    assert snap is not None
+    assert snap["status"] == "completed"
+    assert snap["last_seq"] == 4
+    assert snap["last_frame_id"] == 1
+
+
+def test_stop_requested_flag() -> None:
+    session_id = f"sam3-test-{uuid.uuid4()}"
+    create_session(
+        session_id,
+        workspace_id="ws-1",
+        publish_token="token",
+        owner_api_key_hash="abc",
+    )
+
+    assert is_stop_requested(session_id, client_ttl_seconds=60) is False
+    request_stop(session_id)
+    assert is_stop_requested(session_id, client_ttl_seconds=60) is True

--- a/tests/inference/unit_tests/core/interfaces/sam3_video_session/test_worker.py
+++ b/tests/inference/unit_tests/core/interfaces/sam3_video_session/test_worker.py
@@ -1,0 +1,224 @@
+from typing import Any, Dict, List, Optional, Tuple
+from unittest.mock import MagicMock
+
+import numpy as np
+
+from inference.core.interfaces.sam3_video_session.entities import (
+    SAM3_VIDEO_EVENT_CHECKPOINTED,
+    SAM3_VIDEO_EVENT_DONE,
+    SAM3_VIDEO_EVENT_DOWNLOADING,
+    SAM3_VIDEO_EVENT_FRAME,
+    Sam3VideoArtifactTarget,
+    Sam3VideoTimeBase,
+    Sam3VideoWorkerPayload,
+)
+from inference.core.interfaces.sam3_video_session.worker import (
+    FramePacket,
+    HttpEventPublisher,
+    process_frames,
+    run_sam3_video_session,
+)
+
+
+class FakeResult:
+    def __init__(self) -> None:
+        mask = np.zeros((8, 8), dtype=np.uint8)
+        mask[2:6, 2:6] = 1
+        self.masks = mask[None, ...]
+        self.object_ids = np.array([7])
+        self.scores = np.array([0.91])
+        self.boxes = np.array([[2.0, 2.0, 6.0, 6.0]])
+        self.prompt_to_object_ids = {"forklift": [7]}
+        self.state_dict = {"ok": True}
+
+
+class FakeModel:
+    def __init__(self) -> None:
+        self.prompt_calls = 0
+        self.track_calls = 0
+
+    def prompt(self, image, text, clear_old_prompts=True):
+        self.prompt_calls += 1
+        return FakeResult()
+
+    def track(self, image, state_dict=None):
+        self.track_calls += 1
+        return FakeResult()
+
+
+class FakePublisher:
+    def __init__(self, stop_after: Optional[int] = None) -> None:
+        self.events: List[Tuple[str, Dict[str, Any]]] = []
+        self.stop_after = stop_after
+
+    def publish(
+        self, event_type: str, payload: Optional[Dict[str, Any]] = None
+    ) -> bool:
+        self.events.append((event_type, payload or {}))
+        if self.stop_after is not None and len(self.events) >= self.stop_after:
+            return True
+        return False
+
+
+class FakeWriter:
+    def __init__(self) -> None:
+        self.chunks: List[Dict[str, Any]] = []
+        self.commits: List[Dict[str, Any]] = []
+
+    def checkpoint_chunk(self, **kwargs: Any) -> None:
+        self.chunks.append(kwargs)
+
+    def commit_revision(self, **kwargs: Any) -> None:
+        self.commits.append(kwargs)
+
+
+def _frames(count: int) -> List[FramePacket]:
+    packets = []
+    for index in range(count):
+        packets.append(
+            FramePacket(
+                image_bgr=np.zeros((8, 8, 3), dtype=np.uint8),
+                frame_index=index,
+                pts=index,
+                time_base=1 / 30,
+                source_time_seconds=index / 30,
+                width=8,
+                height=8,
+            )
+        )
+    return packets
+
+
+def _payload() -> Sam3VideoWorkerPayload:
+    return Sam3VideoWorkerPayload(
+        session_id="sess-1",
+        video_url="https://storage.example/video.mp4",
+        class_names=["forklift"],
+        artifact=Sam3VideoArtifactTarget(
+            app_base_url="https://app.roboflow.com",
+            video_id="video-1",
+            workspace_id="ws-1",
+            dataset_id="ds-1",
+            revision_id="rev-1",
+            video_time_base=Sam3VideoTimeBase(numerator=1, denominator=30),
+        ),
+        api_key="rf_key",
+        events_callback_url="https://serverless.example/sam3/video/sessions/sess-1/internal/events",
+        publish_token="pub",
+    )
+
+
+def test_process_frames_checkpoints_every_n_samples_and_commits() -> None:
+    publisher = FakePublisher()
+    writer = FakeWriter()
+    model = FakeModel()
+
+    process_frames(
+        frames=_frames(5),
+        model=model,
+        class_names=["forklift"],
+        threshold=0.35,
+        revision_id="rev-1",
+        publisher=publisher,
+        writer=writer,
+        video_time_base=Sam3VideoTimeBase(numerator=1, denominator=30),
+        chunk_sample_size=2,
+    )
+
+    assert model.prompt_calls == 1
+    assert model.track_calls == 4
+    assert len(writer.chunks) == 3
+    assert [chunk["chunk_index"] for chunk in writer.chunks] == [0, 1, 2]
+    assert [len(chunk["samples"]) for chunk in writer.chunks] == [2, 2, 1]
+    assert writer.chunks[0]["track_id"] == "7"
+    assert writer.chunks[0]["samples"][0]["geometry"]["rleMask"]["size"] == [8, 8]
+    assert len(writer.commits) == 1
+    assert writer.commits[0]["sample_count"] == 5
+    assert writer.commits[0]["chunk_count"] == 3
+    assert writer.commits[0]["track_id"] == "7"
+
+    event_types = [event_type for event_type, _ in publisher.events]
+    assert event_types.count(SAM3_VIDEO_EVENT_FRAME) == 5
+    assert SAM3_VIDEO_EVENT_CHECKPOINTED in event_types
+    assert event_types[-1] == SAM3_VIDEO_EVENT_DONE
+    frame_event = next(
+        payload
+        for event_type, payload in publisher.events
+        if event_type == SAM3_VIDEO_EVENT_FRAME
+    )
+    assert (
+        frame_event["serialized_output_data"]["predictions"]["predictions"][0][
+            "tracker_id"
+        ]
+        == 7
+    )
+    assert frame_event["video_metadata"]["revision_id"] == "rev-1"
+
+
+def test_process_frames_stop_requested_still_flushes_and_commits() -> None:
+    publisher = FakePublisher(stop_after=1)
+    writer = FakeWriter()
+
+    process_frames(
+        frames=_frames(4),
+        model=FakeModel(),
+        class_names=["forklift"],
+        threshold=0.35,
+        revision_id="rev-1",
+        publisher=publisher,
+        writer=writer,
+        video_time_base=Sam3VideoTimeBase(numerator=1, denominator=30),
+        chunk_sample_size=2,
+    )
+
+    assert len(writer.chunks) == 1
+    assert writer.chunks[0]["samples"]
+    assert writer.commits[0]["sample_count"] == 1
+    assert publisher.events[-1][0] == SAM3_VIDEO_EVENT_DONE
+    assert publisher.events[-1][1]["cancelled"] is True
+
+
+def test_run_session_with_injected_frames_emits_downloading() -> None:
+    publisher = FakePublisher()
+    writer = FakeWriter()
+
+    run_sam3_video_session(
+        _payload(),
+        publisher=publisher,
+        writer=writer,
+        model=FakeModel(),
+        frames=_frames(1),
+        chunk_sample_size=500,
+    )
+
+    assert publisher.events[0][0] == SAM3_VIDEO_EVENT_DOWNLOADING
+    assert publisher.events[-1][0] == SAM3_VIDEO_EVENT_DONE
+    assert writer.commits[0]["sample_count"] == 1
+
+
+def test_http_event_publisher_reads_stop_requested(monkeypatch) -> None:
+    response = MagicMock()
+    response.status_code = 200
+    response.json.return_value = {"stop_requested": True}
+    posted = {}
+
+    def fake_post(url, json, headers, timeout):
+        posted["url"] = url
+        posted["json"] = json
+        posted["headers"] = headers
+        return response
+
+    monkeypatch.setattr(
+        "inference.core.interfaces.sam3_video_session.worker.requests.post",
+        fake_post,
+    )
+    publisher = HttpEventPublisher(
+        events_callback_url="https://serverless.example/events",
+        publish_token="pub",
+        api_key="rf_key",
+    )
+
+    assert publisher.publish("frame", {"frame_id": 3}) is True
+    assert posted["json"]["publish_token"] == "pub"
+    assert posted["json"]["event"]["type"] == "frame"
+    assert posted["headers"]["Authorization"] == "Bearer rf_key"


### PR DESCRIPTION
## Summary

Adds a long-lived HTTP SAM3 video session so Track Through Video can pull the clip from an existing signed GCS URL instead of uploading it over WebRTC. The worker tracks with `sam3video` one numpy frame at a time, streams overlay events over SSE, and writes track artifact chunks through Roboflow-signed GCS uploads.

## Changes

- New `/sam3/video/sessions` routes: create, SSE events, internal event publish, end.
- Worker downloads `video_url` to a temp file (streamed to disk, 2GB cap, same SSRF guards as image URL loads), decodes with OpenCV, then `prompt`/`track` on Hugging Face `sam3video`.
- Artifacts: mint upload URL on the app, PUT chunk JSON to GCS, POST commit. Untrusted `app_base_url` hosts are rejected.
- Modal spawn on the existing WebRTC worker app when Modal creds are set; local multiprocessing spawn otherwise.
- Unit tests for artifacts, predictions, service, session store, and worker (15 passing).

## Test plan

- [ ] `pytest tests/inference/unit_tests/core/interfaces/sam3_video_session/`
- [ ] Create a session against local inference with a signed video URL and confirm SSE `downloading` / `frame` / `done`
- [ ] Confirm artifact chunks land under `video-tracks/{videoId}/{groupHash}/{trackId}/{revisionId}/chunk-*.json` and commit succeeds
- [ ] Stop mid-run and confirm the worker flushes, commits, and marks `cancelled`


Made with [Cursor](https://cursor.com)