### PR TITLE
Add token-usage outputs via new VLM block versions (#2850)

### DIFF
--- a/inference/core/version.py
+++ b/inference/core/version.py
@@ -1,4 +1,4 @@
-__version__ = "1.5.0"
+__version__ = "1.5.0-post1"
 
 
 if __name__ == "__main__":

--- a/inference/core/workflows/core_steps/common/openrouter.py
+++ b/inference/core/workflows/core_steps/common/openrouter.py
@@ -22,6 +22,7 @@ the VLM blocks live here too so the per-block files stay small.
 
 import base64
 import json
+from dataclasses import dataclass
 from functools import partial
 from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, Union
 
@@ -37,6 +38,9 @@ from inference.core.logger import logger
 from inference.core.managers.base import ModelManager
 from inference.core.roboflow_api import post_to_roboflow_api
 from inference.core.utils.image_utils import encode_image_to_jpeg_bytes, load_image
+from inference.core.workflows.core_steps.common.token_usage import (
+    parse_chat_completion_usage,
+)
 from inference.core.workflows.core_steps.common.utils import run_in_parallel
 from inference.core.workflows.core_steps.common.vlms import VLM_TASKS_METADATA
 from inference.core.workflows.execution_engine.entities.types import (
@@ -160,6 +164,22 @@ class OpenRouterBlockManifestMixin(WorkflowBlockManifest):
 # ---------------------------------------------------------------------------
 
 
+@dataclass(frozen=True)
+class OpenRouterResult:
+    """One chat-completion result with its reasoning trace and token usage.
+
+    ``reasoning_trace`` is the ``message.reasoning`` string OpenRouter returns
+    for reasoning models (empty string when absent). Token counts are parsed
+    from the provider ``usage`` object; ``None`` means usage was omitted,
+    never a real zero.
+    """
+
+    content: str
+    reasoning_trace: str = ""
+    input_tokens: Optional[int] = None
+    output_tokens: Optional[int] = None
+
+
 class OpenRouterWorkflowBlockBase(WorkflowBlock):
     """Shared base class for blocks that route through OpenRouter.
 
@@ -193,21 +213,52 @@ class OpenRouterWorkflowBlockBase(WorkflowBlock):
     ) -> Union[List[str], List[Tuple[str, str]]]:
         """Run a batch of OpenRouter chat-completion calls in parallel.
 
+        Legacy result shapes, kept stable for shipped block versions: bare
+        content strings by default, ``(content, reasoning_trace)`` tuples
+        with ``include_reasoning=True``. New blocks that need token usage
+        should call :meth:`execute_openrouter_batch_with_usage` instead.
+
+        See :meth:`execute_openrouter_batch_with_usage` for routing,
+        ``temperature`` and ``reasoning`` semantics.
+        """
+        results = self.execute_openrouter_batch_with_usage(
+            openrouter_api_key=openrouter_api_key,
+            model=model,
+            prompts=prompts,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            privacy_level=privacy_level,
+            max_concurrent_requests=max_concurrent_requests,
+            reasoning=reasoning,
+        )
+        if include_reasoning:
+            return [(r.content, r.reasoning_trace) for r in results]
+        return [r.content for r in results]
+
+    def execute_openrouter_batch_with_usage(
+        self,
+        openrouter_api_key: str,
+        model: str,
+        prompts: List[List[dict]],
+        max_tokens: int,
+        temperature: Optional[float],
+        privacy_level: str,
+        max_concurrent_requests: Optional[int],
+        reasoning: Optional[dict] = None,
+    ) -> List[OpenRouterResult]:
+        """Run a batch of OpenRouter chat-completion calls in parallel.
+
         Routes through the Roboflow proxy when ``openrouter_api_key`` starts
         with ``rf_key:`` (managed/user-stored), otherwise calls the OpenRouter
-        API directly using the OpenAI SDK with the provided key.
+        API directly using the OpenAI SDK with the provided key. Works on
+        both paths: the reasoning trace and token usage are always populated
+        on the returned :class:`OpenRouterResult` objects.
 
         ``temperature`` set to ``None`` omits the parameter so the provider
         default applies. ``reasoning`` is an optional OpenRouter reasoning
         config object (e.g. ``{"effort": "low"}`` or ``{"enabled": False}``)
         forwarded verbatim; when the target model rejects the config, the
         request is retried once without it.
-
-        With ``include_reasoning=True`` each result is a
-        ``(content, reasoning_trace)`` tuple, where the trace is the
-        ``message.reasoning`` string OpenRouter returns for reasoning models
-        (empty string when absent). Default returns bare content strings for
-        backward compatibility.
 
         Note: honoring ``reasoning`` on managed ``rf_key:`` keys requires a
         Roboflow platform proxy version that forwards the key upstream
@@ -223,7 +274,6 @@ class OpenRouterWorkflowBlockBase(WorkflowBlock):
                 model=model,
                 privacy_level=privacy_level,
                 reasoning=reasoning,
-                include_reasoning=include_reasoning,
             )
         else:
             single = partial(
@@ -232,7 +282,6 @@ class OpenRouterWorkflowBlockBase(WorkflowBlock):
                 model=model,
                 privacy_level=privacy_level,
                 reasoning=reasoning,
-                include_reasoning=include_reasoning,
             )
         tasks = [
             partial(
@@ -343,8 +392,7 @@ def _execute_proxied_openrouter_request(
     temperature: Optional[float],
     privacy_level: str,
     reasoning: Optional[dict] = None,
-    include_reasoning: bool = False,
-) -> Union[str, Tuple[str, str]]:
+) -> OpenRouterResult:
     payload = {
         "openrouter_api_key": openrouter_api_key,
         "model": model,
@@ -394,6 +442,9 @@ def _execute_proxied_openrouter_request(
         )
     message = choices[0].get("message") or {}
     content = message.get("content")
+    input_tokens, output_tokens = parse_chat_completion_usage(
+        response_data.get("usage")
+    )
     if content is None:
         # Reasoning models (Kimi K2.x, some Qwen 3.5/3.6 variants) emit all
         # of their tokens as `reasoning` and run out before producing visible
@@ -410,10 +461,13 @@ def _execute_proxied_openrouter_request(
         raise RuntimeError(
             "OpenRouter response missing message.content via Roboflow proxy." + hint
         )
-    if include_reasoning:
-        reasoning_trace = message.get("reasoning")
-        return content, reasoning_trace if isinstance(reasoning_trace, str) else ""
-    return content
+    reasoning_trace = message.get("reasoning")
+    return OpenRouterResult(
+        content=content,
+        reasoning_trace=reasoning_trace if isinstance(reasoning_trace, str) else "",
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+    )
 
 
 def _execute_direct_openrouter_request(
@@ -424,8 +478,7 @@ def _execute_direct_openrouter_request(
     temperature: Optional[float],
     privacy_level: str,
     reasoning: Optional[dict] = None,
-    include_reasoning: bool = False,
-) -> Union[str, Tuple[str, str]]:
+) -> OpenRouterResult:
     client = OpenAI(base_url="https://openrouter.ai/api/v1", api_key=api_key)
     extra_body: Dict[str, Any] = {}
     provider = build_provider_routing(privacy_level)
@@ -485,13 +538,19 @@ def _execute_direct_openrouter_request(
             "or reasoning tokens. Try a different prompt or model."
         )
         raise RuntimeError("OpenRouter response missing message.content." + hint)
-    if include_reasoning:
-        # OpenRouter returns the reasoning trace as an extra `reasoning`
-        # field on the message; the OpenAI SDK surfaces unknown fields as
-        # attributes on its pydantic models.
-        reasoning_trace = getattr(response.choices[0].message, "reasoning", None)
-        return content, reasoning_trace if isinstance(reasoning_trace, str) else ""
-    return content
+    # OpenRouter returns the reasoning trace as an extra `reasoning`
+    # field on the message; the OpenAI SDK surfaces unknown fields as
+    # attributes on its pydantic models.
+    reasoning_trace = getattr(response.choices[0].message, "reasoning", None)
+    input_tokens, output_tokens = parse_chat_completion_usage(
+        getattr(response, "usage", None)
+    )
+    return OpenRouterResult(
+        content=content,
+        reasoning_trace=reasoning_trace if isinstance(reasoning_trace, str) else "",
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/inference/core/workflows/core_steps/common/reasoning.py
+++ b/inference/core/workflows/core_steps/common/reasoning.py
@@ -1,0 +1,70 @@
+"""Shared reasoning-effort control for OpenRouter-routed VLM blocks.
+
+Serves the generic blocks (``openrouter@v2``, ``google_gemma@v3``) that accept
+arbitrary or non-reasoning models. Model-family blocks (Qwen, Muse) keep their
+own builders because they encode family-specific behavior: Qwen disables
+reasoning by default and knows which variants reject ``enabled: false``; Muse
+models require reasoning and have no "off" setting.
+"""
+
+from typing import Optional
+
+REASONING_EFFORT_OPTIONS = ["none", "low", "medium", "high", "xhigh"]
+
+REASONING_EFFORT_METADATA = {
+    "none": {
+        "name": "Disabled",
+        "description": (
+            "Explicitly turns extended reasoning off. Models that reject "
+            "`reasoning: {enabled: false}` are retried without the config "
+            "and keep their provider-default behavior."
+        ),
+    },
+    "low": {
+        "name": "Low",
+        "description": "Small reasoning budget before answering.",
+    },
+    "medium": {
+        "name": "Medium",
+        "description": "Moderate reasoning budget before answering.",
+    },
+    "high": {
+        "name": "High",
+        "description": (
+            "Large reasoning budget. Slowest and most expensive; consider "
+            "raising `max_tokens` so reasoning does not crowd out the answer."
+        ),
+    },
+    "xhigh": {
+        "name": "Extra high",
+        "description": (
+            "Maximum reasoning budget. Only some models support it (e.g. the "
+            "GPT-5.2+ generation); models that reject it are retried without "
+            "a reasoning config. Raise `max_tokens` accordingly."
+        ),
+    },
+}
+
+
+def build_openrouter_reasoning_config(
+    reasoning_effort: Optional[str],
+) -> Optional[dict]:
+    """Translate the shared ``reasoning_effort`` value into OpenRouter's config.
+
+    ``None`` (field unset) omits the config entirely so the model keeps its
+    provider-default behavior — this is what shipped block versions without
+    the knob always did. ``"none"`` explicitly disables reasoning; the
+    remaining efforts map to ``{"effort": ...}``. Models that reject the
+    config are retried without it by the shared executor.
+
+    Args:
+        reasoning_effort: ``None`` or one of ``REASONING_EFFORT_OPTIONS``.
+
+    Returns:
+        OpenRouter ``reasoning`` payload object, or ``None`` to omit it.
+    """
+    if reasoning_effort is None:
+        return None
+    if reasoning_effort == "none":
+        return {"enabled": False}
+    return {"effort": reasoning_effort}

--- a/inference/core/workflows/core_steps/common/token_usage.py
+++ b/inference/core/workflows/core_steps/common/token_usage.py
@@ -1,0 +1,80 @@
+"""Shared token-count parsing for remote VLM workflow blocks.
+
+Provider APIs already return usage on every call. Blocks previously dropped
+it; these helpers normalize the three envelopes we see (chat completions,
+Responses/Anthropic, Gemini) into ``(input_tokens, output_tokens)``. Missing
+or malformed counts become ``None``, never ``0``, so a caller can tell
+"usage omitted" from a real zero-token call.
+"""
+
+from typing import Any, List, Optional, Tuple
+
+from inference.core.workflows.execution_engine.entities.base import OutputDefinition
+from inference.core.workflows.execution_engine.entities.types import INTEGER_KIND
+
+OptionalTokenCount = Optional[int]
+
+
+TOKEN_OUTPUT_DEFINITIONS: List[OutputDefinition] = [
+    OutputDefinition(name="input_tokens", kind=[INTEGER_KIND]),
+    OutputDefinition(name="output_tokens", kind=[INTEGER_KIND]),
+]
+
+
+def as_optional_int(value: Any) -> OptionalTokenCount:
+    if isinstance(value, bool) or not isinstance(value, int):
+        return None
+    return value
+
+
+def parse_chat_completion_usage(
+    usage: Any,
+) -> Tuple[OptionalTokenCount, OptionalTokenCount]:
+    """OpenRouter / OpenAI chat-completions: ``prompt_tokens`` / ``completion_tokens``."""
+    if usage is None:
+        return None, None
+    if isinstance(usage, dict):
+        return as_optional_int(usage.get("prompt_tokens")), as_optional_int(
+            usage.get("completion_tokens")
+        )
+    return as_optional_int(getattr(usage, "prompt_tokens", None)), as_optional_int(
+        getattr(usage, "completion_tokens", None)
+    )
+
+
+def parse_responses_api_usage(
+    usage: Any,
+) -> Tuple[OptionalTokenCount, OptionalTokenCount]:
+    """Anthropic / OpenAI Responses / xAI: ``input_tokens`` / ``output_tokens``."""
+    if usage is None:
+        return None, None
+    if isinstance(usage, dict):
+        return as_optional_int(usage.get("input_tokens")), as_optional_int(
+            usage.get("output_tokens")
+        )
+    return as_optional_int(getattr(usage, "input_tokens", None)), as_optional_int(
+        getattr(usage, "output_tokens", None)
+    )
+
+
+def parse_gemini_usage_metadata(
+    usage_metadata: Any,
+) -> Tuple[OptionalTokenCount, OptionalTokenCount]:
+    """Gemini ``usageMetadata``: prompt vs candidates + thinking tokens."""
+    if usage_metadata is None:
+        return None, None
+    if isinstance(usage_metadata, dict):
+        prompt = as_optional_int(usage_metadata.get("promptTokenCount"))
+        candidates = as_optional_int(usage_metadata.get("candidatesTokenCount"))
+        thoughts = as_optional_int(usage_metadata.get("thoughtsTokenCount"))
+    else:
+        prompt = as_optional_int(getattr(usage_metadata, "promptTokenCount", None))
+        candidates = as_optional_int(
+            getattr(usage_metadata, "candidatesTokenCount", None)
+        )
+        thoughts = as_optional_int(getattr(usage_metadata, "thoughtsTokenCount", None))
+    if candidates is None and thoughts is None:
+        output = None
+    else:
+        output = (candidates or 0) + (thoughts or 0)
+    return prompt, output

--- a/inference/core/workflows/core_steps/loader.py
+++ b/inference/core/workflows/core_steps/loader.py
@@ -479,6 +479,9 @@ from inference.core.workflows.core_steps.models.foundation.anthropic_claude.v2 i
 from inference.core.workflows.core_steps.models.foundation.anthropic_claude.v3 import (
     AnthropicClaudeBlockV3,
 )
+from inference.core.workflows.core_steps.models.foundation.anthropic_claude.v4 import (
+    AnthropicClaudeBlockV4,
+)
 
 if not ENABLE_TENSOR_DATA_REPRESENTATION:
     from inference.core.workflows.core_steps.models.foundation.clip.v1 import (
@@ -559,11 +562,17 @@ from inference.core.workflows.core_steps.models.foundation.google_gemini.v3 impo
 from inference.core.workflows.core_steps.models.foundation.google_gemini.v4 import (
     GoogleGeminiBlockV4,
 )
+from inference.core.workflows.core_steps.models.foundation.google_gemini.v5 import (
+    GoogleGeminiBlockV5,
+)
 from inference.core.workflows.core_steps.models.foundation.google_gemma.v1 import (
     GoogleGemmaBlockV1,
 )
 from inference.core.workflows.core_steps.models.foundation.google_gemma.v2 import (
     GoogleGemmaBlockV2,
+)
+from inference.core.workflows.core_steps.models.foundation.google_gemma.v3 import (
+    GoogleGemmaBlockV3,
 )
 
 if not ENABLE_TENSOR_DATA_REPRESENTATION:
@@ -593,6 +602,9 @@ from inference.core.workflows.core_steps.models.foundation.lmm_classifier.v1 imp
 )
 from inference.core.workflows.core_steps.models.foundation.meta_vlm.v1 import (
     MetaVlmBlockV1,
+)
+from inference.core.workflows.core_steps.models.foundation.meta_vlm.v2 import (
+    MetaVlmBlockV2,
 )
 
 if not ENABLE_TENSOR_DATA_REPRESENTATION:
@@ -627,14 +639,23 @@ from inference.core.workflows.core_steps.models.foundation.openai.v4 import (
 from inference.core.workflows.core_steps.models.foundation.openai.v5 import (
     OpenAIBlockV5,
 )
+from inference.core.workflows.core_steps.models.foundation.openai.v6 import (
+    OpenAIBlockV6,
+)
 from inference.core.workflows.core_steps.models.foundation.openai_compatible.v1 import (
     OpenAICompatibleBlockV1,
 )
 from inference.core.workflows.core_steps.models.foundation.openrouter.v1 import (
     OpenRouterBlockV1,
 )
+from inference.core.workflows.core_steps.models.foundation.openrouter.v2 import (
+    OpenRouterBlockV2,
+)
 from inference.core.workflows.core_steps.models.foundation.spacexai.v1 import (
     SpaceXAIBlockV1,
+)
+from inference.core.workflows.core_steps.models.foundation.spacexai.v2 import (
+    SpaceXAIBlockV2,
 )
 
 if not ENABLE_TENSOR_DATA_REPRESENTATION:
@@ -696,6 +717,9 @@ from inference.core.workflows.core_steps.models.foundation.qwen_vlm.v1 import (
 )
 from inference.core.workflows.core_steps.models.foundation.qwen_vlm.v2 import (
     QwenVlmBlockV2,
+)
+from inference.core.workflows.core_steps.models.foundation.qwen_vlm.v3 import (
+    QwenVlmBlockV3,
 )
 
 if not ENABLE_TENSOR_DATA_REPRESENTATION:
@@ -1736,7 +1760,9 @@ def load_blocks() -> List[Type[WorkflowBlock]]:
         AnthropicClaudeBlockV1,
         AnthropicClaudeBlockV2,
         AnthropicClaudeBlockV3,
+        AnthropicClaudeBlockV4,
         SpaceXAIBlockV1,
+        SpaceXAIBlockV2,
         CosineSimilarityBlockV1,
         BackgroundColorVisualizationBlockV1,
         BarcodeDetectorBlockV1,
@@ -1775,6 +1801,7 @@ def load_blocks() -> List[Type[WorkflowBlock]]:
         GoogleGeminiBlockV2,
         GoogleGeminiBlockV3,
         GoogleGeminiBlockV4,
+        GoogleGeminiBlockV5,
         GoogleVisionOCRBlockV1,
         GridVisualizationBlockV1,
         HaloVisualizationBlockV1,
@@ -1808,6 +1835,7 @@ def load_blocks() -> List[Type[WorkflowBlock]]:
         OpenAIBlockV3,
         OpenAIBlockV4,
         OpenAIBlockV5,
+        OpenAIBlockV6,
         PathDeviationAnalyticsBlockV1,
         PathDeviationAnalyticsBlockV2,
         PixelateVisualizationBlockV1,
@@ -1895,8 +1923,10 @@ def load_blocks() -> List[Type[WorkflowBlock]]:
         LlamaVisionBlockV1,
         LlamaVisionBlockV2,
         MetaVlmBlockV1,
+        MetaVlmBlockV2,
         GoogleGemmaBlockV1,
         GoogleGemmaBlockV2,
+        GoogleGemmaBlockV3,
         ImageSlicerBlockV2,
         Cosmos3EdgeBlockV1,
         Qwen25VLBlockV1,
@@ -1907,10 +1937,12 @@ def load_blocks() -> List[Type[WorkflowBlock]]:
         Qwen36OpenRouterBlockV1,
         QwenVlmBlockV1,
         QwenVlmBlockV2,
+        QwenVlmBlockV3,
         OpenAICompatibleBlockV1,
         KimiOpenRouterBlockV1,
         KimiOpenrouterBlockV2,
         OpenRouterBlockV1,
+        OpenRouterBlockV2,
         SmolVLM2BlockV1,
         Moondream2BlockV1,
         OverlapBlockV1,

--- a/inference/core/workflows/core_steps/models/foundation/anthropic_claude/v4.py
+++ b/inference/core/workflows/core_steps/models/foundation/anthropic_claude/v4.py
@@ -1,0 +1,1006 @@
+import base64
+import json
+from functools import partial
+from typing import Any, Dict, List, Literal, Optional, Tuple, Type, Union
+
+import anthropic
+import requests
+from anthropic import NOT_GIVEN
+from pydantic import ConfigDict, Field, model_validator
+
+from inference.core.env import WORKFLOWS_REMOTE_EXECUTION_MAX_STEP_CONCURRENT_REQUESTS
+from inference.core.managers.base import ModelManager
+from inference.core.roboflow_api import post_to_roboflow_api
+from inference.core.utils.image_utils import encode_image_to_jpeg_bytes, load_image
+from inference.core.utils.preprocess import downscale_image_keeping_aspect_ratio
+from inference.core.workflows.core_steps.common.token_usage import (
+    TOKEN_OUTPUT_DEFINITIONS,
+    parse_responses_api_usage,
+)
+from inference.core.workflows.core_steps.common.utils import run_in_parallel
+from inference.core.workflows.core_steps.common.vlms import VLM_TASKS_METADATA
+from inference.core.workflows.execution_engine.entities.base import (
+    Batch,
+    OutputDefinition,
+    WorkflowImageData,
+)
+from inference.core.workflows.execution_engine.entities.types import (
+    FLOAT_KIND,
+    IMAGE_KIND,
+    INTEGER_KIND,
+    LANGUAGE_MODEL_OUTPUT_KIND,
+    LIST_OF_VALUES_KIND,
+    ROBOFLOW_MANAGED_KEY,
+    SECRET_KIND,
+    STRING_KIND,
+    ImageInputField,
+    Selector,
+)
+from inference.core.workflows.prototypes.block import (
+    AirGappedAvailability,
+    BlockResult,
+    DependentResource,
+    WorkflowBlock,
+    WorkflowBlockManifest,
+    is_workflow_selector,
+    third_party_model,
+)
+
+CLAUDE_MODELS = [
+    {
+        "id": "claude-fable-5",
+        "name": "Claude Fable 5",
+        "exact_version": "claude-fable-5",
+        "max_output_tokens": 128000,
+    },
+    {
+        "id": "claude-opus-4-7",
+        "name": "Claude Opus 4.7",
+        "exact_version": "claude-opus-4-7",
+        "max_output_tokens": 128000,
+    },
+    {
+        "id": "claude-opus-4-6",
+        "name": "Claude Opus 4.6",
+        "exact_version": "claude-opus-4-6",
+        "max_output_tokens": 128000,
+    },
+    {
+        "id": "claude-sonnet-4-6",
+        "name": "Claude Sonnet 4.6",
+        "exact_version": "claude-sonnet-4-6",
+        "max_output_tokens": 64000,
+    },
+    {
+        "id": "claude-sonnet-4-5",
+        "name": "Claude Sonnet 4.5",
+        "exact_version": "claude-sonnet-4-5-20250929",
+        "max_output_tokens": 64000,
+    },
+    {
+        "id": "claude-haiku-4-5",
+        "name": "Claude Haiku 4.5",
+        "exact_version": "claude-haiku-4-5-20251001",
+        "max_output_tokens": 64000,
+    },
+    {
+        "id": "claude-opus-4-5",
+        "name": "Claude Opus 4.5",
+        "exact_version": "claude-opus-4-5-20251101",
+        "max_output_tokens": 64000,
+    },
+    {
+        "id": "claude-sonnet-4",
+        "name": "Claude Sonnet 4",
+        "exact_version": "claude-sonnet-4-20250514",
+        "max_output_tokens": 64000,
+    },
+    {
+        "id": "claude-opus-4-1",
+        "name": "Claude Opus 4.1",
+        "exact_version": "claude-opus-4-1-20250805",
+        "max_output_tokens": 32000,
+    },
+    {
+        "id": "claude-opus-4",
+        "name": "Claude Opus 4",
+        "exact_version": "claude-opus-4-20250514",
+        "max_output_tokens": 32000,
+    },
+]
+
+MODEL_VERSION_IDS = [model["id"] for model in CLAUDE_MODELS]
+EXACT_MODEL_VERSIONS = {model["id"]: model["exact_version"] for model in CLAUDE_MODELS}
+
+MODEL_VERSION_METADATA = {
+    model["id"]: {"name": model["name"]} for model in CLAUDE_MODELS
+}
+
+MAX_OUTPUT_TOKENS = {model["id"]: model["max_output_tokens"] for model in CLAUDE_MODELS}
+DEFAULT_MAX_OUTPUT_TOKENS = 64000
+
+SUPPORTED_TASK_TYPES_LIST = [
+    "unconstrained",
+    "ocr",
+    "structured-answering",
+    "classification",
+    "multi-label-classification",
+    "visual-question-answering",
+    "caption",
+    "detailed-caption",
+    "object-detection",
+]
+SUPPORTED_TASK_TYPES = set(SUPPORTED_TASK_TYPES_LIST)
+RELEVANT_TASKS_METADATA = {
+    k: v for k, v in VLM_TASKS_METADATA.items() if k in SUPPORTED_TASK_TYPES
+}
+RELEVANT_TASKS_DOCS_DESCRIPTION = "\n\n".join(
+    f"* **{v['name']}** (`{k}`) - {v['description']}"
+    for k, v in RELEVANT_TASKS_METADATA.items()
+)
+LONG_DESCRIPTION = f"""
+Ask a question to Anthropic Claude model with vision capabilities.
+
+You can specify arbitrary text prompts or predefined ones, the block supports the following types of prompt:
+
+{RELEVANT_TASKS_DOCS_DESCRIPTION}
+
+### API Key Options
+
+This block supports two API key modes:
+
+1. **Roboflow Managed API Key (Default)** - Use `rf_key:account` to proxy requests through Roboflow's API:
+   * **Simplified setup** - no Anthropic API key required
+   * **Secure** - your workflow API key is used for authentication
+   * **Usage-based billing** - charged per token based on the model used
+
+2. **Custom Anthropic API Key** - Provide your own Anthropic API key:
+   * Full control over API usage
+   * You pay Anthropic directly
+"""
+
+TaskType = Literal[tuple(SUPPORTED_TASK_TYPES_LIST)]
+
+TASKS_REQUIRING_PROMPT = {
+    "unconstrained",
+    "visual-question-answering",
+}
+
+TASKS_REQUIRING_CLASSES = {
+    "classification",
+    "multi-label-classification",
+    "object-detection",
+}
+
+TASKS_REQUIRING_OUTPUT_STRUCTURE = {
+    "structured-answering",
+}
+
+
+class BlockManifest(WorkflowBlockManifest):
+    model_config = ConfigDict(
+        json_schema_extra={
+            "name": "Anthropic Claude",
+            "version": "v4",
+            "short_description": "Run Anthropic Claude model with vision capabilities.",
+            "long_description": LONG_DESCRIPTION,
+            "license": "Apache-2.0",
+            "block_type": "model",
+            "search_keywords": ["LMM", "VLM", "Claude", "Anthropic"],
+            "is_vlm_block": True,
+            "task_type_property": "task_type",
+            "ui_manifest": {
+                "section": "model",
+                "icon": "far fa-a",
+                "blockPriority": 5,
+            },
+        },
+        protected_namespaces=(),
+    )
+    type: Literal["roboflow_core/anthropic_claude@v4"]
+    images: Selector(kind=[IMAGE_KIND]) = ImageInputField
+    task_type: TaskType = Field(
+        default="unconstrained",
+        description="Task type to be performed by model. Value determines required parameters and output response.",
+        json_schema_extra={
+            "values_metadata": RELEVANT_TASKS_METADATA,
+            "recommended_parsers": {
+                "structured-answering": "roboflow_core/json_parser@v1",
+                "classification": "roboflow_core/vlm_as_classifier@v2",
+                "multi-label-classification": "roboflow_core/vlm_as_classifier@v2",
+                "object-detection": "roboflow_core/vlm_as_detector@v2",
+            },
+            "always_visible": True,
+        },
+    )
+    prompt: Optional[Union[Selector(kind=[STRING_KIND]), str]] = Field(
+        default=None,
+        description="Text prompt to the Claude model",
+        examples=["my prompt", "$inputs.prompt"],
+        json_schema_extra={
+            "relevant_for": {
+                "task_type": {"values": TASKS_REQUIRING_PROMPT, "required": True},
+            },
+            "multiline": True,
+        },
+    )
+    output_structure: Optional[Dict[str, str]] = Field(
+        default=None,
+        description="Dictionary with structure of expected JSON response",
+        examples=[{"my_key": "description"}, "$inputs.output_structure"],
+        json_schema_extra={
+            "relevant_for": {
+                "task_type": {
+                    "values": TASKS_REQUIRING_OUTPUT_STRUCTURE,
+                    "required": True,
+                },
+            },
+        },
+    )
+    classes: Optional[Union[Selector(kind=[LIST_OF_VALUES_KIND]), List[str]]] = Field(
+        default=None,
+        description="List of classes to be used",
+        examples=[["class-a", "class-b"], "$inputs.classes"],
+        json_schema_extra={
+            "relevant_for": {
+                "task_type": {
+                    "values": TASKS_REQUIRING_CLASSES,
+                    "required": True,
+                },
+            },
+        },
+    )
+    api_key: Union[
+        Selector(kind=[STRING_KIND, SECRET_KIND, ROBOFLOW_MANAGED_KEY]), str
+    ] = Field(
+        default="rf_key:account",
+        description="Your Anthropic API key or 'rf_key:account' to use Roboflow's managed API key",
+        examples=["rf_key:account", "xxx-xxx", "$inputs.anthropic_api_key"],
+        private=True,
+    )
+    model_version: Union[
+        Selector(kind=[STRING_KIND]),
+        Literal[tuple(MODEL_VERSION_IDS)],
+    ] = Field(
+        default="claude-sonnet-4-5",
+        description="Model to be used",
+        examples=["claude-sonnet-4-5", "$inputs.claude_model"],
+        json_schema_extra={
+            "values_metadata": MODEL_VERSION_METADATA,
+        },
+    )
+    extended_thinking: Optional[bool] = Field(
+        default=None,
+        description="Enable extended thinking for deeper reasoning on complex tasks. "
+        "Note: temperature cannot be used when extended thinking is enabled.",
+    )
+    thinking_budget_tokens: Optional[int] = Field(
+        default=None,
+        description="Maximum number of tokens for internal thinking when extended thinking is enabled. "
+        "Higher values allow deeper reasoning but increase latency and cost. "
+        "Must be less than max_tokens. Minimum: 1024.",
+        ge=1024,
+        json_schema_extra={
+            "relevant_for": {
+                "extended_thinking": {
+                    "values": [True],
+                    "required": False,
+                },
+            },
+        },
+    )
+    max_tokens: Optional[int] = Field(
+        default=None,
+        description="Maximum number of tokens the model can generate in its response.",
+    )
+    temperature: Optional[Union[float, Selector(kind=[FLOAT_KIND])]] = Field(
+        default=None,
+        description="Temperature to sample from the model - value in range 0.0-1.0, the higher - the more "
+        'random / "creative" the generations are. Cannot be used when extended_thinking is enabled.',
+        ge=0.0,
+        le=1.0,
+    )
+    max_image_size: Union[int, Selector(kind=[INTEGER_KIND])] = Field(
+        description="Maximum size of the image - if input has larger side, it will be downscaled, keeping aspect ratio",
+        default=1024,
+    )
+    max_concurrent_requests: Optional[int] = Field(
+        default=None,
+        description="Number of concurrent requests that can be executed by block when batch of input images provided. "
+        "If not given - block defaults to value configured globally in Workflows Execution Engine. "
+        "Please restrict if you hit Anthropic API limits.",
+    )
+
+    @model_validator(mode="after")
+    def validate(self) -> "BlockManifest":
+        if self.task_type in TASKS_REQUIRING_PROMPT and self.prompt is None:
+            raise ValueError(
+                f"`prompt` parameter required to be set for task `{self.task_type}`"
+            )
+        if self.task_type in TASKS_REQUIRING_CLASSES and self.classes is None:
+            raise ValueError(
+                f"`classes` parameter required to be set for task `{self.task_type}`"
+            )
+        if (
+            self.task_type in TASKS_REQUIRING_OUTPUT_STRUCTURE
+            and self.output_structure is None
+        ):
+            raise ValueError(
+                f"`output_structure` parameter required to be set for task `{self.task_type}`"
+            )
+        if self.extended_thinking:
+            if self.temperature is not None:
+                raise ValueError(
+                    "`temperature` cannot be used when `extended_thinking` is enabled"
+                )
+            budget_tokens = self.thinking_budget_tokens
+            max_tokens = self.max_tokens
+            if budget_tokens and max_tokens and budget_tokens >= max_tokens:
+                raise ValueError(
+                    f"`thinking_budget_tokens` ({budget_tokens}) must be less than `max_tokens` ({max_tokens})"
+                )
+        return self
+
+    @classmethod
+    def get_air_gapped_availability(cls) -> AirGappedAvailability:
+        return AirGappedAvailability(available=False, reason="requires_internet")
+
+    @classmethod
+    def get_parameters_accepting_batches(cls) -> List[str]:
+        return ["images"]
+
+    @classmethod
+    def describe_outputs(cls) -> List[OutputDefinition]:
+        return [
+            OutputDefinition(
+                name="output", kind=[STRING_KIND, LANGUAGE_MODEL_OUTPUT_KIND]
+            ),
+            OutputDefinition(name="classes", kind=[LIST_OF_VALUES_KIND]),
+            *TOKEN_OUTPUT_DEFINITIONS,
+        ]
+
+    @classmethod
+    def get_execution_engine_compatibility(cls) -> Optional[str]:
+        return ">=1.4.0,<2.0.0"
+
+    def discover_dependent_resources(self) -> Optional[List[DependentResource]]:
+        if is_workflow_selector(self.model_version):
+            # Selector returned verbatim; the attached resolver performs the
+            # EXACT_MODEL_VERSIONS lookup once the input value is substituted.
+            return [
+                third_party_model(
+                    provider="anthropic",
+                    model_id=self.model_version,
+                    model_id_resolver=lambda label: EXACT_MODEL_VERSIONS.get(
+                        label, label
+                    ),
+                )
+            ]
+        return [
+            third_party_model(
+                provider="anthropic",
+                model_id=EXACT_MODEL_VERSIONS.get(
+                    self.model_version, self.model_version
+                ),
+            )
+        ]
+
+
+class AnthropicClaudeBlockV4(WorkflowBlock):
+
+    def __init__(
+        self,
+        model_manager: ModelManager,
+        api_key: Optional[str],
+    ):
+        self._model_manager = model_manager
+        self._api_key = api_key
+
+    @classmethod
+    def get_init_parameters(cls) -> List[str]:
+        return ["model_manager", "api_key"]
+
+    @classmethod
+    def get_manifest(cls) -> Type[WorkflowBlockManifest]:
+        return BlockManifest
+
+    @classmethod
+    def get_execution_engine_compatibility(cls) -> Optional[str]:
+        return ">=1.4.0,<2.0.0"
+
+    def run(
+        self,
+        images: Batch[WorkflowImageData],
+        task_type: TaskType,
+        prompt: Optional[str],
+        output_structure: Optional[Dict[str, str]],
+        classes: Optional[List[str]],
+        model_version: str,
+        max_tokens: Optional[int],
+        temperature: Optional[float],
+        extended_thinking: Optional[bool],
+        thinking_budget_tokens: Optional[int],
+        max_image_size: int,
+        max_concurrent_requests: Optional[int],
+        api_key: str = "rf_key:account",
+    ) -> BlockResult:
+        inference_images = [i.to_inference_format() for i in images]
+        raw_outputs = run_claude_prompting(
+            roboflow_api_key=self._api_key,
+            images=inference_images,
+            task_type=task_type,
+            prompt=prompt,
+            output_structure=output_structure,
+            classes=classes,
+            anthropic_api_key=api_key,
+            model_version=model_version,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            extended_thinking=extended_thinking,
+            thinking_budget_tokens=thinking_budget_tokens,
+            max_image_size=max_image_size,
+            max_concurrent_requests=max_concurrent_requests,
+        )
+        return [
+            {
+                "output": content,
+                "classes": classes,
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+            }
+            for content, input_tokens, output_tokens in raw_outputs
+        ]
+
+
+def run_claude_prompting(
+    roboflow_api_key: Optional[str],
+    images: List[Dict[str, Any]],
+    task_type: TaskType,
+    prompt: Optional[str],
+    output_structure: Optional[Dict[str, str]],
+    classes: Optional[List[str]],
+    anthropic_api_key: str,
+    model_version: str,
+    max_tokens: Optional[int],
+    temperature: Optional[float],
+    extended_thinking: Optional[bool],
+    thinking_budget_tokens: Optional[int],
+    max_image_size: int,
+    max_concurrent_requests: Optional[int],
+) -> List[Tuple[str, Optional[int], Optional[int]]]:
+    if task_type not in PROMPT_BUILDERS:
+        raise ValueError(f"Task type: {task_type} not supported.")
+    prompts = []
+    for image in images:
+        loaded_image, _ = load_image(image)
+        loaded_image = downscale_image_keeping_aspect_ratio(
+            image=loaded_image, desired_size=(max_image_size, max_image_size)
+        )
+        base64_image = base64.b64encode(
+            encode_image_to_jpeg_bytes(loaded_image)
+        ).decode("ascii")
+        generated_prompt = PROMPT_BUILDERS[task_type](
+            base64_image=base64_image,
+            prompt=prompt,
+            output_structure=output_structure,
+            classes=classes,
+        )
+        prompts.append(generated_prompt)
+    return execute_claude_requests(
+        roboflow_api_key=roboflow_api_key,
+        anthropic_api_key=anthropic_api_key,
+        prompts=prompts,
+        model_version=model_version,
+        max_tokens=max_tokens,
+        temperature=temperature,
+        extended_thinking=extended_thinking,
+        thinking_budget_tokens=thinking_budget_tokens,
+        max_concurrent_requests=max_concurrent_requests,
+    )
+
+
+def execute_claude_requests(
+    roboflow_api_key: Optional[str],
+    anthropic_api_key: str,
+    prompts: List[Tuple[Optional[str], List[dict]]],
+    model_version: str,
+    max_tokens: Optional[int],
+    temperature: Optional[float],
+    extended_thinking: Optional[bool],
+    thinking_budget_tokens: Optional[int],
+    max_concurrent_requests: Optional[int],
+) -> List[Tuple[str, Optional[int], Optional[int]]]:
+    tasks = [
+        partial(
+            execute_claude_request,
+            roboflow_api_key=roboflow_api_key,
+            anthropic_api_key=anthropic_api_key,
+            system_prompt=prompt[0],
+            messages=prompt[1],
+            model_version=model_version,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            extended_thinking=extended_thinking,
+            thinking_budget_tokens=thinking_budget_tokens,
+        )
+        for prompt in prompts
+    ]
+    max_workers = (
+        max_concurrent_requests
+        or WORKFLOWS_REMOTE_EXECUTION_MAX_STEP_CONCURRENT_REQUESTS
+    )
+    return run_in_parallel(
+        tasks=tasks,
+        max_workers=max_workers,
+    )
+
+
+def execute_claude_request(
+    roboflow_api_key: Optional[str],
+    anthropic_api_key: str,
+    system_prompt: Optional[str],
+    messages: List[dict],
+    model_version: str,
+    max_tokens: Optional[int],
+    temperature: Optional[float],
+    extended_thinking: Optional[bool],
+    thinking_budget_tokens: Optional[int],
+) -> Tuple[str, Optional[int], Optional[int]]:
+    """Route to proxied or direct execution based on API key format."""
+    if anthropic_api_key.startswith(("rf_key:account", "rf_key:user:")):
+        return _execute_proxied_claude_request(
+            roboflow_api_key=roboflow_api_key,
+            anthropic_api_key=anthropic_api_key,
+            system_prompt=system_prompt,
+            messages=messages,
+            model_version=model_version,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            extended_thinking=extended_thinking,
+            thinking_budget_tokens=thinking_budget_tokens,
+        )
+    else:
+        return _execute_direct_claude_request(
+            anthropic_api_key=anthropic_api_key,
+            system_prompt=system_prompt,
+            messages=messages,
+            model_version=model_version,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            extended_thinking=extended_thinking,
+            thinking_budget_tokens=thinking_budget_tokens,
+        )
+
+
+def _execute_proxied_claude_request(
+    roboflow_api_key: str,
+    anthropic_api_key: str,
+    system_prompt: Optional[str],
+    messages: List[dict],
+    model_version: str,
+    max_tokens: Optional[int],
+    temperature: Optional[float],
+    extended_thinking: Optional[bool],
+    thinking_budget_tokens: Optional[int],
+) -> Tuple[str, Optional[int], Optional[int]]:
+    """Execute Claude request via Roboflow proxy."""
+    model_max_output = MAX_OUTPUT_TOKENS.get(model_version, DEFAULT_MAX_OUTPUT_TOKENS)
+    effective_max_tokens = max_tokens if max_tokens is not None else model_max_output
+
+    payload = {
+        "model": model_version,
+        "anthropic_api_key": anthropic_api_key,
+        "messages": messages,
+        "max_tokens": effective_max_tokens,
+    }
+
+    if system_prompt is not None:
+        payload["system"] = system_prompt
+
+    if temperature is not None and not extended_thinking:
+        payload["temperature"] = temperature
+
+    if extended_thinking:
+        effective_budget = (
+            thinking_budget_tokens
+            if thinking_budget_tokens is not None
+            else model_max_output // 2
+        )
+        payload["thinking"] = {
+            "type": "enabled",
+            "budget_tokens": effective_budget,
+        }
+
+    endpoint = "apiproxy/anthropic"
+
+    try:
+        response_data = post_to_roboflow_api(
+            endpoint=endpoint,
+            api_key=roboflow_api_key,
+            payload=payload,
+        )
+        text = _extract_claude_response_text(response_data)
+        input_tokens, output_tokens = parse_responses_api_usage(
+            response_data.get("usage")
+        )
+        return text, input_tokens, output_tokens
+    except requests.exceptions.RequestException as e:
+        raise RuntimeError(f"Failed to connect to Roboflow proxy: {e}") from e
+    except (KeyError, IndexError) as e:
+        raise RuntimeError(
+            f"Invalid response structure from Roboflow proxy: {e}"
+        ) from e
+
+
+def _execute_direct_claude_request(
+    anthropic_api_key: str,
+    system_prompt: Optional[str],
+    messages: List[dict],
+    model_version: str,
+    max_tokens: Optional[int],
+    temperature: Optional[float],
+    extended_thinking: Optional[bool],
+    thinking_budget_tokens: Optional[int],
+) -> Tuple[str, Optional[int], Optional[int]]:
+    """Execute Claude request directly to Anthropic API."""
+    client = anthropic.Anthropic(api_key=anthropic_api_key)
+
+    if system_prompt is None:
+        system_prompt = NOT_GIVEN
+
+    if temperature is None or extended_thinking:
+        temperature = NOT_GIVEN
+
+    model_max_output = MAX_OUTPUT_TOKENS.get(model_version, DEFAULT_MAX_OUTPUT_TOKENS)
+    effective_max_tokens = max_tokens if max_tokens is not None else model_max_output
+
+    request_params = {
+        "system": system_prompt,
+        "messages": messages,
+        "max_tokens": effective_max_tokens,
+        "model": EXACT_MODEL_VERSIONS.get(model_version, model_version),
+        "temperature": temperature,
+    }
+
+    if extended_thinking:
+        effective_budget = (
+            thinking_budget_tokens
+            if thinking_budget_tokens is not None
+            else model_max_output // 2
+        )
+        request_params["thinking"] = {
+            "type": "enabled",
+            "budget_tokens": effective_budget,
+        }
+
+    # Stream response to avoid max_tokens limitation
+    with client.messages.stream(**request_params) as stream:
+        result = stream.get_final_message()
+
+    text = _validate_and_extract_direct_response(result)
+    input_tokens, output_tokens = parse_responses_api_usage(
+        getattr(result, "usage", None)
+    )
+    return text, input_tokens, output_tokens
+
+
+def _validate_and_extract_direct_response(result) -> str:
+    """Validate and extract text from direct Anthropic API response."""
+    stop_reason = result.stop_reason
+
+    if stop_reason == "max_tokens":
+        raise ValueError(
+            "Claude API stopped generation because the max_tokens limit was reached. "
+            "Please increase the max_tokens parameter to allow for a complete response."
+        )
+
+    if stop_reason not in ["end_turn", "stop_sequence"]:
+        raise ValueError(
+            f"Claude API stopped generation with unexpected stop reason: {stop_reason}."
+        )
+
+    # Ignore thinking blocks and return text content
+    for block in result.content:
+        if block.type == "text":
+            return block.text
+
+    raise ValueError("Claude API returned no text content in response.")
+
+
+def _extract_claude_response_text(response_data: dict) -> str:
+    """Extract text content from Claude API response (proxied)."""
+    stop_reason = response_data.get("stop_reason")
+
+    if stop_reason == "max_tokens":
+        raise ValueError(
+            "Claude API stopped generation because the max_tokens limit was reached. "
+            "Please increase the max_tokens parameter to allow for a complete response."
+        )
+
+    if stop_reason not in ["end_turn", "stop_sequence", None]:
+        raise ValueError(
+            f"Claude API stopped generation with unexpected stop reason: {stop_reason}."
+        )
+
+    content = response_data.get("content", [])
+    if not content:
+        raise ValueError("Claude API returned no content in response.")
+
+    # Ignore thinking blocks and return text content
+    for block in content:
+        if isinstance(block, dict) and block.get("type") == "text":
+            return block.get("text", "")
+
+    raise ValueError("Claude API returned no text content in response.")
+
+
+def prepare_unconstrained_prompt(
+    base64_image: str,
+    prompt: str,
+    **kwargs,
+) -> Tuple[Optional[str], List[dict]]:
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": "image/jpeg",
+                        "data": base64_image,
+                    },
+                },
+                {
+                    "type": "text",
+                    "text": prompt,
+                },
+            ],
+        }
+    ]
+    return None, messages
+
+
+def prepare_classification_prompt(
+    base64_image: str,
+    classes: List[str],
+    **kwargs,
+) -> Tuple[Optional[str], List[dict]]:
+    serialised_classes = ", ".join(classes)
+    system_prompt = (
+        "You act as single-class classification model. You must provide reasonable predictions. "
+        "You are only allowed to produce JSON document. "
+        'Expected structure of json: {"class_name": "class-name", "confidence": 0.4}. '
+        "`class-name` must be one of the class names defined by user. You are only allowed to return "
+        "single JSON document, even if there are potentially multiple classes. You are not allowed to "
+        "return list."
+    )
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": "image/jpeg",
+                        "data": base64_image,
+                    },
+                },
+                {
+                    "type": "text",
+                    "text": f"List of all classes to be recognised by model: {serialised_classes}",
+                },
+            ],
+        }
+    ]
+    return system_prompt, messages
+
+
+def prepare_multi_label_classification_prompt(
+    base64_image: str,
+    classes: List[str],
+    **kwargs,
+) -> Tuple[Optional[str], List[dict]]:
+    serialised_classes = ", ".join(classes)
+    system_prompt = (
+        "You act as multi-label classification model. You must provide reasonable predictions. "
+        "You are only allowed to produce JSON document. "
+        'Expected structure of json: {"predicted_classes": [{"class": "class-name-1", "confidence": 0.9}, '
+        '{"class": "class-name-2", "confidence": 0.7}]}.'
+        "`class-name-X` must be one of the class names defined by user and `confidence` is a float value "
+        "in range 0.0-1.0 that represents how sure you are that the class is present in the image. "
+        "Only return class names that are visible."
+    )
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": "image/jpeg",
+                        "data": base64_image,
+                    },
+                },
+                {
+                    "type": "text",
+                    "text": f"List of all classes to be recognised by model: {serialised_classes}",
+                },
+            ],
+        }
+    ]
+    return system_prompt, messages
+
+
+def prepare_vqa_prompt(
+    base64_image: str,
+    prompt: str,
+    **kwargs,
+) -> Tuple[Optional[str], List[dict]]:
+    system_prompt = (
+        "You act as Visual Question Answering model. Your task is to provide answer to question"
+        "submitted by user. If this is open-question - answer with few sentences, for ABCD question, "
+        "return only the indicator of the answer."
+    )
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": "image/jpeg",
+                        "data": base64_image,
+                    },
+                },
+                {
+                    "type": "text",
+                    "text": f"Question: {prompt}",
+                },
+            ],
+        }
+    ]
+    return system_prompt, messages
+
+
+def prepare_ocr_prompt(
+    base64_image: str,
+    **kwargs,
+) -> Tuple[Optional[str], List[dict]]:
+    system_prompt = (
+        "You act as OCR model. Your task is to read text from the image and return it in "
+        "paragraphs representing the structure of texts in the image. You should only return "
+        "recognised text, nothing else."
+    )
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": "image/jpeg",
+                        "data": base64_image,
+                    },
+                },
+            ],
+        }
+    ]
+    return system_prompt, messages
+
+
+def prepare_caption_prompt(
+    base64_image: str,
+    short_description: bool,
+    **kwargs,
+) -> Tuple[Optional[str], List[dict]]:
+    caption_detail_level = "Caption should be short."
+    if not short_description:
+        caption_detail_level = "Caption should be extensive."
+    system_prompt = (
+        f"You act as image caption model. Your task is to provide description of the image. "
+        f"{caption_detail_level}"
+    )
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": "image/jpeg",
+                        "data": base64_image,
+                    },
+                },
+            ],
+        }
+    ]
+    return system_prompt, messages
+
+
+def prepare_structured_answering_prompt(
+    base64_image: str,
+    output_structure: Dict[str, str],
+    **kwargs,
+) -> Tuple[Optional[str], List[dict]]:
+    output_structure_serialised = json.dumps(output_structure, indent=4)
+    system_prompt = (
+        "You are supposed to produce responses in JSON. User is to provide you dictionary with "
+        "keys and values. Each key must be present in your response. Values in user dictionary "
+        "represent descriptions for JSON fields to be generated. Provide only JSON in response."
+    )
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": "image/jpeg",
+                        "data": base64_image,
+                    },
+                },
+                {
+                    "type": "text",
+                    "text": f"Specification of requirements regarding output fields: \n"
+                    f"{output_structure_serialised}",
+                },
+            ],
+        }
+    ]
+    return system_prompt, messages
+
+
+def prepare_object_detection_prompt(
+    base64_image: str,
+    classes: List[str],
+    **kwargs,
+) -> Tuple[Optional[str], List[dict]]:
+    serialised_classes = ", ".join(classes)
+    system_prompt = (
+        "You act as object-detection model. You must provide reasonable predictions. "
+        "You are only allowed to produce JSON document. "
+        'Expected structure of json: {"detections": [{"x_min": 0.1, "y_min": 0.2, "x_max": 0.3, "y_max": 0.4, "class_name": "my-class-X", "confidence": 0.7}]} '
+        "- remember to close top-level dictionary at the end. "
+        "`my-class-X` must be one of the class names defined by user. All coordinates must be in range 0.0-1.0, representing percentage of image dimensions. "
+        "`confidence` is a value in range 0.0-1.0 representing your confidence in prediction. You should detect all instances of classes provided by user."
+    )
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": "image/jpeg",
+                        "data": base64_image,
+                    },
+                },
+                {
+                    "type": "text",
+                    "text": f"List of all classes to be recognised by model: {serialised_classes}",
+                },
+            ],
+        }
+    ]
+    return system_prompt, messages
+
+
+PROMPT_BUILDERS = {
+    "unconstrained": prepare_unconstrained_prompt,
+    "ocr": prepare_ocr_prompt,
+    "visual-question-answering": prepare_vqa_prompt,
+    "caption": partial(prepare_caption_prompt, short_description=True),
+    "detailed-caption": partial(prepare_caption_prompt, short_description=False),
+    "classification": prepare_classification_prompt,
+    "multi-label-classification": prepare_multi_label_classification_prompt,
+    "structured-answering": prepare_structured_answering_prompt,
+    "object-detection": prepare_object_detection_prompt,
+}

