### PR TITLE
Fix: batch/list-shaped data across the Modal remote-execution boundary

### DIFF
--- a/inference/core/workflows/execution_engine/v1/core.py
+++ b/inference/core/workflows/execution_engine/v1/core.py
@@ -49,7 +49,7 @@ from inference.core.workflows.prototypes.block import (
     is_workflow_selector,
 )
 
-EXECUTION_ENGINE_V1_VERSION = Version("1.15.0")
+EXECUTION_ENGINE_V1_VERSION = Version("1.15.1")
 
 DEFAULT_WORKFLOWS_STEP_ERROR_HANDLER = os.getenv(
     "DEFAULT_WORKFLOWS_STEP_ERROR_HANDLER", "extended_roboflow_errors"

--- a/inference/core/workflows/execution_engine/v1/dynamic_blocks/modal_executor.py
+++ b/inference/core/workflows/execution_engine/v1/dynamic_blocks/modal_executor.py
@@ -281,6 +281,7 @@ def serialize_for_modal_remote_execution(inputs: Dict[str, Any]) -> str:
             serialize_video_metadata_kind,
         )
         from inference.core.workflows.execution_engine.entities.base import (
+            Batch,
             VideoMetadata,
             WorkflowImageData,
         )
@@ -288,6 +289,18 @@ def serialize_for_modal_remote_execution(inputs: Dict[str, Any]) -> str:
         if isinstance(value, sv.Detections):
             serialized = serialise_sv_detections(detections=value)
             serialized["_type"] = "sv_detections"
+        elif isinstance(value, Batch):
+            # Batch is not a list/dict subclass, so without an explicit case it
+            # falls through to the generic encoder, which stringifies it via
+            # `str(obj)` and destroys the payload. Batch-oriented dynamic blocks
+            # then receive the repr instead of their data.
+            serialized = {
+                "_type": "batch",
+                "value": [patch_for_modal_serialization(item) for item in value],
+                "indices": (
+                    [list(index) for index in value.indices] if value.indices else None
+                ),
+            }
         elif isinstance(value, WorkflowImageData):
             serialized = _serialise_image_for_webexec(value)
             serialized["_type"] = "workflow_image"
@@ -747,6 +760,7 @@ def serialize_inputs_for_msgpack(inputs: Dict[str, Any]) -> Dict[str, Any]:
         serialize_video_metadata_kind,
     )
     from inference.core.workflows.execution_engine.entities.base import (
+        Batch,
         VideoMetadata,
         WorkflowImageData,
     )
@@ -756,6 +770,16 @@ def serialize_inputs_for_msgpack(inputs: Dict[str, Any]) -> Dict[str, Any]:
             d = serialise_sv_detections(detections=value)
             d["_type"] = "sv_detections"
             return {k: _pack(v) for k, v in d.items()}
+        if isinstance(value, Batch):
+            # Mirrors the JSON transport: Batch is neither list nor dict, so it
+            # needs an explicit case or its contents never reach the block.
+            return {
+                "_type": "batch",
+                "value": [_pack(item) for item in value],
+                "indices": (
+                    [list(index) for index in value.indices] if value.indices else None
+                ),
+            }
         if isinstance(value, WorkflowImageData):
             d = _serialize_image_for_msgpack(value)
             return {k: _pack(v) for k, v in d.items()}

--- a/inference/core/workflows/execution_engine/v1/dynamic_blocks/modal_executor.py
+++ b/inference/core/workflows/execution_engine/v1/dynamic_blocks/modal_executor.py
@@ -298,7 +298,9 @@ def serialize_for_modal_remote_execution(inputs: Dict[str, Any]) -> str:
                 "_type": "batch",
                 "value": [patch_for_modal_serialization(item) for item in value],
                 "indices": (
-                    [list(index) for index in value.indices] if value.indices else None
+                    [list(index) for index in value.indices]
+                    if value.indices is not None
+                    else None
                 ),
             }
         elif isinstance(value, WorkflowImageData):
@@ -777,7 +779,9 @@ def serialize_inputs_for_msgpack(inputs: Dict[str, Any]) -> Dict[str, Any]:
                 "_type": "batch",
                 "value": [_pack(item) for item in value],
                 "indices": (
-                    [list(index) for index in value.indices] if value.indices else None
+                    [list(index) for index in value.indices]
+                    if value.indices is not None
+                    else None
                 ),
             }
         if isinstance(value, WorkflowImageData):

--- a/modal/modal_app.py
+++ b/modal/modal_app.py
@@ -468,9 +468,22 @@ from datetime import datetime
 
                     return serialized
 
