### PR TITLE
Restrict VLM reasoning levels to what each model natively supports

### DIFF
--- a/inference/core/version.py
+++ b/inference/core/version.py
@@ -1,4 +1,4 @@
-__version__ = "1.5.0-post1"
+__version__ = "1.5.0-post2"
 
 
 if __name__ == "__main__":

--- a/inference/core/workflows/core_steps/common/reasoning.py
+++ b/inference/core/workflows/core_steps/common/reasoning.py
@@ -1,32 +1,9 @@
 """Shared reasoning/thinking-level contract for VLM blocks.
 
-Two groups of consumers:
-
-- Generic OpenRouter blocks (``openrouter@v2``, ``google_gemma@v3``) accept
-  arbitrary model slugs, so they expose the full OpenRouter effort enum
-  (``REASONING_EFFORT_OPTIONS``) and rely on OpenRouter to normalize the value
-  to the nearest level each model supports.
-- Model-dropdown blocks (OpenAI, Gemini, xAI, Muse, Qwen) declare the levels
-  each model natively supports in their model table and validate combinations
-  with ``validate_reasoning_level``. Level sets come from official provider
-  documentation, linked next to each block's table.
-
-How to extend the contract:
-
-- **Add a model to an existing block**: add one row to the block's model
-  table, including its ``reasoning_levels`` (empty list = the model has no
-  reasoning knob). Everything else — UI metadata, visibility, validation —
-  is derived from the table. The contract-consistency test
-  (``test_reasoning_contract.py``) fails with the exact gap if the block's
-  manifest ``Literal`` no longer covers the union of table levels.
-- **Add a level to the shared enum**: extend ``REASONING_EFFORT_OPTIONS`` and
-  ``REASONING_EFFORT_METADATA`` together; the generic blocks pick it up
-  automatically.
-- **Add a provider block**: give it a model table with a per-model
-  ``reasoning_levels`` key, derive a ``{model: levels}`` dict, call
-  ``validate_reasoning_level`` at spec time (``model_validator``) and at the
-  runtime choke point, attach levels to the model dropdown metadata with
-  ``attach_reasoning_levels``, and register the block in the consistency test.
+Extend it by adding a model-table row (empty ``reasoning_levels`` = no knob),
+a value to ``REASONING_EFFORT_OPTIONS`` + metadata, or a new block that
+validates with ``validate_reasoning_level``, attaches metadata with
+``attach_reasoning_levels``, and registers in ``test_reasoning_contract.py``.
 """
 
 from typing import Dict, List, Optional
@@ -92,23 +69,10 @@ def validate_reasoning_level(
     levels_by_model: Dict[str, List[str]],
     parameter: str = "reasoning_effort",
 ) -> None:
-    """Reject a reasoning level the selected model does not natively support.
+    """Reject a level the selected model does not natively support.
 