--- a/inference/core/workflows/core_steps/models/foundation/google_gemini/v5.py
+++ b/inference/core/workflows/core_steps/models/foundation/google_gemini/v5.py
@@ -1,0 +1,1101 @@
+import base64
+import json
+import re
+from functools import partial
+from typing import Any, Dict, List, Literal, Optional, Tuple, Type, Union
+
+import requests
+from pydantic import ConfigDict, Field, field_validator, model_validator
+from requests import Response
+
+from inference.core.env import WORKFLOWS_REMOTE_EXECUTION_MAX_STEP_CONCURRENT_REQUESTS
+from inference.core.managers.base import ModelManager
+from inference.core.roboflow_api import post_to_roboflow_api
+from inference.core.utils.image_utils import encode_image_to_jpeg_bytes, load_image
+from inference.core.workflows.core_steps.common.token_usage import (
+    TOKEN_OUTPUT_DEFINITIONS,
+    parse_gemini_usage_metadata,
+)
+from inference.core.workflows.core_steps.common.utils import run_in_parallel
+from inference.core.workflows.core_steps.common.vlms import VLM_TASKS_METADATA
+from inference.core.workflows.execution_engine.entities.base import (
+    Batch,
+    OutputDefinition,
+    WorkflowImageData,
+)
+from inference.core.workflows.execution_engine.entities.types import (
+    BOOLEAN_KIND,
+    FLOAT_KIND,
+    IMAGE_KIND,
+    LANGUAGE_MODEL_OUTPUT_KIND,
+    LIST_OF_VALUES_KIND,
+    ROBOFLOW_MANAGED_KEY,
+    SECRET_KIND,
+    STRING_KIND,
+    ImageInputField,
+    Selector,
+)
+from inference.core.workflows.prototypes.block import (
+    AirGappedAvailability,
+    BlockResult,
+    DependentResource,
+    WorkflowBlock,
+    WorkflowBlockManifest,
+    third_party_model,
+)
+
+GOOGLE_API_KEY_PATTERN = re.compile(r"key=(.[^&]*)")
+GOOGLE_API_KEY_VALUE_GROUP = 1
+MIN_KEY_LENGTH_TO_REVEAL_PREFIX = 8
+
+MODEL_ALIASES = {
+    "gemini-2.5-pro-preview-06-05": "gemini-2.5-pro",
+    "gemini-2.5-pro-preview-05-06": "gemini-2.5-pro",
+    "gemini-2.5-pro-preview-03-25": "gemini-2.5-pro",
+}
+
+GEMINI_MODELS = [
+    {
+        "id": "gemini-3.7-flash",
+        "name": "Gemini 3.7 Flash",
+        "supports_thinking_level": True,
+        "supports_native_code_execution": True,
+    },
+    {
+        "id": "gemini-3.6-flash",
+        "name": "Gemini 3.6 Flash",
+        "supports_thinking_level": True,
+        "supports_native_code_execution": True,
+    },
+    {
+        "id": "gemini-3.5-flash",
+        "name": "Gemini 3.5 Flash",
+        "supports_thinking_level": True,
+        "supports_native_code_execution": True,
+    },
+    {
+        "id": "gemini-3.5-flash-lite",
+        "name": "Gemini 3.5 Flash-Lite",
+        "supports_thinking_level": True,
+        "supports_native_code_execution": True,
+    },
+    {
+        "id": "gemini-3.1-pro-preview",
+        "name": "Gemini 3.1 Pro",
+        "supports_thinking_level": True,
+        "supports_native_code_execution": True,
+    },
+    {
+        "id": "gemini-3.1-flash-lite",
+        "name": "Gemini 3.1 Flash-Lite",
+        "supports_thinking_level": True,
+        "supports_native_code_execution": True,
+    },
+    {
+        "id": "gemini-3-flash-preview",
+        "name": "Gemini 3 Flash",
+        "supports_thinking_level": True,
+        "supports_native_code_execution": True,
+    },
+    {
+        "id": "gemini-2.5-pro",
+        "name": "Gemini 2.5 Pro",
+        "supports_thinking_level": False,
+        "supports_native_code_execution": False,
+    },
+    {
+        "id": "gemini-2.5-flash",
+        "name": "Gemini 2.5 Flash",
+        "supports_thinking_level": False,
+        "supports_native_code_execution": False,
+    },
+    {
+        "id": "gemini-2.5-flash-lite",
+        "name": "Gemini 2.5 Flash-Lite",
+        "supports_thinking_level": False,
+        "supports_native_code_execution": False,
+    },
+]
+
+MODEL_VERSION_IDS = [model["id"] for model in GEMINI_MODELS]
+
+MODEL_VERSION_METADATA = {
+    model["id"]: {"name": model["name"]} for model in GEMINI_MODELS
+}
+
+MODELS_SUPPORTING_THINKING_LEVEL = [
+    model["id"] for model in GEMINI_MODELS if model["supports_thinking_level"]
+]
+
+MODELS_SUPPORTING_NATIVE_CODE_EXECUTION = [
+    model["id"] for model in GEMINI_MODELS if model["supports_native_code_execution"]
+]
+
+MODELS_NOT_SUPPORTING_THINKING_LEVEL = [
+    model["id"] for model in GEMINI_MODELS if not model["supports_thinking_level"]
+]
+
+SUPPORTED_TASK_TYPES_LIST = [
+    "unconstrained",
+    "ocr",
+    "structured-answering",
+    "classification",
+    "multi-label-classification",
+    "visual-question-answering",
+    "caption",
+    "detailed-caption",
+    "object-detection",
+]
+SUPPORTED_TASK_TYPES = set(SUPPORTED_TASK_TYPES_LIST)
+
+RELEVANT_TASKS_METADATA = {
+    k: v for k, v in VLM_TASKS_METADATA.items() if k in SUPPORTED_TASK_TYPES
+}
+RELEVANT_TASKS_METADATA["object-detection"] = {
+    "name": "Object Detection",
+    "description": "Model detects bounding boxes for the provided classes, "
+    "returning a Gemini-native `box_2d` JSON list (y_min, x_min, y_max, x_max "
+    "integers normalized to 0-1000). Parse the output with "
+    "`roboflow_core/vlm_as_detector@v2`.",
+}
+RELEVANT_TASKS_DOCS_DESCRIPTION = "\n\n".join(
+    f"* **{v['name']}** (`{k}`) - {v['description']}"
+    for k, v in RELEVANT_TASKS_METADATA.items()
+)
+
+LONG_DESCRIPTION = f"""
+Ask a question to Google's Gemini model with vision capabilities.
+
+You can specify arbitrary text prompts or predefined ones, the block supports the following types of prompt:
+
+{RELEVANT_TASKS_DOCS_DESCRIPTION}
+
+### API Key Options
+
+This block supports two API key modes:
+
+1. **Roboflow Managed API Key (Default)** - Use `rf_key:account` to proxy requests through Roboflow's API:
+   * **Simplified setup** - no Google AI API key required
+   * **Secure** - your workflow API key is used for authentication
+   * **Usage-based billing** - charged per token based on the model used
+
+2. **Custom Google AI API Key** - Provide your own Google AI API key:
+   * Full control over API usage
+   * You pay Google directly
+
+**WARNING!**
+
+This block makes use of `/v1beta` API of Google Gemini model - the implementation may change
+in the future, without guarantee of backward compatibility.
+"""
+
+TaskType = Literal[tuple(SUPPORTED_TASK_TYPES_LIST)]
+
+TASKS_REQUIRING_PROMPT = {
+    "unconstrained",
+    "visual-question-answering",
+}
+
+TASKS_REQUIRING_CLASSES = {
+    "classification",
+    "multi-label-classification",
+    "object-detection",
+}
+
+TASKS_REQUIRING_OUTPUT_STRUCTURE = {
+    "structured-answering",
+}
+
+
+class BlockManifest(WorkflowBlockManifest):
+    model_config = ConfigDict(
+        json_schema_extra={
+            "name": "Google Gemini",
+            "version": "v5",
+            "short_description": "Run Google's Gemini model with vision capabilities.",
+            "long_description": LONG_DESCRIPTION,
+            "license": "Apache-2.0",
+            "block_type": "model",
+            "search_keywords": ["LMM", "VLM", "Gemini", "Google"],
+            "is_vlm_block": True,
+            "task_type_property": "task_type",
+            "ui_manifest": {
+                "section": "model",
+                "icon": "fa-brands fa-google",
+                "blockPriority": 5,
+                "popular": True,
+            },
+        },
+        protected_namespaces=(),
+    )
+    type: Literal["roboflow_core/google_gemini@v5"]
+    images: Selector(kind=[IMAGE_KIND]) = ImageInputField
+    task_type: TaskType = Field(
+        default="unconstrained",
+        description="Task type to be performed by model. Value determines required parameters and output response.",
+        json_schema_extra={
+            "values_metadata": RELEVANT_TASKS_METADATA,
+            "recommended_parsers": {
+                "structured-answering": "roboflow_core/json_parser@v1",
+                "classification": "roboflow_core/vlm_as_classifier@v2",
+                "multi-label-classification": "roboflow_core/vlm_as_classifier@v2",
+                "object-detection": "roboflow_core/vlm_as_detector@v2",
+            },
+            "always_visible": True,
+        },
+    )
+    prompt: Optional[Union[Selector(kind=[STRING_KIND]), str]] = Field(
+        default=None,
+        description="Text prompt to the Gemini model",
+        examples=["my prompt", "$inputs.prompt"],
+        json_schema_extra={
+            "relevant_for": {
+                "task_type": {"values": TASKS_REQUIRING_PROMPT, "required": True},
+            },
+            "multiline": True,
+        },
+    )
+    output_structure: Optional[Dict[str, str]] = Field(
+        default=None,
+        description="Dictionary with structure of expected JSON response",
+        examples=[{"my_key": "description"}, "$inputs.output_structure"],
+        json_schema_extra={
+            "relevant_for": {
+                "task_type": {
+                    "values": TASKS_REQUIRING_OUTPUT_STRUCTURE,
+                    "required": True,
+                },
+            },
+        },
+    )
+    classes: Optional[Union[Selector(kind=[LIST_OF_VALUES_KIND]), List[str]]] = Field(
+        default=None,
+        description="List of classes to be used",
+        examples=[["class-a", "class-b"], "$inputs.classes"],
+        json_schema_extra={
+            "relevant_for": {
+                "task_type": {
+                    "values": TASKS_REQUIRING_CLASSES,
+                    "required": True,
+                },
+            },
+        },
+    )
+    api_key: Union[
+        Selector(kind=[STRING_KIND, SECRET_KIND, ROBOFLOW_MANAGED_KEY]), str
+    ] = Field(
+        default="rf_key:account",
+        description="Your Google AI API key or 'rf_key:account' to use Roboflow's managed API key",
+        examples=["rf_key:account", "xxx-xxx", "$inputs.google_api_key"],
+        private=True,
+    )
+    model_version: Union[
+        Selector(kind=[STRING_KIND]),
+        Literal[tuple(MODEL_VERSION_IDS)],
+    ] = Field(
+        default="gemini-3.1-pro-preview",
+        description="Model to be used",
+        examples=["gemini-3.1-pro-preview", "$inputs.gemini_model"],
+        json_schema_extra={
+            "values_metadata": MODEL_VERSION_METADATA,
+        },
+    )
+    thinking_level: Optional[
+        Union[
+            Selector(kind=[STRING_KIND]),
+            Literal["low", "high"],
+        ]
+    ] = Field(
+        default=None,
+        description="Controls the depth of internal reasoning for Gemini 3+ models. "
+        "'low' minimizes latency and cost (best for simple tasks), 'high' maximizes reasoning depth. "
+        "When unset, the Google API default for the selected model is used. "
+        "Only supported by Gemini 3 and newer models.",
+        json_schema_extra={
+            "relevant_for": {
+                "model_version": {
+                    "values": MODELS_SUPPORTING_THINKING_LEVEL,
+                    "required": False,
+                },
+            },
+        },
+    )
+    temperature: Optional[Union[float, Selector(kind=[FLOAT_KIND])]] = Field(
+        default=None,
+        description="Temperature to sample from the model - value in range 0.0-2.0, the higher - the more "
+        'random / "creative" the generations are.',
+        ge=0.0,
+        le=2.0,
+        json_schema_extra={
+            "relevant_for": {
+                "model_version": {
+                    "values": MODELS_NOT_SUPPORTING_THINKING_LEVEL,
+                    "required": False,
+                },
+            },
+        },
+    )
+    max_tokens: Optional[int] = Field(
+        default=None,
+        description="Maximum number of tokens the model can generate in it's response. "
+        "If not specified, the model will use its default limit.",
+    )
+    google_code_execution: Optional[Union[bool, Selector(kind=[BOOLEAN_KIND])]] = Field(
+        default=False,
+        description="Enable native code execution for the Gemini model.",
+        json_schema_extra={
+            "relevant_for": {
+                "model_version": {
+                    "values": MODELS_SUPPORTING_NATIVE_CODE_EXECUTION,
+                    "required": False,
+                },
+            },
+        },
+    )
+    max_concurrent_requests: Optional[int] = Field(
+        default=None,
+        description="Number of concurrent requests that can be executed by block when batch of input images provided. "
+        "If not given - block defaults to value configured globally in Workflows Execution Engine. "
+        "Please restrict if you hit Google Gemini API limits.",
+    )
+
+    @classmethod
+    def get_air_gapped_availability(cls) -> AirGappedAvailability:
+        return AirGappedAvailability(available=False, reason="requires_internet")
+
+    @field_validator("model_version", mode="before")
+    @classmethod
+    def validate_model_version(cls, value):
+        if isinstance(value, str) and value in MODEL_ALIASES:
+            return MODEL_ALIASES[value]
+        return value
+
+    @model_validator(mode="after")
+    def validate(self) -> "BlockManifest":
+        if self.task_type in TASKS_REQUIRING_PROMPT and self.prompt is None:
+            raise ValueError(
+                f"`prompt` parameter required to be set for task `{self.task_type}`"
+            )
+        if self.task_type in TASKS_REQUIRING_CLASSES and self.classes is None:
+            raise ValueError(
+                f"`classes` parameter required to be set for task `{self.task_type}`"
+            )
+        if (
+            self.task_type in TASKS_REQUIRING_OUTPUT_STRUCTURE
+            and self.output_structure is None
+        ):
+            raise ValueError(
+                f"`output_structure` parameter required to be set for task `{self.task_type}`"
+            )
+        return self
+
+    @classmethod
+    def get_parameters_accepting_batches(cls) -> List[str]:
+        return ["images"]
+
+    @classmethod
+    def describe_outputs(cls) -> List[OutputDefinition]:
+        return [
+            OutputDefinition(
+                name="output", kind=[STRING_KIND, LANGUAGE_MODEL_OUTPUT_KIND]
+            ),
+            OutputDefinition(name="classes", kind=[LIST_OF_VALUES_KIND]),
+            *TOKEN_OUTPUT_DEFINITIONS,
+        ]
+
+    @classmethod
+    def get_execution_engine_compatibility(cls) -> Optional[str]:
+        return ">=1.4.0,<2.0.0"
+
+    def discover_dependent_resources(self) -> Optional[List[DependentResource]]:
+        return [third_party_model(provider="google", model_id=self.model_version)]
+
+
+class GoogleGeminiBlockV5(WorkflowBlock):
+
+    def __init__(
+        self,
+        model_manager: ModelManager,
+        api_key: Optional[str],
+    ):
+        self._model_manager = model_manager
+        self._api_key = api_key
+
+    @classmethod
+    def get_init_parameters(cls) -> List[str]:
+        return ["model_manager", "api_key"]
+
+    @classmethod
+    def get_manifest(cls) -> Type[WorkflowBlockManifest]:
+        return BlockManifest
+
+    @classmethod
+    def get_execution_engine_compatibility(cls) -> Optional[str]:
+        return ">=1.4.0,<2.0.0"
+
+    def run(
+        self,
+        images: Batch[WorkflowImageData],
+        task_type: TaskType,
+        prompt: Optional[str],
+        output_structure: Optional[Dict[str, str]],
+        classes: Optional[List[str]],
+        model_version: str,
+        max_tokens: Optional[int],
+        temperature: Optional[float],
+        thinking_level: Optional[str],
+        google_code_execution: Optional[bool],
+        max_concurrent_requests: Optional[int],
+        api_key: str = "rf_key:account",
+    ) -> BlockResult:
+        inference_images = [i.to_inference_format() for i in images]
+        raw_outputs = run_gemini_prompting(
+            roboflow_api_key=self._api_key,
+            images=inference_images,
+            task_type=task_type,
+            prompt=prompt,
+            output_structure=output_structure,
+            classes=classes,
+            google_api_key=api_key,
+            model_version=model_version,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            thinking_level=thinking_level,
+            google_code_execution=google_code_execution,
+            max_concurrent_requests=max_concurrent_requests,
+        )
+        return [
+            {
+                "output": content,
+                "classes": classes,
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+            }
+            for content, input_tokens, output_tokens in raw_outputs
+        ]
+
+
+def run_gemini_prompting(
+    roboflow_api_key: Optional[str],
+    images: List[Dict[str, Any]],
+    task_type: TaskType,
+    prompt: Optional[str],
+    output_structure: Optional[Dict[str, str]],
+    classes: Optional[List[str]],
+    google_api_key: str,
+    model_version: str,
+    max_tokens: Optional[int],
+    temperature: Optional[float],
+    thinking_level: Optional[str],
+    google_code_execution: Optional[bool],
+    max_concurrent_requests: Optional[int],
+) -> List[Tuple[str, Optional[int], Optional[int]]]:
+    if task_type not in PROMPT_BUILDERS:
+        raise ValueError(f"Task type: {task_type} not supported.")
+    gemini_prompts = []
+    for image in images:
+        loaded_image, _ = load_image(image)
+        base64_image = base64.b64encode(
+            encode_image_to_jpeg_bytes(loaded_image)
+        ).decode("ascii")
+        generated_prompt = PROMPT_BUILDERS[task_type](
+            base64_image=base64_image,
+            prompt=prompt,
+            output_structure=output_structure,
+            classes=classes,
+            model_version=model_version,
+            temperature=temperature,
+            thinking_level=thinking_level,
+            max_tokens=max_tokens,
+        )
+
+        if (
+            google_code_execution
+            and model_version in MODELS_SUPPORTING_NATIVE_CODE_EXECUTION
+        ):
+            generated_prompt["tools"] = [{"code_execution": {}}]
+
+        gemini_prompts.append(generated_prompt)
+    return execute_gemini_requests(
+        roboflow_api_key=roboflow_api_key,
+        google_api_key=google_api_key,
+        gemini_prompts=gemini_prompts,
+        model_version=model_version,
+        max_concurrent_requests=max_concurrent_requests,
+    )
+
+
+def execute_gemini_requests(
+    roboflow_api_key: Optional[str],
+    google_api_key: str,
+    gemini_prompts: List[dict],
+    model_version: str,
+    max_concurrent_requests: Optional[int],
+) -> List[Tuple[str, Optional[int], Optional[int]]]:
+    tasks = [
+        partial(
+            execute_gemini_request,
+            roboflow_api_key=roboflow_api_key,
+            google_api_key=google_api_key,
+            prompt=prompt,
+            model_version=model_version,
+        )
+        for prompt in gemini_prompts
+    ]
+    max_workers = (
+        max_concurrent_requests
+        or WORKFLOWS_REMOTE_EXECUTION_MAX_STEP_CONCURRENT_REQUESTS
+    )
+    return run_in_parallel(
+        tasks=tasks,
+        max_workers=max_workers,
+    )
+
+
+def execute_gemini_request(
+    roboflow_api_key: Optional[str],
+    google_api_key: str,
+    prompt: dict,
+    model_version: str,
+) -> Tuple[str, Optional[int], Optional[int]]:
+    """Route to proxied or direct execution based on API key format."""
+    if google_api_key.startswith(("rf_key:account", "rf_key:user:")):
+        return _execute_proxied_gemini_request(
+            roboflow_api_key=roboflow_api_key,
+            google_api_key=google_api_key,
+            prompt=prompt,
+            model_version=model_version,
+        )
+    else:
+        return _execute_direct_gemini_request(
+            google_api_key=google_api_key,
+            prompt=prompt,
+            model_version=model_version,
+        )
+
+
+def _execute_proxied_gemini_request(
+    roboflow_api_key: str,
+    google_api_key: str,
+    prompt: dict,
+    model_version: str,
+) -> Tuple[str, Optional[int], Optional[int]]:
+    """Execute Gemini request via Roboflow proxy."""
+    payload = {
+        "model": model_version,
+        "google_api_key": google_api_key,
+        **prompt,  # Contains contents, generationConfig, systemInstruction
+    }
+
+    endpoint = "apiproxy/gemini"
+
+    try:
+        response_data = post_to_roboflow_api(
+            endpoint=endpoint,
+            api_key=roboflow_api_key,
+            payload=payload,
+        )
+        text = _extract_gemini_response_text(response_data)
+        input_tokens, output_tokens = parse_gemini_usage_metadata(
+            response_data.get("usageMetadata")
+        )
+        return text, input_tokens, output_tokens
+    except requests.exceptions.RequestException as e:
+        raise RuntimeError(f"Failed to connect to Roboflow proxy: {e}") from e
+    except (KeyError, IndexError) as e:
+        raise RuntimeError(
+            f"Invalid response structure from Roboflow proxy: {e}"
+        ) from e
+
+
+def _execute_direct_gemini_request(
+    google_api_key: str,
+    prompt: dict,
+    model_version: str,
+) -> Tuple[str, Optional[int], Optional[int]]:
+    """Execute Gemini request directly to Google API."""
+    response = requests.post(
+        f"https://generativelanguage.googleapis.com/v1beta/models/{model_version}:generateContent",
+        headers={
+            "Content-Type": "application/json",
+            "x-goog-api-key": google_api_key,
+        },
+        json=prompt,
+        timeout=120,
+    )
+    response_data = response.json()
+    google_api_key_safe_raise_for_status(response=response)
+    text = _extract_gemini_response_text(response_data)
+    input_tokens, output_tokens = parse_gemini_usage_metadata(
+        response_data.get("usageMetadata")
+    )
+    return text, input_tokens, output_tokens
+
+
+def _extract_gemini_response_text(response_data: dict) -> str:
+    """Extract text content from Gemini API response."""
+    if "candidates" not in response_data or not response_data["candidates"]:
+        raise ValueError("Gemini API returned no response candidates.")
+
+    candidate = response_data["candidates"][0]
+    finish_reason = candidate.get("finishReason", "FINISH_REASON_UNSPECIFIED")
+
+    if finish_reason == "MAX_TOKENS":
+        raise ValueError(
+            "Gemini API stopped generation because the max_tokens limit was reached. "
+            "Please increase the max_tokens parameter to allow for a complete response."
+        )
+
+    # Check for values different than natural stop or unspecified
+    if finish_reason not in ["STOP", "FINISH_REASON_UNSPECIFIED"]:
+        raise ValueError(
+            f"Gemini API stopped generation with finish reason: {finish_reason}."
+        )
+
+    try:
+        parts = candidate["content"]["parts"]
+        # If code execution is enabled there will be multiple parts (with "executableCode" and "inlineData" fields)
+        for part in parts:
+            if "text" in part:
+                return part["text"]
+
+        # Fallback if no parts are recognized
+        return parts[0]["text"]
+
+    except (KeyError, IndexError, TypeError):
+        raise ValueError("Unable to parse Gemini API response.")
+
+
+def prepare_unconstrained_prompt(
+    base64_image: str,
+    prompt: str,
+    model_version: str,
+    temperature: Optional[float],
+    thinking_level: Optional[str],
+    max_tokens: Optional[int],
+    **kwargs,
+) -> dict:
+    return {
+        "contents": {
+            "parts": [
+                {
+                    "inline_data": {
+                        "mime_type": "image/jpeg",
+                        "data": base64_image,
+                    }
+                },
+                {
+                    "text": prompt,
+                },
+            ],
+            "role": "user",
+        },
+        "generationConfig": prepare_generation_config(
+            max_tokens=max_tokens,
+            temperature=temperature,
+            thinking_level=thinking_level,
+            model_version=model_version,
+        ),
+    }
+
+
+def prepare_classification_prompt(
+    base64_image: str,
+    classes: List[str],
+    model_version: str,
+    temperature: Optional[float],
+    thinking_level: Optional[str],
+    max_tokens: Optional[int],
+    **kwargs,
+) -> dict:
+    serialised_classes = ", ".join(classes)
+    return {
+        "systemInstruction": {
+            "role": "system",
+            "parts": [
+                {
+                    "text": "You act as single-class classification model. You must provide reasonable predictions. "
+                    "You are only allowed to produce JSON document. "
+                    'Expected structure of json: {"class_name": "class-name", "confidence": 0.4}. '
+                    "`class-name` must be one of the class names defined by user. You are only allowed to return "
+                    "single JSON document, even if there are potentially multiple classes. You are not allowed to "
+                    "return list.",
+                }
+            ],
+        },
+        "contents": {
+            "parts": [
+                {
+                    "inline_data": {
+                        "mime_type": "image/jpeg",
+                        "data": base64_image,
+                    }
+                },
+                {
+                    "text": f"List of all classes to be recognised by model: {serialised_classes}",
+                },
+            ],
+            "role": "user",
+        },
+        "generationConfig": prepare_generation_config(
+            max_tokens=max_tokens,
+            temperature=temperature,
+            thinking_level=thinking_level,
+            model_version=model_version,
+            response_mime_type="application/json",
+        ),
+    }
+
+
+def prepare_multi_label_classification_prompt(
+    base64_image: str,
+    classes: List[str],
+    model_version: str,
+    temperature: Optional[float],
+    thinking_level: Optional[str],
+    max_tokens: Optional[int],
+    **kwargs,
+) -> dict:
+    serialised_classes = ", ".join(classes)
+    return {
+        "systemInstruction": {
+            "role": "system",
+            "parts": [
+                {
+                    "text": "You act as multi-label classification model. You must provide reasonable predictions. "
+                    "You are only allowed to produce JSON document. "
+                    'Expected structure of json: {"predicted_classes": [{"class": "class-name-1", "confidence": 0.9}, '
+                    '{"class": "class-name-2", "confidence": 0.7}]}. '
+                    "`class-name-X` must be one of the class names defined by user and `confidence` is a float value "
+                    "in range 0.0-1.0 that represents how sure you are that the class is present in the image. "
+                    "Only return class names that are visible.",
+                }
+            ],
+        },
+        "contents": {
+            "parts": [
+                {
+                    "inline_data": {
+                        "mime_type": "image/jpeg",
+                        "data": base64_image,
+                    }
+                },
+                {
+                    "text": f"List of all classes to be recognised by model: {serialised_classes}",
+                },
+            ],
+            "role": "user",
+        },
+        "generationConfig": prepare_generation_config(
+            max_tokens=max_tokens,
+            temperature=temperature,
+            thinking_level=thinking_level,
+            model_version=model_version,
+            response_mime_type="application/json",
+        ),
+    }
+
+
+def prepare_vqa_prompt(
+    base64_image: str,
+    prompt: str,
+    model_version: str,
+    temperature: Optional[float],
+    thinking_level: Optional[str],
+    max_tokens: Optional[int],
+    **kwargs,
+) -> dict:
+    return {
+        "systemInstruction": {
+            "role": "system",
+            "parts": [
+                {
+                    "text": "You act as Visual Question Answering model. Your task is to provide answer to question"
+                    "submitted by user. If this is open-question - answer with few sentences, for ABCD question, "
+                    "return only the indicator of the answer.",
+                }
+            ],
+        },
+        "contents": {
+            "parts": [
+                {
+                    "inline_data": {
+                        "mime_type": "image/jpeg",
+                        "data": base64_image,
+                    }
+                },
+                {
+                    "text": f"Question: {prompt}",
+                },
+            ],
+            "role": "user",
+        },
+        "generationConfig": prepare_generation_config(
+            max_tokens=max_tokens,
+            temperature=temperature,
+            thinking_level=thinking_level,
+            model_version=model_version,
+        ),
+    }
+
+
+def prepare_ocr_prompt(
+    base64_image: str,
+    model_version: str,
+    temperature: Optional[float],
+    thinking_level: Optional[str],
+    max_tokens: Optional[int],
+    **kwargs,
+) -> dict:
+    return {
+        "systemInstruction": {
+            "role": "system",
+            "parts": [
+                {
+                    "text": "You act as OCR model. Your task is to read text from the image and return it in "
+                    "paragraphs representing the structure of texts in the image. You should only return "
+                    "recognised text, nothing else.",
+                }
+            ],
+        },
+        "contents": {
+            "parts": [
+                {
+                    "inline_data": {
+                        "mime_type": "image/jpeg",
+                        "data": base64_image,
+                    }
+                },
+                {
+                    "text": f"Read the text",
+                },
+            ],
+            "role": "user",
+        },
+        "generationConfig": prepare_generation_config(
+            max_tokens=max_tokens,
+            temperature=temperature,
+            thinking_level=thinking_level,
+            model_version=model_version,
+        ),
+    }
+
+
+def prepare_caption_prompt(
+    base64_image: str,
+    short_description: bool,
+    model_version: str,
+    temperature: Optional[float],
+    thinking_level: Optional[str],
+    max_tokens: Optional[int],
+    **kwargs,
+) -> dict:
+    caption_detail_level = "Caption should be short."
+    if not short_description:
+        caption_detail_level = "Caption should be extensive."
+    return {
+        "systemInstruction": {
+            "role": "system",
+            "parts": [
+                {
+                    "text": f"You act as image caption model. Your task is to provide description of the image. "
+                    f"{caption_detail_level}",
+                }
+            ],
+        },
+        "contents": {
+            "parts": [
+                {
+                    "inline_data": {
+                        "mime_type": "image/jpeg",
+                        "data": base64_image,
+                    }
+                },
+                {
+                    "text": f"Caption the image",
+                },
+            ],
+            "role": "user",
+        },
+        "generationConfig": prepare_generation_config(
+            max_tokens=max_tokens,
+            temperature=temperature,
+            thinking_level=thinking_level,
+            model_version=model_version,
+        ),
+    }
+
+
+def prepare_structured_answering_prompt(
+    base64_image: str,
+    output_structure: Dict[str, str],
+    model_version: str,
+    temperature: Optional[float],
+    thinking_level: Optional[str],
+    max_tokens: Optional[int],
+    **kwargs,
+) -> dict:
+    output_structure_serialised = json.dumps(output_structure, indent=4)
+    return {
+        "systemInstruction": {
+            "role": "system",
+            "parts": [
+                {
+                    "text": "You are supposed to produce responses in JSON. User is to provide you dictionary with "
+                    "keys and values. Each key must be present in your response. Values in user dictionary "
+                    "represent descriptions for JSON fields to be generated. Provide only JSON in response.",
+                }
+            ],
+        },
+        "contents": {
+            "parts": [
+                {
+                    "inline_data": {
+                        "mime_type": "image/jpeg",
+                        "data": base64_image,
+                    }
+                },
+                {
+                    "text": f"Specification of requirements regarding output fields: \n"
+                    f"{output_structure_serialised}",
+                },
+            ],
+            "role": "user",
+        },
+        "generationConfig": prepare_generation_config(
+            max_tokens=max_tokens,
+            temperature=temperature,
+            thinking_level=thinking_level,
+            model_version=model_version,
+            response_mime_type="application/json",
+        ),
+    }
+
+
+def prepare_object_detection_prompt(
+    base64_image: str,
+    classes: List[str],
+    model_version: str,
+    temperature: Optional[float],
+    thinking_level: Optional[str],
+    max_tokens: Optional[int],
+    **kwargs,
+) -> dict:
+    # Gemini is trained to localize with `box_2d` boxes as [y_min, x_min,
+    # y_max, x_max] integers normalized to 0-1000. Requesting any other
+    # coordinate convention (e.g. 0.0-1.0 floats) measurably degrades box
+    # quality and yields mixed pixel/normalized outputs.
+    serialised_classes = ", ".join(classes)
+    prompt_text = (
+        "Detect all objects in this image. "
+        "Output a JSON list where each entry contains the 2D bounding box "
+        'in the key "box_2d" and the text label in the key "label". '
+        'The "box_2d" value must be [y_min, x_min, y_max, x_max]: integers '
+        "between 0 and 1000, normalized to the image height and width. "
+        "Return only the JSON list, with no extra text. "
+        f"Only use these labels: {serialised_classes}"
+    )
+    generation_config = prepare_generation_config(
+        max_tokens=max_tokens,
+        temperature=temperature,
+        thinking_level=thinking_level,
+        model_version=model_version,
+        response_mime_type="application/json",
+    )
+    generation_config["response_schema"] = {
+        "type": "ARRAY",
+        "items": {
+            "type": "OBJECT",
+            "properties": {
+                "box_2d": {
+                    "type": "ARRAY",
+                    "items": {
+                        "type": "INTEGER",
+                        "minimum": 0,
+                        "maximum": 1000,
+                    },
+                    "minItems": 4,
+                    "maxItems": 4,
+                },
+                "label": {
+                    "type": "STRING",
+                    "enum": classes,
+                },
+            },
+            "required": ["box_2d", "label"],
+            "propertyOrdering": ["box_2d", "label"],
+        },
+    }
+    return {
+        "contents": {
+            "parts": [
+                {
+                    "inline_data": {
+                        "mime_type": "image/jpeg",
+                        "data": base64_image,
+                    }
+                },
+                {
+                    "text": prompt_text,
+                },
+            ],
+            "role": "user",
+        },
+        "generationConfig": generation_config,
+    }
+
+
+def prepare_generation_config(
+    max_tokens: Optional[int],
+    temperature: Optional[float],
+    thinking_level: Optional[str],
+    model_version: str,
+    response_mime_type: str = "text/plain",
+) -> dict:
+    result = {
+        "response_mime_type": response_mime_type,
+        "candidate_count": 1,
+    }
+
+    if max_tokens is not None:
+        result["max_output_tokens"] = max_tokens
+
+    supports_thinking_level = model_version in MODELS_SUPPORTING_THINKING_LEVEL
+
+    if thinking_level is not None and supports_thinking_level:
+        result["thinking_config"] = {"thinking_level": thinking_level}
+
+    if temperature is not None and not supports_thinking_level:
+        result["temperature"] = temperature
+
+    return result
+
+
+def google_api_key_safe_raise_for_status(response: Response) -> None:
+    request_is_successful = response.status_code < 400
+    if request_is_successful:
+        return None
+    response.url = GOOGLE_API_KEY_PATTERN.sub(deduct_api_key, response.url)
+    response.raise_for_status()
+
+
+def deduct_api_key(match: re.Match) -> str:
+    key_value = match.group(GOOGLE_API_KEY_VALUE_GROUP)
+    if len(key_value) < MIN_KEY_LENGTH_TO_REVEAL_PREFIX:
+        return f"key=***"
+    key_prefix = key_value[:2]
+    key_postfix = key_value[-2:]
+    return f"key={key_prefix}***{key_postfix}"
+
+
+PROMPT_BUILDERS = {
+    "unconstrained": prepare_unconstrained_prompt,
+    "ocr": prepare_ocr_prompt,
+    "visual-question-answering": prepare_vqa_prompt,
+    "caption": partial(prepare_caption_prompt, short_description=True),
+    "detailed-caption": partial(prepare_caption_prompt, short_description=False),
+    "classification": prepare_classification_prompt,
+    "multi-label-classification": prepare_multi_label_classification_prompt,
+    "structured-answering": prepare_structured_answering_prompt,
+    "object-detection": prepare_object_detection_prompt,
+}