-                serialized_inputs = {}
-                for key, value in inputs.items():
-                    serialized_inputs[key] = patch_for_modal_serialization(value)
+                # This also serialises the block's RETURN value (see the
+                # `serialize_for_modal_remote_execution(result)` call below), and a
+                # BlockResult is a list whenever the block increases output
+                # dimensionality (offset-1) or declares batch_oriented_parameters —
+                # one entry per element. The dict-only path raised
+                # `AttributeError: 'list' object has no attribute 'items'`, which
+                # made both kinds of block unusable over the HTTP transport. The
+                # websocket path already handled lists (_serialize_msgpack_result).
+                if isinstance(inputs, list):
+                    serialized_inputs = [
+                        patch_for_modal_serialization(item) for item in inputs
+                    ]
+                else:
+                    serialized_inputs = {}
+                    for key, value in inputs.items():
+                        serialized_inputs[key] = patch_for_modal_serialization(value)
 
                 # Convert to JSON string
                 return json.dumps(serialized_inputs, cls=InputJSONEncoder)

--- a/modal/modal_app.py
+++ b/modal/modal_app.py
@@ -395,6 +395,7 @@ from datetime import datetime
                 deserialize_image_kind,
                 deserialize_video_metadata_kind,
             )
+            from inference.core.workflows.execution_engine.entities.base import Batch
             from inference.core.workflows.prototypes.block import BlockResult
 
             def serialize_for_modal_remote_execution(inputs: Dict[str, Any]) -> str:
@@ -489,6 +490,19 @@ from datetime import datetime
                             elif obj["_type"] == "ndarray":
                                 arr = np.array(obj["value"], dtype=obj["dtype"])
                                 return arr.reshape(obj["shape"])
+                            elif obj["_type"] == "batch":
+                                # Must precede the "object" case: without it a
+                                # Batch arrives stringified and blocks declaring
+                                # batch_oriented_parameters get a repr, not data.
+                                indices = obj.get("indices")
+                                return Batch(
+                                    content=[decode_inputs(v) for v in obj["value"]],
+                                    indices=(
+                                        [tuple(i) for i in indices]
+                                        if indices
+                                        else None
+                                    ),
+                                )
                             elif obj["_type"] == "object":
                                 return obj["value"]
                             elif obj["_type"] == "sv_detections":
@@ -716,6 +730,7 @@ from datetime import datetime
             deserialize_image_kind,
             deserialize_video_metadata_kind,
         )
+        from inference.core.workflows.execution_engine.entities.base import Batch
 
         def _decode(obj):
             if isinstance(obj, dict):
