### PR TITLE
Bucket model usage by the image the caller sent

### DIFF
--- a/inference/core/models/base.py
+++ b/inference/core/models/base.py
@@ -11,9 +11,10 @@ from inference.core.models.types import PreprocessReturnMetadata
 from inference.core.telemetry import set_span_attribute, start_span
 from inference.usage_tracking.collector import usage_collector
 from inference.usage_tracking.megapixel_buckets import (
-    clear_measured_model_input,
-    parse_image_dims_hw,
-    record_measured_model_input,
+    clear_measured_image_input,
+    get_tensor_batch_size,
+    parse_image_input_hw,
+    record_measured_image_input,
 )
 from inference.usage_tracking.predict_timing import PredictPhaseTimer
 
@@ -30,12 +31,12 @@ class BaseInference:
         - image:
             can be a BGR numpy array, filepath, InferenceRequestImage, PIL Image, byte-string, etc.
         """
-        clear_measured_model_input()
+        clear_measured_image_input()
         with start_span("model.preprocess"):
             preproc_image, returned_metadata = self.preprocess(image, **kwargs)
-            record_measured_model_input(
-                preproc_image,
-                fallback_hw=parse_image_dims_hw(returned_metadata),
+            record_measured_image_input(
+                parse_image_input_hw(returned_metadata),
+                frames=get_tensor_batch_size(preproc_image),
             )
             logger.debug(
                 f"Preprocessed input shape: {getattr(preproc_image, 'shape', None)}"

--- a/inference/models/sam2/segment_anything2.py
+++ b/inference/models/sam2/segment_anything2.py
@@ -43,9 +43,6 @@ from inference.core.utils.image_utils import load_image_rgb
 from inference.core.utils.postprocess import masks2multipoly
 from inference.core.utils.torchscript_guard import _temporarily_disable_torch_jit_script
 from inference.usage_tracking.collector import usage_collector
-from inference.usage_tracking.decorator_helpers import (
-    record_fixed_model_input_for_request,
-)
 
 if DEVICE is None:
     DEVICE = "cuda:0" if torch.cuda.is_available() else "cpu"
@@ -191,7 +188,6 @@ class SegmentAnything2(RoboflowCoreModel):
         Returns:
             Union[SamEmbeddingResponse, SamSegmentationResponse]: The inference response.
         """
-        record_fixed_model_input_for_request(self, request)
         t1 = perf_counter()
         if isinstance(request, Sam2EmbeddingRequest):
             _, _, image_id = self.embed_image(**request.dict())