--- a/inference/core/workflows/core_steps/models/foundation/google_gemma/v3.py
+++ b/inference/core/workflows/core_steps/models/foundation/google_gemma/v3.py
@@ -1,0 +1,310 @@
+from typing import Dict, List, Literal, Optional, Type, Union
+
+from pydantic import ConfigDict, Field, field_validator, model_validator
+
+from inference.core.workflows.core_steps.common.openrouter import (
+    RECOMMENDED_PARSERS,
+    RELEVANT_TASKS_METADATA,
+    SUPPORTED_TASK_TYPES_LIST,
+    OpenRouterBlockManifestMixin,
+    OpenRouterWorkflowBlockBase,
+    build_prompts_from_images,
+    validate_task_type_required_fields,
+)
+from inference.core.workflows.core_steps.common.reasoning import (
+    REASONING_EFFORT_METADATA,
+    REASONING_EFFORT_OPTIONS,
+    build_openrouter_reasoning_config,
+)
+from inference.core.workflows.core_steps.common.token_usage import (
+    TOKEN_OUTPUT_DEFINITIONS,
+)
+from inference.core.workflows.execution_engine.entities.base import (
+    Batch,
+    OutputDefinition,
+    WorkflowImageData,
+)
+from inference.core.workflows.execution_engine.entities.types import (
+    IMAGE_KIND,
+    LANGUAGE_MODEL_OUTPUT_KIND,
+    LIST_OF_VALUES_KIND,
+    STRING_KIND,
+    ImageInputField,
+    Selector,
+)
+from inference.core.workflows.prototypes.block import (
+    AirGappedAvailability,
+    BlockResult,
+    DependentResource,
+    WorkflowBlockManifest,
+    is_workflow_selector,
+    third_party_model,
+)
+
+MODEL_VERSION_MAPPING = {
+    "Gemma 4 31B - OpenRouter": "google/gemma-4-31b-it",
+    "Gemma 4 26B A4B - OpenRouter": "google/gemma-4-26b-a4b-it",
+}
+
+ModelVersion = Literal[
+    "Gemma 4 31B - OpenRouter",
+    "Gemma 4 26B A4B - OpenRouter",
+]
+
+TaskType = Literal[tuple(SUPPORTED_TASK_TYPES_LIST)]
+
+RELEVANT_TASKS_DOCS_DESCRIPTION = "\n\n".join(
+    f"* **{v['name']}** (`{k}`) - {v['description']}"
+    for k, v in RELEVANT_TASKS_METADATA.items()
+)
+
+LONG_DESCRIPTION = f"""
+Ask a question to Google's Gemma model with vision capabilities.
+
+You can specify arbitrary text prompts or predefined ones, the block supports the following types of prompt:
+
+{RELEVANT_TASKS_DOCS_DESCRIPTION}
+
+#### 🛠️ API providers and model variants
+
+Gemma is exposed via [OpenRouter](https://openrouter.ai/). By default this block uses
+the **Roboflow-managed OpenRouter key** and bills your Roboflow credits — no extra
+setup needed. To bypass Roboflow billing, paste your own `sk-or-...` key into the
+`api_key` field.
+
+The `privacy_level` field controls which OpenRouter providers may serve the request:
+
+* **No data collection** *(default)* – providers may not train on your inputs.
+* **Allow data collection** – broader provider pool, including providers that train on inputs.
+* **Zero data retention** – strictest, restricts to providers that retain nothing.
+
+#### 💡 Further reading and Acceptable Use Policy
+
+!!! warning "Model license"
+
+    Check the [Gemma Terms of Use](https://ai.google.dev/gemma/terms) before use.
+"""
+
+
+class BlockManifest(OpenRouterBlockManifestMixin):
+    model_config = ConfigDict(
+        json_schema_extra={
+            "name": "Google Gemma",
+            "version": "v3",
+            "short_description": "Run Google's Gemma model with vision capabilities via OpenRouter.",
+            "long_description": LONG_DESCRIPTION,
+            "license": "Gemma Terms of Use",
+            "block_type": "model",
+            "search_keywords": ["LMM", "VLM", "Gemma", "Google", "OpenRouter"],
+            "is_vlm_block": True,
+            "task_type_property": "task_type",
+            "ui_manifest": {
+                "section": "model",
+                "icon": "fa-brands fa-google",
+            },
+        },
+        protected_namespaces=(),
+    )
+    type: Literal["roboflow_core/google_gemma@v3"]
+    images: Selector(kind=[IMAGE_KIND]) = ImageInputField
+    task_type: TaskType = Field(
+        default="unconstrained",
+        description="Task type to be performed by model. Value determines required parameters and output response.",
+        json_schema_extra={
+            "values_metadata": RELEVANT_TASKS_METADATA,
+            "recommended_parsers": RECOMMENDED_PARSERS,
+            "always_visible": True,
+        },
+    )
+    prompt: Optional[Union[Selector(kind=[STRING_KIND]), str]] = Field(
+        default=None,
+        description="Text prompt to the Gemma model",
+        examples=["my prompt", "$inputs.prompt"],
+        json_schema_extra={
+            "relevant_for": {
+                "task_type": {
+                    "values": ["unconstrained", "visual-question-answering"],
+                    "required": True,
+                },
+            },
+            "multiline": True,
+        },
+    )
+    output_structure: Optional[Dict[str, str]] = Field(
+        default=None,
+        description="Dictionary with structure of expected JSON response",
+        examples=[{"my_key": "description"}, "$inputs.output_structure"],
+        json_schema_extra={
+            "relevant_for": {
+                "task_type": {"values": ["structured-answering"], "required": True},
+            },
+        },
+    )
+    classes: Optional[Union[Selector(kind=[LIST_OF_VALUES_KIND]), List[str]]] = Field(
+        default=None,
+        description="List of classes to be used",
+        examples=[["class-a", "class-b"], "$inputs.classes"],
+        json_schema_extra={
+            "relevant_for": {
+                "task_type": {
+                    "values": [
+                        "classification",
+                        "multi-label-classification",
+                        "object-detection",
+                    ],
+                    "required": True,
+                },
+            },
+        },
+    )
+    model_version: Union[Selector(kind=[STRING_KIND]), ModelVersion] = Field(
+        default="Gemma 4 31B - OpenRouter",
+        description="Model to be used",
+        examples=["Gemma 4 31B - OpenRouter", "$inputs.gemma_model"],
+    )
+
+    # Overrides the mixin default of 500, which reasoning models can burn
+    # entirely on internal thinking and fail with missing content.
+    max_tokens: int = Field(
+        default=2048,
+        description=(
+            "Maximum number of tokens the model can generate in its response. "
+            "Defaults to 2048. Raise it explicitly (e.g. 8192) when a task "
+            "needs a longer answer. Billing is based on tokens actually "
+            "generated, not on this limit."
+        ),
+        gt=1,
+    )
+
+    reasoning_effort: Optional[
+        Union[
+            Selector(kind=[STRING_KIND]),
+            Literal[tuple(REASONING_EFFORT_OPTIONS)],
+        ]
+    ] = Field(
+        default=None,
+        description=(
+            "Extended-reasoning budget forwarded to OpenRouter as "
+            '`reasoning: {"effort": ...}`. Unset keeps the model\'s '
+            "provider-default behavior; `none` explicitly disables reasoning. "
+            "Models that reject the config are retried without it."
+        ),
+        examples=["low", "$inputs.reasoning_effort"],
+        json_schema_extra={"values_metadata": REASONING_EFFORT_METADATA},
+    )
+
+    @model_validator(mode="after")
+    def validate(self) -> "BlockManifest":
+        validate_task_type_required_fields(
+            task_type=self.task_type,
+            prompt=self.prompt,
+            classes=self.classes,
+            output_structure=self.output_structure,
+        )
+        return self
+
+    @field_validator("temperature")
+    @classmethod
+    def validate_temperature(cls, value: Union[str, float]) -> Union[str, float]:
+        if isinstance(value, str):
+            return value
+        if value < 0.0 or value > 2.0:
+            raise ValueError(
+                "'temperature' parameter required to be in range [0.0, 2.0]"
+            )
+        return value
+
+    @classmethod
+    def get_air_gapped_availability(cls) -> AirGappedAvailability:
+        return AirGappedAvailability(available=False, reason="requires_internet")
+
+    @classmethod
+    def get_parameters_accepting_batches(cls) -> List[str]:
+        return ["images"]
+
+    @classmethod
+    def describe_outputs(cls) -> List[OutputDefinition]:
+        return [
+            OutputDefinition(
+                name="output", kind=[STRING_KIND, LANGUAGE_MODEL_OUTPUT_KIND]
+            ),
+            OutputDefinition(name="classes", kind=[LIST_OF_VALUES_KIND]),
+            *TOKEN_OUTPUT_DEFINITIONS,
+        ]
+
+    @classmethod
+    def get_execution_engine_compatibility(cls) -> Optional[str]:
+        return ">=1.3.0,<2.0.0"
+
+    def discover_dependent_resources(self) -> Optional[List[DependentResource]]:
+        if is_workflow_selector(self.model_version):
+            # Friendly-label selector returned verbatim; the attached resolver
+            # performs the MODEL_VERSION_MAPPING lookup once the input value
+            # is substituted.
+            return [
+                third_party_model(
+                    provider="openrouter",
+                    model_id=self.model_version,
+                    model_id_resolver=lambda label: MODEL_VERSION_MAPPING[label],
+                )
+            ]
+        return [
+            third_party_model(
+                provider="openrouter",
+                model_id=MODEL_VERSION_MAPPING[self.model_version],
+            )
+        ]
+
+
+class GoogleGemmaBlockV3(OpenRouterWorkflowBlockBase):
+
+    @classmethod
+    def get_manifest(cls) -> Type[WorkflowBlockManifest]:
+        return BlockManifest
+
+    @classmethod
+    def get_execution_engine_compatibility(cls) -> Optional[str]:
+        return ">=1.3.0,<2.0.0"
+
+    def run(
+        self,
+        images: Batch[WorkflowImageData],
+        task_type: str,
+        prompt: Optional[str],
+        output_structure: Optional[Dict[str, str]],
+        classes: Optional[List[str]],
+        api_key: str,
+        privacy_level: str,
+        model_version: ModelVersion,
+        max_tokens: int,
+        temperature: float,
+        reasoning_effort: Optional[str],
+        max_concurrent_requests: Optional[int],
+    ) -> BlockResult:
+        inference_images = [i.to_inference_format() for i in images]
+        prompts = build_prompts_from_images(
+            images=inference_images,
+            task_type=task_type,
+            prompt=prompt,
+            output_structure=output_structure,
+            classes=classes,
+        )
+        results = self.execute_openrouter_batch_with_usage(
+            openrouter_api_key=api_key,
+            model=MODEL_VERSION_MAPPING[model_version],
+            prompts=prompts,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            privacy_level=privacy_level,
+            max_concurrent_requests=max_concurrent_requests,
+            reasoning=build_openrouter_reasoning_config(reasoning_effort),
+        )
+        return [
+            {
+                "output": result.content,
+                "classes": classes,
+                "input_tokens": result.input_tokens,
+                "output_tokens": result.output_tokens,
+            }
+            for result in results
+        ]

--- a/inference/core/workflows/core_steps/models/foundation/meta_vlm/v2.py
+++ b/inference/core/workflows/core_steps/models/foundation/meta_vlm/v2.py
@@ -1,0 +1,645 @@
+"""Meta Muse vision-language block, v2.
+
+Same surface as ``meta_vlm@v1``, plus ``input_tokens`` / ``output_tokens``
+outputs with per-call token usage.
+
+OpenRouter-only. Three Muse models, using the vlm-exam request contract:
+image-first user message, no system role, reasoning always on, meta-flat
+0-1000 detection prompt. Llama Vision stays on its own block.
+"""
+
+import base64
+import json
+from typing import Any, Dict, List, Literal, Optional, Type, Union
+
+import cv2
+import numpy as np
+from pydantic import ConfigDict, Field, field_validator, model_validator
+
+from inference.core.utils.image_utils import encode_image_to_jpeg_bytes
+from inference.core.workflows.core_steps.common.openrouter import (
+    PRIVACY_LEVEL_LITERAL,
+    PRIVACY_LEVEL_METADATA,
+    RECOMMENDED_PARSERS,
+    RELEVANT_TASKS_METADATA,
+    SUPPORTED_TASK_TYPES_LIST,
+    OpenRouterBlockManifestMixin,
+    OpenRouterWorkflowBlockBase,
+    validate_task_type_required_fields,
+)
+from inference.core.workflows.core_steps.common.token_usage import (
+    TOKEN_OUTPUT_DEFINITIONS,
+)
+from inference.core.workflows.core_steps.common.utils import (
+    scale_dimensions_to_max_edge,
+)
+from inference.core.workflows.execution_engine.entities.base import (
+    Batch,
+    OutputDefinition,
+    WorkflowImageData,
+)
+from inference.core.workflows.execution_engine.entities.types import (
+    FLOAT_KIND,
+    IMAGE_KIND,
+    LANGUAGE_MODEL_OUTPUT_KIND,
+    LIST_OF_VALUES_KIND,
+    ROBOFLOW_MANAGED_KEY,
+    SECRET_KIND,
+    STRING_KIND,
+    ImageInputField,
+    Selector,
+)
+from inference.core.workflows.prototypes.block import (
+    AirGappedAvailability,
+    BlockResult,
+    DependentResource,
+    WorkflowBlockManifest,
+    is_workflow_selector,
+    third_party_model,
+)
+
+MODEL_VARIANTS: Dict[str, str] = {
+    "Muse Spark 1.1": "meta/muse-spark-1.1",
+    "Muse Spark 1.2": "meta/muse-spark-1.2",
+    "Muse Glimmer": "meta/muse-glimmer-30b",
+}
+
+ModelVersion = Literal[tuple(MODEL_VARIANTS.keys())]
+DEFAULT_MODEL_VERSION = "Muse Spark 1.2"
+
+TaskType = Literal[tuple(SUPPORTED_TASK_TYPES_LIST)]
+
+REASONING_EFFORT_OPTIONS = ["low", "medium", "high"]
+ReasoningEffort = Literal[tuple(REASONING_EFFORT_OPTIONS)]
+DEFAULT_REASONING_EFFORT = "low"
+
+REASONING_EFFORT_METADATA = {
+    "low": {
+        "name": "Low (recommended)",
+        "description": (
+            "Small reasoning budget. Muse models require reasoning; this is "
+            "the lowest effort they accept."
+        ),
+    },
+    "medium": {
+        "name": "Medium",
+        "description": "Moderate reasoning budget before answering.",
+    },
+    "high": {
+        "name": "High",
+        "description": (
+            "Large reasoning budget. Slowest and most expensive; consider "
+            "raising `max_tokens` so reasoning does not crowd out the answer."
+        ),
+    },
+}
+
+DEFAULT_MAX_TOKENS = 2048
+OPENROUTER_MAX_BASE64_BYTES = 9_500_000
+OPENROUTER_JPEG_QUALITY = 90
+
+# Ported verbatim from vlm-exam's `_META_FLAT_NORMALIZED_PROMPT_TEMPLATE`.
+MUSE_OBJECT_DETECTION_PROMPT_TEMPLATE = (
+    "You are an object grounding expert. Detect all objects in this image "
+    "matching these labels: {class_list}. Ensure the objects accurately "
+    "match the request and do not miss any objects. For each object, answer "
+    'in the format {{"label": "<name>", "x_min": <int>, "y_min": <int>, '
+    '"x_max": <int>, "y_max": <int>}}. The coordinates should be in the '
+    "0-1000 range. Return a JSON array of results. If you cannot find an "
+    "object, omit it from the results."
+)
+
+_TASK_CLASSIFICATION = (
+    "You act as single-class classification model. You must provide reasonable "
+    "predictions. You are only allowed to produce JSON document in Markdown "
+    "```json [...]``` markers. Expected structure of json: "
+    '{"class_name": "class-name", "confidence": 0.4}. `class-name` must be one '
+    "of the class names defined by user. You are only allowed to return single "
+    "JSON document, even if there are potentially multiple classes. You are not "
+    "allowed to return list. You cannot discuss the result, you are only "
+    "allowed to return JSON document."
+)
+
+_TASK_MULTI_LABEL = (
+    "You act as multi-label classification model. You must provide reasonable "
+    "predictions. You are only allowed to produce JSON document in Markdown "
+    '```json``` markers. Expected structure of json: {"predicted_classes": '
+    '[{"class": "class-name-1", "confidence": 0.9}, {"class": "class-name-2", '
+    '"confidence": 0.7}]}. `class-name-X` must be one of the class names '
+    "defined by user and `confidence` is a float value in range 0.0-1.0 that "
+    "represent how sure you are that the class is present in the image. Only "
+    "return class names that are visible. You cannot discuss the result, you "
+    "are only allowed to return JSON document."
+)
+
+_TASK_VQA = (
+    "You act as Visual Question Answering model. Your task is to provide "
+    "answer to question submitted by user. If this is open-question - answer "
+    "with few sentences, for ABCD question, return only the indicator of "
+    "the answer."
+)
+
+_TASK_OCR = (
+    "You act as OCR model. Your task is to read text from the image and "
+    "return it in paragraphs representing the structure of texts in the "
+    "image. You should only return recognised text, nothing else."
+)
+
+_TASK_STRUCTURED = (
+    "You are supposed to produce responses in JSON wrapped in Markdown "
+    "markers: ```json\nyour-response\n```. User is to provide you "
+    "dictionary with keys and values. Each key must be present in your "
+    "response. Values in user dictionary represent descriptions for JSON "
+    "fields to be generated. Provide only JSON Markdown in response."
+)
+
+
+def encode_image_for_muse_openrouter(numpy_image: np.ndarray) -> str:
+    """Encode a BGR image as base64 JPEG under the OpenRouter payload cap.
+
+    Encodes at fixed JPEG quality and, when the base64 payload exceeds
+    ``OPENROUTER_MAX_BASE64_BYTES``, iteratively downscales the longest
+    edge by 10% until it fits. Detection coordinates are normalized to
+    0-1000, so downscaling does not affect parsing.
+
+    Args:
+        numpy_image: Image in BGR channel order.
+
+    Returns:
+        Base64-encoded JPEG payload.
+    """
+    working = numpy_image
+    while True:
+        jpeg_bytes = encode_image_to_jpeg_bytes(
+            working, jpeg_quality=OPENROUTER_JPEG_QUALITY
+        )
+        base64_image = base64.b64encode(jpeg_bytes).decode("ascii")
+        if len(base64_image) <= OPENROUTER_MAX_BASE64_BYTES:
+            return base64_image
+
+        height, width = working.shape[:2]
+        if max(height, width) <= 1:
+            return base64_image
+
+        target_max_edge = max(int(max(height, width) * 0.9), 1)
+        target_width, target_height = scale_dimensions_to_max_edge(
+            width, height, target_max_edge
+        )
+        working = cv2.resize(
+            working, (target_width, target_height), interpolation=cv2.INTER_AREA
+        )
+
+
+def _user_message(base64_image: str, text: str) -> List[dict]:
+    return [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image_url",
+                    "image_url": {
+                        "url": f"data:image/jpeg;base64,{base64_image}",
+                    },
+                },
+                {"type": "text", "text": text},
+            ],
+        }
+    ]
+
+
+def _prepare_unconstrained_prompt(base64_image: str, prompt: str, **_) -> List[dict]:
+    return _user_message(base64_image=base64_image, text=prompt)
+
+
+def _prepare_ocr_prompt(base64_image: str, **_) -> List[dict]:
+    return _user_message(base64_image=base64_image, text=_TASK_OCR)
+
+
+def _prepare_vqa_prompt(base64_image: str, prompt: str, **_) -> List[dict]:
+    return _user_message(
+        base64_image=base64_image, text=f"{_TASK_VQA}\n\nQuestion: {prompt}"
+    )
+
+
+def _prepare_caption_prompt(
+    base64_image: str, short_description: bool, **_
+) -> List[dict]:
+    detail = (
+        "Caption should be short."
+        if short_description
+        else "Caption should be extensive."
+    )
+    text = (
+        "You act as image caption model. Your task is to provide "
+        f"description of the image. {detail}"
+    )
+    return _user_message(base64_image=base64_image, text=text)
+
+
+def _prepare_classification_prompt(
+    base64_image: str, classes: List[str], **_
+) -> List[dict]:
+    text = (
+        f"{_TASK_CLASSIFICATION}\n\n"
+        f"List of all classes to be recognised by model: {', '.join(classes)}"
+    )
+    return _user_message(base64_image=base64_image, text=text)
+
+
+def _prepare_multi_label_classification_prompt(
+    base64_image: str, classes: List[str], **_
+) -> List[dict]:
+    text = (
+        f"{_TASK_MULTI_LABEL}\n\n"
+        f"List of all classes to be recognised by model: {', '.join(classes)}"
+    )
+    return _user_message(base64_image=base64_image, text=text)
+
+
+def _prepare_structured_answering_prompt(
+    base64_image: str, output_structure: Dict[str, str], **_
+) -> List[dict]:
+    text = (
+        f"{_TASK_STRUCTURED}\n\n"
+        "Specification of requirements regarding output fields: \n"
+        f"{json.dumps(output_structure, indent=4)}"
+    )
+    return _user_message(base64_image=base64_image, text=text)
+
+
+def _prepare_object_detection_prompt(
+    base64_image: str, classes: List[str], **_
+) -> List[dict]:
+    text = MUSE_OBJECT_DETECTION_PROMPT_TEMPLATE.format(class_list=", ".join(classes))
+    return _user_message(base64_image=base64_image, text=text)
+
+
+PROMPT_BUILDERS = {
+    "unconstrained": _prepare_unconstrained_prompt,
+    "ocr": _prepare_ocr_prompt,
+    "visual-question-answering": _prepare_vqa_prompt,
+    "caption": lambda **kwargs: _prepare_caption_prompt(
+        short_description=True, **kwargs
+    ),
+    "detailed-caption": lambda **kwargs: _prepare_caption_prompt(
+        short_description=False, **kwargs
+    ),
+    "classification": _prepare_classification_prompt,
+    "multi-label-classification": _prepare_multi_label_classification_prompt,
+    "structured-answering": _prepare_structured_answering_prompt,
+    "object-detection": _prepare_object_detection_prompt,
+}
+
+
+def build_muse_openrouter_prompts(
+    images: List[np.ndarray],
+    task_type: str,
+    prompt: Optional[str],
+    output_structure: Optional[Dict[str, str]],
+    classes: Optional[List[str]],
+) -> List[List[dict]]:
+    """Build one OpenRouter ``messages`` array per input image, Muse-style.
+
+    Every task sends a single user message with the image part first and
+    the instruction text second, with no system role, matching the
+    vlm-exam Muse request contract.
+
+    Args:
+        images: BGR numpy images.
+        task_type: One of the supported VLM task types.
+        prompt: User prompt for unconstrained / VQA tasks.
+        output_structure: Output spec for structured-answering.
+        classes: Class list for classification / detection tasks.
+
+    Returns:
+        List of ``messages`` arrays, one per image.
+
+    Raises:
+        ValueError: If the task type is not supported.
+    """
+    if task_type not in PROMPT_BUILDERS:
+        raise ValueError(f"Task type: {task_type} not supported.")
+    builder = PROMPT_BUILDERS[task_type]
+    built: List[List[dict]] = []
+    for image in images:
+        built.append(
+            builder(
+                base64_image=encode_image_for_muse_openrouter(numpy_image=image),
+                prompt=prompt,
+                output_structure=output_structure,
+                classes=classes,
+            )
+        )
+    return built
+
+
+def build_reasoning_config(reasoning_effort: str) -> Dict[str, Any]:
+    """Build the OpenRouter ``reasoning`` config for Muse models.
+
+    Muse models reject disabled reasoning, so an ``effort`` is always sent.
+
+    Args:
+        reasoning_effort: ``low``, ``medium``, or ``high``.
+
+    Returns:
+        Reasoning config to attach to the OpenRouter request.
+    """
+    return {"effort": reasoning_effort}
+
+
+RELEVANT_TASKS_DOCS_DESCRIPTION = "\n\n".join(
+    f"* **{v['name']}** (`{k}`) - {v['description']}"
+    for k, v in RELEVANT_TASKS_METADATA.items()
+)
+
+LONG_DESCRIPTION = f"""
+Run Meta Muse vision-language models via [OpenRouter](https://openrouter.ai/).
+
+Supported models: Muse Spark 1.1, Muse Spark 1.2, and Muse Glimmer.
+Llama 3.2 Vision stays on its own block.
+
+You can specify arbitrary text prompts or predefined ones. The block supports:
+
+{RELEVANT_TASKS_DOCS_DESCRIPTION}
+
+Object detection uses Muse's native grounding format: a JSON array of
+`label` / `x_min` / `y_min` / `x_max` / `y_max` fields with coordinates
+normalized to 0-1000. Parse the output with `VLM as Detector`
+(`vlm_as_detector@v2`) using `model_type="muse"`.
+
+Every request sends the image before the instruction text in a single user
+message. Reasoning stays on; the `reasoning_effort` knob defaults to low.
+`max_tokens` defaults to 2048; raise it (e.g. 8192) when you need a longer
+answer.
+
+By default the block uses the Roboflow-managed OpenRouter key and bills
+your Roboflow credits. Paste your own `sk-or-...` key to call OpenRouter
+directly.
+"""
+
+
+class BlockManifest(OpenRouterBlockManifestMixin):
+    model_config = ConfigDict(
+        json_schema_extra={
+            "name": "Meta",
+            "version": "v2",
+            "short_description": "Run Meta Muse vision models via OpenRouter.",
+            "long_description": LONG_DESCRIPTION,
+            "license": "Apache-2.0",
+            "block_type": "model",
+            "search_keywords": [
+                "LMM",
+                "VLM",
+                "Meta",
+                "Muse",
+                "Spark",
+                "Glimmer",
+                "OpenRouter",
+            ],
+            "is_vlm_block": True,
+            "task_type_property": "task_type",
+            "ui_manifest": {
+                "section": "model",
+                "icon": "fa-brands fa-meta",
+                "blockPriority": 5.55,
+            },
+        },
+        protected_namespaces=(),
+    )
+    type: Literal["roboflow_core/meta_vlm@v2"]
+    images: Selector(kind=[IMAGE_KIND]) = ImageInputField
+    model_version: Union[Selector(kind=[STRING_KIND]), ModelVersion] = Field(
+        default=DEFAULT_MODEL_VERSION,
+        description=(
+            "Muse model to run. Spark 1.1, Spark 1.2, and Glimmer are the "
+            "current image-capable Muse chat models on OpenRouter."
+        ),
+        examples=[DEFAULT_MODEL_VERSION, "Muse Glimmer"],
+    )
+    task_type: TaskType = Field(
+        default="unconstrained",
+        description=(
+            "Task type to be performed by model. Value determines required "
+            "parameters and output response."
+        ),
+        json_schema_extra={
+            "values_metadata": RELEVANT_TASKS_METADATA,
+            "recommended_parsers": RECOMMENDED_PARSERS,
+            "always_visible": True,
+        },
+    )
+    prompt: Optional[Union[Selector(kind=[STRING_KIND]), str]] = Field(
+        default=None,
+        description="Text prompt to send to the model.",
+        examples=["my prompt", "$inputs.prompt"],
+        json_schema_extra={
+            "relevant_for": {
+                "task_type": {
+                    "values": ["unconstrained", "visual-question-answering"],
+                    "required": True,
+                },
+            },
+            "multiline": True,
+        },
+    )
+    output_structure: Optional[Dict[str, str]] = Field(
+        default=None,
+        description="Dictionary with structure of expected JSON response.",
+        examples=[{"my_key": "description"}, "$inputs.output_structure"],
+        json_schema_extra={
+            "relevant_for": {
+                "task_type": {"values": ["structured-answering"], "required": True},
+            },
+        },
+    )
+    classes: Optional[Union[Selector(kind=[LIST_OF_VALUES_KIND]), List[str]]] = Field(
+        default=None,
+        description="List of classes to be used.",
+        examples=[["class-a", "class-b"], "$inputs.classes"],
+        json_schema_extra={
+            "relevant_for": {
+                "task_type": {
+                    "values": [
+                        "classification",
+                        "multi-label-classification",
+                        "object-detection",
+                    ],
+                    "required": True,
+                },
+            },
+        },
+    )
+    reasoning_effort: ReasoningEffort = Field(
+        default=DEFAULT_REASONING_EFFORT,
+        description=(
+            "Reasoning budget. Muse models reject disabled reasoning, so this "
+            "is always sent as an effort. Low is the default used in the "
+            "vlm-exam benches."
+        ),
+        json_schema_extra={"values_metadata": REASONING_EFFORT_METADATA},
+    )
+    max_tokens: Optional[int] = Field(
+        default=DEFAULT_MAX_TOKENS,
+        description=(
+            "Maximum number of tokens the model can generate in its response. "
+            f"Defaults to {DEFAULT_MAX_TOKENS}. Raise it explicitly "
+            "(e.g. 8192) when a task needs a longer answer. Billing is based "
+            "on tokens actually generated, not on this limit."
+        ),
+        gt=1,
+    )
+    temperature: Optional[Union[float, Selector(kind=[FLOAT_KIND])]] = Field(
+        default=None,
+        description=(
+            "Sampling temperature. Left unset by default so the provider "
+            "default applies. Range 0.0-2.0."
+        ),
+    )
+    api_key: Union[
+        Selector(kind=[STRING_KIND, SECRET_KIND, ROBOFLOW_MANAGED_KEY]), str
+    ] = Field(
+        default="rf_key:account",
+        description=(
+            "OpenRouter API key. Defaults to Roboflow's managed key. Provide "
+            "your own `sk-or-...` key to call OpenRouter directly without "
+            "Roboflow billing."
+        ),
+        examples=["rf_key:account", "sk-or-...", "$inputs.openrouter_api_key"],
+        private=True,
+    )
+    privacy_level: PRIVACY_LEVEL_LITERAL = Field(
+        default="deny",
+        description=(
+            "Provider privacy filter. Stricter levels reduce the pool of "
+            "providers and may increase per-call cost on the managed key."
+        ),
+        json_schema_extra={"values_metadata": PRIVACY_LEVEL_METADATA},
+    )
+
+    @model_validator(mode="after")
+    def validate(self) -> "BlockManifest":
+        validate_task_type_required_fields(
+            task_type=self.task_type,
+            prompt=self.prompt,
+            classes=self.classes,
+            output_structure=self.output_structure,
+        )
+        return self
+
+    @field_validator("temperature")
+    @classmethod
+    def validate_temperature(
+        cls, value: Optional[Union[str, float]]
+    ) -> Optional[Union[str, float]]:
+        if value is None or isinstance(value, str):
+            return value
+        if value < 0.0 or value > 2.0:
+            raise ValueError(
+                "'temperature' parameter required to be in range [0.0, 2.0]"
+            )
+        return value
+
+    @classmethod
+    def get_air_gapped_availability(cls) -> AirGappedAvailability:
+        return AirGappedAvailability(available=False, reason="requires_internet")
+
+    @classmethod
+    def get_parameters_accepting_batches(cls) -> List[str]:
+        return ["images"]
+
+    @classmethod
+    def describe_outputs(cls) -> List[OutputDefinition]:
+        return [
+            OutputDefinition(
+                name="output", kind=[STRING_KIND, LANGUAGE_MODEL_OUTPUT_KIND]
+            ),
+            OutputDefinition(name="classes", kind=[LIST_OF_VALUES_KIND]),
+            OutputDefinition(
+                name="thinking",
+                kind=[STRING_KIND],
+                description=(
+                    "Reasoning trace from the model when OpenRouter returns "
+                    "one. Empty string otherwise."
+                ),
+            ),
+            *TOKEN_OUTPUT_DEFINITIONS,
+        ]
+
+    @classmethod
+    def get_execution_engine_compatibility(cls) -> Optional[str]:
+        return ">=1.3.0,<2.0.0"
+
+    def discover_dependent_resources(self) -> Optional[List[DependentResource]]:
+        if is_workflow_selector(self.model_version):
+            return [
+                third_party_model(
+                    provider="openrouter",
+                    model_id=self.model_version,
+                    model_id_resolver=lambda label: MODEL_VARIANTS.get(label),
+                )
+            ]
+        return [
+            third_party_model(
+                provider="openrouter",
+                model_id=MODEL_VARIANTS[self.model_version],
+            )
+        ]
+
+
+class MetaVlmBlockV2(OpenRouterWorkflowBlockBase):
+    @classmethod
+    def get_manifest(cls) -> Type[WorkflowBlockManifest]:
+        return BlockManifest
+
+    @classmethod
+    def get_execution_engine_compatibility(cls) -> Optional[str]:
+        return ">=1.3.0,<2.0.0"
+
+    def run(
+        self,
+        images: Batch[WorkflowImageData],
+        model_version: str,
+        task_type: str,
+        prompt: Optional[str],
+        output_structure: Optional[Dict[str, str]],
+        classes: Optional[List[str]],
+        reasoning_effort: str,
+        api_key: str,
+        privacy_level: str,
+        max_tokens: Optional[int],
+        temperature: Optional[float],
+        max_concurrent_requests: Optional[int],
+    ) -> BlockResult:
+        model_id = MODEL_VARIANTS.get(model_version)
+        if model_id is None:
+            raise ValueError(
+                f"Unknown Muse variant '{model_version}'. "
+                f"Pick one of: {list(MODEL_VARIANTS)}"
+            )
+        prompts = build_muse_openrouter_prompts(
+            images=[image.numpy_image for image in images],
+            task_type=task_type,
+            prompt=prompt,
+            output_structure=output_structure,
+            classes=classes,
+        )
+        results = self.execute_openrouter_batch_with_usage(
+            openrouter_api_key=api_key,
+            model=model_id,
+            prompts=prompts,
+            max_tokens=max_tokens if max_tokens is not None else DEFAULT_MAX_TOKENS,
+            temperature=temperature,
+            privacy_level=privacy_level,
+            max_concurrent_requests=max_concurrent_requests,
+            reasoning=build_reasoning_config(reasoning_effort),
+        )
+        return [
+            {
+                "output": result.content,
+                "classes": classes,
+                "thinking": result.reasoning_trace,
+                "input_tokens": result.input_tokens,
+                "output_tokens": result.output_tokens,
+            }
+            for result in results
+        ]

