### PR TITLE
fix(core): resolve Model through the lazy package init

### DIFF
--- a/inference/__init__.py
+++ b/inference/__init__.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
     from inference.models.utils import get_model, get_roboflow_model
 
 _LAZY_ATTRIBUTES: Dict[str, Callable[[], Any]] = {
+    "Model": lambda: _import_from("inference.core.models.base", "Model"),
     "Stream": lambda: _import_from("inference.core.interfaces.stream.stream", "Stream"),
     "InferencePipeline": lambda: _import_from(
         "inference.core.interfaces.stream.inference_pipeline", "InferencePipeline"

--- a/tests/inference/unit_tests/lazy_loading/test_inference_lazy_load.py
+++ b/tests/inference/unit_tests/lazy_loading/test_inference_lazy_load.py
@@ -98,6 +98,22 @@ def test_import_from_function():
         _import_from("nonexistent_module", "attribute")
 
 
+def test_model_lazy_export(monkeypatch):
+    """Model is advertised in __all__ and must resolve through the lazy loader."""
+    for mod_name in [
+        "inference",
+        "inference.core.models.base",
+    ]:
+        monkeypatch.delitem(sys.modules, mod_name, raising=False)
+
+    import inference
+
+    assert "Model" in inference.__all__
+    Model = inference.Model
+    assert Model is inference.Model
+    assert Model is sys.modules["inference.core.models.base"].Model
+
+
 def test_getattr_implementation(monkeypatch):
     """Test that the __getattr__ implementation is being called correctly."""
     for mod_name in [


### PR DESCRIPTION
## What does this PR do?

`inference/__init__.py` advertises `Model` in `__all__` (re-export of
`inference.core.models.base.Model`) and keeps the `TYPE_CHECKING` import for
it, but the lazy loader's `_LAZY_ATTRIBUTES` dict does not register it. The
package therefore fails its own advertised contract at runtime:

```python
import inference
inference.Model               # AttributeError: module 'inference' has no attribute 'Model'
from inference import Model   # ImportError
```

while `Stream`, `InferencePipeline`, `get_model`, and `get_roboflow_model`
all resolve. Type checkers pass because the `TYPE_CHECKING` import is intact,
so the hole only surfaces for real `import` traffic through the advertised
name.

This PR adds `Model` to `_LAZY_ATTRIBUTES` (resolving from
`inference.core.models.base`, the same source the `TYPE_CHECKING` import
uses) and adds a unit test asserting that `Model` resolves through the lazy
loader with identity stability (`inference.Model is inference.core.models.base.Model`).

No behavior change for the other four lazy attributes; laziness is preserved —
`inference.core.models.base` is imported only when `Model` is first accessed,
same as every sibling attribute.

**Unreleased:** `inference.Model` / `from inference import Model` no longer
raise despite being listed in `__all__`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other:

## Testing

### Unit tests

- Added `test_model_lazy_export` in
  `tests/inference/unit_tests/lazy_loading/test_inference_lazy_load.py`.
- File suite: **6 passed**
  (`python -m pytest tests/inference/unit_tests/lazy_loading/ -q`) — this
  directory runs in `unit_tests_inference_x86.yml` on Python 3.10/3.11/3.12.
- Combined run with the neighboring core unit tests:
  **2164 passed, 10 skipped**
  (`pytest tests/inference/unit_tests/lazy_loading/ tests/inference/unit_tests/core/ -q`)
  — no test-order pollution.
- On unpatched code the new test fails with the reproduced `AttributeError`.
- Verified by hand beyond the test: `from inference import *` no longer
  breaks mid-unpack; repeated access returns the same object;
  `inference.core.models.base` stays unloaded until first access.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [ ] I have made corresponding changes to the documentation (n/a — runtime contract fix; the docs already list `Model` among package exports)
- [x] No AI attribution trailers