@@ -790,6 +805,12 @@ from datetime import datetime
                 if _type == "ndarray":
                     return np.array(obj["value"], dtype=obj["dtype"]).reshape(
                         obj["shape"]
+                    )
+                if _type == "batch":
+                    indices = obj.get("indices")
+                    return Batch(
+                        content=[_decode(v) for v in obj["value"]],
+                        indices=[tuple(i) for i in indices] if indices else None,
                     )
                 if _type == "bytes":
                     return (

--- a/modal/modal_app.py
+++ b/modal/modal_app.py
@@ -504,15 +504,15 @@ from datetime import datetime
                                 arr = np.array(obj["value"], dtype=obj["dtype"])
                                 return arr.reshape(obj["shape"])
                             elif obj["_type"] == "batch":
-                                # Must precede the "object" case: without it a
-                                # Batch arrives stringified and blocks declaring
-                                # batch_oriented_parameters get a repr, not data.
+                                # Without this arm a Batch arrives stringified
+                                # and blocks declaring batch_oriented_parameters
+                                # get a repr instead of their data.
                                 indices = obj.get("indices")
                                 return Batch(
                                     content=[decode_inputs(v) for v in obj["value"]],
                                     indices=(
                                         [tuple(i) for i in indices]
-                                        if indices
+                                        if indices is not None
                                         else None
                                     ),
                                 )
@@ -823,7 +823,11 @@ from datetime import datetime
                     indices = obj.get("indices")
                     return Batch(
                         content=[_decode(v) for v in obj["value"]],
-                        indices=[tuple(i) for i in indices] if indices else None,
+                        indices=(
+                            [tuple(i) for i in indices]
+                            if indices is not None
+                            else None
+                        ),
                     )
                 if _type == "bytes":
                     return (

--- a/tests/inference/hosted_platform_tests/test_workflows.py
+++ b/tests/inference/hosted_platform_tests/test_workflows.py
@@ -139,7 +139,7 @@ def test_get_versions_of_execution_engine(
     # then
     response.raise_for_status()
     response_data = response.json()
-    assert response_data["versions"] == ["1.15.0"]
+    assert response_data["versions"] == ["1.15.1"]
 
 
 FUNCTION = """

--- a/tests/inference/integration_tests/test_workflow_endpoints.py
+++ b/tests/inference/integration_tests/test_workflow_endpoints.py
@@ -703,7 +703,7 @@ def test_get_versions_of_execution_engine(server_url: str) -> None:
     # then
     response.raise_for_status()
     response_data = response.json()
-    assert response_data["versions"] == ["1.15.0"]
+    assert response_data["versions"] == ["1.15.1"]
 
 
 def test_getting_block_schema_using_get_endpoint(server_url) -> None:

--- a/tests/workflows/unit_tests/execution_engine/dynamic_blocs/conftest.py
+++ b/tests/workflows/unit_tests/execution_engine/dynamic_blocs/conftest.py
@@ -1,0 +1,67 @@
+"""Shared scaffolding for tests that load ``modal/modal_app.py`` directly.
+
+``modal_app`` imports the real ``modal`` package at module scope and decorates
+``Executor`` with ``@app.cls`` / ``@modal.concurrent`` / ``@modal.fastapi_endpoint``.
+Stubbing those out lets the sandbox-side code be imported and driven in-process,
+so tests can exercise the shipped path instead of reimplementing it.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+class FakeModalImage:
+    @classmethod
+    def debian_slim(cls, *args, **kwargs):
+        return cls()
+
+    @classmethod
+    def from_registry(cls, *args, **kwargs):
+        return cls()
+
+    def apt_install(self, *args, **kwargs):
+        return self
+
+    def pip_install(self, *args, **kwargs):
+        return self
+
+    def entrypoint(self, *args, **kwargs):
+        return self
+
+
+class FakeModalApp:
+    def __init__(self, name: str):
+        self.name = name
+
+    def cls(self, *args, **kwargs):
+        return lambda cls: cls
+
+
+def identity_decorator(*args, **kwargs):
+    return lambda obj: obj
+
+
+@pytest.fixture()
+def modal_app_with_fake_modal(monkeypatch):
+    """Import ``modal/modal_app.py`` with a stubbed ``modal`` package."""
+    fake_modal = ModuleType("modal")
+    fake_modal.App = FakeModalApp
+    fake_modal.Image = FakeModalImage
+    fake_modal.parameter = lambda *args, **kwargs: None
+    fake_modal.enter = identity_decorator
+    fake_modal.fastapi_endpoint = identity_decorator
+    fake_modal.asgi_app = identity_decorator
+    fake_modal.concurrent = identity_decorator
+    monkeypatch.setitem(sys.modules, "modal", fake_modal)
+
+    modal_app_path = Path(__file__).resolve().parents[5] / "modal" / "modal_app.py"
+    spec = importlib.util.spec_from_file_location(
+        "modal_app_under_test", modal_app_path
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module

--- a/tests/workflows/unit_tests/execution_engine/dynamic_blocs/test_modal_app_result_serialization.py
+++ b/tests/workflows/unit_tests/execution_engine/dynamic_blocs/test_modal_app_result_serialization.py
@@ -1,76 +1,35 @@
-"""Result-serialisation contract for the Modal sandbox's HTTP endpoint.
+"""Wire contract between the client and the Modal sandbox for batch-shaped data.
 
-A ``BlockResult`` is a LIST whenever the block increases output dimensionality
-(offset-1) or declares ``batch_oriented_parameters`` — one entry per element.
-The sandbox used to hand that straight to a dict-only serialiser, so those
-blocks failed on the return trip with
-``AttributeError: 'list' object has no attribute 'items'``.
+Two halves, both previously broken:
 
-These drive the real ``Executor.execute_block`` end to end (user code is
-compiled and run in-process) so the assertion covers the shipped path rather
-than a reimplementation of it.
+* **Inputs.** A block declaring ``batch_oriented_parameters`` receives a ``Batch``.
+  ``Batch`` subclasses neither ``list`` nor ``dict``, so it used to fall through to
+  the generic encoder and arrive as ``str(obj)`` — the block saw a repr, not data.
+* **Results.** A ``BlockResult`` is a LIST whenever the block increases output
+  dimensionality (offset-1) or is batch-oriented. The sandbox handed that to a
+  dict-only serialiser, so those blocks failed on the return trip with
+  ``AttributeError: 'list' object has no attribute 'items'``.
+
+These drive the real ``Executor.execute_block`` end to end — user code is compiled
+and run in-process — so they cover the shipped path, including the nested closures
+that are otherwise unreachable. ``modal_app_with_fake_modal`` lives in conftest.
 """
 
 import asyncio
-import importlib.util
 import json
-import sys
-from pathlib import Path
-from types import ModuleType
 
-import pytest
+import msgpack
+import numpy as np
 
-
-class _FakeModalImage:
-    @classmethod
-    def debian_slim(cls, *args, **kwargs):
-        return cls()
-
-    @classmethod
-    def from_registry(cls, *args, **kwargs):
-        return cls()
-
-    def apt_install(self, *args, **kwargs):
-        return self
-
-    def pip_install(self, *args, **kwargs):
-        return self
-
-    def entrypoint(self, *args, **kwargs):
-        return self
-
-
-class _FakeModalApp:
-    def __init__(self, name: str):
-        self.name = name
-
-    def cls(self, *args, **kwargs):
-        return lambda cls: cls
-
-
-def _identity_decorator(*args, **kwargs):
-    return lambda obj: obj
-
-
-@pytest.fixture()
-def modal_app_with_fake_modal(monkeypatch):
-    fake_modal = ModuleType("modal")
-    fake_modal.App = _FakeModalApp
-    fake_modal.Image = _FakeModalImage
-    fake_modal.parameter = lambda *args, **kwargs: None
-    fake_modal.enter = _identity_decorator
-    fake_modal.fastapi_endpoint = _identity_decorator
-    fake_modal.asgi_app = _identity_decorator
-    fake_modal.concurrent = _identity_decorator
-    monkeypatch.setitem(sys.modules, "modal", fake_modal)
-
-    modal_app_path = Path(__file__).resolve().parents[5] / "modal" / "modal_app.py"
-    spec = importlib.util.spec_from_file_location(
-        "modal_app_result_serialization_test", modal_app_path
-    )
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
+from inference.core.workflows.execution_engine.entities.base import (
+    Batch,
+    ImageParentMetadata,
+    WorkflowImageData,
+)
+from inference.core.workflows.execution_engine.v1.dynamic_blocks.modal_executor import (
+    serialize_for_modal_remote_execution,
+    serialize_inputs_for_msgpack,
+)
 
 
 class _FakeRequest:
@@ -84,7 +43,7 @@ class _FakeRequest:
         return self._body
 
 
-def _run_block(module, code: str) -> dict:
+def _run_block(module, code: str, inputs_json: str = "{}") -> dict:
     executor = module.Executor.__new__(module.Executor)
     executor._code_namespaces = {}
     executor._shared_globals = {}
@@ -93,10 +52,121 @@ def _run_block(module, code: str) -> dict:
             "code_str": code,
             "imports": [],
             "run_function_name": "run",
-            "inputs_json": "{}",
+            "inputs_json": inputs_json,
         }
     )
     return asyncio.run(executor.execute_block(request))
+
+
+def _image(seed: int) -> WorkflowImageData:
+    return WorkflowImageData(
+        parent_metadata=ImageParentMetadata(parent_id=f"crop_{seed}"),
+        numpy_image=np.full((4, 4, 3), seed, dtype=np.uint8),
+    )
+
+
+# --------------------------------------------------------------------------- #
+# inputs: a Batch must arrive at user code as a Batch
+# --------------------------------------------------------------------------- #
+
+
+def test_batch_of_images_arrives_in_user_code_as_a_batch(
+    modal_app_with_fake_modal,
+) -> None:
+    """The assertion this fix exists for: the block sees a real ``Batch``."""
+    batch = Batch(content=[_image(1), _image(2)], indices=[(0,), (1,)])
+    inputs_json = serialize_for_modal_remote_execution({"image": batch})
+
+    response = _run_block(
+        modal_app_with_fake_modal,
+        "def run(image):\n"
+        "    return {\n"
+        "        'kind': type(image).__name__,\n"
+        "        'n': len(image),\n"
+        "        'idx': [list(i) for i in image.indices],\n"
+        "        'shapes': [i.numpy_image.shape for i in image],\n"
+        "    }",
+        inputs_json=inputs_json,
+    )
+
+    assert response["success"] is True, response.get("error")
+    result = json.loads(response["result"])
+    assert result["kind"] == "Batch"
+    assert result["n"] == 2
+    assert result["idx"] == [[0], [1]]
+    assert result["shapes"] == [[4, 4, 3], [4, 4, 3]]
+
+
+def test_batch_of_scalars_arrives_in_user_code_as_a_batch(
+    modal_app_with_fake_modal,
+) -> None:
+    """Non-image batch parameters regressed identically (e.g. per-crop fractions)."""
+    batch = Batch(content=[0.357, 0.642], indices=[(0,), (1,)])
+    inputs_json = serialize_for_modal_remote_execution({"box_top_frac": batch})
+
+    response = _run_block(
+        modal_app_with_fake_modal,
+        "def run(box_top_frac):\n"
+        "    return {\n"
+        "        'kind': type(box_top_frac).__name__,\n"
+        "        'values': list(box_top_frac),\n"
+        "    }",
+        inputs_json=inputs_json,
+    )
+
+    assert response["success"] is True, response.get("error")
+    result = json.loads(response["result"])
+    assert result["kind"] == "Batch"
+    assert result["values"] == [0.357, 0.642]
+
+
+def _through_msgpack(payload: dict) -> dict:
+    """Pack and unpack for real.
+
+    Without this the serialiser's output is handed straight back to the decoder
+    in-process, so an unserialised ``Batch`` would survive by object identity and
+    the test would pass even with the packing arm removed. Going through bytes
+    forces the wire format to actually carry the data.
+    """
+    return msgpack.unpackb(msgpack.packb(payload, use_bin_type=True), raw=False)
+
+
+def test_msgpack_input_round_trip_rebuilds_a_batch(
+    modal_app_with_fake_modal,
+) -> None:
+    """The websocket arm: silently reintroduces the bug if left unfixed."""
+    batch = Batch(content=[_image(3), _image(4)], indices=[(0,), (1,)])
+
+    wire = _through_msgpack(serialize_inputs_for_msgpack({"image": batch}))
+    decoded = modal_app_with_fake_modal.Executor._deserialize_msgpack_inputs(wire)
+
+    rebuilt = decoded["image"]
+    assert isinstance(rebuilt, Batch)
+    assert len(rebuilt) == 2
+    # DynamicBatchIndex is `tuple`; Batch.remove_by_indices matches against a
+    # Set[tuple], so lists here would silently never match.
+    assert rebuilt.indices == [(0,), (1,)]
+    assert all(isinstance(index, tuple) for index in rebuilt.indices)
+    assert [i.numpy_image.shape for i in rebuilt] == [(4, 4, 3), (4, 4, 3)]
+
+
+def test_batch_round_trip_preserves_empty_indices(
+    modal_app_with_fake_modal,
+) -> None:
+    """An empty `indices` list must not collapse to None."""
+    wire = _through_msgpack(
+        serialize_inputs_for_msgpack({"image": Batch(content=[], indices=[])})
+    )
+    decoded = modal_app_with_fake_modal.Executor._deserialize_msgpack_inputs(wire)
+
+    rebuilt = decoded["image"]
+    assert isinstance(rebuilt, Batch)
+    assert rebuilt.indices == []
+
+
+# --------------------------------------------------------------------------- #
+# results: list-shaped BlockResults must serialise
+# --------------------------------------------------------------------------- #
 
 
 def test_execute_block_serialises_list_shaped_result(

--- a/tests/workflows/unit_tests/execution_engine/dynamic_blocs/test_modal_app_result_serialization.py
+++ b/tests/workflows/unit_tests/execution_engine/dynamic_blocs/test_modal_app_result_serialization.py
@@ -1,0 +1,141 @@
+"""Result-serialisation contract for the Modal sandbox's HTTP endpoint.
+
+A ``BlockResult`` is a LIST whenever the block increases output dimensionality
+(offset-1) or declares ``batch_oriented_parameters`` — one entry per element.
+The sandbox used to hand that straight to a dict-only serialiser, so those
+blocks failed on the return trip with
+``AttributeError: 'list' object has no attribute 'items'``.
+
+These drive the real ``Executor.execute_block`` end to end (user code is
+compiled and run in-process) so the assertion covers the shipped path rather
+than a reimplementation of it.
+"""
+
+import asyncio
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+class _FakeModalImage:
+    @classmethod
+    def debian_slim(cls, *args, **kwargs):
+        return cls()
+
+    @classmethod
+    def from_registry(cls, *args, **kwargs):
+        return cls()
+
+    def apt_install(self, *args, **kwargs):
+        return self
+
+    def pip_install(self, *args, **kwargs):
+        return self
+
+    def entrypoint(self, *args, **kwargs):
+        return self
+
+
+class _FakeModalApp:
+    def __init__(self, name: str):
+        self.name = name
+
+    def cls(self, *args, **kwargs):
+        return lambda cls: cls
+
+
+def _identity_decorator(*args, **kwargs):
+    return lambda obj: obj
+
+
+@pytest.fixture()
+def modal_app_with_fake_modal(monkeypatch):
+    fake_modal = ModuleType("modal")
+    fake_modal.App = _FakeModalApp
+    fake_modal.Image = _FakeModalImage
+    fake_modal.parameter = lambda *args, **kwargs: None
+    fake_modal.enter = _identity_decorator
+    fake_modal.fastapi_endpoint = _identity_decorator
+    fake_modal.asgi_app = _identity_decorator
+    fake_modal.concurrent = _identity_decorator
+    monkeypatch.setitem(sys.modules, "modal", fake_modal)
+
+    modal_app_path = Path(__file__).resolve().parents[5] / "modal" / "modal_app.py"
+    spec = importlib.util.spec_from_file_location(
+        "modal_app_result_serialization_test", modal_app_path
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _FakeRequest:
+    """Minimal stand-in for starlette's Request: body() + headers.get()."""
+
+    def __init__(self, payload: dict):
+        self._body = json.dumps(payload).encode()
+        self.headers = {}
+
+    async def body(self) -> bytes:
+        return self._body
+
+
+def _run_block(module, code: str) -> dict:
+    executor = module.Executor.__new__(module.Executor)
+    executor._code_namespaces = {}
+    executor._shared_globals = {}
+    request = _FakeRequest(
+        {
+            "code_str": code,
+            "imports": [],
+            "run_function_name": "run",
+            "inputs_json": "{}",
+        }
+    )
+    return asyncio.run(executor.execute_block(request))
+
+
+def test_execute_block_serialises_list_shaped_result(
+    modal_app_with_fake_modal,
+) -> None:
+    """offset-1 / batch-oriented blocks return one entry per element."""
+    response = _run_block(
+        modal_app_with_fake_modal,
+        "def run():\n"
+        "    return [{'measurement': {'w': 1}}, {'measurement': {'w': 2}}]",
+    )
+
+    assert response["success"] is True, response.get("error")
+    assert json.loads(response["result"]) == [
+        {"measurement": {"w": 1}},
+        {"measurement": {"w": 2}},
+    ]
+
+
+def test_execute_block_list_result_survives_nested_values(
+    modal_app_with_fake_modal,
+) -> None:
+    response = _run_block(
+        modal_app_with_fake_modal,
+        "def run():\n    return [{'v': [1, 2]}, {'v': []}]",
+    )
+
+    assert response["success"] is True, response.get("error")
+    assert json.loads(response["result"]) == [{"v": [1, 2]}, {"v": []}]
+
+
+def test_execute_block_dict_shaped_result_is_unchanged(
+    modal_app_with_fake_modal,
+) -> None:
+    """The ordinary (offset-0) contract must keep byte-identical behaviour."""
+    response = _run_block(
+        modal_app_with_fake_modal,
+        "def run():\n    return {'measurement': {'w': 1}}",
+    )
+
+    assert response["success"] is True, response.get("error")
+    assert json.loads(response["result"]) == {"measurement": {"w": 1}}

--- a/tests/workflows/unit_tests/execution_engine/dynamic_blocs/test_modal_code_hash.py
+++ b/tests/workflows/unit_tests/execution_engine/dynamic_blocs/test_modal_code_hash.py
@@ -1,8 +1,4 @@
-import importlib.util
-import sys
 from datetime import datetime
-from pathlib import Path
-from types import ModuleType
 
 import numpy as np
 import pytest
@@ -27,58 +23,6 @@ from inference.core.workflows.execution_engine.v1.dynamic_blocks.modal_executor 
     serialize_for_modal_remote_execution,
     serialize_inputs_for_msgpack,
 )
-
-
-class _FakeModalImage:
-    @classmethod
-    def debian_slim(cls, *args, **kwargs):
-        return cls()
-
-    @classmethod
-    def from_registry(cls, *args, **kwargs):
-        return cls()
-
-    def apt_install(self, *args, **kwargs):
-        return self
-
-    def pip_install(self, *args, **kwargs):
-        return self
-
-    def entrypoint(self, *args, **kwargs):
-        return self
-
-
-class _FakeModalApp:
-    def __init__(self, name: str):
-        self.name = name
-
-    def cls(self, *args, **kwargs):
-        return lambda cls: cls
-
-
-def _identity_decorator(*args, **kwargs):
-    return lambda obj: obj
-
-
-@pytest.fixture()
-def modal_app_with_fake_modal(monkeypatch):
-    fake_modal = ModuleType("modal")
-    fake_modal.App = _FakeModalApp
-    fake_modal.Image = _FakeModalImage
-    fake_modal.parameter = lambda *args, **kwargs: None
-    fake_modal.enter = _identity_decorator
-    fake_modal.fastapi_endpoint = _identity_decorator
-    fake_modal.asgi_app = _identity_decorator
-    fake_modal.concurrent = _identity_decorator
-    monkeypatch.setitem(sys.modules, "modal", fake_modal)
-
-    modal_app_path = Path(__file__).resolve().parents[5] / "modal" / "modal_app.py"
-    spec = importlib.util.spec_from_file_location(
-        "modal_app_code_hash_parity_test", modal_app_path
-    )
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
 
 
 @pytest.mark.parametrize(

--- a/tests/workflows/unit_tests/execution_engine/dynamic_blocs/test_modal_executor.py
+++ b/tests/workflows/unit_tests/execution_engine/dynamic_blocs/test_modal_executor.py
@@ -11,6 +11,11 @@ import pytest
 import supervision as sv
 import torch
 
+from inference.core.workflows.execution_engine.entities.base import (
+    Batch,
+    ImageParentMetadata,
+    WorkflowImageData,
+)
 from inference.core.workflows.execution_engine.v1.dynamic_blocks import (
     representation_boundary,
 )
@@ -146,3 +151,56 @@ def test_modal_serializer_sv_detections_ride_dedicated_arm_when_flag_on() -> Non
     # then
     assert payload["predictions"]["_type"] == "sv_detections"
     assert payload["predictions"]["predictions"][0]["class"] == "widget"
+
+
+def _workflow_image(seed: int) -> WorkflowImageData:
+    return WorkflowImageData(
+        parent_metadata=ImageParentMetadata(parent_id=f"crop_{seed}"),
+        numpy_image=np.full((8, 8, 3), seed, dtype=np.uint8),
+    )
+
+
+def test_modal_serializer_preserves_batch_of_images() -> None:
+    """Batch must ride a dedicated arm.
+
+    ``Batch`` subclasses neither ``list`` nor ``dict``, so without an explicit
+    case it reaches the generic encoder, which stringifies it via ``str(obj)``.
+    Blocks declaring ``batch_oriented_parameters`` then receive the repr instead
+    of their crops.
+    """
+    batch = Batch(
+        content=[_workflow_image(1), _workflow_image(2)], indices=[(0,), (1,)]
+    )
+
+    payload = json.loads(serialize_for_modal_remote_execution(inputs={"image": batch}))
+
+    entry = payload["image"]
+    assert entry["_type"] == "batch"
+    assert entry["indices"] == [[0], [1]]
+    assert len(entry["value"]) == 2
+    for item in entry["value"]:
+        assert item["_type"] == "workflow_image"
+        assert item["value"], "image payload must survive, not be stringified"
+    assert "Batch object at" not in json.dumps(payload)
+
+
+def test_modal_serializer_preserves_batch_of_scalars() -> None:
+    """Non-image batch parameters regress the same way (e.g. per-crop floats)."""
+    batch = Batch(content=[0.357, 0.642], indices=[(0,), (1,)])
+
+    payload = json.loads(serialize_for_modal_remote_execution(inputs={"frac": batch}))
+
+    assert payload["frac"] == {
+        "_type": "batch",
+        "value": [0.357, 0.642],
+        "indices": [[0], [1]],
+    }
+
+
+def test_modal_serializer_handles_batch_without_indices() -> None:
+    batch = Batch(content=[1, 2, 3], indices=None)
+
+    payload = json.loads(serialize_for_modal_remote_execution(inputs={"v": batch}))
+
+    assert payload["v"]["value"] == [1, 2, 3]
+    assert payload["v"]["indices"] is None


### PR DESCRIPTION
## What does this PR do?

Fixes two defects that together make **batch-oriented custom Python blocks impossible to run on serverless**, and one of which independently breaks **every dimensionality-increasing (offset-1) block** on the HTTP transport.

### 1. `Batch` inputs are stringified on the way in

Dynamic blocks declaring `batch_oriented_parameters` (or `accepts_batch_input`) receive a `Batch` from the execution engine. `Batch` subclasses neither `list` nor `dict`, so `patch_for_modal_serialization` had no case for it. The object fell through to the generic JSON encoder, whose `hasattr(obj, "__dict__")` arm serialises it as `{"_type": "object", "value": str(obj)}`. The decoder's `"object"` case returns that string, so the block's `run()` receives:

```
'<inference.core.workflows.execution_engine.entities.base.Batch object at 0x7fa77a1c3990>'
```

usually surfacing as `AttributeError: 'str' object has no attribute 'numpy_image'`. The payload is destroyed at serialisation time, so no workaround inside the block is possible. Non-image batch parameters (e.g. per-crop floats) regress identically.

Observed on serverless with a block declaring `batch_oriented_parameters: ["image", "box_top_frac", "box_bottom_frac"]`. A diagnostic block reporting what it receives returned:

```
image_type=str repr='<...entities.base.Batch object at 0x7fa77a1c3990>'
tops_type=str  repr='<...entities.base.Batch object at 0x7fa77a1c3250>'
```

The same workflow runs correctly against a local inference container, where blocks execute in-process and no serialisation happens.

### 2. List-shaped results explode on the way out

`modal_app.py` passes the block's return value straight into `serialize_for_modal_remote_execution`, whose only path iterated `inputs.items()`. A `BlockResult` is a **list** whenever the block increases output dimensionality (offset-1) or declares `batch_oriented_parameters` — one entry per element — so those blocks died on the return trip with:

```
AttributeError: 'list' object has no attribute 'items'
```

This is the return-path twin of #1: together they made batch-oriented blocks unusable end to end. It **also independently breaks every offset-1 block** on the HTTP transport — reported in the wild in Aug 2026 against a dynamic-crop-style block emitting several crops per image, and reproducible on current `main`. That failure has nothing to do with batching, so it is worth fixing on its own merits.

## The fix

`Batch` gets a dedicated `_type: "batch"` arm on both transports, carrying serialised contents plus `indices`, and is reconstructed sandbox-side. The result serializer grows a list arm mirroring the websocket path.

| # | File | Function | Transport | Fixes |
|---|---|---|---|---|
| 1 | `modal_executor.py` | `patch_for_modal_serialization` | JSON/HTTP, client | Batch in |
| 2 | `modal_executor.py` | `serialize_inputs_for_msgpack` | websocket, client | Batch in |
| 3 | `modal_app.py` | `decode_inputs` | JSON/HTTP, sandbox | Batch in |
| 4 | `modal_app.py` | `_deserialize_msgpack_inputs` | websocket, sandbox | Batch in |
| 5 | `modal_app.py` | `serialize_for_modal_remote_execution` | JSON/HTTP, sandbox | list result out |

Points for reviewer attention:

- **Both halves are required (#1 + #3).** The serializer alone is not enough: without the decoder arm the block receives a raw `{"_type": "batch", ...}` dict instead of a `Batch` — differently broken. *(An earlier revision of this description claimed the `"batch"` case must precede `"object"`; that was wrong — they compare `obj["_type"]` against distinct literals, so order is irrelevant. Corrected in code and here.)*
- **The msgpack pair (#2, #4) is not defensive — it fixes a live failure.** Staging already runs the websocket transport, so bug #1 reproduces there *today*, just with a different signature. Verified with the reproducers below.
- **Only one arm needed for #5:** the websocket path was already correct (`_serialize_msgpack_result`'s `_encode` handles `(list, tuple)`) and the client decoder already recursed into top-level lists. Dict results keep byte-identical behaviour.
- **Import note:** `modal_app.py`'s existing `... import Batch, WorkflowImageData` sits inside the `full_imports` f-string, exec'd into the *user block's* namespace — it does **not** put `Batch` in scope for the file's own deserializers. Both now take a real local import alongside the deserializer helpers they already close over.

### Verified against both environments

Two minimal reproducers — **no model, no project, no dataset**; just an image URL, `image_slicer`, and a custom block. Run 2026-08-26:

| Reproducer | prod (`serverless.roboflow.com`) | staging (`serverless.roboflow.one`) |
|---|---|---|
| batch-oriented block (`batch_oriented_parameters`) | `AttributeError: 'str' object has no attribute 'numpy_image'` | `HTTP 500: can not serialize 'Batch' object` |
| offset-1 block returning a list | `AttributeError: 'list' object has no attribute 'items'` | **passes** |

The two environments run **different transports**, and the split matches the source exactly:

* **prod → HTTP/JSON.** `Batch` falls to the generic encoder and arrives as `str(obj)`; a list-shaped result hits the dict-only `inputs.items()` loop.
* **staging → websocket/msgpack.** `_pack` has no `Batch` arm, so the raw object reaches `msgpack.packb`, which refuses it outright. The list-result path is already correct there (`_serialize_msgpack_result._encode` handles `(list, tuple)`), which is why that one passes.

> [!WARNING]
> **This undermines the value of a staging-only integration test for the list-result bug.** `integration_tests_workflows_x86.yml` runs the Modal integration tests with `PROJECT=roboflow-staging`; since the list-result path already works on the websocket transport, such a test would pass green while prod stays broken. The unit tests in this PR cover both transports directly and do not have that blind spot.

**Related Issue(s):** none filed — both found while debugging a customer workflow.

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] I have tested this change locally
- [x] I have added/updated tests for this change

**Test details:**

`test_modal_executor.py` (bug #1) — batch of images (asserts the base64 payload survives and `"Batch object at"` never appears on the wire), batch of scalars, and `indices=None`.

`test_modal_app_result_serialization.py` (new file) — **inputs:** a `Batch` of images survives the full HTTP round trip and reaches user code *as a `Batch`* with tuple indices and intact pixels (the assertion this fix exists for); the same for a batch of scalars; the msgpack pair rebuilds a `Batch`; empty `indices` do not collapse to `None`. **Results:** list-shaped result, list result with nested values, and a dict-shaped result guarding the unchanged offset-0 contract.

The msgpack tests pack and unpack **for real** — handing the serialiser's output straight back to the decoder in-process let an unserialised `Batch` survive by object identity, so the first draft passed even with the packing arm removed. Mutation testing caught it. Rather than reimplementing the serialiser, these drive the real `Executor.execute_block` end to end: the module is loaded with a stubbed `modal` (same fixture shape as `test_modal_code_hash.py`), user code is compiled and run in-process, and assertions are made on the serialised response — so the nested closure that is otherwise unreachable *is* exercised.


## Additional Context

> [!IMPORTANT]
> **Merging this PR and cutting an `inference` release does not fix hosted serverless.** Three of the five fix sites live in `modal/modal_app.py`, which ships only via a manual `workflow_dispatch` of `.github/workflows/modal.custom_python_block.deploy.yml` (its `workflow_run` trigger is commented out). The webexec app has to be redeployed for either bug to be fixed in production, so the deploy needs sequencing alongside the release.
>
> There is no protocol negotiation on this wire. During the skew window a new client talking to an old sandbox delivers a raw `{"_type": "batch", ...}` dict to the block — still broken, but not a regression, since the pre-patch behaviour was a stringified repr.

**Execution Engine changelog:** companion PR **roboflow/docs#212** (https://github.com/roboflow/docs/pull/212) adds the two user-facing bullets under `## Unreleased` in `workflows/developer-guide/execution-engine-changelog.md`, as required by `.cursor/rules/execution-engine-version-changelog.mdc`. No version chosen or bumped — that is the maintainers' call at release. It should merge alongside or after this PR.

**Deferred:** the batch scenario for the credential-gated `test_workflow_with_custom_python_block_modal.py`. It cannot be executed without Modal credentials, and shipping a test that has never once run seemed worse than leaving the gap visible.