--- a/inference/core/workflows/core_steps/models/foundation/openai/v6.py
+++ b/inference/core/workflows/core_steps/models/foundation/openai/v6.py
@@ -1,0 +1,1413 @@
+import base64
+import json
+from functools import partial
+from typing import Any, Dict, List, Literal, Optional, Tuple, Type, Union
+
+import cv2
+import numpy as np
+import requests
+from openai import OpenAI
+from pydantic import ConfigDict, Field, model_validator
+
+from inference.core.env import WORKFLOWS_REMOTE_EXECUTION_MAX_STEP_CONCURRENT_REQUESTS
+from inference.core.managers.base import ModelManager
+from inference.core.roboflow_api import post_to_roboflow_api
+from inference.core.utils.image_utils import encode_image_to_jpeg_bytes, load_image
+from inference.core.workflows.core_steps.common.token_usage import (
+    TOKEN_OUTPUT_DEFINITIONS,
+    parse_responses_api_usage,
+)
+from inference.core.workflows.core_steps.common.utils import (
+    DETECTION_MAX_EDGE_PIXELS,
+    run_in_parallel,
+    scale_dimensions_to_max_edge,
+)
+from inference.core.workflows.core_steps.common.vlms import VLM_TASKS_METADATA
+from inference.core.workflows.execution_engine.entities.base import (
+    Batch,
+    OutputDefinition,
+    WorkflowImageData,
+)
+from inference.core.workflows.execution_engine.entities.types import (
+    FLOAT_KIND,
+    IMAGE_KIND,
+    LANGUAGE_MODEL_OUTPUT_KIND,
+    LIST_OF_VALUES_KIND,
+    ROBOFLOW_MANAGED_KEY,
+    SECRET_KIND,
+    STRING_KIND,
+    ImageInputField,
+    Selector,
+)
+from inference.core.workflows.prototypes.block import (
+    AirGappedAvailability,
+    BlockResult,
+    DependentResource,
+    WorkflowBlock,
+    WorkflowBlockManifest,
+    third_party_model,
+)
+
+# Detection prompt styles (selected per model based on a 17-model x 10-format
+# x 100-image benchmark; see the object-detection prompt builders below):
+# - "structured-absolute": absolute pixel box_2d enforced via structured
+#   outputs (json_schema). Best for gpt-5.2 and newer generations; the default
+#   for unknown/future models.
+# - "normalized-legacy": v4-style normalized 0.0-1.0 dict. Best for the
+#   gpt-5.1/gpt-5 generation, whose vision pipelines resize internally.
+# - "plain-absolute": absolute pixel box_2d requested via free-text JSON.
+#   Safest for gpt-4.x/4o and nano-tier models, which regress under
+#   structured outputs.
+STRUCTURED_ABSOLUTE_STYLE = "structured-absolute"
+NORMALIZED_LEGACY_STYLE = "normalized-legacy"
+PLAIN_ABSOLUTE_STYLE = "plain-absolute"
+
+OPENAI_MODELS = [
+    {
+        "id": "gpt-5.6-sol",
+        "name": "GPT-5.6 Sol",
+        "reasoning_effort_values": ["none", "low", "medium", "high", "xhigh"],
+        "detection_prompt_style": STRUCTURED_ABSOLUTE_STYLE,
+    },
+    {
+        "id": "gpt-5.6-terra",
+        "name": "GPT-5.6 Terra",
+        "reasoning_effort_values": ["none", "low", "medium", "high", "xhigh"],
+        "detection_prompt_style": STRUCTURED_ABSOLUTE_STYLE,
+    },
+    {
+        "id": "gpt-5.6-luna",
+        "name": "GPT-5.6 Luna",
+        "reasoning_effort_values": ["none", "low", "medium", "high", "xhigh"],
+        "detection_prompt_style": STRUCTURED_ABSOLUTE_STYLE,
+    },
+    {
+        "id": "gpt-5.5",
+        "name": "GPT-5.5",
+        "reasoning_effort_values": ["none", "low", "medium", "high", "xhigh"],
+        "detection_prompt_style": STRUCTURED_ABSOLUTE_STYLE,
+    },
+    {
+        "id": "gpt-5.4",
+        "name": "GPT-5.4",
+        "reasoning_effort_values": ["none", "low", "medium", "high", "xhigh"],
+        "detection_prompt_style": STRUCTURED_ABSOLUTE_STYLE,
+    },
+    {
+        "id": "gpt-5.4-mini",
+        "name": "GPT-5.4 mini",
+        "reasoning_effort_values": ["none", "low", "medium", "high", "xhigh"],
+        "detection_prompt_style": STRUCTURED_ABSOLUTE_STYLE,
+    },
+    {
+        "id": "gpt-5.4-nano",
+        "name": "GPT-5.4 nano",
+        "reasoning_effort_values": ["none", "low", "medium", "high", "xhigh"],
+        "detection_prompt_style": PLAIN_ABSOLUTE_STYLE,
+    },
+    {
+        "id": "gpt-5.2",
+        "name": "GPT-5.2",
+        "reasoning_effort_values": ["none", "low", "medium", "high", "xhigh"],
+        "detection_prompt_style": STRUCTURED_ABSOLUTE_STYLE,
+    },
+    {
+        "id": "gpt-5.1",
+        "name": "GPT-5.1",
+        "reasoning_effort_values": ["none", "low", "medium", "high"],
+        "detection_prompt_style": NORMALIZED_LEGACY_STYLE,
+    },
+    {
+        "id": "gpt-5",
+        "name": "GPT-5",
+        "reasoning_effort_values": ["minimal", "low", "medium", "high"],
+        "detection_prompt_style": NORMALIZED_LEGACY_STYLE,
+    },
+    {
+        "id": "gpt-5-mini",
+        "name": "GPT-5 mini",
+        "reasoning_effort_values": ["minimal", "low", "medium", "high"],
+        "detection_prompt_style": NORMALIZED_LEGACY_STYLE,
+    },
+    {
+        "id": "gpt-5-nano",
+        "name": "GPT-5 nano",
+        "reasoning_effort_values": ["minimal", "low", "medium", "high"],
+        "detection_prompt_style": NORMALIZED_LEGACY_STYLE,
+    },
+    {
+        "id": "gpt-4.1",
+        "name": "GPT-4.1",
+        "reasoning_effort_values": [],
+        "detection_prompt_style": PLAIN_ABSOLUTE_STYLE,
+    },
+    {
+        "id": "gpt-4.1-mini",
+        "name": "GPT-4.1 mini",
+        "reasoning_effort_values": [],
+        "detection_prompt_style": PLAIN_ABSOLUTE_STYLE,
+    },
+    {
+        "id": "gpt-4.1-nano",
+        "name": "GPT-4.1 nano",
+        "reasoning_effort_values": [],
+        "detection_prompt_style": PLAIN_ABSOLUTE_STYLE,
+    },
+    {
+        "id": "gpt-4o",
+        "name": "GPT-4o",
+        "reasoning_effort_values": [],
+        "detection_prompt_style": PLAIN_ABSOLUTE_STYLE,
+    },
+    {
+        "id": "gpt-4o-mini",
+        "name": "GPT-4o mini",
+        "reasoning_effort_values": [],
+        "detection_prompt_style": PLAIN_ABSOLUTE_STYLE,
+    },
+]
+
+MODEL_VERSION_IDS = [model["id"] for model in OPENAI_MODELS]
+
+MODEL_VERSION_METADATA = {
+    model["id"]: {"name": model["name"]} for model in OPENAI_MODELS
+}
+
+MODELS_SUPPORTING_REASONING_EFFORT = [
+    model["id"] for model in OPENAI_MODELS if model["reasoning_effort_values"]
+]
+
+MODELS_NOT_SUPPORTING_REASONING_EFFORT = [
+    model["id"] for model in OPENAI_MODELS if not model["reasoning_effort_values"]
+]
+
+MODEL_REASONING_EFFORT_VALUES = {
+    model["id"]: model["reasoning_effort_values"] for model in OPENAI_MODELS
+}
+
+MODEL_DETECTION_PROMPT_STYLES = {
+    model["id"]: model["detection_prompt_style"] for model in OPENAI_MODELS
+}
+
+
+def get_detection_prompt_style(model_version: str) -> str:
+    """Resolve the object-detection prompt style for a model.
+
+    Unknown (future) models default to the structured-absolute contract, which
+    matches the behavior of the newest generations in the registry.
+
+    Args:
+        model_version: OpenAI model identifier, e.g. ``gpt-5.6-sol``.
+
+    Returns:
+        One of ``STRUCTURED_ABSOLUTE_STYLE``, ``NORMALIZED_LEGACY_STYLE`` or
+        ``PLAIN_ABSOLUTE_STYLE``.
+    """
+    return MODEL_DETECTION_PROMPT_STYLES.get(model_version, STRUCTURED_ABSOLUTE_STYLE)
+
+
+OBJECT_DETECTION_PROMPT_TEMPLATE = (
+    "Detect all objects in this image. "
+    "Output a JSON list where each entry contains the 2D bounding box "
+    'in the key "box_2d" and the text label in the key "label". '
+    'The "box_2d" value must be [x_min, y_min, x_max, y_max]: the '
+    "top-left and bottom-right corners in absolute pixel coordinates "
+    "of the {width}x{height} pixel image. "
+    "Return only the JSON list, with no extra text. "
+    "Only use these labels: {class_list}"
+)
+
+STRUCTURED_OBJECT_DETECTION_PROMPT_TEMPLATE = (
+    "Detect all objects in this image. "
+    'Output JSON with the key "detections" holding a list where each entry '
+    'contains the 2D bounding box in the key "box_2d" and the text label '
+    'in the key "label". '
+    'The "box_2d" value must be [x_min, y_min, x_max, y_max]: the '
+    "top-left and bottom-right corners in absolute pixel coordinates "
+    "of the {width}x{height} pixel image. "
+    "Only use these labels: {class_list}"
+)
+
+NORMALIZED_OBJECT_DETECTION_INSTRUCTIONS = (
+    "You act as object-detection model. You must provide reasonable predictions. "
+    "You are only allowed to produce JSON document. "
+    'Expected structure of json: {"detections": [{"x_min": 0.1, "y_min": 0.2, '
+    '"x_max": 0.3, "y_max": 0.4, "class_name": "my-class-X", "confidence": 0.7}]}. '
+    "`my-class-X` must be one of the class names defined by user. All coordinates "
+    "must be in range 0.0-1.0, representing percentage of image dimensions. "
+    "`confidence` is a value in range 0.0-1.0 representing your confidence in "
+    "prediction. You should detect all instances of classes provided by user."
+)
+
+STRUCTURED_OBJECT_DETECTION_OUTPUT_FORMAT = {
+    "format": {
+        "type": "json_schema",
+        "name": "detections",
+        "strict": True,
+        "schema": {
+            "type": "object",
+            "properties": {
+                "detections": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "label": {"type": "string"},
+                            "box_2d": {
+                                "type": "array",
+                                "items": {"type": "integer"},
+                                "minItems": 4,
+                                "maxItems": 4,
+                            },
+                        },
+                        "required": ["label", "box_2d"],
+                        "additionalProperties": False,
+                    },
+                }
+            },
+            "required": ["detections"],
+            "additionalProperties": False,
+        },
+    }
+}
+
+SUPPORTED_TASK_TYPES_LIST = [
+    "unconstrained",
+    "ocr",
+    "structured-answering",
+    "classification",
+    "multi-label-classification",
+    "visual-question-answering",
+    "caption",
+    "detailed-caption",
+    "object-detection",
+]
+SUPPORTED_TASK_TYPES = set(SUPPORTED_TASK_TYPES_LIST)
+
+RELEVANT_TASKS_METADATA = {
+    k: v for k, v in VLM_TASKS_METADATA.items() if k in SUPPORTED_TASK_TYPES
+}
+RELEVANT_TASKS_DOCS_DESCRIPTION = "\n\n".join(
+    f"* **{v['name']}** (`{k}`) - {v['description']}"
+    for k, v in RELEVANT_TASKS_METADATA.items()
+)
+
+LONG_DESCRIPTION = f"""
+Ask a question to OpenAI's GPT models with vision capabilities (including GPT-5 and GPT-4o).
+
+You can specify arbitrary text prompts or predefined ones, the block supports the following types of prompt:
+
+{RELEVANT_TASKS_DOCS_DESCRIPTION}
+
+The `object-detection` task uses a per-model prompt contract selected from a
+large-scale benchmark - use `roboflow_core/vlm_as_detector@v2` to convert any of
+the outputs into predictions:
+
+* Most models (GPT-5.2 and newer, plus unknown/future models) return
+`{{"detections": [...]}}` with `box_2d` boxes in `[x_min, y_min, x_max, y_max]`
+format (absolute pixel coordinates of the uploaded image) and a `label` key,
+enforced via structured outputs.
+* GPT-5.1/GPT-5 generation models return the legacy normalized dict
+(`x_min`/`y_min`/`x_max`/`y_max` in 0.0-1.0 with `class_name` and `confidence`).
+* GPT-4.x/GPT-4o and nano-tier models return a plain JSON list of `box_2d`
+entries in absolute pixel coordinates.
+
+The absolute-coordinate formats do not provide confidence scores.
+`roboflow_core/vlm_as_detector@v2` assigns these detections a confidence of
+`1.0`, so downstream confidence filtering is not meaningful for these formats.
+
+Images are downscaled so that their longest edge does not exceed
+{DETECTION_MAX_EDGE_PIXELS}px and are sent as lossless PNG for this task.
+
+Provide your OpenAI API key or set the value to ``rf_key:account`` (or
+``rf_key:user:<id>``) to proxy requests through Roboflow's API.
+"""
+
+TaskType = Literal[tuple(SUPPORTED_TASK_TYPES_LIST)]
+
+TASKS_REQUIRING_PROMPT = {
+    "unconstrained",
+    "visual-question-answering",
+}
+
+TASKS_REQUIRING_CLASSES = {
+    "classification",
+    "multi-label-classification",
+    "object-detection",
+}
+
+TASKS_REQUIRING_OUTPUT_STRUCTURE = {
+    "structured-answering",
+}
+
+
+class BlockManifest(WorkflowBlockManifest):
+    model_config = ConfigDict(
+        json_schema_extra={
+            "name": "OpenAI",
+            "version": "v6",
+            "short_description": "Run OpenAI's GPT models with vision capabilities.",
+            "long_description": LONG_DESCRIPTION,
+            "license": "Apache-2.0",
+            "block_type": "model",
+            "search_keywords": ["LMM", "VLM", "ChatGPT", "GPT", "OpenAI"],
+            "is_vlm_block": True,
+            "task_type_property": "task_type",
+            "ui_manifest": {
+                "section": "model",
+                "icon": "fal fa-atom",
+                "blockPriority": 5,
+                "popular": True,
+            },
+        },
+        protected_namespaces=(),
+    )
+    type: Literal["roboflow_core/open_ai@v6"]
+    images: Selector(kind=[IMAGE_KIND]) = ImageInputField
+    task_type: TaskType = Field(
+        default="unconstrained",
+        description="Task type to be performed by model. Value determines required parameters and output response.",
+        json_schema_extra={
+            "values_metadata": RELEVANT_TASKS_METADATA,
+            "recommended_parsers": {
+                "structured-answering": "roboflow_core/json_parser@v1",
+                "classification": "roboflow_core/vlm_as_classifier@v2",
+                "multi-label-classification": "roboflow_core/vlm_as_classifier@v2",
+                "object-detection": "roboflow_core/vlm_as_detector@v2",
+            },
+            "always_visible": True,
+        },
+    )
+    prompt: Optional[Union[Selector(kind=[STRING_KIND]), str]] = Field(
+        default=None,
+        description="Text prompt to the OpenAI model",
+        examples=["my prompt", "$inputs.prompt"],
+        json_schema_extra={
+            "relevant_for": {
+                "task_type": {"values": TASKS_REQUIRING_PROMPT, "required": True},
+            },
+            "multiline": True,
+        },
+    )
+    output_structure: Optional[Dict[str, str]] = Field(
+        default=None,
+        description="Dictionary with structure of expected JSON response",
+        examples=[{"my_key": "description"}, "$inputs.output_structure"],
+        json_schema_extra={
+            "relevant_for": {
+                "task_type": {
+                    "values": TASKS_REQUIRING_OUTPUT_STRUCTURE,
+                    "required": True,
+                },
+            },
+        },
+    )
+    classes: Optional[Union[Selector(kind=[LIST_OF_VALUES_KIND]), List[str]]] = Field(
+        default=None,
+        description="List of classes to be used",
+        examples=[["class-a", "class-b"], "$inputs.classes"],
+        json_schema_extra={
+            "relevant_for": {
+                "task_type": {
+                    "values": TASKS_REQUIRING_CLASSES,
+                    "required": True,
+                },
+            },
+        },
+    )
+    api_key: Union[
+        Selector(kind=[STRING_KIND, SECRET_KIND, ROBOFLOW_MANAGED_KEY]), str
+    ] = Field(
+        default="rf_key:account",
+        description="Your OpenAI API key",
+        examples=["xxx-xxx", "$inputs.openai_api_key"],
+        private=True,
+    )
+    model_version: Union[
+        Selector(kind=[STRING_KIND]),
+        Literal[tuple(MODEL_VERSION_IDS)],
+    ] = Field(
+        default="gpt-5.1",
+        description="Model to be used",
+        examples=["gpt-5.1", "$inputs.openai_model"],
+        json_schema_extra={
+            "values_metadata": MODEL_VERSION_METADATA,
+        },
+    )
+    reasoning_effort: Optional[
+        Union[
+            Selector(kind=[STRING_KIND]),
+            Literal["none", "minimal", "low", "medium", "high", "xhigh"],
+        ]
+    ] = Field(
+        default=None,
+        description="Controls reasoning. Reducing can result in faster responses and fewer tokens. "
+        "GPT-5.1 and higher models default to 'none' (no reasoning) and support 'none', 'low', 'medium', 'high'. "
+        "GPT-5.2 also supports 'xhigh'. "
+        "GPT-5 models default to 'medium' and support 'minimal', 'low', 'medium', 'high'.",
+        json_schema_extra={
+            "relevant_for": {
+                "model_version": {
+                    "values": MODELS_SUPPORTING_REASONING_EFFORT,
+                    "required": False,
+                },
+            },
+        },
+    )
+    image_detail: Union[
+        Selector(kind=[STRING_KIND]), Literal["auto", "high", "low"]
+    ] = Field(
+        default="auto",
+        description="Indicates the image's quality, with 'high' suggesting it is of high resolution and should be processed or displayed with high fidelity. "
+        "Not applied to the `object-detection` task, which always sends the image without the detail hint.",
+        examples=["auto", "high", "low"],
+    )
+    max_tokens: Optional[int] = Field(
+        default=None,
+        description="Maximum number of tokens the model can generate in its response. "
+        "If not specified, the model will use its default limit. Minimum value is 16.",
+        ge=16,
+    )
+    temperature: Optional[Union[float, Selector(kind=[FLOAT_KIND])]] = Field(
+        default=None,
+        description="Temperature to sample from the model - value in range 0.0-2.0, the higher - the more "
+        'random / "creative" the generations are.',
+        ge=0.0,
+        le=2.0,
+    )
+    max_concurrent_requests: Optional[int] = Field(
+        default=None,
+        description="Number of concurrent requests that can be executed by block when batch of input images provided. "
+        "If not given - block defaults to value configured globally in Workflows Execution Engine. "
+        "Please restrict if you hit OpenAI limits.",
+    )
+
+    @model_validator(mode="after")
+    def validate(self) -> "BlockManifest":
+        if self.task_type in TASKS_REQUIRING_PROMPT and self.prompt is None:
+            raise ValueError(
+                f"`prompt` parameter required to be set for task `{self.task_type}`"
+            )
+        if self.task_type in TASKS_REQUIRING_CLASSES and self.classes is None:
+            raise ValueError(
+                f"`classes` parameter required to be set for task `{self.task_type}`"
+            )
+        if (
+            self.task_type in TASKS_REQUIRING_OUTPUT_STRUCTURE
+            and self.output_structure is None
+        ):
+            raise ValueError(
+                f"`output_structure` parameter required to be set for task `{self.task_type}`"
+            )
+        return self
+
+    @classmethod
+    def get_air_gapped_availability(cls) -> AirGappedAvailability:
+        return AirGappedAvailability(available=False, reason="requires_internet")
+
+    @classmethod
+    def get_parameters_accepting_batches(cls) -> List[str]:
+        return ["images"]
+
+    @classmethod
+    def describe_outputs(cls) -> List[OutputDefinition]:
+        return [
+            OutputDefinition(
+                name="output", kind=[STRING_KIND, LANGUAGE_MODEL_OUTPUT_KIND]
+            ),
+            OutputDefinition(name="classes", kind=[LIST_OF_VALUES_KIND]),
+            *TOKEN_OUTPUT_DEFINITIONS,
+        ]
+
+    @classmethod
+    def get_execution_engine_compatibility(cls) -> Optional[str]:
+        return ">=1.4.0,<2.0.0"
+
+    def discover_dependent_resources(self) -> Optional[List[DependentResource]]:
+        return [third_party_model(provider="openai", model_id=self.model_version)]
+
+
+class OpenAIBlockV6(WorkflowBlock):
+
+    def __init__(
+        self,
+        model_manager: ModelManager,
+        api_key: Optional[str],
+    ):
+        self._model_manager = model_manager
+        self._api_key = api_key
+
+    @classmethod
+    def get_init_parameters(cls) -> List[str]:
+        return ["model_manager", "api_key"]
+
+    @classmethod
+    def get_manifest(cls) -> Type[WorkflowBlockManifest]:
+        return BlockManifest
+
+    @classmethod
+    def get_execution_engine_compatibility(cls) -> Optional[str]:
+        return ">=1.4.0,<2.0.0"
+
+    def run(
+        self,
+        images: Batch[WorkflowImageData],
+        task_type: TaskType,
+        prompt: Optional[str],
+        output_structure: Optional[Dict[str, str]],
+        classes: Optional[List[str]],
+        model_version: str,
+        reasoning_effort: Optional[str],
+        image_detail: Literal["low", "high", "auto"],
+        max_tokens: Optional[int],
+        temperature: Optional[float],
+        max_concurrent_requests: Optional[int],
+        api_key: str = "rf_key:account",
+    ) -> BlockResult:
+        inference_images = [i.to_inference_format() for i in images]
+        raw_outputs = run_openai_prompting(
+            roboflow_api_key=self._api_key,
+            images=inference_images,
+            task_type=task_type,
+            prompt=prompt,
+            output_structure=output_structure,
+            classes=classes,
+            openai_api_key=api_key,
+            model_version=model_version,
+            reasoning_effort=reasoning_effort,
+            image_detail=image_detail,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            max_concurrent_requests=max_concurrent_requests,
+        )
+        return [
+            {
+                "output": content,
+                "classes": classes,
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+            }
+            for content, input_tokens, output_tokens in raw_outputs
+        ]
+
+
+def run_openai_prompting(
+    roboflow_api_key: Optional[str],
+    images: List[Dict[str, Any]],
+    task_type: TaskType,
+    prompt: Optional[str],
+    output_structure: Optional[Dict[str, str]],
+    classes: Optional[List[str]],
+    openai_api_key: str,
+    model_version: str,
+    reasoning_effort: Optional[str],
+    image_detail: Literal["auto", "high", "low"],
+    max_tokens: Optional[int],
+    temperature: Optional[float],
+    max_concurrent_requests: Optional[int],
+) -> List[Tuple[str, Optional[int], Optional[int]]]:
+    """Encode images, build per-task prompts and execute OpenAI requests.
+
+    Each image is preprocessed according to the task type (see
+    ``encode_image_for_task``), turned into a request payload by the prompt
+    builder registered for the task in ``PROMPT_BUILDERS`` and executed via
+    ``execute_openai_requests``.
+
+    Args:
+        roboflow_api_key: Roboflow API key, required only for proxied
+            execution with an ``rf_key:`` OpenAI key.
+        images: Input images in loadable form.
+        task_type: Task determining preprocessing and prompt construction.
+        prompt: Free-form text prompt for tasks that accept one.
+        output_structure: Field descriptions for structured answering.
+        classes: Class names for classification and detection tasks.
+        openai_api_key: OpenAI API key or Roboflow-proxied ``rf_key:`` key.
+        model_version: OpenAI model identifier.
+        reasoning_effort: Reasoning effort for models that support it.
+        image_detail: Requested image detail level.
+        max_tokens: Maximum number of output tokens.
+        temperature: Sampling temperature.
+        max_concurrent_requests: Cap on concurrent OpenAI requests.
+
+    Returns:
+        ``(output_text, input_tokens, output_tokens)`` tuples, one per input
+        image; token counts are ``None`` when the provider omits usage data.
+
+    Raises:
+        ValueError: If the task type has no registered prompt builder.
+    """
+    if task_type not in PROMPT_BUILDERS:
+        raise ValueError(f"Task type: {task_type} not supported.")
+    openai_prompts = []
+    for image in images:
+        loaded_image, _ = load_image(image)
+        base64_image, image_width, image_height = encode_image_for_task(
+            loaded_image, task_type=task_type
+        )
+        generated_prompt = PROMPT_BUILDERS[task_type](
+            base64_image=base64_image,
+            prompt=prompt,
+            output_structure=output_structure,
+            classes=classes,
+            image_detail=image_detail,
+            image_width=image_width,
+            image_height=image_height,
+            model_version=model_version,
+        )
+        openai_prompts.append(generated_prompt)
+    return execute_openai_requests(
+        roboflow_api_key=roboflow_api_key,
+        openai_api_key=openai_api_key,
+        openai_prompts=openai_prompts,
+        model_version=model_version,
+        reasoning_effort=reasoning_effort,
+        max_tokens=max_tokens,
+        temperature=temperature,
+        max_concurrent_requests=max_concurrent_requests,
+    )
+
+
+def encode_image_for_task(
+    image: np.ndarray, *, task_type: TaskType
+) -> Tuple[str, int, int]:
+    """Encode an image as base64 using task-appropriate preprocessing.
+
+    The `object-detection` task mirrors the preprocessing used for detection
+    benchmarks: the image is downscaled so its longest edge does not exceed
+    ``DETECTION_MAX_EDGE_PIXELS`` (aspect ratio preserved, never upscaled) and
+    encoded as lossless PNG. All other tasks send the image unchanged as JPEG.
+
+    Args:
+        image: BGR image to be encoded.
+        task_type: Task type determining the preprocessing applied.
+
+    Returns:
+        Tuple of the base64-encoded image payload (without a data URL prefix)
+        and the ``(width, height)`` of the encoded image.
+    """
+    if task_type == "object-detection":
+        encoded_image = _downscale_image_to_max_edge(
+            image, max_edge=DETECTION_MAX_EDGE_PIXELS
+        )
+        image_bytes = _encode_image_to_png_bytes(encoded_image)
+    else:
+        encoded_image = image
+        image_bytes = encode_image_to_jpeg_bytes(encoded_image)
+
+    base64_image = base64.b64encode(image_bytes).decode("ascii")
+    encoded_height, encoded_width = encoded_image.shape[:2]
+
+    return base64_image, encoded_width, encoded_height
+
+
+def _downscale_image_to_max_edge(image: np.ndarray, *, max_edge: int) -> np.ndarray:
+    height, width = image.shape[:2]
+    target_width, target_height = scale_dimensions_to_max_edge(width, height, max_edge)
+    if (target_width, target_height) == (width, height):
+        return image
+
+    resized_image = cv2.resize(
+        image, (target_width, target_height), interpolation=cv2.INTER_LANCZOS4
+    )
+
+    return resized_image
+
+
+def _encode_image_to_png_bytes(image: np.ndarray) -> bytes:
+    _, encoded_image = cv2.imencode(".png", image)
+    return encoded_image.tobytes()
+
+
+def execute_openai_requests(
+    roboflow_api_key: Optional[str],
+    openai_api_key: str,
+    openai_prompts: List[dict],
+    model_version: str,
+    reasoning_effort: Optional[str],
+    max_tokens: Optional[int],
+    temperature: Optional[float],
+    max_concurrent_requests: Optional[int],
+) -> List[Tuple[str, Optional[int], Optional[int]]]:
+    """Execute prepared OpenAI request payloads in parallel.
+
+    Args:
+        roboflow_api_key: Roboflow API key for proxied execution.
+        openai_api_key: OpenAI API key or Roboflow-proxied ``rf_key:`` key.
+        openai_prompts: Prompt payloads with ``input`` and optionally
+            ``instructions`` and ``text`` (structured-output format) keys.
+        model_version: OpenAI model identifier.
+        reasoning_effort: Reasoning effort for models that support it.
+        max_tokens: Maximum number of output tokens.
+        temperature: Sampling temperature.
+        max_concurrent_requests: Cap on concurrent requests; defaults to
+            ``WORKFLOWS_REMOTE_EXECUTION_MAX_STEP_CONCURRENT_REQUESTS``.
+
+    Returns:
+        ``(output_text, input_tokens, output_tokens)`` tuples in the order of
+        the input prompts.
+    """
+    tasks = [
+        partial(
+            execute_openai_request,
+            roboflow_api_key=roboflow_api_key,
+            openai_api_key=openai_api_key,
+            instructions=prompt.get("instructions"),
+            input_content=prompt["input"],
+            text_format=prompt.get("text"),
+            model_version=model_version,
+            reasoning_effort=reasoning_effort,
+            max_tokens=max_tokens,
+            temperature=temperature,
+        )
+        for prompt in openai_prompts
+    ]
+    max_workers = (
+        max_concurrent_requests
+        or WORKFLOWS_REMOTE_EXECUTION_MAX_STEP_CONCURRENT_REQUESTS
+    )
+    return run_in_parallel(
+        tasks=tasks,
+        max_workers=max_workers,
+    )
+
+
+def _execute_proxied_openai_request(
+    roboflow_api_key: str,
+    openai_api_key: str,
+    instructions: Optional[str],
+    input_content: List[dict],
+    model_version: str,
+    reasoning_effort: Optional[str],
+    max_tokens: Optional[int],
+    temperature: Optional[float],
+    text_format: Optional[dict] = None,
+) -> Tuple[str, Optional[int], Optional[int]]:
+    """Executes OpenAI request via Roboflow proxy."""
+    payload = {
+        "model": model_version,
+        "input": input_content,
+        "openai_api_key": openai_api_key,
+    }
+
+    if instructions is not None:
+        payload["instructions"] = instructions
+
+    if text_format is not None:
+        payload["text"] = text_format
+
+    if max_tokens is not None:
+        payload["max_output_tokens"] = max_tokens
+
+    if temperature is not None:
+        payload["temperature"] = temperature
+
+    if (
+        reasoning_effort is not None
+        and model_version in MODELS_SUPPORTING_REASONING_EFFORT
+    ):
+        effort_values = MODEL_REASONING_EFFORT_VALUES.get(model_version, [])
+        if reasoning_effort not in effort_values:
+            raise ValueError(
+                f'Model {model_version} does not support reasoning effort "{reasoning_effort}"'
+            )
+        payload["reasoning"] = {"effort": reasoning_effort}
+
+    endpoint = "apiproxy/openai/v2"
+
+    try:
+        # Use the Roboflow API post function (this ensures proper auth headers used based on invocation context)
+        response_data = post_to_roboflow_api(
+            endpoint=endpoint,
+            api_key=roboflow_api_key,
+            payload=payload,
+        )
+        text = _extract_output_text(response_data)
+        input_tokens, output_tokens = parse_responses_api_usage(
+            response_data.get("usage")
+        )
+        return text, input_tokens, output_tokens
+    except requests.exceptions.RequestException as e:
+        raise RuntimeError(f"Failed to connect to Roboflow proxy: {e}") from e
+    except (KeyError, IndexError) as e:
+        raise RuntimeError(
+            f"Invalid response structure from Roboflow proxy: {e}"
+        ) from e
+
+
+def _extract_output_text(response_data: dict) -> str:
+    """Extract output text from OpenAI Responses API response."""
+    status = response_data.get("status")
+
+    if status == "failed":
+        error = response_data.get("error", {})
+        error_message = (
+            f"{error.get('code', 'Unknown')}: {error.get('message', 'Unknown error')}"
+        )
+        raise ValueError(f"OpenAI API request failed: {error_message}")
+
+    if status == "cancelled":
+        raise ValueError("OpenAI API request was cancelled.")
+
+    if status == "incomplete":
+        incomplete_details = response_data.get("incomplete_details", {})
+        reason = incomplete_details.get("reason", "Unknown reason")
+        if reason == "max_output_tokens":
+            raise ValueError(
+                "OpenAI API stopped generation because the max_tokens limit was reached. "
+                "Please increase the max_tokens parameter to allow for a complete response."
+            )
+        raise ValueError(
+            f"OpenAI API returned an incomplete response. Reason: {reason}"
+        )
+
+    if status not in ["completed", "in_progress", "queued", None]:
+        raise ValueError(f"OpenAI API returned unexpected status: {status}")
+
+    # Extract text from output items
+    output_items = response_data.get("output", [])
+    texts = []
+    for item in output_items:
+        if item.get("type") == "message":
+            for content in item.get("content", []):
+                if content.get("type") == "output_text":
+                    texts.append(content.get("text", ""))
+
+    output_text = "".join(texts)
+    if not output_text:
+        raise ValueError("OpenAI API returned no text content in response.")
+
+    return output_text
+
+
+def _execute_direct_openai_request(
+    openai_api_key: str,
+    instructions: Optional[str],
+    input_content: List[dict],
+    model_version: str,
+    reasoning_effort: Optional[str],
+    max_tokens: Optional[int],
+    temperature: Optional[float],
+    text_format: Optional[dict] = None,
+) -> Tuple[str, Optional[int], Optional[int]]:
+    """Executes OpenAI request directly."""
+    client = _get_openai_client(openai_api_key)
+
+    request_params = {
+        "model": model_version,
+        "input": input_content,
+    }
+
+    if instructions is not None:
+        request_params["instructions"] = instructions
+
+    if text_format is not None:
+        request_params["text"] = text_format
+
+    if max_tokens is not None:
+        request_params["max_output_tokens"] = max_tokens
+
+    if temperature is not None:
+        request_params["temperature"] = temperature
+
+    if (
+        reasoning_effort is not None
+        and model_version in MODELS_SUPPORTING_REASONING_EFFORT
+    ):
+        effort_values = MODEL_REASONING_EFFORT_VALUES.get(model_version, [])
+        if reasoning_effort not in effort_values:
+            raise ValueError(
+                f'Model {model_version} does not support reasoning effort "{reasoning_effort}"'
+            )
+        request_params["reasoning"] = {"effort": reasoning_effort}
+
+    response = client.responses.create(**request_params)
+
+    status = response.status
+    if status == "failed":
+        error_message = "Unknown error"
+        if response.error:
+            error_message = f"{response.error.code}: {response.error.message}"
+        raise ValueError(f"OpenAI API request failed: {error_message}")
+
+    if status == "cancelled":
+        raise ValueError("OpenAI API request was cancelled.")
+
+    if status == "incomplete":
+        reason = "Unknown reason"
+        if response.incomplete_details:
+            reason = response.incomplete_details.reason
+        if reason == "max_output_tokens":
+            raise ValueError(
+                "OpenAI API stopped generation because the max_tokens limit was reached. "
+                "Please increase the max_tokens parameter to allow for a complete response."
+            )
+        raise ValueError(
+            f"OpenAI API returned an incomplete response. Reason: {reason}"
+        )
+
+    if status not in ["completed", "in_progress", "queued"]:
+        raise ValueError(f"OpenAI API returned unexpected status: {status}")
+
+    output_text = response.output_text
+    if not output_text:
+        raise ValueError("OpenAI API returned no text content in response.")
+
+    input_tokens, output_tokens = parse_responses_api_usage(
+        getattr(response, "usage", None)
+    )
+    return output_text, input_tokens, output_tokens
+
+
+def execute_openai_request(
+    roboflow_api_key: Optional[str],
+    openai_api_key: str,
+    instructions: Optional[str],
+    input_content: List[dict],
+    model_version: str,
+    reasoning_effort: Optional[str],
+    max_tokens: Optional[int],
+    temperature: Optional[float],
+    text_format: Optional[dict] = None,
+) -> Tuple[str, Optional[int], Optional[int]]:
+    """Execute a single OpenAI request, routing to direct or proxied mode.
+
+    Requests are proxied through Roboflow when the OpenAI key is a Roboflow
+    managed ``rf_key:`` key; otherwise the OpenAI API is called directly.
+
+    Args:
+        roboflow_api_key: Roboflow API key, required for proxied execution.
+        openai_api_key: OpenAI API key or Roboflow-proxied ``rf_key:`` key.
+        instructions: Optional system instructions.
+        input_content: ``input`` entries of the Responses API payload.
+        model_version: OpenAI model identifier.
+        reasoning_effort: Reasoning effort for models that support it.
+        max_tokens: Maximum number of output tokens.
+        temperature: Sampling temperature.
+        text_format: Optional structured-output ``text`` payload forwarded
+            with the request.
+
+    Returns:
+        Tuple of the raw text output and the input/output token counts
+        (``None`` when the provider omits usage data).
+    """
+    if openai_api_key.startswith(("rf_key:account", "rf_key:user:")):
+        if not roboflow_api_key:
+            raise ValueError(
+                "Roboflow API key is required when using a Roboflow-managed OpenAI API key."
+            )
+
+        return _execute_proxied_openai_request(
+            roboflow_api_key=roboflow_api_key,
+            openai_api_key=openai_api_key,
+            instructions=instructions,
+            input_content=input_content,
+            model_version=model_version,
+            reasoning_effort=reasoning_effort,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            text_format=text_format,
+        )
+    else:
+        return _execute_direct_openai_request(
+            openai_api_key=openai_api_key,
+            instructions=instructions,
+            input_content=input_content,
+            model_version=model_version,
+            reasoning_effort=reasoning_effort,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            text_format=text_format,
+        )
+
+
+def prepare_unconstrained_prompt(
+    base64_image: str,
+    prompt: str,
+    image_detail: str,
+    **kwargs,
+) -> dict:
+    """Build a request forwarding the user's prompt without instructions.
+
+    Args:
+        base64_image: Base64-encoded JPEG image.
+        prompt: Free-form user prompt.
+        image_detail: Requested image detail level.
+        **kwargs: Ignored builder arguments shared across task types.
+
+    Returns:
+        Request payload with an ``input`` key.
+    """
+    return {
+        "input": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "input_text", "text": prompt},
+                    {
+                        "type": "input_image",
+                        "image_url": f"data:image/jpeg;base64,{base64_image}",
+                        "detail": image_detail,
+                    },
+                ],
+            }
+        ],
+    }
+
+
+def prepare_classification_prompt(
+    base64_image: str,
+    classes: List[str],
+    image_detail: str,
+    **kwargs,
+) -> dict:
+    """Build a single-label classification request.
+
+    Args:
+        base64_image: Base64-encoded JPEG image.
+        classes: Class names the model may predict.
+        image_detail: Requested image detail level.
+        **kwargs: Ignored builder arguments shared across task types.
+
+    Returns:
+        Request payload with ``instructions`` and ``input`` keys.
+    """
+    serialised_classes = ", ".join(classes)
+    return {
+        "instructions": (
+            "You act as single-class classification model. You must provide reasonable predictions. "
+            "You are only allowed to produce JSON document in Markdown ```json [...]``` markers. "
+            'Expected structure of json: {"class_name": "class-name", "confidence": 0.4}. '
+            "`class-name` must be one of the class names defined by user. You are only allowed to return "
+            "single JSON document, even if there are potentially multiple classes. You are not allowed to return list."
+        ),
+        "input": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "input_text",
+                        "text": f"List of all classes to be recognised by model: {serialised_classes}",
+                    },
+                    {
+                        "type": "input_image",
+                        "image_url": f"data:image/jpeg;base64,{base64_image}",
+                        "detail": image_detail,
+                    },
+                ],
+            }
+        ],
+    }
+
+
+def prepare_multi_label_classification_prompt(
+    base64_image: str,
+    classes: List[str],
+    image_detail: str,
+    **kwargs,
+) -> dict:
+    """Build a multi-label classification request.
+
+    Args:
+        base64_image: Base64-encoded JPEG image.
+        classes: Class names the model may predict.
+        image_detail: Requested image detail level.
+        **kwargs: Ignored builder arguments shared across task types.
+
+    Returns:
+        Request payload with ``instructions`` and ``input`` keys.
+    """
+    serialised_classes = ", ".join(classes)
+    return {
+        "instructions": (
+            "You act as multi-label classification model. You must provide reasonable predictions. "
+            "You are only allowed to produce JSON document in Markdown ```json``` markers. "
+            'Expected structure of json: {"predicted_classes": [{"class": "class-name-1", "confidence": 0.9}, '
+            '{"class": "class-name-2", "confidence": 0.7}]}. '
+            "`class-name-X` must be one of the class names defined by user and `confidence` is a float value in range "
+            "0.0-1.0 that represent how sure you are that the class is present in the image. Only return class names "
+            "that are visible."
+        ),
+        "input": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "input_text",
+                        "text": f"List of all classes to be recognised by model: {serialised_classes}",
+                    },
+                    {
+                        "type": "input_image",
+                        "image_url": f"data:image/jpeg;base64,{base64_image}",
+                        "detail": image_detail,
+                    },
+                ],
+            }
+        ],
+    }
+
+
+def prepare_vqa_prompt(
+    base64_image: str,
+    prompt: str,
+    image_detail: str,
+    **kwargs,
+) -> dict:
+    """Build a visual-question-answering request.
+
+    Args:
+        base64_image: Base64-encoded JPEG image.
+        prompt: Question to be answered.
+        image_detail: Requested image detail level.
+        **kwargs: Ignored builder arguments shared across task types.
+
+    Returns:
+        Request payload with ``instructions`` and ``input`` keys.
+    """
+    return {
+        "instructions": (
+            "You act as Visual Question Answering model. Your task is to provide answer to question "
+            "submitted by user. If this is open-question - answer with few sentences, for ABCD question, "
+            "return only the indicator of the answer."
+        ),
+        "input": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "input_text", "text": f"Question: {prompt}"},
+                    {
+                        "type": "input_image",
+                        "image_url": f"data:image/jpeg;base64,{base64_image}",
+                        "detail": image_detail,
+                    },
+                ],
+            }
+        ],
+    }
+
+
+def prepare_ocr_prompt(
+    base64_image: str,
+    image_detail: str,
+    **kwargs,
+) -> dict:
+    """Build an OCR request returning recognised text as paragraphs.
+
+    Args:
+        base64_image: Base64-encoded JPEG image.
+        image_detail: Requested image detail level.
+        **kwargs: Ignored builder arguments shared across task types.
+
+    Returns:
+        Request payload with ``instructions`` and ``input`` keys.
+    """
+    return {
+        "instructions": (
+            "You act as OCR model. Your task is to read text from the image and return it in "
+            "paragraphs representing the structure of texts in the image. You should only return "
+            "recognised text, nothing else."
+        ),
+        "input": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "input_image",
+                        "image_url": f"data:image/jpeg;base64,{base64_image}",
+                        "detail": image_detail,
+                    },
+                ],
+            }
+        ],
+    }
+
+
+def prepare_caption_prompt(
+    base64_image: str,
+    image_detail: str,
+    short_description: bool,
+    **kwargs,
+) -> dict:
+    """Build an image captioning request.
+
+    Args:
+        base64_image: Base64-encoded JPEG image.
+        image_detail: Requested image detail level.
+        short_description: Whether to request a short caption instead of an
+            extensive one.
+        **kwargs: Ignored builder arguments shared across task types.
+
+    Returns:
+        Request payload with ``instructions`` and ``input`` keys.
+    """
+    caption_detail_level = "Caption should be short."
+    if not short_description:
+        caption_detail_level = "Caption should be extensive."
+    return {
+        "instructions": (
+            f"You act as image caption model. Your task is to provide description of the image. "
+            f"{caption_detail_level}"
+        ),
+        "input": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "input_image",
+                        "image_url": f"data:image/jpeg;base64,{base64_image}",
+                        "detail": image_detail,
+                    },
+                ],
+            }
+        ],
+    }
+
+
+def prepare_structured_answering_prompt(
+    base64_image: str,
+    output_structure: Dict[str, str],
+    image_detail: str,
+    **kwargs,
+) -> dict:
+    """Build a structured-answering request producing user-defined JSON.
+
+    Args:
+        base64_image: Base64-encoded JPEG image.
+        output_structure: Mapping of output field names to descriptions of
+            the values the model should generate.
+        image_detail: Requested image detail level.
+        **kwargs: Ignored builder arguments shared across task types.
+
+    Returns:
+        Request payload with ``instructions`` and ``input`` keys.
+    """
+    output_structure_serialised = json.dumps(output_structure, indent=4)
+    return {
+        "instructions": (
+            "You are supposed to produce responses in JSON wrapped in Markdown markers: "
+            "```json\nyour-response\n```. User is to provide you dictionary with keys and values. "
+            "Each key must be present in your response. Values in user dictionary represent "
+            "descriptions for JSON fields to be generated. Provide only JSON Markdown in response."
+        ),
+        "input": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "input_text",
+                        "text": f"Specification of requirements regarding output fields: \n"
+                        f"{output_structure_serialised}",
+                    },
+                    {
+                        "type": "input_image",
+                        "image_url": f"data:image/jpeg;base64,{base64_image}",
+                        "detail": image_detail,
+                    },
+                ],
+            }
+        ],
+    }
+
+
+def prepare_object_detection_prompt(
+    base64_image: str,
+    classes: List[str],
+    image_width: int,
+    image_height: int,
+    model_version: str = "",
+    **kwargs,
+) -> dict:
+    """Build the detection request using the model's preferred prompt style.
+
+    All styles share the same preprocessing (max-edge downscale, lossless
+    PNG); they differ only in the coordinate contract and whether structured
+    outputs are enforced:
+
+    - structured-absolute: absolute pixel ``box_2d`` entries wrapped in a
+      ``{"detections": [...]}`` object enforced via a JSON schema in the
+      returned ``text`` key,
+    - plain-absolute: a bare JSON list of absolute pixel ``box_2d`` entries,
+    - normalized-legacy: the v4-style ``{"detections": [{"x_min": ...}]}``
+      dict with coordinates normalized to 0.0-1.0.
+
+    Args:
+        base64_image: Base64-encoded PNG of the (possibly downscaled) image.
+        classes: Class names the model may use as labels.
+        image_width: Width of the encoded image in pixels.
+        image_height: Height of the encoded image in pixels.
+        model_version: OpenAI model identifier used to resolve the style.
+        **kwargs: Ignored builder arguments shared across task types.
+
+    Returns:
+        Request payload with an ``input`` key and, depending on the style,
+        ``instructions`` and a structured-output ``text`` key.
+    """
+    serialised_classes = ", ".join(classes)
+    style = get_detection_prompt_style(model_version)
+    if style == NORMALIZED_LEGACY_STYLE:
+        return {
+            "instructions": NORMALIZED_OBJECT_DETECTION_INSTRUCTIONS,
+            "input": [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "input_text",
+                            "text": f"List of all classes to be recognised by model: {serialised_classes}",
+                        },
+                        {
+                            "type": "input_image",
+                            "image_url": f"data:image/png;base64,{base64_image}",
+                        },
+                    ],
+                }
+            ],
+        }
+    if style == STRUCTURED_ABSOLUTE_STYLE:
+        template = STRUCTURED_OBJECT_DETECTION_PROMPT_TEMPLATE
+    else:
+        template = OBJECT_DETECTION_PROMPT_TEMPLATE
+    prompt_text = template.format(
+        width=image_width,
+        height=image_height,
+        class_list=serialised_classes,
+    )
+    prompt: dict = {
+        "input": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "input_image",
+                        "image_url": f"data:image/png;base64,{base64_image}",
+                    },
+                    {"type": "input_text", "text": prompt_text},
+                ],
+            }
+        ],
+    }
+    if style == STRUCTURED_ABSOLUTE_STYLE:
+        prompt["text"] = STRUCTURED_OBJECT_DETECTION_OUTPUT_FORMAT
+    return prompt
+
+
+def _get_openai_client(api_key: str):
+    client = _openai_client_cache.get(api_key)
+    if client is None:
+        client = OpenAI(api_key=api_key)
+        _openai_client_cache[api_key] = client
+    return client
+
+
+PROMPT_BUILDERS = {
+    "unconstrained": prepare_unconstrained_prompt,
+    "ocr": prepare_ocr_prompt,
+    "visual-question-answering": prepare_vqa_prompt,
+    "caption": partial(prepare_caption_prompt, short_description=True),
+    "detailed-caption": partial(prepare_caption_prompt, short_description=False),
+    "classification": prepare_classification_prompt,
+    "multi-label-classification": prepare_multi_label_classification_prompt,
+    "structured-answering": prepare_structured_answering_prompt,
+    "object-detection": prepare_object_detection_prompt,
+}
+
+_openai_client_cache = {}

