### PR TITLE
Add Claude v5 block with vlm-exam absolute-pixel detection prompt

### DIFF
--- a/inference/core/workflows/core_steps/common/utils.py
+++ b/inference/core/workflows/core_steps/common/utils.py
@@ -1,4 +1,5 @@
 import logging
+import math
 import uuid
 from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
@@ -726,3 +727,84 @@ def scale_dimensions_to_max_edge(
         scaled_width = max(round(width * max_edge / height), 1)
 
     return (scaled_width, scaled_height)
+
+
+ANTHROPIC_DETECTION_MAX_EDGE_PIXELS = 2576
+"""Maximum padded edge length of images uploaded to Anthropic Claude models.
+
+High-resolution tier limit from Anthropic's vision documentation; edges are
+padded up to a multiple of ``ANTHROPIC_IMAGE_TILE_PIXELS`` before the check.
+"""
+
+ANTHROPIC_DETECTION_MAX_IMAGE_TOKENS = 4784
+"""Maximum visual-token budget of images uploaded to Anthropic Claude models."""
+
+ANTHROPIC_IMAGE_TILE_PIXELS = 28
+"""Edge length of the square tiles Claude tokenizes images with."""
+
+
+def count_anthropic_image_tokens(width: int, height: int) -> int:
+    """Count the visual tokens Claude spends on an image of given dimensions.
+
+    Args:
+        width: Image width in pixels.
+        height: Image height in pixels.
+
+    Returns:
+        Number of visual tokens.
+    """
+    tile = ANTHROPIC_IMAGE_TILE_PIXELS
+    return math.ceil(width / tile) * math.ceil(height / tile)
+
+
+def compute_anthropic_upload_dimensions(
+    width: int,
+    height: int,
+    max_edge: int = ANTHROPIC_DETECTION_MAX_EDGE_PIXELS,
+    max_tokens: int = ANTHROPIC_DETECTION_MAX_IMAGE_TOKENS,
+) -> Tuple[int, int]:
+    """Compute the dimensions Claude resizes an image to before processing.
+
+    Mirrors the reference implementation from Anthropic's vision coordinates
+    documentation, so pixel coordinates returned by Claude map one-to-one onto
+    an image pre-resized to these dimensions. Never upscales. The Claude block
+    that pre-resizes detection uploads and the parser that maps returned pixel
+    coordinates back onto the original image must use this exact arithmetic.
+
+    Args:
+        width: Original image width in pixels.
+        height: Original image height in pixels.
+        max_edge: Maximum padded edge length in pixels.
+        max_tokens: Maximum visual-token budget.
+
+    Returns:
+        Target ``(width, height)`` after Claude's internal resize.
+    """
+    tile = ANTHROPIC_IMAGE_TILE_PIXELS
+
+    def fits(candidate_width: int, candidate_height: int) -> bool:
+        return (
+            math.ceil(candidate_width / tile) * tile <= max_edge
+            and math.ceil(candidate_height / tile) * tile <= max_edge
+            and count_anthropic_image_tokens(candidate_width, candidate_height)
+            <= max_tokens
+        )
+
+    if fits(width, height):
+        return (width, height)
+
+    if height > width:
+        resized_height, resized_width = compute_anthropic_upload_dimensions(
+            height, width, max_edge, max_tokens
+        )
+        return (resized_width, resized_height)
+
+    aspect_ratio = width / height
+    low, high = 1, width
+    while low + 1 < high:
+        mid = (low + high) // 2
+        if fits(mid, max(round(mid / aspect_ratio), 1)):
+            low = mid
+        else:
+            high = mid
+    return (low, max(round(low / aspect_ratio), 1))

--- a/inference/core/workflows/core_steps/formatters/vlm_as_detector/anthropic_detection_parsing.py
+++ b/inference/core/workflows/core_steps/formatters/vlm_as_detector/anthropic_detection_parsing.py
@@ -1,0 +1,136 @@
+from typing import List, Union
+from uuid import uuid4
+
+import numpy as np
+import supervision as sv
+from supervision.config import CLASS_NAME_DATA_FIELD
+
+from inference.core.workflows.core_steps.common.utils import (
+    attach_parents_coordinates_to_sv_detections,
+    compute_anthropic_upload_dimensions,
+)
+from inference.core.workflows.core_steps.formatters.vlm_as_detector.gemini_detection_parsing import (
+    create_classes_index,
+    get_gemini_detection_class_name,
+    scale_confidence,
+)
+from inference.core.workflows.execution_engine.constants import (
+    DETECTION_ID_KEY,
+    IMAGE_DIMENSIONS_KEY,
+    INFERENCE_ID_KEY,
+    PREDICTION_TYPE_KEY,
+)
+from inference.core.workflows.execution_engine.entities.base import WorkflowImageData
+
+
+def convert_anthropic_detection_to_pixel_xyxy(
+    detection: dict,
+    image_height: int,
+    image_width: int,
+) -> List[float]:
+    """Convert a ``box_2d`` entry into pixel coordinates of the original image.
+
+    The Claude block (v5+) pre-resizes detection images to the exact
+    dimensions Claude's internal resize would produce, so returned
+    coordinates refer to the uploaded image. This helper recomputes the
+    uploaded dimensions deterministically from the original ones, clamps
+    coordinates to them, and rescales the box back onto the original image.
+
+    Args:
+        detection: Detection entry with a ``box_2d`` field holding
+            ``[x_min, y_min, x_max, y_max]`` in absolute pixel coordinates
+            of the uploaded image.
+        image_height: Original image height in pixels.
+        image_width: Original image width in pixels.
+
+    Returns:
+        ``[x_min, y_min, x_max, y_max]`` in pixel coordinates of the
+        original image.
+    """
+    uploaded_width, uploaded_height = compute_anthropic_upload_dimensions(
+        image_width, image_height
+    )
+    scale_x = image_width / uploaded_width
+    scale_y = image_height / uploaded_height
+    x_min, y_min, x_max, y_max = detection["box_2d"]
+    x_min = min(max(float(x_min), 0.0), uploaded_width)
+    x_max = min(max(float(x_max), 0.0), uploaded_width)
+    y_min = min(max(float(y_min), 0.0), uploaded_height)
+    y_max = min(max(float(y_max), 0.0), uploaded_height)
+    return [x_min * scale_x, y_min * scale_y, x_max * scale_x, y_max * scale_y]
+
+
+def parse_anthropic_object_detection_response(
+    image: WorkflowImageData,
+    parsed_data: Union[dict, list],
+    classes: List[str],
+    inference_id: str,
+) -> sv.Detections:
+    """Parse Claude block (v5+) object-detection output into detections.
+
+    The model returns ``box_2d`` entries as ``[x_min, y_min, x_max, y_max]``
+    in absolute pixel coordinates of the uploaded (pre-resized) image; see
+    ``convert_anthropic_detection_to_pixel_xyxy`` for the coordinate
+    contract.
+
+    Args:
+        image: Workflow image the detections refer to (original resolution).
+        parsed_data: JSON list of detection entries produced by the model.
+        classes: Class names used to map labels onto class ids.
+        inference_id: Identifier attached to every parsed detection.
+
+    Returns:
+        Parsed detections in the original image's coordinate space.
+
+    Raises:
+        ValueError: If the response is not a JSON list.
+    """
+    if not isinstance(parsed_data, list):
+        raise ValueError("Unexpected Anthropic Claude object detection response format")
+    if len(parsed_data) == 0:
+        return sv.Detections.empty()
+
+    class_name2id = create_classes_index(classes=classes)
+    image_height, image_width = image.numpy_image.shape[:2]
+
+    xyxy, class_id, class_name, confidence = [], [], [], []
+    for detection in parsed_data:
+        xyxy.append(
+            convert_anthropic_detection_to_pixel_xyxy(
+                detection=detection,
+                image_height=image_height,
+                image_width=image_width,
+            )
+        )
+        label = get_gemini_detection_class_name(detection=detection)
+        class_id.append(class_name2id.get(label, -1))
+        class_name.append(label)
+        confidence.append(scale_confidence(detection.get("confidence", 1.0)))
+
+    xyxy = np.array(xyxy).round(0) if len(xyxy) > 0 else np.empty((0, 4))
+    confidence = np.array(confidence) if len(confidence) > 0 else np.empty(0)
+    class_id = np.array(class_id).astype(int) if len(class_id) > 0 else np.empty(0)
+    class_name = np.array(class_name) if len(class_name) > 0 else np.empty(0)
+    detection_ids = np.array([str(uuid4()) for _ in range(len(xyxy))])
+    dimensions = np.array([[image_height, image_width]] * len(xyxy))
+    inference_ids = np.array([inference_id] * len(xyxy))
+    prediction_type = np.array(["object-detection"] * len(xyxy))
+    data = {
+        CLASS_NAME_DATA_FIELD: class_name,
+        IMAGE_DIMENSIONS_KEY: dimensions,
+        INFERENCE_ID_KEY: inference_ids,
+        DETECTION_ID_KEY: detection_ids,
+        PREDICTION_TYPE_KEY: prediction_type,
+    }
+    detections_result = sv.Detections(
+        xyxy=xyxy,
+        confidence=confidence,
+        class_id=class_id,
+        mask=None,
+        tracker_id=None,
+        data=data,
+    )
+    return attach_parents_coordinates_to_sv_detections(
+        detections=detections_result,
+        image=image,
+    )

--- a/inference/core/workflows/core_steps/formatters/vlm_as_detector/v2.py
+++ b/inference/core/workflows/core_steps/formatters/vlm_as_detector/v2.py
@@ -15,6 +15,9 @@ from inference.core.workflows.core_steps.common.utils import (
     attach_parents_coordinates_to_sv_detections,
 )
 from inference.core.workflows.core_steps.common.vlms import VLM_TASKS_METADATA
+from inference.core.workflows.core_steps.formatters.vlm_as_detector.anthropic_detection_parsing import (
+    parse_anthropic_object_detection_response,
+)
 from inference.core.workflows.core_steps.formatters.vlm_as_detector.gemini_detection_parsing import (
     parse_gemini_object_detection_response,
 )
@@ -543,11 +546,61 @@ def parse_openai_detection_response(
     )
 
 
+def parse_anthropic_detection_response(
+    image: WorkflowImageData,
+    parsed_data: Union[dict, list],
+    classes: List[str],
+    inference_id: str,
+) -> sv.Detections:
+    """Parse Claude object-detection output, dispatching on response format.
+
+    Claude blocks v1-v4 produce ``{"detections": [{"x_min": ...}]}`` with
+    coordinates normalized to 0.0-1.0. The v5 block produces a JSON list of
+    ``box_2d`` entries with absolute pixel coordinates of the pre-resized
+    upload.
+
+    Args:
+        image: Workflow image the detections refer to.
+        parsed_data: JSON payload extracted from the VLM output.
+        classes: Class names used to map labels onto class ids.
+        inference_id: Identifier attached to every parsed detection.
+
+    Returns:
+        Parsed detections in the original image's coordinate space.
+    """
+    if isinstance(parsed_data, dict) and "detections" in parsed_data:
+        detections = parsed_data["detections"]
+        if (
+            isinstance(detections, list)
+            and len(detections) > 0
+            and isinstance(detections[0], dict)
+            and "box_2d" in detections[0]
+        ):
+            return parse_anthropic_object_detection_response(
+                image=image,
+                parsed_data=detections,
+                classes=classes,
+                inference_id=inference_id,
+            )
+        return parse_llm_object_detection_response(
+            image=image,
+            parsed_data=parsed_data,
+            classes=classes,
+            inference_id=inference_id,
+        )
+    return parse_anthropic_object_detection_response(
+        image=image,
+        parsed_data=parsed_data,
+        classes=classes,
+        inference_id=inference_id,
+    )
+
+
 REGISTERED_PARSERS = {
     # LLMs
     ("openai", "object-detection"): parse_openai_detection_response,
     ("google-gemini", "object-detection"): parse_gemini_object_detection_response,
-    ("anthropic-claude", "object-detection"): parse_llm_object_detection_response,
+    ("anthropic-claude", "object-detection"): parse_anthropic_detection_response,
     ("spacexai", "object-detection"): parse_spacexai_object_detection_response,
     ("qwen", "object-detection"): parse_qwen_object_detection_response,
     ("muse", "object-detection"): parse_muse_object_detection_response,

--- a/inference/core/workflows/core_steps/loader.py
+++ b/inference/core/workflows/core_steps/loader.py
@@ -482,6 +482,9 @@ from inference.core.workflows.core_steps.models.foundation.anthropic_claude.v3 i
 from inference.core.workflows.core_steps.models.foundation.anthropic_claude.v4 import (
     AnthropicClaudeBlockV4,
 )
+from inference.core.workflows.core_steps.models.foundation.anthropic_claude.v5 import (
+    AnthropicClaudeBlockV5,
+)
 
 if not ENABLE_TENSOR_DATA_REPRESENTATION:
     from inference.core.workflows.core_steps.models.foundation.clip.v1 import (
@@ -1761,6 +1764,7 @@ def load_blocks() -> List[Type[WorkflowBlock]]:
         AnthropicClaudeBlockV2,
         AnthropicClaudeBlockV3,
         AnthropicClaudeBlockV4,
+        AnthropicClaudeBlockV5,
         SpaceXAIBlockV1,
         SpaceXAIBlockV2,
         CosineSimilarityBlockV1,

--- a/inference/core/workflows/core_steps/models/foundation/anthropic_claude/v5.py
+++ b/inference/core/workflows/core_steps/models/foundation/anthropic_claude/v5.py
@@ -1,0 +1,1112 @@
+"""Anthropic Claude workflow block (v5).
+
+Based on v4 (token-usage outputs) with an object-detection path aligned with
+the vlm-exam benchmark contract for Claude models: images for that task are
+pre-resized to the exact dimensions Claude's internal resize would produce
+(high-resolution tier) and sent as lossless PNG, and the prompt asks for a
+JSON list of ``box_2d``/``label`` entries with ``[x_min, y_min, x_max, y_max]``
+in absolute pixel coordinates of the uploaded image, with the image placed
+before the text and no system prompt. Use ``roboflow_core/vlm_as_detector@v2``
+with ``model_type="anthropic-claude"`` to parse the output.
+"""
+
+import base64
+import json
+from functools import partial
+from typing import Any, Dict, List, Literal, Optional, Tuple, Type, Union
+
+import anthropic
+import cv2
+import numpy as np
+import requests
+from anthropic import NOT_GIVEN
+from pydantic import ConfigDict, Field, model_validator
+
+from inference.core.env import WORKFLOWS_REMOTE_EXECUTION_MAX_STEP_CONCURRENT_REQUESTS
+from inference.core.managers.base import ModelManager
+from inference.core.roboflow_api import post_to_roboflow_api
+from inference.core.utils.image_utils import encode_image_to_jpeg_bytes, load_image
+from inference.core.utils.preprocess import downscale_image_keeping_aspect_ratio
+from inference.core.workflows.core_steps.common.token_usage import (
+    TOKEN_OUTPUT_DEFINITIONS,
+    parse_responses_api_usage,
+)
+from inference.core.workflows.core_steps.common.utils import (
+    compute_anthropic_upload_dimensions,
+    run_in_parallel,
+)
+from inference.core.workflows.core_steps.common.vlms import VLM_TASKS_METADATA
+from inference.core.workflows.execution_engine.entities.base import (
+    Batch,
+    OutputDefinition,
+    WorkflowImageData,
+)
+from inference.core.workflows.execution_engine.entities.types import (
+    FLOAT_KIND,
+    IMAGE_KIND,
+    INTEGER_KIND,
+    LANGUAGE_MODEL_OUTPUT_KIND,
+    LIST_OF_VALUES_KIND,
+    ROBOFLOW_MANAGED_KEY,
+    SECRET_KIND,
+    STRING_KIND,
+    ImageInputField,
+    Selector,
+)
+from inference.core.workflows.prototypes.block import (
+    AirGappedAvailability,
+    BlockResult,
+    DependentResource,
+    WorkflowBlock,
+    WorkflowBlockManifest,
+    is_workflow_selector,
+    third_party_model,
+)
+
+CLAUDE_MODELS = [
+    {
+        "id": "claude-fable-5",
+        "name": "Claude Fable 5",
+        "exact_version": "claude-fable-5",
+        "max_output_tokens": 128000,
+    },
+    {
+        "id": "claude-opus-4-7",
+        "name": "Claude Opus 4.7",
+        "exact_version": "claude-opus-4-7",
+        "max_output_tokens": 128000,
+    },
+    {
+        "id": "claude-opus-4-6",
+        "name": "Claude Opus 4.6",
+        "exact_version": "claude-opus-4-6",
+        "max_output_tokens": 128000,
+    },
+    {
+        "id": "claude-sonnet-4-6",
+        "name": "Claude Sonnet 4.6",
+        "exact_version": "claude-sonnet-4-6",
+        "max_output_tokens": 64000,
+    },
+    {
+        "id": "claude-sonnet-4-5",
+        "name": "Claude Sonnet 4.5",
+        "exact_version": "claude-sonnet-4-5-20250929",
+        "max_output_tokens": 64000,
+    },
+    {
+        "id": "claude-haiku-4-5",
+        "name": "Claude Haiku 4.5",
+        "exact_version": "claude-haiku-4-5-20251001",
+        "max_output_tokens": 64000,
+    },
+    {
+        "id": "claude-opus-4-5",
+        "name": "Claude Opus 4.5",
+        "exact_version": "claude-opus-4-5-20251101",
+        "max_output_tokens": 64000,
+    },
+    {
+        "id": "claude-sonnet-4",
+        "name": "Claude Sonnet 4",
+        "exact_version": "claude-sonnet-4-20250514",
+        "max_output_tokens": 64000,
+    },
+    {
+        "id": "claude-opus-4-1",
+        "name": "Claude Opus 4.1",
+        "exact_version": "claude-opus-4-1-20250805",
+        "max_output_tokens": 32000,
+    },
+    {
+        "id": "claude-opus-4",
+        "name": "Claude Opus 4",
+        "exact_version": "claude-opus-4-20250514",
+        "max_output_tokens": 32000,
+    },
+]
+
+MODEL_VERSION_IDS = [model["id"] for model in CLAUDE_MODELS]
+EXACT_MODEL_VERSIONS = {model["id"]: model["exact_version"] for model in CLAUDE_MODELS}
+
+MODEL_VERSION_METADATA = {
+    model["id"]: {"name": model["name"]} for model in CLAUDE_MODELS
+}
+
+MAX_OUTPUT_TOKENS = {model["id"]: model["max_output_tokens"] for model in CLAUDE_MODELS}
+DEFAULT_MAX_OUTPUT_TOKENS = 64000
+
+OBJECT_DETECTION_PROMPT_TEMPLATE = (
+    "Detect all objects in this image. "
+    "Output a JSON list where each entry contains the 2D bounding box "
+    'in the key "box_2d" and the text label in the key "label". '
+    'The "box_2d" value must be [x_min, y_min, x_max, y_max]: the '
+    "top-left and bottom-right corners in absolute pixel coordinates "
+    "of the {width}x{height} pixel image. "
+    "Return only the JSON list, with no extra text. "
+    "Only use these labels: {class_list}"
+)
+
+SUPPORTED_TASK_TYPES_LIST = [
+    "unconstrained",
+    "ocr",
+    "structured-answering",
+    "classification",
+    "multi-label-classification",
+    "visual-question-answering",
+    "caption",
+    "detailed-caption",
+    "object-detection",
+]
+SUPPORTED_TASK_TYPES = set(SUPPORTED_TASK_TYPES_LIST)
+RELEVANT_TASKS_METADATA = {
+    k: v for k, v in VLM_TASKS_METADATA.items() if k in SUPPORTED_TASK_TYPES
+}
+RELEVANT_TASKS_DOCS_DESCRIPTION = "\n\n".join(
+    f"* **{v['name']}** (`{k}`) - {v['description']}"
+    for k, v in RELEVANT_TASKS_METADATA.items()
+)
+LONG_DESCRIPTION = f"""
+Ask a question to Anthropic Claude model with vision capabilities.
+
+You can specify arbitrary text prompts or predefined ones, the block supports the following types of prompt:
+
+{RELEVANT_TASKS_DOCS_DESCRIPTION}
+
+The `object-detection` task asks Claude for a JSON list of
+`{{"box_2d": [x_min, y_min, x_max, y_max], "label": ...}}` entries where
+coordinates are absolute pixels of the uploaded image. The image is
+pre-resized to the exact dimensions Claude's internal resize would produce
+and sent as lossless PNG, matching the vlm-exam benchmark setup for Claude
+models; the `max_image_size` parameter is not applied to this task. Use
+`roboflow_core/vlm_as_detector@v2` with `model_type="anthropic-claude"` to
+convert the output into predictions. Confidence scores are not requested;
+the parser assigns `1.0`.
+
+### API Key Options
+
+This block supports two API key modes:
+
+1. **Roboflow Managed API Key (Default)** - Use `rf_key:account` to proxy requests through Roboflow's API:
+   * **Simplified setup** - no Anthropic API key required
+   * **Secure** - your workflow API key is used for authentication
+   * **Usage-based billing** - charged per token based on the model used
+
+2. **Custom Anthropic API Key** - Provide your own Anthropic API key:
+   * Full control over API usage
+   * You pay Anthropic directly
+"""
+
+TaskType = Literal[tuple(SUPPORTED_TASK_TYPES_LIST)]
+
+TASKS_REQUIRING_PROMPT = {
+    "unconstrained",
+    "visual-question-answering",
+}
+
+TASKS_REQUIRING_CLASSES = {
+    "classification",
+    "multi-label-classification",
+    "object-detection",
+}
+
+TASKS_REQUIRING_OUTPUT_STRUCTURE = {
+    "structured-answering",
+}
+
+
+class BlockManifest(WorkflowBlockManifest):
+    model_config = ConfigDict(
+        json_schema_extra={
+            "name": "Anthropic Claude",
+            "version": "v5",
+            "short_description": "Run Anthropic Claude model with vision capabilities.",
+            "long_description": LONG_DESCRIPTION,
+            "license": "Apache-2.0",
+            "block_type": "model",
+            "search_keywords": ["LMM", "VLM", "Claude", "Anthropic"],
+            "is_vlm_block": True,
+            "task_type_property": "task_type",
+            "ui_manifest": {
+                "section": "model",
+                "icon": "far fa-a",
+                "blockPriority": 5,
+            },
+        },
+        protected_namespaces=(),
+    )
+    type: Literal["roboflow_core/anthropic_claude@v5"]
+    images: Selector(kind=[IMAGE_KIND]) = ImageInputField
+    task_type: TaskType = Field(
+        default="unconstrained",
+        description="Task type to be performed by model. Value determines required parameters and output response.",
+        json_schema_extra={
+            "values_metadata": RELEVANT_TASKS_METADATA,
+            "recommended_parsers": {
+                "structured-answering": "roboflow_core/json_parser@v1",
+                "classification": "roboflow_core/vlm_as_classifier@v2",
+                "multi-label-classification": "roboflow_core/vlm_as_classifier@v2",
+                "object-detection": "roboflow_core/vlm_as_detector@v2",
+            },
+            "always_visible": True,
+        },
+    )
+    prompt: Optional[Union[Selector(kind=[STRING_KIND]), str]] = Field(
+        default=None,
+        description="Text prompt to the Claude model",
+        examples=["my prompt", "$inputs.prompt"],
+        json_schema_extra={
+            "relevant_for": {
+                "task_type": {"values": TASKS_REQUIRING_PROMPT, "required": True},
+            },
+            "multiline": True,
+        },
+    )
+    output_structure: Optional[Dict[str, str]] = Field(
+        default=None,
+        description="Dictionary with structure of expected JSON response",
+        examples=[{"my_key": "description"}, "$inputs.output_structure"],
+        json_schema_extra={
+            "relevant_for": {
+                "task_type": {
+                    "values": TASKS_REQUIRING_OUTPUT_STRUCTURE,
+                    "required": True,
+                },
+            },
+        },
+    )
+    classes: Optional[Union[Selector(kind=[LIST_OF_VALUES_KIND]), List[str]]] = Field(
+        default=None,
+        description="List of classes to be used",
+        examples=[["class-a", "class-b"], "$inputs.classes"],
+        json_schema_extra={
+            "relevant_for": {
+                "task_type": {
+                    "values": TASKS_REQUIRING_CLASSES,
+                    "required": True,
+                },
+            },
+        },
+    )
+    api_key: Union[
+        Selector(kind=[STRING_KIND, SECRET_KIND, ROBOFLOW_MANAGED_KEY]), str
+    ] = Field(
+        default="rf_key:account",
+        description="Your Anthropic API key or 'rf_key:account' to use Roboflow's managed API key",
+        examples=["rf_key:account", "xxx-xxx", "$inputs.anthropic_api_key"],
+        private=True,
+    )
+    model_version: Union[
+        Selector(kind=[STRING_KIND]),
+        Literal[tuple(MODEL_VERSION_IDS)],
+    ] = Field(
+        default="claude-sonnet-4-5",
+        description="Model to be used",
+        examples=["claude-sonnet-4-5", "$inputs.claude_model"],
+        json_schema_extra={
+            "values_metadata": MODEL_VERSION_METADATA,
+        },
+    )
+    extended_thinking: Optional[bool] = Field(
+        default=None,
+        description="Enable extended thinking for deeper reasoning on complex tasks. "
+        "Note: temperature cannot be used when extended thinking is enabled.",
+    )
+    thinking_budget_tokens: Optional[int] = Field(
+        default=None,
+        description="Maximum number of tokens for internal thinking when extended thinking is enabled. "
+        "Higher values allow deeper reasoning but increase latency and cost. "
+        "Must be less than max_tokens. Minimum: 1024.",
+        ge=1024,
+        json_schema_extra={
+            "relevant_for": {
+                "extended_thinking": {
+                    "values": [True],
+                    "required": False,
+                },
+            },
+        },
+    )
+    max_tokens: Optional[int] = Field(
+        default=None,
+        description="Maximum number of tokens the model can generate in its response.",
+    )
+    temperature: Optional[Union[float, Selector(kind=[FLOAT_KIND])]] = Field(
+        default=None,
+        description="Temperature to sample from the model - value in range 0.0-1.0, the higher - the more "
+        'random / "creative" the generations are. Cannot be used when extended_thinking is enabled.',
+        ge=0.0,
+        le=1.0,
+    )
+    max_image_size: Union[int, Selector(kind=[INTEGER_KIND])] = Field(
+        description="Maximum size of the image - if input has larger side, it will be downscaled, keeping aspect ratio. "
+        "Not applied to the `object-detection` task, which pre-resizes images to Claude's native resolution instead.",
+        default=1024,
+    )
+    max_concurrent_requests: Optional[int] = Field(
+        default=None,
+        description="Number of concurrent requests that can be executed by block when batch of input images provided. "
+        "If not given - block defaults to value configured globally in Workflows Execution Engine. "
+        "Please restrict if you hit Anthropic API limits.",
+    )
+
+    @model_validator(mode="after")
+    def validate(self) -> "BlockManifest":
+        if self.task_type in TASKS_REQUIRING_PROMPT and self.prompt is None:
+            raise ValueError(
+                f"`prompt` parameter required to be set for task `{self.task_type}`"
+            )
+        if self.task_type in TASKS_REQUIRING_CLASSES and self.classes is None:
+            raise ValueError(
+                f"`classes` parameter required to be set for task `{self.task_type}`"
+            )
+        if (
+            self.task_type in TASKS_REQUIRING_OUTPUT_STRUCTURE
+            and self.output_structure is None
+        ):
+            raise ValueError(
+                f"`output_structure` parameter required to be set for task `{self.task_type}`"
+            )
+        if self.extended_thinking:
+            if self.temperature is not None:
+                raise ValueError(
+                    "`temperature` cannot be used when `extended_thinking` is enabled"
+                )
+            budget_tokens = self.thinking_budget_tokens
+            max_tokens = self.max_tokens
+            if budget_tokens and max_tokens and budget_tokens >= max_tokens:
+                raise ValueError(
+                    f"`thinking_budget_tokens` ({budget_tokens}) must be less than `max_tokens` ({max_tokens})"
+                )
+        return self
+
+    @classmethod
+    def get_air_gapped_availability(cls) -> AirGappedAvailability:
+        return AirGappedAvailability(available=False, reason="requires_internet")
+
+    @classmethod
+    def get_parameters_accepting_batches(cls) -> List[str]:
+        return ["images"]
+
+    @classmethod
+    def describe_outputs(cls) -> List[OutputDefinition]:
+        return [
+            OutputDefinition(
+                name="output", kind=[STRING_KIND, LANGUAGE_MODEL_OUTPUT_KIND]
+            ),
+            OutputDefinition(name="classes", kind=[LIST_OF_VALUES_KIND]),
+            *TOKEN_OUTPUT_DEFINITIONS,
+        ]
+
+    @classmethod
+    def get_execution_engine_compatibility(cls) -> Optional[str]:
+        return ">=1.4.0,<2.0.0"
+
+    def discover_dependent_resources(self) -> Optional[List[DependentResource]]:
+        if is_workflow_selector(self.model_version):
+            # Selector returned verbatim; the attached resolver performs the
+            # EXACT_MODEL_VERSIONS lookup once the input value is substituted.
+            return [
+                third_party_model(
+                    provider="anthropic",
+                    model_id=self.model_version,
+                    model_id_resolver=lambda label: EXACT_MODEL_VERSIONS.get(
+                        label, label
+                    ),
+                )
+            ]
+        return [
+            third_party_model(
+                provider="anthropic",
+                model_id=EXACT_MODEL_VERSIONS.get(
+                    self.model_version, self.model_version
+                ),
+            )
+        ]
+
+
+class AnthropicClaudeBlockV5(WorkflowBlock):
+
+    def __init__(
+        self,
+        model_manager: ModelManager,
+        api_key: Optional[str],
+    ):
+        self._model_manager = model_manager
+        self._api_key = api_key
+
+    @classmethod
+    def get_init_parameters(cls) -> List[str]:
+        return ["model_manager", "api_key"]
+
+    @classmethod
+    def get_manifest(cls) -> Type[WorkflowBlockManifest]:
+        return BlockManifest
+
+    @classmethod
+    def get_execution_engine_compatibility(cls) -> Optional[str]:
+        return ">=1.4.0,<2.0.0"
+
+    def run(
+        self,
+        images: Batch[WorkflowImageData],
+        task_type: TaskType,
+        prompt: Optional[str],
+        output_structure: Optional[Dict[str, str]],
+        classes: Optional[List[str]],
+        model_version: str,
+        max_tokens: Optional[int],
+        temperature: Optional[float],
+        extended_thinking: Optional[bool],
+        thinking_budget_tokens: Optional[int],
+        max_image_size: int,
+        max_concurrent_requests: Optional[int],
+        api_key: str = "rf_key:account",
+    ) -> BlockResult:
+        inference_images = [i.to_inference_format() for i in images]
+        raw_outputs = run_claude_prompting(
+            roboflow_api_key=self._api_key,
+            images=inference_images,
+            task_type=task_type,
+            prompt=prompt,
+            output_structure=output_structure,
+            classes=classes,
+            anthropic_api_key=api_key,
+            model_version=model_version,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            extended_thinking=extended_thinking,
+            thinking_budget_tokens=thinking_budget_tokens,
+            max_image_size=max_image_size,
+            max_concurrent_requests=max_concurrent_requests,
+        )
+        return [
+            {
+                "output": content,
+                "classes": classes,
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+            }
+            for content, input_tokens, output_tokens in raw_outputs
+        ]
+
+
+def run_claude_prompting(
+    roboflow_api_key: Optional[str],
+    images: List[Dict[str, Any]],
+    task_type: TaskType,
+    prompt: Optional[str],
+    output_structure: Optional[Dict[str, str]],
+    classes: Optional[List[str]],
+    anthropic_api_key: str,
+    model_version: str,
+    max_tokens: Optional[int],
+    temperature: Optional[float],
+    extended_thinking: Optional[bool],
+    thinking_budget_tokens: Optional[int],
+    max_image_size: int,
+    max_concurrent_requests: Optional[int],
+) -> List[Tuple[str, Optional[int], Optional[int]]]:
+    if task_type not in PROMPT_BUILDERS:
+        raise ValueError(f"Task type: {task_type} not supported.")
+    prompts = []
+    for image in images:
+        loaded_image, _ = load_image(image)
+        base64_image, image_width, image_height = encode_image_for_task(
+            loaded_image, task_type=task_type, max_image_size=max_image_size
+        )
+        generated_prompt = PROMPT_BUILDERS[task_type](
+            base64_image=base64_image,
+            prompt=prompt,
+            output_structure=output_structure,
+            classes=classes,
+            image_width=image_width,
+            image_height=image_height,
+        )
+        prompts.append(generated_prompt)
+    return execute_claude_requests(
+        roboflow_api_key=roboflow_api_key,
+        anthropic_api_key=anthropic_api_key,
+        prompts=prompts,
+        model_version=model_version,
+        max_tokens=max_tokens,
+        temperature=temperature,
+        extended_thinking=extended_thinking,
+        thinking_budget_tokens=thinking_budget_tokens,
+        max_concurrent_requests=max_concurrent_requests,
+    )
+
+
+def encode_image_for_task(
+    image: np.ndarray, *, task_type: TaskType, max_image_size: int
+) -> Tuple[str, int, int]:
+    """Encode an image as base64 using task-appropriate preprocessing.
+
+    The ``object-detection`` task pre-resizes the image to the exact
+    dimensions Claude's internal resize would produce (high-resolution tier)
+    and encodes it as lossless PNG, so pixel coordinates returned by the
+    model map one-to-one onto the uploaded image - matching the vlm-exam
+    benchmark setup the absolute-pixel contract was validated with. All other
+    tasks downscale to ``max_image_size`` and send JPEG, as previous block
+    versions did.
+
+    Args:
+        image: BGR image to be encoded.
+        task_type: Task type determining the preprocessing applied.
+        max_image_size: Maximum longest edge applied to non-detection tasks.
+
+    Returns:
+        Tuple of the base64-encoded image payload (without a data URL prefix)
+        and the ``(width, height)`` of the encoded image.
+    """
+    if task_type == "object-detection":
+        encoded_image = _resize_image_to_anthropic_upload_dimensions(image)
+        image_bytes = _encode_image_to_png_bytes(encoded_image)
+    else:
+        encoded_image = downscale_image_keeping_aspect_ratio(
+            image=image, desired_size=(max_image_size, max_image_size)
+        )
+        image_bytes = encode_image_to_jpeg_bytes(encoded_image)
+
+    base64_image = base64.b64encode(image_bytes).decode("ascii")
+    encoded_height, encoded_width = encoded_image.shape[:2]
+
+    return base64_image, encoded_width, encoded_height
+
+
+def _resize_image_to_anthropic_upload_dimensions(image: np.ndarray) -> np.ndarray:
+    height, width = image.shape[:2]
+    target_width, target_height = compute_anthropic_upload_dimensions(width, height)
+    if (target_width, target_height) == (width, height):
+        return image
+
+    return cv2.resize(
+        image, (target_width, target_height), interpolation=cv2.INTER_LANCZOS4
+    )
+
+
+def _encode_image_to_png_bytes(image: np.ndarray) -> bytes:
+    _, encoded_image = cv2.imencode(".png", image)
+    return encoded_image.tobytes()
+
+
+def execute_claude_requests(
+    roboflow_api_key: Optional[str],
+    anthropic_api_key: str,
+    prompts: List[Tuple[Optional[str], List[dict]]],
+    model_version: str,
+    max_tokens: Optional[int],
+    temperature: Optional[float],
+    extended_thinking: Optional[bool],
+    thinking_budget_tokens: Optional[int],
+    max_concurrent_requests: Optional[int],
+) -> List[Tuple[str, Optional[int], Optional[int]]]:
+    tasks = [
+        partial(
+            execute_claude_request,
+            roboflow_api_key=roboflow_api_key,
+            anthropic_api_key=anthropic_api_key,
+            system_prompt=prompt[0],
+            messages=prompt[1],
+            model_version=model_version,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            extended_thinking=extended_thinking,
+            thinking_budget_tokens=thinking_budget_tokens,
+        )
+        for prompt in prompts
+    ]
+    max_workers = (
+        max_concurrent_requests
+        or WORKFLOWS_REMOTE_EXECUTION_MAX_STEP_CONCURRENT_REQUESTS
+    )
+    return run_in_parallel(
+        tasks=tasks,
+        max_workers=max_workers,
+    )
+
+
+def execute_claude_request(
+    roboflow_api_key: Optional[str],
+    anthropic_api_key: str,
+    system_prompt: Optional[str],
+    messages: List[dict],
+    model_version: str,
+    max_tokens: Optional[int],
+    temperature: Optional[float],
+    extended_thinking: Optional[bool],
+    thinking_budget_tokens: Optional[int],
+) -> Tuple[str, Optional[int], Optional[int]]:
+    """Route to proxied or direct execution based on API key format."""
+    if anthropic_api_key.startswith(("rf_key:account", "rf_key:user:")):
+        return _execute_proxied_claude_request(
+            roboflow_api_key=roboflow_api_key,
+            anthropic_api_key=anthropic_api_key,
+            system_prompt=system_prompt,
+            messages=messages,
+            model_version=model_version,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            extended_thinking=extended_thinking,
+            thinking_budget_tokens=thinking_budget_tokens,
+        )
+    else:
+        return _execute_direct_claude_request(
+            anthropic_api_key=anthropic_api_key,
+            system_prompt=system_prompt,
+            messages=messages,
+            model_version=model_version,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            extended_thinking=extended_thinking,
+            thinking_budget_tokens=thinking_budget_tokens,
+        )
+
+
+def _execute_proxied_claude_request(
+    roboflow_api_key: str,
+    anthropic_api_key: str,
+    system_prompt: Optional[str],
+    messages: List[dict],
+    model_version: str,
+    max_tokens: Optional[int],
+    temperature: Optional[float],
+    extended_thinking: Optional[bool],
+    thinking_budget_tokens: Optional[int],
+) -> Tuple[str, Optional[int], Optional[int]]:
+    """Execute Claude request via Roboflow proxy."""
+    model_max_output = MAX_OUTPUT_TOKENS.get(model_version, DEFAULT_MAX_OUTPUT_TOKENS)
+    effective_max_tokens = max_tokens if max_tokens is not None else model_max_output
+
+    payload = {
+        "model": model_version,
+        "anthropic_api_key": anthropic_api_key,
+        "messages": messages,
+        "max_tokens": effective_max_tokens,
+    }
+
+    if system_prompt is not None:
+        payload["system"] = system_prompt
+
+    if temperature is not None and not extended_thinking:
+        payload["temperature"] = temperature
+
+    if extended_thinking:
+        effective_budget = (
+            thinking_budget_tokens
+            if thinking_budget_tokens is not None
+            else model_max_output // 2
+        )
+        payload["thinking"] = {
+            "type": "enabled",
+            "budget_tokens": effective_budget,
+        }
+
+    endpoint = "apiproxy/anthropic"
+
+    try:
+        response_data = post_to_roboflow_api(
+            endpoint=endpoint,
+            api_key=roboflow_api_key,
+            payload=payload,
+        )
+        text = _extract_claude_response_text(response_data)
+        input_tokens, output_tokens = parse_responses_api_usage(
+            response_data.get("usage")
+        )
+        return text, input_tokens, output_tokens
+    except requests.exceptions.RequestException as e:
+        raise RuntimeError(f"Failed to connect to Roboflow proxy: {e}") from e
+    except (KeyError, IndexError) as e:
+        raise RuntimeError(
+            f"Invalid response structure from Roboflow proxy: {e}"
+        ) from e
+
+
+def _execute_direct_claude_request(
+    anthropic_api_key: str,
+    system_prompt: Optional[str],
+    messages: List[dict],
+    model_version: str,
+    max_tokens: Optional[int],
+    temperature: Optional[float],
+    extended_thinking: Optional[bool],
+    thinking_budget_tokens: Optional[int],
+) -> Tuple[str, Optional[int], Optional[int]]:
+    """Execute Claude request directly to Anthropic API."""
+    client = anthropic.Anthropic(api_key=anthropic_api_key)
+
+    if system_prompt is None:
+        system_prompt = NOT_GIVEN
+
+    if temperature is None or extended_thinking:
+        temperature = NOT_GIVEN
+
+    model_max_output = MAX_OUTPUT_TOKENS.get(model_version, DEFAULT_MAX_OUTPUT_TOKENS)
+    effective_max_tokens = max_tokens if max_tokens is not None else model_max_output
+
+    request_params = {
+        "system": system_prompt,
+        "messages": messages,
+        "max_tokens": effective_max_tokens,
+        "model": EXACT_MODEL_VERSIONS.get(model_version, model_version),
+        "temperature": temperature,
+    }
+
+    if extended_thinking:
+        effective_budget = (
+            thinking_budget_tokens
+            if thinking_budget_tokens is not None
+            else model_max_output // 2
+        )
+        request_params["thinking"] = {
+            "type": "enabled",
+            "budget_tokens": effective_budget,
+        }
+
+    # Stream response to avoid max_tokens limitation
+    with client.messages.stream(**request_params) as stream:
+        result = stream.get_final_message()
+
+    text = _validate_and_extract_direct_response(result)
+    input_tokens, output_tokens = parse_responses_api_usage(
+        getattr(result, "usage", None)
+    )
+    return text, input_tokens, output_tokens
+
+
+def _validate_and_extract_direct_response(result) -> str:
+    """Validate and extract text from direct Anthropic API response."""
+    stop_reason = result.stop_reason
+
+    if stop_reason == "max_tokens":
+        raise ValueError(
+            "Claude API stopped generation because the max_tokens limit was reached. "
+            "Please increase the max_tokens parameter to allow for a complete response."
+        )
+
+    if stop_reason not in ["end_turn", "stop_sequence"]:
+        raise ValueError(
+            f"Claude API stopped generation with unexpected stop reason: {stop_reason}."
+        )
+
+    # Ignore thinking blocks and return text content
+    for block in result.content:
+        if block.type == "text":
+            return block.text
+
+    raise ValueError("Claude API returned no text content in response.")
+
+
+def _extract_claude_response_text(response_data: dict) -> str:
+    """Extract text content from Claude API response (proxied)."""
+    stop_reason = response_data.get("stop_reason")
+
+    if stop_reason == "max_tokens":
+        raise ValueError(
+            "Claude API stopped generation because the max_tokens limit was reached. "
+            "Please increase the max_tokens parameter to allow for a complete response."
+        )
+
+    if stop_reason not in ["end_turn", "stop_sequence", None]:
+        raise ValueError(
+            f"Claude API stopped generation with unexpected stop reason: {stop_reason}."
+        )
+
+    content = response_data.get("content", [])
+    if not content:
+        raise ValueError("Claude API returned no content in response.")
+
+    # Ignore thinking blocks and return text content
+    for block in content:
+        if isinstance(block, dict) and block.get("type") == "text":
+            return block.get("text", "")
+
+    raise ValueError("Claude API returned no text content in response.")
+
+
+def prepare_unconstrained_prompt(
+    base64_image: str,
+    prompt: str,
+    **kwargs,
+) -> Tuple[Optional[str], List[dict]]:
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": "image/jpeg",
+                        "data": base64_image,
+                    },
+                },
+                {
+                    "type": "text",
+                    "text": prompt,
+                },
+            ],
+        }
+    ]
+    return None, messages
+
+
+def prepare_classification_prompt(
+    base64_image: str,
+    classes: List[str],
+    **kwargs,
+) -> Tuple[Optional[str], List[dict]]:
+    serialised_classes = ", ".join(classes)
+    system_prompt = (
+        "You act as single-class classification model. You must provide reasonable predictions. "
+        "You are only allowed to produce JSON document. "
+        'Expected structure of json: {"class_name": "class-name", "confidence": 0.4}. '
+        "`class-name` must be one of the class names defined by user. You are only allowed to return "
+        "single JSON document, even if there are potentially multiple classes. You are not allowed to "
+        "return list."
+    )
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": "image/jpeg",
+                        "data": base64_image,
+                    },
+                },
+                {
+                    "type": "text",
+                    "text": f"List of all classes to be recognised by model: {serialised_classes}",
+                },
+            ],
+        }
+    ]
+    return system_prompt, messages
+
+
+def prepare_multi_label_classification_prompt(
+    base64_image: str,
+    classes: List[str],
+    **kwargs,
+) -> Tuple[Optional[str], List[dict]]:
+    serialised_classes = ", ".join(classes)
+    system_prompt = (
+        "You act as multi-label classification model. You must provide reasonable predictions. "
+        "You are only allowed to produce JSON document. "
+        'Expected structure of json: {"predicted_classes": [{"class": "class-name-1", "confidence": 0.9}, '
+        '{"class": "class-name-2", "confidence": 0.7}]}.'
+        "`class-name-X` must be one of the class names defined by user and `confidence` is a float value "
+        "in range 0.0-1.0 that represents how sure you are that the class is present in the image. "
+        "Only return class names that are visible."
+    )
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": "image/jpeg",
+                        "data": base64_image,
+                    },
+                },
+                {
+                    "type": "text",
+                    "text": f"List of all classes to be recognised by model: {serialised_classes}",
+                },
+            ],
+        }
+    ]
+    return system_prompt, messages
+
+
+def prepare_vqa_prompt(
+    base64_image: str,
+    prompt: str,
+    **kwargs,
+) -> Tuple[Optional[str], List[dict]]:
+    system_prompt = (
+        "You act as Visual Question Answering model. Your task is to provide answer to question"
+        "submitted by user. If this is open-question - answer with few sentences, for ABCD question, "
+        "return only the indicator of the answer."
+    )
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": "image/jpeg",
+                        "data": base64_image,
+                    },
+                },
+                {
+                    "type": "text",
+                    "text": f"Question: {prompt}",
+                },
+            ],
+        }
+    ]
+    return system_prompt, messages
+
+
+def prepare_ocr_prompt(
+    base64_image: str,
+    **kwargs,
+) -> Tuple[Optional[str], List[dict]]:
+    system_prompt = (
+        "You act as OCR model. Your task is to read text from the image and return it in "
+        "paragraphs representing the structure of texts in the image. You should only return "
+        "recognised text, nothing else."
+    )
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": "image/jpeg",
+                        "data": base64_image,
+                    },
+                },
+            ],
+        }
+    ]
+    return system_prompt, messages
+
+
+def prepare_caption_prompt(
+    base64_image: str,
+    short_description: bool,
+    **kwargs,
+) -> Tuple[Optional[str], List[dict]]:
+    caption_detail_level = "Caption should be short."
+    if not short_description:
+        caption_detail_level = "Caption should be extensive."
+    system_prompt = (
+        f"You act as image caption model. Your task is to provide description of the image. "
+        f"{caption_detail_level}"
+    )
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": "image/jpeg",
+                        "data": base64_image,
+                    },
+                },
+            ],
+        }
+    ]
+    return system_prompt, messages
+
+
+def prepare_structured_answering_prompt(
+    base64_image: str,
+    output_structure: Dict[str, str],
+    **kwargs,
+) -> Tuple[Optional[str], List[dict]]:
+    output_structure_serialised = json.dumps(output_structure, indent=4)
+    system_prompt = (
+        "You are supposed to produce responses in JSON. User is to provide you dictionary with "
+        "keys and values. Each key must be present in your response. Values in user dictionary "
+        "represent descriptions for JSON fields to be generated. Provide only JSON in response."
+    )
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": "image/jpeg",
+                        "data": base64_image,
+                    },
+                },
+                {
+                    "type": "text",
+                    "text": f"Specification of requirements regarding output fields: \n"
+                    f"{output_structure_serialised}",
+                },
+            ],
+        }
+    ]
+    return system_prompt, messages
+
+
+def prepare_object_detection_prompt(
+    base64_image: str,
+    classes: List[str],
+    image_width: int,
+    image_height: int,
+    **kwargs,
+) -> Tuple[Optional[str], List[dict]]:
+    """Build the absolute-pixel detection request used by Claude models.
+
+    Matches the vlm-exam benchmark setup: lossless PNG placed before the text
+    prompt, no system prompt, and coordinates requested as absolute pixels of
+    the uploaded ``image_width`` x ``image_height`` image.
+
+    Args:
+        base64_image: Base64-encoded PNG image.
+        classes: Class names the model may predict.
+        image_width: Width of the uploaded image in pixels.
+        image_height: Height of the uploaded image in pixels.
+        **kwargs: Ignored builder arguments shared across task types.
+
+    Returns:
+        Tuple of the system prompt (``None``) and the request messages.
+    """
+    class_list = ", ".join(classes)
+    prompt_text = OBJECT_DETECTION_PROMPT_TEMPLATE.format(
+        width=image_width,
+        height=image_height,
+        class_list=class_list,
+    )
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": "image/png",
+                        "data": base64_image,
+                    },
+                },
+                {
+                    "type": "text",
+                    "text": prompt_text,
+                },
+            ],
+        }
+    ]
+    return None, messages
+
+
+PROMPT_BUILDERS = {
+    "unconstrained": prepare_unconstrained_prompt,
+    "ocr": prepare_ocr_prompt,
+    "visual-question-answering": prepare_vqa_prompt,
+    "caption": partial(prepare_caption_prompt, short_description=True),
+    "detailed-caption": partial(prepare_caption_prompt, short_description=False),
+    "classification": prepare_classification_prompt,
+    "multi-label-classification": prepare_multi_label_classification_prompt,
+    "structured-answering": prepare_structured_answering_prompt,
+    "object-detection": prepare_object_detection_prompt,
+}