-    Lenient by design where strictness would break workflows: an unset level,
-    a selector-provided model or level (resolved only at runtime), and a model
-    absent from the table (future model reaching the block through a selector)
-    all pass — the provider then applies its own contract.
-
-    Args:
-        model: Model identifier as the block's table keys it.
-        level: Requested reasoning level, or ``None`` when unset.
-        levels_by_model: Mapping of model identifier to the list of levels the
-            model natively supports (empty list = no reasoning knob).
-        parameter: Field name used in the error message.
-
-    Raises:
-        ValueError: If the model is known and the level is set but
-            unsupported.
+    Unset values, selectors, and models absent from the table all pass so
+    existing workflows and future selector-supplied models keep working.
     """
     if model is None or level is None:
         return
@@ -139,12 +103,7 @@ def attach_reasoning_levels(
     values_metadata: Dict[str, dict],
     levels_by_model: Dict[str, List[str]],
 ) -> Dict[str, dict]:
-    """Extend model-dropdown ``values_metadata`` with per-model levels.
-
-    Adds a machine-readable ``reasoning_levels`` key to every model entry so
-    UIs can restrict the level dropdown per model. The key name is uniform
-    across blocks even where the manifest field is called ``thinking_level``.
-    """
+    """Copy ``values_metadata`` and attach each model's ``reasoning_levels``."""
     return {
         model: {**metadata, "reasoning_levels": levels_by_model.get(model, [])}
         for model, metadata in values_metadata.items()

--- a/inference/core/workflows/core_steps/common/reasoning.py
+++ b/inference/core/workflows/core_steps/common/reasoning.py
@@ -1,15 +1,39 @@
-"""Shared reasoning-effort control for OpenRouter-routed VLM blocks.
+"""Shared reasoning/thinking-level contract for VLM blocks.
 
-Serves the generic blocks (``openrouter@v2``, ``google_gemma@v3``) that accept
-arbitrary or non-reasoning models. Model-family blocks (Qwen, Muse) keep their
-own builders because they encode family-specific behavior: Qwen disables
-reasoning by default and knows which variants reject ``enabled: false``; Muse
-models require reasoning and have no "off" setting.
+Two groups of consumers:
+
+- Generic OpenRouter blocks (``openrouter@v2``, ``google_gemma@v3``) accept
+  arbitrary model slugs, so they expose the full OpenRouter effort enum
+  (``REASONING_EFFORT_OPTIONS``) and rely on OpenRouter to normalize the value
+  to the nearest level each model supports.
+- Model-dropdown blocks (OpenAI, Gemini, xAI, Muse, Qwen) declare the levels
+  each model natively supports in their model table and validate combinations
+  with ``validate_reasoning_level``. Level sets come from official provider
+  documentation, linked next to each block's table.
+
+How to extend the contract:
+
+- **Add a model to an existing block**: add one row to the block's model
+  table, including its ``reasoning_levels`` (empty list = the model has no
+  reasoning knob). Everything else — UI metadata, visibility, validation —
+  is derived from the table. The contract-consistency test
+  (``test_reasoning_contract.py``) fails with the exact gap if the block's
+  manifest ``Literal`` no longer covers the union of table levels.
+- **Add a level to the shared enum**: extend ``REASONING_EFFORT_OPTIONS`` and
+  ``REASONING_EFFORT_METADATA`` together; the generic blocks pick it up
+  automatically.
+- **Add a provider block**: give it a model table with a per-model
+  ``reasoning_levels`` key, derive a ``{model: levels}`` dict, call
+  ``validate_reasoning_level`` at spec time (``model_validator``) and at the
+  runtime choke point, attach levels to the model dropdown metadata with
+  ``attach_reasoning_levels``, and register the block in the consistency test.
 """
 
-from typing import Optional
+from typing import Dict, List, Optional
 
-REASONING_EFFORT_OPTIONS = ["none", "low", "medium", "high", "xhigh"]
+# Full OpenRouter platform enum (https://openrouter.ai/docs/api/reference/parameters).
+# OpenRouter normalizes the value to the nearest level each model supports.
+REASONING_EFFORT_OPTIONS = ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
 
 REASONING_EFFORT_METADATA = {
     "none": {
@@ -18,6 +42,13 @@ REASONING_EFFORT_METADATA = {
             "Explicitly turns extended reasoning off. Models that reject "
             "`reasoning: {enabled: false}` are retried without the config "
             "and keep their provider-default behavior."
+        ),
+    },
+    "minimal": {
+        "name": "Minimal",
+        "description": (
+            "Smallest reasoning budget above off. Models without a distinct "
+            "minimal level are normalized to the nearest supported level."
         ),
     },
     "low": {
@@ -38,12 +69,86 @@ REASONING_EFFORT_METADATA = {
     "xhigh": {
         "name": "Extra high",
         "description": (
-            "Maximum reasoning budget. Only some models support it (e.g. the "
-            "GPT-5.2+ generation); models that reject it are retried without "
-            "a reasoning config. Raise `max_tokens` accordingly."
+            "Maximum reasoning budget on most models. Only some models "
+            "support it (e.g. the GPT-5.2+ generation); models that reject "
+            "it are retried without a reasoning config. Raise `max_tokens` "
+            "accordingly."
+        ),
+    },
+    "max": {
+        "name": "Max",
+        "description": (
+            "Largest reasoning budget where available (e.g. the GPT-5.6 "
+            "generation); elsewhere normalized down to the nearest supported "
+            "level. Raise `max_tokens` accordingly."
         ),
     },
 }
+
+
+def validate_reasoning_level(
+    model: Optional[str],
+    level: Optional[str],
+    levels_by_model: Dict[str, List[str]],
+    parameter: str = "reasoning_effort",
+) -> None:
+    """Reject a reasoning level the selected model does not natively support.
+
+    Lenient by design where strictness would break workflows: an unset level,
+    a selector-provided model or level (resolved only at runtime), and a model
+    absent from the table (future model reaching the block through a selector)
+    all pass — the provider then applies its own contract.
+
+    Args:
+        model: Model identifier as the block's table keys it.
+        level: Requested reasoning level, or ``None`` when unset.
+        levels_by_model: Mapping of model identifier to the list of levels the
+            model natively supports (empty list = no reasoning knob).
+        parameter: Field name used in the error message.
+
+    Raises:
+        ValueError: If the model is known and the level is set but
+            unsupported.
+    """
+    if model is None or level is None:
+        return
+    if _is_selector(model) or _is_selector(level):
+        return
+    if model not in levels_by_model:
+        return
+    supported = levels_by_model[model]
+    if level in supported:
+        return
+    if supported:
+        raise ValueError(
+            f"Model {model} supports {parameter} values {supported}, " f"got {level!r}."
+        )
+    raise ValueError(
+        f"Model {model} does not support configurable {parameter} " f"(got {level!r})."
+    )
+
+
+def models_supporting_reasoning(
+    levels_by_model: Dict[str, List[str]],
+) -> List[str]:
+    """List models with a non-empty reasoning-level set, preserving order."""
+    return [model for model, levels in levels_by_model.items() if levels]
+
+
+def attach_reasoning_levels(
+    values_metadata: Dict[str, dict],
+    levels_by_model: Dict[str, List[str]],
+) -> Dict[str, dict]:
+    """Extend model-dropdown ``values_metadata`` with per-model levels.
+
+    Adds a machine-readable ``reasoning_levels`` key to every model entry so
+    UIs can restrict the level dropdown per model. The key name is uniform
+    across blocks even where the manifest field is called ``thinking_level``.
+    """
+    return {
+        model: {**metadata, "reasoning_levels": levels_by_model.get(model, [])}
+        for model, metadata in values_metadata.items()
+    }
 
 
 def build_openrouter_reasoning_config(
@@ -68,3 +173,7 @@ def build_openrouter_reasoning_config(
     if reasoning_effort == "none":
         return {"enabled": False}
     return {"effort": reasoning_effort}
+
+
+def _is_selector(value: str) -> bool:
+    return isinstance(value, str) and value.startswith("$")

--- a/inference/core/workflows/core_steps/models/foundation/google_gemini/v5.py
+++ b/inference/core/workflows/core_steps/models/foundation/google_gemini/v5.py
@@ -12,6 +12,11 @@ from inference.core.env import WORKFLOWS_REMOTE_EXECUTION_MAX_STEP_CONCURRENT_RE
 from inference.core.managers.base import ModelManager
 from inference.core.roboflow_api import post_to_roboflow_api
 from inference.core.utils.image_utils import encode_image_to_jpeg_bytes, load_image
+from inference.core.workflows.core_steps.common.reasoning import (
+    attach_reasoning_levels,
+    models_supporting_reasoning,
+    validate_reasoning_level,
+)
 from inference.core.workflows.core_steps.common.token_usage import (
     TOKEN_OUTPUT_DEFINITIONS,
     parse_gemini_usage_metadata,
@@ -54,86 +59,101 @@ MODEL_ALIASES = {
     "gemini-2.5-pro-preview-03-25": "gemini-2.5-pro",
 }
 
+# Per-model thinking_level values follow the official Gemini docs:
+# https://ai.google.dev/gemini-api/docs/thinking (per-model level table)
+# https://ai.google.dev/gemini-api/docs/gemini-3 (Gemini 3 defaults)
+# Notable: Gemini 3.1 Pro has no `minimal` and cannot disable thinking.
+# gemini-3.7-flash is not yet in Google's table; the API was probed live
+# (2026-08-25) and rejects `minimal` with "Thinking level MINIMAL is not
+# supported for this model", while low/medium/high succeed. The Gemini 2.5
+# series keeps an empty set: Google's pages are contradictory about 2.5
+# (`thinking_level` listed in one table, but the thinking guide says 2.5 only
+# supports the legacy `thinking_budget`), so we stay on the conservative side.
 GEMINI_MODELS = [
     {
         "id": "gemini-3.7-flash",
         "name": "Gemini 3.7 Flash",
-        "supports_thinking_level": True,
+        "thinking_levels": ["low", "medium", "high"],
         "supports_native_code_execution": True,
     },
     {
         "id": "gemini-3.6-flash",
         "name": "Gemini 3.6 Flash",
-        "supports_thinking_level": True,
+        "thinking_levels": ["minimal", "low", "medium", "high"],
         "supports_native_code_execution": True,
     },
     {
         "id": "gemini-3.5-flash",
         "name": "Gemini 3.5 Flash",
-        "supports_thinking_level": True,
+        "thinking_levels": ["minimal", "low", "medium", "high"],
         "supports_native_code_execution": True,
     },
     {
         "id": "gemini-3.5-flash-lite",
         "name": "Gemini 3.5 Flash-Lite",
-        "supports_thinking_level": True,
+        "thinking_levels": ["minimal", "low", "medium", "high"],
         "supports_native_code_execution": True,
     },
     {
         "id": "gemini-3.1-pro-preview",
         "name": "Gemini 3.1 Pro",
-        "supports_thinking_level": True,
+        "thinking_levels": ["low", "medium", "high"],
         "supports_native_code_execution": True,
     },
     {
         "id": "gemini-3.1-flash-lite",
         "name": "Gemini 3.1 Flash-Lite",
-        "supports_thinking_level": True,
+        "thinking_levels": ["minimal", "low", "medium", "high"],
         "supports_native_code_execution": True,
     },
     {
         "id": "gemini-3-flash-preview",
         "name": "Gemini 3 Flash",
-        "supports_thinking_level": True,
+        "thinking_levels": ["minimal", "low", "medium", "high"],
         "supports_native_code_execution": True,
     },
     {
         "id": "gemini-2.5-pro",
         "name": "Gemini 2.5 Pro",
-        "supports_thinking_level": False,
+        "thinking_levels": [],
         "supports_native_code_execution": False,
     },
     {
         "id": "gemini-2.5-flash",
         "name": "Gemini 2.5 Flash",
-        "supports_thinking_level": False,
+        "thinking_levels": [],
         "supports_native_code_execution": False,
     },
     {
         "id": "gemini-2.5-flash-lite",
         "name": "Gemini 2.5 Flash-Lite",
-        "supports_thinking_level": False,
+        "thinking_levels": [],
         "supports_native_code_execution": False,
     },
 ]
 
 MODEL_VERSION_IDS = [model["id"] for model in GEMINI_MODELS]
 
-MODEL_VERSION_METADATA = {
-    model["id"]: {"name": model["name"]} for model in GEMINI_MODELS
+MODEL_THINKING_LEVELS = {
+    model["id"]: model["thinking_levels"] for model in GEMINI_MODELS
 }
 
-MODELS_SUPPORTING_THINKING_LEVEL = [
-    model["id"] for model in GEMINI_MODELS if model["supports_thinking_level"]
-]
+MODEL_VERSION_METADATA = attach_reasoning_levels(
+    {model["id"]: {"name": model["name"]} for model in GEMINI_MODELS},
+    MODEL_THINKING_LEVELS,
+)
+
+MODELS_SUPPORTING_THINKING_LEVEL = models_supporting_reasoning(MODEL_THINKING_LEVELS)
 
 MODELS_SUPPORTING_NATIVE_CODE_EXECUTION = [
     model["id"] for model in GEMINI_MODELS if model["supports_native_code_execution"]
 ]
 
 MODELS_NOT_SUPPORTING_THINKING_LEVEL = [
-    model["id"] for model in GEMINI_MODELS if not model["supports_thinking_level"]
+    model["id"] for model in GEMINI_MODELS if not model["thinking_levels"]
 ]
+
+THINKING_LEVEL_VALUES = ["minimal", "low", "medium", "high"]
 
 SUPPORTED_TASK_TYPES_LIST = [
     "unconstrained",
@@ -303,14 +323,18 @@ class BlockManifest(WorkflowBlockManifest):
     thinking_level: Optional[
         Union[
             Selector(kind=[STRING_KIND]),
-            Literal["low", "high"],
+            Literal[tuple(THINKING_LEVEL_VALUES)],
         ]
     ] = Field(
         default=None,
         description="Controls the depth of internal reasoning for Gemini 3+ models. "
-        "'low' minimizes latency and cost (best for simple tasks), 'high' maximizes reasoning depth. "
-        "When unset, the Google API default for the selected model is used. "
-        "Only supported by Gemini 3 and newer models.",
+        "'minimal' matches no-thinking for most queries, 'low' minimizes latency and cost, "
+        "'medium' balances both, 'high' maximizes reasoning depth. Supported values differ "
+        "per model (see the model dropdown): Gemini 3.1 Pro and Gemini 3.7 Flash have no "
+        "'minimal'; Gemini 3.1 Pro also cannot disable thinking. When unset, the Google "
+        "API default for the selected model is used (e.g. 'high' for Gemini 3.1 Pro, "
+        "'medium' for Gemini 3.5/3.6 Flash). "
+        "Not supported by the Gemini 2.5 series.",
         json_schema_extra={
             "relevant_for": {
                 "model_version": {
@@ -387,6 +411,12 @@ class BlockManifest(WorkflowBlockManifest):
             raise ValueError(
                 f"`output_structure` parameter required to be set for task `{self.task_type}`"
             )
+        validate_reasoning_level(
+            model=self.model_version,
+            level=self.thinking_level,
+            levels_by_model=MODEL_THINKING_LEVELS,
+            parameter="thinking_level",
+        )
         return self
 
     @classmethod
@@ -1060,6 +1090,12 @@ def prepare_generation_config(
     if max_tokens is not None:
         result["max_output_tokens"] = max_tokens
 
+    validate_reasoning_level(
+        model=model_version,
+        level=thinking_level,
+        levels_by_model=MODEL_THINKING_LEVELS,
+        parameter="thinking_level",
+    )
     supports_thinking_level = model_version in MODELS_SUPPORTING_THINKING_LEVEL
 
     if thinking_level is not None and supports_thinking_level:

--- a/inference/core/workflows/core_steps/models/foundation/google_gemini/v5.py
+++ b/inference/core/workflows/core_steps/models/foundation/google_gemini/v5.py
@@ -59,16 +59,8 @@ MODEL_ALIASES = {
     "gemini-2.5-pro-preview-03-25": "gemini-2.5-pro",
 }
 
-# Per-model thinking_level values follow the official Gemini docs:
-# https://ai.google.dev/gemini-api/docs/thinking (per-model level table)
-# https://ai.google.dev/gemini-api/docs/gemini-3 (Gemini 3 defaults)
-# Notable: Gemini 3.1 Pro has no `minimal` and cannot disable thinking.
-# gemini-3.7-flash is not yet in Google's table; the API was probed live
-# (2026-08-25) and rejects `minimal` with "Thinking level MINIMAL is not
-# supported for this model", while low/medium/high succeed. The Gemini 2.5
-# series keeps an empty set: Google's pages are contradictory about 2.5
-# (`thinking_level` listed in one table, but the thinking guide says 2.5 only
-# supports the legacy `thinking_budget`), so we stay on the conservative side.
+# 3.7-flash probed 2026-08-25: API rejects `minimal`. 2.5 pages contradict
+# (`thinking_level` vs `thinking_budget` only); we keep 2.5 unsupported.
 GEMINI_MODELS = [
     {
         "id": "gemini-3.7-flash",

--- a/inference/core/workflows/core_steps/models/foundation/meta_vlm/v2.py
+++ b/inference/core/workflows/core_steps/models/foundation/meta_vlm/v2.py
@@ -62,11 +62,7 @@ from inference.core.workflows.prototypes.block import (
     third_party_model,
 )
 
-# Per-model reasoning_effort values follow the official Meta docs:
-# https://dev.meta.ai/docs/features/reasoning (Muse Spark: minimal..xhigh,
-# "none" returns HTTP 400)
-# https://huggingface.co/meta-models/Muse-Glimmer-30B (Glimmer reasoning
-# strength: low..xhigh, no minimal)
+# Spark `none` is HTTP 400. Glimmer has no `minimal`.
 MODEL_VARIANTS: Dict[str, Dict[str, Any]] = {
     "Muse Spark 1.1": {
         "model_id": "meta/muse-spark-1.1",

--- a/inference/core/workflows/core_steps/models/foundation/meta_vlm/v2.py
+++ b/inference/core/workflows/core_steps/models/foundation/meta_vlm/v2.py
@@ -27,6 +27,10 @@ from inference.core.workflows.core_steps.common.openrouter import (
     OpenRouterWorkflowBlockBase,
     validate_task_type_required_fields,
 )
+from inference.core.workflows.core_steps.common.reasoning import (
+    attach_reasoning_levels,
+    validate_reasoning_level,
+)
 from inference.core.workflows.core_steps.common.token_usage import (
     TOKEN_OUTPUT_DEFINITIONS,
 )
@@ -58,27 +62,59 @@ from inference.core.workflows.prototypes.block import (
     third_party_model,
 )
 
-MODEL_VARIANTS: Dict[str, str] = {
-    "Muse Spark 1.1": "meta/muse-spark-1.1",
-    "Muse Spark 1.2": "meta/muse-spark-1.2",
-    "Muse Glimmer": "meta/muse-glimmer-30b",
+# Per-model reasoning_effort values follow the official Meta docs:
+# https://dev.meta.ai/docs/features/reasoning (Muse Spark: minimal..xhigh,
+# "none" returns HTTP 400)
+# https://huggingface.co/meta-models/Muse-Glimmer-30B (Glimmer reasoning
+# strength: low..xhigh, no minimal)
+MODEL_VARIANTS: Dict[str, Dict[str, Any]] = {
+    "Muse Spark 1.1": {
+        "model_id": "meta/muse-spark-1.1",
+        "reasoning_levels": ["minimal", "low", "medium", "high", "xhigh"],
+    },
+    "Muse Spark 1.2": {
+        "model_id": "meta/muse-spark-1.2",
+        "reasoning_levels": ["minimal", "low", "medium", "high", "xhigh"],
+    },
+    "Muse Glimmer": {
+        "model_id": "meta/muse-glimmer-30b",
+        "reasoning_levels": ["low", "medium", "high", "xhigh"],
+    },
 }
+
+MODEL_IDS = {label: variant["model_id"] for label, variant in MODEL_VARIANTS.items()}
+
+MODEL_REASONING_LEVELS = {
+    label: variant["reasoning_levels"] for label, variant in MODEL_VARIANTS.items()
+}
+
+MODEL_VERSION_METADATA = attach_reasoning_levels(
+    {label: {"name": label} for label in MODEL_VARIANTS},
+    MODEL_REASONING_LEVELS,
+)
 
 ModelVersion = Literal[tuple(MODEL_VARIANTS.keys())]
 DEFAULT_MODEL_VERSION = "Muse Spark 1.2"
 
 TaskType = Literal[tuple(SUPPORTED_TASK_TYPES_LIST)]
 
-REASONING_EFFORT_OPTIONS = ["low", "medium", "high"]
+REASONING_EFFORT_OPTIONS = ["minimal", "low", "medium", "high", "xhigh"]
 ReasoningEffort = Literal[tuple(REASONING_EFFORT_OPTIONS)]
 DEFAULT_REASONING_EFFORT = "low"
 
 REASONING_EFFORT_METADATA = {
+    "minimal": {
+        "name": "Minimal",
+        "description": (
+            "Shortest reasoning pass. Supported by Muse Spark models only — "
+            "Muse Glimmer starts at low."
+        ),
+    },
     "low": {
         "name": "Low (recommended)",
         "description": (
             "Small reasoning budget. Muse models require reasoning; this is "
-            "the lowest effort they accept."
+            "the lowest effort every variant accepts."
         ),
     },
     "medium": {
@@ -88,8 +124,15 @@ REASONING_EFFORT_METADATA = {
     "high": {
         "name": "High",
         "description": (
-            "Large reasoning budget. Slowest and most expensive; consider "
-            "raising `max_tokens` so reasoning does not crowd out the answer."
+            "Large reasoning budget. Slow and expensive; consider raising "
+            "`max_tokens` so reasoning does not crowd out the answer."
+        ),
+    },
+    "xhigh": {
+        "name": "Extra high",
+        "description": (
+            "Maximum reasoning depth. Slowest and most expensive; raise "
+            "`max_tokens` accordingly."
         ),
     },
 }
@@ -339,7 +382,7 @@ def build_reasoning_config(reasoning_effort: str) -> Dict[str, Any]:
     Muse models reject disabled reasoning, so an ``effort`` is always sent.
 
     Args:
-        reasoning_effort: ``low``, ``medium``, or ``high``.
+        reasoning_effort: One of ``REASONING_EFFORT_OPTIONS``.
 
     Returns:
         Reasoning config to attach to the OpenRouter request.
@@ -415,6 +458,9 @@ class BlockManifest(OpenRouterBlockManifestMixin):
             "current image-capable Muse chat models on OpenRouter."
         ),
         examples=[DEFAULT_MODEL_VERSION, "Muse Glimmer"],
+        json_schema_extra={
+            "values_metadata": MODEL_VERSION_METADATA,
+        },
     )
     task_type: TaskType = Field(
         default="unconstrained",
@@ -474,7 +520,8 @@ class BlockManifest(OpenRouterBlockManifestMixin):
         description=(
             "Reasoning budget. Muse models reject disabled reasoning, so this "
             "is always sent as an effort. Low is the default used in the "
-            "vlm-exam benches."
+            "vlm-exam benches. Supported values differ per model (see the "
+            "model dropdown): 'minimal' is Spark-only."
         ),
         json_schema_extra={"values_metadata": REASONING_EFFORT_METADATA},
     )
@@ -523,6 +570,11 @@ class BlockManifest(OpenRouterBlockManifestMixin):
             prompt=self.prompt,
             classes=self.classes,
             output_structure=self.output_structure,
+        )
+        validate_reasoning_level(
+            model=self.model_version,
+            level=self.reasoning_effort,
+            levels_by_model=MODEL_REASONING_LEVELS,
         )
         return self
 
@@ -575,13 +627,13 @@ class BlockManifest(OpenRouterBlockManifestMixin):
                 third_party_model(
                     provider="openrouter",
                     model_id=self.model_version,
-                    model_id_resolver=lambda label: MODEL_VARIANTS.get(label),
+                    model_id_resolver=lambda label: MODEL_IDS.get(label),
                 )
             ]
         return [
             third_party_model(
                 provider="openrouter",
-                model_id=MODEL_VARIANTS[self.model_version],
+                model_id=MODEL_IDS[self.model_version],
             )
         ]
 
@@ -610,12 +662,17 @@ class MetaVlmBlockV2(OpenRouterWorkflowBlockBase):
         temperature: Optional[float],
         max_concurrent_requests: Optional[int],
     ) -> BlockResult:
-        model_id = MODEL_VARIANTS.get(model_version)
+        model_id = MODEL_IDS.get(model_version)
         if model_id is None:
             raise ValueError(
                 f"Unknown Muse variant '{model_version}'. "
                 f"Pick one of: {list(MODEL_VARIANTS)}"
             )
+        validate_reasoning_level(
+            model=model_version,
+            level=reasoning_effort,
+            levels_by_model=MODEL_REASONING_LEVELS,
+        )
         prompts = build_muse_openrouter_prompts(
             images=[image.numpy_image for image in images],
             task_type=task_type,

--- a/inference/core/workflows/core_steps/models/foundation/openai/v6.py
+++ b/inference/core/workflows/core_steps/models/foundation/openai/v6.py
@@ -13,6 +13,11 @@ from inference.core.env import WORKFLOWS_REMOTE_EXECUTION_MAX_STEP_CONCURRENT_RE
 from inference.core.managers.base import ModelManager
 from inference.core.roboflow_api import post_to_roboflow_api
 from inference.core.utils.image_utils import encode_image_to_jpeg_bytes, load_image
+from inference.core.workflows.core_steps.common.reasoning import (
+    attach_reasoning_levels,
+    models_supporting_reasoning,
+    validate_reasoning_level,
+)
 from inference.core.workflows.core_steps.common.token_usage import (
     TOKEN_OUTPUT_DEFINITIONS,
     parse_responses_api_usage,
@@ -62,23 +67,28 @@ STRUCTURED_ABSOLUTE_STYLE = "structured-absolute"
 NORMALIZED_LEGACY_STYLE = "normalized-legacy"
 PLAIN_ABSOLUTE_STYLE = "plain-absolute"
 
+# Per-model reasoning_effort values follow the official OpenAI docs:
+# https://developers.openai.com/api/docs/guides/reasoning (per-generation sets)
+# https://developers.openai.com/api/docs/models/gpt-5.6-sol (5.6 adds `max`)
+# The GPT-5.6 rows assume Terra/Luna match Sol, as the docs describe the set
+# family-wide ("GPT-5.6 models").
 OPENAI_MODELS = [
     {
         "id": "gpt-5.6-sol",
         "name": "GPT-5.6 Sol",
-        "reasoning_effort_values": ["none", "low", "medium", "high", "xhigh"],
+        "reasoning_effort_values": ["none", "low", "medium", "high", "xhigh", "max"],
         "detection_prompt_style": STRUCTURED_ABSOLUTE_STYLE,
     },
     {
         "id": "gpt-5.6-terra",
         "name": "GPT-5.6 Terra",
-        "reasoning_effort_values": ["none", "low", "medium", "high", "xhigh"],
+        "reasoning_effort_values": ["none", "low", "medium", "high", "xhigh", "max"],
         "detection_prompt_style": STRUCTURED_ABSOLUTE_STYLE,
     },
     {
         "id": "gpt-5.6-luna",
         "name": "GPT-5.6 Luna",
-        "reasoning_effort_values": ["none", "low", "medium", "high", "xhigh"],
+        "reasoning_effort_values": ["none", "low", "medium", "high", "xhigh", "max"],
         "detection_prompt_style": STRUCTURED_ABSOLUTE_STYLE,
     },
     {
@@ -169,21 +179,24 @@ OPENAI_MODELS = [
 
 MODEL_VERSION_IDS = [model["id"] for model in OPENAI_MODELS]
 
-MODEL_VERSION_METADATA = {
-    model["id"]: {"name": model["name"]} for model in OPENAI_MODELS
+MODEL_REASONING_EFFORT_VALUES = {
+    model["id"]: model["reasoning_effort_values"] for model in OPENAI_MODELS
 }
 
-MODELS_SUPPORTING_REASONING_EFFORT = [
-    model["id"] for model in OPENAI_MODELS if model["reasoning_effort_values"]
-]
+MODEL_VERSION_METADATA = attach_reasoning_levels(
+    {model["id"]: {"name": model["name"]} for model in OPENAI_MODELS},
+    MODEL_REASONING_EFFORT_VALUES,
+)
+
+MODELS_SUPPORTING_REASONING_EFFORT = models_supporting_reasoning(
+    MODEL_REASONING_EFFORT_VALUES
+)
 
 MODELS_NOT_SUPPORTING_REASONING_EFFORT = [
     model["id"] for model in OPENAI_MODELS if not model["reasoning_effort_values"]
 ]
 
-MODEL_REASONING_EFFORT_VALUES = {
-    model["id"]: model["reasoning_effort_values"] for model in OPENAI_MODELS
-}
+REASONING_EFFORT_VALUES = ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
 
 MODEL_DETECTION_PROMPT_STYLES = {
     model["id"]: model["detection_prompt_style"] for model in OPENAI_MODELS
@@ -437,14 +450,16 @@ class BlockManifest(WorkflowBlockManifest):
     reasoning_effort: Optional[
         Union[
             Selector(kind=[STRING_KIND]),
-            Literal["none", "minimal", "low", "medium", "high", "xhigh"],
+            Literal[tuple(REASONING_EFFORT_VALUES)],
         ]
     ] = Field(
         default=None,
         description="Controls reasoning. Reducing can result in faster responses and fewer tokens. "
-        "GPT-5.1 and higher models default to 'none' (no reasoning) and support 'none', 'low', 'medium', 'high'. "
-        "GPT-5.2 also supports 'xhigh'. "
-        "GPT-5 models default to 'medium' and support 'minimal', 'low', 'medium', 'high'.",
+        "Supported values differ per model (see the model dropdown): the GPT-5.6 family "
+        "supports 'none' through 'max' (default 'medium'), GPT-5.5/5.4/5.2 support 'none' "
+        "through 'xhigh', GPT-5.1 supports 'none' through 'high' (default 'none'), and "
+        "GPT-5 models support 'minimal' through 'high' (default 'medium'). "
+        "When unset, the OpenAI default for the selected model is used.",
         json_schema_extra={
             "relevant_for": {
                 "model_version": {
@@ -499,6 +514,11 @@ class BlockManifest(WorkflowBlockManifest):
             raise ValueError(
                 f"`output_structure` parameter required to be set for task `{self.task_type}`"
             )
+        validate_reasoning_level(
+            model=self.model_version,
+            level=self.reasoning_effort,
+            levels_by_model=MODEL_REASONING_EFFORT_VALUES,
+        )
         return self
 
     @classmethod
@@ -801,15 +821,15 @@ def _execute_proxied_openai_request(
     if temperature is not None:
         payload["temperature"] = temperature
 
+    validate_reasoning_level(
+        model=model_version,
+        level=reasoning_effort,
+        levels_by_model=MODEL_REASONING_EFFORT_VALUES,
+    )
     if (
         reasoning_effort is not None
         and model_version in MODELS_SUPPORTING_REASONING_EFFORT
     ):
-        effort_values = MODEL_REASONING_EFFORT_VALUES.get(model_version, [])
-        if reasoning_effort not in effort_values:
-            raise ValueError(
-                f'Model {model_version} does not support reasoning effort "{reasoning_effort}"'
-            )
         payload["reasoning"] = {"effort": reasoning_effort}
 
     endpoint = "apiproxy/openai/v2"
@@ -909,15 +929,15 @@ def _execute_direct_openai_request(
     if temperature is not None:
         request_params["temperature"] = temperature
 
+    validate_reasoning_level(
+        model=model_version,
+        level=reasoning_effort,
+        levels_by_model=MODEL_REASONING_EFFORT_VALUES,
+    )
     if (
         reasoning_effort is not None
         and model_version in MODELS_SUPPORTING_REASONING_EFFORT
     ):
-        effort_values = MODEL_REASONING_EFFORT_VALUES.get(model_version, [])
-        if reasoning_effort not in effort_values:
-            raise ValueError(
-                f'Model {model_version} does not support reasoning effort "{reasoning_effort}"'
-            )
         request_params["reasoning"] = {"effort": reasoning_effort}
 
     response = client.responses.create(**request_params)

--- a/inference/core/workflows/core_steps/models/foundation/openai/v6.py
+++ b/inference/core/workflows/core_steps/models/foundation/openai/v6.py
@@ -67,11 +67,7 @@ STRUCTURED_ABSOLUTE_STYLE = "structured-absolute"
 NORMALIZED_LEGACY_STYLE = "normalized-legacy"
 PLAIN_ABSOLUTE_STYLE = "plain-absolute"
 
-# Per-model reasoning_effort values follow the official OpenAI docs:
-# https://developers.openai.com/api/docs/guides/reasoning (per-generation sets)
-# https://developers.openai.com/api/docs/models/gpt-5.6-sol (5.6 adds `max`)
-# The GPT-5.6 rows assume Terra/Luna match Sol, as the docs describe the set
-# family-wide ("GPT-5.6 models").
+# GPT-5.6 Terra/Luna assumed to match Sol's `max` (docs describe the set family-wide).
 OPENAI_MODELS = [
     {
         "id": "gpt-5.6-sol",

--- a/inference/core/workflows/core_steps/models/foundation/qwen_vlm/v3.py
+++ b/inference/core/workflows/core_steps/models/foundation/qwen_vlm/v3.py
@@ -55,6 +55,10 @@ from inference.core.workflows.core_steps.common.openrouter import (
     OpenRouterWorkflowBlockBase,
     validate_task_type_required_fields,
 )
+from inference.core.workflows.core_steps.common.reasoning import (
+    attach_reasoning_levels,
+    validate_reasoning_level,
+)
 from inference.core.workflows.core_steps.common.token_usage import (
     TOKEN_OUTPUT_DEFINITIONS,
 )
@@ -289,6 +293,28 @@ REASONING_EFFORT_METADATA = {
         ),
     },
 }
+
+# Per-variant reasoning levels. All OpenRouter-hosted variants expose the
+# block's full effort set: OpenRouter normalizes the value to the nearest
+# level each model natively supports
+# (https://openrouter.ai/docs/guides/best-practices/reasoning-tokens), and
+# "none" falls back to low effort on reasoning-required variants (Qwen 3.8
+# Max, the VL Thinking editions). Native variants have no effort knob —
+# Qwen3.5-VL uses the boolean `enable_thinking` instead. A variant row can
+# override with an explicit "reasoning_levels" key if a future model
+# diverges from its backend's default set.
+MODEL_REASONING_LEVELS = {
+    label: variant.get(
+        "reasoning_levels",
+        REASONING_EFFORT_OPTIONS if variant["backend"] == "openrouter" else [],
+    )
+    for label, variant in MODEL_VARIANTS.items()
+}
+
+OPENROUTER_MODEL_VERSION_METADATA = attach_reasoning_levels(
+    {label: {"name": label} for label in OPENROUTER_VARIANT_LABELS},
+    MODEL_REASONING_LEVELS,
+)
 
 # Fallback effort applied when reasoning is disabled by the user but the
 # selected model rejects `reasoning: {"enabled": false}`.
@@ -870,6 +896,7 @@ class BlockManifest(OpenRouterBlockManifestMixin):
         ),
         examples=[DEFAULT_OPENROUTER_MODEL_VERSION, "Qwen 3.8 Max"],
         json_schema_extra={
+            "values_metadata": OPENROUTER_MODEL_VERSION_METADATA,
             "relevant_for": {
                 "backend": {"values": ["openrouter"], "required": True},
             },
@@ -1055,6 +1082,12 @@ class BlockManifest(OpenRouterBlockManifestMixin):
                 "`fine_tuned_model_id` is required when `model_version="
                 f"'{FINE_TUNED_NATIVE_LABEL}'`. Pick a fine-tuned Qwen3 model "
                 "from your workspace."
+            )
+        if self.backend == "openrouter":
+            validate_reasoning_level(
+                model=self.openrouter_model_version,
+                level=self.reasoning_effort,
+                levels_by_model=MODEL_REASONING_LEVELS,
             )
         return self
 
@@ -1248,6 +1281,11 @@ class QwenVlmBlockV3(OpenRouterWorkflowBlockBase):
                 prompt=prompt,
                 output_structure=output_structure,
                 classes=classes,
+            )
+            validate_reasoning_level(
+                model=openrouter_model_version,
+                level=reasoning_effort,
+                levels_by_model=MODEL_REASONING_LEVELS,
             )
             reasoning = build_reasoning_config(
                 reasoning_effort,

--- a/inference/core/workflows/core_steps/models/foundation/qwen_vlm/v3.py
+++ b/inference/core/workflows/core_steps/models/foundation/qwen_vlm/v3.py
@@ -294,15 +294,9 @@ REASONING_EFFORT_METADATA = {
     },
 }
 
-# Per-variant reasoning levels. All OpenRouter-hosted variants expose the
-# block's full effort set: OpenRouter normalizes the value to the nearest
-# level each model natively supports
-# (https://openrouter.ai/docs/guides/best-practices/reasoning-tokens), and
-# "none" falls back to low effort on reasoning-required variants (Qwen 3.8
-# Max, the VL Thinking editions). Native variants have no effort knob —
-# Qwen3.5-VL uses the boolean `enable_thinking` instead. A variant row can
-# override with an explicit "reasoning_levels" key if a future model
-# diverges from its backend's default set.
+# OpenRouter variants use the shared set (OpenRouter normalizes). Native
+# variants have no effort knob. Override a row with `reasoning_levels` if
+# a future model diverges.
 MODEL_REASONING_LEVELS = {
     label: variant.get(
         "reasoning_levels",

--- a/inference/core/workflows/core_steps/models/foundation/spacexai/v2.py
+++ b/inference/core/workflows/core_steps/models/foundation/spacexai/v2.py
@@ -65,11 +65,7 @@ from inference.core.workflows.prototypes.block import (
 
 XAI_BASE_URL = "https://api.x.ai/v1"
 
-# Per-model reasoning_effort values follow the official xAI docs:
-# https://docs.x.ai/developers/model-capabilities/text/reasoning
-# Both models default to "high" and cannot disable reasoning. xAI silently
-# treats "xhigh" as "high" on grok-4.5, so we exclude it there rather than
-# offer a level that does nothing.
+# grok-4.5 `xhigh` excluded: xAI silently downgrades it to `high`.
 GROK_MODELS = [
     {
         "id": "grok-4.6",

--- a/inference/core/workflows/core_steps/models/foundation/spacexai/v2.py
+++ b/inference/core/workflows/core_steps/models/foundation/spacexai/v2.py
@@ -28,6 +28,10 @@ from inference.core.env import (
 from inference.core.managers.base import ModelManager
 from inference.core.roboflow_api import post_to_roboflow_api
 from inference.core.utils.image_utils import encode_image_to_jpeg_bytes, load_image
+from inference.core.workflows.core_steps.common.reasoning import (
+    attach_reasoning_levels,
+    validate_reasoning_level,
+)
 from inference.core.workflows.core_steps.common.token_usage import (
     TOKEN_OUTPUT_DEFINITIONS,
     parse_responses_api_usage,
@@ -61,20 +65,36 @@ from inference.core.workflows.prototypes.block import (
 
 XAI_BASE_URL = "https://api.x.ai/v1"
 
+# Per-model reasoning_effort values follow the official xAI docs:
+# https://docs.x.ai/developers/model-capabilities/text/reasoning
+# Both models default to "high" and cannot disable reasoning. xAI silently
+# treats "xhigh" as "high" on grok-4.5, so we exclude it there rather than
+# offer a level that does nothing.
 GROK_MODELS = [
     {
         "id": "grok-4.6",
         "name": "Grok 4.6",
+        "reasoning_levels": ["low", "medium", "high", "xhigh"],
     },
     {
         "id": "grok-4.5",
         "name": "Grok 4.5",
+        "reasoning_levels": ["low", "medium", "high"],
     },
 ]
 
 MODEL_VERSION_IDS = [model["id"] for model in GROK_MODELS]
 
-MODEL_VERSION_METADATA = {model["id"]: {"name": model["name"]} for model in GROK_MODELS}
+MODEL_REASONING_LEVELS = {
+    model["id"]: model["reasoning_levels"] for model in GROK_MODELS
+}
+
+MODEL_VERSION_METADATA = attach_reasoning_levels(
+    {model["id"]: {"name": model["name"]} for model in GROK_MODELS},
+    MODEL_REASONING_LEVELS,
+)
+
+REASONING_EFFORT_VALUES = ["low", "medium", "high", "xhigh"]
 
 OBJECT_DETECTION_PROMPT_TEMPLATE = (
     "Detect all objects in this image. "
@@ -270,15 +290,16 @@ class BlockManifest(WorkflowBlockManifest):
     reasoning_effort: Optional[
         Union[
             Selector(kind=[STRING_KIND]),
-            Literal["low", "high"],
+            Literal[tuple(REASONING_EFFORT_VALUES)],
         ]
     ] = Field(
         default=None,
         description=(
             "Optional reasoning effort passed to xAI as "
-            '`reasoning: {"effort": ...}`. For requests with a direct xAI key, '
-            "the request is retried without reasoning when the model rejects "
-            "the parameter."
+            '`reasoning: {"effort": ...}`. Grok models default to "high" and '
+            'cannot disable reasoning. "xhigh" is only supported by grok-4.6. '
+            "For requests with a direct xAI key, the request is retried "
+            "without reasoning when the model rejects the parameter."
         ),
         examples=["low", "high"],
     )
@@ -326,6 +347,11 @@ class BlockManifest(WorkflowBlockManifest):
             raise ValueError(
                 f"`output_structure` parameter required to be set for task `{self.task_type}`"
             )
+        validate_reasoning_level(
+            model=self.model_version,
+            level=self.reasoning_effort,
+            levels_by_model=MODEL_REASONING_LEVELS,
+        )
         return self
 
     @classmethod
@@ -651,6 +677,11 @@ def _execute_proxied_spacexai_request(
     if temperature is not None:
         payload["temperature"] = temperature
 
+    validate_reasoning_level(
+        model=model_version,
+        level=reasoning_effort,
+        levels_by_model=MODEL_REASONING_LEVELS,
+    )
     if reasoning_effort is not None:
         payload["reasoning"] = {"effort": reasoning_effort}
 
@@ -712,6 +743,11 @@ def _execute_direct_spacexai_request(
     if temperature is not None:
         request_params["temperature"] = temperature
 
+    validate_reasoning_level(
+        model=model_version,
+        level=reasoning_effort,
+        levels_by_model=MODEL_REASONING_LEVELS,
+    )
     if reasoning_effort is not None:
         request_params["reasoning"] = {"effort": reasoning_effort}
 

--- a/tests/workflows/unit_tests/core_steps/common/test_openrouter.py
+++ b/tests/workflows/unit_tests/core_steps/common/test_openrouter.py
@@ -762,10 +762,12 @@ def test_validate_task_type_ocr_passes_with_no_extra_fields():
     [
         (None, None),
         ("none", {"enabled": False}),
+        ("minimal", {"effort": "minimal"}),
         ("low", {"effort": "low"}),
         ("medium", {"effort": "medium"}),
         ("high", {"effort": "high"}),
         ("xhigh", {"effort": "xhigh"}),
+        ("max", {"effort": "max"}),
     ],
 )
 def test_build_openrouter_reasoning_config(effort, expected):

--- a/tests/workflows/unit_tests/core_steps/common/test_openrouter.py
+++ b/tests/workflows/unit_tests/core_steps/common/test_openrouter.py
@@ -762,12 +762,10 @@ def test_validate_task_type_ocr_passes_with_no_extra_fields():
     [
         (None, None),
         ("none", {"enabled": False}),
-        ("minimal", {"effort": "minimal"}),
         ("low", {"effort": "low"}),
         ("medium", {"effort": "medium"}),
         ("high", {"effort": "high"}),
         ("xhigh", {"effort": "xhigh"}),
-        ("max", {"effort": "max"}),
     ],
 )
 def test_build_openrouter_reasoning_config(effort, expected):

--- a/tests/workflows/unit_tests/core_steps/common/test_reasoning_contract.py
+++ b/tests/workflows/unit_tests/core_steps/common/test_reasoning_contract.py
@@ -1,0 +1,303 @@
+"""Contract tests for per-model reasoning/thinking-level support.
+
+Every model-dropdown VLM block declares the levels each model natively
+supports in its model table (per official provider docs) and validates
+combinations with the shared ``validate_reasoning_level``. These tests pin
+the contract:
+
+- the shared validator's accept/reject semantics,
+- per-block consistency (table levels within the shared vocabulary, manifest
+  ``Literal`` covering the union of table levels, dropdown metadata matching
+  the table), so adding a model or level in one place but not the other
+  fails here with the exact gap named,
+- spec-time rejection of unsupported model+level combos on each block.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from inference.core.workflows.core_steps.common.reasoning import (
+    REASONING_EFFORT_OPTIONS,
+    validate_reasoning_level,
+)
+from inference.core.workflows.core_steps.models.foundation.google_gemini import (
+    v5 as gemini_v5,
+)
+from inference.core.workflows.core_steps.models.foundation.meta_vlm import (
+    v2 as meta_vlm_v2,
+)
+from inference.core.workflows.core_steps.models.foundation.openai import v6 as openai_v6
+from inference.core.workflows.core_steps.models.foundation.qwen_vlm import (
+    v3 as qwen_vlm_v3,
+)
+from inference.core.workflows.core_steps.models.foundation.spacexai import (
+    v2 as spacexai_v2,
+)
+
+# ---------------------------------------------------------------------------
+# validate_reasoning_level semantics
+# ---------------------------------------------------------------------------
+
+_LEVELS = {"model-a": ["low", "high"], "model-b": []}
+
+
+@pytest.mark.parametrize(
+    "model, level",
+    [
+        ("model-a", "low"),
+        ("model-a", None),
+        (None, "high"),
+        ("model-a", "$inputs.effort"),
+        ("$inputs.model", "xhigh"),
+        ("future-model", "xhigh"),
+    ],
+)
+def test_validate_reasoning_level_accepts(model, level):
+    validate_reasoning_level(model=model, level=level, levels_by_model=_LEVELS)
+
+
+def test_validate_reasoning_level_rejects_unsupported_level():
+    with pytest.raises(ValueError, match=r"model-a supports .* \['low', 'high'\]"):
+        validate_reasoning_level(
+            model="model-a", level="xhigh", levels_by_model=_LEVELS
+        )
+
+
+def test_validate_reasoning_level_rejects_model_without_levels():
+    with pytest.raises(ValueError, match="does not support configurable"):
+        validate_reasoning_level(model="model-b", level="low", levels_by_model=_LEVELS)
+
+
+def test_validate_reasoning_level_uses_parameter_name_in_error():
+    with pytest.raises(ValueError, match="thinking_level"):
+        validate_reasoning_level(
+            model="model-b",
+            level="low",
+            levels_by_model=_LEVELS,
+            parameter="thinking_level",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Per-block contract consistency
+# ---------------------------------------------------------------------------
+# One entry per model-dropdown block:
+# (levels_by_model, manifest Literal values, model-dropdown values_metadata,
+#  default level sent when the field is left unset — None means "omitted").
+
+BLOCK_CONTRACTS = {
+    "open_ai@v6": (
+        openai_v6.MODEL_REASONING_EFFORT_VALUES,
+        openai_v6.REASONING_EFFORT_VALUES,
+        openai_v6.MODEL_VERSION_METADATA,
+        None,
+    ),
+    "google_gemini@v5": (
+        gemini_v5.MODEL_THINKING_LEVELS,
+        gemini_v5.THINKING_LEVEL_VALUES,
+        gemini_v5.MODEL_VERSION_METADATA,
+        None,
+    ),
+    "spacexai@v2": (
+        spacexai_v2.MODEL_REASONING_LEVELS,
+        spacexai_v2.REASONING_EFFORT_VALUES,
+        spacexai_v2.MODEL_VERSION_METADATA,
+        None,
+    ),
+    "meta_vlm@v2": (
+        meta_vlm_v2.MODEL_REASONING_LEVELS,
+        meta_vlm_v2.REASONING_EFFORT_OPTIONS,
+        meta_vlm_v2.MODEL_VERSION_METADATA,
+        meta_vlm_v2.DEFAULT_REASONING_EFFORT,
+    ),
+    "qwen_vlm@v3": (
+        qwen_vlm_v3.MODEL_REASONING_LEVELS,
+        qwen_vlm_v3.REASONING_EFFORT_OPTIONS,
+        qwen_vlm_v3.OPENROUTER_MODEL_VERSION_METADATA,
+        "none",
+    ),
+}
+
+
+@pytest.mark.parametrize("block", BLOCK_CONTRACTS, ids=BLOCK_CONTRACTS.keys())
+def test_block_levels_stay_within_shared_vocabulary(block):
+    levels_by_model, manifest_values, _, _ = BLOCK_CONTRACTS[block]
+    shared = set(REASONING_EFFORT_OPTIONS)
+    for model, levels in levels_by_model.items():
+        unknown = set(levels) - shared
+        assert not unknown, f"{block}: {model} declares unknown levels {unknown}"
+    assert set(manifest_values) <= shared
+
+
+@pytest.mark.parametrize("block", BLOCK_CONTRACTS, ids=BLOCK_CONTRACTS.keys())
+def test_block_manifest_literal_covers_union_of_table_levels(block):
+    levels_by_model, manifest_values, _, _ = BLOCK_CONTRACTS[block]
+    union = set().union(*levels_by_model.values())
+    missing = union - set(manifest_values)
+    assert not missing, f"{block}: manifest Literal is missing levels {missing}"
+
+
+@pytest.mark.parametrize("block", BLOCK_CONTRACTS, ids=BLOCK_CONTRACTS.keys())
+def test_block_dropdown_metadata_matches_table(block):
+    levels_by_model, _, values_metadata, _ = BLOCK_CONTRACTS[block]
+    for model, metadata in values_metadata.items():
+        assert (
+            metadata["reasoning_levels"] == levels_by_model[model]
+        ), f"{block}: dropdown metadata for {model} diverged from the table"
+    for model, levels in levels_by_model.items():
+        if levels:
+            assert model in values_metadata, (
+                f"{block}: {model} supports reasoning but is missing from "
+                "dropdown metadata"
+            )
+
+
+@pytest.mark.parametrize("block", BLOCK_CONTRACTS, ids=BLOCK_CONTRACTS.keys())
+def test_block_default_level_is_valid_for_every_model(block):
+    levels_by_model, _, _, default = BLOCK_CONTRACTS[block]
+    if default is None:
+        return
+    for model, levels in levels_by_model.items():
+        if levels:
+            assert (
+                default in levels
+            ), f"{block}: default level {default!r} is unsupported by {model}"
+
+
+# ---------------------------------------------------------------------------
+# Spec-time validation on block manifests
+# ---------------------------------------------------------------------------
+
+
+def _openai_manifest(**overrides):
+    spec = {
+        "type": "roboflow_core/open_ai@v6",
+        "name": "step",
+        "images": "$inputs.image",
+        "task_type": "unconstrained",
+        "prompt": "describe",
+    }
+    spec.update(overrides)
+    return openai_v6.BlockManifest.model_validate(spec)
+
+
+def _gemini_manifest(**overrides):
+    spec = {
+        "type": "roboflow_core/google_gemini@v5",
+        "name": "step",
+        "images": "$inputs.image",
+        "task_type": "unconstrained",
+        "prompt": "describe",
+    }
+    spec.update(overrides)
+    return gemini_v5.BlockManifest.model_validate(spec)
+
+
+def _spacexai_manifest(**overrides):
+    spec = {
+        "type": "roboflow_core/spacexai@v2",
+        "name": "step",
+        "images": "$inputs.image",
+        "task_type": "unconstrained",
+        "prompt": "describe",
+        # Required when the managed-key feature flag is off.
+        "api_key": "$inputs.xai_api_key",
+    }
+    spec.update(overrides)
+    return spacexai_v2.BlockManifest.model_validate(spec)
+
+
+def _meta_vlm_manifest(**overrides):
+    spec = {
+        "type": "roboflow_core/meta_vlm@v2",
+        "name": "step",
+        "images": "$inputs.image",
+        "task_type": "unconstrained",
+        "prompt": "describe",
+    }
+    spec.update(overrides)
+    return meta_vlm_v2.BlockManifest.model_validate(spec)
+
+
+def _qwen_manifest(**overrides):
+    spec = {
+        "type": "roboflow_core/qwen_vlm@v3",
+        "name": "step",
+        "images": "$inputs.image",
+        "task_type": "unconstrained",
+        "prompt": "describe",
+    }
+    spec.update(overrides)
+    return qwen_vlm_v3.BlockManifest.model_validate(spec)
+
+
+@pytest.mark.parametrize(
+    "build, overrides",
+    [
+        (_openai_manifest, {"model_version": "gpt-5.6-sol", "reasoning_effort": "max"}),
+        (_openai_manifest, {"model_version": "gpt-5", "reasoning_effort": "minimal"}),
+        (_openai_manifest, {"model_version": "gpt-4o"}),
+        (
+            _openai_manifest,
+            {"model_version": "$inputs.model", "reasoning_effort": "xhigh"},
+        ),
+        (
+            _gemini_manifest,
+            {"model_version": "gemini-3.6-flash", "thinking_level": "minimal"},
+        ),
+        (_gemini_manifest, {"model_version": "gemini-2.5-pro"}),
+        (
+            _spacexai_manifest,
+            {"model_version": "grok-4.6", "reasoning_effort": "xhigh"},
+        ),
+        (
+            _meta_vlm_manifest,
+            {"model_version": "Muse Spark 1.2", "reasoning_effort": "minimal"},
+        ),
+        (_meta_vlm_manifest, {"model_version": "Muse Glimmer"}),
+        (
+            _qwen_manifest,
+            {
+                "backend": "openrouter",
+                "openrouter_model_version": "Qwen 3.8 Max",
+                "reasoning_effort": "high",
+            },
+        ),
+        (_qwen_manifest, {"backend": "native"}),
+    ],
+)
+def test_manifest_accepts_supported_combination(build, overrides):
+    build(**overrides)
+
+
+@pytest.mark.parametrize(
+    "build, overrides",
+    [
+        (_openai_manifest, {"model_version": "gpt-5.4", "reasoning_effort": "max"}),
+        (_openai_manifest, {"model_version": "gpt-5.1", "reasoning_effort": "xhigh"}),
+        (_openai_manifest, {"model_version": "gpt-4o", "reasoning_effort": "high"}),
+        (
+            _gemini_manifest,
+            {"model_version": "gemini-3.1-pro-preview", "thinking_level": "minimal"},
+        ),
+        (
+            _gemini_manifest,
+            {"model_version": "gemini-3.7-flash", "thinking_level": "minimal"},
+        ),
+        (
+            _gemini_manifest,
+            {"model_version": "gemini-2.5-pro", "thinking_level": "low"},
+        ),
+        (
+            _spacexai_manifest,
+            {"model_version": "grok-4.5", "reasoning_effort": "xhigh"},
+        ),
+        (
+            _meta_vlm_manifest,
+            {"model_version": "Muse Glimmer", "reasoning_effort": "minimal"},
+        ),
+    ],
+)
+def test_manifest_rejects_unsupported_combination(build, overrides):
+    with pytest.raises(ValidationError, match="support"):
+        build(**overrides)

--- a/tests/workflows/unit_tests/core_steps/common/test_reasoning_contract.py
+++ b/tests/workflows/unit_tests/core_steps/common/test_reasoning_contract.py
@@ -1,17 +1,4 @@
-"""Contract tests for per-model reasoning/thinking-level support.
-
-Every model-dropdown VLM block declares the levels each model natively
-supports in its model table (per official provider docs) and validates
-combinations with the shared ``validate_reasoning_level``. These tests pin
-the contract:
-
-- the shared validator's accept/reject semantics,
-- per-block consistency (table levels within the shared vocabulary, manifest
-  ``Literal`` covering the union of table levels, dropdown metadata matching
-  the table), so adding a model or level in one place but not the other
-  fails here with the exact gap named,
-- spec-time rejection of unsupported model+level combos on each block.
-"""
+"""Per-model reasoning levels: validator edges, table/Literal drift, spec rejects."""
 
 import pytest
 from pydantic import ValidationError
@@ -33,10 +20,6 @@ from inference.core.workflows.core_steps.models.foundation.qwen_vlm import (
 from inference.core.workflows.core_steps.models.foundation.spacexai import (
     v2 as spacexai_v2,
 )
-
-# ---------------------------------------------------------------------------
-# validate_reasoning_level semantics
-# ---------------------------------------------------------------------------
 
 _LEVELS = {"model-a": ["low", "high"], "model-b": []}
 
@@ -64,12 +47,9 @@ def test_validate_reasoning_level_rejects_unsupported_level():
 
 
 def test_validate_reasoning_level_rejects_model_without_levels():
-    with pytest.raises(ValueError, match="does not support configurable"):
-        validate_reasoning_level(model="model-b", level="low", levels_by_model=_LEVELS)
-
-
-def test_validate_reasoning_level_uses_parameter_name_in_error():
-    with pytest.raises(ValueError, match="thinking_level"):
+    with pytest.raises(
+        ValueError, match="does not support configurable thinking_level"
+    ):
         validate_reasoning_level(
             model="model-b",
             level="low",
@@ -77,13 +57,6 @@ def test_validate_reasoning_level_uses_parameter_name_in_error():
             parameter="thinking_level",
         )
 
-
-# ---------------------------------------------------------------------------
-# Per-block contract consistency
-# ---------------------------------------------------------------------------
-# One entry per model-dropdown block:
-# (levels_by_model, manifest Literal values, model-dropdown values_metadata,
-#  default level sent when the field is left unset — None means "omitted").
 
 BLOCK_CONTRACTS = {
     "open_ai@v6": (
@@ -164,140 +137,65 @@ def test_block_default_level_is_valid_for_every_model(block):
             ), f"{block}: default level {default!r} is unsupported by {model}"
 
 
-# ---------------------------------------------------------------------------
-# Spec-time validation on block manifests
-# ---------------------------------------------------------------------------
+_MANIFESTS = {
+    "open_ai@v6": openai_v6.BlockManifest,
+    "google_gemini@v5": gemini_v5.BlockManifest,
+    "spacexai@v2": spacexai_v2.BlockManifest,
+    "meta_vlm@v2": meta_vlm_v2.BlockManifest,
+    "qwen_vlm@v3": qwen_vlm_v3.BlockManifest,
+}
 
 
-def _openai_manifest(**overrides):
+def _manifest(block_type: str, **overrides):
     spec = {
-        "type": "roboflow_core/open_ai@v6",
+        "type": f"roboflow_core/{block_type}",
         "name": "step",
         "images": "$inputs.image",
         "task_type": "unconstrained",
         "prompt": "describe",
     }
+    if block_type == "spacexai@v2":
+        spec["api_key"] = "$inputs.xai_api_key"
     spec.update(overrides)
-    return openai_v6.BlockManifest.model_validate(spec)
-
-
-def _gemini_manifest(**overrides):
-    spec = {
-        "type": "roboflow_core/google_gemini@v5",
-        "name": "step",
-        "images": "$inputs.image",
-        "task_type": "unconstrained",
-        "prompt": "describe",
-    }
-    spec.update(overrides)
-    return gemini_v5.BlockManifest.model_validate(spec)
-
-
-def _spacexai_manifest(**overrides):
-    spec = {
-        "type": "roboflow_core/spacexai@v2",
-        "name": "step",
-        "images": "$inputs.image",
-        "task_type": "unconstrained",
-        "prompt": "describe",
-        # Required when the managed-key feature flag is off.
-        "api_key": "$inputs.xai_api_key",
-    }
-    spec.update(overrides)
-    return spacexai_v2.BlockManifest.model_validate(spec)
-
-
-def _meta_vlm_manifest(**overrides):
-    spec = {
-        "type": "roboflow_core/meta_vlm@v2",
-        "name": "step",
-        "images": "$inputs.image",
-        "task_type": "unconstrained",
-        "prompt": "describe",
-    }
-    spec.update(overrides)
-    return meta_vlm_v2.BlockManifest.model_validate(spec)
-
-
-def _qwen_manifest(**overrides):
-    spec = {
-        "type": "roboflow_core/qwen_vlm@v3",
-        "name": "step",
-        "images": "$inputs.image",
-        "task_type": "unconstrained",
-        "prompt": "describe",
-    }
-    spec.update(overrides)
-    return qwen_vlm_v3.BlockManifest.model_validate(spec)
+    return _MANIFESTS[block_type].model_validate(spec)
 
 
 @pytest.mark.parametrize(
-    "build, overrides",
+    "block_type, overrides",
     [
-        (_openai_manifest, {"model_version": "gpt-5.6-sol", "reasoning_effort": "max"}),
-        (_openai_manifest, {"model_version": "gpt-5", "reasoning_effort": "minimal"}),
-        (_openai_manifest, {"model_version": "gpt-4o"}),
-        (
-            _openai_manifest,
-            {"model_version": "$inputs.model", "reasoning_effort": "xhigh"},
-        ),
-        (
-            _gemini_manifest,
-            {"model_version": "gemini-3.6-flash", "thinking_level": "minimal"},
-        ),
-        (_gemini_manifest, {"model_version": "gemini-2.5-pro"}),
-        (
-            _spacexai_manifest,
-            {"model_version": "grok-4.6", "reasoning_effort": "xhigh"},
-        ),
-        (
-            _meta_vlm_manifest,
-            {"model_version": "Muse Spark 1.2", "reasoning_effort": "minimal"},
-        ),
-        (_meta_vlm_manifest, {"model_version": "Muse Glimmer"}),
-        (
-            _qwen_manifest,
-            {
-                "backend": "openrouter",
-                "openrouter_model_version": "Qwen 3.8 Max",
-                "reasoning_effort": "high",
-            },
-        ),
-        (_qwen_manifest, {"backend": "native"}),
+        ("open_ai@v6", {"model_version": "$inputs.model", "reasoning_effort": "xhigh"}),
+        ("open_ai@v6", {"model_version": "gpt-4o"}),
+        ("qwen_vlm@v3", {"backend": "native"}),
     ],
 )
-def test_manifest_accepts_supported_combination(build, overrides):
-    build(**overrides)
+def test_manifest_accepts_edges_rejects_cannot_cover(block_type, overrides):
+    _manifest(block_type, **overrides)
 
 
 @pytest.mark.parametrize(
-    "build, overrides",
+    "block_type, overrides",
     [
-        (_openai_manifest, {"model_version": "gpt-5.4", "reasoning_effort": "max"}),
-        (_openai_manifest, {"model_version": "gpt-5.1", "reasoning_effort": "xhigh"}),
-        (_openai_manifest, {"model_version": "gpt-4o", "reasoning_effort": "high"}),
+        ("open_ai@v6", {"model_version": "gpt-5.4", "reasoning_effort": "max"}),
+        ("open_ai@v6", {"model_version": "gpt-4o", "reasoning_effort": "high"}),
         (
-            _gemini_manifest,
+            "google_gemini@v5",
             {"model_version": "gemini-3.1-pro-preview", "thinking_level": "minimal"},
         ),
         (
-            _gemini_manifest,
+            "google_gemini@v5",
             {"model_version": "gemini-3.7-flash", "thinking_level": "minimal"},
         ),
         (
-            _gemini_manifest,
+            "google_gemini@v5",
             {"model_version": "gemini-2.5-pro", "thinking_level": "low"},
         ),
+        ("spacexai@v2", {"model_version": "grok-4.5", "reasoning_effort": "xhigh"}),
         (
-            _spacexai_manifest,
-            {"model_version": "grok-4.5", "reasoning_effort": "xhigh"},
-        ),
-        (
-            _meta_vlm_manifest,
+            "meta_vlm@v2",
             {"model_version": "Muse Glimmer", "reasoning_effort": "minimal"},
         ),
     ],
 )
-def test_manifest_rejects_unsupported_combination(build, overrides):
+def test_manifest_rejects_unsupported_combination(block_type, overrides):
     with pytest.raises(ValidationError, match="support"):
-        build(**overrides)
+        _manifest(block_type, **overrides)


### PR DESCRIPTION
Each VLM block now exposes only the thinking levels the selected model actually supports.

The previous shared enums were incomplete. GPT-5.6 was missing `max`. Gemini was stuck on `low`/`high` (no `minimal` or `medium`). Grok was missing `medium` and 4.6 `xhigh`. Muse hid `minimal` (Spark) and `xhigh` (all). One model-table row now drives validation and UI metadata. Unset still means the provider default, so existing workflows do not change.

## How

New unreleased versions only: `open_ai@v6`, `google_gemini@v5`, `spacexai@v2`, `meta_vlm@v2`, `qwen_vlm@v3`. Generic `openrouter@v2` / `google_gemma@v3` keep the full OpenRouter enum (`none` through `max`) and let OpenRouter normalize.

| Block | Model | Levels |
|---|---|---|
| `open_ai@v6` | gpt-5.6-sol / terra / luna | none, low, medium, high, xhigh, max |
| | gpt-5.5, 5.4(-mini/-nano), 5.2 | none, low, medium, high, xhigh |
| | gpt-5.1 | none, low, medium, high |
| | gpt-5(-mini/-nano) | minimal, low, medium, high |
| | gpt-4.1(-mini/-nano), gpt-4o(-mini) | no knob |
| `google_gemini@v5` | 3.6-flash, 3.5-flash(-lite), 3.1-flash-lite, 3-flash-preview | minimal, low, medium, high |
| | 3.7-flash, 3.1-pro-preview | low, medium, high |
| | 2.5-pro / flash / flash-lite | no knob |
| `spacexai@v2` | grok-4.6 | low, medium, high, xhigh |
| | grok-4.5 | low, medium, high |
| `meta_vlm@v2` | Muse Spark 1.1 / 1.2 | minimal, low, medium, high, xhigh |
| | Muse Glimmer | low, medium, high, xhigh |
| `qwen_vlm@v3` | OpenRouter variants | none, low, medium, high (`none` falls back to low on thinking-only models) |
| | Native variants | no knob (`enable_thinking` bool) |
| `openrouter@v2` / `google_gemma@v3` | any slug | none, minimal, low, medium, high, xhigh, max |

Sources: [OpenAI reasoning](https://developers.openai.com/api/docs/guides/reasoning), [GPT-5.6 Sol](https://developers.openai.com/api/docs/models/gpt-5.6-sol), [Gemini thinking](https://ai.google.dev/gemini-api/docs/thinking), [Gemini 3](https://ai.google.dev/gemini-api/docs/gemini-3), [xAI reasoning](https://docs.x.ai/developers/model-capabilities/text/reasoning), [Meta reasoning](https://dev.meta.ai/docs/features/reasoning), [QwenCloud thinking](https://docs.qwencloud.com/developer-guides/text-generation/thinking), [OpenRouter reasoning](https://openrouter.ai/docs/guides/best-practices/reasoning-tokens).

## Experiments

210 live model x level combos plus 6 rejection checks (all rejected at spec time, no API call). First pass: 205 pass. 48 contract tests pass.

| Config | Result |
|---|---|
| Qwen 3.7 Flash low, Qwen 3.5 122B medium, openrouter qwen3.7-plus minimal | crowd-out at `max_tokens=2048`; pass at 8192 |
| Qwen 3.8 Max medium | Alibaba 400 unless `max_tokens` > thinking_budget 32768; pass at 40960 |
| Grok 4.5 / 4.6, all native levels, both key modes | 14/14 pass after the prod proxy change |
| gemini-3.7-flash + minimal | API 400 (`MINIMAL is not supported`); row fixed to low/medium/high |
| gpt-5.6-sol + max proxied | 403 then 502 on apiproxy; direct max passed |

## Docs gaps

- Gemini 2.5: one official page lists `thinking_level`; the thinking guide says 2.5 only has `thinking_budget`. We keep 2.5 unsupported.
- Qwen 3.8 Max: QwenCloud lists `low`/`medium`/`xhigh` (no `high`). We route via OpenRouter, which normalizes. Live `medium` works once the token cap clears the thinking budget.
- Gemini 3.7 Flash is not in Google's table. Live probe (2026-08-25) rejects `minimal`; `low`/`medium`/`high` succeed.

Assumptions: GPT-5.6 Terra/Luna match Sol's `max`. grok-4.5 `xhigh` is excluded even though xAI silently downgrades it. OpenRouter normalization is trusted for Qwen/Gemma.

## Test plan

- [x] Unit: shared validator, per-block contract consistency, unsupported combos, no-thinking models, selector passthrough
- [x] Live: every model x supported level (direct keys) plus proxied spot-checks
- [x] Live: Grok full proxied sweep after prod proxy change
- [x] Manifest rejections make no API call
- [ ] Reviewer: confirm GPT-5.6 `max` and Gemini 3.7 (no `minimal`) match current product intent