--- a/inference/core/workflows/core_steps/models/foundation/openrouter/v2.py
+++ b/inference/core/workflows/core_steps/models/foundation/openrouter/v2.py
@@ -1,0 +1,340 @@
+"""Generic OpenRouter workflow block.
+
+Like the Qwen-VL / Kimi / Gemma OpenRouter blocks, but the model is a free-form
+string instead of a fixed dropdown. The user pastes any OpenRouter model slug
+(e.g. ``openai/gpt-4o-mini``, ``anthropic/claude-3.5-sonnet``,
+``qwen/qwen3.6-27b``) and the block routes through Roboflow's
+``apiproxy/openrouter`` proxy by default, or directly to OpenRouter when the
+user provides their own ``sk-or-...`` key.
+
+The task-type surface (unconstrained, OCR, classification, detection, etc.)
+is the one shared via ``common.openrouter`` with the other VLM blocks.
+"""
+
+from typing import Dict, List, Literal, Optional, Type, Union
+
+from pydantic import ConfigDict, Field, field_validator, model_validator
+
+from inference.core.workflows.core_steps.common.openrouter import (
+    RECOMMENDED_PARSERS,
+    RELEVANT_TASKS_METADATA,
+    SUPPORTED_TASK_TYPES_LIST,
+    OpenRouterBlockManifestMixin,
+    OpenRouterWorkflowBlockBase,
+    build_prompts_from_images,
+    validate_task_type_required_fields,
+)
+from inference.core.workflows.core_steps.common.reasoning import (
+    REASONING_EFFORT_METADATA,
+    REASONING_EFFORT_OPTIONS,
+    build_openrouter_reasoning_config,
+)
+from inference.core.workflows.core_steps.common.token_usage import (
+    TOKEN_OUTPUT_DEFINITIONS,
+)
+from inference.core.workflows.execution_engine.entities.base import (
+    Batch,
+    OutputDefinition,
+    WorkflowImageData,
+)
+from inference.core.workflows.execution_engine.entities.types import (
+    IMAGE_KIND,
+    LANGUAGE_MODEL_OUTPUT_KIND,
+    LIST_OF_VALUES_KIND,
+    STRING_KIND,
+    ImageInputField,
+    Selector,
+)
+from inference.core.workflows.prototypes.block import (
+    AirGappedAvailability,
+    BlockResult,
+    DependentResource,
+    WorkflowBlockManifest,
+    third_party_model,
+)
+
+TaskType = Literal[tuple(SUPPORTED_TASK_TYPES_LIST)]
+
+
+RELEVANT_TASKS_DOCS_DESCRIPTION = "\n\n".join(
+    f"* **{v['name']}** (`{k}`) - {v['description']}"
+    for k, v in RELEVANT_TASKS_METADATA.items()
+)
+
+
+LONG_DESCRIPTION = f"""
+Run **any** vision-language model available on [OpenRouter](https://openrouter.ai/) by
+pasting its model slug into the `model_id` field — e.g.
+`openai/gpt-4o-mini`, `anthropic/claude-3.5-sonnet`, `google/gemini-2.5-pro`,
+`qwen/qwen3.6-27b`.
+
+This is the generic escape hatch for OpenRouter — when you want a model that
+doesn't have a dedicated block (Qwen-VL, Kimi, Gemma, Llama Vision) and you
+want to try it out without waiting for a new block to be added.
+
+The block supports the standard VLM task-type surface:
+
+{RELEVANT_TASKS_DOCS_DESCRIPTION}
+
+#### 🛠️ API key
+
+By default the block uses the **Roboflow-managed OpenRouter key** and bills your
+Roboflow credits — no extra setup needed. To bypass Roboflow billing, paste your
+own `sk-or-...` key into the `api_key` field.
+
+#### 🔒 Privacy filter
+
+* **No data collection** *(default)* – providers may not train on your inputs.
+* **Allow data collection** – broader provider pool.
+* **Zero data retention** – strictest, restricts to providers that retain nothing.
+
+!!! warning "Model availability"
+
+    OpenRouter exposes hundreds of models with different capabilities. Not every
+    model supports image inputs, and some are text-only or reasoning-only. If
+    the model can't return a visible response (e.g. a reasoning model that
+    burns all of `max_tokens` on internal thinking), try increasing
+    `max_tokens` or pick a different model.
+"""
+
+
+class BlockManifest(OpenRouterBlockManifestMixin):
+    model_config = ConfigDict(
+        json_schema_extra={
+            "name": "OpenRouter",
+            "version": "v2",
+            "short_description": "Run any OpenRouter model by pasting its model slug.",
+            "long_description": LONG_DESCRIPTION,
+            "license": "Apache-2.0",
+            "block_type": "model",
+            "search_keywords": [
+                "OpenRouter",
+                "VLM",
+                "LMM",
+                "Qwen",
+                "Llama",
+                "generic",
+            ],
+            "is_vlm_block": True,
+            "task_type_property": "task_type",
+            "ui_manifest": {
+                "section": "model",
+                "icon": "fal fa-globe",
+                "blockPriority": 5.6,
+            },
+        },
+        protected_namespaces=(),
+    )
+    type: Literal["roboflow_core/openrouter@v2"]
+
+    images: Selector(kind=[IMAGE_KIND]) = ImageInputField
+
+    model_id: Union[Selector(kind=[STRING_KIND]), str] = Field(
+        description=(
+            "OpenRouter model slug, e.g. `openai/gpt-4o-mini`, "
+            "`anthropic/claude-3.5-sonnet`, `qwen/qwen3.6-27b`. See "
+            "https://openrouter.ai/models for the full list."
+        ),
+        examples=[
+            "openai/gpt-4o-mini",
+            "anthropic/claude-3.5-sonnet",
+            "google/gemini-2.5-pro",
+            "qwen/qwen3.6-27b",
+            "$inputs.openrouter_model_id",
+        ],
+    )
+
+    # Overrides the mixin default of 500, which reasoning models can burn
+    # entirely on internal thinking and fail with missing content.
+    max_tokens: int = Field(
+        default=2048,
+        description=(
+            "Maximum number of tokens the model can generate in its response. "
+            "Defaults to 2048. Raise it explicitly (e.g. 8192) when a task "
+            "needs a longer answer. Billing is based on tokens actually "
+            "generated, not on this limit."
+        ),
+        gt=1,
+    )
+
+    reasoning_effort: Optional[
+        Union[
+            Selector(kind=[STRING_KIND]),
+            Literal[tuple(REASONING_EFFORT_OPTIONS)],
+        ]
+    ] = Field(
+        default=None,
+        description=(
+            "Extended-reasoning budget forwarded to OpenRouter as "
+            '`reasoning: {"effort": ...}`. Unset keeps the model\'s '
+            "provider-default behavior; `none` explicitly disables reasoning. "
+            "Models that reject the config are retried without it. Reasoning "
+            "tokens count toward `max_tokens`, so raise it for medium/high."
+        ),
+        examples=["low", "$inputs.reasoning_effort"],
+        json_schema_extra={"values_metadata": REASONING_EFFORT_METADATA},
+    )
+
+    task_type: TaskType = Field(
+        default="unconstrained",
+        description=(
+            "Task type to be performed by model. Value determines required "
+            "parameters and output response."
+        ),
+        json_schema_extra={
+            "values_metadata": RELEVANT_TASKS_METADATA,
+            "recommended_parsers": RECOMMENDED_PARSERS,
+            "always_visible": True,
+        },
+    )
+
+    prompt: Optional[Union[Selector(kind=[STRING_KIND]), str]] = Field(
+        default=None,
+        description="Text prompt to send to the model.",
+        examples=["my prompt", "$inputs.prompt"],
+        json_schema_extra={
+            "relevant_for": {
+                "task_type": {
+                    "values": ["unconstrained", "visual-question-answering"],
+                    "required": True,
+                },
+            },
+            "multiline": True,
+        },
+    )
+    output_structure: Optional[Dict[str, str]] = Field(
+        default=None,
+        description="Dictionary with structure of expected JSON response.",
+        examples=[{"my_key": "description"}, "$inputs.output_structure"],
+        json_schema_extra={
+            "relevant_for": {
+                "task_type": {"values": ["structured-answering"], "required": True},
+            },
+        },
+    )
+    classes: Optional[Union[Selector(kind=[LIST_OF_VALUES_KIND]), List[str]]] = Field(
+        default=None,
+        description="List of classes to be used.",
+        examples=[["class-a", "class-b"], "$inputs.classes"],
+        json_schema_extra={
+            "relevant_for": {
+                "task_type": {
+                    "values": [
+                        "classification",
+                        "multi-label-classification",
+                        "object-detection",
+                    ],
+                    "required": True,
+                },
+            },
+        },
+    )
+
+    @model_validator(mode="after")
+    def validate(self) -> "BlockManifest":
+        validate_task_type_required_fields(
+            task_type=self.task_type,
+            prompt=self.prompt,
+            classes=self.classes,
+            output_structure=self.output_structure,
+        )
+        return self
+
+    @field_validator("temperature")
+    @classmethod
+    def validate_temperature(cls, value: Union[str, float]) -> Union[str, float]:
+        if isinstance(value, str):
+            return value
+        if value < 0.0 or value > 2.0:
+            raise ValueError(
+                "'temperature' parameter required to be in range [0.0, 2.0]"
+            )
+        return value
+
+    @classmethod
+    def get_air_gapped_availability(cls) -> AirGappedAvailability:
+        return AirGappedAvailability(available=False, reason="requires_internet")
+
+    @classmethod
+    def get_parameters_accepting_batches(cls) -> List[str]:
+        return ["images"]
+
+    @classmethod
+    def describe_outputs(cls) -> List[OutputDefinition]:
+        return [
+            OutputDefinition(
+                name="output", kind=[STRING_KIND, LANGUAGE_MODEL_OUTPUT_KIND]
+            ),
+            OutputDefinition(name="classes", kind=[LIST_OF_VALUES_KIND]),
+            OutputDefinition(
+                name="thinking",
+                kind=[STRING_KIND],
+                description=(
+                    "Reasoning trace when OpenRouter returns one (reasoning "
+                    "models with reasoning enabled). Empty string otherwise."
+                ),
+            ),
+            *TOKEN_OUTPUT_DEFINITIONS,
+        ]
+
+    @classmethod
+    def get_execution_engine_compatibility(cls) -> Optional[str]:
+        return ">=1.3.0,<2.0.0"
+
+    def discover_dependent_resources(self) -> Optional[List[DependentResource]]:
+        return [third_party_model(provider="openrouter", model_id=self.model_id)]
+
+
+class OpenRouterBlockV2(OpenRouterWorkflowBlockBase):
+
+    @classmethod
+    def get_manifest(cls) -> Type[WorkflowBlockManifest]:
+        return BlockManifest
+
+    @classmethod
+    def get_execution_engine_compatibility(cls) -> Optional[str]:
+        return ">=1.3.0,<2.0.0"
+
+    def run(
+        self,
+        images: Batch[WorkflowImageData],
+        model_id: str,
+        task_type: str,
+        prompt: Optional[str],
+        output_structure: Optional[Dict[str, str]],
+        classes: Optional[List[str]],
+        api_key: str,
+        privacy_level: str,
+        max_tokens: int,
+        temperature: float,
+        reasoning_effort: Optional[str],
+        max_concurrent_requests: Optional[int],
+    ) -> BlockResult:
+        inference_images = [i.to_inference_format() for i in images]
+        prompts = build_prompts_from_images(
+            images=inference_images,
+            task_type=task_type,
+            prompt=prompt,
+            output_structure=output_structure,
+            classes=classes,
+        )
+        results = self.execute_openrouter_batch_with_usage(
+            openrouter_api_key=api_key,
+            model=model_id,
+            prompts=prompts,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            privacy_level=privacy_level,
+            max_concurrent_requests=max_concurrent_requests,
+            reasoning=build_openrouter_reasoning_config(reasoning_effort),
+        )
+        return [
+            {
+                "output": result.content,
+                "classes": classes,
+                "thinking": result.reasoning_trace,
+                "input_tokens": result.input_tokens,
+                "output_tokens": result.output_tokens,
+            }
+            for result in results
+        ]

