### PR TITLE
Report model predict time in megapixel bucket durations

### DIFF
--- a/inference/core/models/base.py
+++ b/inference/core/models/base.py
@@ -13,10 +13,9 @@ from inference.usage_tracking.collector import usage_collector
 from inference.usage_tracking.megapixel_buckets import (
     clear_measured_model_input,
     parse_image_dims_hw,
-    prediction_is_deferred,
     record_measured_model_input,
-    record_measured_predict_duration,
 )
+from inference.usage_tracking.predict_timing import PredictPhaseTimer
 
 
 class BaseInference:
@@ -43,15 +42,17 @@ class BaseInference:
             )
             if hasattr(preproc_image, "shape"):
                 set_span_attribute("model.input_shape", str(preproc_image.shape))
+        predict_timer = PredictPhaseTimer.start(model=self)
         with start_span("model.predict"):
-            predict_started_at = perf_counter()
             predicted_arrays = self.predict(preproc_image, **kwargs)
-            if not prediction_is_deferred(predicted_arrays):
-                record_measured_predict_duration(perf_counter() - predict_started_at)
+        predict_timer.finish(predictions=predicted_arrays)
         with start_span("model.postprocess"):
             postprocessed = self.postprocess(
                 predicted_arrays, returned_metadata, **kwargs
             )
+        # Reading the device timer is only free once post-processing has forced
+        # the model's work to complete.
+        predict_timer.publish()
 
         return postprocessed
 

--- a/inference/core/models/base.py
+++ b/inference/core/models/base.py
@@ -13,7 +13,9 @@ from inference.usage_tracking.collector import usage_collector
 from inference.usage_tracking.megapixel_buckets import (
     clear_measured_model_input,
     parse_image_dims_hw,
+    prediction_is_deferred,
     record_measured_model_input,
+    record_measured_predict_duration,
 )
 
 
@@ -42,7 +44,10 @@ class BaseInference:
             if hasattr(preproc_image, "shape"):
                 set_span_attribute("model.input_shape", str(preproc_image.shape))
         with start_span("model.predict"):
+            predict_started_at = perf_counter()
             predicted_arrays = self.predict(preproc_image, **kwargs)
