### PR TITLE
Emit model-category usage rows for local in-infra models

### DIFF
--- a/inference/core/workflows/core_steps/models/foundation/segment_anything2_video/v1.py
+++ b/inference/core/workflows/core_steps/models/foundation/segment_anything2_video/v1.py
@@ -28,7 +28,6 @@ from pydantic import ConfigDict, Field
 
 from inference.core.managers.base import ModelManager
 from inference.core.roboflow_api import get_extra_weights_provider_headers
-from inference.usage_tracking.collector import usage_collector
 from inference.core.workflows.core_steps.common.entities import StepExecutionMode
 from inference.core.workflows.core_steps.common.utils import (
     attach_parents_coordinates_to_batch_of_sv_detections,
@@ -68,6 +67,7 @@ from inference.core.workflows.prototypes.block import (
     WorkflowBlock,
     WorkflowBlockManifest,
 )
+from inference.usage_tracking.collector import usage_collector
 
 PromptMode = Literal["first_frame", "every_n_frames", "every_frame"]
 

--- a/inference/core/workflows/core_steps/models/foundation/segment_anything2_video/v1.py
+++ b/inference/core/workflows/core_steps/models/foundation/segment_anything2_video/v1.py
@@ -28,6 +28,7 @@ from pydantic import ConfigDict, Field
 
 from inference.core.managers.base import ModelManager
 from inference.core.roboflow_api import get_extra_weights_provider_headers
+from inference.usage_tracking.collector import usage_collector
 from inference.core.workflows.core_steps.common.entities import StepExecutionMode
 from inference.core.workflows.core_steps.common.utils import (
     attach_parents_coordinates_to_batch_of_sv_detections,
@@ -274,6 +275,7 @@ class SegmentAnything2VideoBlockV1(WorkflowBlock):
             self._sessions.clear()
         return self._model
 
+    @usage_collector("model")
     def run(
         self,
         images: Batch[WorkflowImageData],

--- a/inference/core/workflows/core_steps/models/foundation/segment_anything2_video/v1_tensor.py
+++ b/inference/core/workflows/core_steps/models/foundation/segment_anything2_video/v1_tensor.py
@@ -17,7 +17,9 @@ The tensor-native surface is the IMAGE (CHW RGB tensor), the INPUT boxes
 mask carriage (an execution-level choice driven by the
 WORKFLOWS_SAM_VIDEO_MASK_REPRESENTATION env variable — NOT a manifest field,
 so the manifest stays identical to the numpy sibling; GCP_SERVERLESS forces
-"rle"). The layout-agnostic session/state helpers
+"rle"). This sibling does not decorate ``run()`` with
+``@usage_collector("model")``, so flag-on deployments emit no model-category
+usage row for SAM2 video. The layout-agnostic session/state helpers
 (VideoSessionBookkeeping, decide_prompt_vs_track, build_obj_id_metadata_from_boxes,
 BoxPromptMetadata) are shared with the NumPy sibling. Tensor-native prompt
 extraction and prediction assembly live in
@@ -261,6 +263,8 @@ class SegmentAnything2VideoBlockV1(WorkflowBlock):
             self._sessions.clear()
         return self._model
 
+    # No @usage_collector("model") here: the numpy sibling decorates run(),
+    # but this tensor-native path is left without a model-category usage row.
     def run(
         self,
         images: Batch[WorkflowImageData],

--- a/inference/core/workflows/core_steps/models/foundation/segment_anything3_video/v1.py
+++ b/inference/core/workflows/core_steps/models/foundation/segment_anything3_video/v1.py
@@ -26,6 +26,7 @@ from pydantic import ConfigDict, Field, model_validator
 
 from inference.core.managers.base import ModelManager
 from inference.core.roboflow_api import get_extra_weights_provider_headers
+from inference.usage_tracking.collector import usage_collector
 from inference.core.workflows.core_steps.common.entities import StepExecutionMode
 from inference.core.workflows.core_steps.common.utils import (
     attach_parents_coordinates_to_batch_of_sv_detections,
@@ -371,6 +372,7 @@ class SegmentAnything3VideoBlockV1(WorkflowBlock):
             self._visual_sessions.clear()
         return self._model
 
+    @usage_collector("model")
     def run(
         self,
         images: Batch[WorkflowImageData],

--- a/inference/core/workflows/core_steps/models/foundation/segment_anything3_video/v1.py
+++ b/inference/core/workflows/core_steps/models/foundation/segment_anything3_video/v1.py
@@ -372,7 +372,6 @@ class SegmentAnything3VideoBlockV1(WorkflowBlock):
             self._visual_sessions.clear()
         return self._model
 
-    @usage_collector("model")
     def run(
         self,
         images: Batch[WorkflowImageData],
@@ -388,8 +387,35 @@ class SegmentAnything3VideoBlockV1(WorkflowBlock):
     ) -> BlockResult:
         if self._step_execution_mode is not StepExecutionMode.LOCAL:
             raise NotImplementedError(self._REMOTE_EXECUTION_NOT_SUPPORTED_MESSAGE)
+        # The usage decorator reads `model_id` off the tracked call, so the
+        # dispatch happens out here where the mode-dependent model is picked.
         selected_model_id = model_id if tracking_mode == "concept" else visual_model_id
-        model = self._get_model(model_id=selected_model_id)
+        return self._tracked_run(
+            images=images,
+            class_names=class_names,
+            model_id=selected_model_id,
+            threshold=threshold,
+            tracking_mode=tracking_mode,
+            points=points,
+            boxes=boxes,
+            prompt_mode=prompt_mode,
+            prompt_interval=prompt_interval,
+        )
+
+    @usage_collector("model")
+    def _tracked_run(
+        self,
+        images: Batch[WorkflowImageData],
+        class_names: Optional[Union[List[str], str]],
+        model_id: str,
+        threshold: float,
+        tracking_mode: TrackingMode,
+        points: Optional[List[Any]],
+        boxes: Optional[Batch[sv.Detections]],
+        prompt_mode: PromptMode,
+        prompt_interval: int,
+    ) -> BlockResult:
+        model = self._get_model(model_id=model_id)
         if tracking_mode == "visual":
             return self._run_visual(
                 model=model,

--- a/inference/core/workflows/core_steps/models/foundation/segment_anything3_video/v1.py
+++ b/inference/core/workflows/core_steps/models/foundation/segment_anything3_video/v1.py
@@ -26,7 +26,6 @@ from pydantic import ConfigDict, Field, model_validator
 
 from inference.core.managers.base import ModelManager
 from inference.core.roboflow_api import get_extra_weights_provider_headers
-from inference.usage_tracking.collector import usage_collector
 from inference.core.workflows.core_steps.common.entities import StepExecutionMode
 from inference.core.workflows.core_steps.common.utils import (
     attach_parents_coordinates_to_batch_of_sv_detections,
@@ -77,6 +76,7 @@ from inference.core.workflows.prototypes.block import (
     WorkflowBlock,
     WorkflowBlockManifest,
 )
+from inference.usage_tracking.collector import usage_collector
 
 PromptMode = Literal["first_frame", "every_n_frames", "every_frame"]
 TrackingMode = Literal["concept", "visual"]

--- a/inference/core/workflows/core_steps/models/foundation/segment_anything3_video/v1_tensor.py
+++ b/inference/core/workflows/core_steps/models/foundation/segment_anything3_video/v1_tensor.py
@@ -16,7 +16,9 @@ sibling. Only image and prediction representations differ:
   ``WORKFLOWS_SAM_VIDEO_MASK_REPRESENTATION`` env variable ("rle"/"dense",
   same convention as the SAM2 video sibling; GCP_SERVERLESS forces "rle") —
   NOT a manifest field, so the manifest stays identical to the numpy
-  sibling. Per-box
+  sibling. This sibling does not decorate ``run()`` / ``_tracked_run()``
+  with ``@usage_collector("model")``, so flag-on deployments emit no
+  model-category usage row for SAM3 video. Per-box
   ``bboxes_metadata`` carries ``detection_id`` / ``class`` / ``tracker_id``;
   ``image_metadata`` is built via ``build_native_image_metadata`` with the
   full prompt-position ``class_id -> name`` map (``class_id`` is the
@@ -410,6 +412,9 @@ class SegmentAnything3VideoBlockV1(WorkflowBlock):
             self._visual_sessions.clear()
         return self._model
 
+    # No @usage_collector("model") here: the numpy sibling attributes usage
+    # via decorated _tracked_run(); this tensor-native path is left without
+    # a model-category usage row.
     def run(
         self,
         images: Batch[WorkflowImageData],

--- a/inference/models/clip/clip_inference_models.py
+++ b/inference/models/clip/clip_inference_models.py
@@ -83,10 +83,14 @@ class InferenceModelsClipAdapter(Model):
         )
         # Usage telemetry reads the fixed canvas from `image_size`. ClipOnnx
         # keeps it as `_image_size`; ClipTorch only on the inner visual tower.
+        # Never let a telemetry lookup fail model construction.
         if isinstance(self._model, ClipTorch):
-            self.image_size = self._model._model.visual.input_resolution
+            inner = getattr(self._model, "_model", None)
+            self.image_size = getattr(
+                getattr(inner, "visual", None), "input_resolution", None
+            )
         else:
-            self.image_size = self._model._image_size
+            self.image_size = getattr(self._model, "_image_size", None)
 
     def run_tensor_native_inference(
         self, action: Literal["compare", "embed-image", "embed-text"], **kwargs

--- a/inference/models/clip/clip_inference_models.py
+++ b/inference/models/clip/clip_inference_models.py
@@ -32,6 +32,10 @@ from inference.core.models.types import PreprocessReturnMetadata
 from inference.core.roboflow_api import get_extra_weights_provider_headers
 from inference.core.utils.image_utils import load_image_bgr
 from inference.core.utils.postprocess import cosine_similarity
+from inference.usage_tracking.collector import usage_collector
+from inference.usage_tracking.decorator_helpers import (
+    record_fixed_model_input_for_request,
+)
 from inference_models import AutoModel
 from inference_models.models.clip.clip_onnx import ClipOnnx
 from inference_models.models.clip.clip_pytorch import ClipTorch
@@ -80,6 +84,13 @@ class InferenceModelsClipAdapter(Model):
             backend=backend,
             **kwargs,
         )
+        # ClipOnnx stores the square canvas as `_image_size`; ClipTorch only
+        # keeps it on the inner CLIP visual tower. Usage telemetry reads
+        # `resolution` the same way the legacy ONNX Clip class does.
+        self.resolution = getattr(self._model, "_image_size", None)
+        if self.resolution is None:
+            visual = getattr(getattr(self._model, "_model", None), "visual", None)
+            self.resolution = getattr(visual, "input_resolution", None)
 
     def run_tensor_native_inference(
         self, action: Literal["compare", "embed-image", "embed-text"], **kwargs
@@ -303,6 +314,7 @@ class InferenceModelsClipAdapter(Model):
         response = ClipEmbeddingResponse(embeddings=embeddings.tolist())
         return response
 
+    @usage_collector("model")
     def infer_from_request(
         self, request: ClipInferenceRequest
     ) -> ClipEmbeddingResponse:
@@ -314,6 +326,7 @@ class InferenceModelsClipAdapter(Model):
         Returns:
             ClipEmbeddingResponse: The response object containing the embeddings.
         """
+        record_fixed_model_input_for_request(self, request)
         t1 = perf_counter()
         if isinstance(request, ClipImageEmbeddingRequest):
             infer_func = self.embed_image

--- a/inference/models/clip/clip_inference_models.py
+++ b/inference/models/clip/clip_inference_models.py
@@ -33,9 +33,6 @@ from inference.core.roboflow_api import get_extra_weights_provider_headers
 from inference.core.utils.image_utils import load_image_bgr
 from inference.core.utils.postprocess import cosine_similarity
 from inference.usage_tracking.collector import usage_collector
-from inference.usage_tracking.decorator_helpers import (
-    record_fixed_model_input_for_request,
-)
 from inference_models import AutoModel
 from inference_models.models.clip.clip_onnx import ClipOnnx
 from inference_models.models.clip.clip_pytorch import ClipTorch
@@ -84,13 +81,12 @@ class InferenceModelsClipAdapter(Model):
             backend=backend,
             **kwargs,
         )
-        # ClipOnnx stores the square canvas as `_image_size`; ClipTorch only
-        # keeps it on the inner CLIP visual tower. Usage telemetry reads
-        # `resolution` the same way the legacy ONNX Clip class does.
-        self.resolution = getattr(self._model, "_image_size", None)
-        if self.resolution is None:
-            visual = getattr(getattr(self._model, "_model", None), "visual", None)
-            self.resolution = getattr(visual, "input_resolution", None)
+        # Usage telemetry reads the fixed canvas from `image_size`. ClipOnnx
+        # keeps it as `_image_size`; ClipTorch only on the inner visual tower.
+        if isinstance(self._model, ClipTorch):
+            self.image_size = self._model._model.visual.input_resolution
+        else:
+            self.image_size = self._model._image_size
 
     def run_tensor_native_inference(
         self, action: Literal["compare", "embed-image", "embed-text"], **kwargs
@@ -326,7 +322,6 @@ class InferenceModelsClipAdapter(Model):
         Returns:
             ClipEmbeddingResponse: The response object containing the embeddings.
         """
-        record_fixed_model_input_for_request(self, request)
         t1 = perf_counter()
         if isinstance(request, ClipImageEmbeddingRequest):
             infer_func = self.embed_image

--- a/inference/models/clip/clip_model.py
+++ b/inference/models/clip/clip_model.py
@@ -33,9 +33,6 @@ from inference.core.utils.image_utils import load_image_rgb
 from inference.core.utils.onnx import get_onnxruntime_execution_providers
 from inference.core.utils.postprocess import cosine_similarity
 from inference.usage_tracking.collector import usage_collector
-from inference.usage_tracking.decorator_helpers import (
-    record_fixed_model_input_for_request,
-)
 
 
 class Clip(OnnxRoboflowCoreModel):
@@ -85,6 +82,8 @@ class Clip(OnnxRoboflowCoreModel):
                     )
 
         self.resolution = self.visual_onnx_session.get_inputs()[0].shape[2]
+        # Usage telemetry reads the fixed canvas from `image_size`.
+        self.image_size = self.resolution
 
         self.clip_preprocess = clip.clip._transform(self.resolution)
         self.log(f"CLIP model loaded in {perf_counter() - t1:.2f} seconds")
@@ -319,7 +318,6 @@ class Clip(OnnxRoboflowCoreModel):
         Returns:
             ClipEmbeddingResponse: The response object containing the embeddings.
         """
-        record_fixed_model_input_for_request(self, request)
         t1 = perf_counter()
         if isinstance(request, ClipImageEmbeddingRequest):
             infer_func = self.embed_image

--- a/inference/models/clip/clip_model.py
+++ b/inference/models/clip/clip_model.py
@@ -32,6 +32,10 @@ from inference.core.models.utils.batching import create_batches
 from inference.core.utils.image_utils import load_image_rgb
 from inference.core.utils.onnx import get_onnxruntime_execution_providers
 from inference.core.utils.postprocess import cosine_similarity
+from inference.usage_tracking.collector import usage_collector
+from inference.usage_tracking.decorator_helpers import (
+    record_fixed_model_input_for_request,
+)
 
 
 class Clip(OnnxRoboflowCoreModel):
@@ -303,6 +307,7 @@ class Clip(OnnxRoboflowCoreModel):
         """
         return ["textual.onnx", "visual.onnx"]
 
+    @usage_collector("model")
     def infer_from_request(
         self, request: ClipInferenceRequest
     ) -> ClipEmbeddingResponse:
@@ -314,6 +319,7 @@ class Clip(OnnxRoboflowCoreModel):
         Returns:
             ClipEmbeddingResponse: The response object containing the embeddings.
         """
+        record_fixed_model_input_for_request(self, request)
         t1 = perf_counter()
         if isinstance(request, ClipImageEmbeddingRequest):
             infer_func = self.embed_image

--- a/inference/models/perception_encoder/perception_encoder.py
+++ b/inference/models/perception_encoder/perception_encoder.py
@@ -26,6 +26,10 @@ from inference.core.models.types import PreprocessReturnMetadata
 from inference.core.models.utils.batching import create_batches
 from inference.core.utils.image_utils import load_image_rgb
 from inference.core.utils.postprocess import cosine_similarity
+from inference.usage_tracking.collector import usage_collector
+from inference.usage_tracking.decorator_helpers import (
+    record_fixed_model_input_for_request,
+)
 
 if DEVICE is None:
     if torch.cuda.is_available():
@@ -72,6 +76,7 @@ class PerceptionEncoder(RoboflowCoreModel):
 
         self.preprocessor = transforms.get_image_transform(self.model.image_size)
         self.tokenizer = transforms.get_text_tokenizer(self.model.context_length)
+        self.image_size = self.model.image_size
 
         self.task_type = "embedding"
 
@@ -277,10 +282,12 @@ class PerceptionEncoder(RoboflowCoreModel):
         response = PerceptionEncoderEmbeddingResponse(embeddings=embeddings.tolist())
         return response
 
+    @usage_collector("model")
     def infer_from_request(
         self, request: PerceptionEncoderInferenceRequest
     ) -> PerceptionEncoderEmbeddingResponse:
         """Routes the request to the appropriate inference function."""
+        record_fixed_model_input_for_request(self, request)
         t1 = perf_counter()
         if isinstance(request, PerceptionEncoderImageEmbeddingRequest):
             infer_func = self.embed_image

--- a/inference/models/perception_encoder/perception_encoder.py
+++ b/inference/models/perception_encoder/perception_encoder.py
@@ -27,9 +27,6 @@ from inference.core.models.utils.batching import create_batches
 from inference.core.utils.image_utils import load_image_rgb
 from inference.core.utils.postprocess import cosine_similarity
 from inference.usage_tracking.collector import usage_collector
-from inference.usage_tracking.decorator_helpers import (
-    record_fixed_model_input_for_request,
-)
 
 if DEVICE is None:
     if torch.cuda.is_available():
@@ -287,7 +284,6 @@ class PerceptionEncoder(RoboflowCoreModel):
         self, request: PerceptionEncoderInferenceRequest
     ) -> PerceptionEncoderEmbeddingResponse:
         """Routes the request to the appropriate inference function."""
-        record_fixed_model_input_for_request(self, request)
         t1 = perf_counter()
         if isinstance(request, PerceptionEncoderImageEmbeddingRequest):
             infer_func = self.embed_image

--- a/inference/models/perception_encoder/perception_encoder_inference_models.py
+++ b/inference/models/perception_encoder/perception_encoder_inference_models.py
@@ -78,7 +78,9 @@ class InferenceModelsPerceptionEncoderAdapter(Model):
             **kwargs,
         )
         # Usage telemetry reads the fixed canvas from `image_size`.
-        self.image_size = self._model.model.image_size
+        # Never let a telemetry lookup fail model construction.
+        inner = getattr(self._model, "model", None)
+        self.image_size = getattr(inner, "image_size", None)
 
     def preproc_image(self, image: InferenceRequestImage) -> np.ndarray:
         """Preprocesses an inference request image."""

--- a/inference/models/perception_encoder/perception_encoder_inference_models.py
+++ b/inference/models/perception_encoder/perception_encoder_inference_models.py
@@ -33,9 +33,6 @@ from inference.core.roboflow_api import get_extra_weights_provider_headers
 from inference.core.utils.image_utils import load_image_bgr
 from inference.core.utils.postprocess import cosine_similarity
 from inference.usage_tracking.collector import usage_collector
-from inference.usage_tracking.decorator_helpers import (
-    record_fixed_model_input_for_request,
-)
 from inference_models import AutoModel
 from inference_models.models.perception_encoder.perception_encoder_pytorch import (
     PerceptionEncoderTorch,
@@ -80,8 +77,8 @@ class InferenceModelsPerceptionEncoderAdapter(Model):
             backend=backend,
             **kwargs,
         )
-        inner = getattr(self._model, "model", None)
-        self.image_size = getattr(inner, "image_size", None)
+        # Usage telemetry reads the fixed canvas from `image_size`.
+        self.image_size = self._model.model.image_size
 
     def preproc_image(self, image: InferenceRequestImage) -> np.ndarray:
         """Preprocesses an inference request image."""
@@ -271,7 +268,6 @@ class InferenceModelsPerceptionEncoderAdapter(Model):
         self, request: PerceptionEncoderInferenceRequest
     ) -> PerceptionEncoderEmbeddingResponse:
         """Routes the request to the appropriate inference function."""
-        record_fixed_model_input_for_request(self, request)
         t1 = perf_counter()
         if isinstance(request, PerceptionEncoderImageEmbeddingRequest):
             infer_func = self.embed_image

--- a/inference/models/perception_encoder/perception_encoder_inference_models.py
+++ b/inference/models/perception_encoder/perception_encoder_inference_models.py
@@ -32,6 +32,10 @@ from inference.core.models.types import PreprocessReturnMetadata
 from inference.core.roboflow_api import get_extra_weights_provider_headers
 from inference.core.utils.image_utils import load_image_bgr
 from inference.core.utils.postprocess import cosine_similarity
+from inference.usage_tracking.collector import usage_collector
+from inference.usage_tracking.decorator_helpers import (
+    record_fixed_model_input_for_request,
+)
 from inference_models import AutoModel
 from inference_models.models.perception_encoder.perception_encoder_pytorch import (
     PerceptionEncoderTorch,
@@ -76,6 +80,8 @@ class InferenceModelsPerceptionEncoderAdapter(Model):
             backend=backend,
             **kwargs,
         )
+        inner = getattr(self._model, "model", None)
+        self.image_size = getattr(inner, "image_size", None)
 
     def preproc_image(self, image: InferenceRequestImage) -> np.ndarray:
         """Preprocesses an inference request image."""
@@ -260,10 +266,12 @@ class InferenceModelsPerceptionEncoderAdapter(Model):
         prompt_embeddings_norm = F.normalize(prompt_embeddings, dim=1)
         return subject_embeddings_norm @ prompt_embeddings_norm.T
 
+    @usage_collector("model")
     def infer_from_request(
         self, request: PerceptionEncoderInferenceRequest
     ) -> PerceptionEncoderEmbeddingResponse:
         """Routes the request to the appropriate inference function."""
+        record_fixed_model_input_for_request(self, request)
         t1 = perf_counter()
         if isinstance(request, PerceptionEncoderImageEmbeddingRequest):
             infer_func = self.embed_image

--- a/inference/models/sam/segment_anything.py
+++ b/inference/models/sam/segment_anything.py
@@ -25,6 +25,10 @@ from inference.core.env import SAM_MAX_EMBEDDING_CACHE_SIZE, SAM_VERSION_ID
 from inference.core.models.roboflow import RoboflowCoreModel
 from inference.core.utils.image_utils import load_image_rgb
 from inference.core.utils.postprocess import masks2poly
+from inference.usage_tracking.collector import usage_collector
+from inference.usage_tracking.decorator_helpers import (
+    record_fixed_model_input_for_request,
+)
 
 
 class SegmentAnything(RoboflowCoreModel):
@@ -122,6 +126,7 @@ class SegmentAnything(RoboflowCoreModel):
                 del self.image_size_cache[cache_key]
         return (embedding, img_in.shape[:2])
 
+    @usage_collector("model")
     def infer_from_request(self, request: SamInferenceRequest):
         """Performs inference based on the request type.
 
@@ -131,6 +136,7 @@ class SegmentAnything(RoboflowCoreModel):
         Returns:
             Union[SamEmbeddingResponse, SamSegmentationResponse]: The inference response.
         """
+        record_fixed_model_input_for_request(self, request)
         with self._state_lock:
             t1 = perf_counter()
             if isinstance(request, SamEmbeddingRequest):

--- a/inference/models/sam/segment_anything.py
+++ b/inference/models/sam/segment_anything.py
@@ -26,9 +26,6 @@ from inference.core.models.roboflow import RoboflowCoreModel
 from inference.core.utils.image_utils import load_image_rgb
 from inference.core.utils.postprocess import masks2poly
 from inference.usage_tracking.collector import usage_collector
-from inference.usage_tracking.decorator_helpers import (
-    record_fixed_model_input_for_request,
-)
 
 
 class SegmentAnything(RoboflowCoreModel):
@@ -58,6 +55,8 @@ class SegmentAnything(RoboflowCoreModel):
         )
         self.sam.to(device="cuda" if torch.cuda.is_available() else "cpu")
         self.predictor = SamPredictor(self.sam)
+        # Usage telemetry reads the fixed canvas from `image_size`.
+        self.image_size = self.sam.image_encoder.img_size
         self.ort_session = onnxruntime.InferenceSession(
             self.cache_file("decoder.onnx"),
             providers=[
@@ -136,7 +135,6 @@ class SegmentAnything(RoboflowCoreModel):
         Returns:
             Union[SamEmbeddingResponse, SamSegmentationResponse]: The inference response.
         """
-        record_fixed_model_input_for_request(self, request)
         with self._state_lock:
             t1 = perf_counter()
             if isinstance(request, SamEmbeddingRequest):

--- a/inference/models/sam/segment_anything_inference_models.py
+++ b/inference/models/sam/segment_anything_inference_models.py
@@ -87,8 +87,10 @@ class InferenceModelsSAMAdapter(Model):
             **kwargs,
         )
         # Usage telemetry reads the fixed canvas from `image_size`; SAMTorch
-        # only keeps it on the wrapped encoder.
-        self.image_size = self._model._model.image_encoder.img_size
+        # only keeps it on the wrapped encoder. Never let a telemetry lookup
+        # fail model construction.
+        encoder = getattr(getattr(self._model, "_model", None), "image_encoder", None)
+        self.image_size = getattr(encoder, "img_size", None)
 
     def map_inference_kwargs(self, kwargs: dict) -> dict:
         return kwargs

--- a/inference/models/sam/segment_anything_inference_models.py
+++ b/inference/models/sam/segment_anything_inference_models.py
@@ -30,6 +30,10 @@ from inference.core.models.base import Model
 from inference.core.roboflow_api import get_extra_weights_provider_headers
 from inference.core.utils.image_utils import load_image_bgr
 from inference.core.utils.postprocess import masks2poly
+from inference.usage_tracking.collector import usage_collector
+from inference.usage_tracking.decorator_helpers import (
+    record_fixed_model_input_for_request,
+)
 from inference_models import AutoModel
 from inference_models.models.sam.cache import (
     SamImageEmbeddingsInMemoryCache,
@@ -97,7 +101,9 @@ class InferenceModelsSAMAdapter(Model):
             return self._model.embed_images(**kwargs)
         return self._model.segment_images(**kwargs)
 
+    @usage_collector("model")
     def infer_from_request(self, request: SamInferenceRequest):
+        record_fixed_model_input_for_request(self, request)
         t1 = perf_counter()
         if isinstance(request, SamEmbeddingRequest):
             embedding, _ = self.embed_image(**request.dict())

--- a/inference/models/sam/segment_anything_inference_models.py
+++ b/inference/models/sam/segment_anything_inference_models.py
@@ -31,9 +31,6 @@ from inference.core.roboflow_api import get_extra_weights_provider_headers
 from inference.core.utils.image_utils import load_image_bgr
 from inference.core.utils.postprocess import masks2poly
 from inference.usage_tracking.collector import usage_collector
-from inference.usage_tracking.decorator_helpers import (
-    record_fixed_model_input_for_request,
-)
 from inference_models import AutoModel
 from inference_models.models.sam.cache import (
     SamImageEmbeddingsInMemoryCache,
@@ -89,6 +86,9 @@ class InferenceModelsSAMAdapter(Model):
             backend=backend,
             **kwargs,
         )
+        # Usage telemetry reads the fixed canvas from `image_size`; SAMTorch
+        # only keeps it on the wrapped encoder.
+        self.image_size = self._model._model.image_encoder.img_size
 
     def map_inference_kwargs(self, kwargs: dict) -> dict:
         return kwargs
@@ -103,7 +103,6 @@ class InferenceModelsSAMAdapter(Model):
 
     @usage_collector("model")
     def infer_from_request(self, request: SamInferenceRequest):
-        record_fixed_model_input_for_request(self, request)
         t1 = perf_counter()
         if isinstance(request, SamEmbeddingRequest):
             embedding, _ = self.embed_image(**request.dict())

--- a/inference/models/sam3_3d/segment_anything_3d.py
+++ b/inference/models/sam3_3d/segment_anything_3d.py
@@ -33,9 +33,6 @@ from inference.core.roboflow_api import (
 )
 from inference.core.utils.image_utils import load_image_rgb
 from inference.usage_tracking.collector import usage_collector
-from inference.usage_tracking.decorator_helpers import (
-    record_fixed_model_input_for_request,
-)
 
 try:
     import pycocotools.mask as mask_utils
@@ -366,7 +363,6 @@ class SegmentAnything3_3D_Objects(RoboflowCoreModel):
     def infer_from_request(
         self, request: Sam3_3D_Objects_InferenceRequest
     ) -> Sam3_3D_Objects_Response:
-        record_fixed_model_input_for_request(self, request)
         with self._state_lock:
             t1 = perf_counter()
             raw_result = self.create_3d(**request.model_dump())

--- a/inference/models/sam3_3d/segment_anything_3d.py
+++ b/inference/models/sam3_3d/segment_anything_3d.py
@@ -32,6 +32,10 @@ from inference.core.roboflow_api import (
     stream_url_to_cache,
 )
 from inference.core.utils.image_utils import load_image_rgb
+from inference.usage_tracking.collector import usage_collector
+from inference.usage_tracking.decorator_helpers import (
+    record_fixed_model_input_for_request,
+)
 
 try:
     import pycocotools.mask as mask_utils
@@ -358,9 +362,11 @@ class SegmentAnything3_3D_Objects(RoboflowCoreModel):
                     model_id=self.endpoint,
                 )
 
+    @usage_collector("model")
     def infer_from_request(
         self, request: Sam3_3D_Objects_InferenceRequest
     ) -> Sam3_3D_Objects_Response:
+        record_fixed_model_input_for_request(self, request)
         with self._state_lock:
             t1 = perf_counter()
             raw_result = self.create_3d(**request.model_dump())

--- a/inference/usage_tracking/decorator_helpers.py
+++ b/inference/usage_tracking/decorator_helpers.py
@@ -71,6 +71,11 @@ def get_model_api_key_from_kwargs(func_kwargs: Dict[str, Any]) -> Optional[str]:
         api_key = getattr(request, "api_key", None)
         if api_key:
             return api_key
+    if "self" in func_kwargs:
+        _self = func_kwargs["self"]
+        api_key = getattr(_self, "api_key", None) or getattr(_self, "_api_key", None)
+        if api_key:
+            return api_key
     return None
 
 
@@ -109,12 +114,28 @@ def get_model_resource_details_from_kwargs(
     return resource_details
 
 
+def _as_image_sequence(value: Any) -> Any:
+    """Normalize a workflow Batch of images to a list for frame counting.
+
+    ``Batch`` is sized and iterable but is not a list/tuple, so
+    ``count_inference_images`` would otherwise treat a multi-image batch as
+    a single frame.
+    """
+    if value is not None and hasattr(value, "iter_with_indices"):
+        return list(value)
+    return value
+
+
 def get_model_image_from_kwargs(func_kwargs: Dict[str, Any]) -> Any:
     if "image" in func_kwargs:
-        return func_kwargs["image"]
+        return _as_image_sequence(func_kwargs["image"])
+    if "images" in func_kwargs:
+        return _as_image_sequence(func_kwargs["images"])
     nested_kwargs = func_kwargs.get("kwargs")
     if isinstance(nested_kwargs, dict) and "image" in nested_kwargs:
-        return nested_kwargs["image"]
+        return _as_image_sequence(nested_kwargs["image"])
+    if isinstance(nested_kwargs, dict) and "images" in nested_kwargs:
+        return _as_image_sequence(nested_kwargs["images"])
     for request_key in ("inference_request", "request"):
         request = func_kwargs.get(request_key)
         image = getattr(request, "image", None)

--- a/inference/usage_tracking/decorator_helpers.py
+++ b/inference/usage_tracking/decorator_helpers.py
@@ -4,6 +4,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 from inference.core.env import SAM3_EXEC_MODE
 from inference.core.logger import logger
 from inference.core.roboflow_api import service_secret_is_valid
+from inference.core.workflows.execution_engine.entities.base import Batch
 from inference.core.workflows.execution_engine.v1.compiler.entities import (
     CompiledWorkflow,
 )
@@ -342,9 +343,31 @@ def _as_image_sequence(value: Any) -> Any:
     ``count_inference_images`` would otherwise treat a multi-image batch as
     a single frame.
     """
-    if value is not None and hasattr(value, "iter_with_indices"):
+    if isinstance(value, Batch):
         return list(value)
     return value
+
+
+def _compare_request_images(request: Any) -> Optional[List[Any]]:
+    """Imagery carried by a CLIP/PE compare request, which has no ``image``.
+
+    Compare requests hold their images under ``subject`` / ``prompt``; each
+    side participates only when its ``*_type`` says it is an image.
+    """
+    images = []
+    if getattr(request, "subject_type", None) == "image":
+        subject = getattr(request, "subject", None)
+        if subject is not None:
+            images.append(subject)
+    if getattr(request, "prompt_type", None) == "image":
+        prompt = getattr(request, "prompt", None)
+        if isinstance(prompt, dict):
+            images.extend(prompt.values())
+        elif isinstance(prompt, (list, tuple)):
+            images.extend(prompt)
+        elif prompt is not None:
+            images.append(prompt)
+    return images or None
 
 
 def get_model_image_from_kwargs(func_kwargs: Dict[str, Any]) -> Any:
@@ -362,6 +385,9 @@ def get_model_image_from_kwargs(func_kwargs: Dict[str, Any]) -> Any:
         image = getattr(request, "image", None)
         if image is not None:
             return image
+        compare_images = _compare_request_images(request)
+        if compare_images is not None:
+            return compare_images
     return None
 
 
@@ -384,7 +410,10 @@ def get_model_frames_and_input_hw(
     if frames <= 0 and measured_frames:
         frames = measured_frames
     if frames <= 0:
-        frames = 1
+        # No imagery anywhere in the call (text-only embeds). One frame is
+        # still billed, but crediting the model's visual canvas to it would
+        # fabricate image-resolution telemetry - leave the bucket unknown.
+        return 1, None
 
     return frames, resolve_model_input_hw(model, measured_hw=measured_hw)
 

--- a/inference/usage_tracking/decorator_helpers.py
+++ b/inference/usage_tracking/decorator_helpers.py
@@ -412,8 +412,13 @@ def get_model_frames_and_input_hw(
     if frames <= 0:
         # No imagery anywhere in the call (text-only embeds). One frame is
         # still billed, but crediting the model's visual canvas to it would
-        # fabricate image-resolution telemetry - leave the bucket unknown.
-        return 1, None
+        # fabricate image-resolution telemetry — leave the bucket unknown
+        # unless the call explicitly published a size (SAM2/SAM3 cache-hit
+        # embed_image with image=None).
+        if measured_hw is None:
+            return 1, None
+
+        return 1, resolve_model_input_hw(model, measured_hw=measured_hw)
 
     return frames, resolve_model_input_hw(model, measured_hw=measured_hw)
 

--- a/tests/inference/unit_tests/usage_tracking/test_collector.py
+++ b/tests/inference/unit_tests/usage_tracking/test_collector.py
@@ -17,7 +17,10 @@ from inference.core.env import LAMBDA
 from inference.core.version import __version__ as inference_version
 from inference.core.workflows.errors import ClientCausedStepExecutionError
 from inference.usage_tracking import payload_helpers
-from inference.usage_tracking.decorator_helpers import usage_billing_suppressed
+from inference.usage_tracking.decorator_helpers import (
+    record_fixed_model_input_for_request,
+    usage_billing_suppressed,
+)
 from inference.usage_tracking.megapixel_buckets import (
     clear_measured_model_input,
     record_measured_model_input,
@@ -2609,6 +2612,42 @@ def test_clip_shaped_infer_from_request_records_model_row(
     assert details["task_type"] == "embedding"
     assert row["processed_frames"] == 1
     assert row["megapixel_buckets"]["0-0.25"]["processed_frames"] == 1
+
+
+def test_sam2_cache_hit_embed_keeps_published_canvas_bucket(
+    usage_collector_with_mocked_threads,
+):
+    """SAM2 /sam2/embed_image reuses a cached embedding with image=None.
+
+    record_fixed_model_input_for_request still publishes the encoder canvas;
+    that size must land in a real megapixel bucket, not unknown.
+    """
+    usage_collector = usage_collector_with_mocked_threads
+
+    class Sam2Like:
+        api_key = "test_key"
+        dataset_id = "sam2"
+        version_id = "hiera-large"
+        image_size = 1024
+
+        @usage_collector(category="model")
+        def infer_from_request(self, request):
+            record_fixed_model_input_for_request(self, request)
+            return {"ok": True}
+
+    request = SimpleNamespace(
+        image=None,
+        image_id="cached-embed",
+        model_id="sam2/hiera-large",
+        api_key="test_key",
+    )
+
+    Sam2Like().infer_from_request(request)
+
+    key = usage_key("model", "sam2/hiera-large")
+    row = usage_collector._usage["test_key"][key]
+    assert row["processed_frames"] == 1
+    assert row["megapixel_buckets"]["1-2"]["processed_frames"] == 1
 
 
 def test_model_decorator_records_fixed_input_megapixel_buckets(

--- a/tests/inference/unit_tests/usage_tracking/test_collector.py
+++ b/tests/inference/unit_tests/usage_tracking/test_collector.py
@@ -4,6 +4,7 @@ import json
 import sys
 import threading
 from queue import Queue
+from types import SimpleNamespace
 from typing import Optional
 from unittest import mock
 
@@ -14,6 +15,9 @@ from inference.core.env import LAMBDA
 from inference.core.version import __version__ as inference_version
 from inference.core.workflows.errors import ClientCausedStepExecutionError
 from inference.usage_tracking import payload_helpers
+from inference.usage_tracking.decorator_helpers import (
+    record_fixed_model_input_for_request,
+)
 from inference.usage_tracking.megapixel_buckets import (
     clear_measured_model_input,
     record_measured_model_input,
@@ -2113,6 +2117,45 @@ def test_record_usage_accumulates_megapixel_buckets(
     )
     details = json.loads(row["resource_details"])
     assert details["model_type"] == "rfdetr-seg-nano"
+
+
+def test_clip_shaped_infer_from_request_records_model_row(
+    usage_collector_with_mocked_threads,
+):
+    """CLIP serves production traffic through infer_from_request, not infer().
+
+    The request entrypoint must emit a model-category row. Canvas size is
+    attributed via megapixel buckets when the model exposes a fixed size
+    that ``get_fixed_model_input_hw`` already recognizes (``image_size``).
+    """
+    usage_collector = usage_collector_with_mocked_threads
+
+    class ClipLike:
+        api_key = "test_key"
+        dataset_id = "clip"
+        version_id = "ViT-B-32"
+        task_type = "embedding"
+        image_size = 224
+
+        @usage_collector(category="model")
+        def infer_from_request(self, request):
+            record_fixed_model_input_for_request(self, request)
+            return {"ok": True}
+
+    request = SimpleNamespace(
+        image=object(),
+        model_id="clip/ViT-B-32",
+        api_key="test_key",
+    )
+
+    ClipLike().infer_from_request(request)
+
+    key = usage_key("model", "clip/ViT-B-32")
+    row = usage_collector._usage["test_key"][key]
+    details = json.loads(row["resource_details"])
+    assert details["task_type"] == "embedding"
+    assert row["processed_frames"] == 1
+    assert row["megapixel_buckets"]["0-0.25"]["processed_frames"] == 1
 
 
 def test_model_decorator_records_fixed_input_megapixel_buckets(

--- a/tests/inference/unit_tests/usage_tracking/test_collector.py
+++ b/tests/inference/unit_tests/usage_tracking/test_collector.py
@@ -17,10 +17,7 @@ from inference.core.env import LAMBDA
 from inference.core.version import __version__ as inference_version
 from inference.core.workflows.errors import ClientCausedStepExecutionError
 from inference.usage_tracking import payload_helpers
-from inference.usage_tracking.decorator_helpers import (
-    record_fixed_model_input_for_request,
-    usage_billing_suppressed,
-)
+from inference.usage_tracking.decorator_helpers import usage_billing_suppressed
 from inference.usage_tracking.megapixel_buckets import (
     clear_measured_model_input,
     record_measured_model_input,
@@ -2596,7 +2593,6 @@ def test_clip_shaped_infer_from_request_records_model_row(
 
         @usage_collector(category="model")
         def infer_from_request(self, request):
-            record_fixed_model_input_for_request(self, request)
             return {"ok": True}
 
     request = SimpleNamespace(

--- a/tests/inference/unit_tests/usage_tracking/test_decorator_helpers.py
+++ b/tests/inference/unit_tests/usage_tracking/test_decorator_helpers.py
@@ -18,6 +18,7 @@ from inference.usage_tracking.decorator_helpers import (
     get_source_info_from_kwargs,
     non_billable_intent_is_authenticated,
     read_source_tags_bound_to_call,
+    record_fixed_model_input_for_request,
 )
 from inference.usage_tracking.model_types import (
     bind_usage_model_identity,
@@ -559,6 +560,19 @@ def test_text_only_embedding_bills_one_frame_without_visual_canvas():
 
     assert frames == 1
     assert input_hw is None
+
+
+def test_published_canvas_without_imagery_keeps_bucket():
+    model = SimpleNamespace(image_size=1024)
+    request = SimpleNamespace(image=None, image_id="cached-embed")
+
+    record_fixed_model_input_for_request(model, request)
+    frames, input_hw = get_model_frames_and_input_hw(
+        {"self": model, "request": request}
+    )
+
+    assert frames == 1
+    assert input_hw == (1024, 1024)
 
 
 def test_model_api_key_from_workflow_block_private_attr():

--- a/tests/inference/unit_tests/usage_tracking/test_decorator_helpers.py
+++ b/tests/inference/unit_tests/usage_tracking/test_decorator_helpers.py
@@ -5,6 +5,7 @@ import pytest
 
 from inference.core.entities.requests.sam2 import Sam2InferenceRequest
 from inference.core.env import SAM2_VERSION_ID, SAM3_EXEC_MODE
+from inference.core.workflows.execution_engine.entities.base import Batch
 from inference.usage_tracking import decorator_helpers
 from inference.usage_tracking.decorator_helpers import (
     call_carries_authenticated_non_billable_intent,
@@ -529,24 +530,35 @@ def test_model_frames_count_images_kwarg_used_by_video_blocks():
 
 
 def test_model_frames_count_workflow_batch_used_by_video_blocks():
-    class FakeWorkflowBatch:
-        def __init__(self, items):
-            self._content = items
+    batch = Batch(content=[object(), object(), object()], indices=None)
 
-        def __len__(self):
-            return len(self._content)
-
-        def __iter__(self):
-            return iter(self._content)
-
-        def iter_with_indices(self):
-            return enumerate(self._content)
-
-    frames, _ = get_model_frames_and_input_hw(
-        {"images": FakeWorkflowBatch([object(), object(), object()])}
-    )
+    frames, _ = get_model_frames_and_input_hw({"images": batch})
 
     assert frames == 3
+
+
+def test_model_frames_count_compare_request_subject_and_prompt_images():
+    request = SimpleNamespace(
+        subject=object(),
+        subject_type="image",
+        prompt=[object(), object()],
+        prompt_type="image",
+    )
+
+    frames, _ = get_model_frames_and_input_hw({"request": request})
+
+    assert frames == 3
+
+
+def test_text_only_embedding_bills_one_frame_without_visual_canvas():
+    model = SimpleNamespace(image_size=224)
+
+    frames, input_hw = get_model_frames_and_input_hw(
+        {"self": model, "request": SimpleNamespace()}
+    )
+
+    assert frames == 1
+    assert input_hw is None
 
 
 def test_model_api_key_from_workflow_block_private_attr():

--- a/tests/inference/unit_tests/usage_tracking/test_decorator_helpers.py
+++ b/tests/inference/unit_tests/usage_tracking/test_decorator_helpers.py
@@ -5,6 +5,8 @@ from inference.core.entities.requests.sam2 import Sam2InferenceRequest
 from inference.core.env import SAM2_VERSION_ID, SAM3_EXEC_MODE
 from inference.usage_tracking import decorator_helpers
 from inference.usage_tracking.decorator_helpers import (
+    get_model_api_key_from_kwargs,
+    get_model_frames_and_input_hw,
     get_model_id_from_kwargs,
     get_model_type_from_kwargs,
     get_request_resource_details_from_kwargs,
@@ -431,6 +433,43 @@ def test_recorded_model_types_evict_oldest_when_full(monkeypatch):
         assert get_recorded_model_type("d/1") == "yolov8l"
     finally:
         clear_recorded_model_types()
+
+
+def test_model_frames_count_images_kwarg_used_by_video_blocks():
+    frames, _ = get_model_frames_and_input_hw(
+        {"images": [object(), object(), object()]}
+    )
+
+    assert frames == 3
+
+
+def test_model_frames_count_workflow_batch_used_by_video_blocks():
+    class FakeWorkflowBatch:
+        def __init__(self, items):
+            self._content = items
+
+        def __len__(self):
+            return len(self._content)
+
+        def __iter__(self):
+            return iter(self._content)
+
+        def iter_with_indices(self):
+            return enumerate(self._content)
+
+    frames, _ = get_model_frames_and_input_hw(
+        {"images": FakeWorkflowBatch([object(), object(), object()])}
+    )
+
+    assert frames == 3
+
+
+def test_model_api_key_from_workflow_block_private_attr():
+    api_key = get_model_api_key_from_kwargs(
+        {"self": SimpleNamespace(_api_key="workflow-block-key")}
+    )
+
+    assert api_key == "workflow-block-key"
 
 
 def test_explicit_model_usage_api_key_takes_precedence_over_request(

--- a/tests/inference/unit_tests/usage_tracking/test_model_usage_coverage.py
+++ b/tests/inference/unit_tests/usage_tracking/test_model_usage_coverage.py
@@ -115,14 +115,14 @@ def test_model_overriding_infer_is_usage_collected(module_path, class_name):
     ), f"{class_name}.infer() must be decorated with @usage_collector('model')"
 
 
-@pytest.mark.parametrize("module_path, class_name", MODELS_DECORATING_INFER_FROM_REQUEST)
+@pytest.mark.parametrize(
+    "module_path, class_name", MODELS_DECORATING_INFER_FROM_REQUEST
+)
 def test_model_infer_from_request_is_usage_collected(module_path, class_name):
     module = pytest.importorskip(module_path)
     model_class = getattr(module, class_name)
 
-    assert _is_usage_collected(
-        model_class.infer_from_request
-    ), (
+    assert _is_usage_collected(model_class.infer_from_request), (
         f"{class_name}.infer_from_request() must be decorated with "
         "@usage_collector('model')"
     )

--- a/tests/inference/unit_tests/usage_tracking/test_model_usage_coverage.py
+++ b/tests/inference/unit_tests/usage_tracking/test_model_usage_coverage.py
@@ -85,15 +85,19 @@ MODELS_DECORATING_INFER_FROM_REQUEST = [
 ]
 
 # Video trackers load ``AutoModel`` in the block and never go through
-# ModelManager, so ``run()`` itself must emit the model-category row.
+# ModelManager, so the block's tracked entrypoint must emit the model-category
+# row. SAM3 tracks ``_tracked_run`` so that ``run()`` can first swap in the
+# visual model id the decorator should attribute usage to.
 BLOCKS_DECORATING_RUN = [
     (
         "inference.core.workflows.core_steps.models.foundation.segment_anything2_video.v1",
         "SegmentAnything2VideoBlockV1",
+        "run",
     ),
     (
         "inference.core.workflows.core_steps.models.foundation.segment_anything3_video.v1",
         "SegmentAnything3VideoBlockV1",
+        "_tracked_run",
     ),
 ]
 
@@ -128,14 +132,15 @@ def test_model_infer_from_request_is_usage_collected(module_path, class_name):
     )
 
 
-@pytest.mark.parametrize("module_path, class_name", BLOCKS_DECORATING_RUN)
-def test_video_block_run_is_usage_collected(module_path, class_name):
+@pytest.mark.parametrize("module_path, class_name, method_name", BLOCKS_DECORATING_RUN)
+def test_video_block_run_is_usage_collected(module_path, class_name, method_name):
     module = pytest.importorskip(module_path)
     block_class = getattr(module, class_name)
 
-    assert _is_usage_collected(
-        block_class.run
-    ), f"{class_name}.run() must be decorated with @usage_collector('model')"
+    assert _is_usage_collected(getattr(block_class, method_name)), (
+        f"{class_name}.{method_name}() must be decorated with "
+        "@usage_collector('model')"
+    )
 
 
 def test_detection_helper_rejects_undecorated_function():

--- a/tests/inference/unit_tests/usage_tracking/test_model_usage_coverage.py
+++ b/tests/inference/unit_tests/usage_tracking/test_model_usage_coverage.py
@@ -5,9 +5,14 @@ Families that override ``infer()`` without calling ``super()``, or that serve
 production traffic through ``infer_from_request`` / a workflow ``run()`` that
 never calls ``infer()``, must decorate those entrypoints themselves. Without
 that they emit no model-category row and disappear from per-model telemetry.
+
+These checks parse the module source with ``ast`` so they run on the stock
+unit-test image. Importing the modules would skip CLIP/SAM/SAM2/SAM3 under
+``pytest.importorskip`` because those extras are not installed in CI.
 """
 
-import inspect
+import ast
+from pathlib import Path
 
 import pytest
 
@@ -88,6 +93,8 @@ MODELS_DECORATING_INFER_FROM_REQUEST = [
 # ModelManager, so the block's tracked entrypoint must emit the model-category
 # row. SAM3 tracks ``_tracked_run`` so that ``run()`` can first swap in the
 # visual model id the decorator should attribute usage to.
+# Tensor-native siblings (v1_tensor.py) are not decorated; they currently
+# emit no model-category row under ENABLE_TENSOR_DATA_REPRESENTATION.
 BLOCKS_DECORATING_RUN = [
     (
         "inference.core.workflows.core_steps.models.foundation.segment_anything2_video.v1",
@@ -101,51 +108,92 @@ BLOCKS_DECORATING_RUN = [
     ),
 ]
 
+_REPO_ROOT = Path(__file__).resolve().parents[4]
 
-def _is_usage_collected(func) -> bool:
-    # functools.wraps hides the wrapper, so read the unfollowed signature and
-    # look for the keyword-only arguments the decorator injects.
-    parameters = inspect.signature(func, follow_wrapped=False).parameters
-    return "usage_api_key" in parameters and "usage_billable" in parameters
+
+def _module_source_path(module_path: str) -> Path:
+    return _REPO_ROOT / Path(*module_path.split(".")).with_suffix(".py")
+
+
+def _decorator_callable_name(node: ast.AST) -> str:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    if isinstance(node, ast.Call):
+        return _decorator_callable_name(node.func)
+    return ""
+
+
+def _decorator_category(call: ast.Call) -> str:
+    if call.args and isinstance(call.args[0], ast.Constant):
+        value = call.args[0].value
+        if isinstance(value, str):
+            return value
+    for keyword in call.keywords:
+        if keyword.arg == "category" and isinstance(keyword.value, ast.Constant):
+            value = keyword.value.value
+            if isinstance(value, str):
+                return value
+    return ""
+
+
+def _has_usage_collector_model_decorator(func: ast.FunctionDef) -> bool:
+    for decorator in func.decorator_list:
+        if not isinstance(decorator, ast.Call):
+            continue
+        if _decorator_callable_name(decorator) != "usage_collector":
+            continue
+        if _decorator_category(decorator) == "model":
+            return True
+    return False
+
+
+def _class_method_has_usage_collector(
+    source: str, class_name: str, method_name: str
+) -> bool:
+    tree = ast.parse(source)
+    for node in tree.body:
+        if not isinstance(node, ast.ClassDef) or node.name != class_name:
+            continue
+        for item in node.body:
+            if isinstance(item, ast.FunctionDef) and item.name == method_name:
+                return _has_usage_collector_model_decorator(item)
+    return False
+
+
+def _assert_method_is_usage_collected(module_path, class_name, method_name):
+    source_path = _module_source_path(module_path)
+    source = source_path.read_text()
+
+    assert _class_method_has_usage_collector(source, class_name, method_name), (
+        f"{class_name}.{method_name}() in {source_path} must be decorated "
+        "with @usage_collector('model')"
+    )
 
 
 @pytest.mark.parametrize("module_path, class_name", MODELS_OVERRIDING_INFER)
 def test_model_overriding_infer_is_usage_collected(module_path, class_name):
-    module = pytest.importorskip(module_path)
-    model_class = getattr(module, class_name)
-
-    assert _is_usage_collected(
-        model_class.infer
-    ), f"{class_name}.infer() must be decorated with @usage_collector('model')"
+    _assert_method_is_usage_collected(module_path, class_name, "infer")
 
 
 @pytest.mark.parametrize(
     "module_path, class_name", MODELS_DECORATING_INFER_FROM_REQUEST
 )
 def test_model_infer_from_request_is_usage_collected(module_path, class_name):
-    module = pytest.importorskip(module_path)
-    model_class = getattr(module, class_name)
-
-    assert _is_usage_collected(model_class.infer_from_request), (
-        f"{class_name}.infer_from_request() must be decorated with "
-        "@usage_collector('model')"
-    )
+    _assert_method_is_usage_collected(module_path, class_name, "infer_from_request")
 
 
 @pytest.mark.parametrize("module_path, class_name, method_name", BLOCKS_DECORATING_RUN)
 def test_video_block_run_is_usage_collected(module_path, class_name, method_name):
-    module = pytest.importorskip(module_path)
-    block_class = getattr(module, class_name)
-
-    assert _is_usage_collected(getattr(block_class, method_name)), (
-        f"{class_name}.{method_name}() must be decorated with "
-        "@usage_collector('model')"
-    )
+    _assert_method_is_usage_collected(module_path, class_name, method_name)
 
 
 def test_detection_helper_rejects_undecorated_function():
-    # Without this the parametrized test above would pass vacuously.
-    def infer(self, image, **kwargs):
-        return None
+    source = (
+        "class Fake:\n"
+        "    def infer(self, image, **kwargs):\n"
+        "        return None\n"
+    )
 
-    assert not _is_usage_collected(infer)
+    assert not _class_method_has_usage_collector(source, "Fake", "infer")

--- a/tests/inference/unit_tests/usage_tracking/test_model_usage_coverage.py
+++ b/tests/inference/unit_tests/usage_tracking/test_model_usage_coverage.py
@@ -1,9 +1,10 @@
-"""Guards that model families reimplementing ``infer()`` still report usage.
+"""Guards that model families still report a ``model``-category usage row.
 
 ``@usage_collector("model")`` normally rides along on ``BaseInference.infer``.
-These families override ``infer()`` and never call ``super()``, so the decorator
-has to be applied to each override; without it they emit no model-category row
-and disappear from per-model telemetry entirely.
+Families that override ``infer()`` without calling ``super()``, or that serve
+production traffic through ``infer_from_request`` / a workflow ``run()`` that
+never calls ``infer()``, must decorate those entrypoints themselves. Without
+that they emit no model-category row and disappear from per-model telemetry.
 """
 
 import inspect
@@ -32,6 +33,70 @@ MODELS_OVERRIDING_INFER = [
     ),
 ]
 
+# Production traffic for these families is ``infer_from_request``, which does
+# not call ``infer()``. The decorator has to live on that method.
+MODELS_DECORATING_INFER_FROM_REQUEST = [
+    ("inference.models.clip.clip_model", "Clip"),
+    (
+        "inference.models.clip.clip_inference_models",
+        "InferenceModelsClipAdapter",
+    ),
+    (
+        "inference.models.perception_encoder.perception_encoder",
+        "PerceptionEncoder",
+    ),
+    (
+        "inference.models.perception_encoder.perception_encoder_inference_models",
+        "InferenceModelsPerceptionEncoderAdapter",
+    ),
+    ("inference.models.sam.segment_anything", "SegmentAnything"),
+    (
+        "inference.models.sam.segment_anything_inference_models",
+        "InferenceModelsSAMAdapter",
+    ),
+    (
+        "inference.models.sam2.segment_anything2",
+        "SegmentAnything2",
+    ),
+    (
+        "inference.models.sam2.segment_anything2_inference_models",
+        "InferenceModelsSAM2Adapter",
+    ),
+    (
+        "inference.models.sam3.segment_anything3",
+        "SegmentAnything3",
+    ),
+    (
+        "inference.models.sam3.segment_anything3_inference_models",
+        "InferenceModelsSAM3Adapter",
+    ),
+    (
+        "inference.models.sam3.visual_segmentation",
+        "Sam3ForInteractiveImageSegmentation",
+    ),
+    (
+        "inference.models.sam3.visual_segmentation_inference_models",
+        "InferenceModelsSAM3InteractiveAdapter",
+    ),
+    (
+        "inference.models.sam3_3d.segment_anything_3d",
+        "SegmentAnything3_3D_Objects",
+    ),
+]
+
+# Video trackers load ``AutoModel`` in the block and never go through
+# ModelManager, so ``run()`` itself must emit the model-category row.
+BLOCKS_DECORATING_RUN = [
+    (
+        "inference.core.workflows.core_steps.models.foundation.segment_anything2_video.v1",
+        "SegmentAnything2VideoBlockV1",
+    ),
+    (
+        "inference.core.workflows.core_steps.models.foundation.segment_anything3_video.v1",
+        "SegmentAnything3VideoBlockV1",
+    ),
+]
+
 
 def _is_usage_collected(func) -> bool:
     # functools.wraps hides the wrapper, so read the unfollowed signature and
@@ -48,6 +113,29 @@ def test_model_overriding_infer_is_usage_collected(module_path, class_name):
     assert _is_usage_collected(
         model_class.infer
     ), f"{class_name}.infer() must be decorated with @usage_collector('model')"
+
+
+@pytest.mark.parametrize("module_path, class_name", MODELS_DECORATING_INFER_FROM_REQUEST)
+def test_model_infer_from_request_is_usage_collected(module_path, class_name):
+    module = pytest.importorskip(module_path)
+    model_class = getattr(module, class_name)
+
+    assert _is_usage_collected(
+        model_class.infer_from_request
+    ), (
+        f"{class_name}.infer_from_request() must be decorated with "
+        "@usage_collector('model')"
+    )
+
+
+@pytest.mark.parametrize("module_path, class_name", BLOCKS_DECORATING_RUN)
+def test_video_block_run_is_usage_collected(module_path, class_name):
+    module = pytest.importorskip(module_path)
+    block_class = getattr(module, class_name)
+
+    assert _is_usage_collected(
+        block_class.run
+    ), f"{class_name}.run() must be decorated with @usage_collector('model')"
 
 
 def test_detection_helper_rejects_undecorated_function():


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Linked issue: [LAKE-812](https://linear.app/roboflow/issue/LAKE-812/ensure-all-models-report-model-category-rows)

Follow-up to the model-variant / fixed-input usage work: several local models that run on Roboflow infra never emit a `model`-category usage row.

`@usage_collector("model")` lives on `BaseInference.infer`. CLIP, Perception Encoder, SAM1, and SAM3-3D serve HTTP and workflow traffic through `infer_from_request`, which dispatches to `embed_*` / `compare` / `create_3d` and never calls `infer()`. SAM2 and SAM3 video blocks load `AutoModel` in the block and skip `ModelManager` entirely. Without a decorator on those entrypoints, those families disappear from per-model telemetry.

This PR decorates those production entrypoints the same way SAM2 image already does. Models that use a fixed canvas expose it as `image_size` so the existing usage probe can bucket them; the wrapper recomputes that size, so the new entrypoints do not call `record_fixed_model_input_for_request`. Helpers count workflow `images` / `Batch` frames, CLIP/PE compare subject and prompt images, and a workflow block's `_api_key`. Text-only embeds still record one frame but leave the megapixel bucket unknown rather than attributing a visual canvas. SAM3 video `run()` chooses the model id first and delegates to a decorated `_tracked_run`, so visual-mode rows attribute to the visual model. Tensor-native siblings and remote VLM blocks are left alone; Roboflow trained models already emit `model` rows through `Model.infer_from_request` → `BaseInference.infer`.

**Main elements:**
- CLIP, Perception Encoder, SAM1, SAM3-3D `infer_from_request` (legacy + inference-models adapters)
- CLIP / PE / SAM1 `image_size` so the existing probe can bucket them
- SAM2 / SAM3 video workflow entrypoints (`run` / `_tracked_run`)
- Usage helpers for `_api_key`, `images`, workflow `Batch`, compare-request imagery, and text-only calls
- Coverage and collector unit tests

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Testing

### Unit tests

- Coverage guard that `infer_from_request` / video `run()` / `_tracked_run` stay decorated
- CLIP-shaped `infer_from_request` records a model row and buckets from `image_size`
- Workflow `images` / `Batch` frame counts and block `_api_key` attribution
- Compare requests count subject and prompt images
- Text-only embeds bill one frame without a visual canvas

### Integration tests

- None for this PR.

### Other

```
PYTHONPATH=/workspace:/workspace/inference_models pytest \
  tests/inference/unit_tests/usage_tracking/test_model_usage_coverage.py \
  tests/inference/unit_tests/usage_tracking/test_decorator_helpers.py \
  tests/inference/unit_tests/usage_tracking/test_collector.py::test_clip_shaped_infer_from_request_records_model_row
```

Review fixes from #2883 are included; that PR's unit tests passed in CI. black + isort on the touched files.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [ ] I have updated the documentation accordingly (if applicable)

## Additional Context

Includes the review fixes from #2883: CLIP/SAM1/PE canvas via `image_size`, compare-request frame counts, text-only unknown bucket, SAM3 visual-mode attribution, and removal of redundant `record_fixed_model_input_for_request` call sites.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8754e007-e92d-415b-b6d9-f0f823c0055f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8754e007-e92d-415b-b6d9-f0f823c0055f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>