--- a/inference/core/workflows/core_steps/models/foundation/qwen_vlm/v3.py
+++ b/inference/core/workflows/core_steps/models/foundation/qwen_vlm/v3.py
@@ -1,0 +1,1407 @@
+"""Unified Qwen-VL workflow block, v3 — Qwen-specific OpenRouter plumbing.
+
+Same surface as ``qwen_vlm@v2``, plus ``input_tokens`` / ``output_tokens``
+outputs with per-call token usage (``None`` on the native backend).
+
+v2 kept the surface of ``qwen_vlm@v1`` (``backend`` = "Native (Roboflow)" or
+"OpenRouter", combined ``model_version`` pickers, the shared VLM
+``task_type`` set) but the OpenRouter path no longer relies on the generic
+prompt builders from ``common.openrouter``. Instead it uses the contract
+that performed best for Qwen models in the vlm-exam benchmarks:
+
+* **object-detection** asks for a bare JSON list of ``box_2d``/``label``
+  entries with ``[x_min, y_min, x_max, y_max]`` integer coordinates
+  normalized to 0-1000 — Qwen's native grounding convention — parsed by
+  ``vlm_as_detector@v2`` with ``model_type="qwen"``. Both backends emit
+  this same contract: the native path replaces v1's ad-hoc
+  ``x_min``/0.0-1.0 detection prompt with the benchmarked template.
+* every task sends a single user message with the **image before the
+  text** and no system role, matching how the benchmarks prompt Qwen.
+* requests carry an explicit OpenRouter ``reasoning`` config: disabled by
+  default (Qwen models default to extended reasoning, which bloats latency
+  and can truncate answers), always-on for models that require it.
+* uploads are JPEG-encoded with iterative downscaling so the base64
+  payload stays under Alibaba DashScope's data-URI limit.
+* ``temperature`` is not sent unless the user sets it.
+
+The native backend is carried over from v1 except for the
+object-detection prompt, which is unified on the benchmarked template.
+"""
+
+import base64
+import json
+from typing import Any, Dict, List, Literal, Optional, Tuple, Type, Union
+
+import cv2
+import numpy as np
+from pydantic import ConfigDict, Field, field_validator, model_validator
+
+from inference.core.entities.requests.inference import LMMInferenceRequest
+from inference.core.env import (
+    HOSTED_CORE_MODEL_URL,
+    LOCAL_INFERENCE_API_URL,
+    WORKFLOWS_REMOTE_API_TARGET,
+)
+from inference.core.managers.base import ModelManager
+from inference.core.utils.image_utils import encode_image_to_jpeg_bytes
+from inference.core.workflows.core_steps.common.entities import StepExecutionMode
+from inference.core.workflows.core_steps.common.openrouter import (
+    PRIVACY_LEVEL_LITERAL,
+    PRIVACY_LEVEL_METADATA,
+    RECOMMENDED_PARSERS,
+    RELEVANT_TASKS_METADATA,
+    SUPPORTED_TASK_TYPES_LIST,
+    OpenRouterBlockManifestMixin,
+    OpenRouterWorkflowBlockBase,
+    validate_task_type_required_fields,
+)
+from inference.core.workflows.core_steps.common.token_usage import (
+    TOKEN_OUTPUT_DEFINITIONS,
+)
+from inference.core.workflows.core_steps.common.utils import (
+    scale_dimensions_to_max_edge,
+)
+from inference.core.workflows.execution_engine.entities.base import (
+    Batch,
+    OutputDefinition,
+    WorkflowImageData,
+)
+from inference.core.workflows.execution_engine.entities.types import (
+    FLOAT_KIND,
+    IMAGE_KIND,
+    LANGUAGE_MODEL_OUTPUT_KIND,
+    LIST_OF_VALUES_KIND,
+    ROBOFLOW_MANAGED_KEY,
+    ROBOFLOW_MODEL_ID_KIND,
+    SECRET_KIND,
+    STRING_KIND,
+    ImageInputField,
+    Selector,
+)
+from inference.core.workflows.prototypes.block import (
+    AirGappedAvailability,
+    BlockResult,
+    DependentResource,
+    WorkflowBlockManifest,
+    is_workflow_selector,
+    roboflow_platform_model,
+    third_party_model,
+)
+from inference_sdk import InferenceHTTPClient
+
+# ---------------------------------------------------------------------------
+# Model variants
+# ---------------------------------------------------------------------------
+# Each entry is ``"<friendly label>": {"backend": "native" | "openrouter",
+# "model_id": <id used by the chosen backend>, ...}``.
+#
+# - Native model_ids are Roboflow inference model IDs (e.g. ``qwen3_5-2b``).
+# - OpenRouter model_ids are OpenRouter slugs (e.g. ``qwen/qwen3.7-plus``).
+#   ``reasoning_required`` marks models that reject
+#   ``reasoning: {"enabled": false}`` and must always receive an effort.
+
+MODEL_VARIANTS: Dict[str, Dict[str, Any]] = {
+    # Native — small models that run on Roboflow infrastructure.
+    "Qwen 2.5 VL 7B": {
+        "backend": "native",
+        "model_id": "qwen25-vl-7b",
+    },
+    "Qwen 3 VL 2B": {
+        "backend": "native",
+        "model_id": "qwen3vl-2b-instruct",
+    },
+    "Qwen 3.5 VL 0.8B": {
+        "backend": "native",
+        "model_id": "qwen3_5-0.8b",
+    },
+    "Qwen 3.5 VL 2B": {
+        "backend": "native",
+        "model_id": "qwen3_5-2b",
+    },
+    # OpenRouter — image-capable hosted Qwen chat models.
+    "Qwen 3.8 Max": {
+        "backend": "openrouter",
+        "model_id": "qwen/qwen3.8-max",
+        "reasoning_required": True,
+    },
+    "Qwen 3.7 Plus": {
+        "backend": "openrouter",
+        "model_id": "qwen/qwen3.7-plus",
+    },
+    "Qwen 3.7 Flash": {
+        "backend": "openrouter",
+        "model_id": "qwen/qwen3.7-flash",
+    },
+    "Qwen 3.8 27B": {
+        "backend": "openrouter",
+        "model_id": "qwen/qwen3.8-27b",
+    },
+    "Qwen 3.6 Plus": {
+        "backend": "openrouter",
+        "model_id": "qwen/qwen3.6-plus",
+    },
+    "Qwen 3.6 Flash": {
+        "backend": "openrouter",
+        "model_id": "qwen/qwen3.6-flash",
+    },
+    "Qwen 3.6 27B": {
+        "backend": "openrouter",
+        "model_id": "qwen/qwen3.6-27b",
+    },
+    "Qwen 3.6 35B A3B": {
+        "backend": "openrouter",
+        "model_id": "qwen/qwen3.6-35b-a3b",
+    },
+    "Qwen 3.5 Plus": {
+        "backend": "openrouter",
+        "model_id": "qwen/qwen3.5-plus-20260420",
+    },
+    "Qwen 3.5 Plus 02-15": {
+        "backend": "openrouter",
+        "model_id": "qwen/qwen3.5-plus-02-15",
+    },
+    "Qwen 3.5 Flash": {
+        "backend": "openrouter",
+        "model_id": "qwen/qwen3.5-flash-02-23",
+    },
+    "Qwen 3.5 9B": {
+        "backend": "openrouter",
+        "model_id": "qwen/qwen3.5-9b",
+    },
+    "Qwen 3.5 27B": {
+        "backend": "openrouter",
+        "model_id": "qwen/qwen3.5-27b",
+    },
+    "Qwen 3.5 35B A3B": {
+        "backend": "openrouter",
+        "model_id": "qwen/qwen3.5-35b-a3b",
+    },
+    "Qwen 3.5 122B A10B": {
+        "backend": "openrouter",
+        "model_id": "qwen/qwen3.5-122b-a10b",
+    },
+    "Qwen 3.5 397B A17B": {
+        "backend": "openrouter",
+        "model_id": "qwen/qwen3.5-397b-a17b",
+    },
+    "Qwen 3 VL 8B Instruct": {
+        "backend": "openrouter",
+        "model_id": "qwen/qwen3-vl-8b-instruct",
+    },
+    "Qwen 3 VL 8B Thinking": {
+        "backend": "openrouter",
+        "model_id": "qwen/qwen3-vl-8b-thinking",
+        "reasoning_required": True,
+    },
+    "Qwen 3 VL 30B A3B Instruct": {
+        "backend": "openrouter",
+        "model_id": "qwen/qwen3-vl-30b-a3b-instruct",
+    },
+    "Qwen 3 VL 30B A3B Thinking": {
+        "backend": "openrouter",
+        "model_id": "qwen/qwen3-vl-30b-a3b-thinking",
+        "reasoning_required": True,
+    },
+    "Qwen 3 VL 32B Instruct": {
+        "backend": "openrouter",
+        "model_id": "qwen/qwen3-vl-32b-instruct",
+    },
+    "Qwen 3 VL 235B A22B": {
+        "backend": "openrouter",
+        "model_id": "qwen/qwen3-vl-235b-a22b-instruct",
+    },
+    "Qwen 3 VL 235B A22B Thinking": {
+        "backend": "openrouter",
+        "model_id": "qwen/qwen3-vl-235b-a22b-thinking",
+        "reasoning_required": True,
+    },
+}
+
+ModelVersion = Literal[tuple(MODEL_VARIANTS.keys())]
+TaskType = Literal[tuple(SUPPORTED_TASK_TYPES_LIST)]
+Backend = Literal["native", "openrouter"]
+
+# Sentinel value the native dropdown exposes alongside the pre-trained variants
+# so the user can opt into picking a fine-tuned workspace model.
+FINE_TUNED_NATIVE_LABEL = "Fine-tuned model"
+DEFAULT_NATIVE_MODEL_VERSION = "Qwen 3.5 VL 2B"
+DEFAULT_OPENROUTER_MODEL_VERSION = "Qwen 3.7 Plus"
+
+# Per-backend variant lists, derived from MODEL_VARIANTS so the two stay in sync.
+NATIVE_VARIANT_LABELS = [
+    label for label, v in MODEL_VARIANTS.items() if v["backend"] == "native"
+]
+OPENROUTER_VARIANT_LABELS = [
+    label for label, v in MODEL_VARIANTS.items() if v["backend"] == "openrouter"
+]
+NATIVE_DROPDOWN_LABELS = NATIVE_VARIANT_LABELS + [FINE_TUNED_NATIVE_LABEL]
+NativeModelVersion = Literal[tuple(NATIVE_DROPDOWN_LABELS)]
+OpenRouterModelVersion = Literal[tuple(OPENROUTER_VARIANT_LABELS)]
+
+# Native model_id values that the unified block knows how to run directly,
+# plus the Roboflow pretrains registry name used by the legacy qwen3-vl block
+# so users can pick fine-tuned Qwen3 checkpoints from their workspace.
+NATIVE_MODEL_IDS = [
+    v["model_id"] for v in MODEL_VARIANTS.values() if v["backend"] == "native"
+]
+NATIVE_SUPPORTED_VARIANTS = NATIVE_MODEL_IDS + ["qwen-pretrains/2"]
+
+# Native dropdown entries whose underlying checkpoints expose Qwen3.5-VL's
+# `enable_thinking` mode (reasoning tokens emitted ahead of the answer).
+# Fine-tuned workspace checkpoints derive from the qwen-pretrains/2 family,
+# which is the qwen3.5-2b base — so include the sentinel here too.
+NATIVE_THINKING_MODEL_VERSIONS = [
+    "Qwen 3.5 VL 2B",
+    FINE_TUNED_NATIVE_LABEL,
+]
+
+# ---------------------------------------------------------------------------
+# OpenRouter reasoning control
+# ---------------------------------------------------------------------------
+
+REASONING_EFFORT_OPTIONS = ["none", "low", "medium", "high"]
+ReasoningEffort = Literal[tuple(REASONING_EFFORT_OPTIONS)]
+
+REASONING_EFFORT_METADATA = {
+    "none": {
+        "name": "Disabled (recommended)",
+        "description": (
+            "Turns extended reasoning off. Qwen models default to extended "
+            "reasoning on OpenRouter, which bloats latency and can consume "
+            "the whole token budget before a visible answer is produced. "
+            "Models that require reasoning (Qwen 3.8 Max and the Qwen 3 VL "
+            "Thinking variants) fall back to low effort instead."
+        ),
+    },
+    "low": {
+        "name": "Low",
+        "description": "Small reasoning budget before answering.",
+    },
+    "medium": {
+        "name": "Medium",
+        "description": "Moderate reasoning budget before answering.",
+    },
+    "high": {
+        "name": "High",
+        "description": (
+            "Large reasoning budget. Slowest and most expensive; consider "
+            "raising `max_tokens` so reasoning does not crowd out the answer."
+        ),
+    },
+}
+
+# Fallback effort applied when reasoning is disabled by the user but the
+# selected model rejects `reasoning: {"enabled": false}`.
+REASONING_REQUIRED_FALLBACK_EFFORT = "low"
+
+# Default completion budget when max_tokens is unset.
+QWEN_OPENROUTER_DEFAULT_MAX_TOKENS = 2048
+
+
+def build_reasoning_config(
+    reasoning_effort: str,
+    *,
+    reasoning_required: bool,
+) -> dict:
+    """Translate the block's reasoning effort into OpenRouter's config object.
+
+    Mirrors the vlm-exam benchmark behavior: reasoning is explicitly
+    disabled unless an effort is requested, except for models that require
+    reasoning and reject ``enabled: false`` — those always receive an
+    effort (falling back to low when the user disabled reasoning).
+
+    Args:
+        reasoning_effort: One of ``REASONING_EFFORT_OPTIONS``.
+        reasoning_required: True when the target model rejects
+            ``reasoning: {"enabled": false}``.
+
+    Returns:
+        OpenRouter ``reasoning`` payload object.
+    """
+    if reasoning_required:
+        if reasoning_effort == "none":
+            return {"effort": REASONING_REQUIRED_FALLBACK_EFFORT}
+        return {"effort": reasoning_effort}
+    if reasoning_effort == "none":
+        return {"enabled": False}
+    return {"effort": reasoning_effort}
+
+
+# ---------------------------------------------------------------------------
+# OpenRouter image encoding
+# ---------------------------------------------------------------------------
+
+# Safety cap below Alibaba DashScope's 10,485,760-byte data-URI limit —
+# DashScope backs the Qwen API-tier models on OpenRouter and rejects larger
+# payloads outright.
+OPENROUTER_MAX_BASE64_BYTES = 9_500_000
+OPENROUTER_JPEG_QUALITY = 90
+
+
+def encode_image_for_qwen_openrouter(numpy_image: np.ndarray) -> str:
+    """Encode a BGR image as base64 JPEG under the OpenRouter payload cap.
+
+    Encodes at fixed JPEG quality and, when the base64 payload exceeds
+    ``OPENROUTER_MAX_BASE64_BYTES``, iteratively downscales the longest
+    edge by 10% until it fits. Detection coordinates are normalized to
+    0-1000, so downscaling does not affect parsing.
+
+    Args:
+        numpy_image: Image in BGR channel order.
+
+    Returns:
+        Base64-encoded JPEG payload.
+    """
+    working = numpy_image
+    while True:
+        jpeg_bytes = encode_image_to_jpeg_bytes(
+            working, jpeg_quality=OPENROUTER_JPEG_QUALITY
+        )
+        base64_image = base64.b64encode(jpeg_bytes).decode("ascii")
+        if len(base64_image) <= OPENROUTER_MAX_BASE64_BYTES:
+            return base64_image
+
+        height, width = working.shape[:2]
+        if max(height, width) <= 1:
+            return base64_image
+
+        target_max_edge = max(int(max(height, width) * 0.9), 1)
+        target_width, target_height = scale_dimensions_to_max_edge(
+            width, height, target_max_edge
+        )
+        working = cv2.resize(
+            working, (target_width, target_height), interpolation=cv2.INTER_AREA
+        )
+
+
+# ---------------------------------------------------------------------------
+# OpenRouter prompt building (Qwen-specific)
+# ---------------------------------------------------------------------------
+# Every task sends a single user message with the image part FIRST and the
+# instruction text second, with no system role — the structure used for
+# Qwen models in the vlm-exam benchmarks. Output-format contracts for
+# non-detection tasks stay identical to the generic builders so downstream
+# parsers (`vlm_as_classifier@v2`, `json_parser@v1`) keep working.
+
+# Ported verbatim from vlm-exam's detection prompt for the
+# xyxy_normalized_0_to_1000 coordinate format — the format pinned for every
+# Qwen model in the benchmark configs.
+QWEN_OBJECT_DETECTION_PROMPT_TEMPLATE = (
+    "Detect all objects in this image. "
+    "Output a JSON list where each entry contains the 2D bounding box "
+    'in the key "box_2d" and the text label in the key "label". '
+    'The "box_2d" value must be [x_min, y_min, x_max, y_max]: the '
+    "top-left and bottom-right corners as integers between 0 and 1000, "
+    "normalized to the image width (x) and height (y). "
+    "Return only the JSON list, with no extra text. "
+    "Only use these labels: {class_list}"
+)
+
+_TASK_CLASSIFICATION = (
+    "You act as single-class classification model. You must provide reasonable "
+    "predictions. You are only allowed to produce JSON document in Markdown "
+    "```json [...]``` markers. Expected structure of json: "
+    '{"class_name": "class-name", "confidence": 0.4}. `class-name` must be one '
+    "of the class names defined by user. You are only allowed to return single "
+    "JSON document, even if there are potentially multiple classes. You are not "
+    "allowed to return list. You cannot discuss the result, you are only "
+    "allowed to return JSON document."
+)
+
+_TASK_MULTI_LABEL = (
+    "You act as multi-label classification model. You must provide reasonable "
+    "predictions. You are only allowed to produce JSON document in Markdown "
+    '```json``` markers. Expected structure of json: {"predicted_classes": '
+    '[{"class": "class-name-1", "confidence": 0.9}, {"class": "class-name-2", '
+    '"confidence": 0.7}]}. `class-name-X` must be one of the class names '
+    "defined by user and `confidence` is a float value in range 0.0-1.0 that "
+    "represent how sure you are that the class is present in the image. Only "
+    "return class names that are visible. You cannot discuss the result, you "
+    "are only allowed to return JSON document."
+)
+
+_TASK_VQA = (
+    "You act as Visual Question Answering model. Your task is to provide "
+    "answer to question submitted by user. If this is open-question - answer "
+    "with few sentences, for ABCD question, return only the indicator of "
+    "the answer."
+)
+
+_TASK_OCR = (
+    "You act as OCR model. Your task is to read text from the image and "
+    "return it in paragraphs representing the structure of texts in the "
+    "image. You should only return recognised text, nothing else."
+)
+
+_TASK_STRUCTURED = (
+    "You are supposed to produce responses in JSON wrapped in Markdown "
+    "markers: ```json\nyour-response\n```. User is to provide you "
+    "dictionary with keys and values. Each key must be present in your "
+    "response. Values in user dictionary represent descriptions for JSON "
+    "fields to be generated. Provide only JSON Markdown in response."
+)
+
+
+def _prepare_qwen_user_message(base64_image: str, text: str) -> List[dict]:
+    return [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image_url",
+                    "image_url": {
+                        "url": f"data:image/jpeg;base64,{base64_image}",
+                    },
+                },
+                {"type": "text", "text": text},
+            ],
+        }
+    ]
+
+
+def _prepare_unconstrained_prompt(base64_image: str, prompt: str, **_) -> List[dict]:
+    return _prepare_qwen_user_message(base64_image=base64_image, text=prompt)
+
+
+def _prepare_ocr_prompt(base64_image: str, **_) -> List[dict]:
+    return _prepare_qwen_user_message(base64_image=base64_image, text=_TASK_OCR)
+
+
+def _prepare_vqa_prompt(base64_image: str, prompt: str, **_) -> List[dict]:
+    text = f"{_TASK_VQA}\n\nQuestion: {prompt}"
+
+    return _prepare_qwen_user_message(base64_image=base64_image, text=text)
+
+
+def _prepare_caption_prompt(
+    base64_image: str, short_description: bool, **_
+) -> List[dict]:
+    caption_detail_level = (
+        "Caption should be short."
+        if short_description
+        else "Caption should be extensive."
+    )
+    text = (
+        "You act as image caption model. Your task is to provide "
+        f"description of the image. {caption_detail_level}"
+    )
+
+    return _prepare_qwen_user_message(base64_image=base64_image, text=text)
+
+
+def _prepare_classification_prompt(
+    base64_image: str, classes: List[str], **_
+) -> List[dict]:
+    serialised_classes = ", ".join(classes)
+    text = (
+        f"{_TASK_CLASSIFICATION}\n\n"
+        f"List of all classes to be recognised by model: {serialised_classes}"
+    )
+
+    return _prepare_qwen_user_message(base64_image=base64_image, text=text)
+
+
+def _prepare_multi_label_classification_prompt(
+    base64_image: str, classes: List[str], **_
+) -> List[dict]:
+    serialised_classes = ", ".join(classes)
+    text = (
+        f"{_TASK_MULTI_LABEL}\n\n"
+        f"List of all classes to be recognised by model: {serialised_classes}"
+    )
+
+    return _prepare_qwen_user_message(base64_image=base64_image, text=text)
+
+
+def _prepare_structured_answering_prompt(
+    base64_image: str, output_structure: Dict[str, str], **_
+) -> List[dict]:
+    output_structure_serialised = json.dumps(output_structure, indent=4)
+    text = (
+        f"{_TASK_STRUCTURED}\n\n"
+        "Specification of requirements regarding output fields: \n"
+        f"{output_structure_serialised}"
+    )
+
+    return _prepare_qwen_user_message(base64_image=base64_image, text=text)
+
+
+def _prepare_object_detection_prompt(
+    base64_image: str, classes: List[str], **_
+) -> List[dict]:
+    text = QWEN_OBJECT_DETECTION_PROMPT_TEMPLATE.format(
+        class_list=", ".join(classes),
+    )
+
+    return _prepare_qwen_user_message(base64_image=base64_image, text=text)
+
+
+QWEN_PROMPT_BUILDERS = {
+    "unconstrained": _prepare_unconstrained_prompt,
+    "ocr": _prepare_ocr_prompt,
+    "visual-question-answering": _prepare_vqa_prompt,
+    "caption": lambda **kwargs: _prepare_caption_prompt(
+        short_description=True, **kwargs
+    ),
+    "detailed-caption": lambda **kwargs: _prepare_caption_prompt(
+        short_description=False, **kwargs
+    ),
+    "classification": _prepare_classification_prompt,
+    "multi-label-classification": _prepare_multi_label_classification_prompt,
+    "structured-answering": _prepare_structured_answering_prompt,
+    "object-detection": _prepare_object_detection_prompt,
+}
+
+
+def build_qwen_openrouter_prompts(
+    images: List[np.ndarray],
+    task_type: str,
+    prompt: Optional[str],
+    output_structure: Optional[Dict[str, str]],
+    classes: Optional[List[str]],
+) -> List[List[dict]]:
+    """Build one OpenRouter ``messages`` array per input image, Qwen-style.
+
+    Args:
+        images: BGR numpy images.
+        task_type: One of the supported VLM task types.
+        prompt: User prompt for unconstrained / VQA tasks.
+        output_structure: Output spec for structured-answering.
+        classes: Class list for classification / detection tasks.
+
+    Returns:
+        List of ``messages`` arrays, one per image.
+
+    Raises:
+        ValueError: If the task type is not supported.
+    """
+    if task_type not in QWEN_PROMPT_BUILDERS:
+        raise ValueError(f"Task type: {task_type} not supported.")
+
+    builder = QWEN_PROMPT_BUILDERS[task_type]
+    built: List[List[dict]] = []
+    for image in images:
+        base64_image = encode_image_for_qwen_openrouter(numpy_image=image)
+        built.append(
+            builder(
+                base64_image=base64_image,
+                prompt=prompt,
+                output_structure=output_structure,
+                classes=classes,
+            )
+        )
+
+    return built
+
+
+# ---------------------------------------------------------------------------
+# Native prompt building (carried over from v1, except object-detection)
+# ---------------------------------------------------------------------------
+# The native Qwen API takes a single ``prompt`` string and the image
+# separately (via LMMInferenceRequest). It uses the ``<system_prompt>``
+# separator convention from the legacy native qwen blocks. Object detection
+# uses the same benchmarked box_2d/0-1000 template as the OpenRouter path so
+# both backends share one output contract.
+
+_DEFAULT_UNCONSTRAINED_SYSTEM_PROMPT = (
+    "You are a Qwen vision-language model that can answer questions " "about any image."
+)
+
+
+def _coerce_native_response(response: Any) -> Tuple[str, str]:
+    """Normalize a native Qwen prediction.response into (output, thinking).
+
+    When ``enable_thinking`` is on, some Qwen variants return a
+    ``{"thinking": "...", "answer": "..."}`` dict; split that into the two
+    output fields. For string responses, return them as-is with an empty
+    thinking trace. For any other non-string type, JSON-serialize so
+    downstream parsers (``vlm_as_classifier@v2``, ``json_parser@v1``) still
+    get a string they can parse.
+    """
+    if isinstance(response, str):
+        return response, ""
+    if isinstance(response, dict):
+        thinking = response.get("thinking")
+        answer = response.get("answer")
+        if isinstance(answer, str) and answer:
+            return answer, thinking if isinstance(thinking, str) else ""
+        return json.dumps(response), ""
+    if response is None:
+        return "", ""
+    return json.dumps(response, default=str), ""
+
+
+def _build_native_prompt(
+    task_type: str,
+    prompt: Optional[str],
+    output_structure: Optional[Dict[str, str]],
+    classes: Optional[List[str]],
+) -> str:
+    """Build the single-string prompt for the native Qwen API (LMMInferenceRequest).
+
+    Returns ``user_text + "<system_prompt>" + system_text`` per the legacy
+    native qwen convention. The system half is fully derived from
+    ``task_type`` — for unconstrained we identity-prime as Qwen-VL, for
+    every other task we use a task-tuned system prompt whose output format
+    is contractually tied to downstream parsers (``vlm_as_classifier@v2``,
+    ``json_parser@v1``).
+    """
+    if task_type == "unconstrained":
+        # Manifest validation guarantees `prompt` is non-None for unconstrained,
+        # so no fallback default is needed. Identity-prime the model as Qwen-VL
+        # to match the legacy v1 native qwen blocks (some Qwen variants are
+        # sensitive to identity priming).
+        user_text = prompt or ""
+        system_text = _DEFAULT_UNCONSTRAINED_SYSTEM_PROMPT
+    elif task_type == "ocr":
+        user_text = "Extract the text from this image."
+        system_text = _TASK_OCR
+    elif task_type == "visual-question-answering":
+        user_text = f"Question: {prompt}" if prompt else "Describe this image."
+        system_text = _TASK_VQA
+    elif task_type == "caption":
+        user_text = "Caption this image."
+        system_text = (
+            "You act as image caption model. Your task is to provide "
+            "description of the image. Caption should be short."
+        )
+    elif task_type == "detailed-caption":
+        user_text = "Describe this image in detail."
+        system_text = (
+            "You act as image caption model. Your task is to provide "
+            "description of the image. Caption should be extensive."
+        )
+    elif task_type == "classification":
+        cls_str = ", ".join(classes or [])
+        user_text = f"List of all classes to be recognised by model: {cls_str}"
+        system_text = _TASK_CLASSIFICATION
+    elif task_type == "multi-label-classification":
+        cls_str = ", ".join(classes or [])
+        user_text = f"List of all classes to be recognised by model: {cls_str}"
+        system_text = _TASK_MULTI_LABEL
+    elif task_type == "object-detection":
+        # Same benchmarked box_2d/0-1000 contract as the OpenRouter path, so
+        # both backends parse with vlm_as_detector@v2 model_type="qwen". Sent
+        # as user text with an empty system half — the model server falls
+        # back to its default system prompt, which is the closest native
+        # equivalent of the benchmark's single-user-message structure.
+        cls_str = ", ".join(classes or [])
+        user_text = QWEN_OBJECT_DETECTION_PROMPT_TEMPLATE.format(class_list=cls_str)
+        system_text = ""
+    elif task_type == "structured-answering":
+        spec = json.dumps(output_structure or {}, indent=4)
+        user_text = f"Specification of requirements regarding output fields: \n{spec}"
+        system_text = _TASK_STRUCTURED
+    else:
+        raise ValueError(f"Task type: {task_type} not supported.")
+    return user_text + "<system_prompt>" + system_text
+
+
+# ---------------------------------------------------------------------------
+# Manifest
+# ---------------------------------------------------------------------------
+
+RELEVANT_TASKS_DOCS_DESCRIPTION = "\n\n".join(
+    f"* **{v['name']}** (`{k}`) - {v['description']}"
+    for k, v in RELEVANT_TASKS_METADATA.items()
+)
+
+LONG_DESCRIPTION = f"""
+Run any Qwen vision-language model — natively on Roboflow infrastructure or via OpenRouter.
+
+You can specify arbitrary text prompts or predefined ones, the block supports the following types of prompt:
+
+{RELEVANT_TASKS_DOCS_DESCRIPTION}
+
+#### 🆕 What's new in v2
+
+The block uses Qwen-tuned inference plumbing validated by benchmarks:
+
+* **Object detection** prompts for Qwen's native grounding format on **both backends**:
+  a JSON list of `box_2d`/`label` entries with `[x_min, y_min, x_max, y_max]` integer
+  coordinates normalized to 0-1000. Parse the output with `VLM as Detector`
+  (`vlm_as_detector@v2`) using `model_type="qwen"`.
+* Every request sends the image **before** the instruction text in a single user
+  message, matching how Qwen models are trained.
+* **Reasoning control**: Qwen models default to extended reasoning on OpenRouter,
+  which bloats latency and can consume the whole token budget. v2 disables it by
+  default and exposes a `reasoning_effort` knob. Qwen 3.8 Max and the Qwen 3 VL
+  Thinking variants require reasoning and fall back to low effort when disabled.
+* Uploads are downscaled automatically when they would exceed the Qwen provider
+  payload limit. `max_tokens` defaults to 2048 on both backends; raise it
+  explicitly (e.g. 8192) when you need a longer answer.
+
+#### 🛠️ Backend selection
+
+* **Native (Roboflow)** — small Qwen-VL models (0.8B–7B) run on the same infrastructure as
+  your other Roboflow models. Lower latency. Recommended for tasks
+  like OCR, captioning, and visual question answering.
+
+* **OpenRouter** — hosted Qwen vision models reached via
+  [OpenRouter](https://openrouter.ai/). Defaults to a Roboflow-managed API key and
+  bills your Roboflow credits. Paste your own `sk-or-...` key in the `api_key`
+  field to bypass Roboflow billing. Recommended for structured tasks that benefit
+  from larger models (classification, object-detection, structured-answering).
+
+The `model_version` dropdown lists every supported variant; each is bound to one backend.
+A validator catches mismatches between your selected backend and model.
+
+#### 🔒 Privacy filter (OpenRouter only)
+
+* **No data collection** *(default)* – providers may not train on your inputs.
+* **Allow data collection** – broader provider pool.
+* **Zero data retention** – strictest, restricts to providers that retain nothing.
+"""
+
+
+class BlockManifest(OpenRouterBlockManifestMixin):
+    model_config = ConfigDict(
+        json_schema_extra={
+            "name": "Qwen",
+            "version": "v3",
+            "short_description": "Run any Qwen vision model — natively or via OpenRouter.",
+            "long_description": LONG_DESCRIPTION,
+            "license": "Apache-2.0",
+            "block_type": "model",
+            "search_keywords": [
+                "Qwen",
+                "qwen-vl",
+                "qwen3.5",
+                "qwen3.7",
+                "qwen3.8",
+                "VLM",
+                "Alibaba",
+                "OpenRouter",
+            ],
+            "is_vlm_block": True,
+            "task_type_property": "task_type",
+            "ui_manifest": {
+                "section": "model",
+                "icon": "fal fa-atom",
+                "blockPriority": 5.5,
+            },
+        },
+        protected_namespaces=(),
+    )
+    type: Literal["roboflow_core/qwen_vlm@v3"]
+
+    images: Selector(kind=[IMAGE_KIND]) = ImageInputField
+
+    backend: Backend = Field(
+        default="native",
+        description=(
+            "Where to run inference. Native = Roboflow infrastructure. "
+            "OpenRouter = large hosted Qwen models via OpenRouter."
+        ),
+        json_schema_extra={
+            "values_metadata": {
+                "native": {
+                    "name": "Native (Roboflow)",
+                    "description": (
+                        "Runs locally on the inference server, or remotely "
+                        "via Roboflow Hosted Inference. Smaller models, "
+                        "lower latency."
+                    ),
+                },
+                "openrouter": {
+                    "name": "OpenRouter",
+                    "description": (
+                        "Routes to large hosted Qwen models via OpenRouter. "
+                        "Defaults to a Roboflow-managed key (billed in "
+                        "credits)."
+                    ),
+                },
+            },
+            "always_visible": True,
+        },
+    )
+
+    # Native model picker: friendly-name dropdown listing the built-in
+    # pre-trained variants AND a `Fine-tuned model` sentinel entry that,
+    # when selected, reveals the `fine_tuned_model_id` field below.
+    model_version: Union[Selector(kind=[STRING_KIND]), NativeModelVersion] = Field(
+        default=DEFAULT_NATIVE_MODEL_VERSION,
+        description=(
+            "Native Qwen-VL variant. Pick a pre-trained model or "
+            f"`{FINE_TUNED_NATIVE_LABEL}` to use a Qwen3 fine-tune from your "
+            "workspace."
+        ),
+        examples=[DEFAULT_NATIVE_MODEL_VERSION, FINE_TUNED_NATIVE_LABEL],
+        json_schema_extra={
+            "relevant_for": {
+                "backend": {"values": ["native"], "required": True},
+            },
+        },
+    )
+
+    # Fine-tuned native picker: Roboflow model-id selector so the UI
+    # surfaces the user's workspace Qwen3 fine-tunes (qwen-pretrains/2
+    # family). Gated solely on `model_version=FINE_TUNED_NATIVE_LABEL` —
+    # the UI honors only one `relevant_for` key. The companion
+    # `model_validator` below resets `model_version` back to a pre-trained
+    # variant when the user switches to OpenRouter, which makes the gate
+    # condition false on revalidation and hides this field as well.
+    fine_tuned_model_id: Optional[
+        Union[Selector(kind=[ROBOFLOW_MODEL_ID_KIND, STRING_KIND]), str]
+    ] = Field(
+        default=None,
+        description=(
+            "Fine-tuned Qwen3-VL model from your workspace, in "
+            "`workspace/version` form."
+        ),
+        examples=["your-workspace/3", "$inputs.qwen_finetune"],
+        json_schema_extra={
+            "relevant_for": {
+                "model_version": {
+                    "values": [FINE_TUNED_NATIVE_LABEL],
+                    "required": True,
+                },
+            },
+        },
+    )
+
+    openrouter_model_version: Union[
+        Selector(kind=[STRING_KIND]), OpenRouterModelVersion
+    ] = Field(
+        default=DEFAULT_OPENROUTER_MODEL_VERSION,
+        description=(
+            "OpenRouter-hosted Qwen vision variant. The roster is every "
+            "current image-capable Qwen chat model except Qwen 2.5 VL."
+        ),
+        examples=[DEFAULT_OPENROUTER_MODEL_VERSION, "Qwen 3.8 Max"],
+        json_schema_extra={
+            "relevant_for": {
+                "backend": {"values": ["openrouter"], "required": True},
+            },
+        },
+    )
+
+    task_type: TaskType = Field(
+        default="unconstrained",
+        description="Task type to be performed by model. Value determines required parameters and output response.",
+        json_schema_extra={
+            "values_metadata": RELEVANT_TASKS_METADATA,
+            "recommended_parsers": RECOMMENDED_PARSERS,
+            "always_visible": True,
+        },
+    )
+
+    prompt: Optional[Union[Selector(kind=[STRING_KIND]), str]] = Field(
+        default=None,
+        description="Text prompt to the Qwen model",
+        examples=["my prompt", "$inputs.prompt"],
+        json_schema_extra={
+            "relevant_for": {
+                "task_type": {
+                    "values": ["unconstrained", "visual-question-answering"],
+                    "required": True,
+                },
+            },
+            "multiline": True,
+        },
+    )
+    enable_thinking: bool = Field(
+        default=False,
+        description=(
+            "Enable Qwen3.5-VL's reasoning mode, where the model emits "
+            "thinking tokens before its answer. The reasoning trace is "
+            "returned in the `thinking` output. Only the Qwen 3.5 VL 2B "
+            "checkpoint (and Qwen3-VL fine-tunes derived from it) supports "
+            "this; ignored elsewhere."
+        ),
+        json_schema_extra={
+            "relevant_for": {
+                "model_version": {
+                    "values": NATIVE_THINKING_MODEL_VERSIONS,
+                    "required": False,
+                },
+            },
+        },
+    )
+    reasoning_effort: ReasoningEffort = Field(
+        default="none",
+        description=(
+            "Extended-reasoning budget for OpenRouter-hosted Qwen models. "
+            "Disabled by default: Qwen models default to extended reasoning, "
+            "which bloats latency and can consume the whole token budget "
+            "before a visible answer is produced. Models that require "
+            "reasoning (Qwen 3.8 Max) fall back to low effort when disabled. "
+            "Only used when backend=openrouter."
+        ),
+        json_schema_extra={
+            "values_metadata": REASONING_EFFORT_METADATA,
+            "relevant_for": {"backend": {"values": ["openrouter"], "required": False}},
+        },
+    )
+    output_structure: Optional[Dict[str, str]] = Field(
+        default=None,
+        description="Dictionary with structure of expected JSON response",
+        examples=[{"my_key": "description"}, "$inputs.output_structure"],
+        json_schema_extra={
+            "relevant_for": {
+                "task_type": {"values": ["structured-answering"], "required": True},
+            },
+        },
+    )
+    classes: Optional[Union[Selector(kind=[LIST_OF_VALUES_KIND]), List[str]]] = Field(
+        default=None,
+        description="List of classes to be used",
+        examples=[["class-a", "class-b"], "$inputs.classes"],
+        json_schema_extra={
+            "relevant_for": {
+                "task_type": {
+                    "values": [
+                        "classification",
+                        "multi-label-classification",
+                        "object-detection",
+                    ],
+                    "required": True,
+                },
+            },
+        },
+    )
+
+    # --- Override inherited OpenRouter fields with relevant_for=openrouter ---
+    api_key: Union[
+        Selector(kind=[STRING_KIND, SECRET_KIND, ROBOFLOW_MANAGED_KEY]), str
+    ] = Field(
+        default="rf_key:account",
+        description=(
+            "OpenRouter API key (only used when backend=openrouter). Defaults "
+            "to Roboflow's managed key. Provide your own `sk-or-...` key to "
+            "call OpenRouter directly without Roboflow billing."
+        ),
+        examples=["rf_key:account", "sk-or-...", "$inputs.openrouter_api_key"],
+        private=True,
+        json_schema_extra={
+            "relevant_for": {"backend": {"values": ["openrouter"], "required": False}},
+        },
+    )
+    privacy_level: PRIVACY_LEVEL_LITERAL = Field(
+        default="deny",
+        description=(
+            "Provider privacy filter (only used when backend=openrouter). "
+            "Stricter levels reduce the pool of providers and may increase "
+            "per-call cost on the managed key."
+        ),
+        json_schema_extra={
+            "values_metadata": PRIVACY_LEVEL_METADATA,
+            "relevant_for": {"backend": {"values": ["openrouter"], "required": False}},
+        },
+    )
+    max_tokens: Optional[int] = Field(
+        default=QWEN_OPENROUTER_DEFAULT_MAX_TOKENS,
+        description=(
+            "Maximum number of tokens the model can generate in its response. "
+            f"Defaults to {QWEN_OPENROUTER_DEFAULT_MAX_TOKENS} on both backends. "
+            "Raise it explicitly (e.g. 8192) when a task needs a longer answer. "
+            "Billing is based on tokens actually generated, not on this limit."
+        ),
+        gt=1,
+    )
+    temperature: Optional[Union[float, Selector(kind=[FLOAT_KIND])]] = Field(
+        default=None,
+        description=(
+            "Sampling temperature (only used when backend=openrouter). "
+            "Left unset by default so the provider's per-model default "
+            "applies — this matches how the models were benchmarked. "
+            'Range 0.0-2.0 — higher = more random / "creative" generations.'
+        ),
+        json_schema_extra={
+            "relevant_for": {"backend": {"values": ["openrouter"], "required": False}},
+        },
+    )
+    max_concurrent_requests: Optional[int] = Field(
+        default=None,
+        description=(
+            "Maximum number of OpenRouter requests to run in parallel for a "
+            "batch of images (only used when backend=openrouter). The native "
+            "backend processes images sequentially. If unset, falls back to "
+            "the global Workflows Execution Engine default. Restrict this if "
+            "you hit OpenRouter rate limits."
+        ),
+        json_schema_extra={
+            "relevant_for": {"backend": {"values": ["openrouter"], "required": False}},
+        },
+    )
+
+    @model_validator(mode="after")
+    def validate(self) -> "BlockManifest":
+        # Re-coupling step for the OpenRouter backend: when the user
+        # switches `backend` away from `native`, the native `model_version`
+        # dropdown is hidden but its underlying value persists. If that
+        # stale value is `FINE_TUNED_NATIVE_LABEL`, the `fine_tuned_model_id`
+        # field — gated solely on `model_version=FINE_TUNED_NATIVE_LABEL`
+        # — keeps showing in the UI. Resetting `model_version` here makes
+        # the gate condition false on the next revalidation pass, so the
+        # selector hides itself for the OpenRouter flow.
+        if (
+            self.backend == "openrouter"
+            and self.model_version == FINE_TUNED_NATIVE_LABEL
+        ):
+            self.model_version = DEFAULT_NATIVE_MODEL_VERSION
+        validate_task_type_required_fields(
+            task_type=self.task_type,
+            prompt=self.prompt,
+            classes=self.classes,
+            output_structure=self.output_structure,
+        )
+        if (
+            self.backend == "native"
+            and self.model_version == FINE_TUNED_NATIVE_LABEL
+            and not self.fine_tuned_model_id
+        ):
+            raise ValueError(
+                "`fine_tuned_model_id` is required when `model_version="
+                f"'{FINE_TUNED_NATIVE_LABEL}'`. Pick a fine-tuned Qwen3 model "
+                "from your workspace."
+            )
+        return self
+
+    @field_validator("temperature")
+    @classmethod
+    def validate_temperature(
+        cls, value: Optional[Union[str, float]]
+    ) -> Optional[Union[str, float]]:
+        if value is None or isinstance(value, str):
+            return value
+        if value < 0.0 or value > 2.0:
+            raise ValueError(
+                "'temperature' parameter required to be in range [0.0, 2.0]"
+            )
+        return value
+
+    @classmethod
+    def get_air_gapped_availability(cls) -> AirGappedAvailability:
+        return AirGappedAvailability(available=False, reason="requires_internet")
+
+    @classmethod
+    def get_parameters_accepting_batches(cls) -> List[str]:
+        return ["images"]
+
+    @classmethod
+    def describe_outputs(cls) -> List[OutputDefinition]:
+        return [
+            OutputDefinition(
+                name="output", kind=[STRING_KIND, LANGUAGE_MODEL_OUTPUT_KIND]
+            ),
+            OutputDefinition(name="classes", kind=[LIST_OF_VALUES_KIND]),
+            OutputDefinition(
+                name="thinking",
+                kind=[STRING_KIND],
+                description=(
+                    "Reasoning trace emitted by the model: populated on the "
+                    "native backend when `enable_thinking` is on, and on the "
+                    "OpenRouter backend when the model performs extended "
+                    "reasoning (see `reasoning_effort`). Empty string "
+                    "otherwise."
+                ),
+            ),
+            *TOKEN_OUTPUT_DEFINITIONS,
+        ]
+
+    @classmethod
+    def get_execution_engine_compatibility(cls) -> Optional[str]:
+        return ">=1.3.0,<2.0.0"
+
+    @classmethod
+    def get_supported_model_variants(cls) -> Optional[List[str]]:
+        """Tell the UI which native model_ids (and fine-tune families) this
+        block can run, so the workspace model picker shows Qwen3 fine-tunes.
+        """
+        return NATIVE_SUPPORTED_VARIANTS
+
+    def discover_dependent_resources(self) -> Optional[List[DependentResource]]:
+        # Mirrors the model-id resolution performed in `run()`.
+        if self.backend == "openrouter":
+            if is_workflow_selector(self.openrouter_model_version):
+                # Friendly-label selector returned verbatim; the attached
+                # resolver performs the MODEL_VARIANTS lookup once the input
+                # value is substituted.
+                return [
+                    third_party_model(
+                        provider="openrouter",
+                        model_id=self.openrouter_model_version,
+                        model_id_resolver=lambda label: MODEL_VARIANTS[label][
+                            "model_id"
+                        ],
+                    )
+                ]
+            return [
+                third_party_model(
+                    provider="openrouter",
+                    model_id=MODEL_VARIANTS[self.openrouter_model_version]["model_id"],
+                )
+            ]
+        if self.model_version == FINE_TUNED_NATIVE_LABEL:
+            if not self.fine_tuned_model_id:
+                return []
+            return [roboflow_platform_model(model_id=self.fine_tuned_model_id)]
+        if is_workflow_selector(self.model_version):
+            # Friendly-label selector returned verbatim; the attached resolver
+            # performs the MODEL_VARIANTS lookup once the input value is
+            # substituted. The fine-tuned sentinel label is valid at runtime
+            # but its final id depends on `fine_tuned_model_id` — statically
+            # unresolvable, so the resolver returns None and pre-loading
+            # skips (execution resolves it).
+            return [
+                roboflow_platform_model(
+                    model_id=self.model_version,
+                    model_id_resolver=lambda label: (
+                        MODEL_VARIANTS[label]["model_id"]
+                        if label in MODEL_VARIANTS
+                        else None
+                    ),
+                )
+            ]
+        return [
+            roboflow_platform_model(
+                model_id=MODEL_VARIANTS[self.model_version]["model_id"]
+            )
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Block class
+# ---------------------------------------------------------------------------
+
+
+class QwenVlmBlockV3(OpenRouterWorkflowBlockBase):
+    """Unified Qwen-VL block v2. Inherits OpenRouter routing/execution from
+    base, uses Qwen-specific prompt building on the OpenRouter path, and
+    keeps the native local/remote dispatch from v1.
+    """
+
+    def __init__(
+        self,
+        model_manager: ModelManager,
+        api_key: Optional[str],
+        step_execution_mode: StepExecutionMode,
+    ):
+        super().__init__(model_manager=model_manager, api_key=api_key)
+        self._step_execution_mode = step_execution_mode
+
+    @classmethod
+    def get_init_parameters(cls) -> List[str]:
+        return ["model_manager", "api_key", "step_execution_mode"]
+
+    @classmethod
+    def get_manifest(cls) -> Type[WorkflowBlockManifest]:
+        return BlockManifest
+
+    @classmethod
+    def get_execution_engine_compatibility(cls) -> Optional[str]:
+        return ">=1.3.0,<2.0.0"
+
+    def run(
+        self,
+        images: Batch[WorkflowImageData],
+        backend: str,
+        model_version: str,
+        fine_tuned_model_id: Optional[str],
+        openrouter_model_version: str,
+        task_type: str,
+        prompt: Optional[str],
+        enable_thinking: bool,
+        reasoning_effort: str,
+        output_structure: Optional[Dict[str, str]],
+        classes: Optional[List[str]],
+        api_key: str,
+        privacy_level: str,
+        max_tokens: Optional[int],
+        temperature: Optional[float],
+        max_concurrent_requests: Optional[int],
+    ) -> BlockResult:
+        if backend == "native":
+            if model_version == FINE_TUNED_NATIVE_LABEL:
+                if not fine_tuned_model_id:
+                    raise ValueError(
+                        "`fine_tuned_model_id` is required when "
+                        f"`model_version='{FINE_TUNED_NATIVE_LABEL}'`."
+                    )
+                model_id = fine_tuned_model_id
+            else:
+                variant = MODEL_VARIANTS.get(model_version)
+                if variant is None or variant["backend"] != "native":
+                    raise ValueError(
+                        f"Unknown pre-trained Qwen variant '{model_version}'. "
+                        f"Pick one of: {NATIVE_VARIANT_LABELS} or "
+                        f"'{FINE_TUNED_NATIVE_LABEL}'."
+                    )
+                model_id = variant["model_id"]
+        elif backend == "openrouter":
+            variant = MODEL_VARIANTS.get(openrouter_model_version)
+            if variant is None or variant["backend"] != "openrouter":
+                raise ValueError(
+                    f"Unknown OpenRouter Qwen variant "
+                    f"'{openrouter_model_version}'. Pick one of: "
+                    f"{OPENROUTER_VARIANT_LABELS}"
+                )
+            model_id = variant["model_id"]
+        else:
+            raise ValueError(f"Unknown backend: {backend}")
+
+        if backend == "openrouter":
+            prompts = build_qwen_openrouter_prompts(
+                images=[i.numpy_image for i in images],
+                task_type=task_type,
+                prompt=prompt,
+                output_structure=output_structure,
+                classes=classes,
+            )
+            reasoning = build_reasoning_config(
+                reasoning_effort,
+                reasoning_required=variant.get("reasoning_required", False),
+            )
+            results = self.execute_openrouter_batch_with_usage(
+                openrouter_api_key=api_key,
+                model=model_id,
+                prompts=prompts,
+                max_tokens=(
+                    max_tokens
+                    if max_tokens is not None
+                    else QWEN_OPENROUTER_DEFAULT_MAX_TOKENS
+                ),
+                temperature=temperature,
+                privacy_level=privacy_level,
+                max_concurrent_requests=max_concurrent_requests,
+                reasoning=reasoning,
+            )
+            return [
+                {
+                    "output": result.content,
+                    "classes": classes,
+                    "thinking": result.reasoning_trace,
+                    "input_tokens": result.input_tokens,
+                    "output_tokens": result.output_tokens,
+                }
+                for result in results
+            ]
+
+        # `enable_thinking` is only meaningful on Qwen3.5-VL native variants
+        # (and qwen3-vl fine-tunes derived from them). Silently ignore on
+        # other native checkpoints so the field stays harmless if it's left
+        # toggled on after a model switch.
+        supports_thinking = model_version in NATIVE_THINKING_MODEL_VERSIONS
+        native_outputs = self._run_native(
+            images=images,
+            model_id=model_id,
+            task_type=task_type,
+            prompt=prompt,
+            output_structure=output_structure,
+            classes=classes,
+            enable_thinking=enable_thinking and supports_thinking,
+            max_tokens=max_tokens,
+        )
+        return [
+            {
+                "output": o["output"],
+                "classes": classes,
+                "thinking": o["thinking"],
+                "input_tokens": None,
+                "output_tokens": None,
+            }
+            for o in native_outputs
+        ]
+
+    # ----------------------- Native dispatch -----------------------
+
+    def _run_native(
+        self,
+        images: Batch[WorkflowImageData],
+        model_id: str,
+        task_type: str,
+        prompt: Optional[str],
+        output_structure: Optional[Dict[str, str]],
+        classes: Optional[List[str]],
+        enable_thinking: bool,
+        max_tokens: Optional[int],
+    ) -> List[Dict[str, str]]:
+        combined_prompt = _build_native_prompt(
+            task_type=task_type,
+            prompt=prompt,
+            output_structure=output_structure,
+            classes=classes,
+        )
+        if self._step_execution_mode == StepExecutionMode.LOCAL:
+            return self._run_native_locally(
+                images=images,
+                model_id=model_id,
+                combined_prompt=combined_prompt,
+                enable_thinking=enable_thinking,
+                max_new_tokens=max_tokens,
+            )
+        if self._step_execution_mode == StepExecutionMode.REMOTE:
+            return self._run_native_remotely(
+                images=images,
+                model_id=model_id,
+                combined_prompt=combined_prompt,
+                enable_thinking=enable_thinking,
+                max_new_tokens=max_tokens,
+            )
+        raise ValueError(f"Unknown step_execution_mode: {self._step_execution_mode}")
+
+    def _run_native_locally(
+        self,
+        images: Batch[WorkflowImageData],
+        model_id: str,
+        combined_prompt: str,
+        enable_thinking: bool,
+        max_new_tokens: Optional[int],
+    ) -> List[Dict[str, str]]:
+        inference_images = [
+            i.to_inference_format(numpy_preferred=False) for i in images
+        ]
+        self._model_manager.add_model(model_id=model_id, api_key=self._roboflow_api_key)
+        outputs: List[Dict[str, str]] = []
+        for image in inference_images:
+            request_kwargs: Dict[str, Any] = dict(
+                api_key=self._roboflow_api_key,
+                model_id=model_id,
+                image=image,
+                source="workflow-execution",
+                prompt=combined_prompt,
+                enable_thinking=enable_thinking,
+            )
+            if max_new_tokens is not None:
+                request_kwargs["max_new_tokens"] = max_new_tokens
+            request = LMMInferenceRequest(**request_kwargs)
+            prediction = self._model_manager.infer_from_request_sync(
+                model_id=model_id, request=request
+            )
+            output, thinking = _coerce_native_response(prediction.response)
+            outputs.append({"output": output, "thinking": thinking})
+        return outputs
+
+    def _run_native_remotely(
+        self,
+        images: Batch[WorkflowImageData],
+        model_id: str,
+        combined_prompt: str,
+        enable_thinking: bool,
+        max_new_tokens: Optional[int],
+    ) -> List[Dict[str, str]]:
+        api_url = (
+            LOCAL_INFERENCE_API_URL
+            if WORKFLOWS_REMOTE_API_TARGET != "hosted"
+            else HOSTED_CORE_MODEL_URL
+        )
+        client = InferenceHTTPClient(api_url=api_url, api_key=self._roboflow_api_key)
+        if WORKFLOWS_REMOTE_API_TARGET == "hosted":
+            client.select_api_v0()
+        outputs: List[Dict[str, str]] = []
+        for image in images:
+            kwargs: Dict[str, Any] = dict(
+                inference_input=image.base64_image,
+                model_id=model_id,
+                prompt=combined_prompt,
+                model_id_in_path=True,
+                enable_thinking=enable_thinking,
+            )
+            if max_new_tokens is not None:
+                kwargs["max_new_tokens"] = max_new_tokens
+            result = client.infer_lmm(**kwargs)
+            response_text = result.get("response", result)
+            output, thinking = _coerce_native_response(response_text)
+            outputs.append({"output": output, "thinking": thinking})
+        return outputs

--- a/inference/core/workflows/core_steps/models/foundation/spacexai/v2.py
+++ b/inference/core/workflows/core_steps/models/foundation/spacexai/v2.py
@@ -1,0 +1,1033 @@
+"""SpaceXAI (Grok) workflow block.
+
+Calls Grok vision models via xAI's OpenAI-compatible Responses API, either
+directly with a user-provided xAI key or through Roboflow's ``apiproxy/xai``
+managed-key proxy. The managed-key (``rf_key``) option is gated behind the
+``WORKFLOWS_SPACEXAI_MANAGED_KEY_ENABLED`` env flag (off by default) until the
+platform-side proxy is deployed; with the flag off users must provide their
+own xAI API key and the block never contacts the proxy. Object-detection
+prompting uses the percent-of-image ``box_2d`` contract validated in the
+vlm-exam benchmark for Grok 4.5/4.6.
+"""
+
+import base64
+import json
+from functools import partial
+from typing import Any, Dict, List, Literal, Optional, Tuple, Type, Union
+
+import cv2
+import numpy as np
+import requests
+from openai import OpenAI
+from pydantic import ConfigDict, Field, model_validator
+
+from inference.core.env import (
+    WORKFLOWS_REMOTE_EXECUTION_MAX_STEP_CONCURRENT_REQUESTS,
+    WORKFLOWS_SPACEXAI_MANAGED_KEY_ENABLED,
+)
+from inference.core.managers.base import ModelManager
+from inference.core.roboflow_api import post_to_roboflow_api
+from inference.core.utils.image_utils import encode_image_to_jpeg_bytes, load_image
+from inference.core.workflows.core_steps.common.token_usage import (
+    TOKEN_OUTPUT_DEFINITIONS,
+    parse_responses_api_usage,
+)
+from inference.core.workflows.core_steps.common.utils import run_in_parallel
+from inference.core.workflows.core_steps.common.vlms import VLM_TASKS_METADATA
+from inference.core.workflows.execution_engine.entities.base import (
+    Batch,
+    OutputDefinition,
+    WorkflowImageData,
+)
+from inference.core.workflows.execution_engine.entities.types import (
+    FLOAT_KIND,
+    IMAGE_KIND,
+    LANGUAGE_MODEL_OUTPUT_KIND,
+    LIST_OF_VALUES_KIND,
+    ROBOFLOW_MANAGED_KEY,
+    SECRET_KIND,
+    STRING_KIND,
+    ImageInputField,
+    Selector,
+)
+from inference.core.workflows.prototypes.block import (
+    AirGappedAvailability,
+    BlockResult,
+    DependentResource,
+    WorkflowBlock,
+    WorkflowBlockManifest,
+    third_party_model,
+)
+
+XAI_BASE_URL = "https://api.x.ai/v1"
+
+GROK_MODELS = [
+    {
+        "id": "grok-4.6",
+        "name": "Grok 4.6",
+    },
+    {
+        "id": "grok-4.5",
+        "name": "Grok 4.5",
+    },
+]
+
+MODEL_VERSION_IDS = [model["id"] for model in GROK_MODELS]
+
+MODEL_VERSION_METADATA = {model["id"]: {"name": model["name"]} for model in GROK_MODELS}
+
+OBJECT_DETECTION_PROMPT_TEMPLATE = (
+    "Detect all objects in this image. "
+    "Output a JSON list where each entry contains the text label in the key "
+    '"label" and the 2D bounding box in the key "box_2d". '
+    'The "box_2d" value must be [x_min, y_min, x_max, y_max] as percentages '
+    "of image width and height (floats between 0 and 100). "
+    "Return only the JSON list, with no extra text. "
+    "Only use these labels: {class_list}"
+)
+
+SUPPORTED_TASK_TYPES_LIST = [
+    "unconstrained",
+    "ocr",
+    "structured-answering",
+    "classification",
+    "multi-label-classification",
+    "visual-question-answering",
+    "caption",
+    "detailed-caption",
+    "object-detection",
+]
+SUPPORTED_TASK_TYPES = set(SUPPORTED_TASK_TYPES_LIST)
+
+RELEVANT_TASKS_METADATA = {
+    k: v for k, v in VLM_TASKS_METADATA.items() if k in SUPPORTED_TASK_TYPES
+}
+RELEVANT_TASKS_DOCS_DESCRIPTION = "\n\n".join(
+    f"* **{v['name']}** (`{k}`) - {v['description']}"
+    for k, v in RELEVANT_TASKS_METADATA.items()
+)
+
+if WORKFLOWS_SPACEXAI_MANAGED_KEY_ENABLED:
+    API_KEY_OPTIONS_DOCS = """### API Key Options
+
+1. **Roboflow Managed API Key (Default)** - Use `rf_key:account` to proxy
+   requests through Roboflow's API. Usage is billed against Roboflow credits.
+2. **Custom xAI API Key** - Provide your own xAI API key and pay xAI directly.
+"""
+else:
+    API_KEY_OPTIONS_DOCS = """### API Key
+
+Provide your own xAI API key (created at https://console.x.ai). Requests are
+sent directly to xAI and billed to your xAI account.
+"""
+
+LONG_DESCRIPTION = f"""
+Ask a question to SpaceXAI Grok models with vision capabilities.
+
+You can specify arbitrary text prompts or predefined ones, the block supports
+the following types of prompt:
+
+{RELEVANT_TASKS_DOCS_DESCRIPTION}
+
+The `object-detection` task asks Grok for a JSON list of
+`{{"label": ..., "box_2d": [x_min, y_min, x_max, y_max]}}` entries where
+coordinates are percentages of image width and height (floats 0-100). Use
+`roboflow_core/vlm_as_detector@v2` with `model_type="spacexai"` to convert the
+output into predictions. Confidence scores are optional; when absent the
+parser assigns `1.0`.
+
+Images for object detection are sent at original resolution as lossless PNG
+with `detail: "high"`, matching the vlm-exam benchmark setup for Grok 4.5/4.6.
+
+{API_KEY_OPTIONS_DOCS}"""
+
+TaskType = Literal[tuple(SUPPORTED_TASK_TYPES_LIST)]
+
+TASKS_REQUIRING_PROMPT = {
+    "unconstrained",
+    "visual-question-answering",
+}
+
+TASKS_REQUIRING_CLASSES = {
+    "classification",
+    "multi-label-classification",
+    "object-detection",
+}
+
+TASKS_REQUIRING_OUTPUT_STRUCTURE = {
+    "structured-answering",
+}
+
+if WORKFLOWS_SPACEXAI_MANAGED_KEY_ENABLED:
+    ApiKeyType = Union[
+        Selector(kind=[STRING_KIND, SECRET_KIND, ROBOFLOW_MANAGED_KEY]), str
+    ]
+    API_KEY_FIELD = Field(
+        default="rf_key:account",
+        description=(
+            "Your xAI API key or 'rf_key:account' to use Roboflow's managed API key"
+        ),
+        examples=["rf_key:account", "xxx-xxx", "$inputs.xai_api_key"],
+        private=True,
+    )
+else:
+    ApiKeyType = Union[Selector(kind=[STRING_KIND, SECRET_KIND]), str]
+    API_KEY_FIELD = Field(
+        description="Your xAI API key",
+        examples=["xxx-xxx", "$inputs.xai_api_key"],
+        private=True,
+    )
+
+
+class BlockManifest(WorkflowBlockManifest):
+    model_config = ConfigDict(
+        json_schema_extra={
+            "name": "SpaceXAI",
+            "version": "v2",
+            "short_description": "Run SpaceXAI Grok models with vision capabilities.",
+            "long_description": LONG_DESCRIPTION,
+            "license": "Apache-2.0",
+            "block_type": "model",
+            "search_keywords": ["LMM", "VLM", "Grok", "xAI", "SpaceXAI"],
+            "is_vlm_block": True,
+            "task_type_property": "task_type",
+            "ui_manifest": {
+                "section": "model",
+                "icon": "fal fa-rocket",
+                "blockPriority": 5.1,
+            },
+        },
+        protected_namespaces=(),
+    )
+    type: Literal["roboflow_core/spacexai@v2"]
+    images: Selector(kind=[IMAGE_KIND]) = ImageInputField
+    task_type: TaskType = Field(
+        default="unconstrained",
+        description=(
+            "Task type to be performed by model. Value determines required "
+            "parameters and output response."
+        ),
+        json_schema_extra={
+            "values_metadata": RELEVANT_TASKS_METADATA,
+            "recommended_parsers": {
+                "structured-answering": "roboflow_core/json_parser@v1",
+                "classification": "roboflow_core/vlm_as_classifier@v2",
+                "multi-label-classification": "roboflow_core/vlm_as_classifier@v2",
+                "object-detection": "roboflow_core/vlm_as_detector@v2",
+            },
+            "always_visible": True,
+        },
+    )
+    prompt: Optional[Union[Selector(kind=[STRING_KIND]), str]] = Field(
+        default=None,
+        description="Text prompt to the Grok model",
+        examples=["my prompt", "$inputs.prompt"],
+        json_schema_extra={
+            "relevant_for": {
+                "task_type": {"values": TASKS_REQUIRING_PROMPT, "required": True},
+            },
+            "multiline": True,
+        },
+    )
+    output_structure: Optional[Dict[str, str]] = Field(
+        default=None,
+        description="Dictionary with structure of expected JSON response",
+        examples=[{"my_key": "description"}, "$inputs.output_structure"],
+        json_schema_extra={
+            "relevant_for": {
+                "task_type": {
+                    "values": TASKS_REQUIRING_OUTPUT_STRUCTURE,
+                    "required": True,
+                },
+            },
+        },
+    )
+    classes: Optional[Union[Selector(kind=[LIST_OF_VALUES_KIND]), List[str]]] = Field(
+        default=None,
+        description="List of classes to be used",
+        examples=[["class-a", "class-b"], "$inputs.classes"],
+        json_schema_extra={
+            "relevant_for": {
+                "task_type": {
+                    "values": TASKS_REQUIRING_CLASSES,
+                    "required": True,
+                },
+            },
+        },
+    )
+    api_key: ApiKeyType = API_KEY_FIELD
+    model_version: Union[
+        Selector(kind=[STRING_KIND]),
+        Literal[tuple(MODEL_VERSION_IDS)],
+    ] = Field(
+        default="grok-4.6",
+        description="Model to be used",
+        examples=["grok-4.6", "grok-4.5", "$inputs.grok_model"],
+        json_schema_extra={
+            "values_metadata": MODEL_VERSION_METADATA,
+        },
+    )
+    reasoning_effort: Optional[
+        Union[
+            Selector(kind=[STRING_KIND]),
+            Literal["low", "high"],
+        ]
+    ] = Field(
+        default=None,
+        description=(
+            "Optional reasoning effort passed to xAI as "
+            '`reasoning: {"effort": ...}`. For requests with a direct xAI key, '
+            "the request is retried without reasoning when the model rejects "
+            "the parameter."
+        ),
+        examples=["low", "high"],
+    )
+    max_tokens: Optional[int] = Field(
+        default=None,
+        description=(
+            "Maximum number of tokens the model can generate in its response. "
+            "If not specified, the model will use its default limit. Minimum value is 16."
+        ),
+        ge=16,
+    )
+    temperature: Optional[Union[float, Selector(kind=[FLOAT_KIND])]] = Field(
+        default=None,
+        description=(
+            "Temperature to sample from the model - value in range 0.0-2.0, the "
+            'higher - the more random / "creative" the generations are.'
+        ),
+        ge=0.0,
+        le=2.0,
+    )
+    max_concurrent_requests: Optional[int] = Field(
+        default=None,
+        description=(
+            "Number of concurrent requests that can be executed by block when "
+            "batch of input images provided. If not given - block defaults to "
+            "value configured globally in Workflows Execution Engine. Please "
+            "restrict if you hit xAI limits."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def validate(self) -> "BlockManifest":
+        if self.task_type in TASKS_REQUIRING_PROMPT and self.prompt is None:
+            raise ValueError(
+                f"`prompt` parameter required to be set for task `{self.task_type}`"
+            )
+        if self.task_type in TASKS_REQUIRING_CLASSES and self.classes is None:
+            raise ValueError(
+                f"`classes` parameter required to be set for task `{self.task_type}`"
+            )
+        if (
+            self.task_type in TASKS_REQUIRING_OUTPUT_STRUCTURE
+            and self.output_structure is None
+        ):
+            raise ValueError(
+                f"`output_structure` parameter required to be set for task `{self.task_type}`"
+            )
+        return self
+
+    @classmethod
+    def get_air_gapped_availability(cls) -> AirGappedAvailability:
+        return AirGappedAvailability(available=False, reason="requires_internet")
+
+    @classmethod
+    def get_parameters_accepting_batches(cls) -> List[str]:
+        return ["images"]
+
+    @classmethod
+    def describe_outputs(cls) -> List[OutputDefinition]:
+        return [
+            OutputDefinition(
+                name="output", kind=[STRING_KIND, LANGUAGE_MODEL_OUTPUT_KIND]
+            ),
+            OutputDefinition(name="classes", kind=[LIST_OF_VALUES_KIND]),
+            *TOKEN_OUTPUT_DEFINITIONS,
+        ]
+
+    @classmethod
+    def get_execution_engine_compatibility(cls) -> Optional[str]:
+        return ">=1.4.0,<2.0.0"
+
+    def discover_dependent_resources(self) -> Optional[List[DependentResource]]:
+        return [third_party_model(provider="xai", model_id=self.model_version)]
+
+
+class SpaceXAIBlockV2(WorkflowBlock):
+
+    def __init__(
+        self,
+        model_manager: ModelManager,
+        api_key: Optional[str],
+    ):
+        self._model_manager = model_manager
+        self._api_key = api_key
+
+    @classmethod
+    def get_init_parameters(cls) -> List[str]:
+        return ["model_manager", "api_key"]
+
+    @classmethod
+    def get_manifest(cls) -> Type[WorkflowBlockManifest]:
+        return BlockManifest
+
+    @classmethod
+    def get_execution_engine_compatibility(cls) -> Optional[str]:
+        return ">=1.4.0,<2.0.0"
+
+    def run(
+        self,
+        images: Batch[WorkflowImageData],
+        task_type: TaskType,
+        prompt: Optional[str],
+        output_structure: Optional[Dict[str, str]],
+        classes: Optional[List[str]],
+        model_version: str,
+        reasoning_effort: Optional[str],
+        max_tokens: Optional[int],
+        temperature: Optional[float],
+        max_concurrent_requests: Optional[int],
+        api_key: str,
+    ) -> BlockResult:
+        inference_images = [i.to_inference_format() for i in images]
+        raw_outputs = run_spacexai_prompting(
+            roboflow_api_key=self._api_key,
+            images=inference_images,
+            task_type=task_type,
+            prompt=prompt,
+            output_structure=output_structure,
+            classes=classes,
+            xai_api_key=api_key,
+            model_version=model_version,
+            reasoning_effort=reasoning_effort,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            max_concurrent_requests=max_concurrent_requests,
+        )
+        return [
+            {
+                "output": content,
+                "classes": classes,
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+            }
+            for content, input_tokens, output_tokens in raw_outputs
+        ]
+
+
+def run_spacexai_prompting(
+    roboflow_api_key: Optional[str],
+    images: List[Dict[str, Any]],
+    task_type: TaskType,
+    prompt: Optional[str],
+    output_structure: Optional[Dict[str, str]],
+    classes: Optional[List[str]],
+    xai_api_key: str,
+    model_version: str,
+    reasoning_effort: Optional[str],
+    max_tokens: Optional[int],
+    temperature: Optional[float],
+    max_concurrent_requests: Optional[int],
+) -> List[Tuple[str, Optional[int], Optional[int]]]:
+    """Encode images, build per-task prompts and execute xAI requests.
+
+    Args:
+        roboflow_api_key: Roboflow API key for proxied execution.
+        images: Input images in loadable form.
+        task_type: Task determining preprocessing and prompt construction.
+        prompt: Free-form text prompt for tasks that accept one.
+        output_structure: Field descriptions for structured answering.
+        classes: Class names for classification and detection tasks.
+        xai_api_key: xAI API key or Roboflow-proxied ``rf_key:`` key.
+        model_version: Grok model identifier.
+        reasoning_effort: Optional reasoning effort.
+        max_tokens: Maximum number of output tokens.
+        temperature: Sampling temperature.
+        max_concurrent_requests: Cap on concurrent xAI requests.
+
+    Returns:
+        Raw text outputs, one per input image.
+
+    Raises:
+        ValueError: If the task type has no registered prompt builder.
+    """
+    if task_type not in PROMPT_BUILDERS:
+        raise ValueError(f"Task type: {task_type} not supported.")
+    spacexai_prompts = []
+    for image in images:
+        loaded_image, _ = load_image(image)
+        base64_image, image_width, image_height = encode_image_for_task(
+            loaded_image, task_type=task_type
+        )
+        generated_prompt = PROMPT_BUILDERS[task_type](
+            base64_image=base64_image,
+            prompt=prompt,
+            output_structure=output_structure,
+            classes=classes,
+            image_width=image_width,
+            image_height=image_height,
+        )
+        spacexai_prompts.append(generated_prompt)
+    return execute_spacexai_requests(
+        roboflow_api_key=roboflow_api_key,
+        xai_api_key=xai_api_key,
+        spacexai_prompts=spacexai_prompts,
+        model_version=model_version,
+        reasoning_effort=reasoning_effort,
+        max_tokens=max_tokens,
+        temperature=temperature,
+        max_concurrent_requests=max_concurrent_requests,
+    )
+
+
+def encode_image_for_task(
+    image: np.ndarray, *, task_type: TaskType
+) -> Tuple[str, int, int]:
+    """Encode an image as base64 using task-appropriate preprocessing.
+
+    The ``object-detection`` task sends the image unchanged, at original
+    resolution, as lossless PNG — matching the vlm-exam benchmark setup the
+    percent-coordinate contract was validated with. All other tasks send the
+    image unchanged as JPEG.
+
+    Args:
+        image: BGR image to be encoded.
+        task_type: Task type determining the encoding applied.
+
+    Returns:
+        Tuple of the base64-encoded image payload (without a data URL prefix)
+        and the ``(width, height)`` of the encoded image.
+    """
+    if task_type == "object-detection":
+        image_bytes = _encode_image_to_png_bytes(image)
+    else:
+        image_bytes = encode_image_to_jpeg_bytes(image)
+
+    base64_image = base64.b64encode(image_bytes).decode("ascii")
+    height, width = image.shape[:2]
+
+    return base64_image, width, height
+
+
+def _encode_image_to_png_bytes(image: np.ndarray) -> bytes:
+    _, encoded_image = cv2.imencode(".png", image)
+    return encoded_image.tobytes()
+
+
+def execute_spacexai_requests(
+    roboflow_api_key: Optional[str],
+    xai_api_key: str,
+    spacexai_prompts: List[dict],
+    model_version: str,
+    reasoning_effort: Optional[str],
+    max_tokens: Optional[int],
+    temperature: Optional[float],
+    max_concurrent_requests: Optional[int],
+) -> List[Tuple[str, Optional[int], Optional[int]]]:
+    """Execute prepared xAI request payloads in parallel.
+
+    Args:
+        roboflow_api_key: Roboflow API key for proxied execution.
+        xai_api_key: xAI API key or Roboflow-proxied ``rf_key:`` key.
+        spacexai_prompts: Prompt payloads with ``input`` and optionally
+            ``instructions`` keys.
+        model_version: Grok model identifier.
+        reasoning_effort: Optional reasoning effort.
+        max_tokens: Maximum number of output tokens.
+        temperature: Sampling temperature.
+        max_concurrent_requests: Cap on concurrent requests.
+
+    Returns:
+        Raw text outputs in the order of the input prompts.
+    """
+    tasks = [
+        partial(
+            execute_spacexai_request,
+            roboflow_api_key=roboflow_api_key,
+            xai_api_key=xai_api_key,
+            instructions=prompt.get("instructions"),
+            input_content=prompt["input"],
+            model_version=model_version,
+            reasoning_effort=reasoning_effort,
+            max_tokens=max_tokens,
+            temperature=temperature,
+        )
+        for prompt in spacexai_prompts
+    ]
+    max_workers = (
+        max_concurrent_requests
+        or WORKFLOWS_REMOTE_EXECUTION_MAX_STEP_CONCURRENT_REQUESTS
+    )
+    return run_in_parallel(
+        tasks=tasks,
+        max_workers=max_workers,
+    )
+
+
+def execute_spacexai_request(
+    roboflow_api_key: Optional[str],
+    xai_api_key: str,
+    instructions: Optional[str],
+    input_content: List[dict],
+    model_version: str,
+    reasoning_effort: Optional[str],
+    max_tokens: Optional[int],
+    temperature: Optional[float],
+) -> Tuple[str, Optional[int], Optional[int]]:
+    """Execute a single xAI request, routing to direct or proxied mode.
+
+    Args:
+        roboflow_api_key: Roboflow API key, required for proxied execution.
+        xai_api_key: xAI API key or Roboflow-proxied ``rf_key:`` key.
+        instructions: Optional system instructions.
+        input_content: ``input`` entries of the Responses API payload.
+        model_version: Grok model identifier.
+        reasoning_effort: Optional reasoning effort.
+        max_tokens: Maximum number of output tokens.
+        temperature: Sampling temperature.
+
+    Returns:
+        Raw text output of the model.
+    """
+    if xai_api_key.startswith(("rf_key:account", "rf_key:user:")):
+        if not WORKFLOWS_SPACEXAI_MANAGED_KEY_ENABLED:
+            raise ValueError(
+                "Roboflow-managed xAI API keys are not enabled on this "
+                "installation. Provide your own xAI API key in the SpaceXAI "
+                "block's `api_key` field."
+            )
+        if not roboflow_api_key:
+            raise ValueError(
+                "Roboflow API key is required when using a Roboflow-managed xAI API key."
+            )
+
+        return _execute_proxied_spacexai_request(
+            roboflow_api_key=roboflow_api_key,
+            xai_api_key=xai_api_key,
+            instructions=instructions,
+            input_content=input_content,
+            model_version=model_version,
+            reasoning_effort=reasoning_effort,
+            max_tokens=max_tokens,
+            temperature=temperature,
+        )
+
+    return _execute_direct_spacexai_request(
+        xai_api_key=xai_api_key,
+        instructions=instructions,
+        input_content=input_content,
+        model_version=model_version,
+        reasoning_effort=reasoning_effort,
+        max_tokens=max_tokens,
+        temperature=temperature,
+    )
+
+
+def _execute_proxied_spacexai_request(
+    roboflow_api_key: str,
+    xai_api_key: str,
+    instructions: Optional[str],
+    input_content: List[dict],
+    model_version: str,
+    reasoning_effort: Optional[str],
+    max_tokens: Optional[int],
+    temperature: Optional[float],
+) -> Tuple[str, Optional[int], Optional[int]]:
+    """Execute xAI request via Roboflow proxy."""
+    payload = {
+        "model": model_version,
+        "input": input_content,
+        "xai_api_key": xai_api_key,
+        "store": False,
+    }
+
+    if instructions is not None:
+        payload["instructions"] = instructions
+
+    if max_tokens is not None:
+        payload["max_output_tokens"] = max_tokens
+
+    if temperature is not None:
+        payload["temperature"] = temperature
+
+    if reasoning_effort is not None:
+        payload["reasoning"] = {"effort": reasoning_effort}
+
+    try:
+        response_data = post_to_roboflow_api(
+            endpoint="apiproxy/xai",
+            api_key=roboflow_api_key,
+            payload=payload,
+        )
+        text = _extract_output_text(response_data)
+        input_tokens, output_tokens = parse_responses_api_usage(
+            response_data.get("usage")
+        )
+        return text, input_tokens, output_tokens
+    except requests.exceptions.RequestException as e:
+        raise RuntimeError(f"Failed to connect to Roboflow proxy: {e}") from e
+    except (KeyError, IndexError) as e:
+        raise RuntimeError(
+            f"Invalid response structure from Roboflow proxy: {e}"
+        ) from e
+
+
+def _is_unsupported_reasoning_error(error: Exception) -> bool:
+    message = str(error).lower()
+    return "reasoning" in message and (
+        "unsupported" in message
+        or "not supported" in message
+        or "unknown" in message
+        or "invalid" in message
+    )
+
+
+def _execute_direct_spacexai_request(
+    xai_api_key: str,
+    instructions: Optional[str],
+    input_content: List[dict],
+    model_version: str,
+    reasoning_effort: Optional[str],
+    max_tokens: Optional[int],
+    temperature: Optional[float],
+) -> Tuple[str, Optional[int], Optional[int]]:
+    """Execute xAI request directly against api.x.ai."""
+    client = OpenAI(base_url=XAI_BASE_URL, api_key=xai_api_key)
+
+    request_params: Dict[str, Any] = {
+        "model": model_version,
+        "input": input_content,
+        # xAI rejects responses exceeding its server-side storage limit;
+        # we never retrieve stored responses, so disable storage entirely.
+        "store": False,
+    }
+
+    if instructions is not None:
+        request_params["instructions"] = instructions
+
+    if max_tokens is not None:
+        request_params["max_output_tokens"] = max_tokens
+
+    if temperature is not None:
+        request_params["temperature"] = temperature
+
+    if reasoning_effort is not None:
+        request_params["reasoning"] = {"effort": reasoning_effort}
+
+    try:
+        response = client.responses.create(**request_params)
+    except Exception as error:
+        if reasoning_effort is None or not _is_unsupported_reasoning_error(error):
+            raise
+        request_params.pop("reasoning", None)
+        response = client.responses.create(**request_params)
+
+    status = response.status
+    if status == "failed":
+        error_message = "Unknown error"
+        if response.error:
+            error_message = f"{response.error.code}: {response.error.message}"
+        raise ValueError(f"xAI API request failed: {error_message}")
+
+    if status == "cancelled":
+        raise ValueError("xAI API request was cancelled.")
+
+    if status == "incomplete":
+        reason = "Unknown reason"
+        if response.incomplete_details:
+            reason = response.incomplete_details.reason
+        if reason == "max_output_tokens":
+            raise ValueError(
+                "xAI API stopped generation because the max_tokens limit was reached. "
+                "Please increase the max_tokens parameter to allow for a complete response."
+            )
+        raise ValueError(f"xAI API returned an incomplete response. Reason: {reason}")
+
+    if status not in ["completed", "in_progress", "queued"]:
+        raise ValueError(f"xAI API returned unexpected status: {status}")
+
+    output_text = response.output_text
+    if not output_text:
+        raise ValueError("xAI API returned no text content in response.")
+
+    input_tokens, output_tokens = parse_responses_api_usage(
+        getattr(response, "usage", None)
+    )
+    return output_text, input_tokens, output_tokens
+
+
+def _extract_output_text(response_data: dict) -> str:
+    """Extract output text from xAI / OpenAI Responses API response."""
+    status = response_data.get("status")
+
+    if status == "failed":
+        error = response_data.get("error", {})
+        error_message = (
+            f"{error.get('code', 'Unknown')}: {error.get('message', 'Unknown error')}"
+        )
+        raise ValueError(f"xAI API request failed: {error_message}")
+
+    if status == "cancelled":
+        raise ValueError("xAI API request was cancelled.")
+
+    if status == "incomplete":
+        incomplete_details = response_data.get("incomplete_details", {})
+        reason = incomplete_details.get("reason", "Unknown reason")
+        if reason == "max_output_tokens":
+            raise ValueError(
+                "xAI API stopped generation because the max_tokens limit was reached. "
+                "Please increase the max_tokens parameter to allow for a complete response."
+            )
+        raise ValueError(f"xAI API returned an incomplete response. Reason: {reason}")
+
+    if status not in ["completed", "in_progress", "queued", None]:
+        raise ValueError(f"xAI API returned unexpected status: {status}")
+
+    output_items = response_data.get("output", [])
+    texts = []
+    for item in output_items:
+        if item.get("type") == "message":
+            for content in item.get("content", []):
+                if content.get("type") == "output_text":
+                    texts.append(content.get("text", ""))
+
+    output_text = "".join(texts)
+    if not output_text:
+        raise ValueError("xAI API returned no text content in response.")
+
+    return output_text
+
+
+def _image_content(base64_image: str, *, media_type: str, detail: str = "auto") -> dict:
+    return {
+        "type": "input_image",
+        "image_url": f"data:{media_type};base64,{base64_image}",
+        "detail": detail,
+    }
+
+
+def prepare_unconstrained_prompt(
+    base64_image: str,
+    prompt: str,
+    **kwargs,
+) -> dict:
+    """Build a request forwarding the user's prompt without instructions."""
+    return {
+        "input": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "input_text", "text": prompt},
+                    _image_content(base64_image, media_type="image/jpeg"),
+                ],
+            }
+        ],
+    }
+
+
+def prepare_classification_prompt(
+    base64_image: str,
+    classes: List[str],
+    **kwargs,
+) -> dict:
+    """Build a single-label classification request."""
+    serialised_classes = ", ".join(classes)
+    return {
+        "instructions": (
+            "You act as single-class classification model. You must provide reasonable predictions. "
+            "You are only allowed to produce JSON document in Markdown ```json [...]``` markers. "
+            'Expected structure of json: {"class_name": "class-name", "confidence": 0.4}. '
+            "`class-name` must be one of the class names defined by user. You are only allowed to return "
+            "single JSON document, even if there are potentially multiple classes. You are not allowed to return list."
+        ),
+        "input": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "input_text",
+                        "text": f"List of all classes to be recognised by model: {serialised_classes}",
+                    },
+                    _image_content(base64_image, media_type="image/jpeg"),
+                ],
+            }
+        ],
+    }
+
+
+def prepare_multi_label_classification_prompt(
+    base64_image: str,
+    classes: List[str],
+    **kwargs,
+) -> dict:
+    """Build a multi-label classification request."""
+    serialised_classes = ", ".join(classes)
+    return {
+        "instructions": (
+            "You act as multi-label classification model. You must provide reasonable predictions. "
+            "You are only allowed to produce JSON document in Markdown ```json``` markers. "
+            'Expected structure of json: {"predicted_classes": [{"class": "class-name-1", "confidence": 0.9}, '
+            '{"class": "class-name-2", "confidence": 0.7}]}. '
+            "`class-name-X` must be one of the class names defined by user and `confidence` is a float value in range "
+            "0.0-1.0 that represent how sure you are that the class is present in the image. Only return class names "
+            "that are visible."
+        ),
+        "input": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "input_text",
+                        "text": f"List of all classes to be recognised by model: {serialised_classes}",
+                    },
+                    _image_content(base64_image, media_type="image/jpeg"),
+                ],
+            }
+        ],
+    }
+
+
+def prepare_vqa_prompt(
+    base64_image: str,
+    prompt: str,
+    **kwargs,
+) -> dict:
+    """Build a visual-question-answering request."""
+    return {
+        "instructions": (
+            "You act as Visual Question Answering model. Your task is to provide answer to question "
+            "submitted by user. If this is open-question - answer with few sentences, for ABCD question, "
+            "return only the indicator of the answer."
+        ),
+        "input": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "input_text", "text": f"Question: {prompt}"},
+                    _image_content(base64_image, media_type="image/jpeg"),
+                ],
+            }
+        ],
+    }
+
+
+def prepare_ocr_prompt(
+    base64_image: str,
+    **kwargs,
+) -> dict:
+    """Build an OCR request returning recognised text as paragraphs."""
+    return {
+        "instructions": (
+            "You act as OCR model. Your task is to read text from the image and return it in "
+            "paragraphs representing the structure of texts in the image. You should only return "
+            "recognised text, nothing else."
+        ),
+        "input": [
+            {
+                "role": "user",
+                "content": [
+                    _image_content(base64_image, media_type="image/jpeg"),
+                ],
+            }
+        ],
+    }
+
+
+def prepare_caption_prompt(
+    base64_image: str,
+    short_description: bool,
+    **kwargs,
+) -> dict:
+    """Build an image captioning request."""
+    caption_detail_level = "Caption should be short."
+    if not short_description:
+        caption_detail_level = "Caption should be extensive."
+    return {
+        "instructions": (
+            f"You act as image caption model. Your task is to provide description of the image. "
+            f"{caption_detail_level}"
+        ),
+        "input": [
+            {
+                "role": "user",
+                "content": [
+                    _image_content(base64_image, media_type="image/jpeg"),
+                ],
+            }
+        ],
+    }
+
+
+def prepare_structured_answering_prompt(
+    base64_image: str,
+    output_structure: Dict[str, str],
+    **kwargs,
+) -> dict:
+    """Build a structured-answering request producing user-defined JSON."""
+    output_structure_serialised = json.dumps(output_structure, indent=4)
+    return {
+        "instructions": (
+            "You are supposed to produce responses in JSON wrapped in Markdown markers: "
+            "```json\nyour-response\n```. User is to provide you dictionary with keys and values. "
+            "Each key must be present in your response. Values in user dictionary represent "
+            "descriptions for JSON fields to be generated. Provide only JSON Markdown in response."
+        ),
+        "input": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "input_text",
+                        "text": f"Specification of requirements regarding output fields: \n"
+                        f"{output_structure_serialised}",
+                    },
+                    _image_content(base64_image, media_type="image/jpeg"),
+                ],
+            }
+        ],
+    }
+
+
+def prepare_object_detection_prompt(
+    base64_image: str,
+    classes: List[str],
+    **kwargs,
+) -> dict:
+    """Build the percent-format detection request used by Grok 4.5/4.6.
+
+    Args:
+        base64_image: Base64-encoded PNG image.
+        classes: Class names the model may predict.
+        **kwargs: Ignored builder arguments shared across task types.
+
+    Returns:
+        Request payload with an ``input`` key containing the detection prompt
+        and a high-detail PNG image.
+    """
+    class_list = ", ".join(classes)
+    prompt_text = OBJECT_DETECTION_PROMPT_TEMPLATE.format(class_list=class_list)
+    return {
+        "input": [
+            {
+                "role": "user",
+                "content": [
+                    _image_content(base64_image, media_type="image/png", detail="high"),
+                    {"type": "input_text", "text": prompt_text},
+                ],
+            }
+        ],
+    }
+
+
+PROMPT_BUILDERS = {
+    "unconstrained": prepare_unconstrained_prompt,
+    "ocr": prepare_ocr_prompt,
+    "visual-question-answering": prepare_vqa_prompt,
+    "caption": partial(prepare_caption_prompt, short_description=True),
+    "detailed-caption": partial(prepare_caption_prompt, short_description=False),
+    "classification": prepare_classification_prompt,
+    "multi-label-classification": prepare_multi_label_classification_prompt,
+    "structured-answering": prepare_structured_answering_prompt,
+    "object-detection": prepare_object_detection_prompt,
+}