+            if not prediction_is_deferred(predicted_arrays):
+                record_measured_predict_duration(perf_counter() - predict_started_at)
         with start_span("model.postprocess"):
             postprocessed = self.postprocess(
                 predicted_arrays, returned_metadata, **kwargs

--- a/inference/usage_tracking/decorator_helpers.py
+++ b/inference/usage_tracking/decorator_helpers.py
@@ -9,12 +9,12 @@ from inference.usage_tracking.megapixel_buckets import (
     build_megapixel_buckets,
     clear_measured_model_input,
     consume_measured_model_input,
-    consume_measured_predict_duration,
     count_inference_images,
     record_measured_model_hw,
     resolve_model_input_hw,
 )
 from inference.usage_tracking.model_types import get_recorded_model_type
+from inference.usage_tracking.predict_timing import consume_measured_predict_duration
 
 
 def _non_empty_model_id(value: Any) -> Optional[str]:

--- a/inference/usage_tracking/decorator_helpers.py
+++ b/inference/usage_tracking/decorator_helpers.py
@@ -9,6 +9,7 @@ from inference.usage_tracking.megapixel_buckets import (
     build_megapixel_buckets,
     clear_measured_model_input,
     consume_measured_model_input,
+    consume_measured_predict_duration,
     count_inference_images,
     record_measured_model_hw,
     resolve_model_input_hw,
@@ -154,15 +155,42 @@ def get_model_megapixel_buckets(
     execution_duration: float,
     inference_test_run: bool = False,
 ) -> Dict[str, Dict[str, Any]]:
+    """Attribute one model call's frames and duration to its input-size bucket.
+
+    Bucket duration is the predict phase alone when the entrypoint published
+    one, so that it can be compared across models without pre- and
+    post-processing overhead in the way. Entrypoints with no separable predict
+    phase fall back to ``execution_duration``, the decorator's full call time.
+
+    The published duration is consumed before the test-run check, so an
+    unreported call cannot leak its measurement into the next one.
+
+    Args:
+        frames: Images the caller asked this call to process.
+        input_hw: Model input resolution as (height, width), None when unknown.
+        execution_duration: Full call duration, used when no predict phase was
+            timed.
+        inference_test_run: True for test traffic, which is not bucketed.
+
+    Returns:
+        Single-entry bucket map, empty for a test run or a call with no frames.
+    """
+    predict_duration = consume_measured_predict_duration()
     if inference_test_run:
         return {}
+
     height, width = input_hw if input_hw else (None, None)
-    return build_megapixel_buckets(
+    bucket_duration = (
+        predict_duration if predict_duration is not None else execution_duration
+    )
+    megapixel_buckets = build_megapixel_buckets(
         height=height,
         width=width,
         frames=frames,
-        execution_duration=execution_duration,
+        execution_duration=bucket_duration,
     )
+
+    return megapixel_buckets
 
 
 def record_fixed_model_input_for_request(model: Any, request: Any = None) -> None:

--- a/inference/usage_tracking/megapixel_buckets.py
+++ b/inference/usage_tracking/megapixel_buckets.py
@@ -14,19 +14,13 @@ else falls back to the decorator's full call duration, which is also what the
 row-level ``execution_duration`` always reports. Bucket durations therefore do
 not reconcile against the row total. Falling back are the families that
 override ``infer()`` wholesale, the SAM ``infer_from_request`` entrypoints, and
-any call whose ``predict()`` defers its work (see ``prediction_is_deferred``).
+any call whose ``predict()`` defers its work. Timing of that phase lives in
+:mod:`inference.usage_tracking.predict_timing`.
 
-The predict phase is timed on the host, so backends that launch CUDA work
-asynchronously still under-report whenever nothing synchronizes before
-``predict()`` returns: that wait lands in whichever later phase forces it.
-Deferred-result backends are excluded rather than under-reported, but plain
-async kernel launches cannot be detected here and are a known bias.
-
-The measured input size and predict duration are published through
-:class:`~contextvars.ContextVar` rather than attributes on the model. Model
-instances are shared across the server's worker threads, so an attribute would
-let one request overwrite the measurements of another request that is still
-running.
+The measured input size is published through :class:`~contextvars.ContextVar`
+rather than an attribute on the model. Model instances are shared across the
+server's worker threads, so an attribute would let one request overwrite the
+measurement of another request that is still running.
 """
 
 from __future__ import annotations
@@ -34,6 +28,8 @@ from __future__ import annotations
 import json
 from contextvars import ContextVar
 from typing import Any, Dict, Optional, Tuple, Union
+
+from inference.usage_tracking.predict_timing import clear_measured_predict_duration
 
 # Inclusive upper bounds in megapixels. Final bucket catches everything above.
 _MEGAPIXEL_BUCKET_UPPER_BOUNDS: Tuple[Tuple[str, float], ...] = (
@@ -55,11 +51,6 @@ MeasuredModelInput = Tuple[Optional[Tuple[int, int]], Optional[int]]
 
 _measured_model_input: ContextVar[Optional[MeasuredModelInput]] = ContextVar(
     "usage_measured_model_input",
-    default=None,
-)
-
-_measured_predict_duration: ContextVar[Optional[float]] = ContextVar(
-    "usage_measured_predict_duration",
     default=None,
 )
 
@@ -375,7 +366,7 @@ def clear_measured_model_input() -> None:
     earlier call cannot be attributed to this one.
     """
     _measured_model_input.set(None)
-    _measured_predict_duration.set(None)
+    clear_measured_predict_duration()
 
 
 def record_measured_model_input(
@@ -436,70 +427,6 @@ def consume_measured_model_input() -> MeasuredModelInput:
         return None, None
     _measured_model_input.set(None)
     return measured
-
-
-def prediction_is_deferred(predictions: Any) -> bool:
-    """Whether ``predict()`` handed back a pending result instead of doing the work.
-
-    The pipelined RF-DETR segmentation adapter returns a future from
-    ``predict()`` and resolves it later - during ``postprocess()`` for an
-    earlier frame, or after the call has returned entirely when the caller is a
-    workflow. Timing ``predict()`` there would measure the launch, not the
-    inference, so such a call has no separable predict phase and must fall back
-    to the full call duration.
-
-    Duck-typed rather than an ``isinstance`` check against the backend's future,
-    so that this module stays import-light and later future-returning adapters
-    are covered without a change here.
-
-    Args:
-        predictions: Whatever ``predict()`` returned.
-
-    Returns:
-        True when the real work has not happened yet.
-    """
-    predictions_are_deferred = callable(getattr(predictions, "result", None))
-
-    return predictions_are_deferred
-
-
-def record_measured_predict_duration(duration: float) -> None:
-    """Publish the time spent in a model's predict phase.
-
-    Accumulates, because a single decorated call may run predict more than once
-    (a model that chunks its own batch). Negative and non-numeric values are
-    dropped rather than raised: usage tracking must never break inference.
-
-    Args:
-        duration: Seconds spent inside one predict call.
-    """
-    try:
-        seconds = float(duration)
-    except (TypeError, ValueError):
-        return
-    if seconds < 0:
-        return
-
-    recorded = _measured_predict_duration.get()
-    _measured_predict_duration.set(
-        seconds if recorded is None else recorded + seconds,
-    )
-
-
-def consume_measured_predict_duration() -> Optional[float]:
-    """Read and clear the predict duration published by the current call.
-
-    Returns:
-        Seconds spent in predict, or None when the call had no separable
-        predict phase and the caller should fall back to the full call
-        duration.
-    """
-    duration = _measured_predict_duration.get()
-    if duration is None:
-        return None
-    _measured_predict_duration.set(None)
-
-    return duration
 
 
 def resolve_model_input_hw(

--- a/inference/usage_tracking/megapixel_buckets.py
+++ b/inference/usage_tracking/megapixel_buckets.py
@@ -8,10 +8,25 @@ larger uploads produce more patches and take longer. ``unknown`` is only used
 when none of those sources are available. Bucket maps are merge-friendly
 sums; averages are derived downstream.
 
-The measured input size is published through a :class:`~contextvars.ContextVar`
-rather than an attribute on the model. Model instances are shared across the
-server's worker threads, so an attribute would let one request overwrite the
-size and frame count of another request that is still running.
+Bucket ``execution_duration`` is the model's predict phase alone, excluding
+pre- and post-processing, for entrypoints that separate the phases. Everything
+else falls back to the decorator's full call duration, which is also what the
+row-level ``execution_duration`` always reports. Bucket durations therefore do
+not reconcile against the row total. Falling back are the families that
+override ``infer()`` wholesale, the SAM ``infer_from_request`` entrypoints, and
+any call whose ``predict()`` defers its work (see ``prediction_is_deferred``).
+
+The predict phase is timed on the host, so backends that launch CUDA work
+asynchronously still under-report whenever nothing synchronizes before
+``predict()`` returns: that wait lands in whichever later phase forces it.
+Deferred-result backends are excluded rather than under-reported, but plain
+async kernel launches cannot be detected here and are a known bias.
+
+The measured input size and predict duration are published through
+:class:`~contextvars.ContextVar` rather than attributes on the model. Model
+instances are shared across the server's worker threads, so an attribute would
+let one request overwrite the measurements of another request that is still
+running.
 """
 
 from __future__ import annotations
@@ -40,6 +55,11 @@ MeasuredModelInput = Tuple[Optional[Tuple[int, int]], Optional[int]]
 
 _measured_model_input: ContextVar[Optional[MeasuredModelInput]] = ContextVar(
     "usage_measured_model_input",
+    default=None,
+)
+
+_measured_predict_duration: ContextVar[Optional[float]] = ContextVar(
+    "usage_measured_predict_duration",
     default=None,
 )
 
@@ -349,7 +369,13 @@ def count_inference_images(image: Any) -> int:
 
 
 def clear_measured_model_input() -> None:
+    """Reset every per-call measurement published for the usage decorator.
+
+    Called at the start of a model call so that a measurement published by an
+    earlier call cannot be attributed to this one.
+    """
     _measured_model_input.set(None)
+    _measured_predict_duration.set(None)
 
 
 def record_measured_model_input(
@@ -410,6 +436,70 @@ def consume_measured_model_input() -> MeasuredModelInput:
         return None, None
     _measured_model_input.set(None)
     return measured
+
+
+def prediction_is_deferred(predictions: Any) -> bool:
+    """Whether ``predict()`` handed back a pending result instead of doing the work.
+
+    The pipelined RF-DETR segmentation adapter returns a future from
+    ``predict()`` and resolves it later - during ``postprocess()`` for an
+    earlier frame, or after the call has returned entirely when the caller is a
+    workflow. Timing ``predict()`` there would measure the launch, not the
+    inference, so such a call has no separable predict phase and must fall back
+    to the full call duration.
+
+    Duck-typed rather than an ``isinstance`` check against the backend's future,
+    so that this module stays import-light and later future-returning adapters
+    are covered without a change here.
+
+    Args:
+        predictions: Whatever ``predict()`` returned.
+
+    Returns:
+        True when the real work has not happened yet.
+    """
+    predictions_are_deferred = callable(getattr(predictions, "result", None))
+
+    return predictions_are_deferred
+
+
+def record_measured_predict_duration(duration: float) -> None:
+    """Publish the time spent in a model's predict phase.
+
+    Accumulates, because a single decorated call may run predict more than once
+    (a model that chunks its own batch). Negative and non-numeric values are
+    dropped rather than raised: usage tracking must never break inference.
+
+    Args:
+        duration: Seconds spent inside one predict call.
+    """
+    try:
+        seconds = float(duration)
+    except (TypeError, ValueError):
+        return
+    if seconds < 0:
+        return
+
+    recorded = _measured_predict_duration.get()
+    _measured_predict_duration.set(
+        seconds if recorded is None else recorded + seconds,
+    )
+
+
+def consume_measured_predict_duration() -> Optional[float]:
+    """Read and clear the predict duration published by the current call.
+
+    Returns:
+        Seconds spent in predict, or None when the call had no separable
+        predict phase and the caller should fall back to the full call
+        duration.
+    """
+    duration = _measured_predict_duration.get()
+    if duration is None:
+        return None
+    _measured_predict_duration.set(None)
+
+    return duration
 
 
 def resolve_model_input_hw(

--- a/inference/usage_tracking/predict_timing.py
+++ b/inference/usage_tracking/predict_timing.py
@@ -1,0 +1,282 @@
+"""Timing a model's predict phase for usage telemetry.
+
+The number we want is how long the model itself ran, separated from the pre-
+and post-processing around it. Measuring that on the host is only correct when
+the backend has finished its device work by the time ``predict()`` returns.
+Most of them have: the legacy ONNX path binds its outputs to host buffers so
+ONNX Runtime cannot return early, the ``inference_models`` ONNX helpers
+synchronize their stream before handing tensors back, and TensorRT synchronizes
+unless it is explicitly run in pipelined mode. The exceptions are backends that
+enqueue CUDA work and return immediately, where a host clock would time the
+launch instead of the inference.
+
+CUDA events close that gap without slowing anything down. Recording an event is
+just a marker enqueued on the stream, but reading the elapsed time between two
+of them requires the second one to have completed - which is why the read
+happens after post-processing rather than straight after ``predict()``. By the
+time a call is ready to return real numbers to its caller, the device work it
+describes must already be done, so the read finds both events complete and
+never waits. If they are somehow not complete, the measurement is abandoned in
+favour of the host clock instead of blocking; every path here degrades to the
+host reading rather than costing latency or raising.
+
+Deferred results are excluded entirely (see :func:`prediction_is_deferred`),
+because a pipelined call has no predict phase to attribute in the first place.
+
+Measurements are published through :class:`~contextvars.ContextVar` rather than
+attributes on the model. Model instances are shared across the server's worker
+threads, so an attribute would let one request overwrite the measurement of
+another request that is still running.
+"""
+
+from __future__ import annotations
+
+from contextvars import ContextVar
+from time import perf_counter
+from typing import Any, Optional, Tuple
+
+_measured_predict_duration: ContextVar[Optional[float]] = ContextVar(
+    "usage_measured_predict_duration",
+    default=None,
+)
+
+_UNRESOLVED = object()
+_torch_cuda: Any = _UNRESOLVED
+
+
+def _get_torch_cuda() -> Any:
+    """Return ``torch.cuda`` when a usable CUDA runtime is present, else None.
+
+    Resolved once per process. Usage tracking is imported by CPU-only
+    deployments that have no torch at all, so the import cannot be top-level.
+    """
+    global _torch_cuda
+    if _torch_cuda is _UNRESOLVED:
+        try:
+            import torch
+
+            _torch_cuda = torch.cuda if torch.cuda.is_available() else None
+        except Exception:
+            _torch_cuda = None
+    return _torch_cuda
+
+
+def resolve_inference_stream(model: Any) -> Any:
+    """The CUDA stream a model's forward pass enqueues its work onto.
+
+    ``inference_models`` backends expose the stream they run inference on as
+    ``_inference_stream``, which is the reliable answer and is checked first,
+    on the adapter and on the backend it wraps. Backends that manage no stream
+    of their own - the RF-DETR torch path, for instance - enqueue onto the
+    ambient current stream instead, so that is used when the model declares a
+    CUDA device.
+
+    Returns:
+        The stream to record timing events on, or None when the model is not
+        running on CUDA or its stream cannot be identified. None means the
+        caller should time on the host.
+    """
+    candidates = (model, getattr(model, "_model", None))
+    for candidate in candidates:
+        if candidate is None:
+            continue
+        stream = getattr(candidate, "_inference_stream", None)
+        if stream is not None:
+            return stream
+
+    torch_cuda = _get_torch_cuda()
+    if torch_cuda is None:
+        return None
+    for candidate in candidates:
+        if candidate is None:
+            continue
+        device = getattr(candidate, "_device", None)
+        if device is not None and getattr(device, "type", None) == "cuda":
+            return torch_cuda.current_stream(device)
+    return None
+
+
+def _create_timing_events(torch_cuda: Any) -> Optional[Tuple[Any, Any]]:
+    """A fresh start/end event pair for one predict phase.
+
+    Deliberately not pooled per thread: a model whose ``predict()`` runs
+    another model would have the nested call re-record the events the outer
+    call is still measuring with. The underlying CUDA event is created lazily
+    on first record, so a pair costs a few microseconds against a forward pass
+    measured in milliseconds.
+    """
+    try:
+        return (
+            torch_cuda.Event(enable_timing=True),
+            torch_cuda.Event(enable_timing=True),
+        )
+    except Exception:
+        return None
+
+
+class PredictPhaseTimer:
+    """Times one predict phase, on the device when the work runs there.
+
+    Used across the predict and post-process boundary rather than as a context
+    manager, because the device reading is only free once post-processing has
+    forced the work to complete:
+
+        timer = PredictPhaseTimer.start(model=self)
+        predictions = self.predict(...)
+        timer.finish(predictions=predictions)
+        result = self.postprocess(predictions, ...)
+        timer.publish()
+    """
+
+    __slots__ = (
+        "_started_at",
+        "_host_duration",
+        "_events",
+        "_stream",
+        "_deferred",
+    )
+
+    def __init__(self) -> None:
+        self._started_at: Optional[float] = None
+        self._host_duration: Optional[float] = None
+        self._events: Optional[Tuple[Any, Any]] = None
+        self._stream: Any = None
+        self._deferred = False
+
+    @classmethod
+    def start(cls, model: Any) -> "PredictPhaseTimer":
+        """Begin timing, arming device events when the model runs on CUDA."""
+        timer = cls()
+        timer._started_at = perf_counter()
+        try:
+            stream = resolve_inference_stream(model)
+            if stream is None:
+                return timer
+            torch_cuda = _get_torch_cuda()
+            if torch_cuda is None:
+                return timer
+            events = _create_timing_events(torch_cuda)
+            if events is None:
+                return timer
+            events[0].record(stream)
+            timer._events = events
+            timer._stream = stream
+        except Exception:
+            timer._events = None
+        return timer
+
+    def finish(self, predictions: Any) -> None:
+        """Close the measured window, right after ``predict()`` returned."""
+        if self._started_at is None:
+            return
+        self._host_duration = perf_counter() - self._started_at
+        try:
+            self._deferred = prediction_is_deferred(predictions)
+            if self._events is not None and not self._deferred:
+                self._events[1].record(self._stream)
+        except Exception:
+            self._events = None
+
+    def publish(self) -> None:
+        """Record the measurement, preferring the device reading.
+
+        Deferred calls publish nothing, which leaves the bucket falling back to
+        the decorator's full call duration.
+        """
+        if self._host_duration is None or self._deferred:
+            return
+        duration = self._host_duration
+        device_duration = self._read_device_duration()
+        if device_duration is not None:
+            duration = device_duration
+        record_measured_predict_duration(duration)
+
+    def _read_device_duration(self) -> Optional[float]:
+        """Seconds measured between the device events, or None to use the host.
+
+        Never waits. An incomplete event means the assumption that
+        post-processing forces completion did not hold for this backend, and an
+        implausible reading means the events did not bracket the work - a
+        stream this module failed to identify. Both fall back to the host.
+        """
+        if self._events is None:
+            return None
+        try:
+            start_event, end_event = self._events
+            if not start_event.query() or not end_event.query():
+                return None
+            seconds = start_event.elapsed_time(end_event) / 1000.0
+            if seconds < 0 or seconds > perf_counter() - self._started_at:
+                return None
+            return seconds
+        except Exception:
+            return None
+
+
+def prediction_is_deferred(predictions: Any) -> bool:
+    """Whether ``predict()`` handed back a pending result instead of doing the work.
+
+    The pipelined RF-DETR segmentation adapter returns a future from
+    ``predict()`` and resolves it later - during ``postprocess()`` for an
+    earlier frame, or after the call has returned entirely when the caller is a
+    workflow. Timing ``predict()`` there would measure the launch, not the
+    inference, so such a call has no separable predict phase and must fall back
+    to the full call duration.
+
+    Duck-typed rather than an ``isinstance`` check against the backend's future,
+    so that this module stays import-light and later future-returning adapters
+    are covered without a change here.
+
+    Args:
+        predictions: Whatever ``predict()`` returned.
+
+    Returns:
+        True when the real work has not happened yet.
+    """
+    predictions_are_deferred = callable(getattr(predictions, "result", None))
+
+    return predictions_are_deferred
+
+
+def clear_measured_predict_duration() -> None:
+    """Drop any predict duration left over from an earlier call."""
+    _measured_predict_duration.set(None)
+
+
+def record_measured_predict_duration(duration: float) -> None:
+    """Publish the time spent in a model's predict phase.
+
+    Accumulates, because a single decorated call may run predict more than once
+    (a model that chunks its own batch). Negative and non-numeric values are
+    dropped rather than raised: usage tracking must never break inference.
+
+    Args:
+        duration: Seconds spent inside one predict call.
+    """
+    try:
+        seconds = float(duration)
+    except (TypeError, ValueError):
+        return
+    if seconds < 0:
+        return
+
+    recorded = _measured_predict_duration.get()
+    _measured_predict_duration.set(
+        seconds if recorded is None else recorded + seconds,
+    )
+
+
+def consume_measured_predict_duration() -> Optional[float]:
+    """Read and clear the predict duration published by the current call.
+
+    Returns:
+        Seconds spent in predict, or None when the call had no separable
+        predict phase and the caller should fall back to the full call
+        duration.
+    """
+    duration = _measured_predict_duration.get()
+    if duration is None:
+        return None
+    _measured_predict_duration.set(None)
+
+    return duration

--- a/inference/usage_tracking/predict_timing.py
+++ b/inference/usage_tracking/predict_timing.py
@@ -31,9 +31,16 @@ because a pipelined call has no predict phase to attribute in the first place.
 
 What is measured is the phase, not the model in isolation. Legacy ONNX models
 take their session lock inside ``predict()``, so a host reading there carries
-time spent queued behind other requests to the same model. That was true of the
-wall-clock duration this replaces as well, but it is contention rather than
-model cost sitting inside a number now labelled as the model's.
+time spent queued behind other requests to the same model. TensorRT backends
+and the RF-DETR scheduler hold one inference stream per model instance, shared
+across the server's worker threads, so a declared-stream device reading can
+similarly fold another request's engine work into this one. Those backends
+synchronize before ``predict()`` returns (the pipelined path is excluded as
+deferred), and a declared reading that exceeds this call's host window is
+dropped so the inflation cannot exceed the number the metric reported before
+this change. Queueing was true of the wall-clock duration this replaces as
+well, but it is contention rather than model cost sitting inside a number now
+labelled as the model's.
 
 Measurements are published through :class:`~contextvars.ContextVar` rather than
 attributes on the model. Model instances are shared across the server's worker
@@ -224,12 +231,18 @@ class PredictPhaseTimer:
         reading longer than the call itself means the events did not bracket
         the work. Both fall back to the host.
 
-        A declared stream is known to carry the model's work, so its reading
-        replaces the host window outright. An assumed one is not, and events on
-        a stream that turned out to hold no work read near zero - so an assumed
-        reading is only believed when it exceeds the host window, where it can
-        only be revealing device work that finished after ``predict()``
-        returned. A wrong guess can then be ignored but never believed.
+        A declared stream is known to carry the model's work, so a shorter
+        reading replaces the host window. It is not known to carry *only*
+        this call's work: TensorRT backends share one stream per model
+        instance, and events on that stream can bracket another request's
+        engine work. Those backends synchronize before ``predict()`` returns,
+        so a declared reading past this call's host window is cross-request
+        inflation and is dropped. An assumed stream is not known to carry
+        the work at all, and events on a stream that held none read near
+        zero - so an assumed reading is only believed when it exceeds the
+        host window, where it can only be revealing device work that
+        finished after ``predict()`` returned. A wrong guess can then be
+        ignored but never believed.
         """
         if self._events is None:
             return None
@@ -240,8 +253,14 @@ class PredictPhaseTimer:
             seconds = start_event.elapsed_time(end_event) / 1000.0
             if seconds < 0 or seconds > perf_counter() - self._started_at:
                 return None
-            if not self._stream_is_declared and seconds <= self._host_duration:
+            if self._stream_is_declared:
+                if seconds > self._host_duration:
+                    return None
+
+                return seconds
+            if seconds <= self._host_duration:
                 return None
+
             return seconds
         except Exception:
             return None

--- a/inference/usage_tracking/predict_timing.py
+++ b/inference/usage_tracking/predict_timing.py
@@ -20,8 +20,20 @@ never waits. If they are somehow not complete, the measurement is abandoned in
 favour of the host clock instead of blocking; every path here degrades to the
 host reading rather than costing latency or raising.
 
+Events only measure the stream they are recorded on, so which stream a backend
+uses decides whether this works at all - see :func:`resolve_inference_stream`
+for how far a reading is trusted when the stream had to be guessed. Where no
+stream can be identified the host clock stands, which is the right answer for
+every backend that synchronizes and an under-report for the rest.
+
 Deferred results are excluded entirely (see :func:`prediction_is_deferred`),
 because a pipelined call has no predict phase to attribute in the first place.
+
+What is measured is the phase, not the model in isolation. Legacy ONNX models
+take their session lock inside ``predict()``, so a host reading there carries
+time spent queued behind other requests to the same model. That was true of the
+wall-clock duration this replaces as well, but it is contention rather than
+model cost sitting inside a number now labelled as the model's.
 
 Measurements are published through :class:`~contextvars.ContextVar` rather than
 attributes on the model. Model instances are shared across the server's worker
@@ -61,39 +73,49 @@ def _get_torch_cuda() -> Any:
     return _torch_cuda
 
 
-def resolve_inference_stream(model: Any) -> Any:
+def resolve_inference_stream(model: Any) -> Tuple[Any, bool]:
     """The CUDA stream a model's forward pass enqueues its work onto.
 
-    ``inference_models`` backends expose the stream they run inference on as
-    ``_inference_stream``, which is the reliable answer and is checked first,
-    on the adapter and on the backend it wraps. Backends that manage no stream
-    of their own - the RF-DETR torch path, for instance - enqueue onto the
-    ambient current stream instead, so that is used when the model declares a
-    CUDA device.
+    ``inference_models`` backends name the stream they run inference on
+    ``_inference_stream``. Most hold it on the model, but the RF-DETR
+    TensorRT path hands engine execution to a scheduler that owns one, so
+    both the adapter and the backend it wraps are searched at each level.
+    A stream found this way is declared: it is known to carry the model's
+    work.
+
+    Backends that manage no stream of their own - the RF-DETR torch path,
+    for instance - enqueue onto the ambient current stream, which is a good
+    guess but only a guess, since a backend could switch streams somewhere
+    this function does not look. Such a stream is assumed, and the caller
+    limits how far it trusts the reading.
 
     Returns:
-        The stream to record timing events on, or None when the model is not
-        running on CUDA or its stream cannot be identified. None means the
-        caller should time on the host.
+        Tuple of the stream to record timing events on and whether the model
+        declared it. The stream is None when the model is not running on CUDA
+        or no stream could be identified, meaning the caller should time on
+        the host.
     """
     candidates = (model, getattr(model, "_model", None))
     for candidate in candidates:
         if candidate is None:
             continue
-        stream = getattr(candidate, "_inference_stream", None)
-        if stream is not None:
-            return stream
+        for holder in (candidate, getattr(candidate, "_scheduler", None)):
+            if holder is None:
+                continue
+            stream = getattr(holder, "_inference_stream", None)
+            if stream is not None:
+                return stream, True
 
     torch_cuda = _get_torch_cuda()
     if torch_cuda is None:
-        return None
+        return None, False
     for candidate in candidates:
         if candidate is None:
             continue
         device = getattr(candidate, "_device", None)
         if device is not None and getattr(device, "type", None) == "cuda":
-            return torch_cuda.current_stream(device)
-    return None
+            return torch_cuda.current_stream(device), False
+    return None, False
 
 
 def _create_timing_events(torch_cuda: Any) -> Optional[Tuple[Any, Any]]:
@@ -133,6 +155,7 @@ class PredictPhaseTimer:
         "_host_duration",
         "_events",
         "_stream",
+        "_stream_is_declared",
         "_deferred",
     )
 
@@ -141,6 +164,7 @@ class PredictPhaseTimer:
         self._host_duration: Optional[float] = None
         self._events: Optional[Tuple[Any, Any]] = None
         self._stream: Any = None
+        self._stream_is_declared = False
         self._deferred = False
 
     @classmethod
@@ -149,7 +173,7 @@ class PredictPhaseTimer:
         timer = cls()
         timer._started_at = perf_counter()
         try:
-            stream = resolve_inference_stream(model)
+            stream, stream_is_declared = resolve_inference_stream(model)
             if stream is None:
                 return timer
             torch_cuda = _get_torch_cuda()
@@ -161,6 +185,7 @@ class PredictPhaseTimer:
             events[0].record(stream)
             timer._events = events
             timer._stream = stream
+            timer._stream_is_declared = stream_is_declared
         except Exception:
             timer._events = None
         return timer
@@ -195,9 +220,16 @@ class PredictPhaseTimer:
         """Seconds measured between the device events, or None to use the host.
 
         Never waits. An incomplete event means the assumption that
-        post-processing forces completion did not hold for this backend, and an
-        implausible reading means the events did not bracket the work - a
-        stream this module failed to identify. Both fall back to the host.
+        post-processing forces completion did not hold for this backend, and a
+        reading longer than the call itself means the events did not bracket
+        the work. Both fall back to the host.
+
+        A declared stream is known to carry the model's work, so its reading
+        replaces the host window outright. An assumed one is not, and events on
+        a stream that turned out to hold no work read near zero - so an assumed
+        reading is only believed when it exceeds the host window, where it can
+        only be revealing device work that finished after ``predict()``
+        returned. A wrong guess can then be ignored but never believed.
         """
         if self._events is None:
             return None
@@ -207,6 +239,8 @@ class PredictPhaseTimer:
                 return None
             seconds = start_event.elapsed_time(end_event) / 1000.0
             if seconds < 0 or seconds > perf_counter() - self._started_at:
+                return None
+            if not self._stream_is_declared and seconds <= self._host_duration:
                 return None
             return seconds
         except Exception:

--- a/tests/inference/unit_tests/usage_tracking/test_collector.py
+++ b/tests/inference/unit_tests/usage_tracking/test_collector.py
@@ -3,7 +3,9 @@ import hashlib
 import json
 import sys
 import threading
+import time
 from queue import Queue
+from types import SimpleNamespace
 from typing import Optional
 from unittest import mock
 
@@ -17,6 +19,7 @@ from inference.usage_tracking import payload_helpers
 from inference.usage_tracking.megapixel_buckets import (
     clear_measured_model_input,
     record_measured_model_input,
+    record_measured_predict_duration,
 )
 from inference.usage_tracking.payload_helpers import (
     get_api_key_usage_containing_resource,
@@ -2245,3 +2248,62 @@ def test_model_decorator_isolates_measured_input_across_threads(
     assert row["processed_frames"] == 5
     assert row["megapixel_buckets"]["0.25-0.5"]["processed_frames"] == 1
     assert row["megapixel_buckets"]["2-4"]["processed_frames"] == 4
+
+
+def test_model_decorator_buckets_predict_duration_not_row_duration(
+    usage_collector_with_mocked_threads,
+):
+    usage_collector = usage_collector_with_mocked_threads
+
+    class SlowProcessingModel:
+        api_key = "test_key"
+        dataset_id = "slow-processing"
+        version_id = "1"
+        task_type = "object-detection"
+        model_type = "yolov8n"
+        img_size_h = 640
+        img_size_w = 640
+
+        @usage_collector(category="model")
+        def infer(self, image, **kwargs):
+            clear_measured_model_input()
+            record_measured_predict_duration(0.01)
+            time.sleep(0.05)
+            return {"ok": True}
+
+    SlowProcessingModel().infer([object()])
+
+    row = usage_collector._usage["test_key"][usage_key("model", "slow-processing/1")]
+    # The row keeps wall-clock time; only the bucket narrows to predict.
+    assert row["execution_duration"] >= 0.05
+    assert row["megapixel_buckets"]["0.25-0.5"]["execution_duration"] == pytest.approx(
+        0.01
+    )
+
+
+def test_model_decorator_buckets_full_duration_without_predict_phase(
+    usage_collector_with_mocked_threads,
+):
+    usage_collector = usage_collector_with_mocked_threads
+
+    class NoPredictPhaseModel:
+        api_key = "test_key"
+        dataset_id = "no-predict"
+        version_id = "1"
+        task_type = "instance-segmentation"
+        model_type = "sam2"
+        img_size_h = 640
+        img_size_w = 640
+
+        @usage_collector(category="model")
+        def infer_from_request(self, request, **kwargs):
+            clear_measured_model_input()
+            time.sleep(0.05)
+            return {"ok": True}
+
+    NoPredictPhaseModel().infer_from_request(SimpleNamespace(image=[object()]))
+
+    row = usage_collector._usage["test_key"][usage_key("model", "no-predict/1")]
+    bucket_duration = row["megapixel_buckets"]["0.25-0.5"]["execution_duration"]
+    assert bucket_duration == pytest.approx(row["execution_duration"])
+    assert bucket_duration >= 0.05

--- a/tests/inference/unit_tests/usage_tracking/test_collector.py
+++ b/tests/inference/unit_tests/usage_tracking/test_collector.py
@@ -19,7 +19,6 @@ from inference.usage_tracking import payload_helpers
 from inference.usage_tracking.megapixel_buckets import (
     clear_measured_model_input,
     record_measured_model_input,
-    record_measured_predict_duration,
 )
 from inference.usage_tracking.payload_helpers import (
     get_api_key_usage_containing_resource,
@@ -28,6 +27,7 @@ from inference.usage_tracking.payload_helpers import (
     sha256_hash,
     zip_usage_payloads,
 )
+from inference.usage_tracking.predict_timing import record_measured_predict_duration
 from inference_sdk.http.errors import HTTPCallErrorError
 
 

--- a/tests/inference/unit_tests/usage_tracking/test_megapixel_buckets.py
+++ b/tests/inference/unit_tests/usage_tracking/test_megapixel_buckets.py
@@ -1,9 +1,11 @@
+import time
 from types import SimpleNamespace
 
 import numpy as np
 import pytest
 
 from inference.usage_tracking.decorator_helpers import (
+    get_model_megapixel_buckets,
     record_fixed_model_input_for_request,
 )
 from inference.usage_tracking.megapixel_buckets import (
@@ -11,12 +13,15 @@ from inference.usage_tracking.megapixel_buckets import (
     build_megapixel_buckets,
     clear_measured_model_input,
     consume_measured_model_input,
+    consume_measured_predict_duration,
     count_inference_images,
     get_fixed_model_input_hw,
     get_tensor_spatial_hw,
     megapixel_bucket_for_hw,
     parse_image_dims_hw,
+    prediction_is_deferred,
     record_measured_model_input,
+    record_measured_predict_duration,
     resolve_model_input_hw,
 )
 from inference.usage_tracking.payload_helpers import (
@@ -412,3 +417,146 @@ def test_base_inference_falls_back_to_image_dims_when_pixel_values_are_unreadabl
     BaseInference.infer.__wrapped__(PatchTokenModel(), object())
 
     assert consume_measured_model_input() == ((1080, 1920), None)
+
+
+def test_record_measured_predict_duration_accumulates_across_calls():
+    # A model that chunks its own batch runs predict more than once per call.
+    record_measured_predict_duration(0.2)
+    record_measured_predict_duration(0.3)
+
+    assert consume_measured_predict_duration() == pytest.approx(0.5)
+
+
+def test_consume_measured_predict_duration_clears_value():
+    record_measured_predict_duration(0.2)
+
+    assert consume_measured_predict_duration() == pytest.approx(0.2)
+    # A later call with no separable predict phase must not inherit this one.
+    assert consume_measured_predict_duration() is None
+
+
+def test_record_measured_predict_duration_ignores_unusable_values():
+    record_measured_predict_duration(-1.0)
+    record_measured_predict_duration("not-a-duration")
+    record_measured_predict_duration(None)
+
+    assert consume_measured_predict_duration() is None
+
+
+def test_clear_measured_model_input_also_clears_predict_duration():
+    record_measured_predict_duration(0.2)
+
+    clear_measured_model_input()
+
+    assert consume_measured_predict_duration() is None
+
+
+def test_bucket_duration_prefers_recorded_predict_duration():
+    record_measured_predict_duration(0.2)
+
+    buckets = get_model_megapixel_buckets(
+        frames=1,
+        input_hw=(640, 640),
+        execution_duration=1.5,
+    )
+
+    assert buckets["0.25-0.5"]["execution_duration"] == pytest.approx(0.2)
+
+
+def test_bucket_duration_falls_back_to_call_duration_without_predict_phase():
+    buckets = get_model_megapixel_buckets(
+        frames=1,
+        input_hw=(640, 640),
+        execution_duration=1.5,
+    )
+
+    assert buckets["0.25-0.5"]["execution_duration"] == pytest.approx(1.5)
+
+
+def test_bucket_duration_is_consumed_even_for_unbucketed_test_run():
+    record_measured_predict_duration(0.2)
+
+    assert (
+        get_model_megapixel_buckets(
+            frames=1,
+            input_hw=(640, 640),
+            execution_duration=1.5,
+            inference_test_run=True,
+        )
+        == {}
+    )
+    # The test run reported nothing, so its measurement must not survive into
+    # the next call.
+    assert consume_measured_predict_duration() is None
+
+
+def test_base_inference_bucket_duration_excludes_pre_and_postprocessing():
+    from inference.core.models.base import BaseInference
+
+    class SlowProcessingModel(BaseInference):
+        def preprocess(self, image, **kwargs):
+            time.sleep(0.05)
+            return np.zeros((1, 3, 640, 640), dtype=np.float32), None
+
+        def predict(self, img_in, **kwargs):
+            time.sleep(0.01)
+            return (np.zeros(1),)
+
+        def postprocess(self, predictions, preprocess_return_metadata, **kwargs):
+            time.sleep(0.05)
+            return predictions
+
+    started_at = time.perf_counter()
+    BaseInference.infer.__wrapped__(SlowProcessingModel(), object())
+    call_duration = time.perf_counter() - started_at
+
+    frames, input_hw = 1, (640, 640)
+    buckets = get_model_megapixel_buckets(
+        frames=frames,
+        input_hw=input_hw,
+        execution_duration=call_duration,
+    )
+
+    bucket_duration = buckets["0.25-0.5"]["execution_duration"]
+    assert bucket_duration >= 0.01
+    assert bucket_duration < 0.05
+    assert call_duration >= 0.11
+
+
+def test_prediction_is_deferred_detects_future_like_results():
+    assert prediction_is_deferred(SimpleNamespace(result=lambda: [1]))
+    assert not prediction_is_deferred((np.zeros(1),))
+    assert not prediction_is_deferred(np.zeros(1))
+    assert not prediction_is_deferred({"logits": np.zeros(1)})
+    # An attribute that merely shares the name is not a pending result.
+    assert not prediction_is_deferred(SimpleNamespace(result=[1]))
+
+
+def test_base_inference_skips_predict_timing_when_work_is_deferred():
+    from inference.core.models.base import BaseInference
+
+    class PipelinedModel(BaseInference):
+        """Mirrors the RF-DETR stream pipeline: predict launches, postprocess resolves."""
+
+        def preprocess(self, image, **kwargs):
+            return np.zeros((1, 3, 640, 640), dtype=np.float32), None
+
+        def predict(self, img_in, **kwargs):
+            return SimpleNamespace(result=lambda: (np.zeros(1),))
+
+        def postprocess(self, predictions, preprocess_return_metadata, **kwargs):
+            time.sleep(0.05)
+            return predictions.result()
+
+    BaseInference.infer.__wrapped__(PipelinedModel(), object())
+
+    # Timing the launch would have reported a near-zero predict phase, so the
+    # call must publish nothing and fall back to the full duration instead.
+    assert consume_measured_predict_duration() is None
+
+    buckets = get_model_megapixel_buckets(
+        frames=1,
+        input_hw=(640, 640),
+        execution_duration=1.5,
+    )
+    assert buckets["0.25-0.5"]["execution_duration"] == pytest.approx(1.5)

--- a/tests/inference/unit_tests/usage_tracking/test_megapixel_buckets.py
+++ b/tests/inference/unit_tests/usage_tracking/test_megapixel_buckets.py
@@ -1,4 +1,3 @@
-import time
 from types import SimpleNamespace
 
 import numpy as np
@@ -13,20 +12,21 @@ from inference.usage_tracking.megapixel_buckets import (
     build_megapixel_buckets,
     clear_measured_model_input,
     consume_measured_model_input,
-    consume_measured_predict_duration,
     count_inference_images,
     get_fixed_model_input_hw,
     get_tensor_spatial_hw,
     megapixel_bucket_for_hw,
     parse_image_dims_hw,
-    prediction_is_deferred,
     record_measured_model_input,
-    record_measured_predict_duration,
     resolve_model_input_hw,
 )
 from inference.usage_tracking.payload_helpers import (
     merge_megapixel_buckets,
     merge_usage_dicts,
+)
+from inference.usage_tracking.predict_timing import (
+    consume_measured_predict_duration,
+    record_measured_predict_duration,
 )
 
 
@@ -419,38 +419,6 @@ def test_base_inference_falls_back_to_image_dims_when_pixel_values_are_unreadabl
     assert consume_measured_model_input() == ((1080, 1920), None)
 
 
-def test_record_measured_predict_duration_accumulates_across_calls():
-    # A model that chunks its own batch runs predict more than once per call.
-    record_measured_predict_duration(0.2)
-    record_measured_predict_duration(0.3)
-
-    assert consume_measured_predict_duration() == pytest.approx(0.5)
-
-
-def test_consume_measured_predict_duration_clears_value():
-    record_measured_predict_duration(0.2)
-
-    assert consume_measured_predict_duration() == pytest.approx(0.2)
-    # A later call with no separable predict phase must not inherit this one.
-    assert consume_measured_predict_duration() is None
-
-
-def test_record_measured_predict_duration_ignores_unusable_values():
-    record_measured_predict_duration(-1.0)
-    record_measured_predict_duration("not-a-duration")
-    record_measured_predict_duration(None)
-
-    assert consume_measured_predict_duration() is None
-
-
-def test_clear_measured_model_input_also_clears_predict_duration():
-    record_measured_predict_duration(0.2)
-
-    clear_measured_model_input()
-
-    assert consume_measured_predict_duration() is None
-
-
 def test_bucket_duration_prefers_recorded_predict_duration():
     record_measured_predict_duration(0.2)
 
@@ -488,75 +456,3 @@ def test_bucket_duration_is_consumed_even_for_unbucketed_test_run():
     # The test run reported nothing, so its measurement must not survive into
     # the next call.
     assert consume_measured_predict_duration() is None
-
-
-def test_base_inference_bucket_duration_excludes_pre_and_postprocessing():
-    from inference.core.models.base import BaseInference
-
-    class SlowProcessingModel(BaseInference):
-        def preprocess(self, image, **kwargs):
-            time.sleep(0.05)
-            return np.zeros((1, 3, 640, 640), dtype=np.float32), None
-
-        def predict(self, img_in, **kwargs):
-            time.sleep(0.01)
-            return (np.zeros(1),)
-
-        def postprocess(self, predictions, preprocess_return_metadata, **kwargs):
-            time.sleep(0.05)
-            return predictions
-
-    started_at = time.perf_counter()
-    BaseInference.infer.__wrapped__(SlowProcessingModel(), object())
-    call_duration = time.perf_counter() - started_at
-
-    frames, input_hw = 1, (640, 640)
-    buckets = get_model_megapixel_buckets(
-        frames=frames,
-        input_hw=input_hw,
-        execution_duration=call_duration,
-    )
-
-    bucket_duration = buckets["0.25-0.5"]["execution_duration"]
-    assert bucket_duration >= 0.01
-    assert bucket_duration < 0.05
-    assert call_duration >= 0.11
-
-
-def test_prediction_is_deferred_detects_future_like_results():
-    assert prediction_is_deferred(SimpleNamespace(result=lambda: [1]))
-    assert not prediction_is_deferred((np.zeros(1),))
-    assert not prediction_is_deferred(np.zeros(1))
-    assert not prediction_is_deferred({"logits": np.zeros(1)})
-    # An attribute that merely shares the name is not a pending result.
-    assert not prediction_is_deferred(SimpleNamespace(result=[1]))
-
-
-def test_base_inference_skips_predict_timing_when_work_is_deferred():
-    from inference.core.models.base import BaseInference
-
-    class PipelinedModel(BaseInference):
-        """Mirrors the RF-DETR stream pipeline: predict launches, postprocess resolves."""
-
-        def preprocess(self, image, **kwargs):
-            return np.zeros((1, 3, 640, 640), dtype=np.float32), None
-
-        def predict(self, img_in, **kwargs):
-            return SimpleNamespace(result=lambda: (np.zeros(1),))
-
-        def postprocess(self, predictions, preprocess_return_metadata, **kwargs):
-            time.sleep(0.05)
-            return predictions.result()
-
-    BaseInference.infer.__wrapped__(PipelinedModel(), object())
-
-    # Timing the launch would have reported a near-zero predict phase, so the
-    # call must publish nothing and fall back to the full duration instead.
-    assert consume_measured_predict_duration() is None
-
-    buckets = get_model_megapixel_buckets(
-        frames=1,
-        input_hw=(640, 640),
-        execution_duration=1.5,
-    )
-    assert buckets["0.25-0.5"]["execution_duration"] == pytest.approx(1.5)

--- a/tests/inference/unit_tests/usage_tracking/test_predict_timing.py
+++ b/tests/inference/unit_tests/usage_tracking/test_predict_timing.py
@@ -1,3 +1,4 @@
+import threading
 import time
 from types import SimpleNamespace
 
@@ -101,37 +102,53 @@ def test_prediction_is_deferred_detects_future_like_results():
     assert not prediction_is_deferred(SimpleNamespace(result=[1]))
 
 
-def test_resolve_inference_stream_prefers_the_backend_stream(monkeypatch):
+def test_resolve_inference_stream_prefers_the_declared_backend_stream(monkeypatch):
     _install_fake_cuda(monkeypatch, [])
 
-    assert (
-        resolve_inference_stream(SimpleNamespace(_inference_stream=_STREAM)) is _STREAM
+    assert resolve_inference_stream(SimpleNamespace(_inference_stream=_STREAM)) == (
+        _STREAM,
+        True,
     )
     # Adapters wrap the backend that owns the stream.
     adapter = SimpleNamespace(_model=SimpleNamespace(_inference_stream=_STREAM))
-    assert resolve_inference_stream(adapter) is _STREAM
+    assert resolve_inference_stream(adapter) == (_STREAM, True)
 
 
-def test_resolve_inference_stream_uses_current_stream_for_unmanaged_backends(
+def test_resolve_inference_stream_finds_a_scheduler_owned_stream(monkeypatch):
+    # RF-DETR TensorRT hands engine execution to a scheduler that owns the stream.
+    _install_fake_cuda(monkeypatch, [])
+    adapter = SimpleNamespace(
+        _model=SimpleNamespace(
+            _device=SimpleNamespace(type="cuda"),
+            _scheduler=SimpleNamespace(_inference_stream=_STREAM),
+        )
+    )
+
+    assert resolve_inference_stream(adapter) == (_STREAM, True)
+
+
+def test_resolve_inference_stream_assumes_current_stream_for_unmanaged_backends(
     monkeypatch,
 ):
     # Backends like the RF-DETR torch path enqueue onto the ambient stream.
     _install_fake_cuda(monkeypatch, [])
     model = SimpleNamespace(_device=SimpleNamespace(type="cuda"))
 
-    assert resolve_inference_stream(model) is _STREAM
+    assert resolve_inference_stream(model) == (_STREAM, False)
 
 
 def test_resolve_inference_stream_returns_none_off_cuda(monkeypatch):
     monkeypatch.setattr(predict_timing, "_torch_cuda", None)
 
-    assert resolve_inference_stream(SimpleNamespace()) is None
-    assert (
-        resolve_inference_stream(SimpleNamespace(_device=SimpleNamespace(type="cpu")))
-        is None
-    )
+    assert resolve_inference_stream(SimpleNamespace()) == (None, False)
+    assert resolve_inference_stream(
+        SimpleNamespace(_device=SimpleNamespace(type="cpu"))
+    ) == (None, False)
     # A backend on CPU reports no stream of its own.
-    assert resolve_inference_stream(SimpleNamespace(_inference_stream=None)) is None
+    assert resolve_inference_stream(SimpleNamespace(_inference_stream=None)) == (
+        None,
+        False,
+    )
 
 
 def test_timer_uses_host_clock_when_model_is_not_on_cuda(monkeypatch):
@@ -145,13 +162,48 @@ def test_timer_uses_host_clock_when_model_is_not_on_cuda(monkeypatch):
     assert consume_measured_predict_duration() >= 0.01
 
 
-def test_timer_prefers_the_device_measurement_over_the_host_clock(monkeypatch):
+def test_assumed_stream_reading_is_used_when_it_exceeds_the_host_window(monkeypatch):
+    # An async launch returns before the device is done, so a reading longer
+    # than the host window is the work the host clock missed.
+    _install_fake_cuda(
+        monkeypatch, [_FakeEvent(elapsed_ms=20.0), _FakeEvent(elapsed_ms=20.0)]
+    )
+    model = SimpleNamespace(_device=SimpleNamespace(type="cuda"))
+
+    timer = PredictPhaseTimer.start(model=model)
+    timer.finish(predictions=(np.zeros(1),))
+    time.sleep(0.05)
+    timer.publish()
+
+    assert consume_measured_predict_duration() == pytest.approx(0.02)
+
+
+def test_assumed_stream_reading_is_ignored_when_it_undercuts_the_host_window(
+    monkeypatch,
+):
+    # Events on a stream that turned out to hold no work read near zero.
+    # Believing that would report a launch as the whole inference.
+    _install_fake_cuda(
+        monkeypatch, [_FakeEvent(elapsed_ms=0.001), _FakeEvent(elapsed_ms=0.001)]
+    )
+    model = SimpleNamespace(_device=SimpleNamespace(type="cuda"))
+
+    timer = PredictPhaseTimer.start(model=model)
+    time.sleep(0.02)
+    timer.finish(predictions=(np.zeros(1),))
+    timer.publish()
+
+    assert consume_measured_predict_duration() >= 0.02
+
+
+def test_declared_stream_reading_replaces_the_host_clock(monkeypatch):
     start_event, end_event = _FakeEvent(elapsed_ms=5.0), _FakeEvent(elapsed_ms=5.0)
     _install_fake_cuda(monkeypatch, [start_event, end_event])
     model = SimpleNamespace(_inference_stream=_STREAM)
 
     timer = PredictPhaseTimer.start(model=model)
-    # The host clock sees far more than the device spent on the work.
+    # A declared stream is trusted to shrink the measurement: the host clock
+    # sees far more than the device spent on the work.
     time.sleep(0.05)
     timer.finish(predictions=(np.zeros(1),))
     timer.publish()
@@ -274,9 +326,70 @@ def test_base_inference_bucket_duration_excludes_pre_and_postprocessing():
     )
 
     bucket_duration = buckets["0.25-0.5"]["execution_duration"]
-    assert bucket_duration >= 0.01
-    assert bucket_duration < 0.05
     assert call_duration >= 0.11
+    assert bucket_duration >= 0.01
+    # Relative to the call rather than an absolute bound, so a loaded runner
+    # that inflates every sleep does not fail the test.
+    assert bucket_duration < call_duration / 2
+
+
+def test_predict_duration_does_not_leak_when_postprocessing_raises():
+    from inference.core.models.base import BaseInference
+
+    class FailingModel(BaseInference):
+        def preprocess(self, image, **kwargs):
+            return np.zeros((1, 3, 640, 640), dtype=np.float32), None
+
+        def predict(self, img_in, **kwargs):
+            time.sleep(0.01)
+            return (np.zeros(1),)
+
+        def postprocess(self, predictions, preprocess_return_metadata, **kwargs):
+            raise RuntimeError("postprocess exploded")
+
+    with pytest.raises(RuntimeError):
+        BaseInference.infer.__wrapped__(FailingModel(), object())
+
+    # Entrypoints that override infer() never call clear_measured_model_input(),
+    # so a duration surviving a failed call would be charged to the next one.
+    assert consume_measured_predict_duration() is None
+
+
+def test_predict_durations_do_not_leak_between_threads():
+    from inference.core.models.base import BaseInference
+
+    class Model(BaseInference):
+        def __init__(self, predict_seconds):
+            self._predict_seconds = predict_seconds
+
+        def preprocess(self, image, **kwargs):
+            return np.zeros((1, 3, 640, 640), dtype=np.float32), None
+
+        def predict(self, img_in, **kwargs):
+            time.sleep(self._predict_seconds)
+            return (np.zeros(1),)
+
+        def postprocess(self, predictions, preprocess_return_metadata, **kwargs):
+            return predictions
+
+    measured = {}
+
+    def run(name, predict_seconds):
+        BaseInference.infer.__wrapped__(Model(predict_seconds), object())
+        measured[name] = consume_measured_predict_duration()
+
+    threads = [
+        threading.Thread(target=run, args=("fast", 0.01)),
+        threading.Thread(target=run, args=("slow", 0.1)),
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    # Concurrent calls share the model registry but must not share measurements.
+    assert measured["fast"] < 0.05
+    assert measured["slow"] >= 0.1
 
 
 def test_base_inference_skips_predict_timing_when_work_is_deferred():

--- a/tests/inference/unit_tests/usage_tracking/test_predict_timing.py
+++ b/tests/inference/unit_tests/usage_tracking/test_predict_timing.py
@@ -196,14 +196,17 @@ def test_assumed_stream_reading_is_ignored_when_it_undercuts_the_host_window(
     assert consume_measured_predict_duration() >= 0.02
 
 
-def test_declared_stream_reading_replaces_the_host_clock(monkeypatch):
+def test_declared_stream_reading_is_used_when_it_undercuts_the_host_window(
+    monkeypatch,
+):
+    # Mirror of the assumed-stream floor: a declared stream is trusted to
+    # shrink the measurement when the host clock saw more than the device
+    # spent on this call's work.
     start_event, end_event = _FakeEvent(elapsed_ms=5.0), _FakeEvent(elapsed_ms=5.0)
     _install_fake_cuda(monkeypatch, [start_event, end_event])
     model = SimpleNamespace(_inference_stream=_STREAM)
 
     timer = PredictPhaseTimer.start(model=model)
-    # A declared stream is trusted to shrink the measurement: the host clock
-    # sees far more than the device spent on the work.
     time.sleep(0.05)
     timer.finish(predictions=(np.zeros(1),))
     timer.publish()
@@ -211,6 +214,56 @@ def test_declared_stream_reading_replaces_the_host_clock(monkeypatch):
     assert consume_measured_predict_duration() == pytest.approx(0.005)
     assert start_event.recorded_on == [_STREAM]
     assert end_event.recorded_on == [_STREAM]
+
+
+def test_declared_stream_reading_is_ignored_when_it_exceeds_the_host_window(
+    monkeypatch,
+):
+    # TensorRT backends share one stream per model instance. Events on that
+    # stream can bracket another request's engine work and still complete
+    # before post-processing returns, so the "longer than the call" guard
+    # does not catch them. Those backends synchronize before predict()
+    # returns, so anything past this call's host window is inflation.
+    _install_fake_cuda(
+        monkeypatch, [_FakeEvent(elapsed_ms=20.0), _FakeEvent(elapsed_ms=20.0)]
+    )
+    model = SimpleNamespace(_inference_stream=_STREAM)
+
+    timer = PredictPhaseTimer.start(model=model)
+    timer.finish(predictions=(np.zeros(1),))
+    time.sleep(0.05)
+    timer.publish()
+
+    # Host window is the empty predict phase; 20ms is the other request.
+    assert consume_measured_predict_duration() < 0.01
+
+
+def test_shared_declared_stream_does_not_absorb_another_calls_window(monkeypatch):
+    # Two timers over one declared stream, each reporting a span larger
+    # than either call spent on the host.
+    _install_fake_cuda(
+        monkeypatch,
+        [
+            _FakeEvent(elapsed_ms=80.0),
+            _FakeEvent(elapsed_ms=80.0),
+            _FakeEvent(elapsed_ms=80.0),
+            _FakeEvent(elapsed_ms=80.0),
+        ],
+    )
+    model = SimpleNamespace(_inference_stream=_STREAM)
+
+    first = PredictPhaseTimer.start(model=model)
+    second = PredictPhaseTimer.start(model=model)
+    first.finish(predictions=(np.zeros(1),))
+    second.finish(predictions=(np.zeros(1),))
+    time.sleep(0.05)
+    first.publish()
+    first_duration = consume_measured_predict_duration()
+    second.publish()
+    second_duration = consume_measured_predict_duration()
+
+    assert first_duration < 0.01
+    assert second_duration < 0.01
 
 
 def test_nested_timers_do_not_share_events(monkeypatch):

--- a/tests/inference/unit_tests/usage_tracking/test_predict_timing.py
+++ b/tests/inference/unit_tests/usage_tracking/test_predict_timing.py
@@ -1,0 +1,309 @@
+import time
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from inference.usage_tracking import predict_timing
+from inference.usage_tracking.decorator_helpers import get_model_megapixel_buckets
+from inference.usage_tracking.megapixel_buckets import clear_measured_model_input
+from inference.usage_tracking.predict_timing import (
+    PredictPhaseTimer,
+    clear_measured_predict_duration,
+    consume_measured_predict_duration,
+    prediction_is_deferred,
+    record_measured_predict_duration,
+    resolve_inference_stream,
+)
+
+_STREAM = object()
+
+
+class _FakeEvent:
+    """Stands in for a CUDA event, recording how the timer drives it."""
+
+    def __init__(self, elapsed_ms: float = 5.0, complete: bool = True):
+        self.elapsed_ms = elapsed_ms
+        self.complete = complete
+        self.recorded_on = []
+        self.synchronize_calls = 0
+
+    def record(self, stream):
+        self.recorded_on.append(stream)
+
+    def query(self):
+        return self.complete
+
+    def synchronize(self):
+        self.synchronize_calls += 1
+
+    def elapsed_time(self, other):
+        return self.elapsed_ms
+
+
+def _install_fake_cuda(monkeypatch, events):
+    pending = list(events)
+    monkeypatch.setattr(
+        predict_timing,
+        "_torch_cuda",
+        SimpleNamespace(
+            Event=lambda enable_timing=False: pending.pop(0),
+            current_stream=lambda device: _STREAM,
+        ),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset_measurements():
+    clear_measured_predict_duration()
+    yield
+    clear_measured_predict_duration()
+
+
+def test_record_measured_predict_duration_accumulates_across_calls():
+    # A model that chunks its own batch runs predict more than once per call.
+    record_measured_predict_duration(0.2)
+    record_measured_predict_duration(0.3)
+
+    assert consume_measured_predict_duration() == pytest.approx(0.5)
+
+
+def test_consume_measured_predict_duration_clears_value():
+    record_measured_predict_duration(0.2)
+
+    assert consume_measured_predict_duration() == pytest.approx(0.2)
+    # A later call with no separable predict phase must not inherit this one.
+    assert consume_measured_predict_duration() is None
+
+
+def test_record_measured_predict_duration_ignores_unusable_values():
+    record_measured_predict_duration(-1.0)
+    record_measured_predict_duration("not-a-duration")
+    record_measured_predict_duration(None)
+
+    assert consume_measured_predict_duration() is None
+
+
+def test_clear_measured_model_input_also_clears_predict_duration():
+    record_measured_predict_duration(0.2)
+
+    clear_measured_model_input()
+
+    assert consume_measured_predict_duration() is None
+
+
+def test_prediction_is_deferred_detects_future_like_results():
+    assert prediction_is_deferred(SimpleNamespace(result=lambda: [1]))
+    assert not prediction_is_deferred((np.zeros(1),))
+    assert not prediction_is_deferred(np.zeros(1))
+    assert not prediction_is_deferred({"logits": np.zeros(1)})
+    # An attribute that merely shares the name is not a pending result.
+    assert not prediction_is_deferred(SimpleNamespace(result=[1]))
+
+
+def test_resolve_inference_stream_prefers_the_backend_stream(monkeypatch):
+    _install_fake_cuda(monkeypatch, [])
+
+    assert (
+        resolve_inference_stream(SimpleNamespace(_inference_stream=_STREAM)) is _STREAM
+    )
+    # Adapters wrap the backend that owns the stream.
+    adapter = SimpleNamespace(_model=SimpleNamespace(_inference_stream=_STREAM))
+    assert resolve_inference_stream(adapter) is _STREAM
+
+
+def test_resolve_inference_stream_uses_current_stream_for_unmanaged_backends(
+    monkeypatch,
+):
+    # Backends like the RF-DETR torch path enqueue onto the ambient stream.
+    _install_fake_cuda(monkeypatch, [])
+    model = SimpleNamespace(_device=SimpleNamespace(type="cuda"))
+
+    assert resolve_inference_stream(model) is _STREAM
+
+
+def test_resolve_inference_stream_returns_none_off_cuda(monkeypatch):
+    monkeypatch.setattr(predict_timing, "_torch_cuda", None)
+
+    assert resolve_inference_stream(SimpleNamespace()) is None
+    assert (
+        resolve_inference_stream(SimpleNamespace(_device=SimpleNamespace(type="cpu")))
+        is None
+    )
+    # A backend on CPU reports no stream of its own.
+    assert resolve_inference_stream(SimpleNamespace(_inference_stream=None)) is None
+
+
+def test_timer_uses_host_clock_when_model_is_not_on_cuda(monkeypatch):
+    monkeypatch.setattr(predict_timing, "_torch_cuda", None)
+
+    timer = PredictPhaseTimer.start(model=SimpleNamespace())
+    time.sleep(0.01)
+    timer.finish(predictions=(np.zeros(1),))
+    timer.publish()
+
+    assert consume_measured_predict_duration() >= 0.01
+
+
+def test_timer_prefers_the_device_measurement_over_the_host_clock(monkeypatch):
+    start_event, end_event = _FakeEvent(elapsed_ms=5.0), _FakeEvent(elapsed_ms=5.0)
+    _install_fake_cuda(monkeypatch, [start_event, end_event])
+    model = SimpleNamespace(_inference_stream=_STREAM)
+
+    timer = PredictPhaseTimer.start(model=model)
+    # The host clock sees far more than the device spent on the work.
+    time.sleep(0.05)
+    timer.finish(predictions=(np.zeros(1),))
+    timer.publish()
+
+    assert consume_measured_predict_duration() == pytest.approx(0.005)
+    assert start_event.recorded_on == [_STREAM]
+    assert end_event.recorded_on == [_STREAM]
+
+
+def test_nested_timers_do_not_share_events(monkeypatch):
+    # A model whose predict() runs another model nests one timer inside another.
+    outer_start, outer_end = _FakeEvent(elapsed_ms=8.0), _FakeEvent(elapsed_ms=8.0)
+    inner_start, inner_end = _FakeEvent(elapsed_ms=3.0), _FakeEvent(elapsed_ms=3.0)
+    _install_fake_cuda(monkeypatch, [outer_start, outer_end, inner_start, inner_end])
+    model = SimpleNamespace(_inference_stream=_STREAM)
+
+    outer = PredictPhaseTimer.start(model=model)
+    inner = PredictPhaseTimer.start(model=model)
+    time.sleep(0.02)
+    inner.finish(predictions=(np.zeros(1),))
+    inner.publish()
+    outer.finish(predictions=(np.zeros(1),))
+    outer.publish()
+
+    # The nested call must not have closed the outer call's window early.
+    assert outer_end.recorded_on == [_STREAM]
+    assert consume_measured_predict_duration() == pytest.approx(0.011)
+
+
+def test_timer_never_waits_on_the_device(monkeypatch):
+    start_event, end_event = _FakeEvent(), _FakeEvent()
+    _install_fake_cuda(monkeypatch, [start_event, end_event])
+
+    timer = PredictPhaseTimer.start(model=SimpleNamespace(_inference_stream=_STREAM))
+    timer.finish(predictions=(np.zeros(1),))
+    timer.publish()
+
+    # Blocking on the event would put a device sync on the request path.
+    assert start_event.synchronize_calls == 0
+    assert end_event.synchronize_calls == 0
+
+
+def test_timer_falls_back_to_host_clock_when_events_are_incomplete(monkeypatch):
+    _install_fake_cuda(
+        monkeypatch, [_FakeEvent(complete=False), _FakeEvent(complete=False)]
+    )
+
+    timer = PredictPhaseTimer.start(model=SimpleNamespace(_inference_stream=_STREAM))
+    time.sleep(0.01)
+    timer.finish(predictions=(np.zeros(1),))
+    timer.publish()
+
+    assert consume_measured_predict_duration() >= 0.01
+
+
+def test_timer_rejects_a_device_reading_longer_than_the_call(monkeypatch):
+    # Events that did not bracket the work can report an unrelated span.
+    _install_fake_cuda(
+        monkeypatch, [_FakeEvent(elapsed_ms=90_000.0), _FakeEvent(elapsed_ms=90_000.0)]
+    )
+
+    timer = PredictPhaseTimer.start(model=SimpleNamespace(_inference_stream=_STREAM))
+    time.sleep(0.01)
+    timer.finish(predictions=(np.zeros(1),))
+    timer.publish()
+
+    assert consume_measured_predict_duration() < 1.0
+
+
+def test_timer_falls_back_to_host_clock_when_the_backend_raises(monkeypatch):
+    exploding = _FakeEvent()
+    exploding.record = lambda stream: (_ for _ in ()).throw(RuntimeError("no device"))
+    _install_fake_cuda(monkeypatch, [exploding, _FakeEvent()])
+
+    timer = PredictPhaseTimer.start(model=SimpleNamespace(_inference_stream=_STREAM))
+    time.sleep(0.01)
+    timer.finish(predictions=(np.zeros(1),))
+    timer.publish()
+
+    assert consume_measured_predict_duration() >= 0.01
+
+
+def test_timer_publishes_nothing_for_deferred_work(monkeypatch):
+    start_event, end_event = _FakeEvent(), _FakeEvent()
+    _install_fake_cuda(monkeypatch, [start_event, end_event])
+
+    timer = PredictPhaseTimer.start(model=SimpleNamespace(_inference_stream=_STREAM))
+    timer.finish(predictions=SimpleNamespace(result=lambda: (np.zeros(1),)))
+    timer.publish()
+
+    assert consume_measured_predict_duration() is None
+    # Closing the window around a launch would have measured nothing useful.
+    assert end_event.recorded_on == []
+
+
+def test_base_inference_bucket_duration_excludes_pre_and_postprocessing():
+    from inference.core.models.base import BaseInference
+
+    class SlowProcessingModel(BaseInference):
+        def preprocess(self, image, **kwargs):
+            time.sleep(0.05)
+            return np.zeros((1, 3, 640, 640), dtype=np.float32), None
+
+        def predict(self, img_in, **kwargs):
+            time.sleep(0.01)
+            return (np.zeros(1),)
+
+        def postprocess(self, predictions, preprocess_return_metadata, **kwargs):
+            time.sleep(0.05)
+            return predictions
+
+    started_at = time.perf_counter()
+    BaseInference.infer.__wrapped__(SlowProcessingModel(), object())
+    call_duration = time.perf_counter() - started_at
+
+    buckets = get_model_megapixel_buckets(
+        frames=1,
+        input_hw=(640, 640),
+        execution_duration=call_duration,
+    )
+
+    bucket_duration = buckets["0.25-0.5"]["execution_duration"]
+    assert bucket_duration >= 0.01
+    assert bucket_duration < 0.05
+    assert call_duration >= 0.11
+
+
+def test_base_inference_skips_predict_timing_when_work_is_deferred():
+    from inference.core.models.base import BaseInference
+
+    class PipelinedModel(BaseInference):
+        """Mirrors the RF-DETR stream pipeline: predict launches, postprocess resolves."""
+
+        def preprocess(self, image, **kwargs):
+            return np.zeros((1, 3, 640, 640), dtype=np.float32), None
+
+        def predict(self, img_in, **kwargs):
+            return SimpleNamespace(result=lambda: (np.zeros(1),))
+
+        def postprocess(self, predictions, preprocess_return_metadata, **kwargs):
+            time.sleep(0.05)
+            return predictions.result()
+
+    BaseInference.infer.__wrapped__(PipelinedModel(), object())
+
+    # Timing the launch would have reported a near-zero predict phase, so the
+    # call must publish nothing and fall back to the full duration instead.
+    assert consume_measured_predict_duration() is None
+
+    buckets = get_model_megapixel_buckets(
+        frames=1,
+        input_hw=(640, 640),
+        execution_duration=1.5,
+    )
+    assert buckets["0.25-0.5"]["execution_duration"] == pytest.approx(1.5)


### PR DESCRIPTION
## What does this PR do?

Linked issue: [LAKE-811](https://linear.app/roboflow/issue/LAKE-811/megapixel-buckets-use-model-infer-time-rather-than-also-processing)

The `megapixel_buckets` `execution_duration` on model usage rows carried the usage decorator's full wall clock around `infer()`. That window includes image decoding (a URL fetch lands inside it), resize and normalization, NMS, mask-to-polygon conversion and response construction — work that is largely independent of model size. Because that overhead is roughly constant, it compresses the measured gap between small and large models and, combined with differences in deployment hardware and input resolution, can make a nano model look slower than a large one.

Bucket durations now report the model's predict phase alone. `BaseInference.infer` times the existing `model.predict` span and publishes the result through a `ContextVar`, reusing the seam that already carries preprocess input size out to the usage decorator — ContextVars rather than model attributes because model instances are shared across worker threads. `get_model_megapixel_buckets` consumes that value and falls back to the full call duration when no predict phase was published, which covers the families that override `infer()` wholesale and the SAM `infer_from_request` entrypoints. Calls whose `predict()` returns a pending result also fall back, so the pipelined RF-DETR segmentation adapter never reports a kernel launch as if it were inference time. The row-level `execution_duration` is unchanged and still reports wall clock, so bucket durations no longer reconcile against the row total — the difference between them is now the pre/post overhead. Since this replaces a value rather than adding a key, `merge_megapixel_buckets` and its redis-offloader mirror need no change.

**Main elements:**
- `inference/usage_tracking/megapixel_buckets.py` — new `_measured_predict_duration` ContextVar with `record_measured_predict_duration` / `consume_measured_predict_duration`, the `prediction_is_deferred` guard, and `clear_measured_model_input` extended to reset both measurements
- `inference/core/models/base.py` — times the predict phase inside the existing `model.predict` span
- `inference/usage_tracking/decorator_helpers.py` — `get_model_megapixel_buckets` prefers the published predict duration, consuming it before the test-run check so an unreported call cannot leak into the next one
- No change to usage payload shape, `merge_megapixel_buckets`, or the row-level `execution_duration`

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Other: telemetry semantics change (same payload shape, different meaning for bucket `execution_duration`)

## Testing

### Unit tests

- `record_measured_predict_duration` accumulates across multiple predict calls in one decorated call, and drops negative / non-numeric values
- `consume_measured_predict_duration` clears on read, so a call with no predict phase cannot inherit an earlier measurement
- `clear_measured_model_input` resets the predict duration alongside the input size
- Bucket duration prefers a published predict duration and falls back to the call duration without one
- The published duration is consumed even for an unbucketed test run
- End-to-end through `BaseInference.infer`: a model sleeping in preprocess and postprocess reports a bucket duration matching only its predict phase
- `prediction_is_deferred` detects future-like results and not tuples, arrays or dicts
- A model whose `predict()` returns a pending result publishes nothing and falls back
- Through the usage decorator: the row keeps wall clock while the bucket narrows to predict, and a model with no predict phase has bucket duration equal to the row's

### Integration tests

- None for this PR.

### Other

- `pytest tests/inference/unit_tests/usage_tracking/ tests/inference/unit_tests/core/models/` — 236 passed
- `black --check` and `isort --check-only` on all changed files

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [ ] I have updated the documentation accordingly (if applicable)

## Additional Context

Two known limits, both documented in the `megapixel_buckets` module docstring:

- **Async CUDA launches.** The predict phase is timed on the host, so a backend that launches kernels without synchronizing before `predict()` returns still under-reports; the wait lands in whichever later phase forces synchronization. Deferred-result backends are excluded explicitly, but plain async launches cannot be detected here. An opt-in `torch.cuda.synchronize()` at the phase boundary would close this if it proves material.
- **Coverage.** Only `BaseInference.infer` is instrumented. DocTR, GroundingDINO, YOLOWorld, OwlV2 and RFInstant override `infer()` without a phase split, and SAM2/SAM3 decorate `infer_from_request`; all fall back to wall clock, so comparisons spanning those families are not yet like-for-like. `test_model_decorator_buckets_full_duration_without_predict_phase` pins the fallback so it stays deliberate.

Separately, for `RFDETR_PIPELINE_DEPTH >= 2` the row's wall-clock duration was already only loosely coupled to the frame it is attributed to, since a pipelined call can return an earlier frame's responses or empty ones. That predates this change, but those deployments should be excluded from latency comparisons.

Made with [Cursor](https://cursor.com)