--- a/inference/core/workflows/core_steps/models/foundation/anthropic_claude/v5.py
+++ b/inference/core/workflows/core_steps/models/foundation/anthropic_claude/v5.py
@@ -136,6 +136,17 @@ MODEL_VERSION_METADATA = {
 MAX_OUTPUT_TOKENS = {model["id"]: model["max_output_tokens"] for model in CLAUDE_MODELS}
 DEFAULT_MAX_OUTPUT_TOKENS = 64000
 
+DETECTION_MAX_PNG_PAYLOAD_BYTES = 2_500_000
+"""Largest PNG payload sent for object detection, before base64 growth.
+
+Lossless PNG of a large photographic upload can exceed the request body
+limits of the Roboflow proxy and Anthropic's per-image maximum. Above this
+size the block re-encodes the image as JPEG (quality 95) at the same
+resolution, which keeps the coordinate contract intact.
+"""
+
+DETECTION_JPEG_FALLBACK_QUALITY = 95
+
 OBJECT_DETECTION_PROMPT_TEMPLATE = (
     "Detect all objects in this image. "
     "Output a JSON list where each entry contains the 2D bounding box "
@@ -512,7 +523,7 @@ def run_claude_prompting(
     prompts = []
     for image in images:
         loaded_image, _ = load_image(image)
-        base64_image, image_width, image_height = encode_image_for_task(
+        base64_image, media_type, image_width, image_height = encode_image_for_task(
             loaded_image, task_type=task_type, max_image_size=max_image_size
         )
         generated_prompt = PROMPT_BUILDERS[task_type](
@@ -522,6 +533,7 @@ def run_claude_prompting(
             classes=classes,
             image_width=image_width,
             image_height=image_height,
+            media_type=media_type,
         )
         prompts.append(generated_prompt)
     return execute_claude_requests(
@@ -556,22 +568,29 @@ def encode_image_for_task(
         max_image_size: Maximum longest edge applied to non-detection tasks.
 
     Returns:
-        Tuple of the base64-encoded image payload (without a data URL prefix)
-        and the ``(width, height)`` of the encoded image.
+        Tuple of the base64-encoded image payload (without a data URL prefix),
+        its media type, and the ``(width, height)`` of the encoded image.
     """
     if task_type == "object-detection":
         encoded_image = _resize_image_to_anthropic_upload_dimensions(image)
         image_bytes = _encode_image_to_png_bytes(encoded_image)
+        media_type = "image/png"
+        if len(image_bytes) > DETECTION_MAX_PNG_PAYLOAD_BYTES:
+            image_bytes = _encode_image_to_jpeg_bytes_with_quality(
+                encoded_image, quality=DETECTION_JPEG_FALLBACK_QUALITY
+            )
+            media_type = "image/jpeg"
     else:
         encoded_image = downscale_image_keeping_aspect_ratio(
             image=image, desired_size=(max_image_size, max_image_size)
         )
         image_bytes = encode_image_to_jpeg_bytes(encoded_image)
+        media_type = "image/jpeg"
 
     base64_image = base64.b64encode(image_bytes).decode("ascii")
     encoded_height, encoded_width = encoded_image.shape[:2]
 
-    return base64_image, encoded_width, encoded_height
+    return base64_image, media_type, encoded_width, encoded_height
 
 
 def _resize_image_to_anthropic_upload_dimensions(image: np.ndarray) -> np.ndarray:
@@ -587,6 +606,13 @@ def _resize_image_to_anthropic_upload_dimensions(image: np.ndarray) -> np.ndarra
 
 def _encode_image_to_png_bytes(image: np.ndarray) -> bytes:
     _, encoded_image = cv2.imencode(".png", image)
+    return encoded_image.tobytes()
+
+
+def _encode_image_to_jpeg_bytes_with_quality(
+    image: np.ndarray, *, quality: int
+) -> bytes:
+    _, encoded_image = cv2.imencode(".jpg", image, [cv2.IMWRITE_JPEG_QUALITY, quality])
     return encoded_image.tobytes()
 
 
@@ -1053,19 +1079,23 @@ def prepare_object_detection_prompt(
     classes: List[str],
     image_width: int,
     image_height: int,
+    media_type: str = "image/png",
     **kwargs,
 ) -> Tuple[Optional[str], List[dict]]:
     """Build the absolute-pixel detection request used by Claude models.
 
-    Matches the vlm-exam benchmark setup: lossless PNG placed before the text
+    Matches the vlm-exam benchmark setup: the image placed before the text
     prompt, no system prompt, and coordinates requested as absolute pixels of
-    the uploaded ``image_width`` x ``image_height`` image.
+    the uploaded ``image_width`` x ``image_height`` image. The image is
+    lossless PNG unless its payload exceeded the size limit, in which case
+    it is JPEG at the same resolution.
 
     Args:
-        base64_image: Base64-encoded PNG image.
+        base64_image: Base64-encoded image.
         classes: Class names the model may predict.
         image_width: Width of the uploaded image in pixels.
         image_height: Height of the uploaded image in pixels.
+        media_type: Media type of the encoded image.
         **kwargs: Ignored builder arguments shared across task types.
 
     Returns:
@@ -1085,7 +1115,7 @@ def prepare_object_detection_prompt(
                     "type": "image",
                     "source": {
                         "type": "base64",
-                        "media_type": "image/png",
+                        "media_type": media_type,
                         "data": base64_image,
                     },
                 },

--- a/tests/workflows/unit_tests/core_steps/common/test_token_usage.py
+++ b/tests/workflows/unit_tests/core_steps/common/test_token_usage.py
@@ -20,6 +20,7 @@ NEW_BLOCK_MODULES = [
     f"{_FOUNDATION}.meta_vlm.v2",
     f"{_FOUNDATION}.qwen_vlm.v3",
     f"{_FOUNDATION}.anthropic_claude.v4",
+    f"{_FOUNDATION}.anthropic_claude.v5",
     f"{_FOUNDATION}.google_gemini.v5",
     f"{_FOUNDATION}.openai.v6",
     f"{_FOUNDATION}.spacexai.v2",

--- a/tests/workflows/unit_tests/core_steps/common/test_utils.py
+++ b/tests/workflows/unit_tests/core_steps/common/test_utils.py
@@ -1,3 +1,4 @@
+import math
 from copy import deepcopy
 
 import cv2
@@ -11,12 +12,17 @@ from inference.core.workflows.core_steps.common.serializers import (
     serialise_rle_sv_detections,
 )
 from inference.core.workflows.core_steps.common.utils import (
+    ANTHROPIC_DETECTION_MAX_EDGE_PIXELS,
+    ANTHROPIC_DETECTION_MAX_IMAGE_TOKENS,
+    ANTHROPIC_IMAGE_TILE_PIXELS,
     DETECTION_MAX_EDGE_PIXELS,
     add_inference_keypoints_to_sv_detections,
     attach_parents_coordinates_to_sv_detections,
     attach_prediction_type_info,
     attach_prediction_type_info_to_sv_detections_batch,
+    compute_anthropic_upload_dimensions,
     convert_inference_detections_batch_to_sv_detections,
+    count_anthropic_image_tokens,
     filter_out_unwanted_classes_from_sv_detections_batch,
     grab_batch_parameters,
     grab_non_batch_parameters,
@@ -1633,4 +1639,63 @@ def test_scale_dimensions_to_max_edge_preserves_invariants(
     )
     assert scale_dimensions_to_max_edge(
         width=scaled_width, height=scaled_height, max_edge=DETECTION_MAX_EDGE_PIXELS
+    ) == (scaled_width, scaled_height)
+
+
+@pytest.mark.parametrize(
+    "width, height, expected",
+    [
+        pytest.param(1000, 800, (1000, 800), id="within-budget-noop"),
+        pytest.param(1932, 1932, (1932, 1932), id="square-at-token-budget-noop"),
+        pytest.param(4000, 3000, (2212, 1659), id="landscape-downscale"),
+        pytest.param(3000, 4000, (1659, 2212), id="portrait-mirrors-landscape"),
+        pytest.param(8000, 200, (2576, 64), id="wide-capped-by-max-edge"),
+        pytest.param(200, 8000, (64, 2576), id="tall-capped-by-max-edge"),
+    ],
+)
+def test_compute_anthropic_upload_dimensions(
+    width: int, height: int, expected: tuple
+) -> None:
+    # when
+    result = compute_anthropic_upload_dimensions(width=width, height=height)
+
+    # then
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    "width, height",
+    [
+        (2899, 2841),
+        (1920, 2560),
+        (5000, 1200),
+        (16000, 9000),
+    ],
+)
+def test_compute_anthropic_upload_dimensions_preserves_invariants(
+    width: int, height: int
+) -> None:
+    # when
+    scaled_width, scaled_height = compute_anthropic_upload_dimensions(
+        width=width, height=height
+    )
+
+    # then
+    tile = ANTHROPIC_IMAGE_TILE_PIXELS
+    assert math.ceil(scaled_width / tile) * tile <= ANTHROPIC_DETECTION_MAX_EDGE_PIXELS
+    assert math.ceil(scaled_height / tile) * tile <= ANTHROPIC_DETECTION_MAX_EDGE_PIXELS
+    assert (
+        count_anthropic_image_tokens(scaled_width, scaled_height)
+        <= ANTHROPIC_DETECTION_MAX_IMAGE_TOKENS
+    )
+    assert scaled_width <= width and scaled_height <= height
+    # aspect ratio preserved within the error introduced by rounding one edge
+    original_ratio = width / height
+    scaled_ratio = scaled_width / scaled_height
+    assert abs(scaled_ratio - original_ratio) <= original_ratio / min(
+        scaled_width, scaled_height
+    )
+    # stable: already-fitting dimensions are returned unchanged
+    assert compute_anthropic_upload_dimensions(
+        width=scaled_width, height=scaled_height
     ) == (scaled_width, scaled_height)

--- a/tests/workflows/unit_tests/core_steps/formatters/test_anthropic_detection_parsing.py
+++ b/tests/workflows/unit_tests/core_steps/formatters/test_anthropic_detection_parsing.py
@@ -1,0 +1,191 @@
+import numpy as np
+import pytest
+
+from inference.core.workflows.core_steps.formatters.vlm_as_detector.anthropic_detection_parsing import (
+    convert_anthropic_detection_to_pixel_xyxy,
+    parse_anthropic_object_detection_response,
+)
+from inference.core.workflows.execution_engine.constants import (
+    DETECTION_ID_KEY,
+    IMAGE_DIMENSIONS_KEY,
+    INFERENCE_ID_KEY,
+    PARENT_COORDINATES_KEY,
+    PARENT_DIMENSIONS_KEY,
+    PARENT_ID_KEY,
+    PREDICTION_TYPE_KEY,
+    ROOT_PARENT_COORDINATES_KEY,
+    ROOT_PARENT_DIMENSIONS_KEY,
+    ROOT_PARENT_ID_KEY,
+)
+from inference.core.workflows.execution_engine.entities.base import (
+    ImageParentMetadata,
+    WorkflowImageData,
+)
+
+# 4000x3000 uploads at 2212x1659 under the high-resolution tier limits;
+# see compute_anthropic_upload_dimensions.
+_UPLOADED_WIDTH_4000x3000 = 2212
+_UPLOADED_HEIGHT_4000x3000 = 1659
+
+
+@pytest.mark.parametrize(
+    "box_2d,image_height,image_width,expected",
+    [
+        pytest.param(
+            [10, 20, 100, 200],
+            480,
+            640,
+            [10.0, 20.0, 100.0, 200.0],
+            id="within-budget-passes-through",
+        ),
+        pytest.param(
+            [1106, 830, 2212, 1659],
+            3000,
+            4000,
+            [
+                1106 * 4000 / _UPLOADED_WIDTH_4000x3000,
+                830 * 3000 / _UPLOADED_HEIGHT_4000x3000,
+                4000.0,
+                3000.0,
+            ],
+            id="landscape-rescale-to-original",
+        ),
+        pytest.param(
+            [830, 1106, 1659, 2212],
+            4000,
+            3000,
+            [
+                830 * 3000 / _UPLOADED_HEIGHT_4000x3000,
+                1106 * 4000 / _UPLOADED_WIDTH_4000x3000,
+                3000.0,
+                4000.0,
+            ],
+            id="portrait-rescale-to-original",
+        ),
+    ],
+)
+def test_box_2d_is_converted_to_pixel_xyxy(
+    box_2d: list,
+    image_height: int,
+    image_width: int,
+    expected: list,
+) -> None:
+    result = convert_anthropic_detection_to_pixel_xyxy(
+        detection={"box_2d": box_2d},
+        image_height=image_height,
+        image_width=image_width,
+    )
+
+    assert result == pytest.approx(expected)
+
+
+@pytest.mark.parametrize(
+    "box_2d,image_height,image_width,expected",
+    [
+        pytest.param(
+            [-50, -10, 100, 200],
+            480,
+            640,
+            [0.0, 0.0, 100.0, 200.0],
+            id="negative-coordinates-clamp-to-zero",
+        ),
+        pytest.param(
+            [10, 20, 700, 500],
+            480,
+            640,
+            [10.0, 20.0, 640.0, 480.0],
+            id="coordinates-beyond-image-clamp-to-edges",
+        ),
+        pytest.param(
+            [-100, 0, 3000, 3000],
+            3000,
+            4000,
+            [0.0, 0.0, 4000.0, 3000.0],
+            id="clamp-against-uploaded-dims-before-rescaling",
+        ),
+    ],
+)
+def test_out_of_bounds_coordinates_are_clamped(
+    box_2d: list,
+    image_height: int,
+    image_width: int,
+    expected: list,
+) -> None:
+    result = convert_anthropic_detection_to_pixel_xyxy(
+        detection={"box_2d": box_2d},
+        image_height=image_height,
+        image_width=image_width,
+    )
+
+    assert result == expected
+
+
+def _build_image(height: int, width: int) -> WorkflowImageData:
+    return WorkflowImageData(
+        parent_metadata=ImageParentMetadata(parent_id="parent"),
+        numpy_image=np.zeros((height, width, 3), dtype=np.uint8),
+    )
+
+
+@pytest.mark.parametrize(
+    "parsed_data",
+    [
+        pytest.param({"detections": []}, id="dict"),
+        pytest.param("not-a-list", id="string"),
+        pytest.param(None, id="none"),
+    ],
+)
+def test_parse_anthropic_object_detection_response_raises_on_non_list(
+    parsed_data,
+) -> None:
+    with pytest.raises(ValueError):
+        parse_anthropic_object_detection_response(
+            image=_build_image(height=480, width=640),
+            parsed_data=parsed_data,
+            classes=["cat", "dog"],
+            inference_id="inference-id",
+        )
+
+
+def test_parse_anthropic_object_detection_response_for_empty_list() -> None:
+    result = parse_anthropic_object_detection_response(
+        image=_build_image(height=480, width=640),
+        parsed_data=[],
+        classes=["cat", "dog"],
+        inference_id="inference-id",
+    )
+
+    assert len(result) == 0
+
+
+def test_parse_anthropic_object_detection_response_assembles_detections() -> None:
+    parsed_data = [
+        {"box_2d": [10, 20, 100, 200], "label": "cat", "confidence": 0.75},
+        {"box_2d": [0, 0, 50, 50], "label": "unicorn"},
+    ]
+
+    result = parse_anthropic_object_detection_response(
+        image=_build_image(height=480, width=640),
+        parsed_data=parsed_data,
+        classes=["cat", "dog"],
+        inference_id="inference-id",
+    )
+
+    assert np.allclose(result.xyxy, [[10, 20, 100, 200], [0, 0, 50, 50]])
+    assert result.class_id.tolist() == [0, -1]
+    assert result["class_name"].tolist() == ["cat", "unicorn"]
+    assert np.allclose(result.confidence, [0.75, 1.0])
+    assert result.mask is None
+    assert result.tracker_id is None
+    assert result[INFERENCE_ID_KEY].tolist() == ["inference-id"] * 2
+    assert result[PREDICTION_TYPE_KEY].tolist() == ["object-detection"] * 2
+    assert result[IMAGE_DIMENSIONS_KEY].tolist() == [[480, 640]] * 2
+    detection_ids = result[DETECTION_ID_KEY].tolist()
+    assert len(set(detection_ids)) == 2
+    assert all(detection_id for detection_id in detection_ids)
+    assert result[PARENT_ID_KEY].tolist() == ["parent"] * 2
+    assert result[PARENT_COORDINATES_KEY].tolist() == [[0, 0]] * 2
+    assert result[PARENT_DIMENSIONS_KEY].tolist() == [[480, 640]] * 2
+    assert result[ROOT_PARENT_ID_KEY].tolist() == ["parent"] * 2
+    assert result[ROOT_PARENT_COORDINATES_KEY].tolist() == [[0, 0]] * 2
+    assert result[ROOT_PARENT_DIMENSIONS_KEY].tolist() == [[480, 640]] * 2

--- a/tests/workflows/unit_tests/core_steps/formatters/vlm_as_detector/test_v2.py
+++ b/tests/workflows/unit_tests/core_steps/formatters/vlm_as_detector/test_v2.py
@@ -357,6 +357,90 @@ def test_run_method_for_spacexai_unknown_label_gets_class_id_minus_one() -> None
     assert np.allclose(result["predictions"].class_id, np.array([-1]))
 
 
+def test_run_method_for_anthropic_claude_box_2d_output_with_resize() -> None:
+    # given - original 4000x3000 image is uploaded at 2212x1659 (Claude's
+    # high-resolution tier resize), so absolute pixel coordinates must be
+    # rescaled back onto the original image
+    block = VLMAsDetectorBlockV2()
+    image = WorkflowImageData(
+        numpy_image=np.zeros((3000, 4000, 3), dtype=np.uint8),
+        parent_metadata=ImageParentMetadata(parent_id="parent"),
+    )
+    vlm_output = """
+[
+  {"box_2d": [553, 415, 1106, 830], "label": "cat"},
+  {"box_2d": [1106, 830, 2500, 1800], "label": "dog"}
+]
+    """
+
+    # when
+    result = block.run(
+        image=image,
+        vlm_output=vlm_output,
+        classes=["cat", "dog"],
+        model_type="anthropic-claude",
+        task_type="object-detection",
+    )
+
+    # then - second box exceeds the 2212x1659 upload and is clamped before scaling
+    assert result["error_status"] is False
+    assert isinstance(result["predictions"], sv.Detections)
+    assert result["predictions"].data["class_name"].tolist() == ["cat", "dog"]
+    assert np.allclose(result["predictions"].class_id, np.array([0, 1]))
+    assert np.allclose(
+        result["predictions"].xyxy,
+        np.array(
+            [
+                [
+                    553 * 4000 / 2212,
+                    415 * 3000 / 1659,
+                    1106 * 4000 / 2212,
+                    830 * 3000 / 1659,
+                ],
+                [1106 * 4000 / 2212, 830 * 3000 / 1659, 4000, 3000],
+            ]
+        ),
+        atol=1.0,
+    )
+    assert np.allclose(result["predictions"].confidence, np.array([1.0, 1.0]))
+
+
+def test_run_method_for_anthropic_claude_legacy_detections_output() -> None:
+    # given - v1-v4 Claude blocks emit the normalized {"detections": [...]}
+    # contract, which must keep parsing through the legacy path
+    block = VLMAsDetectorBlockV2()
+    image = WorkflowImageData(
+        numpy_image=np.zeros((192, 168, 3), dtype=np.uint8),
+        parent_metadata=ImageParentMetadata(parent_id="parent"),
+    )
+    vlm_output = """
+{"detections": [
+  {"x_min": 0.1, "y_min": 0.2, "x_max": 0.5, "y_max": 0.6, "class_name": "cat", "confidence": 0.9}
+]}
+    """
+
+    # when
+    result = block.run(
+        image=image,
+        vlm_output=vlm_output,
+        classes=["cat", "dog"],
+        model_type="anthropic-claude",
+        task_type="object-detection",
+    )
+
+    # then
+    assert result["error_status"] is False
+    assert isinstance(result["predictions"], sv.Detections)
+    assert result["predictions"].data["class_name"].tolist() == ["cat"]
+    assert np.allclose(result["predictions"].class_id, np.array([0]))
+    assert np.allclose(
+        result["predictions"].xyxy,
+        np.array([[17, 38, 84, 115]]),
+        atol=1.0,
+    )
+    assert np.allclose(result["predictions"].confidence, np.array([0.9]))
+
+
 def test_run_method_for_invalid_claude_and_gemini_output() -> None:
     # given
     block = VLMAsDetectorBlockV2()

--- a/tests/workflows/unit_tests/core_steps/models/foundation/test_anthropic_claude_v5.py
+++ b/tests/workflows/unit_tests/core_steps/models/foundation/test_anthropic_claude_v5.py
@@ -85,12 +85,13 @@ def test_encode_image_for_task_resizes_detection_images_to_upload_dimensions() -
     image = np.zeros((3000, 4000, 3), dtype=np.uint8)
 
     # when
-    base64_image, width, height = encode_image_for_task(
+    base64_image, media_type, width, height = encode_image_for_task(
         image, task_type="object-detection", max_image_size=1024
     )
 
     # then - 4000x3000 uploads at 2212x1659; max_image_size is not applied
     assert (width, height) == (2212, 1659)
+    assert media_type == "image/png"
     decoded = cv2.imdecode(
         np.frombuffer(base64.b64decode(base64_image), dtype=np.uint8),
         cv2.IMREAD_COLOR,
@@ -103,12 +104,34 @@ def test_encode_image_for_task_keeps_small_detection_images_unchanged() -> None:
     image = np.zeros((480, 640, 3), dtype=np.uint8)
 
     # when
-    _, width, height = encode_image_for_task(
+    _, media_type, width, height = encode_image_for_task(
         image, task_type="object-detection", max_image_size=1024
     )
 
     # then
     assert (width, height) == (640, 480)
+    assert media_type == "image/png"
+
+
+def test_encode_image_for_task_falls_back_to_jpeg_for_oversized_png() -> None:
+    # given - random noise compresses terribly in PNG, exceeding the payload
+    # limit at Claude's upload resolution
+    rng = np.random.default_rng(42)
+    image = rng.integers(0, 256, size=(2500, 3000, 3), dtype=np.uint8)
+
+    # when
+    base64_image, media_type, width, height = encode_image_for_task(
+        image, task_type="object-detection", max_image_size=1024
+    )
+
+    # then - resolution keeps the coordinate contract, only the codec changes
+    assert media_type == "image/jpeg"
+    assert (width, height) == (2100, 1750)
+    decoded = cv2.imdecode(
+        np.frombuffer(base64.b64decode(base64_image), dtype=np.uint8),
+        cv2.IMREAD_COLOR,
+    )
+    assert decoded.shape[:2] == (1750, 2100)
 
 
 def test_encode_image_for_task_downscales_other_tasks_to_max_image_size() -> None:
@@ -116,12 +139,13 @@ def test_encode_image_for_task_downscales_other_tasks_to_max_image_size() -> Non
     image = np.zeros((3000, 4000, 3), dtype=np.uint8)
 
     # when
-    base64_image, width, height = encode_image_for_task(
+    base64_image, media_type, width, height = encode_image_for_task(
         image, task_type="unconstrained", max_image_size=1024
     )
 
     # then - JPEG payload downscaled to the max_image_size limit
     assert (width, height) == (1024, 768)
+    assert media_type == "image/jpeg"
     decoded = cv2.imdecode(
         np.frombuffer(base64.b64decode(base64_image), dtype=np.uint8),
         cv2.IMREAD_COLOR,

--- a/tests/workflows/unit_tests/core_steps/models/foundation/test_anthropic_claude_v5.py
+++ b/tests/workflows/unit_tests/core_steps/models/foundation/test_anthropic_claude_v5.py
@@ -1,0 +1,166 @@
+"""Tests for the Anthropic Claude v5 block (v4 + vlm-exam detection contract).
+
+The v1-v3 behavior suite lives in ``test_anthropic_claude.py`` and the
+token-usage delta in ``test_anthropic_claude_v4.py``; this file covers the
+v5 delta: the absolute-pixel object-detection prompt on a PNG image
+pre-resized to Claude's native upload dimensions.
+"""
+
+import base64
+from typing import List
+from unittest.mock import Mock, patch
+
+import cv2
+import numpy as np
+import pytest
+
+from inference.core.workflows.core_steps.models.foundation.anthropic_claude.v5 import (
+    BlockManifest,
+    encode_image_for_task,
+    prepare_object_detection_prompt,
+    run_claude_prompting,
+)
+
+
+def test_manifest_parsing_for_object_detection_task() -> None:
+    # given
+    raw_manifest = {
+        "type": "roboflow_core/anthropic_claude@v5",
+        "name": "claude",
+        "images": "$inputs.image",
+        "task_type": "object-detection",
+        "classes": ["cat", "dog"],
+        "api_key": "$inputs.api_key",
+    }
+
+    # when
+    result = BlockManifest.model_validate(raw_manifest)
+
+    # then
+    assert result.task_type == "object-detection"
+    assert result.classes == ["cat", "dog"]
+
+
+def test_manifest_parsing_fails_for_object_detection_without_classes() -> None:
+    # given
+    raw_manifest = {
+        "type": "roboflow_core/anthropic_claude@v5",
+        "name": "claude",
+        "images": "$inputs.image",
+        "task_type": "object-detection",
+        "api_key": "$inputs.api_key",
+    }
+
+    # when / then
+    with pytest.raises(ValueError):
+        BlockManifest.model_validate(raw_manifest)
+
+
+def test_prepare_object_detection_prompt_matches_vlm_exam_contract() -> None:
+    # when
+    system_prompt, messages = prepare_object_detection_prompt(
+        base64_image="base64-image",
+        classes=["cat", "dog"],
+        image_width=2212,
+        image_height=1659,
+    )
+
+    # then - no system prompt, PNG image placed before the text
+    assert system_prompt is None
+    assert len(messages) == 1
+    content = messages[0]["content"]
+    assert content[0]["type"] == "image"
+    assert content[0]["source"]["media_type"] == "image/png"
+    assert content[0]["source"]["data"] == "base64-image"
+    assert content[1]["type"] == "text"
+    prompt_text = content[1]["text"]
+    assert "[x_min, y_min, x_max, y_max]" in prompt_text
+    assert "absolute pixel coordinates" in prompt_text
+    assert "2212x1659 pixel image" in prompt_text
+    assert "Only use these labels: cat, dog" in prompt_text
+
+
+def test_encode_image_for_task_resizes_detection_images_to_upload_dimensions() -> None:
+    # given
+    image = np.zeros((3000, 4000, 3), dtype=np.uint8)
+
+    # when
+    base64_image, width, height = encode_image_for_task(
+        image, task_type="object-detection", max_image_size=1024
+    )
+
+    # then - 4000x3000 uploads at 2212x1659; max_image_size is not applied
+    assert (width, height) == (2212, 1659)
+    decoded = cv2.imdecode(
+        np.frombuffer(base64.b64decode(base64_image), dtype=np.uint8),
+        cv2.IMREAD_COLOR,
+    )
+    assert decoded.shape[:2] == (1659, 2212)
+
+
+def test_encode_image_for_task_keeps_small_detection_images_unchanged() -> None:
+    # given
+    image = np.zeros((480, 640, 3), dtype=np.uint8)
+
+    # when
+    _, width, height = encode_image_for_task(
+        image, task_type="object-detection", max_image_size=1024
+    )
+
+    # then
+    assert (width, height) == (640, 480)
+
+
+def test_encode_image_for_task_downscales_other_tasks_to_max_image_size() -> None:
+    # given
+    image = np.zeros((3000, 4000, 3), dtype=np.uint8)
+
+    # when
+    base64_image, width, height = encode_image_for_task(
+        image, task_type="unconstrained", max_image_size=1024
+    )
+
+    # then - JPEG payload downscaled to the max_image_size limit
+    assert (width, height) == (1024, 768)
+    decoded = cv2.imdecode(
+        np.frombuffer(base64.b64decode(base64_image), dtype=np.uint8),
+        cv2.IMREAD_COLOR,
+    )
+    assert decoded.shape[:2] == (768, 1024)
+
+
+@patch(
+    "inference.core.workflows.core_steps.models.foundation.anthropic_claude.v5.execute_claude_requests"
+)
+def test_run_claude_prompting_states_uploaded_dimensions_in_detection_prompt(
+    mock_execute: Mock,
+) -> None:
+    # given
+    mock_execute.return_value = [("[]", 10, 2)]
+    images = [{"type": "numpy_object", "value": np.zeros((3000, 4000, 3), np.uint8)}]
+
+    # when
+    result = run_claude_prompting(
+        roboflow_api_key="rf-key",
+        images=images,
+        task_type="object-detection",
+        prompt=None,
+        output_structure=None,
+        classes=["cat", "dog"],
+        anthropic_api_key="sk-ant-test",
+        model_version="claude-sonnet-4-5",
+        max_tokens=None,
+        temperature=None,
+        extended_thinking=None,
+        thinking_budget_tokens=None,
+        max_image_size=1024,
+        max_concurrent_requests=None,
+    )
+
+    # then
+    assert result == [("[]", 10, 2)]
+    prompts: List = mock_execute.call_args.kwargs["prompts"]
+    assert len(prompts) == 1
+    system_prompt, messages = prompts[0]
+    assert system_prompt is None
+    assert "2212x1659 pixel image" in messages[0]["content"][1]["text"]


### PR DESCRIPTION
## What

Brings the Anthropic Claude block in line with the vlm-exam detection benchmarks, the same way #2750 (OpenAI), #2734 (Gemini) and #2799 (xAI) did. All four Claude models scored best with `detection_coordinate_format: xyxy_absolute_resized_image` at the high resolution tier, but the shipped block still prompts for xyxy normalized 0.0-1.0.

## Changes

- `anthropic_claude@v5` (based on v4, keeps token-usage outputs). For `object-detection` it pre-resizes the image to the exact dimensions Claude's internal resize would produce (high tier: max padded edge 2576, token budget 4784), sends it as lossless PNG before the text, drops the system prompt, and asks for a JSON list of `box_2d`/`label` entries in absolute pixels of the uploaded WxH image. All other task types behave as in v4. `max_image_size` is not applied to the detection task.
- `compute_anthropic_upload_dimensions` in `common/utils.py` ports the resize arithmetic from Anthropic's vision coordinates docs (same code vlm-exam uses). The block and the parser share it.
- `vlm_as_detector@v2` gains `anthropic_detection_parsing.py`: recompute upload dims, clamp, rescale onto the original image. The `anthropic-claude` parser now dispatches on payload shape, so the legacy normalized `{"detections": [...]}` output from v1-v4 blocks keeps parsing through the old path.

## Testing

- Unit tests: resize arithmetic, prompt contract, parser conversion and clamping, dispatch of legacy vs new format, loader and token-output guards (187 affected tests pass locally).
- Planned before merge: e2e run on a vlm-exam detection dataset through the workflow to compare accuracy, latency and token usage against the v4 prompt.

**Tested v4 vs v5:**
<img width="1914" height="618" alt="image" src="https://github.com/user-attachments/assets/b7327e65-686c-438f-955e-78fd891b3579" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)