--- a/inference/models/sam2/segment_anything2_inference_models.py
+++ b/inference/models/sam2/segment_anything2_inference_models.py
@@ -54,9 +54,6 @@ from inference.core.env import (
 from inference.core.models.base import Model
 from inference.core.utils.image_utils import load_image_bgr
 from inference.usage_tracking.collector import usage_collector
-from inference.usage_tracking.decorator_helpers import (
-    record_fixed_model_input_for_request,
-)
 from inference_models.errors import ModelInputError
 
 if DEVICE is None:
@@ -152,7 +149,6 @@ class InferenceModelsSAM2Adapter(Model):
         Returns:
             Union[SamEmbeddingResponse, SamSegmentationResponse]: The inference response.
         """
-        record_fixed_model_input_for_request(self, request)
         t1 = perf_counter()
         if isinstance(request, Sam2EmbeddingRequest):
             _, _, image_id = self.embed_image(**request.dict())

--- a/inference/models/sam3/segment_anything3.py
+++ b/inference/models/sam3/segment_anything3.py
@@ -67,9 +67,6 @@ from inference.core.roboflow_api import (
 from inference.core.utils.image_utils import load_image_rgb
 from inference.core.utils.postprocess import masks2multipoly
 from inference.usage_tracking.collector import usage_collector
-from inference.usage_tracking.decorator_helpers import (
-    record_fixed_model_input_for_request,
-)
 
 
 def _to_numpy_masks(masks_any) -> np.ndarray:
@@ -513,7 +510,6 @@ class SegmentAnything3(RoboflowCoreModel):
     @usage_collector("model")
     def infer_from_request(self, request: Sam3InferenceRequest):
         # with self.sam3_lock:
-        record_fixed_model_input_for_request(self, request)
         t1 = perf_counter()
         if isinstance(request, Sam3SegmentationRequest):
             # Pass strongly-typed fields to preserve Sam3Prompt objects

--- a/inference/models/sam3/segment_anything3_inference_models.py
+++ b/inference/models/sam3/segment_anything3_inference_models.py
@@ -31,9 +31,6 @@ from inference.core.roboflow_api import get_extra_weights_provider_headers
 from inference.core.utils.image_utils import load_image_rgb
 from inference.core.utils.postprocess import masks2multipoly
 from inference.usage_tracking.collector import usage_collector
-from inference.usage_tracking.decorator_helpers import (
-    record_fixed_model_input_for_request,
-)
 from inference_models import AutoModel
 from inference_models.models.sam3.sam3_torch import SAM3Torch
 
@@ -87,7 +84,6 @@ class InferenceModelsSAM3Adapter(Model):
 
     @usage_collector("model")
     def infer_from_request(self, request: Sam3InferenceRequest):
-        record_fixed_model_input_for_request(self, request)
         t1 = perf_counter()
         if isinstance(request, Sam3SegmentationRequest):
             return self.segment_image(

--- a/inference/models/sam3/visual_segmentation.py
+++ b/inference/models/sam3/visual_segmentation.py
@@ -54,9 +54,6 @@ from inference.core.utils.image_utils import load_image_rgb
 from inference.core.utils.postprocess import masks2multipoly
 from inference.core.utils.torchscript_guard import _temporarily_disable_torch_jit_script
 from inference.usage_tracking.collector import usage_collector
-from inference.usage_tracking.decorator_helpers import (
-    record_fixed_model_input_for_request,
-)
 
 # from sam3.model.sam1_task_predictor import SAM3InteractiveImagePredictor
 # from sam3.sam3_video_model_builder import build_sam3_tracking_predictor
@@ -206,7 +203,6 @@ class Sam3ForInteractiveImageSegmentation(RoboflowCoreModel):
         Returns:
             Union[SamEmbeddingResponse, SamSegmentationResponse]: The inference response.
         """
-        record_fixed_model_input_for_request(self, request)
         t1 = perf_counter()
         if isinstance(request, Sam2EmbeddingRequest):
             _, _, image_id = self.embed_image(**request.dict())

--- a/inference/models/sam3/visual_segmentation_inference_models.py
+++ b/inference/models/sam3/visual_segmentation_inference_models.py
@@ -39,9 +39,6 @@ from inference.core.roboflow_api import get_extra_weights_provider_headers
 from inference.core.utils.image_utils import load_image_rgb
 from inference.core.utils.postprocess import masks2multipoly
 from inference.usage_tracking.collector import usage_collector
-from inference.usage_tracking.decorator_helpers import (
-    record_fixed_model_input_for_request,
-)
 from inference_models import AutoModel
 from inference_models.errors import ModelInputError
 from inference_models.models.sam3.cache import (
@@ -124,7 +121,6 @@ class InferenceModelsSAM3InteractiveAdapter(Model):
 
     @usage_collector("model")
     def infer_from_request(self, request: Sam2InferenceRequest):
-        record_fixed_model_input_for_request(self, request)
         t1 = perf_counter()
         if isinstance(request, Sam2EmbeddingRequest):
             _, _, image_id = self.embed_image(**request.dict())

--- a/inference/usage_tracking/decorator_helpers.py
+++ b/inference/usage_tracking/decorator_helpers.py
@@ -7,11 +7,8 @@ from inference.core.workflows.execution_engine.v1.compiler.entities import (
 )
 from inference.usage_tracking.megapixel_buckets import (
     build_megapixel_buckets,
-    clear_measured_model_input,
-    consume_measured_model_input,
+    consume_measured_image_input,
     count_inference_images,
-    record_measured_model_hw,
-    resolve_model_input_hw,
 )
 from inference.usage_tracking.model_types import get_recorded_model_type
 from inference.usage_tracking.predict_timing import consume_measured_predict_duration
@@ -127,8 +124,7 @@ def get_model_image_from_kwargs(func_kwargs: Dict[str, Any]) -> Any:
 def get_model_frames_and_input_hw(
     func_kwargs: Dict[str, Any],
 ) -> Tuple[int, Optional[Tuple[int, int]]]:
-    """Frames recorded for one model call, and the input resolution to attribute
-    them to.
+    """Frames recorded for one model call, and the image size to attribute them to.
 
     The frame count comes from the request rather than from the preprocessed
     tensor: preprocessing pads the batch dimension up to a fixed model batch size
@@ -136,8 +132,7 @@ def get_model_frames_and_input_hw(
     caller asked for. The tensor batch size is only a fallback for calls whose
     images are not introspectable.
     """
-    model = func_kwargs.get("self")
-    measured_hw, measured_frames = consume_measured_model_input()
+    measured_hw, measured_frames = consume_measured_image_input()
 
     frames = count_inference_images(get_model_image_from_kwargs(func_kwargs))
     if frames <= 0 and measured_frames:
@@ -145,7 +140,7 @@ def get_model_frames_and_input_hw(
     if frames <= 0:
         frames = 1
 
-    return frames, resolve_model_input_hw(model, measured_hw=measured_hw)
+    return frames, measured_hw
 
 
 def get_model_megapixel_buckets(
@@ -155,7 +150,7 @@ def get_model_megapixel_buckets(
     execution_duration: float,
     inference_test_run: bool = False,
 ) -> Dict[str, Dict[str, Any]]:
-    """Attribute one model call's frames and duration to its input-size bucket.
+    """Attribute one model call's frames and duration to its image-size bucket.
 
     Bucket duration is the predict phase alone when the entrypoint published
     one, so that it can be compared across models without pre- and
@@ -167,7 +162,7 @@ def get_model_megapixel_buckets(
 
     Args:
         frames: Images the caller asked this call to process.
-        input_hw: Model input resolution as (height, width), None when unknown.
+        input_hw: Native image size as (height, width), None when unknown.
         execution_duration: Full call duration, used when no predict phase was
             timed.
         inference_test_run: True for test traffic, which is not bucketed.
@@ -191,25 +186,6 @@ def get_model_megapixel_buckets(
     )
 
     return megapixel_buckets
-
-
-def record_fixed_model_input_for_request(model: Any, request: Any = None) -> None:
-    """Publish a model's fixed input size for usage telemetry on a request call.
-
-    Use this for entrypoints that decorate ``infer_from_request`` (rather than
-    ``BaseInference.infer``), so they never hit the preprocess hook that normally
-    records measured tensor size. The model's configured/fixed size is preferred
-    over native upload resolution.
-    """
-    clear_measured_model_input()
-    input_hw = resolve_model_input_hw(model)
-    if input_hw is None:
-        return
-    record_measured_model_hw(
-        height=input_hw[0],
-        width=input_hw[1],
-        frames=count_inference_images(getattr(request, "image", None)),
-    )
 
 
 def get_source_info_from_kwargs(func_kwargs: Dict[str, Any]) -> Optional[str]:

--- a/inference/usage_tracking/megapixel_buckets.py
+++ b/inference/usage_tracking/megapixel_buckets.py
@@ -1,12 +1,20 @@
 """Megapixel bucketing for model usage telemetry.
 
-Buckets prefer a configured fixed input (including HuggingFace processor /
-vision-config size), then the observed preprocess tensor (including
-``pixel_values``), then native ``image_dims``. That last fallback is a cost
-proxy for models whose tensor is not spatial (Qwen-style patch tokens):
-larger uploads produce more patches and take longer. ``unknown`` is only used
-when none of those sources are available. Bucket maps are merge-friendly
-sums; averages are derived downstream.
+Buckets are keyed on the size of the image the caller sent, measured before any
+resize, so a bucket describes the work a request asked for rather than the
+shape the model happens to run at. Model input size is deliberately not used
+here. ``unknown`` covers calls whose native size is not recoverable, which
+keeps the sum of bucket frames equal to the row's processed frames. Bucket maps
+are merge-friendly sums; averages are derived downstream.
+
+Preprocess records that size under one of four conventions, all read here:
+``img_dims``, a per-image sequence of (height, width), from core Roboflow
+models; ``image_dims``, a single (width, height) pair, from the VLM and depth
+families; a per-image sequence of records carrying ``original_size``, from the
+``inference_models`` detection, segmentation and keypoint adapters; and a bare
+per-image sequence of (height, width), from the ``inference_models``
+classification adapter. A batch is attributed to its first image, since a call
+reports one bucket.
 
 Bucket ``execution_duration`` is the model's predict phase alone, excluding
 pre- and post-processing, for entrypoints that separate the phases. Everything
@@ -17,7 +25,7 @@ override ``infer()`` wholesale, the SAM ``infer_from_request`` entrypoints, and
 any call whose ``predict()`` defers its work. Timing of that phase lives in
 :mod:`inference.usage_tracking.predict_timing`.
 
-The measured input size is published through :class:`~contextvars.ContextVar`
+The measured image size is published through :class:`~contextvars.ContextVar`
 rather than an attribute on the model. Model instances are shared across the
 server's worker threads, so an attribute would let one request overwrite the
 measurement of another request that is still running.
@@ -25,7 +33,6 @@ measurement of another request that is still running.
 
 from __future__ import annotations
 
-import json
 from contextvars import ContextVar
 from typing import Any, Dict, Optional, Tuple, Union
 
@@ -47,10 +54,10 @@ _MEGAPIXEL_BUCKET_OVERFLOW = "8+"
 # can always reconcile the two.
 MEGAPIXEL_BUCKET_UNKNOWN = "unknown"
 
-MeasuredModelInput = Tuple[Optional[Tuple[int, int]], Optional[int]]
+MeasuredImageInput = Tuple[Optional[Tuple[int, int]], Optional[int]]
 
-_measured_model_input: ContextVar[Optional[MeasuredModelInput]] = ContextVar(
-    "usage_measured_model_input",
+_measured_image_input: ContextVar[Optional[MeasuredImageInput]] = ContextVar(
+    "usage_measured_image_input",
     default=None,
 )
 
@@ -101,139 +108,6 @@ def _as_positive_int(value: Any) -> Optional[int]:
     return parsed
 
 
-def _image_size_to_hw(value: Any) -> Optional[Tuple[int, int]]:
-    """Normalize an ``image_size``-style attribute to (height, width).
-
-    Backends express it either as a single edge length for square inputs or as
-    an explicit (height, width) pair.
-    """
-    if isinstance(value, (tuple, list)):
-        if len(value) != 2:
-            return None
-        height = _as_positive_int(value[0])
-        width = _as_positive_int(value[1])
-        if height is None or width is None:
-            return None
-        return height, width
-    size = _as_positive_int(value)
-    if size is None:
-        return None
-    return size, size
-
-
-def get_fixed_model_input_hw(model: Any) -> Optional[Tuple[int, int]]:
-    """Return (height, width) when the model has a fixed numeric input size."""
-    height = _as_positive_int(getattr(model, "img_size_h", None))
-    width = _as_positive_int(getattr(model, "img_size_w", None))
-    if height is not None and width is not None:
-        return height, width
-
-    for attr in ("image_size", "img_size"):
-        size = _image_size_to_hw(getattr(model, attr, None))
-        if size is not None:
-            return size
-
-    # Adapters wrap backends that expose image_size / _image_size.
-    for attr in ("_model", "sam", "sam_model", "owlv2"):
-        inner = getattr(model, attr, None)
-        if inner is None:
-            continue
-        for size_attr in ("image_size", "_image_size", "img_size"):
-            size = _image_size_to_hw(getattr(inner, size_attr, None))
-            if size is not None:
-                return size
-        nested = getattr(inner, "_model", None)
-        if nested is not None:
-            for size_attr in ("image_size", "_image_size", "img_size"):
-                size = _image_size_to_hw(getattr(nested, size_attr, None))
-                if size is not None:
-                    return size
-
-    environment = getattr(model, "environment", None)
-    if isinstance(environment, dict):
-        resolution = environment.get("RESOLUTION")
-        if isinstance(resolution, (list, tuple)) and resolution:
-            resolution = resolution[0]
-        resolution = _as_positive_int(resolution)
-        if resolution is not None:
-            return resolution, resolution
-
-        preproc = environment.get("PREPROCESSING")
-        if isinstance(preproc, str):
-            try:
-                preproc = json.loads(preproc)
-            except ValueError:
-                preproc = None
-        if isinstance(preproc, dict):
-            resize = preproc.get("resize") or {}
-            if isinstance(resize, dict):
-                height = _as_positive_int(resize.get("height"))
-                width = _as_positive_int(resize.get("width"))
-                if height is not None and width is not None:
-                    return height, width
-
-    preproc = getattr(model, "preproc", None)
-    if isinstance(preproc, dict):
-        resize = preproc.get("resize") or {}
-        if isinstance(resize, dict):
-            height = _as_positive_int(resize.get("height"))
-            width = _as_positive_int(resize.get("width"))
-            if height is not None and width is not None:
-                return height, width
-
-    return _get_hf_fixed_input_hw(model)
-
-
-def _hf_size_to_hw(value: Any) -> Optional[Tuple[int, int]]:
-    """Normalize a HuggingFace ``image_processor.size`` value to (height, width)."""
-    if value is None or isinstance(value, bool):
-        return None
-    if isinstance(value, dict):
-        height = _as_positive_int(value.get("height"))
-        width = _as_positive_int(value.get("width"))
-        if height is not None and width is not None:
-            return height, width
-        edge = _as_positive_int(value.get("shortest_edge"))
-        if edge is not None:
-            return edge, edge
-        return None
-    height = _as_positive_int(getattr(value, "height", None))
-    width = _as_positive_int(getattr(value, "width", None))
-    if height is not None and width is not None:
-        return height, width
-    return _image_size_to_hw(value)
-
-
-def _get_hf_fixed_input_hw(model: Any) -> Optional[Tuple[int, int]]:
-    """Read a fixed canvas from an HF processor or ``vision_config.image_size``."""
-    processor = getattr(model, "processor", None)
-    image_processor = getattr(processor, "image_processor", None)
-    size = _hf_size_to_hw(getattr(image_processor, "size", None))
-    if size is not None:
-        return size
-
-    for candidate in (getattr(model, "model", None), model):
-        if candidate is None:
-            continue
-        config = getattr(candidate, "config", None)
-        if config is None:
-            continue
-        if isinstance(config, dict):
-            vision_config = config.get("vision_config")
-        else:
-            vision_config = getattr(config, "vision_config", None)
-        if vision_config is None:
-            continue
-        if isinstance(vision_config, dict):
-            image_size = vision_config.get("image_size")
-        else:
-            image_size = getattr(vision_config, "image_size", None)
-        size = _image_size_to_hw(image_size)
-        if size is not None:
-            return size
-    return None
-
-
 def _get_pixel_values(value: Any) -> Any:
     if value is None:
         return None
@@ -251,58 +125,6 @@ def _get_pixel_values(value: Any) -> Any:
     return None
 
 
-def get_tensor_spatial_hw(
-    tensor: Any,
-    *,
-    require_channel_axis: bool = False,
-) -> Optional[Tuple[int, int]]:
-    """Best-effort spatial (height, width) from a preprocessed model tensor.
-
-    HuggingFace VLM preprocess returns a mapping with ``pixel_values`` instead of
-    a raw image tensor. Those values are unwrapped here. Patch-style tensors
-    without a channel axis are not treated as spatial.
-    """
-    pixel_values = _get_pixel_values(tensor)
-    if pixel_values is not None and pixel_values is not tensor:
-        return get_tensor_spatial_hw(
-            pixel_values,
-            require_channel_axis=True,
-        )
-
-    shape = getattr(tensor, "shape", None)
-    if shape is None:
-        return None
-    try:
-        dims = tuple(int(dim) for dim in shape)
-    except (TypeError, ValueError):
-        return None
-    if len(dims) < 2:
-        return None
-
-    # NCHW / CHW
-    if len(dims) >= 3 and dims[-3] in (1, 3, 4):
-        height = dims[-2]
-        width = dims[-1]
-        if height > 0 and width > 0:
-            return height, width
-
-    # NHWC / HWC
-    if dims[-1] in (1, 3, 4):
-        height = dims[-3] if len(dims) >= 3 else dims[-2]
-        width = dims[-2] if len(dims) >= 3 else dims[-1]
-        if height > 0 and width > 0:
-            return height, width
-
-    if require_channel_axis:
-        return None
-
-    height = dims[-2]
-    width = dims[-1]
-    if height > 0 and width > 0:
-        return height, width
-    return None
-
-
 def get_tensor_batch_size(tensor: Any) -> Optional[int]:
     pixel_values = _get_pixel_values(tensor)
     if pixel_values is not None and pixel_values is not tensor:
@@ -317,33 +139,101 @@ def get_tensor_batch_size(tensor: Any) -> Optional[int]:
         return None
 
 
-def parse_image_dims_hw(metadata: Any) -> Optional[Tuple[int, int]]:
-    """Parse preprocess ``image_dims`` (width, height) into (height, width)."""
+def _read_metadata_key(metadata: Any, key: str) -> Any:
+    """Read a key from preprocess metadata, dict-like or attribute-style."""
+    if isinstance(metadata, dict):
+        return metadata.get(key)
+    getter = getattr(metadata, "get", None)
+    if callable(getter):
+        try:
+            value = getter(key)
+        except (TypeError, ValueError, KeyError):
+            value = None
+        if value is not None:
+            return value
+    return getattr(metadata, key, None)
+
+
+def _hw_pair(height: Any, width: Any) -> Optional[Tuple[int, int]]:
+    height = _as_positive_int(height)
+    width = _as_positive_int(width)
+    if height is None or width is None:
+        return None
+    return height, width
+
+
+def _first_dims_pair(dims: Any) -> Optional[Tuple[Any, Any]]:
+    """The leading two-element pair, unwrapping a per-image sequence.
+
+    Dims arrive as one pair per image even for a single image, so the first
+    element is unwrapped when it is itself a pair. A bare pair is taken as-is.
+    """
+    if not isinstance(dims, (tuple, list)) or not dims:
+        return None
+    if isinstance(dims[0], (tuple, list)):
+        dims = dims[0]
+    if not isinstance(dims, (tuple, list)) or len(dims) != 2:
+        return None
+    return dims[0], dims[1]
+
+
+def _hw_from_original_size(metadata: Any) -> Optional[Tuple[int, int]]:
+    """(height, width) from an ``inference_models`` per-image metadata record."""
+    record = metadata
+    if not hasattr(record, "original_size"):
+        try:
+            record = metadata[0]
+        except (TypeError, KeyError, IndexError):
+            return None
+    original_size = getattr(record, "original_size", None)
+    if original_size is None:
+        return None
+    return _hw_pair(
+        getattr(original_size, "height", None),
+        getattr(original_size, "width", None),
+    )
+
+
+def parse_image_input_hw(metadata: Any) -> Optional[Tuple[int, int]]:
+    """Native (height, width) of the image a preprocess call was handed.
+
+    Reads whichever of the four conventions the model family uses, in
+    descending order of how explicit they are. A batch is attributed to its
+    first image.
+
+    Args:
+        metadata: The metadata returned alongside the preprocessed tensor.
+
+    Returns:
+        (height, width) before any resize, or None when no convention yielded a
+        usable pair.
+    """
     if metadata is None:
         return None
 
-    dims = None
-    if isinstance(metadata, dict):
-        dims = metadata.get("image_dims")
-    else:
-        getter = getattr(metadata, "get", None)
-        if callable(getter):
-            try:
-                dims = getter("image_dims")
-            except (TypeError, ValueError, KeyError):
-                dims = None
-        if dims is None:
-            dims = getattr(metadata, "image_dims", None)
+    pair = _first_dims_pair(_read_metadata_key(metadata, "img_dims"))
+    if pair is not None:
+        image_hw = _hw_pair(pair[0], pair[1])
+        if image_hw is not None:
+            return image_hw
 
-    if not isinstance(dims, (tuple, list)) or len(dims) != 2:
-        return None
+    pair = _first_dims_pair(_read_metadata_key(metadata, "image_dims"))
+    if pair is not None:
+        image_hw = _hw_pair(pair[1], pair[0])
+        if image_hw is not None:
+            return image_hw
 
-    width = _as_positive_int(dims[0])
-    height = _as_positive_int(dims[1])
-    if width is None or height is None:
-        return None
+    image_hw = _hw_from_original_size(metadata)
+    if image_hw is not None:
+        return image_hw
 
-    return height, width
+    # A bare per-image sequence of (height, width), with no key to name it.
+    if not isinstance(metadata, dict):
+        pair = _first_dims_pair(metadata)
+        if pair is not None:
+            return _hw_pair(pair[0], pair[1])
+
+    return None
 
 
 def count_inference_images(image: Any) -> int:
@@ -359,94 +249,50 @@ def count_inference_images(image: Any) -> int:
     return 1
 
 
-def clear_measured_model_input() -> None:
+def clear_measured_image_input() -> None:
     """Reset every per-call measurement published for the usage decorator.
 
     Called at the start of a model call so that a measurement published by an
     earlier call cannot be attributed to this one.
     """
-    _measured_model_input.set(None)
+    _measured_image_input.set(None)
     clear_measured_predict_duration()
 
 
-def record_measured_model_input(
-    preprocessed_tensor: Any,
+def record_measured_image_input(
+    image_hw: Optional[Tuple[int, int]],
     *,
-    fallback_hw: Optional[Tuple[int, int]] = None,
+    frames: Optional[int] = None,
 ) -> None:
-    """Publish post-preprocess spatial metadata for the usage decorator to read.
+    """Publish the caller's image size for the usage decorator to read.
 
-    ``fallback_hw`` is native ``image_dims``. It is used when the preprocess
-    object has no readable spatial tensor, including HF ``pixel_values`` that
-    are flattened patches rather than NCHW.
+    Args:
+        image_hw: Native (height, width), or None when preprocess recorded
+            neither dims convention.
+        frames: Batch size of the preprocessed tensor, used only as a frame
+            count fallback for calls whose images are not introspectable.
     """
     try:
-        measured_hw = get_tensor_spatial_hw(preprocessed_tensor)
-        if measured_hw is None and fallback_hw is not None:
-            height = _as_positive_int(fallback_hw[0])
-            width = _as_positive_int(fallback_hw[1])
+        measured_hw = None
+        if image_hw is not None:
+            height = _as_positive_int(image_hw[0])
+            width = _as_positive_int(image_hw[1])
             if height is not None and width is not None:
                 measured_hw = (height, width)
 
-        _measured_model_input.set(
-            (
-                measured_hw,
-                get_tensor_batch_size(preprocessed_tensor),
-            )
-        )
+        _measured_image_input.set((measured_hw, frames))
     except Exception:
         pass
 
 
-def record_measured_model_hw(
-    *,
-    height: int,
-    width: int,
-    frames: Optional[int] = None,
-) -> None:
-    """Publish an explicit input size (used by SAM request entrypoints)."""
-    try:
-        _measured_model_input.set(
-            (
-                (int(height), int(width)),
-                max(int(frames), 1) if frames else None,
-            )
-        )
-    except Exception:
-        pass
-
-
-def consume_measured_model_input() -> MeasuredModelInput:
-    """Read and clear the input size published by the current call.
+def consume_measured_image_input() -> MeasuredImageInput:
+    """Read and clear the image size published by the current call.
 
     Clearing on read keeps a stale value from leaking into a later call that did
     not publish one, which would otherwise attribute it to the wrong resolution.
     """
-    measured = _measured_model_input.get()
+    measured = _measured_image_input.get()
     if measured is None:
         return None, None
-    _measured_model_input.set(None)
+    _measured_image_input.set(None)
     return measured
-
-
-def resolve_model_input_hw(
-    model: Any,
-    measured_hw: Optional[Tuple[int, int]] = None,
-) -> Optional[Tuple[int, int]]:
-    """Fixed model input size when there is one, otherwise the observed size.
-
-    Observed size is the preprocessed tensor (including HF ``pixel_values``),
-    or native ``image_dims`` when that tensor is missing or not spatial.
-    """
-    if model is not None:
-        fixed_hw = get_fixed_model_input_hw(model)
-        if fixed_hw is not None:
-            return fixed_hw
-    if (
-        isinstance(measured_hw, tuple)
-        and len(measured_hw) == 2
-        and _as_positive_int(measured_hw[0]) is not None
-        and _as_positive_int(measured_hw[1]) is not None
-    ):
-        return int(measured_hw[0]), int(measured_hw[1])
-    return None

--- a/tests/inference/unit_tests/usage_tracking/test_collector.py
+++ b/tests/inference/unit_tests/usage_tracking/test_collector.py
@@ -17,8 +17,8 @@ from inference.core.version import __version__ as inference_version
 from inference.core.workflows.errors import ClientCausedStepExecutionError
 from inference.usage_tracking import payload_helpers
 from inference.usage_tracking.megapixel_buckets import (
-    clear_measured_model_input,
-    record_measured_model_input,
+    clear_measured_image_input,
+    record_measured_image_input,
 )
 from inference.usage_tracking.payload_helpers import (
     get_api_key_usage_containing_resource,
@@ -2118,30 +2118,34 @@ def test_record_usage_accumulates_megapixel_buckets(
     assert details["model_type"] == "rfdetr-seg-nano"
 
 
-def test_model_decorator_records_fixed_input_megapixel_buckets(
+def test_model_decorator_records_measured_image_megapixel_buckets(
     usage_collector_with_mocked_threads,
 ):
     usage_collector = usage_collector_with_mocked_threads
 
-    class FixedInputModel:
+    class UploadSizeModel:
         api_key = "test_key"
         dataset_id = "st-inst-seg"
         version_id = "9"
         task_type = "instance-segmentation"
         model_type = "rfdetr-seg-nano"
+        # A fixed model input size must not decide the bucket.
         img_size_h = 640
         img_size_w = 640
 
         @usage_collector(category="model")
         def infer(self, image, **kwargs):
+            clear_measured_image_input()
+            record_measured_image_input((1080, 1920))
             return {"ok": True}
 
-    FixedInputModel().infer([object(), object()])
+    UploadSizeModel().infer([object(), object()])
 
     key = usage_key("model", "st-inst-seg/9")
     row = usage_collector._usage["test_key"][key]
     assert row["processed_frames"] == 2
-    assert row["megapixel_buckets"]["0.25-0.5"]["processed_frames"] == 2
+    # 1080x1920 uploads bucket at ~2.07 MP, not at the model's 640x640 canvas.
+    assert row["megapixel_buckets"]["2-4"]["processed_frames"] == 2
     details = json.loads(row["resource_details"])
     assert details["model_type"] == "rfdetr-seg-nano"
     assert details["task_type"] == "instance-segmentation"
@@ -2165,8 +2169,8 @@ def test_model_decorator_does_not_count_batch_padding(
         def infer(self, image, **kwargs):
             # Preprocessing pads the batch up to MAX_BATCH_SIZE when
             # FIX_BATCH_SIZE is set; the padding is not part of the request.
-            clear_measured_model_input()
-            record_measured_model_input(np.zeros((8, 3, 640, 640), dtype=np.uint8))
+            clear_measured_image_input()
+            record_measured_image_input((640, 640), frames=8)
             return {"ok": True}
 
     PaddedBatchModel().infer([object()])
@@ -2221,11 +2225,9 @@ def test_model_decorator_isolates_measured_input_across_threads(
 
         @usage_collector(category="model")
         def infer(self, image, tag=None, **kwargs):
-            clear_measured_model_input()
+            clear_measured_image_input()
             size = 640 if tag == "first" else 1600
-            record_measured_model_input(
-                np.zeros((len(image), 3, size, size), dtype=np.uint8)
-            )
+            record_measured_image_input((size, size), frames=len(image))
             if tag == "first":
                 # Hand over to the concurrent call, which shares this instance.
                 first_published.set()
@@ -2261,12 +2263,11 @@ def test_model_decorator_buckets_predict_duration_not_row_duration(
         version_id = "1"
         task_type = "object-detection"
         model_type = "yolov8n"
-        img_size_h = 640
-        img_size_w = 640
 
         @usage_collector(category="model")
         def infer(self, image, **kwargs):
-            clear_measured_model_input()
+            clear_measured_image_input()
+            record_measured_image_input((640, 640))
             record_measured_predict_duration(0.01)
             time.sleep(0.05)
             return {"ok": True}
@@ -2292,18 +2293,17 @@ def test_model_decorator_buckets_full_duration_without_predict_phase(
         version_id = "1"
         task_type = "instance-segmentation"
         model_type = "sam2"
-        img_size_h = 640
-        img_size_w = 640
 
         @usage_collector(category="model")
         def infer_from_request(self, request, **kwargs):
-            clear_measured_model_input()
+            clear_measured_image_input()
             time.sleep(0.05)
             return {"ok": True}
 
     NoPredictPhaseModel().infer_from_request(SimpleNamespace(image=[object()]))
 
     row = usage_collector._usage["test_key"][usage_key("model", "no-predict/1")]
-    bucket_duration = row["megapixel_buckets"]["0.25-0.5"]["execution_duration"]
+    # SAM entrypoints never reach preprocess, so they report no image size.
+    bucket_duration = row["megapixel_buckets"]["unknown"]["execution_duration"]
     assert bucket_duration == pytest.approx(row["execution_duration"])
     assert bucket_duration >= 0.05

--- a/tests/inference/unit_tests/usage_tracking/test_decorator_helpers.py
+++ b/tests/inference/unit_tests/usage_tracking/test_decorator_helpers.py
@@ -9,6 +9,7 @@ from inference.usage_tracking.decorator_helpers import (
     get_model_type_from_kwargs,
     get_request_resource_details_from_kwargs,
 )
+from inference.usage_tracking.megapixel_buckets import record_measured_image_input
 from inference.usage_tracking.model_types import (
     bind_usage_model_identity,
     clear_recorded_model_types,
@@ -152,11 +153,11 @@ def test_extract_usage_params_for_model_includes_megapixel_buckets(
         version_id = "9"
         task_type = "instance-segmentation"
         model_type = "rfdetr-seg-nano"
-        img_size_h = 640
-        img_size_w = 640
 
         def infer(self, image, **kwargs): ...
 
+    # Published by preprocess in a real call; the buckets read what it recorded.
+    record_measured_image_input((640, 640))
     usage_params = (
         usage_collector_with_mocked_threads._extract_usage_params_from_func_kwargs(
             usage_fps=0,
@@ -185,7 +186,7 @@ def test_extract_usage_params_for_model_includes_megapixel_buckets(
     }
 
 
-def test_extract_usage_params_for_sam_uses_encoder_image_size(
+def test_extract_usage_params_for_sam_reports_unknown_image_size(
     usage_collector_with_mocked_threads,
 ):
     class SamLikeModel:
@@ -194,6 +195,7 @@ def test_extract_usage_params_for_sam_uses_encoder_image_size(
         version_id = "hiera_tiny"
         task_type = "unsupervised-segmentation"
         model_type = "sam2"
+        # The encoder canvas is a model input size, so it no longer buckets.
         image_size = 1024
 
         def infer_from_request(self, request): ...
@@ -221,9 +223,9 @@ def test_extract_usage_params_for_sam_uses_encoder_image_size(
     assert usage_params["resource_id"] == "sam2/hiera_tiny"
     assert usage_params["frames"] == 1
     assert usage_params["resource_details"]["model_type"] == "sam2"
-    # 1024x1024 = ~1.05 MP -> 1-2 bucket
+    # infer_from_request never reaches preprocess, so no image size is recorded.
     assert usage_params["megapixel_buckets"] == {
-        "1-2": {
+        "unknown": {
             "processed_frames": 1,
             "execution_duration": 0.5,
         }

--- a/tests/inference/unit_tests/usage_tracking/test_megapixel_buckets.py
+++ b/tests/inference/unit_tests/usage_tracking/test_megapixel_buckets.py
@@ -3,22 +3,16 @@ from types import SimpleNamespace
 import numpy as np
 import pytest
 
-from inference.usage_tracking.decorator_helpers import (
-    get_model_megapixel_buckets,
-    record_fixed_model_input_for_request,
-)
+from inference.usage_tracking.decorator_helpers import get_model_megapixel_buckets
 from inference.usage_tracking.megapixel_buckets import (
     MEGAPIXEL_BUCKET_UNKNOWN,
     build_megapixel_buckets,
-    clear_measured_model_input,
-    consume_measured_model_input,
+    clear_measured_image_input,
+    consume_measured_image_input,
     count_inference_images,
-    get_fixed_model_input_hw,
-    get_tensor_spatial_hw,
     megapixel_bucket_for_hw,
-    parse_image_dims_hw,
-    record_measured_model_input,
-    resolve_model_input_hw,
+    parse_image_input_hw,
+    record_measured_image_input,
 )
 from inference.usage_tracking.payload_helpers import (
     merge_megapixel_buckets,
@@ -32,9 +26,9 @@ from inference.usage_tracking.predict_timing import (
 
 @pytest.fixture(autouse=True)
 def _clear_measured_input():
-    clear_measured_model_input()
+    clear_measured_image_input()
     yield
-    clear_measured_model_input()
+    clear_measured_image_input()
 
 
 def test_megapixel_bucket_boundaries():
@@ -131,96 +125,71 @@ def test_merge_usage_dicts_sums_megapixel_buckets():
     assert merged["megapixel_buckets"]["1-2"]["processed_frames"] == 1
 
 
-def test_get_fixed_model_input_hw_prefers_img_size_attrs():
-    model = SimpleNamespace(img_size_h=640, img_size_w=640)
-
-    assert get_fixed_model_input_hw(model) == (640, 640)
-
-
-def test_get_fixed_model_input_hw_ignores_dynamic_onnx_strings():
-    model = SimpleNamespace(img_size_h="height", img_size_w="width", preproc={})
-
-    assert get_fixed_model_input_hw(model) is None
+def test_parse_image_input_hw_reads_core_img_dims():
+    # Core Roboflow preprocess records one (height, width) pair per image.
+    assert parse_image_input_hw({"img_dims": [(1080, 1920)]}) == (1080, 1920)
+    assert parse_image_input_hw({"img_dims": ((1080, 1920),)}) == (1080, 1920)
 
 
-def test_get_tensor_spatial_hw_nchw_and_nhwc():
-    assert get_tensor_spatial_hw(np.zeros((2, 3, 640, 480))) == (640, 480)
-    assert get_tensor_spatial_hw(np.zeros((2, 640, 480, 3))) == (640, 480)
+def test_parse_image_input_hw_attributes_a_batch_to_its_first_image():
+    metadata = {"img_dims": [(1080, 1920), (480, 640)]}
+
+    assert parse_image_input_hw(metadata) == (1080, 1920)
 
 
-def test_get_tensor_spatial_hw_reads_hf_pixel_values():
-    pixel_values = np.zeros((1, 3, 224, 224), dtype=np.float32)
+def test_parse_image_input_hw_accepts_an_unwrapped_pair():
+    assert parse_image_input_hw({"img_dims": (1080, 1920)}) == (1080, 1920)
 
-    assert get_tensor_spatial_hw({"pixel_values": pixel_values}) == (224, 224)
-    assert get_tensor_spatial_hw(SimpleNamespace(pixel_values=pixel_values)) == (
-        224,
-        224,
+
+def test_parse_image_input_hw_reads_vlm_image_dims_as_width_height():
+    # The VLM and depth families record a single (width, height) pair.
+    assert parse_image_input_hw({"image_dims": (1920, 1080)}) == (1080, 1920)
+
+
+def test_parse_image_input_hw_reads_inference_models_original_size():
+    # The inference_models detection / segmentation / keypoint adapters return a
+    # per-image metadata record rather than a dims key.
+    metadata = [
+        SimpleNamespace(original_size=SimpleNamespace(height=1080, width=1920)),
+        SimpleNamespace(original_size=SimpleNamespace(height=480, width=640)),
+    ]
+
+    assert parse_image_input_hw(metadata) == (1080, 1920)
+
+
+def test_parse_image_input_hw_reads_bare_per_image_shapes():
+    # The inference_models classification adapter returns np_image.shape[:2].
+    assert parse_image_input_hw([(1080, 1920), (480, 640)]) == (1080, 1920)
+
+
+def test_parse_image_input_hw_rejects_missing_and_malformed_dims():
+    assert parse_image_input_hw(None) is None
+    assert parse_image_input_hw({}) is None
+    assert parse_image_input_hw({"img_dims": []}) is None
+    assert parse_image_input_hw({"img_dims": [(0, 1920)]}) is None
+    assert parse_image_input_hw({"image_dims": (0, 1080)}) is None
+    assert parse_image_input_hw({"img_dims": [(1080, 1920, 3)]}) is None
+
+
+def test_parse_image_input_hw_reads_attribute_style_metadata():
+    assert parse_image_input_hw(SimpleNamespace(img_dims=[(1080, 1920)])) == (
+        1080,
+        1920,
     )
 
 
-def test_get_tensor_spatial_hw_ignores_non_spatial_pixel_values():
-    # Qwen-style patch tokens: no channel axis, must not be treated as H×W.
-    assert (
-        get_tensor_spatial_hw({"pixel_values": np.zeros((256, 1176), dtype=np.float32)})
-        is None
-    )
+def test_consume_measured_image_input_clears_value():
+    record_measured_image_input((512, 768), frames=2)
 
-
-def test_parse_image_dims_hw_converts_width_height():
-    assert parse_image_dims_hw({"image_dims": (1920, 1080)}) == (1080, 1920)
-    assert parse_image_dims_hw(None) is None
-    assert parse_image_dims_hw({"image_dims": (0, 1080)}) is None
-
-
-def test_input_hw_prefers_fixed_size_over_measured():
-    model = SimpleNamespace(img_size_h=420, img_size_w=420)
-    record_measured_model_input(np.zeros((1, 3, 800, 800)))
-    measured_hw, _ = consume_measured_model_input()
-
-    assert resolve_model_input_hw(model, measured_hw=measured_hw) == (420, 420)
-
-
-def test_input_hw_uses_measured_size_when_dynamic():
-    record_measured_model_input(np.zeros((4, 3, 512, 768)))
-    measured_hw, measured_frames = consume_measured_model_input()
-
-    assert measured_frames == 4
-    assert resolve_model_input_hw(SimpleNamespace(), measured_hw=measured_hw) == (
-        512,
-        768,
-    )
-
-
-def test_fixed_input_hw_reads_non_square_image_size_pair():
-    # OwlV2 exposes image_size as a (height, width) pair rather than an edge length.
-    model = SimpleNamespace(image_size=(960, 1024))
-
-    assert get_fixed_model_input_hw(model) == (960, 1024)
-
-
-def test_fixed_input_hw_reads_square_image_size_scalar():
-    assert get_fixed_model_input_hw(SimpleNamespace(image_size=768)) == (768, 768)
-
-
-def test_fixed_input_hw_ignores_malformed_image_size():
-    assert get_fixed_model_input_hw(SimpleNamespace(image_size=(960,))) is None
-    assert get_fixed_model_input_hw(SimpleNamespace(image_size=(0, 640))) is None
-    assert get_fixed_model_input_hw(SimpleNamespace(image_size=(None, None))) is None
-
-
-def test_fixed_input_hw_reads_wrapped_owlv2_backend():
-    # SerializedOwlV2 delegates inference to a wrapped OwlV2 instance.
-    model = SimpleNamespace(owlv2=SimpleNamespace(image_size=(960, 960)))
-
-    assert get_fixed_model_input_hw(model) == (960, 960)
-
-
-def test_consume_measured_model_input_clears_value():
-    record_measured_model_input(np.zeros((1, 3, 512, 512)))
-
-    assert consume_measured_model_input() == ((512, 512), 1)
+    assert consume_measured_image_input() == ((512, 768), 2)
     # A later call that publishes nothing must not inherit the previous size.
-    assert consume_measured_model_input() == (None, None)
+    assert consume_measured_image_input() == (None, None)
+
+
+def test_record_measured_image_input_rejects_unusable_sizes():
+    record_measured_image_input((0, 768))
+
+    assert consume_measured_image_input() == (None, None)
 
 
 def test_count_inference_images():
@@ -229,98 +198,19 @@ def test_count_inference_images():
     assert count_inference_images([1, 2, 3]) == 3
 
 
-def test_get_fixed_model_input_hw_from_image_size_and_nested_backend():
-    assert get_fixed_model_input_hw(SimpleNamespace(image_size=1024)) == (1024, 1024)
-    assert get_fixed_model_input_hw(
-        SimpleNamespace(_model=SimpleNamespace(_image_size=1008))
-    ) == (1008, 1008)
-    assert get_fixed_model_input_hw(
-        SimpleNamespace(_model=SimpleNamespace(_model=SimpleNamespace(image_size=1024)))
-    ) == (1024, 1024)
-
-
-def test_fixed_input_hw_reads_hf_processor_size():
-    model = SimpleNamespace(
-        processor=SimpleNamespace(
-            image_processor=SimpleNamespace(size={"height": 224, "width": 224})
-        )
-    )
-
-    assert get_fixed_model_input_hw(model) == (224, 224)
-    assert resolve_model_input_hw(model, measured_hw=(1080, 1920)) == (224, 224)
-
-
-def test_fixed_input_hw_reads_hf_processor_size_object():
-    model = SimpleNamespace(
-        processor=SimpleNamespace(
-            image_processor=SimpleNamespace(size=SimpleNamespace(height=448, width=448))
-        )
-    )
-
-    assert get_fixed_model_input_hw(model) == (448, 448)
-
-
-def test_fixed_input_hw_reads_hf_vision_config_image_size():
-    model = SimpleNamespace(
-        model=SimpleNamespace(
-            config=SimpleNamespace(vision_config=SimpleNamespace(image_size=224))
-        )
-    )
-
-    assert get_fixed_model_input_hw(model) == (224, 224)
-
-
-def test_legacy_hf_vlm_uses_processor_size_not_native_image_dims():
+def test_base_inference_publishes_native_size_not_model_input_size():
     from inference.core.models.base import BaseInference
 
-    class LegacyHFVLM(BaseInference):
-        def __init__(self):
-            self.processor = SimpleNamespace(
-                image_processor=SimpleNamespace(size={"height": 224, "width": 224})
+    class CoreStyleModel(BaseInference):
+        # A fixed model input size must no longer influence the bucket.
+        img_size_h = 640
+        img_size_w = 640
+
+        def preprocess(self, image, **kwargs):
+            return (
+                np.zeros((1, 3, 640, 640), dtype=np.float32),
+                {"img_dims": [(1080, 1920)]},
             )
-
-        def preprocess(self, image, **kwargs):
-            return object(), {"image_dims": (1920, 1080)}
-
-        def predict(self, img_in, **kwargs):
-            return (np.zeros(1),)
-
-        def postprocess(self, predictions, preprocess_return_metadata, **kwargs):
-            return predictions
-
-    model = LegacyHFVLM()
-    BaseInference.infer.__wrapped__(model, object())
-    measured_hw, _ = consume_measured_model_input()
-
-    assert measured_hw == (1080, 1920)
-    assert resolve_model_input_hw(model, measured_hw=measured_hw) == (224, 224)
-
-
-def test_record_fixed_model_input_for_request_publishes_encoder_size():
-    record_fixed_model_input_for_request(
-        SimpleNamespace(image_size=1024),
-        SimpleNamespace(image=object()),
-    )
-
-    assert consume_measured_model_input() == ((1024, 1024), 1)
-
-
-def test_record_fixed_model_input_for_request_clears_stale_value_for_unknown_encoder():
-    record_measured_model_input(np.zeros((1, 3, 4000, 4000)))
-
-    record_fixed_model_input_for_request(
-        SimpleNamespace(), SimpleNamespace(image=object())
-    )
-
-    assert consume_measured_model_input() == (None, None)
-
-
-def test_base_inference_publishes_preprocessed_input_size():
-    from inference.core.models.base import BaseInference
-
-    class DynamicInputModel(BaseInference):
-        def preprocess(self, image, **kwargs):
-            return np.zeros((2, 3, 512, 768), dtype=np.float32), None
 
         def predict(self, img_in, **kwargs):
             return (np.zeros(1),)
@@ -330,40 +220,18 @@ def test_base_inference_publishes_preprocessed_input_size():
 
     # Call the undecorated function so the published value survives for assertion;
     # the usage decorator consumes it.
-    BaseInference.infer.__wrapped__(DynamicInputModel(), [object(), object()])
+    BaseInference.infer.__wrapped__(CoreStyleModel(), object())
 
-    assert consume_measured_model_input() == ((512, 768), 2)
-
-
-def test_record_measured_model_input_reads_hf_pixel_values():
-    record_measured_model_input(
-        {"pixel_values": np.zeros((1, 3, 224, 224), dtype=np.float32)},
-        fallback_hw=(1080, 1920),
-    )
-
-    assert consume_measured_model_input() == ((224, 224), 1)
+    measured_hw, _ = consume_measured_image_input()
+    assert measured_hw == (1080, 1920)
 
 
-def test_record_measured_model_input_falls_back_to_image_dims_for_unreadable_pixel_values():
-    record_measured_model_input(
-        {"pixel_values": np.zeros((256, 1176), dtype=np.float32)},
-        fallback_hw=(1080, 1920),
-    )
-
-    assert consume_measured_model_input() == ((1080, 1920), None)
-
-
-def test_record_measured_model_input_uses_image_dims_when_no_model_tensor():
-    record_measured_model_input(object(), fallback_hw=(1080, 1920))
-
-    assert consume_measured_model_input() == ((1080, 1920), None)
-
-
-def test_base_inference_publishes_hf_pixel_values_not_native_image_dims():
+def test_base_inference_publishes_native_size_for_vlm_preprocess():
     from inference.core.models.base import BaseInference
 
     class PaligemmaLikeModel(BaseInference):
         def preprocess(self, image, **kwargs):
+            # The processor canvas is a model input size and must be ignored.
             return (
                 {"pixel_values": np.zeros((1, 3, 224, 224), dtype=np.float32)},
                 {"image_dims": (1920, 1080)},
@@ -377,15 +245,16 @@ def test_base_inference_publishes_hf_pixel_values_not_native_image_dims():
 
     BaseInference.infer.__wrapped__(PaligemmaLikeModel(), object())
 
-    assert consume_measured_model_input() == ((224, 224), 1)
+    measured_hw, _ = consume_measured_image_input()
+    assert measured_hw == (1080, 1920)
 
 
-def test_base_inference_publishes_image_dims_when_preprocess_has_no_tensor():
+def test_base_inference_publishes_no_size_when_preprocess_records_no_dims():
     from inference.core.models.base import BaseInference
 
-    class NativeSizeModel(BaseInference):
+    class UndimensionedModel(BaseInference):
         def preprocess(self, image, **kwargs):
-            return object(), {"image_dims": (1920, 1080)}
+            return np.zeros((2, 3, 512, 768), dtype=np.float32), None
 
         def predict(self, img_in, **kwargs):
             return (np.zeros(1),)
@@ -393,30 +262,23 @@ def test_base_inference_publishes_image_dims_when_preprocess_has_no_tensor():
         def postprocess(self, predictions, preprocess_return_metadata, **kwargs):
             return predictions
 
-    BaseInference.infer.__wrapped__(NativeSizeModel(), object())
+    BaseInference.infer.__wrapped__(UndimensionedModel(), [object(), object()])
 
-    assert consume_measured_model_input() == ((1080, 1920), None)
+    measured_hw, measured_frames = consume_measured_image_input()
+    # The preprocessed tensor is the model's canvas, so it cannot stand in for
+    # the image size - but it still answers how many frames were processed.
+    assert measured_hw is None
+    assert measured_frames == 2
 
 
-def test_base_inference_falls_back_to_image_dims_when_pixel_values_are_unreadable():
-    from inference.core.models.base import BaseInference
+def test_unsized_call_lands_in_the_unknown_bucket():
+    buckets = get_model_megapixel_buckets(
+        frames=2,
+        input_hw=None,
+        execution_duration=0.8,
+    )
 
-    class PatchTokenModel(BaseInference):
-        def preprocess(self, image, **kwargs):
-            return (
-                {"pixel_values": np.zeros((256, 1176), dtype=np.float32)},
-                {"image_dims": (1920, 1080)},
-            )
-
-        def predict(self, img_in, **kwargs):
-            return (np.zeros(1),)
-
-        def postprocess(self, predictions, preprocess_return_metadata, **kwargs):
-            return predictions
-
-    BaseInference.infer.__wrapped__(PatchTokenModel(), object())
-
-    assert consume_measured_model_input() == ((1080, 1920), None)
+    assert buckets[MEGAPIXEL_BUCKET_UNKNOWN]["processed_frames"] == 2
 
 
 def test_bucket_duration_prefers_recorded_predict_duration():

--- a/tests/inference/unit_tests/usage_tracking/test_predict_timing.py
+++ b/tests/inference/unit_tests/usage_tracking/test_predict_timing.py
@@ -7,7 +7,7 @@ import pytest
 
 from inference.usage_tracking import predict_timing
 from inference.usage_tracking.decorator_helpers import get_model_megapixel_buckets
-from inference.usage_tracking.megapixel_buckets import clear_measured_model_input
+from inference.usage_tracking.megapixel_buckets import clear_measured_image_input
 from inference.usage_tracking.predict_timing import (
     PredictPhaseTimer,
     clear_measured_predict_duration,
@@ -85,10 +85,10 @@ def test_record_measured_predict_duration_ignores_unusable_values():
     assert consume_measured_predict_duration() is None
 
 
-def test_clear_measured_model_input_also_clears_predict_duration():
+def test_clear_measured_image_input_also_clears_predict_duration():
     record_measured_predict_duration(0.2)
 
-    clear_measured_model_input()
+    clear_measured_image_input()
 
     assert consume_measured_predict_duration() is None
 
@@ -350,7 +350,7 @@ def test_predict_duration_does_not_leak_when_postprocessing_raises():
     with pytest.raises(RuntimeError):
         BaseInference.infer.__wrapped__(FailingModel(), object())
 
-    # Entrypoints that override infer() never call clear_measured_model_input(),
+    # Entrypoints that override infer() never call clear_measured_image_input(),
     # so a duration surviving a failed call would be charged to the next one.
     assert consume_measured_predict_duration() is None
 


### PR DESCRIPTION
## What does this PR do?

Linked issue: [LAKE-811](https://linear.app/roboflow/issue/LAKE-811/megapixel-buckets-use-model-infer-time-rather-than-also-processing)

Stacked on #2853. `megapixel_buckets` keyed frames on the model's input size, which answered how the model was configured rather than how much work the request asked for: every call to a 640x640 model landed in the same bucket whether the upload was a thumbnail or 4K. Model input size is being reported separately on another branch, so the bucket is free to describe the request instead.

Buckets are now keyed on the native size of the image the caller sent, measured before any resize. Native size was already the last-resort fallback in the resolution chain, but only under the `image_dims` key that the VLM and depth families write — core Roboflow models and the `inference_models` adapters use different conventions, so the bulk of traffic never reached the fallback and would have dropped to `unknown` on a naive simplification. All four conventions are now read: `img_dims` from core Roboflow preprocess, `original_size` records from the `inference_models` detection, segmentation and keypoint adapters, and bare per-image shapes from its classification adapter. A batch reports its first image, since a call attributes all its frames to one bucket. The fixed-input resolution chain this replaces is deleted, along with the SAM entrypoints that published their encoder canvas; those calls report the `unknown` bucket rather than a model input size dressed up as an image size. Payload shape, `merge_megapixel_buckets` and the row-level `execution_duration` are unchanged.

**Main elements:**
- `inference/usage_tracking/megapixel_buckets.py` — `parse_image_input_hw` reads all four preprocess dims conventions; `get_fixed_model_input_hw`, `resolve_model_input_hw`, `get_tensor_spatial_hw` and the HF processor / vision-config probes are removed
- `inference/core/models/base.py` — publishes the native image size from preprocess metadata, and the tensor batch size only as a frame-count fallback
- `inference/usage_tracking/decorator_helpers.py` — buckets read the measured image size directly; `record_fixed_model_input_for_request` is removed
- `inference/models/sam2/**`, `inference/models/sam3/**` — six `infer_from_request` entrypoints no longer publish the encoder canvas
- No change to usage payload shape, `merge_megapixel_buckets`, or the row-level `execution_duration`

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Other: telemetry semantics change (same payload shape, different meaning for the bucket key)

## Testing

### Unit tests

- `parse_image_input_hw` reads each convention: `img_dims` pairs (wrapped and bare), `image_dims` as width-height, `original_size` records, and bare per-image shapes
- A mixed-size batch is attributed to its first image
- Missing, empty and malformed dims yield no size, and attribute-style metadata is read alongside dict-style
- End-to-end through `BaseInference.infer`: a core-style model with `img_size_h/w` of 640 buckets on its 1080x1920 upload, not on the model canvas; a Paligemma-style model buckets on `image_dims` rather than its 224x224 processor canvas
- A preprocess that records no dims publishes no size but still reports its frame count, and lands in `unknown`
- Through the usage decorator: a 1080x1920 upload buckets at 2-4 MP on a 640x640 model, batch padding still does not inflate frames, concurrent calls on a shared instance stay isolated, and SAM-style `infer_from_request` reports `unknown`
- Predict-phase duration behavior from #2853 is unchanged and still covered

### Integration tests

- None for this PR.

### Other

- `pytest tests/inference/unit_tests/usage_tracking/` — 158 passed
- `pytest tests/inference/unit_tests/core/models/` — 81 passed
- Verified `parse_image_input_hw` against real objects rather than only stand-ins: a `PreProcessingMetadata` built from `inference_models`, and the tuple `inference.core.utils.preprocess.prepare()` actually returns — all four conventions resolve to the true native size
- `black` and `isort` on all changed files

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [ ] I have updated the documentation accordingly (if applicable)

## Additional Context

**Bucket keys shift for existing models.** A model previously reported at its input size now reports at its upload size, so historical series will step at deploy rather than continue. For a 640x640 model fed 1080p uploads that is a move from `0.25-0.5` to `2-4`. Worth planning for if any dashboard compares across the boundary.

**SAM moves to `unknown`.** `infer_from_request` never reaches preprocess, so there is no cheap point to observe the image size without decoding it on the telemetry path. Reporting `unknown` is honest about that; publishing the size from inside SAM's own image load would recover it later if the family turns out to matter.

**Coverage caveat from #2853 narrows.** Families that override `infer()` wholesale still fall back to wall clock for the bucket *duration*, and now also report no image *size*, so they land in `unknown`. Both are pinned by tests so the fallback stays deliberate.

Made with [Cursor](https://cursor.com)