### PR TITLE
Remove SpaceXAI managed-key gate

### DIFF
--- a/inference/core/env.py
+++ b/inference/core/env.py
@@ -913,12 +913,6 @@ WORKFLOWS_REMOTE_EXECUTION_MAX_STEP_BATCH_SIZE = int(
 WORKFLOWS_REMOTE_EXECUTION_MAX_STEP_CONCURRENT_REQUESTS = int(
     os.getenv("WORKFLOWS_REMOTE_EXECUTION_MAX_STEP_CONCURRENT_REQUESTS", "8")
 )
-# Enables the Roboflow-managed (rf_key) API key option in the SpaceXAI block.
-# Off by default until the platform-side xAI proxy (apiproxy/xai) is deployed;
-# with the flag off users must provide their own xAI API key.
-WORKFLOWS_SPACEXAI_MANAGED_KEY_ENABLED = str2bool(
-    os.getenv("WORKFLOWS_SPACEXAI_MANAGED_KEY_ENABLED", False)
-)
 ALLOW_CUSTOM_PYTHON_EXECUTION_IN_WORKFLOWS = str2bool(
     os.getenv("ALLOW_CUSTOM_PYTHON_EXECUTION_IN_WORKFLOWS", True)
 )

--- a/inference/core/workflows/core_steps/models/foundation/spacexai/v1.py
+++ b/inference/core/workflows/core_steps/models/foundation/spacexai/v1.py
@@ -2,12 +2,8 @@
 
 Calls Grok vision models via xAI's OpenAI-compatible Responses API, either
 directly with a user-provided xAI key or through Roboflow's ``apiproxy/xai``
-managed-key proxy. The managed-key (``rf_key``) option is gated behind the
-``WORKFLOWS_SPACEXAI_MANAGED_KEY_ENABLED`` env flag (off by default) until the
-platform-side proxy is deployed; with the flag off users must provide their
-own xAI API key and the block never contacts the proxy. Object-detection
-prompting uses the percent-of-image ``box_2d`` contract validated in the
-vlm-exam benchmark for Grok 4.5/4.6.
+managed-key proxy. Object-detection prompting uses the percent-of-image
+``box_2d`` contract validated in the vlm-exam benchmark for Grok 4.5/4.6.
 """
 
 import base64
@@ -21,10 +17,7 @@ import requests
 from openai import OpenAI
 from pydantic import ConfigDict, Field, model_validator
 
-from inference.core.env import (
-    WORKFLOWS_REMOTE_EXECUTION_MAX_STEP_CONCURRENT_REQUESTS,
-    WORKFLOWS_SPACEXAI_MANAGED_KEY_ENABLED,
-)
+from inference.core.env import WORKFLOWS_REMOTE_EXECUTION_MAX_STEP_CONCURRENT_REQUESTS
 from inference.core.managers.base import ModelManager
 from inference.core.roboflow_api import post_to_roboflow_api
 from inference.core.utils.image_utils import encode_image_to_jpeg_bytes, load_image
@@ -103,18 +96,11 @@ RELEVANT_TASKS_DOCS_DESCRIPTION = "\n\n".join(
     for k, v in RELEVANT_TASKS_METADATA.items()
 )
 
-if WORKFLOWS_SPACEXAI_MANAGED_KEY_ENABLED:
-    API_KEY_OPTIONS_DOCS = """### API Key Options
+API_KEY_OPTIONS_DOCS = """### API Key Options
 
 1. **Roboflow Managed API Key (Default)** - Use `rf_key:account` to proxy
    requests through Roboflow's API. Usage is billed against Roboflow credits.
 2. **Custom xAI API Key** - Provide your own xAI API key and pay xAI directly.
-"""
-else:
-    API_KEY_OPTIONS_DOCS = """### API Key
-
-Provide your own xAI API key (created at https://console.x.ai). Requests are
-sent directly to xAI and billed to your xAI account.
 """
 
 LONG_DESCRIPTION = f"""
@@ -154,25 +140,15 @@ TASKS_REQUIRING_OUTPUT_STRUCTURE = {
     "structured-answering",
 }
 
-if WORKFLOWS_SPACEXAI_MANAGED_KEY_ENABLED:
-    ApiKeyType = Union[
-        Selector(kind=[STRING_KIND, SECRET_KIND, ROBOFLOW_MANAGED_KEY]), str
-    ]
-    API_KEY_FIELD = Field(
-        default="rf_key:account",
-        description=(
-            "Your xAI API key or 'rf_key:account' to use Roboflow's managed API key"
-        ),
-        examples=["rf_key:account", "xxx-xxx", "$inputs.xai_api_key"],
-        private=True,
-    )
-else:
-    ApiKeyType = Union[Selector(kind=[STRING_KIND, SECRET_KIND]), str]
-    API_KEY_FIELD = Field(
-        description="Your xAI API key",
-        examples=["xxx-xxx", "$inputs.xai_api_key"],
-        private=True,
-    )
+ApiKeyType = Union[Selector(kind=[STRING_KIND, SECRET_KIND, ROBOFLOW_MANAGED_KEY]), str]
+API_KEY_FIELD = Field(
+    default="rf_key:account",
+    description=(
+        "Your xAI API key or 'rf_key:account' to use Roboflow's managed API key"
+    ),
+    examples=["rf_key:account", "xxx-xxx", "$inputs.xai_api_key"],
+    private=True,
+)
 
 
 class BlockManifest(WorkflowBlockManifest):
@@ -580,12 +556,6 @@ def execute_spacexai_request(
         Raw text output of the model.
     """
     if xai_api_key.startswith(("rf_key:account", "rf_key:user:")):
-        if not WORKFLOWS_SPACEXAI_MANAGED_KEY_ENABLED:
-            raise ValueError(
-                "Roboflow-managed xAI API keys are not enabled on this "
-                "installation. Provide your own xAI API key in the SpaceXAI "
-                "block's `api_key` field."
-            )
         if not roboflow_api_key:
             raise ValueError(
                 "Roboflow API key is required when using a Roboflow-managed xAI API key."

--- a/inference/core/workflows/core_steps/models/foundation/spacexai/v2.py
+++ b/inference/core/workflows/core_steps/models/foundation/spacexai/v2.py
@@ -2,12 +2,8 @@
 
 Calls Grok vision models via xAI's OpenAI-compatible Responses API, either
 directly with a user-provided xAI key or through Roboflow's ``apiproxy/xai``
-managed-key proxy. The managed-key (``rf_key``) option is gated behind the
-``WORKFLOWS_SPACEXAI_MANAGED_KEY_ENABLED`` env flag (off by default) until the
-platform-side proxy is deployed; with the flag off users must provide their
-own xAI API key and the block never contacts the proxy. Object-detection
-prompting uses the percent-of-image ``box_2d`` contract validated in the
-vlm-exam benchmark for Grok 4.5/4.6.
+managed-key proxy. Object-detection prompting uses the percent-of-image
+``box_2d`` contract validated in the vlm-exam benchmark for Grok 4.5/4.6.
 """
 
 import base64
@@ -21,10 +17,7 @@ import requests
 from openai import OpenAI
 from pydantic import ConfigDict, Field, model_validator
 
-from inference.core.env import (
-    WORKFLOWS_REMOTE_EXECUTION_MAX_STEP_CONCURRENT_REQUESTS,
-    WORKFLOWS_SPACEXAI_MANAGED_KEY_ENABLED,
-)
+from inference.core.env import WORKFLOWS_REMOTE_EXECUTION_MAX_STEP_CONCURRENT_REQUESTS
 from inference.core.managers.base import ModelManager
 from inference.core.roboflow_api import post_to_roboflow_api
 from inference.core.utils.image_utils import encode_image_to_jpeg_bytes, load_image
@@ -123,18 +116,11 @@ RELEVANT_TASKS_DOCS_DESCRIPTION = "\n\n".join(
     for k, v in RELEVANT_TASKS_METADATA.items()
 )
 
-if WORKFLOWS_SPACEXAI_MANAGED_KEY_ENABLED:
-    API_KEY_OPTIONS_DOCS = """### API Key Options
+API_KEY_OPTIONS_DOCS = """### API Key Options
 
 1. **Roboflow Managed API Key (Default)** - Use `rf_key:account` to proxy
    requests through Roboflow's API. Usage is billed against Roboflow credits.
 2. **Custom xAI API Key** - Provide your own xAI API key and pay xAI directly.
-"""
-else:
-    API_KEY_OPTIONS_DOCS = """### API Key
-
-Provide your own xAI API key (created at https://console.x.ai). Requests are
-sent directly to xAI and billed to your xAI account.
 """
 
 LONG_DESCRIPTION = f"""
@@ -174,25 +160,15 @@ TASKS_REQUIRING_OUTPUT_STRUCTURE = {
     "structured-answering",
 }
 
-if WORKFLOWS_SPACEXAI_MANAGED_KEY_ENABLED:
-    ApiKeyType = Union[
-        Selector(kind=[STRING_KIND, SECRET_KIND, ROBOFLOW_MANAGED_KEY]), str
-    ]
-    API_KEY_FIELD = Field(
-        default="rf_key:account",
-        description=(
-            "Your xAI API key or 'rf_key:account' to use Roboflow's managed API key"
-        ),
-        examples=["rf_key:account", "xxx-xxx", "$inputs.xai_api_key"],
-        private=True,
-    )
-else:
-    ApiKeyType = Union[Selector(kind=[STRING_KIND, SECRET_KIND]), str]
-    API_KEY_FIELD = Field(
-        description="Your xAI API key",
-        examples=["xxx-xxx", "$inputs.xai_api_key"],
-        private=True,
-    )
+ApiKeyType = Union[Selector(kind=[STRING_KIND, SECRET_KIND, ROBOFLOW_MANAGED_KEY]), str]
+API_KEY_FIELD = Field(
+    default="rf_key:account",
+    description=(
+        "Your xAI API key or 'rf_key:account' to use Roboflow's managed API key"
+    ),
+    examples=["rf_key:account", "xxx-xxx", "$inputs.xai_api_key"],
+    private=True,
+)
 
 
 class BlockManifest(WorkflowBlockManifest):
@@ -613,12 +589,6 @@ def execute_spacexai_request(
         Raw text output of the model.
     """
     if xai_api_key.startswith(("rf_key:account", "rf_key:user:")):
-        if not WORKFLOWS_SPACEXAI_MANAGED_KEY_ENABLED:
-            raise ValueError(
-                "Roboflow-managed xAI API keys are not enabled on this "
-                "installation. Provide your own xAI API key in the SpaceXAI "
-                "block's `api_key` field."
-            )
         if not roboflow_api_key:
             raise ValueError(
                 "Roboflow API key is required when using a Roboflow-managed xAI API key."

--- a/tests/workflows/unit_tests/core_steps/models/foundation/test_spacexai.py
+++ b/tests/workflows/unit_tests/core_steps/models/foundation/test_spacexai.py
@@ -179,28 +179,6 @@ def test_encode_image_for_task_uses_jpeg_for_caption() -> None:
 
 @patch(
     "inference.core.workflows.core_steps.models.foundation.spacexai.v1."
-    "_execute_proxied_spacexai_request"
-)
-def test_execute_spacexai_request_routes_rf_key_to_proxy(
-    proxied_mock: MagicMock,
-) -> None:
-    proxied_mock.return_value = "proxied"
-    result = execute_spacexai_request(
-        roboflow_api_key="rf_abc",
-        xai_api_key="rf_key:account",
-        instructions=None,
-        input_content=[{"role": "user", "content": []}],
-        model_version="grok-4.6",
-        reasoning_effort=None,
-        max_tokens=None,
-        temperature=None,
-    )
-    assert result == "proxied"
-    proxied_mock.assert_called_once()
-
-
-@patch(
-    "inference.core.workflows.core_steps.models.foundation.spacexai.v1."
     "_execute_direct_spacexai_request"
 )
 def test_execute_spacexai_request_routes_direct_key(

--- a/tests/workflows/unit_tests/core_steps/models/foundation/test_spacexai.py
+++ b/tests/workflows/unit_tests/core_steps/models/foundation/test_spacexai.py
@@ -39,9 +39,7 @@ def test_spacexai_step_validation_when_input_is_valid() -> None:
     assert result.api_key == "$inputs.xai_api_key"
 
 
-def test_spacexai_step_validation_requires_api_key_when_managed_key_disabled() -> None:
-    # WORKFLOWS_SPACEXAI_MANAGED_KEY_ENABLED is off by default, so the block
-    # must demand a user-provided xAI key instead of defaulting to rf_key.
+def test_spacexai_step_validation_defaults_api_key_to_rf_key_account() -> None:
     specification = {
         "type": "roboflow_core/spacexai@v1",
         "name": "step_1",
@@ -49,8 +47,9 @@ def test_spacexai_step_validation_requires_api_key_when_managed_key_disabled() -
         "task_type": "caption",
     }
 
-    with pytest.raises(ValidationError):
-        _ = BlockManifest.model_validate(specification)
+    result = BlockManifest.model_validate(specification)
+
+    assert result.api_key == "rf_key:account"
 
 
 def test_spacexai_step_discovers_dependent_model() -> None:
@@ -178,27 +177,6 @@ def test_encode_image_for_task_uses_jpeg_for_caption() -> None:
     assert (width, height) == (200, 100)
 
 
-def test_execute_spacexai_request_rejects_rf_key_when_managed_key_disabled() -> None:
-    # Default flag state: managed keys are off and the proxy must never be
-    # contacted; the block demands a user-provided xAI key.
-    with pytest.raises(ValueError, match="Provide your own xAI API key"):
-        execute_spacexai_request(
-            roboflow_api_key="rf_abc",
-            xai_api_key="rf_key:account",
-            instructions=None,
-            input_content=[{"role": "user", "content": []}],
-            model_version="grok-4.6",
-            reasoning_effort=None,
-            max_tokens=None,
-            temperature=None,
-        )
-
-
-@patch(
-    "inference.core.workflows.core_steps.models.foundation.spacexai.v1."
-    "WORKFLOWS_SPACEXAI_MANAGED_KEY_ENABLED",
-    True,
-)
 @patch(
     "inference.core.workflows.core_steps.models.foundation.spacexai.v1."
     "_execute_proxied_spacexai_request"

--- a/tests/workflows/unit_tests/core_steps/models/foundation/test_spacexai_v2.py
+++ b/tests/workflows/unit_tests/core_steps/models/foundation/test_spacexai_v2.py
@@ -8,10 +8,8 @@ and direct execution paths.
 from unittest.mock import MagicMock, patch
 
 from inference.core.workflows.core_steps.models.foundation.spacexai.v2 import (
-    BlockManifest,
     _execute_direct_spacexai_request,
     _execute_proxied_spacexai_request,
-    execute_spacexai_request,
 )
 
 _XAI_OK = {
@@ -23,41 +21,6 @@ _XAI_OK = {
         }
     ],
 }
-
-
-def test_spacexai_v2_defaults_api_key_to_rf_key_account() -> None:
-    result = BlockManifest.model_validate(
-        {
-            "type": "roboflow_core/spacexai@v2",
-            "name": "step_1",
-            "images": "$inputs.image",
-            "task_type": "caption",
-        }
-    )
-
-    assert result.api_key == "rf_key:account"
-
-
-@patch(
-    "inference.core.workflows.core_steps.models.foundation.spacexai.v2."
-    "_execute_proxied_spacexai_request"
-)
-def test_execute_spacexai_request_routes_rf_key_to_proxy(
-    proxied_mock: MagicMock,
-) -> None:
-    proxied_mock.return_value = ("proxied", 16, 5)
-    result = execute_spacexai_request(
-        roboflow_api_key="rf_abc",
-        xai_api_key="rf_key:account",
-        instructions=None,
-        input_content=[{"role": "user", "content": []}],
-        model_version="grok-4.6",
-        reasoning_effort=None,
-        max_tokens=None,
-        temperature=None,
-    )
-    assert result == ("proxied", 16, 5)
-    proxied_mock.assert_called_once()
 
 
 @patch(

--- a/tests/workflows/unit_tests/core_steps/models/foundation/test_spacexai_v2.py
+++ b/tests/workflows/unit_tests/core_steps/models/foundation/test_spacexai_v2.py
@@ -8,8 +8,10 @@ and direct execution paths.
 from unittest.mock import MagicMock, patch
 
 from inference.core.workflows.core_steps.models.foundation.spacexai.v2 import (
+    BlockManifest,
     _execute_direct_spacexai_request,
     _execute_proxied_spacexai_request,
+    execute_spacexai_request,
 )
 
 _XAI_OK = {
@@ -21,6 +23,41 @@ _XAI_OK = {
         }
     ],
 }
+
+
+def test_spacexai_v2_defaults_api_key_to_rf_key_account() -> None:
+    result = BlockManifest.model_validate(
+        {
+            "type": "roboflow_core/spacexai@v2",
+            "name": "step_1",
+            "images": "$inputs.image",
+            "task_type": "caption",
+        }
+    )
+
+    assert result.api_key == "rf_key:account"
+
+
+@patch(
+    "inference.core.workflows.core_steps.models.foundation.spacexai.v2."
+    "_execute_proxied_spacexai_request"
+)
+def test_execute_spacexai_request_routes_rf_key_to_proxy(
+    proxied_mock: MagicMock,
+) -> None:
+    proxied_mock.return_value = ("proxied", 16, 5)
+    result = execute_spacexai_request(
+        roboflow_api_key="rf_abc",
+        xai_api_key="rf_key:account",
+        instructions=None,
+        input_content=[{"role": "user", "content": []}],
+        model_version="grok-4.6",
+        reasoning_effort=None,
+        max_tokens=None,
+        temperature=None,
+    )
+    assert result == ("proxied", 16, 5)
+    proxied_mock.assert_called_once()
 
 
 @patch(


### PR DESCRIPTION
## Summary

`apiproxy/xai` is deployed, so this **deletes** `WORKFLOWS_SPACEXAI_MANAGED_KEY_ENABLED`. SpaceXAI now matches OpenAI/Gemini: omitted `api_key` defaults to `rf_key:account` and `rf_key:` always routes to the proxy.

A leftover `WORKFLOWS_SPACEXAI_MANAGED_KEY_ENABLED` env var is ignored. Workflows that already set a user xAI key still take the direct path. `rf_key:user:` is still rejected at the proxy and is not advertised.

No new block version. Cherry-picked onto `fast-track/post-v1.5.0-pt3` (which already includes #2860) so this PR is managed-key only.

## Test plan

- [x] `test_spacexai.py` + `test_spacexai_v2.py` (17 passed). One new pin: omitted `api_key` defaults to `rf_key:account`.
- [x] Earlier live Grok 4.6 caption (`reasoning_effort=low`, `dogs.jpg`): proxied `rf_key:account` and direct user key both returned usage + text
- [ ] UI: new SpaceXAI step can run without pasting an xAI key


Made with [Cursor](https://cursor.com)