--- a/tests/workflows/unit_tests/core_steps/common/test_openrouter.py
+++ b/tests/workflows/unit_tests/core_steps/common/test_openrouter.py
@@ -12,6 +12,7 @@ from inference.core.exceptions import (
     RoboflowAPIUnsuccessfulRequestError,
 )
 from inference.core.workflows.core_steps.common.openrouter import (
+    OpenRouterResult,
     OpenRouterWorkflowBlockBase,
     _execute_direct_openrouter_request,
     _execute_proxied_openrouter_request,
@@ -100,7 +101,10 @@ def _stub_messages():
 def test_execute_openrouter_batch_routes_to_proxy_for_managed_key(
     mock_direct, mock_proxied
 ):
-    mock_proxied.side_effect = ["resp-1", "resp-2"]
+    mock_proxied.side_effect = [
+        OpenRouterResult(content="resp-1"),
+        OpenRouterResult(content="resp-2"),
+    ]
     block = _FakeBlock(model_manager=MagicMock(), api_key="rf-workspace-abc")
 
     out = block.execute_openrouter_batch(
@@ -138,7 +142,7 @@ def test_execute_openrouter_batch_routes_to_proxy_for_user_managed_key(
 ):
     """Both `rf_key:account` and `rf_key:user:<id>` route through the proxy.
     The platform decides whether to honor the user-stored variant."""
-    mock_proxied.side_effect = ["resp"]
+    mock_proxied.side_effect = [OpenRouterResult(content="resp")]
     block = _FakeBlock(model_manager=MagicMock(), api_key="ws-key")
 
     block.execute_openrouter_batch(
@@ -165,7 +169,7 @@ def test_execute_openrouter_batch_routes_to_proxy_for_user_managed_key(
 def test_execute_openrouter_batch_routes_to_direct_for_user_key(
     mock_direct, mock_proxied
 ):
-    mock_direct.side_effect = ["direct-resp"]
+    mock_direct.side_effect = [OpenRouterResult(content="direct-resp")]
     block = _FakeBlock(model_manager=MagicMock(), api_key="ws-key")
 
     out = block.execute_openrouter_batch(
@@ -205,7 +209,7 @@ def test_proxied_request_sends_expected_payload_to_roboflow(mock_post):
         privacy_level="deny",
     )
 
-    assert out == "hello world"
+    assert out == OpenRouterResult(content="hello world")
     mock_post.assert_called_once()
     call_kwargs = mock_post.call_args.kwargs
     assert call_kwargs["endpoint"] == "apiproxy/openrouter"
@@ -240,12 +244,12 @@ def test_proxied_request_raises_when_choices_empty(mock_post):
 
 
 # ---------------------------------------------------------------------------
-# include_reasoning: reasoning-trace extraction
+# OpenRouterResult: reasoning-trace and usage extraction
 # ---------------------------------------------------------------------------
 
 
 @patch("inference.core.workflows.core_steps.common.openrouter.post_to_roboflow_api")
-def test_proxied_request_returns_reasoning_trace_when_requested(mock_post):
+def test_proxied_request_populates_reasoning_trace(mock_post):
     mock_post.return_value = {
         "choices": [{"message": {"content": "answer", "reasoning": "trace"}}]
     }
@@ -258,10 +262,9 @@ def test_proxied_request_returns_reasoning_trace_when_requested(mock_post):
         max_tokens=10,
         temperature=None,
         privacy_level="deny",
-        include_reasoning=True,
     )
 
-    assert out == ("answer", "trace")
+    assert out == OpenRouterResult(content="answer", reasoning_trace="trace")
 
 
 @patch("inference.core.workflows.core_steps.common.openrouter.OpenAI")
@@ -270,7 +273,8 @@ def test_direct_request_returns_empty_trace_when_reasoning_missing(mock_openai_c
     response = MagicMock()
     choice = MagicMock()
     choice.message.content = "answer"
-    # MagicMock auto-creates attributes; a non-str `reasoning` must map to "".
+    # MagicMock auto-creates attributes; a non-str `reasoning` must map to ""
+    # and non-int usage fields to None.
     response.choices = [choice]
     client.chat.completions.create.return_value = response
     mock_openai_cls.return_value = client
@@ -282,10 +286,60 @@ def test_direct_request_returns_empty_trace_when_reasoning_missing(mock_openai_c
         max_tokens=10,
         temperature=None,
         privacy_level="deny",
-        include_reasoning=True,
     )
 
-    assert out == ("answer", "")
+    assert out == OpenRouterResult(content="answer")
+
+
+@patch("inference.core.workflows.core_steps.common.openrouter.post_to_roboflow_api")
+def test_proxied_request_returns_usage_and_none_when_omitted(mock_post):
+    def call():
+        return _execute_proxied_openrouter_request(
+            roboflow_api_key="k",
+            openrouter_api_key="rf_key:account",
+            model="qwen/qwen3.7-plus",
+            messages=[{"role": "user", "content": "hi"}],
+            max_tokens=10,
+            temperature=None,
+            privacy_level="deny",
+        )
+
+    mock_post.return_value = {
+        "choices": [{"message": {"content": "answer"}}],
+        "usage": {"prompt_tokens": 11, "completion_tokens": 7},
+    }
+    assert call() == OpenRouterResult(
+        content="answer", input_tokens=11, output_tokens=7
+    )
+
+    mock_post.return_value = {"choices": [{"message": {"content": "answer"}}]}
+    assert call() == OpenRouterResult(content="answer")
+
+
+@patch("inference.core.workflows.core_steps.common.openrouter.OpenAI")
+def test_direct_request_returns_trace_and_usage(mock_openai_cls):
+    client = MagicMock()
+    response = MagicMock()
+    choice = MagicMock()
+    choice.message.content = "answer"
+    choice.message.reasoning = "trace"
+    response.choices = [choice]
+    response.usage = MagicMock(prompt_tokens=9, completion_tokens=4)
+    client.chat.completions.create.return_value = response
+    mock_openai_cls.return_value = client
+
+    out = _execute_direct_openrouter_request(
+        api_key="sk-or-v1-test",
+        model="qwen/qwen3.7-plus",
+        messages=[{"role": "user", "content": "hi"}],
+        max_tokens=10,
+        temperature=None,
+        privacy_level="deny",
+    )
+
+    assert out == OpenRouterResult(
+        content="answer", reasoning_trace="trace", input_tokens=9, output_tokens=4
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -523,7 +577,7 @@ def test_proxied_request_retries_without_reasoning_on_rejection(mock_post, mock_
         reasoning={"enabled": False},
     )
 
-    assert out == "ok"
+    assert out == OpenRouterResult(content="ok")
     assert mock_post.call_count == 2
     assert "reasoning" in mock_post.call_args_list[0].kwargs["payload"]
     assert "reasoning" not in mock_post.call_args_list[1].kwargs["payload"]
@@ -591,7 +645,7 @@ def test_direct_request_retries_without_reasoning_on_rejection(
         reasoning={"effort": "low"},
     )
 
-    assert out == "ok"
+    assert out == OpenRouterResult(content="ok")
     assert client.chat.completions.create.call_count == 2
     first_extra = client.chat.completions.create.call_args_list[0].kwargs["extra_body"]
     second_extra = client.chat.completions.create.call_args_list[1].kwargs["extra_body"]
@@ -609,7 +663,7 @@ def test_direct_request_retries_without_reasoning_on_rejection(
     "inference.core.workflows.core_steps.common.openrouter._execute_proxied_openrouter_request"
 )
 def test_execute_openrouter_batch_forwards_reasoning_on_managed_key(mock_proxied):
-    mock_proxied.side_effect = ["resp"]
+    mock_proxied.side_effect = [OpenRouterResult(content="resp")]
     block = _FakeBlock(model_manager=MagicMock(), api_key="ws-key")
 
     block.execute_openrouter_batch(
@@ -624,6 +678,38 @@ def test_execute_openrouter_batch_forwards_reasoning_on_managed_key(mock_proxied
     )
 
     assert mock_proxied.call_args.kwargs["reasoning"] == {"enabled": False}
+
+
+# ---------------------------------------------------------------------------
+# batch result shapes: legacy conversion vs. with_usage
+# ---------------------------------------------------------------------------
+
+
+@patch(
+    "inference.core.workflows.core_steps.common.openrouter._execute_proxied_openrouter_request"
+)
+def test_execute_openrouter_batch_legacy_shapes_and_with_usage(mock_proxied):
+    """Legacy method keeps its shipped shapes; with_usage exposes full results."""
+    rich = OpenRouterResult(
+        content="answer", reasoning_trace="trace", input_tokens=11, output_tokens=7
+    )
+    block = _FakeBlock(model_manager=MagicMock(), api_key="ws-key")
+    kwargs = {
+        "openrouter_api_key": "rf_key:account",
+        "model": "qwen/qwen3.7-plus",
+        "prompts": [[{"role": "user", "content": "hi"}]],
+        "max_tokens": 50,
+        "temperature": None,
+        "privacy_level": "deny",
+        "max_concurrent_requests": 1,
+    }
+
+    mock_proxied.return_value = rich
+    assert block.execute_openrouter_batch(**kwargs) == ["answer"]
+    assert block.execute_openrouter_batch(**kwargs, include_reasoning=True) == [
+        ("answer", "trace")
+    ]
+    assert block.execute_openrouter_batch_with_usage(**kwargs) == [rich]
 
 
 # ---------------------------------------------------------------------------
@@ -669,3 +755,22 @@ def test_validate_task_type_ocr_passes_with_no_extra_fields():
         classes=None,
         output_structure=None,
     )
+
+
+@pytest.mark.parametrize(
+    "effort, expected",
+    [
+        (None, None),
+        ("none", {"enabled": False}),
+        ("low", {"effort": "low"}),
+        ("medium", {"effort": "medium"}),
+        ("high", {"effort": "high"}),
+        ("xhigh", {"effort": "xhigh"}),
+    ],
+)
+def test_build_openrouter_reasoning_config(effort, expected):
+    from inference.core.workflows.core_steps.common.reasoning import (
+        build_openrouter_reasoning_config,
+    )
+
+    assert build_openrouter_reasoning_config(effort) == expected

--- a/tests/workflows/unit_tests/core_steps/common/test_token_usage.py
+++ b/tests/workflows/unit_tests/core_steps/common/test_token_usage.py
@@ -1,0 +1,113 @@
+"""Contracts for shared token-usage parsing and VLM block outputs."""
+
+import importlib
+from types import SimpleNamespace
+
+from inference.core.workflows.core_steps.common.token_usage import (
+    TOKEN_OUTPUT_DEFINITIONS,
+    as_optional_int,
+    parse_chat_completion_usage,
+    parse_gemini_usage_metadata,
+    parse_responses_api_usage,
+)
+
+_FOUNDATION = "inference.core.workflows.core_steps.models.foundation"
+
+# New versions introduced for token usage: must declare the token outputs.
+NEW_BLOCK_MODULES = [
+    f"{_FOUNDATION}.openrouter.v2",
+    f"{_FOUNDATION}.google_gemma.v3",
+    f"{_FOUNDATION}.meta_vlm.v2",
+    f"{_FOUNDATION}.qwen_vlm.v3",
+    f"{_FOUNDATION}.anthropic_claude.v4",
+    f"{_FOUNDATION}.google_gemini.v5",
+    f"{_FOUNDATION}.openai.v6",
+    f"{_FOUNDATION}.spacexai.v2",
+]
+
+# Shipped predecessors: their output contracts must stay frozen.
+OLD_BLOCK_MODULES = [
+    f"{_FOUNDATION}.openrouter.v1",
+    f"{_FOUNDATION}.google_gemma.v2",
+    f"{_FOUNDATION}.meta_vlm.v1",
+    f"{_FOUNDATION}.qwen_vlm.v2",
+    f"{_FOUNDATION}.anthropic_claude.v3",
+    f"{_FOUNDATION}.google_gemini.v4",
+    f"{_FOUNDATION}.openai.v4",
+    f"{_FOUNDATION}.openai.v5",
+    f"{_FOUNDATION}.spacexai.v1",
+]
+
+
+def _manifest(module_path: str):
+    return importlib.import_module(module_path).BlockManifest
+
+
+def test_as_optional_int_rejects_bool_and_non_ints():
+    assert as_optional_int(0) == 0
+    assert as_optional_int(12) == 12
+    assert as_optional_int(True) is None
+    assert as_optional_int(1.5) is None
+    assert as_optional_int("9") is None
+    assert as_optional_int(None) is None
+
+
+def test_parse_chat_completion_usage_from_dict_and_object():
+    assert parse_chat_completion_usage(None) == (None, None)
+    assert parse_chat_completion_usage({}) == (None, None)
+    assert parse_chat_completion_usage(
+        {"prompt_tokens": 11, "completion_tokens": 7}
+    ) == (11, 7)
+    assert parse_chat_completion_usage(
+        SimpleNamespace(prompt_tokens=3, completion_tokens=1)
+    ) == (3, 1)
+
+
+def test_parse_responses_api_usage_from_dict_and_object():
+    assert parse_responses_api_usage(None) == (None, None)
+    assert parse_responses_api_usage({"input_tokens": 20, "output_tokens": 8}) == (
+        20,
+        8,
+    )
+    assert parse_responses_api_usage(
+        SimpleNamespace(input_tokens=4, output_tokens=2)
+    ) == (4, 2)
+
+
+def test_parse_gemini_usage_adds_thoughts_to_output():
+    assert parse_gemini_usage_metadata(None) == (None, None)
+    assert parse_gemini_usage_metadata({}) == (None, None)
+    assert parse_gemini_usage_metadata(
+        {
+            "promptTokenCount": 15,
+            "candidatesTokenCount": 6,
+            "thoughtsTokenCount": 4,
+        }
+    ) == (15, 10)
+    assert parse_gemini_usage_metadata({"thoughtsTokenCount": 3}) == (None, 3)
+
+
+def test_token_outputs_declared_on_new_versions_and_absent_on_old():
+    token_outputs = {definition.name for definition in TOKEN_OUTPUT_DEFINITIONS}
+    for module_path in NEW_BLOCK_MODULES:
+        names = {
+            definition.name for definition in _manifest(module_path).describe_outputs()
+        }
+        assert token_outputs <= names, f"{module_path} must declare token outputs"
+    for module_path in OLD_BLOCK_MODULES:
+        names = {
+            definition.name for definition in _manifest(module_path).describe_outputs()
+        }
+        assert not (
+            token_outputs & names
+        ), f"{module_path} is shipped — its output contract must stay frozen"
+
+
+def test_new_vlm_block_versions_are_registered():
+    from inference.core.workflows.core_steps.loader import load_blocks
+
+    registered_manifests = {block.get_manifest() for block in load_blocks()}
+    for module_path in NEW_BLOCK_MODULES:
+        assert (
+            _manifest(module_path) in registered_manifests
+        ), f"{module_path} block is not registered in the loader"

--- a/tests/workflows/unit_tests/core_steps/models/foundation/test_anthropic_claude_v4.py
+++ b/tests/workflows/unit_tests/core_steps/models/foundation/test_anthropic_claude_v4.py
@@ -1,0 +1,81 @@
+"""Tests for the Anthropic Claude v4 block (v3 + token-usage outputs).
+
+The v1-v3 behavior suite lives in ``test_anthropic_claude.py``; this file
+covers the v4 delta: ``input_tokens`` / ``output_tokens`` outputs on both
+the proxied and direct execution paths.
+"""
+
+from unittest.mock import MagicMock, Mock, patch
+
+from inference.core.workflows.core_steps.models.foundation.anthropic_claude.v4 import (
+    _execute_direct_claude_request,
+    _execute_proxied_claude_request,
+)
+
+_CLAUDE_OK = {
+    "stop_reason": "end_turn",
+    "content": [{"type": "text", "text": "ok"}],
+}
+
+
+@patch(
+    "inference.core.workflows.core_steps.models.foundation.anthropic_claude.v4.post_to_roboflow_api"
+)
+def test_proxied_request_returns_usage_and_none_when_omitted(mock_post: Mock) -> None:
+    def call():
+        return _execute_proxied_claude_request(
+            roboflow_api_key="rf_api_key",
+            anthropic_api_key="rf_key:account",
+            system_prompt=None,
+            messages=[],
+            model_version="claude-sonnet-4-5",
+            max_tokens=1000,
+            temperature=None,
+            extended_thinking=None,
+            thinking_budget_tokens=None,
+        )
+
+    mock_post.return_value = {
+        **_CLAUDE_OK,
+        "usage": {"input_tokens": 30, "output_tokens": 9},
+    }
+    assert call() == ("ok", 30, 9)
+
+    mock_post.return_value = _CLAUDE_OK
+    assert call() == ("ok", None, None)
+
+
+@patch(
+    "inference.core.workflows.core_steps.models.foundation.anthropic_claude.v4.anthropic.Anthropic"
+)
+def test_direct_request_returns_usage(mock_anthropic_class: Mock) -> None:
+    mock_client = MagicMock()
+    mock_anthropic_class.return_value = mock_client
+
+    mock_text_block = Mock()
+    mock_text_block.type = "text"
+    mock_text_block.text = "ok"
+
+    mock_result = Mock()
+    mock_result.stop_reason = "end_turn"
+    mock_result.content = [mock_text_block]
+    mock_result.usage = Mock(input_tokens=18, output_tokens=5)
+
+    mock_stream = MagicMock()
+    mock_stream.__enter__ = Mock(return_value=mock_stream)
+    mock_stream.__exit__ = Mock(return_value=False)
+    mock_stream.get_final_message.return_value = mock_result
+    mock_client.messages.stream.return_value = mock_stream
+
+    result = _execute_direct_claude_request(
+        anthropic_api_key="sk-ant-test",
+        system_prompt=None,
+        messages=[],
+        model_version="claude-sonnet-4-5",
+        max_tokens=1000,
+        temperature=None,
+        extended_thinking=None,
+        thinking_budget_tokens=None,
+    )
+
+    assert result == ("ok", 18, 5)

--- a/tests/workflows/unit_tests/core_steps/models/foundation/test_google_gemini_v5.py
+++ b/tests/workflows/unit_tests/core_steps/models/foundation/test_google_gemini_v5.py
@@ -1,0 +1,71 @@
+"""Tests for the Google Gemini v5 block (v4 + token-usage outputs).
+
+The v1-v4 behavior suite lives in ``test_google_gemini.py``; this file
+covers the v5 delta: ``input_tokens`` / ``output_tokens`` outputs on both
+the proxied and direct execution paths. ``output_tokens`` includes
+Gemini's ``thoughtsTokenCount`` (billing parity).
+"""
+
+from unittest.mock import Mock, patch
+
+from inference.core.workflows.core_steps.models.foundation.google_gemini.v5 import (
+    _execute_direct_gemini_request,
+    _execute_proxied_gemini_request,
+)
+
+_GEMINI_OK = {
+    "candidates": [
+        {
+            "content": {"parts": [{"text": "ok"}]},
+            "finishReason": "STOP",
+        }
+    ]
+}
+
+
+@patch(
+    "inference.core.workflows.core_steps.models.foundation.google_gemini.v5.post_to_roboflow_api"
+)
+def test_proxied_request_returns_usage_and_none_when_omitted(mock_post: Mock) -> None:
+    def call():
+        return _execute_proxied_gemini_request(
+            roboflow_api_key="rf_api_key",
+            google_api_key="rf_key:account",
+            prompt={"contents": {"parts": [{"text": "test"}]}},
+            model_version="gemini-2.5-pro",
+        )
+
+    # thoughtsTokenCount is folded into output_tokens (billing parity)
+    mock_post.return_value = {
+        **_GEMINI_OK,
+        "usageMetadata": {
+            "promptTokenCount": 15,
+            "candidatesTokenCount": 6,
+            "thoughtsTokenCount": 4,
+        },
+    }
+    assert call() == ("ok", 15, 10)
+
+    mock_post.return_value = _GEMINI_OK
+    assert call() == ("ok", None, None)
+
+
+@patch(
+    "inference.core.workflows.core_steps.models.foundation.google_gemini.v5.requests.post"
+)
+def test_direct_request_returns_usage(mock_post: Mock) -> None:
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        **_GEMINI_OK,
+        "usageMetadata": {"promptTokenCount": 8, "candidatesTokenCount": 2},
+    }
+    mock_post.return_value = mock_response
+
+    result = _execute_direct_gemini_request(
+        google_api_key="user-google-key",
+        prompt={"contents": {"parts": [{"text": "test"}]}},
+        model_version="gemini-2.5-pro",
+    )
+
+    assert result == ("ok", 8, 2)

--- a/tests/workflows/unit_tests/core_steps/models/foundation/test_google_gemma_v3.py
+++ b/tests/workflows/unit_tests/core_steps/models/foundation/test_google_gemma_v3.py
@@ -1,0 +1,60 @@
+"""Tests for the Gemma v3 block (v2 + token-usage outputs).
+
+The v2 behavior suite lives in ``test_google_gemma_v2.py``; this file
+covers the v3 delta: ``input_tokens`` / ``output_tokens`` outputs.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+
+from inference.core.workflows.core_steps.common.openrouter import OpenRouterResult
+from inference.core.workflows.core_steps.models.foundation.google_gemma.v3 import (
+    MODEL_VERSION_MAPPING,
+    GoogleGemmaBlockV3,
+)
+from inference.core.workflows.execution_engine.entities.base import WorkflowImageData
+
+
+def _stub_image() -> WorkflowImageData:
+    return WorkflowImageData(
+        parent_metadata=MagicMock(
+            parent_id="root", workflow_root_ancestor_metadata=None
+        ),
+        numpy_image=np.zeros((10, 10, 3), dtype=np.uint8),
+    )
+
+
+@patch.object(GoogleGemmaBlockV3, "execute_openrouter_batch_with_usage")
+def test_run_surfaces_token_usage(mock_execute):
+    mock_execute.return_value = [
+        OpenRouterResult(content="caption text", input_tokens=11, output_tokens=4)
+    ]
+    block = GoogleGemmaBlockV3(model_manager=MagicMock(), api_key="ws-key")
+
+    result = block.run(
+        images=[_stub_image()],
+        task_type="caption",
+        prompt=None,
+        output_structure=None,
+        classes=None,
+        api_key="rf_key:account",
+        privacy_level="deny",
+        model_version="Gemma 4 26B A4B - OpenRouter",
+        max_tokens=128,
+        temperature=0.2,
+        reasoning_effort=None,
+        max_concurrent_requests=None,
+    )
+
+    assert result == [
+        {
+            "output": "caption text",
+            "classes": None,
+            "input_tokens": 11,
+            "output_tokens": 4,
+        }
+    ]
+    kwargs = mock_execute.call_args.kwargs
+    assert kwargs["model"] == MODEL_VERSION_MAPPING["Gemma 4 26B A4B - OpenRouter"]
+    assert kwargs["reasoning"] is None

--- a/tests/workflows/unit_tests/core_steps/models/foundation/test_meta_vlm_v2.py
+++ b/tests/workflows/unit_tests/core_steps/models/foundation/test_meta_vlm_v2.py
@@ -1,0 +1,77 @@
+"""Tests for the Meta VLM v2 block (v1 + token-usage outputs).
+
+The v1 behavior suite lives in ``test_meta_vlm_v1.py``; this file covers
+the v2 delta: ``input_tokens`` / ``output_tokens`` outputs.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+
+from inference.core.workflows.core_steps.common.openrouter import OpenRouterResult
+from inference.core.workflows.core_steps.models.foundation.meta_vlm.v2 import (
+    DEFAULT_MAX_TOKENS,
+    DEFAULT_MODEL_VERSION,
+    DEFAULT_REASONING_EFFORT,
+    MetaVlmBlockV2,
+)
+from inference.core.workflows.execution_engine.entities.base import WorkflowImageData
+
+
+def _stub_image() -> WorkflowImageData:
+    return WorkflowImageData(
+        parent_metadata=MagicMock(
+            parent_id="root", workflow_root_ancestor_metadata=None
+        ),
+        numpy_image=np.zeros((10, 10, 3), dtype=np.uint8),
+    )
+
+
+def _base_run_kwargs(**overrides):
+    kwargs = dict(
+        images=[_stub_image()],
+        model_version=DEFAULT_MODEL_VERSION,
+        task_type="caption",
+        prompt=None,
+        output_structure=None,
+        classes=None,
+        reasoning_effort=DEFAULT_REASONING_EFFORT,
+        api_key="rf_key:account",
+        privacy_level="deny",
+        max_tokens=DEFAULT_MAX_TOKENS,
+        temperature=None,
+        max_concurrent_requests=None,
+    )
+    kwargs.update(overrides)
+    return kwargs
+
+
+@patch(
+    "inference.core.workflows.core_steps.models.foundation.meta_vlm.v2."
+    "OpenRouterWorkflowBlockBase.execute_openrouter_batch_with_usage"
+)
+def test_run_surfaces_token_usage(mock_or):
+    mock_or.return_value = [
+        OpenRouterResult(
+            content="boxes", reasoning_trace="trace", input_tokens=20, output_tokens=8
+        )
+    ]
+    block = MetaVlmBlockV2(model_manager=MagicMock(), api_key="rf_key")
+
+    result = block.run(
+        **_base_run_kwargs(
+            task_type="object-detection",
+            classes=["cat"],
+            model_version="Muse Glimmer",
+        )
+    )
+
+    assert result == [
+        {
+            "output": "boxes",
+            "classes": ["cat"],
+            "thinking": "trace",
+            "input_tokens": 20,
+            "output_tokens": 8,
+        }
+    ]

--- a/tests/workflows/unit_tests/core_steps/models/foundation/test_openai_v6.py
+++ b/tests/workflows/unit_tests/core_steps/models/foundation/test_openai_v6.py
@@ -1,0 +1,74 @@
+"""Tests for the OpenAI v6 block (v5 + token-usage outputs).
+
+The v5 behavior suite lives in ``test_openai_v5.py``; this file covers the
+v6 delta: ``input_tokens`` / ``output_tokens`` outputs on both the proxied
+and direct execution paths.
+"""
+
+from unittest.mock import MagicMock, Mock, patch
+
+from inference.core.workflows.core_steps.models.foundation.openai.v6 import (
+    _execute_direct_openai_request,
+    _execute_proxied_openai_request,
+)
+
+_OPENAI_OK = {
+    "status": "completed",
+    "output": [
+        {
+            "type": "message",
+            "content": [{"type": "output_text", "text": "ok"}],
+        }
+    ],
+}
+
+
+@patch(
+    "inference.core.workflows.core_steps.models.foundation.openai.v6.post_to_roboflow_api"
+)
+def test_proxied_request_returns_usage_and_none_when_omitted(mock_post: Mock) -> None:
+    def call():
+        return _execute_proxied_openai_request(
+            roboflow_api_key="rf_api_key",
+            openai_api_key="rf_key:account",
+            instructions="test",
+            input_content=[],
+            model_version="gpt-5.1",
+            reasoning_effort=None,
+            max_tokens=None,
+            temperature=None,
+        )
+
+    mock_post.return_value = {
+        **_OPENAI_OK,
+        "usage": {"input_tokens": 21, "output_tokens": 6},
+    }
+    assert call() == ("ok", 21, 6)
+
+    mock_post.return_value = _OPENAI_OK
+    assert call() == ("ok", None, None)
+
+
+@patch(
+    "inference.core.workflows.core_steps.models.foundation.openai.v6._get_openai_client"
+)
+def test_direct_request_returns_usage(mock_get_client: Mock) -> None:
+    mock_client = MagicMock()
+    mock_response = MagicMock()
+    mock_response.status = "completed"
+    mock_response.output_text = "response"
+    mock_response.usage = MagicMock(input_tokens=14, output_tokens=3)
+    mock_client.responses.create.return_value = mock_response
+    mock_get_client.return_value = mock_client
+
+    result = _execute_direct_openai_request(
+        openai_api_key="sk-test",
+        instructions="test",
+        input_content=[{"role": "user", "content": []}],
+        model_version="gpt-5.1",
+        reasoning_effort=None,
+        max_tokens=None,
+        temperature=None,
+    )
+
+    assert result == ("response", 14, 3)

--- a/tests/workflows/unit_tests/core_steps/models/foundation/test_openrouter_v2.py
+++ b/tests/workflows/unit_tests/core_steps/models/foundation/test_openrouter_v2.py
@@ -1,0 +1,60 @@
+"""Tests for the OpenRouter v2 block (v1 + token-usage outputs).
+
+Shared routing/privacy logic is exercised in
+``tests/workflows/unit_tests/core_steps/common/test_openrouter.py``; the
+v1 behavior suite lives with the v1 block. This file covers the v2 delta:
+``input_tokens`` / ``output_tokens`` outputs.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+
+from inference.core.workflows.core_steps.common.openrouter import OpenRouterResult
+from inference.core.workflows.core_steps.models.foundation.openrouter.v2 import (
+    OpenRouterBlockV2,
+)
+from inference.core.workflows.execution_engine.entities.base import WorkflowImageData
+
+
+def _stub_image() -> WorkflowImageData:
+    return WorkflowImageData(
+        parent_metadata=MagicMock(
+            parent_id="root", workflow_root_ancestor_metadata=None
+        ),
+        numpy_image=np.zeros((10, 10, 3), dtype=np.uint8),
+    )
+
+
+@patch.object(OpenRouterBlockV2, "execute_openrouter_batch_with_usage")
+def test_run_surfaces_token_usage(mock_execute):
+    mock_execute.return_value = [
+        OpenRouterResult(content="caption text", input_tokens=11, output_tokens=4)
+    ]
+    block = OpenRouterBlockV2(model_manager=MagicMock(), api_key="ws-key")
+
+    result = block.run(
+        images=[_stub_image()],
+        model_id="google/gemma-4-26b-a4b-it",
+        task_type="caption",
+        prompt=None,
+        output_structure=None,
+        classes=None,
+        api_key="rf_key:account",
+        privacy_level="deny",
+        max_tokens=128,
+        temperature=0.2,
+        reasoning_effort="low",
+        max_concurrent_requests=None,
+    )
+
+    assert mock_execute.call_args.kwargs["reasoning"] == {"effort": "low"}
+    assert result == [
+        {
+            "output": "caption text",
+            "classes": None,
+            "thinking": "",
+            "input_tokens": 11,
+            "output_tokens": 4,
+        }
+    ]

--- a/tests/workflows/unit_tests/core_steps/models/foundation/test_qwen_vlm_v3.py
+++ b/tests/workflows/unit_tests/core_steps/models/foundation/test_qwen_vlm_v3.py
@@ -1,0 +1,101 @@
+"""Tests for the Qwen VLM v3 block (v2 + token-usage outputs).
+
+The v2 behavior suite lives in ``test_qwen_vlm_v2.py``; this file covers
+the v3 delta: ``input_tokens`` / ``output_tokens`` outputs on the
+OpenRouter backend, and ``None`` token counts on the native backend.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+
+from inference.core.workflows.core_steps.common.entities import StepExecutionMode
+from inference.core.workflows.core_steps.common.openrouter import OpenRouterResult
+from inference.core.workflows.core_steps.models.foundation.qwen_vlm.v3 import (
+    DEFAULT_OPENROUTER_MODEL_VERSION,
+    QwenVlmBlockV3,
+)
+from inference.core.workflows.execution_engine.entities.base import WorkflowImageData
+
+
+def _stub_image() -> WorkflowImageData:
+    return WorkflowImageData(
+        parent_metadata=MagicMock(
+            parent_id="root", workflow_root_ancestor_metadata=None
+        ),
+        numpy_image=np.zeros((10, 10, 3), dtype=np.uint8),
+    )
+
+
+def _base_run_kwargs(**overrides):
+    kwargs = dict(
+        images=[_stub_image()],
+        backend="native",
+        model_version="Qwen 3.5 VL 2B",
+        fine_tuned_model_id=None,
+        openrouter_model_version=DEFAULT_OPENROUTER_MODEL_VERSION,
+        task_type="caption",
+        prompt=None,
+        enable_thinking=False,
+        reasoning_effort="none",
+        output_structure=None,
+        classes=None,
+        api_key="rf_key:account",
+        privacy_level="deny",
+        max_tokens=2048,
+        temperature=None,
+        max_concurrent_requests=None,
+    )
+    kwargs.update(overrides)
+    return kwargs
+
+
+@patch.object(QwenVlmBlockV3, "execute_openrouter_batch_with_usage")
+def test_run_openrouter_surfaces_token_usage(mock_or):
+    mock_or.return_value = [
+        OpenRouterResult(
+            content="resp", reasoning_trace="trace", input_tokens=11, output_tokens=7
+        )
+    ]
+    block = QwenVlmBlockV3(
+        model_manager=MagicMock(),
+        api_key="ws-key",
+        step_execution_mode=StepExecutionMode.LOCAL,
+    )
+
+    result = block.run(**_base_run_kwargs(backend="openrouter"))
+
+    assert result == [
+        {
+            "output": "resp",
+            "classes": None,
+            "thinking": "trace",
+            "input_tokens": 11,
+            "output_tokens": 7,
+        }
+    ]
+
+
+def test_run_native_reports_none_token_usage():
+    model_manager = MagicMock()
+    fake_prediction = MagicMock()
+    fake_prediction.response = "native local answer"
+    model_manager.infer_from_request_sync.return_value = fake_prediction
+
+    block = QwenVlmBlockV3(
+        model_manager=model_manager,
+        api_key="ws-key",
+        step_execution_mode=StepExecutionMode.LOCAL,
+    )
+
+    result = block.run(**_base_run_kwargs())
+
+    assert result == [
+        {
+            "output": "native local answer",
+            "classes": None,
+            "thinking": "",
+            "input_tokens": None,
+            "output_tokens": None,
+        }
+    ]

--- a/tests/workflows/unit_tests/core_steps/models/foundation/test_spacexai_v2.py
+++ b/tests/workflows/unit_tests/core_steps/models/foundation/test_spacexai_v2.py
@@ -1,0 +1,74 @@
+"""Tests for the SpaceXAI v2 block (v1 + token-usage outputs).
+
+The v1 behavior suite lives in ``test_spacexai.py``; this file covers the
+v2 delta: ``input_tokens`` / ``output_tokens`` outputs on both the proxied
+and direct execution paths.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from inference.core.workflows.core_steps.models.foundation.spacexai.v2 import (
+    _execute_direct_spacexai_request,
+    _execute_proxied_spacexai_request,
+)
+
+_XAI_OK = {
+    "status": "completed",
+    "output": [
+        {
+            "type": "message",
+            "content": [{"type": "output_text", "text": "ok"}],
+        }
+    ],
+}
+
+
+@patch(
+    "inference.core.workflows.core_steps.models.foundation.spacexai.v2.post_to_roboflow_api"
+)
+def test_proxied_request_returns_usage_and_none_when_omitted(
+    mock_post: MagicMock,
+) -> None:
+    def call():
+        return _execute_proxied_spacexai_request(
+            roboflow_api_key="rf_abc",
+            xai_api_key="rf_key:account",
+            instructions=None,
+            input_content=[],
+            model_version="grok-4.6",
+            reasoning_effort=None,
+            max_tokens=None,
+            temperature=None,
+        )
+
+    mock_post.return_value = {
+        **_XAI_OK,
+        "usage": {"input_tokens": 16, "output_tokens": 5},
+    }
+    assert call() == ("ok", 16, 5)
+
+    mock_post.return_value = _XAI_OK
+    assert call() == ("ok", None, None)
+
+
+@patch("inference.core.workflows.core_steps.models.foundation.spacexai.v2.OpenAI")
+def test_direct_request_returns_usage(mock_openai_cls: MagicMock) -> None:
+    client = MagicMock()
+    response = MagicMock()
+    response.status = "completed"
+    response.output_text = "ok"
+    response.usage = MagicMock(input_tokens=12, output_tokens=4)
+    client.responses.create.return_value = response
+    mock_openai_cls.return_value = client
+
+    result = _execute_direct_spacexai_request(
+        xai_api_key="xai-secret",
+        instructions=None,
+        input_content=[],
+        model_version="grok-4.6",
+        reasoning_effort=None,
+        max_tokens=None,
+        temperature=None,
+    )
+
+    assert result == ("ok", 12, 4)


### PR DESCRIPTION
* Add input_tokens and output_tokens outputs to remote VLM blocks

Provider APIs and Roboflow proxies already return usage; the blocks dropped it. Expose billed counts on both rf_key pass-through and user-supplied keys so Playground can estimate per-call cost.



* Ship token usage as new block versions instead of in-place changes

Per block-versioning discipline, keep the shipped block contracts untouched and introduce the input_tokens/output_tokens outputs in new versions: openrouter@v2, google_gemma@v3, meta_vlm@v2, qwen_vlm@v3, anthropic_claude@v4, google_gemini@v5, open_ai@v6 (based on v5) and spacexai@v2. Old versions and their tests are restored to their pre-branch state.



* Slim token-usage tests: drop duplicates, add loader and frozen-contract guards

Remove per-block manifest tests duplicating the central contract check and a test that asserted a mock through a pass-through router; fold usage-omitted edge cases into their sibling usage tests. Add two guards: new block versions must be registered in the loader, and shipped predecessor versions must not grow token outputs.



* Fix copy artifacts in new block versions flagged in review

Correct stale version numbers in meta_vlm v2 and qwen_vlm v3 module docstrings, and align the block-class execution-engine compatibility with the manifest (>=1.4.0) in openai v6, spacexai v2, anthropic_claude v4 and google_gemini v5. The mismatch was inherited from the shipped predecessors, which stay untouched.



* Replace flag-driven tuple shapes with OpenRouterResult dataclass

execute_openrouter_batch grew a four-shape Union return selected by two boolean flags. Leaf executors now always return a frozen OpenRouterResult (content, reasoning_trace, input_tokens, output_tokens); the legacy method keeps its shipped string/tuple shapes for existing block versions, and the new blocks consume execute_openrouter_batch_with_usage with named fields.



* Raise default max_tokens to 2048 on openrouter v2 and gemma v3

The mixin default of 500 lets reasoning models burn the whole budget on internal thinking and fail with missing content. Override in the new manifests only, matching qwen v3 and meta v2; the mixin and shipped block versions keep their 500 default.



* Change version to 1.5.0-post1



* Add reasoning_effort to openrouter v2 and gemma v3 blocks

Unifies the effort knob across the OpenRouter-family blocks: a shared none/low/medium/high/xhigh vocabulary in common/reasoning.py, forwarded to the existing reasoning parameter of the shared executor (both key modes, with the established retry-without-reasoning fallback). Unset keeps provider-default behavior, so existing workflows are unaffected. openrouter v2 also exposes the reasoning trace as a thinking output.

Live-verified on qwen3.7-plus and gemma-4-26b through real workflows in both key modes: output tokens scale none=39 < low~800 < high=941 on qwen; OpenRouter honors effort even for Gemma (18 -> 308-440 tokens with a real trace).



---------

## What does this PR do?

<!-- Provide a clear and concise description of the changes -->

**Related Issue(s):** <!-- Link to related issues, e.g., Fixes #123 or Related to #456 -->

## Type of Change

<!-- Please select one and delete the others, or describe if Other -->

- Bug fix (non-breaking change that fixes an issue)
- New feature (non-breaking change that adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
- Refactoring (no functional changes)
- Other:

## Testing

<!-- Describe how you tested your changes -->

- [ ] I have tested this change locally
- [ ] I have added/updated tests for this change

**Test details:**
<!-- Describe what tests were added/updated and what they cover -->

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where necessary, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have updated the documentation accordingly (if applicable)

## Additional Context

<!-- Add any other context, screenshots, or notes about the PR here -->
