### PR TITLE
Paint unmatched VLM detections gray in visualization blocks

### DIFF
--- a/inference/core/workflows/core_steps/formatters/vlm_as_detector/v2.py
+++ b/inference/core/workflows/core_steps/formatters/vlm_as_detector/v2.py
@@ -108,7 +108,7 @@ This block converts VLM/LLM text outputs containing object detection predictions
 6. Creates class name to class ID mapping:
    - For OpenAI/Gemini/Claude: uses provided classes list to create index mapping (class_name → class_id)
    - Classes are mapped in order (first class = ID 0, second = ID 1, etc.)
-   - Classes not in the provided list get class_id = -1
+   - Classes not in the provided list get class_id = -1. The model's original label is kept as class_name, and visualization blocks paint those detections in a neutral gray.
    - For Florence-2: uses different mapping strategies based on task type
 7. Constructs object detection predictions:
    - Creates supervision Detections objects with bounding boxes (xyxy format)
@@ -158,7 +158,7 @@ This version (v2) includes the following enhancements over v1:
 
 ## Requirements
 
-This block requires an image input (for metadata and dimensions) and a VLM output string containing JSON detection data. The JSON can be raw JSON or wrapped in Markdown code blocks (```json ... ```). The block supports seven model types: "openai", "google-gemini", "anthropic-claude", "spacexai", "qwen", "muse", and "florence-2". It supports multiple task types: "object-detection", "open-vocabulary-object-detection", "object-detection-and-caption", "phrase-grounded-object-detection", "region-proposal", and "ocr-with-text-detection". The `classes` parameter is required for OpenAI, Gemini, Claude, SpaceXAI, Qwen, and Muse models (to map class names to IDs) but optional for Florence-2 (some tasks don't require it). Classes are mapped to IDs by index (first class = 0, second = 1, etc.). Classes not in the list get class_id = -1. The block outputs object detection predictions in standard format (compatible with detection blocks), error_status (boolean), and inference_id (INFERENCE_ID_KIND) for tracking.
+This block requires an image input (for metadata and dimensions) and a VLM output string containing JSON detection data. The JSON can be raw JSON or wrapped in Markdown code blocks (```json ... ```). The block supports seven model types: "openai", "google-gemini", "anthropic-claude", "spacexai", "qwen", "muse", and "florence-2". It supports multiple task types: "object-detection", "open-vocabulary-object-detection", "object-detection-and-caption", "phrase-grounded-object-detection", "region-proposal", and "ocr-with-text-detection". The `classes` parameter is required for OpenAI, Gemini, Claude, SpaceXAI, Qwen, and Muse models (to map class names to IDs) but optional for Florence-2 (some tasks don't require it). Classes are mapped to IDs by index (first class = 0, second = 1, etc.). Classes not in the list get class_id = -1; the model's original label is kept as class_name and visualization blocks paint those detections in a neutral gray. The block outputs object detection predictions in standard format (compatible with detection blocks), error_status (boolean), and inference_id (INFERENCE_ID_KIND) for tracking.
 """
 
 SHORT_DESCRIPTION = "Parses raw string into object-detection prediction."
@@ -214,7 +214,7 @@ class BlockManifest(WorkflowBlockManifest):
             List[str],
         ]
     ] = Field(
-        description="List of all class names used by the classification model, in order. Required to generate mapping between class names (from VLM output) and class IDs (for detection format). Classes are mapped to IDs by index: first class = ID 0, second = ID 1, etc. Classes from VLM output that are not in this list get class_id = -1. Required for OpenAI, Gemini, and Claude models. Optional for Florence-2 (some tasks don't require it). Should match the classes the VLM was asked to detect.",
+        description="List of all class names used by the classification model, in order. Required to generate mapping between class names (from VLM output) and class IDs (for detection format). Classes are mapped to IDs by index: first class = ID 0, second = ID 1, etc. Classes from VLM output that are not in this list get class_id = -1; the model's original label is kept as class_name and visualization blocks paint those detections in a neutral gray. Required for OpenAI, Gemini, and Claude models. Optional for Florence-2 (some tasks don't require it). Should match the classes the VLM was asked to detect.",
         examples=[
             [
                 "$steps.lmm.classes",

--- a/inference/core/workflows/core_steps/formatters/vlm_as_detector/v2_tensor.py
+++ b/inference/core/workflows/core_steps/formatters/vlm_as_detector/v2_tensor.py
@@ -125,7 +125,7 @@ This block converts VLM/LLM text outputs containing object detection predictions
 6. Creates class name to class ID mapping:
    - For OpenAI/Gemini/Claude: uses provided classes list to create index mapping (class_name → class_id)
    - Classes are mapped in order (first class = ID 0, second = ID 1, etc.)
-   - Classes not in the provided list get class_id = -1
+   - Classes not in the provided list get class_id = -1. The model's original label is kept as class_name, and visualization blocks paint those detections in a neutral gray.
    - For Florence-2: uses different mapping strategies based on task type
 7. Constructs object detection predictions:
    - Creates supervision Detections objects with bounding boxes (xyxy format)
@@ -175,7 +175,7 @@ This version (v2) includes the following enhancements over v1:
 
 ## Requirements
 
-This block requires an image input (for metadata and dimensions) and a VLM output string containing JSON detection data. The JSON can be raw JSON or wrapped in Markdown code blocks (```json ... ```). The block supports seven model types: "openai", "google-gemini", "anthropic-claude", "spacexai", "qwen", "muse", and "florence-2". It supports multiple task types: "object-detection", "open-vocabulary-object-detection", "object-detection-and-caption", "phrase-grounded-object-detection", "region-proposal", and "ocr-with-text-detection". The `classes` parameter is required for OpenAI, Gemini, Claude, SpaceXAI, Qwen, and Muse models (to map class names to IDs) but optional for Florence-2 (some tasks don't require it). Classes are mapped to IDs by index (first class = 0, second = 1, etc.). Classes not in the list get class_id = -1. The block outputs object detection predictions in standard format (compatible with detection blocks), error_status (boolean), and inference_id (INFERENCE_ID_KIND) for tracking.
+This block requires an image input (for metadata and dimensions) and a VLM output string containing JSON detection data. The JSON can be raw JSON or wrapped in Markdown code blocks (```json ... ```). The block supports seven model types: "openai", "google-gemini", "anthropic-claude", "spacexai", "qwen", "muse", and "florence-2". It supports multiple task types: "object-detection", "open-vocabulary-object-detection", "object-detection-and-caption", "phrase-grounded-object-detection", "region-proposal", and "ocr-with-text-detection". The `classes` parameter is required for OpenAI, Gemini, Claude, SpaceXAI, Qwen, and Muse models (to map class names to IDs) but optional for Florence-2 (some tasks don't require it). Classes are mapped to IDs by index (first class = 0, second = 1, etc.). Classes not in the list get class_id = -1; the model's original label is kept as class_name and visualization blocks paint those detections in a neutral gray. The block outputs object detection predictions in standard format (compatible with detection blocks), error_status (boolean), and inference_id (INFERENCE_ID_KIND) for tracking.
 """
 
 SHORT_DESCRIPTION = "Parses raw string into object-detection prediction."
@@ -231,7 +231,7 @@ class BlockManifest(WorkflowBlockManifest):
             List[str],
         ]
     ] = Field(
-        description="List of all class names used by the classification model, in order. Required to generate mapping between class names (from VLM output) and class IDs (for detection format). Classes are mapped to IDs by index: first class = ID 0, second = ID 1, etc. Classes from VLM output that are not in this list get class_id = -1. Required for OpenAI, Gemini, and Claude models. Optional for Florence-2 (some tasks don't require it). Should match the classes the VLM was asked to detect.",
+        description="List of all class names used by the classification model, in order. Required to generate mapping between class names (from VLM output) and class IDs (for detection format). Classes are mapped to IDs by index: first class = ID 0, second = ID 1, etc. Classes from VLM output that are not in this list get class_id = -1; the model's original label is kept as class_name and visualization blocks paint those detections in a neutral gray. Required for OpenAI, Gemini, and Claude models. Optional for Florence-2 (some tasks don't require it). Should match the classes the VLM was asked to detect.",
         examples=[
             [
                 "$steps.lmm.classes",

--- a/inference/core/workflows/core_steps/visualizations/common/base_colorable.py
+++ b/inference/core/workflows/core_steps/visualizations/common/base_colorable.py
@@ -8,7 +8,10 @@ from inference.core.workflows.core_steps.visualizations.common.base import (
     PredictionsVisualizationBlock,
     PredictionsVisualizationManifest,
 )
-from inference.core.workflows.core_steps.visualizations.common.utils import str_to_color
+from inference.core.workflows.core_steps.visualizations.common.utils import (
+    str_to_color,
+    wrap_color_palette,
+)
 from inference.core.workflows.execution_engine.entities.base import WorkflowImageData
 from inference.core.workflows.execution_engine.entities.types import (
     INTEGER_KIND,
@@ -17,15 +20,6 @@ from inference.core.workflows.execution_engine.entities.types import (
     Selector,
 )
 from inference.core.workflows.prototypes.block import BlockResult
-
-
-class _WrappingColorPalette(sv.ColorPalette):
-    """Apply palette modulo arithmetic to positive and negative indices."""
-
-    def by_idx(self, idx: int) -> sv.Color:
-        if not self.colors:
-            raise ValueError("A color palette must contain at least one color.")
-        return self.colors[idx % len(self.colors)]
 
 
 class ColorableVisualizationManifest(PredictionsVisualizationManifest, ABC):
@@ -112,7 +106,7 @@ class ColorableVisualizationManifest(PredictionsVisualizationManifest, ABC):
         Selector(kind=[STRING_KIND]),
     ] = Field(  # type: ignore
         default="CLASS",
-        description="Choose how bounding box colors are assigned.",
+        description="Choose how bounding box colors are assigned. Detections with a negative class or tracker id (for example unmatched VLM labels with class_id = -1) are painted in a neutral gray.",
         examples=["CLASS", "$inputs.color_axis"],
     )
 
@@ -155,7 +149,7 @@ class ColorableVisualizationBlock(PredictionsVisualizationBlock, ABC):
                 palette_name = palette_name.lower()
 
             palette = sv.ColorPalette.from_matplotlib(palette_name, int(palette_size))
-        return _WrappingColorPalette(colors=palette.colors)
+        return wrap_color_palette(palette)
 
     @abstractmethod
     def run(

--- a/inference/core/workflows/core_steps/visualizations/common/base_colorable_tensor.py
+++ b/inference/core/workflows/core_steps/visualizations/common/base_colorable_tensor.py
@@ -8,7 +8,10 @@ from inference.core.workflows.core_steps.visualizations.common.base_tensor impor
     PredictionsVisualizationBlock,
     PredictionsVisualizationManifest,
 )
-from inference.core.workflows.core_steps.visualizations.common.utils import str_to_color
+from inference.core.workflows.core_steps.visualizations.common.utils import (
+    str_to_color,
+    wrap_color_palette,
+)
 from inference.core.workflows.execution_engine.entities.base import WorkflowImageData
 from inference.core.workflows.execution_engine.entities.types import (
     INTEGER_KIND,
@@ -17,15 +20,6 @@ from inference.core.workflows.execution_engine.entities.types import (
     Selector,
 )
 from inference.core.workflows.prototypes.block import BlockResult
-
-
-class _WrappingColorPalette(sv.ColorPalette):
-    """Apply palette modulo arithmetic to positive and negative indices."""
-
-    def by_idx(self, idx: int) -> sv.Color:
-        if not self.colors:
-            raise ValueError("A color palette must contain at least one color.")
-        return self.colors[idx % len(self.colors)]
 
 
 class ColorableVisualizationManifest(PredictionsVisualizationManifest, ABC):
@@ -112,7 +106,7 @@ class ColorableVisualizationManifest(PredictionsVisualizationManifest, ABC):
         Selector(kind=[STRING_KIND]),
     ] = Field(  # type: ignore
         default="CLASS",
-        description="Choose how bounding box colors are assigned.",
+        description="Choose how bounding box colors are assigned. Detections with a negative class or tracker id (for example unmatched VLM labels with class_id = -1) are painted in a neutral gray.",
         examples=["CLASS", "$inputs.color_axis"],
     )
 
@@ -155,7 +149,7 @@ class ColorableVisualizationBlock(PredictionsVisualizationBlock, ABC):
                 palette_name = palette_name.lower()
 
             palette = sv.ColorPalette.from_matplotlib(palette_name, int(palette_size))
-        return _WrappingColorPalette(colors=palette.colors)
+        return wrap_color_palette(palette)
 
     @abstractmethod
     def run(

--- a/inference/core/workflows/core_steps/visualizations/common/utils.py
+++ b/inference/core/workflows/core_steps/visualizations/common/utils.py
@@ -1,5 +1,56 @@
 import supervision as sv
 
+UNKNOWN_CLASS_COLOR = sv.Color.GREY
+UNKNOWN_CLASS_COLOR_RGB = UNKNOWN_CLASS_COLOR.as_rgb()
+
+
+class NegativeSafeColorPalette(sv.ColorPalette):
+    """Color palette that paints unknown (negative) ids in a fixed gray.
+
+    Supervision's ``ColorPalette.by_idx`` raises on negative indices. Workflow
+    parsers keep unmatched VLM labels as ``class_id == -1`` while preserving
+    the model's original string in ``class_name``. This palette renders those
+    detections in a neutral gray so they stay visible without colliding with a
+    real class color.
+
+    Non-negative indices keep the usual wrap-around palette lookup.
+    """
+
+    def by_idx(self, idx: int) -> sv.Color:
+        """Return the color for ``idx``, or gray when ``idx`` is negative.
+
+        Args:
+            idx: Palette index. Negative values (unknown class or pending
+                track) map to ``UNKNOWN_CLASS_COLOR``.
+
+        Returns:
+            Palette color for a non-negative index, or gray for a negative
+            index.
+
+        Raises:
+            ValueError: If the palette is empty and ``idx`` is non-negative.
+        """
+        if idx < 0:
+            return UNKNOWN_CLASS_COLOR
+        if not self.colors:
+            raise ValueError("A color palette must contain at least one color.")
+        return self.colors[idx % len(self.colors)]
+
+
+def wrap_color_palette(palette: sv.ColorPalette) -> NegativeSafeColorPalette:
+    """Wrap a palette so negative ids resolve to gray instead of raising.
+
+    Args:
+        palette: Palette produced by a visualization block's ``getPalette``.
+
+    Returns:
+        A ``NegativeSafeColorPalette`` with the same colors. The input is
+        returned unchanged when it is already a safe palette.
+    """
+    if isinstance(palette, NegativeSafeColorPalette):
+        return palette
+    return NegativeSafeColorPalette(colors=list(palette.colors))
+
 
 def str_to_color(color: str) -> sv.Color:
     if color.startswith("#"):

--- a/inference/core/workflows/core_steps/visualizations/mask/v1_tensor.py
+++ b/inference/core/workflows/core_steps/visualizations/mask/v1_tensor.py
@@ -18,6 +18,9 @@ from inference.core.workflows.core_steps.visualizations.common.base_tensor impor
     empty_predictions_passthrough,
     to_supervision_for_annotation,
 )
+from inference.core.workflows.core_steps.visualizations.common.utils import (
+    UNKNOWN_CLASS_COLOR_RGB,
+)
 from inference.core.workflows.execution_engine.entities.base import WorkflowImageData
 from inference.core.workflows.execution_engine.entities.tensor_native_types import (
     TENSOR_NATIVE_INSTANCE_SEGMENTATION_PREDICTION_KIND,
@@ -70,13 +73,6 @@ The annotated image from this block can be connected to:
 - **Notification blocks** (e.g., Email Notification, Slack Notification) to send annotated images with mask overlays as visual evidence in alerts or reports
 - **Video output blocks** to create annotated video streams or recordings with mask fills for live monitoring, segmentation visualization, or post-processing analysis
 """
-
-#: supervision's pending-track sentinel and its color (``PENDING_TRACK_ID`` /
-#: ``PENDING_TRACK_COLOR = Color.GREY``, supervision 0.29.0
-#: ``annotators/utils.py``). Values are copied so the runtime path never
-#: touches supervision.
-_PENDING_TRACK_ID = -1
-_PENDING_TRACK_COLOR_RGB = (128, 128, 128)
 
 _SUPPORTED_COLOR_AXES = ("CLASS", "INDEX", "TRACK")
 
@@ -554,18 +550,14 @@ class MaskVisualizationBlockV1(ColorableVisualizationBlock):
         device = scene.device
         ids = _resolve_color_ids(predictions, color_axis, device)
         lut = self._get_palette_lut(color_palette, palette_size, custom_colors, device)
-        # Same color sv's `by_idx` picks: idx % palette size, on device. (For
-        # negative ids torch's remainder wraps instead of raising like sv's
-        # by_idx — checking would require a device→host read.)
+        # Non-negative ids wrap like ColorPalette.by_idx. Negative ids
+        # (unmatched VLM class_id, pending tracker) paint the same gray
+        # NegativeSafeColorPalette uses — on device, no host sync.
         colors_rgb = lut[ids.remainder(int(lut.shape[0]))]
-        if color_axis == "TRACK":
-            # sv resolve_color: the pending-track id (-1) gets Color.GREY.
-            pending = torch.tensor(
-                _PENDING_TRACK_COLOR_RGB, dtype=torch.uint8, device=device
-            )
-            colors_rgb = torch.where(
-                (ids == _PENDING_TRACK_ID).unsqueeze(1), pending, colors_rgb
-            )
+        unknown = torch.tensor(
+            UNKNOWN_CLASS_COLOR_RGB, dtype=torch.uint8, device=device
+        )
+        colors_rgb = torch.where((ids < 0).unsqueeze(1), unknown, colors_rgb)
         return gpu_mask_composite(scene, predictions.mask, colors_rgb, float(opacity))
 
     def run(

--- a/tests/workflows/unit_tests/core_steps/visualizations/test_bounding_box.py
+++ b/tests/workflows/unit_tests/core_steps/visualizations/test_bounding_box.py
@@ -108,7 +108,7 @@ def test_bounding_box_visualization_block() -> None:
     )
 
 
-def test_bounding_box_visualization_wraps_negative_class_id() -> None:
+def test_bounding_box_visualization_paints_unknown_class_gray() -> None:
     predictions = sv.Detections(
         xyxy=np.array([[4, 4, 20, 20]], dtype=np.float64),
         class_id=np.array([-1]),
@@ -129,7 +129,8 @@ def test_bounding_box_visualization_wraps_negative_class_id() -> None:
         roundness=0,
     )
 
-    assert np.any(output["image"].numpy_image)
+    annotated = output["image"].numpy_image
+    assert np.any(np.all(annotated == (128, 128, 128), axis=-1))
     assert predictions.class_id.tolist() == [-1]
 
 

--- a/tests/workflows/unit_tests/core_steps/visualizations/test_bounding_box.py
+++ b/tests/workflows/unit_tests/core_steps/visualizations/test_bounding_box.py
@@ -108,32 +108,6 @@ def test_bounding_box_visualization_block() -> None:
     )
 
 
-def test_bounding_box_visualization_paints_unknown_class_gray() -> None:
-    predictions = sv.Detections(
-        xyxy=np.array([[4, 4, 20, 20]], dtype=np.float64),
-        class_id=np.array([-1]),
-    )
-
-    output = BoundingBoxVisualizationBlockV1().run(
-        image=WorkflowImageData(
-            parent_metadata=ImageParentMetadata(parent_id="some"),
-            numpy_image=np.zeros((32, 32, 3), dtype=np.uint8),
-        ),
-        predictions=predictions,
-        copy_image=True,
-        color_palette="DEFAULT",
-        palette_size=10,
-        custom_colors=[],
-        color_axis="CLASS",
-        thickness=1,
-        roundness=0,
-    )
-
-    annotated = output["image"].numpy_image
-    assert np.any(np.all(annotated == (128, 128, 128), axis=-1))
-    assert predictions.class_id.tolist() == [-1]
-
-
 def test_bounding_box_visualization_block_nocopy() -> None:
     # given
     block = BoundingBoxVisualizationBlockV1()

--- a/tests/workflows/unit_tests/core_steps/visualizations/test_bounding_box_v1_tensor_gpu.py
+++ b/tests/workflows/unit_tests/core_steps/visualizations/test_bounding_box_v1_tensor_gpu.py
@@ -315,21 +315,6 @@ def _run_block(image: WorkflowImageData, detections: Detections, copy_image: boo
     )["image"]
 
 
-def test_class_axis_paints_unknown_class_gray() -> None:
-    detections = _build_detections(
-        boxes=np.array([[10, 10, 50, 50]], dtype=np.float32),
-        class_id=np.array([-1]),
-        device="cpu",
-    )
-
-    out = _run_block(_tensor_backed_image(), detections, copy_image=True)
-
-    assert out._tensor_image is not None and out._numpy_image is None
-    annotated = out._tensor_image.permute(1, 2, 0).cpu().numpy()
-    assert np.any(np.all(annotated == (128, 128, 128), axis=-1))
-    assert detections.class_id.tolist() == [-1]
-
-
 def test_empty_predictions_take_the_tensor_passthrough_with_copy() -> None:
     image = _tensor_backed_image()
 

--- a/tests/workflows/unit_tests/core_steps/visualizations/test_bounding_box_v1_tensor_gpu.py
+++ b/tests/workflows/unit_tests/core_steps/visualizations/test_bounding_box_v1_tensor_gpu.py
@@ -315,7 +315,7 @@ def _run_block(image: WorkflowImageData, detections: Detections, copy_image: boo
     )["image"]
 
 
-def test_class_axis_wraps_negative_class_id() -> None:
+def test_class_axis_paints_unknown_class_gray() -> None:
     detections = _build_detections(
         boxes=np.array([[10, 10, 50, 50]], dtype=np.float32),
         class_id=np.array([-1]),
@@ -325,7 +325,8 @@ def test_class_axis_wraps_negative_class_id() -> None:
     out = _run_block(_tensor_backed_image(), detections, copy_image=True)
 
     assert out._tensor_image is not None and out._numpy_image is None
-    assert torch.any(out._tensor_image)
+    annotated = out._tensor_image.permute(1, 2, 0).cpu().numpy()
+    assert np.any(np.all(annotated == (128, 128, 128), axis=-1))
     assert detections.class_id.tolist() == [-1]
 
 

--- a/tests/workflows/unit_tests/core_steps/visualizations/test_label.py
+++ b/tests/workflows/unit_tests/core_steps/visualizations/test_label.py
@@ -3,6 +3,9 @@ import pytest
 import supervision as sv
 from pydantic import ValidationError
 
+from inference.core.workflows.core_steps.visualizations.common.label_text import (
+    build_detection_labels,
+)
 from inference.core.workflows.core_steps.visualizations.label.v1 import (
     LabelManifest,
     LabelVisualizationBlockV1,
@@ -121,12 +124,14 @@ def test_label_visualization_block() -> None:
     )
 
 
-def test_label_visualization_wraps_negative_class_id() -> None:
+def test_label_visualization_paints_unknown_class_gray_with_model_label() -> None:
     predictions = sv.Detections(
         xyxy=np.array([[4, 12, 20, 28]], dtype=np.float64),
         class_id=np.array([-1]),
-        data={"class_name": np.array(["foreground"], dtype=object)},
+        data={"class_name": np.array(["traffic signal"], dtype=object)},
     )
+
+    assert list(build_detection_labels(predictions, "Class")) == ["traffic signal"]
 
     output = LabelVisualizationBlockV1().run(
         image=WorkflowImageData(
@@ -148,7 +153,8 @@ def test_label_visualization_wraps_negative_class_id() -> None:
         border_radius=0,
     )
 
-    assert np.any(output["image"].numpy_image)
+    annotated = output["image"].numpy_image
+    assert np.any(np.all(annotated == (128, 128, 128), axis=-1))
     assert predictions.class_id.tolist() == [-1]
 
 

--- a/tests/workflows/unit_tests/core_steps/visualizations/test_label.py
+++ b/tests/workflows/unit_tests/core_steps/visualizations/test_label.py
@@ -3,9 +3,6 @@ import pytest
 import supervision as sv
 from pydantic import ValidationError
 
-from inference.core.workflows.core_steps.visualizations.common.label_text import (
-    build_detection_labels,
-)
 from inference.core.workflows.core_steps.visualizations.label.v1 import (
     LabelManifest,
     LabelVisualizationBlockV1,
@@ -122,40 +119,6 @@ def test_label_visualization_block() -> None:
     assert not np.array_equal(
         output.get("image").numpy_image, np.zeros((1000, 1000, 3), dtype=np.uint8)
     )
-
-
-def test_label_visualization_paints_unknown_class_gray_with_model_label() -> None:
-    predictions = sv.Detections(
-        xyxy=np.array([[4, 12, 20, 28]], dtype=np.float64),
-        class_id=np.array([-1]),
-        data={"class_name": np.array(["traffic signal"], dtype=object)},
-    )
-
-    assert list(build_detection_labels(predictions, "Class")) == ["traffic signal"]
-
-    output = LabelVisualizationBlockV1().run(
-        image=WorkflowImageData(
-            parent_metadata=ImageParentMetadata(parent_id="some"),
-            numpy_image=np.zeros((32, 32, 3), dtype=np.uint8),
-        ),
-        predictions=predictions,
-        copy_image=True,
-        color_palette="DEFAULT",
-        palette_size=10,
-        custom_colors=[],
-        color_axis="CLASS",
-        text="Class",
-        text_position="TOP_LEFT",
-        text_color="WHITE",
-        text_scale=0.5,
-        text_thickness=1,
-        text_padding=2,
-        border_radius=0,
-    )
-
-    annotated = output["image"].numpy_image
-    assert np.any(np.all(annotated == (128, 128, 128), axis=-1))
-    assert predictions.class_id.tolist() == [-1]
 
 
 def test_label_visualization_block_with_area_px() -> None:

--- a/tests/workflows/unit_tests/core_steps/visualizations/test_label_v1_tensor_gpu.py
+++ b/tests/workflows/unit_tests/core_steps/visualizations/test_label_v1_tensor_gpu.py
@@ -146,27 +146,6 @@ def _assert_gpu_bit_exact(out, expected_bgr: np.ndarray) -> None:
     assert np.array_equal(actual, expected_bgr)
 
 
-def test_class_axis_paints_unknown_class_gray() -> None:
-    scene = np.zeros((64, 64, 3), dtype=np.uint8)
-    detections = _build_detections(
-        boxes=np.array([[10, 20, 50, 54]], dtype=np.float32),
-        class_id=np.array([-1]),
-    )
-
-    out = _run_block(
-        _tensor_image_from_bgr(scene),
-        detections,
-        text="Confidence",
-        text_scale=0.5,
-        text_padding=2,
-    )
-
-    assert out._tensor_image is not None and out._numpy_image is None
-    annotated = _to_bgr(out._tensor_image)
-    assert np.any(np.all(annotated == (128, 128, 128), axis=-1))
-    assert detections.class_id.tolist() == [-1]
-
-
 @pytest.mark.parametrize("device", DEVICES)
 @pytest.mark.parametrize("text_position", ALL_ANCHORS)
 def test_gpu_labels_match_sv_bit_exact_for_every_anchor(

--- a/tests/workflows/unit_tests/core_steps/visualizations/test_label_v1_tensor_gpu.py
+++ b/tests/workflows/unit_tests/core_steps/visualizations/test_label_v1_tensor_gpu.py
@@ -146,7 +146,7 @@ def _assert_gpu_bit_exact(out, expected_bgr: np.ndarray) -> None:
     assert np.array_equal(actual, expected_bgr)
 
 
-def test_class_axis_wraps_negative_class_id() -> None:
+def test_class_axis_paints_unknown_class_gray() -> None:
     scene = np.zeros((64, 64, 3), dtype=np.uint8)
     detections = _build_detections(
         boxes=np.array([[10, 20, 50, 54]], dtype=np.float32),
@@ -162,7 +162,8 @@ def test_class_axis_wraps_negative_class_id() -> None:
     )
 
     assert out._tensor_image is not None and out._numpy_image is None
-    assert torch.any(out._tensor_image)
+    annotated = _to_bgr(out._tensor_image)
+    assert np.any(np.all(annotated == (128, 128, 128), axis=-1))
     assert detections.class_id.tolist() == [-1]
 
 

--- a/tests/workflows/unit_tests/core_steps/visualizations/test_mask.py
+++ b/tests/workflows/unit_tests/core_steps/visualizations/test_mask.py
@@ -100,7 +100,7 @@ def test_mask_visualization_block() -> None:
     )
 
 
-def test_mask_visualization_wraps_negative_class_id() -> None:
+def test_mask_visualization_paints_unknown_class_gray() -> None:
     mask = np.zeros((1, 32, 32), dtype=np.bool_)
     mask[0, 4:20, 4:20] = True
     predictions = sv.Detections(
@@ -123,7 +123,9 @@ def test_mask_visualization_wraps_negative_class_id() -> None:
         opacity=0.5,
     )
 
-    assert np.any(output["image"].numpy_image)
+    annotated = output["image"].numpy_image
+    # opacity 0.5 over black: round(128 * 0.5) = 64
+    assert np.any(np.all(annotated[mask[0]] == (64, 64, 64), axis=-1))
     assert predictions.class_id.tolist() == [-1]
 
 

--- a/tests/workflows/unit_tests/core_steps/visualizations/test_mask.py
+++ b/tests/workflows/unit_tests/core_steps/visualizations/test_mask.py
@@ -100,35 +100,6 @@ def test_mask_visualization_block() -> None:
     )
 
 
-def test_mask_visualization_paints_unknown_class_gray() -> None:
-    mask = np.zeros((1, 32, 32), dtype=np.bool_)
-    mask[0, 4:20, 4:20] = True
-    predictions = sv.Detections(
-        xyxy=np.array([[4, 4, 20, 20]], dtype=np.float64),
-        mask=mask,
-        class_id=np.array([-1]),
-    )
-
-    output = MaskVisualizationBlockV1().run(
-        image=WorkflowImageData(
-            parent_metadata=ImageParentMetadata(parent_id="some"),
-            numpy_image=np.zeros((32, 32, 3), dtype=np.uint8),
-        ),
-        predictions=predictions,
-        copy_image=True,
-        color_palette="DEFAULT",
-        palette_size=10,
-        custom_colors=[],
-        color_axis="CLASS",
-        opacity=0.5,
-    )
-
-    annotated = output["image"].numpy_image
-    # opacity 0.5 over black: round(128 * 0.5) = 64
-    assert np.any(np.all(annotated[mask[0]] == (64, 64, 64), axis=-1))
-    assert predictions.class_id.tolist() == [-1]
-
-
 def test_mask_visualization_block_with_semantic_segmentation() -> None:
     """Block renders sv.Detections with RLE-encoded masks as produced by the
     semantic segmentation model block (mask=None, data["rle_mask"] populated)."""

--- a/tests/workflows/unit_tests/core_steps/visualizations/test_mask_v1_tensor_gpu.py
+++ b/tests/workflows/unit_tests/core_steps/visualizations/test_mask_v1_tensor_gpu.py
@@ -757,7 +757,7 @@ def test_block_numpy_path_copy_semantics() -> None:
     assert not np.array_equal(buffer, scene)
 
 
-def test_block_numpy_path_wraps_negative_class_id() -> None:
+def test_block_numpy_path_paints_unknown_class_gray() -> None:
     scene = np.zeros((64, 64, 3), dtype=np.uint8)
     masks, boxes, _ = _single_mask_inputs()
     detections = _build_dense_detections(
@@ -770,8 +770,29 @@ def test_block_numpy_path_wraps_negative_class_id() -> None:
     out = _run_block(_numpy_backed_image(scene), detections)
 
     assert out._numpy_image is not None and out._tensor_image is None
-    assert np.any(out._numpy_image)
+    assert np.any(np.all(out._numpy_image == (64, 64, 64), axis=-1))
     assert detections.class_id.tolist() == [-1]
+
+
+def test_block_unknown_class_id_paints_sv_gray() -> None:
+    scene = np.full((128, 128, 3), 200, dtype=np.uint8)
+    masks = np.zeros((1, 128, 128), dtype=bool)
+    masks[0, 20:60, 30:90] = True
+    detections = _build_dense_detections(
+        masks,
+        np.array([[30, 20, 89, 59]], dtype=np.int32),
+        np.array([-1], dtype=np.int32),
+        device="cpu",
+    )
+    image = _tensor_backed_image(scene)
+
+    out = _run_block(image, detections, color_axis="CLASS")
+
+    actual = out._tensor_image.permute(1, 2, 0).cpu().numpy()[:, :, ::-1]
+    assert np.array_equal(
+        actual[masks[0]], np.full((int(masks[0].sum()), 3), 164, dtype=np.uint8)
+    )
+    assert np.array_equal(actual[~masks[0]], scene[~masks[0]])
 
 
 def test_block_empty_predictions_take_the_tensor_passthrough() -> None:

--- a/tests/workflows/unit_tests/core_steps/visualizations/test_mask_v1_tensor_gpu.py
+++ b/tests/workflows/unit_tests/core_steps/visualizations/test_mask_v1_tensor_gpu.py
@@ -757,23 +757,6 @@ def test_block_numpy_path_copy_semantics() -> None:
     assert not np.array_equal(buffer, scene)
 
 
-def test_block_numpy_path_paints_unknown_class_gray() -> None:
-    scene = np.zeros((64, 64, 3), dtype=np.uint8)
-    masks, boxes, _ = _single_mask_inputs()
-    detections = _build_dense_detections(
-        masks,
-        boxes,
-        np.array([-1], dtype=np.int32),
-        device="cpu",
-    )
-
-    out = _run_block(_numpy_backed_image(scene), detections)
-
-    assert out._numpy_image is not None and out._tensor_image is None
-    assert np.any(np.all(out._numpy_image == (64, 64, 64), axis=-1))
-    assert detections.class_id.tolist() == [-1]
-
-
 def test_block_unknown_class_id_paints_sv_gray() -> None:
     scene = np.full((128, 128, 3), 200, dtype=np.uint8)
     masks = np.zeros((1, 128, 128), dtype=bool)

--- a/tests/workflows/unit_tests/core_steps/visualizations/test_negative_safe_palette.py
+++ b/tests/workflows/unit_tests/core_steps/visualizations/test_negative_safe_palette.py
@@ -1,0 +1,59 @@
+import supervision as sv
+
+from inference.core.workflows.core_steps.visualizations.bounding_box.v1 import (
+    BoundingBoxVisualizationBlockV1,
+)
+from inference.core.workflows.core_steps.visualizations.common.utils import (
+    UNKNOWN_CLASS_COLOR,
+    NegativeSafeColorPalette,
+    wrap_color_palette,
+)
+
+
+def test_negative_index_returns_gray() -> None:
+    palette = NegativeSafeColorPalette(
+        colors=[sv.Color.RED, sv.Color.GREEN, sv.Color.BLUE]
+    )
+
+    assert palette.by_idx(-1) == UNKNOWN_CLASS_COLOR
+    assert palette.by_idx(-2) == UNKNOWN_CLASS_COLOR
+
+
+def test_non_negative_index_uses_palette_wrap() -> None:
+    palette = NegativeSafeColorPalette(
+        colors=[sv.Color.RED, sv.Color.GREEN, sv.Color.BLUE]
+    )
+
+    assert palette.by_idx(0) == sv.Color.RED
+    assert palette.by_idx(1) == sv.Color.GREEN
+    assert palette.by_idx(2) == sv.Color.BLUE
+    assert palette.by_idx(3) == sv.Color.RED
+
+
+def test_wrap_color_palette_preserves_named_palette_colors() -> None:
+    wrapped = wrap_color_palette(sv.ColorPalette.DEFAULT)
+
+    assert isinstance(wrapped, NegativeSafeColorPalette)
+    assert wrapped.by_idx(0) == sv.ColorPalette.DEFAULT.by_idx(0)
+    assert wrapped.by_idx(-1) == UNKNOWN_CLASS_COLOR
+
+
+def test_wrap_color_palette_is_idempotent() -> None:
+    palette = NegativeSafeColorPalette(colors=[sv.Color.RED])
+
+    assert wrap_color_palette(palette) is palette
+
+
+def test_get_palette_returns_gray_for_negative_index_on_every_branch() -> None:
+    default = BoundingBoxVisualizationBlockV1.getPalette("DEFAULT", 10, [])
+    custom = BoundingBoxVisualizationBlockV1.getPalette(
+        "CUSTOM", 10, ["#FF0000", "#00FF00"]
+    )
+    matplotlib_palette = BoundingBoxVisualizationBlockV1.getPalette(
+        "Matplotlib Viridis", 8, []
+    )
+
+    for palette in (default, custom, matplotlib_palette):
+        assert isinstance(palette, NegativeSafeColorPalette)
+        assert palette.by_idx(-1) == UNKNOWN_CLASS_COLOR
+        assert palette.by_idx(0) != UNKNOWN_CLASS_COLOR

--- a/tests/workflows/unit_tests/core_steps/visualizations/test_negative_safe_palette.py
+++ b/tests/workflows/unit_tests/core_steps/visualizations/test_negative_safe_palette.py
@@ -1,3 +1,5 @@
+import numpy as np
+import pytest
 import supervision as sv
 
 from inference.core.workflows.core_steps.visualizations.bounding_box.v1 import (
@@ -6,54 +8,79 @@ from inference.core.workflows.core_steps.visualizations.bounding_box.v1 import (
 from inference.core.workflows.core_steps.visualizations.common.utils import (
     UNKNOWN_CLASS_COLOR,
     NegativeSafeColorPalette,
-    wrap_color_palette,
+)
+from inference.core.workflows.execution_engine.entities.base import (
+    ImageParentMetadata,
+    WorkflowImageData,
 )
 
+_PALETTE = [sv.Color.RED, sv.Color.GREEN, sv.Color.BLUE]
 
-def test_negative_index_returns_gray() -> None:
-    palette = NegativeSafeColorPalette(
-        colors=[sv.Color.RED, sv.Color.GREEN, sv.Color.BLUE]
-    )
+
+def test_by_idx_paints_negative_gray_and_keeps_positive_wrap() -> None:
+    palette = NegativeSafeColorPalette(colors=list(_PALETTE))
 
     assert palette.by_idx(-1) == UNKNOWN_CLASS_COLOR
     assert palette.by_idx(-2) == UNKNOWN_CLASS_COLOR
-
-
-def test_non_negative_index_uses_palette_wrap() -> None:
-    palette = NegativeSafeColorPalette(
-        colors=[sv.Color.RED, sv.Color.GREEN, sv.Color.BLUE]
-    )
-
     assert palette.by_idx(0) == sv.Color.RED
-    assert palette.by_idx(1) == sv.Color.GREEN
-    assert palette.by_idx(2) == sv.Color.BLUE
     assert palette.by_idx(3) == sv.Color.RED
 
 
-def test_wrap_color_palette_preserves_named_palette_colors() -> None:
-    wrapped = wrap_color_palette(sv.ColorPalette.DEFAULT)
+def test_by_idx_raises_on_empty_palette_for_known_class() -> None:
+    palette = NegativeSafeColorPalette(colors=[])
 
-    assert isinstance(wrapped, NegativeSafeColorPalette)
-    assert wrapped.by_idx(0) == sv.ColorPalette.DEFAULT.by_idx(0)
-    assert wrapped.by_idx(-1) == UNKNOWN_CLASS_COLOR
-
-
-def test_wrap_color_palette_is_idempotent() -> None:
-    palette = NegativeSafeColorPalette(colors=[sv.Color.RED])
-
-    assert wrap_color_palette(palette) is palette
+    assert palette.by_idx(-1) == UNKNOWN_CLASS_COLOR
+    with pytest.raises(ValueError, match="at least one color"):
+        palette.by_idx(0)
 
 
-def test_get_palette_returns_gray_for_negative_index_on_every_branch() -> None:
+def test_get_palette_wraps_every_construction_branch() -> None:
     default = BoundingBoxVisualizationBlockV1.getPalette("DEFAULT", 10, [])
-    custom = BoundingBoxVisualizationBlockV1.getPalette(
-        "CUSTOM", 10, ["#FF0000", "#00FF00"]
-    )
+    custom = BoundingBoxVisualizationBlockV1.getPalette("CUSTOM", 10, ["#FF0000"])
     matplotlib_palette = BoundingBoxVisualizationBlockV1.getPalette(
         "Matplotlib Viridis", 8, []
     )
 
-    for palette in (default, custom, matplotlib_palette):
-        assert isinstance(palette, NegativeSafeColorPalette)
-        assert palette.by_idx(-1) == UNKNOWN_CLASS_COLOR
-        assert palette.by_idx(0) != UNKNOWN_CLASS_COLOR
+    assert default.by_idx(-1) == UNKNOWN_CLASS_COLOR
+    assert default.by_idx(0) == sv.ColorPalette.DEFAULT.by_idx(0)
+    assert custom.by_idx(-1) == UNKNOWN_CLASS_COLOR
+    assert custom.by_idx(0) == sv.Color.from_hex("#FF0000")
+    assert matplotlib_palette.by_idx(-1) == UNKNOWN_CLASS_COLOR
+    assert matplotlib_palette.by_idx(0) == sv.ColorPalette.from_matplotlib(
+        "viridis", 8
+    ).by_idx(0)
+
+
+def test_bounding_box_keeps_known_class_color_and_paints_unknown_gray() -> None:
+    default = sv.ColorPalette.DEFAULT
+    known_bgr = default.by_idx(0).as_bgr()
+    wrapped_bgr = default.by_idx(len(default.colors) - 1).as_bgr()
+    gray_bgr = UNKNOWN_CLASS_COLOR.as_bgr()
+
+    output = BoundingBoxVisualizationBlockV1().run(
+        image=WorkflowImageData(
+            parent_metadata=ImageParentMetadata(parent_id="some"),
+            numpy_image=np.zeros((48, 80, 3), dtype=np.uint8),
+        ),
+        predictions=sv.Detections(
+            xyxy=np.array([[2, 2, 22, 22], [50, 2, 70, 22]], dtype=np.float64),
+            class_id=np.array([0, -1]),
+        ),
+        copy_image=True,
+        color_palette="DEFAULT",
+        palette_size=10,
+        custom_colors=[],
+        color_axis="CLASS",
+        thickness=1,
+        roundness=0,
+    )
+
+    annotated = output["image"].numpy_image
+    known_region = annotated[2:23, 2:23]
+    unknown_region = annotated[2:23, 50:71]
+
+    assert np.any(np.all(known_region == known_bgr, axis=-1))
+    assert np.any(np.all(unknown_region == gray_bgr, axis=-1))
+    assert not np.any(np.all(unknown_region == known_bgr, axis=-1))
+    assert not np.any(np.all(unknown_region == wrapped_bgr, axis=-1))
+    assert not np.any(np.all(known_region == gray_bgr, axis=-1))


### PR DESCRIPTION
VLM-as-detector keeps unmatched labels as class_id = -1 and stores the model's original string in class_name. Visualization used to map -1 onto the last palette color, so a mismatch looked like a real class.

We paint negative class and tracker ids gray (128, 128, 128) from getPalette, so every colorable annotator treats them the same way. Label blocks still draw class_name. The mask tensor LUT, which used to wrap negative ids on device, uses the same gray. Parser output is unchanged.

Tests cover the palette contract (negative gray, positive wrap, empty palette), getPalette wiring for DEFAULT, CUSTOM, and Matplotlib, a mixed box render where class 0 stays the DEFAULT color and class -1 is gray rather than the last palette color, and the mask tensor LUT blend (164 over a 200 background at 0.5 opacity).

<img width="841" height="432" alt="img1_modified" src="https://github.com/user-attachments/assets/7a469655-c3d6-41ae-aac6-d5d7cf8ba786" />

<img width="2000" height="2000" alt="img2_modified" src="https://github.com/user-attachments/assets/eefa89d3-e9b2-4640-8843-e7fb335914c3" />

<img width="1400" height="1050" alt="img3_modified" src="https://github.com/user-attachments/assets/ed7b6ee1-2978-48ad-ab2b-9f256efc1711" />