### PR TITLE
Add Cloud Agent development environment config

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,18 @@
+{
+  "name": "Roboflow Inference",
+  "user": "ubuntu",
+  "install": "bash .cursor/install.sh",
+  "terminals": [
+    {
+      "name": "inference-server",
+      "command": "bash .cursor/start-server.sh",
+      "description": "Roboflow Inference HTTP API (CPU) on http://127.0.0.1:9001 — serves the landing page, Swagger docs at /docs, model inference (e.g. /clip/compare) and Workflows (/workflows/run)."
+    }
+  ],
+  "ports": [
+    {
+      "name": "inference-server",
+      "port": 9001
+    }
+  ]
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Cloud Agent install script for Roboflow Inference.
+#
+# Idempotent bootstrap that installs the system libraries needed by OpenCV /
+# video handling and then installs the repository in editable mode into the
+# system Python interpreter (mirroring the project's own Docker images, so
+# `python3`, `pytest` and the `inference` CLI are available in any shell without
+# activating a virtualenv).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# --- System libraries -------------------------------------------------------
+# Runtime shared libraries required by opencv-python / scikit-image / ffmpeg.
+# Guarded so the script stays fast and idempotent when they are already present
+# (e.g. when booting from a prebuilt environment snapshot).
+if command -v apt-get >/dev/null 2>&1; then
+    APT_PACKAGES=(
+        python3-venv
+        python3-dev
+        build-essential
+        libgl1
+        libglib2.0-0
+        libsm6
+        libxext6
+        libxrender1
+        ffmpeg
+    )
+    MISSING=()
+    for pkg in "${APT_PACKAGES[@]}"; do
+        if ! dpkg -s "$pkg" >/dev/null 2>&1; then
+            MISSING+=("$pkg")
+        fi
+    done
+    if [ "${#MISSING[@]}" -gt 0 ]; then
+        sudo apt-get update -qq
+        sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends "${MISSING[@]}"
+    fi
+fi
+
+# --- Python dependencies ----------------------------------------------------
+PIP="python3 -m pip"
+PIP_FLAGS="--break-system-packages"
+
+$PIP install $PIP_FLAGS --upgrade pip "wheel>=0.38.1,<=0.45.1" "setuptools>=83.0.0"
+
+# Editable install of the full development stack (server, CLI, SDK, workflows,
+# torch-cpu based models). Mirrors the `pip install -e .` flow documented in
+# CONTRIBUTING.md / AGENTS.md.
+$PIP install $PIP_FLAGS -e .
+
+echo "inference install complete: $(python3 -c 'import inference; print("import OK")')"

--- a/.cursor/start-server.sh
+++ b/.cursor/start-server.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Launch the Roboflow Inference HTTP server (CPU) for local development.
+#
+# Runs the same ASGI app the CPU Docker image serves
+# (docker/config/cpu_http.py:app) via uvicorn. Static landing-page assets are
+# resolved relative to the repository root, so this script always runs from
+# there.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+export PYTHONPATH="${REPO_ROOT}:${REPO_ROOT}/docker/config"
+export PROJECT="${PROJECT:-roboflow-platform}"
+export HOST="${HOST:-127.0.0.1}"
+export PORT="${PORT:-9001}"
+export NUM_WORKERS="${NUM_WORKERS:-1}"
+export WORKFLOWS_STEP_EXECUTION_MODE="${WORKFLOWS_STEP_EXECUTION_MODE:-local}"
+export MODEL_CACHE_DIR="${MODEL_CACHE_DIR:-/tmp/cache}"
+export ENABLE_STREAM_API="${ENABLE_STREAM_API:-False}"
+export API_LOGGING_ENABLED="${API_LOGGING_ENABLED:-True}"
+
+exec python3 -m uvicorn cpu_http:app --host "$HOST" --port "$PORT" --workers "$NUM_WORKERS"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What & why

Adds a Cursor Cloud Agent development environment for this repository so agents boot into a ready-to-use Roboflow Inference dev setup (core library, CLI, SDK, Workflows engine, and the CPU HTTP server).

## Changes

- `​.cursor/environment.json` — environment definition (`install`, an `inference-server` terminal, and exposed port `9001`).
- `​.cursor/install.sh` — idempotent bootstrap: installs the system libraries OpenCV/scikit-image/ffmpeg need, then `pip install -e .` into the system interpreter (mirroring the repo's own Docker images, so `python3`, `pytest`, and the `inference` CLI work in any shell without activating a venv).
- `​.cursor/start-server.sh` — launches the same ASGI app the CPU image serves (`docker/config/cpu_http.py:app`) via uvicorn on `127.0.0.1:9001`, with the landing-page static paths resolved from the repo root.

The install follows the flow documented in `CONTRIBUTING.md` / `AGENTS.md` (`pip install -e .`).

## Validation

Everything below ran on this environment.

- `pip install -e .` completes and is idempotent (~7s on rerun).
- Unit tests: `tests/inference/unit_tests` (2647 passed), `tests/workflows/unit_tests` (5771 passed, 129 skipped), `tests/inference_sdk/unit_tests` (537 passed), `tests/inference_cli/unit_tests` (189 passed).
- `flake8` syntax check (E9,F63,F7,F82) clean; `black --check` clean on sampled sources.
- Server boots and serves the landing page, `/docs`, and `/info`.
- End-to-end model inference: `POST /clip/compare` on a solid-red image ranks `"a red image"` highest.
- End-to-end Workflow: `POST /workflows/run` with `roboflow_core/clip_comparison@v2` classifies a solid-green image as `"a green image"`.

[Inference server landing page](https://cursor.com/agents/bc-3e5c5565-c28c-4e21-90b2-b10a28e06094/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fserver_landing_page.webp)
[Inference server Swagger API docs](https://cursor.com/agents/bc-3e5c5565-c28c-4e21-90b2-b10a28e06094/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fserver_api_docs.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3e5c5565-c28c-4e21-90b2-b10a28e06094?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3e5c5565-c28c-4e21-90b2-b10a28e06094&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

