### PR TITLE
Add Z.ai GLM block via OpenRouter with the vlm-exam detection contract

### DIFF
--- a/inference/core/workflows/core_steps/formatters/vlm_as_detector/v2.py
+++ b/inference/core/workflows/core_steps/formatters/vlm_as_detector/v2.py
@@ -34,6 +34,9 @@ from inference.core.workflows.core_steps.formatters.vlm_as_detector.qwen_detecti
 from inference.core.workflows.core_steps.formatters.vlm_as_detector.spacexai_detection_parsing import (
     parse_spacexai_object_detection_response,
 )
+from inference.core.workflows.core_steps.formatters.vlm_as_detector.zai_detection_parsing import (
+    parse_zai_object_detection_response,
+)
 from inference.core.workflows.execution_engine.constants import (
     DETECTION_ID_KEY,
     IMAGE_DIMENSIONS_KEY,
@@ -607,9 +610,7 @@ REGISTERED_PARSERS = {
     ("spacexai", "object-detection"): parse_spacexai_object_detection_response,
     ("qwen", "object-detection"): parse_qwen_object_detection_response,
     ("muse", "object-detection"): parse_muse_object_detection_response,
-    # The Z.ai GLM block prompts for the same box_2d / 0-1000 xyxy contract
-    # as the Qwen blocks, so the Qwen parser handles it unchanged.
-    ("zai", "object-detection"): parse_qwen_object_detection_response,
+    ("zai", "object-detection"): parse_zai_object_detection_response,
     # Florence 2
     ("florence-2", "object-detection"): partial(
         parse_florence2_object_detection_response, florence_task_type="<OD>"

--- a/inference/core/workflows/core_steps/formatters/vlm_as_detector/v2.py
+++ b/inference/core/workflows/core_steps/formatters/vlm_as_detector/v2.py
@@ -158,7 +158,7 @@ This version (v2) includes the following enhancements over v1:
 
 ## Requirements
 
-This block requires an image input (for metadata and dimensions) and a VLM output string containing JSON detection data. The JSON can be raw JSON or wrapped in Markdown code blocks (```json ... ```). The block supports seven model types: "openai", "google-gemini", "anthropic-claude", "spacexai", "qwen", "muse", and "florence-2". It supports multiple task types: "object-detection", "open-vocabulary-object-detection", "object-detection-and-caption", "phrase-grounded-object-detection", "region-proposal", and "ocr-with-text-detection". The `classes` parameter is required for OpenAI, Gemini, Claude, SpaceXAI, Qwen, and Muse models (to map class names to IDs) but optional for Florence-2 (some tasks don't require it). Classes are mapped to IDs by index (first class = 0, second = 1, etc.). Classes not in the list get class_id = -1. The block outputs object detection predictions in standard format (compatible with detection blocks), error_status (boolean), and inference_id (INFERENCE_ID_KIND) for tracking.
+This block requires an image input (for metadata and dimensions) and a VLM output string containing JSON detection data. The JSON can be raw JSON or wrapped in Markdown code blocks (```json ... ```). The block supports eight model types: "openai", "google-gemini", "anthropic-claude", "spacexai", "qwen", "muse", "zai", and "florence-2". It supports multiple task types: "object-detection", "open-vocabulary-object-detection", "object-detection-and-caption", "phrase-grounded-object-detection", "region-proposal", and "ocr-with-text-detection". The `classes` parameter is required for OpenAI, Gemini, Claude, SpaceXAI, Qwen, Muse, and Z.ai models (to map class names to IDs) but optional for Florence-2 (some tasks don't require it). Classes are mapped to IDs by index (first class = 0, second = 1, etc.). Classes not in the list get class_id = -1. The block outputs object detection predictions in standard format (compatible with detection blocks), error_status (boolean), and inference_id (INFERENCE_ID_KIND) for tracking.
 """
 
 SHORT_DESCRIPTION = "Parses raw string into object-detection prediction."
@@ -233,6 +233,7 @@ class BlockManifest(WorkflowBlockManifest):
                         "spacexai",
                         "qwen",
                         "muse",
+                        "zai",
                     ],
                     "required": True,
                 },
@@ -246,9 +247,10 @@ class BlockManifest(WorkflowBlockManifest):
         "spacexai",
         "qwen",
         "muse",
+        "zai",
         "florence-2",
     ] = Field(
-        description="Type of the VLM/LLM model that generated the prediction. Determines which parser is used to extract detection data from the JSON output. Supported models: 'openai' (GPT-4V), 'google-gemini' (Gemini Vision), 'anthropic-claude' (Claude Vision), 'spacexai' (Grok), 'qwen' (Qwen-VL via OpenRouter), 'muse' (Meta Muse via OpenRouter), 'florence-2' (Microsoft Florence-2). Each model type has different JSON output formats, so the correct model type must be specified for proper parsing.",
+        description="Type of the VLM/LLM model that generated the prediction. Determines which parser is used to extract detection data from the JSON output. Supported models: 'openai' (GPT-4V), 'google-gemini' (Gemini Vision), 'anthropic-claude' (Claude Vision), 'spacexai' (Grok), 'qwen' (Qwen-VL via OpenRouter), 'muse' (Meta Muse via OpenRouter), 'zai' (Z.ai GLM via OpenRouter), 'florence-2' (Microsoft Florence-2). Each model type has different JSON output formats, so the correct model type must be specified for proper parsing.",
         examples=[
             ["openai"],
             ["google-gemini"],
@@ -256,6 +258,7 @@ class BlockManifest(WorkflowBlockManifest):
             ["spacexai"],
             ["qwen"],
             ["muse"],
+            ["zai"],
             ["florence-2"],
         ],
     )
@@ -604,6 +607,9 @@ REGISTERED_PARSERS = {
     ("spacexai", "object-detection"): parse_spacexai_object_detection_response,
     ("qwen", "object-detection"): parse_qwen_object_detection_response,
     ("muse", "object-detection"): parse_muse_object_detection_response,
+    # The Z.ai GLM block prompts for the same box_2d / 0-1000 xyxy contract
+    # as the Qwen blocks, so the Qwen parser handles it unchanged.
+    ("zai", "object-detection"): parse_qwen_object_detection_response,
     # Florence 2
     ("florence-2", "object-detection"): partial(
         parse_florence2_object_detection_response, florence_task_type="<OD>"

--- a/inference/core/workflows/core_steps/formatters/vlm_as_detector/v2_tensor.py
+++ b/inference/core/workflows/core_steps/formatters/vlm_as_detector/v2_tensor.py
@@ -40,6 +40,10 @@ from inference.core.workflows.core_steps.formatters.vlm_as_detector.spacexai_det
     convert_spacexai_detection_to_pixel_xyxy,
     extract_spacexai_detection_entries,
 )
+from inference.core.workflows.core_steps.formatters.vlm_as_detector.zai_detection_parsing import (
+    convert_zai_pixel_entries_to_normalized,
+    zai_entries_use_absolute_pixels,
+)
 from inference.core.workflows.execution_engine.constants import (
     CLASS_NAME_KEY,
     CLASS_NAMES_KEY,
@@ -866,6 +870,40 @@ def parse_qwen_object_detection_response(
     )
 
 
+def parse_zai_object_detection_response(
+    image: WorkflowImageData,
+    parsed_data: Union[dict, list],
+    classes: List[str],
+    inference_id: str,
+) -> Detections:
+    """Parse Z.ai block object-detection output into native detections.
+
+    Dispatches on the box key the response carries: ``bbox_2d`` entries
+    (GLM 5.3 Flash) are rescaled from absolute pixels into the 0-1000
+    space first; either way the tensor-native Qwen parser does the parsing.
+    Tensor-native sibling of the numpy
+    ``zai_detection_parsing.parse_zai_object_detection_response``.
+
+    Raises:
+        ValueError: If the response is neither a JSON list nor a
+            ``{"detections": [...]}`` object.
+    """
+    entries = extract_qwen_detection_entries(parsed_data=parsed_data)
+    if zai_entries_use_absolute_pixels(entries):
+        image_height, image_width = image._read_shape_without_materialization()
+        parsed_data = convert_zai_pixel_entries_to_normalized(
+            entries=entries,
+            image_height=image_height,
+            image_width=image_width,
+        )
+    return parse_qwen_object_detection_response(
+        image=image,
+        parsed_data=parsed_data,
+        classes=classes,
+        inference_id=inference_id,
+    )
+
+
 def parse_muse_object_detection_response(
     image: WorkflowImageData,
     parsed_data: Union[dict, list],
@@ -970,9 +1008,7 @@ REGISTERED_PARSERS = {
     ("spacexai", "object-detection"): parse_spacexai_object_detection_response,
     ("qwen", "object-detection"): parse_qwen_object_detection_response,
     ("muse", "object-detection"): parse_muse_object_detection_response,
-    # The Z.ai GLM block prompts for the same box_2d / 0-1000 xyxy contract
-    # as the Qwen blocks, so the Qwen parser handles it unchanged.
-    ("zai", "object-detection"): parse_qwen_object_detection_response,
+    ("zai", "object-detection"): parse_zai_object_detection_response,
     # Florence 2
     ("florence-2", "object-detection"): partial(
         parse_florence2_object_detection_response, florence_task_type="<OD>"

--- a/inference/core/workflows/core_steps/formatters/vlm_as_detector/v2_tensor.py
+++ b/inference/core/workflows/core_steps/formatters/vlm_as_detector/v2_tensor.py
@@ -175,7 +175,7 @@ This version (v2) includes the following enhancements over v1:
 
 ## Requirements
 
-This block requires an image input (for metadata and dimensions) and a VLM output string containing JSON detection data. The JSON can be raw JSON or wrapped in Markdown code blocks (```json ... ```). The block supports seven model types: "openai", "google-gemini", "anthropic-claude", "spacexai", "qwen", "muse", and "florence-2". It supports multiple task types: "object-detection", "open-vocabulary-object-detection", "object-detection-and-caption", "phrase-grounded-object-detection", "region-proposal", and "ocr-with-text-detection". The `classes` parameter is required for OpenAI, Gemini, Claude, SpaceXAI, Qwen, and Muse models (to map class names to IDs) but optional for Florence-2 (some tasks don't require it). Classes are mapped to IDs by index (first class = 0, second = 1, etc.). Classes not in the list get class_id = -1. The block outputs object detection predictions in standard format (compatible with detection blocks), error_status (boolean), and inference_id (INFERENCE_ID_KIND) for tracking.
+This block requires an image input (for metadata and dimensions) and a VLM output string containing JSON detection data. The JSON can be raw JSON or wrapped in Markdown code blocks (```json ... ```). The block supports eight model types: "openai", "google-gemini", "anthropic-claude", "spacexai", "qwen", "muse", "zai", and "florence-2". It supports multiple task types: "object-detection", "open-vocabulary-object-detection", "object-detection-and-caption", "phrase-grounded-object-detection", "region-proposal", and "ocr-with-text-detection". The `classes` parameter is required for OpenAI, Gemini, Claude, SpaceXAI, Qwen, Muse, and Z.ai models (to map class names to IDs) but optional for Florence-2 (some tasks don't require it). Classes are mapped to IDs by index (first class = 0, second = 1, etc.). Classes not in the list get class_id = -1. The block outputs object detection predictions in standard format (compatible with detection blocks), error_status (boolean), and inference_id (INFERENCE_ID_KIND) for tracking.
 """
 
 SHORT_DESCRIPTION = "Parses raw string into object-detection prediction."
@@ -250,6 +250,7 @@ class BlockManifest(WorkflowBlockManifest):
                         "spacexai",
                         "qwen",
                         "muse",
+                        "zai",
                     ],
                     "required": True,
                 },
@@ -263,9 +264,10 @@ class BlockManifest(WorkflowBlockManifest):
         "spacexai",
         "qwen",
         "muse",
+        "zai",
         "florence-2",
     ] = Field(
-        description="Type of the VLM/LLM model that generated the prediction. Determines which parser is used to extract detection data from the JSON output. Supported models: 'openai' (GPT-4V), 'google-gemini' (Gemini Vision), 'anthropic-claude' (Claude Vision), 'spacexai' (Grok), 'qwen' (Qwen-VL via OpenRouter), 'muse' (Meta Muse via OpenRouter), 'florence-2' (Microsoft Florence-2). Each model type has different JSON output formats, so the correct model type must be specified for proper parsing.",
+        description="Type of the VLM/LLM model that generated the prediction. Determines which parser is used to extract detection data from the JSON output. Supported models: 'openai' (GPT-4V), 'google-gemini' (Gemini Vision), 'anthropic-claude' (Claude Vision), 'spacexai' (Grok), 'qwen' (Qwen-VL via OpenRouter), 'muse' (Meta Muse via OpenRouter), 'zai' (Z.ai GLM via OpenRouter), 'florence-2' (Microsoft Florence-2). Each model type has different JSON output formats, so the correct model type must be specified for proper parsing.",
         examples=[
             ["openai"],
             ["google-gemini"],
@@ -273,6 +275,7 @@ class BlockManifest(WorkflowBlockManifest):
             ["spacexai"],
             ["qwen"],
             ["muse"],
+            ["zai"],
             ["florence-2"],
         ],
     )
@@ -967,6 +970,9 @@ REGISTERED_PARSERS = {
     ("spacexai", "object-detection"): parse_spacexai_object_detection_response,
     ("qwen", "object-detection"): parse_qwen_object_detection_response,
     ("muse", "object-detection"): parse_muse_object_detection_response,
+    # The Z.ai GLM block prompts for the same box_2d / 0-1000 xyxy contract
+    # as the Qwen blocks, so the Qwen parser handles it unchanged.
+    ("zai", "object-detection"): parse_qwen_object_detection_response,
     # Florence 2
     ("florence-2", "object-detection"): partial(
         parse_florence2_object_detection_response, florence_task_type="<OD>"

--- a/inference/core/workflows/core_steps/formatters/vlm_as_detector/zai_detection_parsing.py
+++ b/inference/core/workflows/core_steps/formatters/vlm_as_detector/zai_detection_parsing.py
@@ -1,0 +1,125 @@
+from typing import List, Union
+
+import supervision as sv
+
+from inference.core.workflows.core_steps.formatters.vlm_as_detector.qwen_detection_parsing import (
+    QWEN_BOX_COORDINATE_SCALE,
+    extract_qwen_detection_entries,
+    get_qwen_detection_box,
+    parse_qwen_object_detection_response,
+)
+from inference.core.workflows.execution_engine.entities.base import WorkflowImageData
+
+# The two Z.ai detection contracts, keyed by the box field each prompt pins:
+# GLM 5V Turbo prompts for "box_2d" xyxy integers normalized to 0-1000 (the
+# Qwen contract), while GLM 5.3 Flash prompts for "bbox_2d" in absolute
+# pixels of the original image (the format that scored best for it in the
+# vlm-exam benchmarks; it scores ~0 mAP with normalized prompts). Rather
+# than duplicating the Qwen assembly, absolute-pixel entries are rescaled
+# into the 0-1000 space and handed to the Qwen parser, which scales them
+# back onto the image exactly.
+ZAI_ABSOLUTE_PIXEL_BOX_KEY = "bbox_2d"
+
+
+def zai_entries_use_absolute_pixels(entries: List[dict]) -> bool:
+    """Tell whether Z.ai detection entries carry absolute-pixel boxes.
+
+    The GLM 5.3 Flash prompt pins the ``bbox_2d`` key for absolute-pixel
+    boxes; the GLM 5V Turbo prompt pins ``box_2d`` for 0-1000 normalized
+    boxes. The models echo the prompted key, so its presence selects the
+    coordinate space.
+
+    Args:
+        entries: Raw detection entry dicts.
+
+    Returns:
+        True when any dict entry contains the ``bbox_2d`` key.
+    """
+    return any(
+        isinstance(entry, dict) and ZAI_ABSOLUTE_PIXEL_BOX_KEY in entry
+        for entry in entries
+    )
+
+
+def convert_zai_pixel_entries_to_normalized(
+    entries: List[dict],
+    image_height: int,
+    image_width: int,
+) -> List[dict]:
+    """Rescale absolute-pixel ``bbox_2d`` entries into the 0-1000 space.
+
+    Coordinates are absolute pixels of the image the model saw. The block
+    only downscales uploads above the OpenRouter payload cap (extremely
+    large images), so the coordinates map onto the original image directly.
+    Entries without a well-formed box pass through untouched and are
+    skipped downstream.
+
+    Args:
+        entries: Raw detection entry dicts.
+        image_height: Original image height in pixels.
+        image_width: Original image width in pixels.
+
+    Returns:
+        Entries with ``box_2d`` normalized to 0-1000, consumable by the
+        Qwen parser.
+    """
+    scale = QWEN_BOX_COORDINATE_SCALE
+    normalized: List[dict] = []
+    for entry in entries:
+        box = (
+            get_qwen_detection_box(detection=entry) if isinstance(entry, dict) else None
+        )
+        if box is None:
+            normalized.append(entry)
+            continue
+        x_min, y_min, x_max, y_max = box
+        converted = {k: v for k, v in entry.items() if k != ZAI_ABSOLUTE_PIXEL_BOX_KEY}
+        converted["box_2d"] = [
+            x_min / image_width * scale,
+            y_min / image_height * scale,
+            x_max / image_width * scale,
+            y_max / image_height * scale,
+        ]
+        normalized.append(converted)
+    return normalized
+
+
+def parse_zai_object_detection_response(
+    image: WorkflowImageData,
+    parsed_data: Union[dict, list],
+    classes: List[str],
+    inference_id: str,
+) -> sv.Detections:
+    """Parse Z.ai block object-detection output into detections.
+
+    Dispatches on the box key the response carries: ``bbox_2d`` entries
+    (GLM 5.3 Flash) are rescaled from absolute pixels into the 0-1000
+    space first; either way the Qwen parser does the parsing.
+
+    Args:
+        image: Workflow image the detections refer to.
+        parsed_data: JSON payload extracted from the VLM output.
+        classes: Class names used to map labels onto class ids.
+        inference_id: Identifier attached to every parsed detection.
+
+    Returns:
+        Parsed detections in the original image's coordinate space.
+
+    Raises:
+        ValueError: If the response is neither a JSON list nor a
+            ``{"detections": [...]}`` object.
+    """
+    entries = extract_qwen_detection_entries(parsed_data=parsed_data)
+    if zai_entries_use_absolute_pixels(entries):
+        image_height, image_width = image.numpy_image.shape[:2]
+        parsed_data = convert_zai_pixel_entries_to_normalized(
+            entries=entries,
+            image_height=image_height,
+            image_width=image_width,
+        )
+    return parse_qwen_object_detection_response(
+        image=image,
+        parsed_data=parsed_data,
+        classes=classes,
+        inference_id=inference_id,
+    )

--- a/inference/core/workflows/core_steps/loader.py
+++ b/inference/core/workflows/core_steps/loader.py
@@ -721,6 +721,9 @@ from inference.core.workflows.core_steps.models.foundation.qwen_vlm.v2 import (
 from inference.core.workflows.core_steps.models.foundation.qwen_vlm.v3 import (
     QwenVlmBlockV3,
 )
+from inference.core.workflows.core_steps.models.foundation.zai_vlm.v1 import (
+    ZaiVlmBlockV1,
+)
 
 if not ENABLE_TENSOR_DATA_REPRESENTATION:
     from inference.core.workflows.core_steps.models.foundation.seg_preview.v1 import (
@@ -1938,6 +1941,7 @@ def load_blocks() -> List[Type[WorkflowBlock]]:
         QwenVlmBlockV1,
         QwenVlmBlockV2,
         QwenVlmBlockV3,
+        ZaiVlmBlockV1,
         OpenAICompatibleBlockV1,
         KimiOpenRouterBlockV1,
         KimiOpenrouterBlockV2,

--- a/inference/core/workflows/core_steps/models/foundation/zai_vlm/v1.py
+++ b/inference/core/workflows/core_steps/models/foundation/zai_vlm/v1.py
@@ -62,11 +62,45 @@ from inference.core.workflows.prototypes.block import (
     third_party_model,
 )
 
-# One row per model; add future Z.ai models (e.g. Ox Alpha) here. A row may
-# override `reasoning_levels` if a model diverges from the shared set.
+# Ported verbatim from vlm-exam's `_NORMALIZED_XYXY_PROMPT_TEMPLATE`, the
+# detection coordinate format pinned for GLM 5V Turbo in the benchmark
+# configs (`xyxy_normalized_0_to_1000`).
+ZAI_OBJECT_DETECTION_PROMPT_TEMPLATE = (
+    "Detect all objects in this image. "
+    "Output a JSON list where each entry contains the 2D bounding box "
+    'in the key "box_2d" and the text label in the key "label". '
+    'The "box_2d" value must be [x_min, y_min, x_max, y_max]: the '
+    "top-left and bottom-right corners as integers between 0 and 1000, "
+    "normalized to the image width (x) and height (y). "
+    "Return only the JSON list, with no extra text. "
+    "Only use these labels: {class_list}"
+)
+
+# Ported verbatim from vlm-exam's `_BBOX_2D_PIXEL_PROMPT_TEMPLATE`, the
+# format pinned for GLM 5.3 Flash (`xyxy_absolute_original_image_bbox_2d`).
+# The model scores ~0 mAP with normalized 0-1000 prompts.
+ZAI_BBOX_2D_PIXEL_DETECTION_PROMPT_TEMPLATE = (
+    "Detect all objects in this image and return their locations in the "
+    "form of coordinates. The format of output should be like "
+    '{{"bbox_2d": [x1, y1, x2, y2], "label": "<name>"}}. '
+    "Only use these labels: {class_list}. Return a JSON array only."
+)
+
+# One row per model; add future Z.ai models here. A row may override
+# `reasoning_levels` if a model diverges from the shared set;
+# `reasoning_required` marks models that reject `reasoning: {enabled:
+# false}` and fall back to low effort when the user disables reasoning.
 MODEL_VARIANTS: Dict[str, Dict[str, Any]] = {
     "GLM 5V Turbo": {
         "model_id": "z-ai/glm-5v-turbo",
+        "detection_prompt_template": ZAI_OBJECT_DETECTION_PROMPT_TEMPLATE,
+    },
+    # GLM 5.3 Flash ran as the OpenRouter stealth model "Ox Alpha"; the
+    # retirement notice confirms they are the same model.
+    "GLM 5.3 Flash": {
+        "model_id": "z-ai/glm-5.3-flash",
+        "detection_prompt_template": ZAI_BBOX_2D_PIXEL_DETECTION_PROMPT_TEMPLATE,
+        "reasoning_required": True,
     },
 }
 
@@ -88,7 +122,9 @@ REASONING_EFFORT_METADATA = {
             "Turns extended reasoning off. GLM models default to extended "
             "reasoning on OpenRouter, which bloats latency and can consume "
             "the whole token budget before a visible answer is produced. "
-            "This is the configuration validated in the vlm-exam benchmarks."
+            "This is the configuration validated in the vlm-exam benchmarks. "
+            "GLM 5.3 Flash requires reasoning and falls back to low effort "
+            "instead."
         ),
     },
     "low": {
@@ -118,23 +154,38 @@ MODEL_VERSION_METADATA = attach_reasoning_levels(
     MODEL_REASONING_LEVELS,
 )
 
+# Fallback effort applied when reasoning is disabled by the user but the
+# selected model rejects `reasoning: {"enabled": false}`.
+REASONING_REQUIRED_FALLBACK_EFFORT = "low"
+
+
+def build_zai_reasoning_config(
+    reasoning_effort: str,
+    *,
+    reasoning_required: bool,
+) -> Optional[dict]:
+    """Translate the block's reasoning effort into OpenRouter's config.
+
+    Mirrors the vlm-exam benchmark behavior: reasoning is explicitly
+    disabled unless an effort is requested, except for models that require
+    reasoning and reject ``enabled: false``; those always receive an
+    effort (falling back to low when the user disabled reasoning).
+
+    Args:
+        reasoning_effort: One of ``REASONING_EFFORT_OPTIONS``.
+        reasoning_required: Whether the model rejects disabled reasoning.
+
+    Returns:
+        OpenRouter ``reasoning`` payload object.
+    """
+    if reasoning_required and reasoning_effort == "none":
+        return {"effort": REASONING_REQUIRED_FALLBACK_EFFORT}
+    return build_openrouter_reasoning_config(reasoning_effort)
+
+
 DEFAULT_MAX_TOKENS = 2048
 OPENROUTER_MAX_BASE64_BYTES = 9_500_000
 OPENROUTER_JPEG_QUALITY = 90
-
-# Ported verbatim from vlm-exam's `_NORMALIZED_XYXY_PROMPT_TEMPLATE` — the
-# detection coordinate format pinned for GLM 5V Turbo in the benchmark
-# configs (`xyxy_normalized_0_to_1000`).
-ZAI_OBJECT_DETECTION_PROMPT_TEMPLATE = (
-    "Detect all objects in this image. "
-    "Output a JSON list where each entry contains the 2D bounding box "
-    'in the key "box_2d" and the text label in the key "label". '
-    'The "box_2d" value must be [x_min, y_min, x_max, y_max]: the '
-    "top-left and bottom-right corners as integers between 0 and 1000, "
-    "normalized to the image width (x) and height (y). "
-    "Return only the JSON list, with no extra text. "
-    "Only use these labels: {class_list}"
-)
 
 _TASK_CLASSIFICATION = (
     "You act as single-class classification model. You must provide reasonable "
@@ -295,9 +346,9 @@ def _prepare_structured_answering_prompt(
 
 
 def _prepare_object_detection_prompt(
-    base64_image: str, classes: List[str], **_
+    base64_image: str, classes: List[str], detection_prompt_template: str, **_
 ) -> List[dict]:
-    text = ZAI_OBJECT_DETECTION_PROMPT_TEMPLATE.format(class_list=", ".join(classes))
+    text = detection_prompt_template.format(class_list=", ".join(classes))
     return _user_message(base64_image=base64_image, text=text)
 
 
@@ -324,6 +375,7 @@ def build_zai_openrouter_prompts(
     prompt: Optional[str],
     output_structure: Optional[Dict[str, str]],
     classes: Optional[List[str]],
+    detection_prompt_template: str = ZAI_OBJECT_DETECTION_PROMPT_TEMPLATE,
 ) -> List[List[dict]]:
     """Build one OpenRouter ``messages`` array per input image, GLM-style.
 
@@ -337,6 +389,8 @@ def build_zai_openrouter_prompts(
         prompt: User prompt for unconstrained / VQA tasks.
         output_structure: Output spec for structured-answering.
         classes: Class list for classification / detection tasks.
+        detection_prompt_template: Per-model object-detection template,
+            from ``MODEL_VARIANTS``.
 
     Returns:
         List of ``messages`` arrays, one per image.
@@ -355,6 +409,7 @@ def build_zai_openrouter_prompts(
                 prompt=prompt,
                 output_structure=output_structure,
                 classes=classes,
+                detection_prompt_template=detection_prompt_template,
             )
         )
     return built
@@ -368,23 +423,25 @@ RELEVANT_TASKS_DOCS_DESCRIPTION = "\n\n".join(
 LONG_DESCRIPTION = f"""
 Run Z.ai GLM vision-language models via [OpenRouter](https://openrouter.ai/).
 
-Supported model: GLM 5V Turbo.
+Supported models: GLM 5V Turbo and GLM 5.3 Flash (previously served as the
+OpenRouter stealth model "Ox Alpha").
 
 You can specify arbitrary text prompts or predefined ones. The block supports:
 
 {RELEVANT_TASKS_DOCS_DESCRIPTION}
 
-Object detection uses the format validated for GLM in the vlm-exam
-benchmarks: a JSON list of `box_2d`/`label` entries with
-`[x_min, y_min, x_max, y_max]` integer coordinates normalized to 0-1000.
-Parse the output with `VLM as Detector` (`vlm_as_detector@v2`) using
-`model_type="zai"`.
+Object detection uses the per-model format validated in the vlm-exam
+benchmarks: GLM 5V Turbo emits `box_2d`/`label` entries with coordinates
+normalized to 0-1000, while GLM 5.3 Flash emits `bbox_2d`/`label` entries
+in absolute pixels. Parse either output with `VLM as Detector`
+(`vlm_as_detector@v2`) using `model_type="zai"`; it detects the format.
 
 Every request sends the image before the instruction text in a single user
 message. GLM models default to extended reasoning on OpenRouter; the block
 disables it by default (the benchmarked configuration) and exposes a
-`reasoning_effort` knob to turn it back on. `max_tokens` defaults to 2048;
-raise it (e.g. 8192) when you need a longer answer.
+`reasoning_effort` knob to turn it back on. GLM 5.3 Flash requires
+reasoning and falls back to low effort when disabled. `max_tokens`
+defaults to 2048; raise it (e.g. 8192) when you need a longer answer.
 
 By default the block uses the Roboflow-managed OpenRouter key and bills
 your Roboflow credits. Paste your own `sk-or-...` key to call OpenRouter
@@ -425,7 +482,7 @@ class BlockManifest(OpenRouterBlockManifestMixin):
     model_version: Union[Selector(kind=[STRING_KIND]), ModelVersion] = Field(
         default=DEFAULT_MODEL_VERSION,
         description="Z.ai GLM model to run.",
-        examples=[DEFAULT_MODEL_VERSION],
+        examples=[DEFAULT_MODEL_VERSION, "GLM 5.3 Flash"],
         json_schema_extra={
             "values_metadata": MODEL_VERSION_METADATA,
         },
@@ -629,8 +686,8 @@ class ZaiVlmBlockV1(OpenRouterWorkflowBlockBase):
         temperature: Optional[float],
         max_concurrent_requests: Optional[int],
     ) -> BlockResult:
-        model_id = MODEL_IDS.get(model_version)
-        if model_id is None:
+        variant = MODEL_VARIANTS.get(model_version)
+        if variant is None:
             raise ValueError(
                 f"Unknown Z.ai model '{model_version}'. "
                 f"Pick one of: {list(MODEL_VARIANTS)}"
@@ -646,16 +703,20 @@ class ZaiVlmBlockV1(OpenRouterWorkflowBlockBase):
             prompt=prompt,
             output_structure=output_structure,
             classes=classes,
+            detection_prompt_template=variant["detection_prompt_template"],
         )
         results = self.execute_openrouter_batch_with_usage(
             openrouter_api_key=api_key,
-            model=model_id,
+            model=variant["model_id"],
             prompts=prompts,
             max_tokens=max_tokens if max_tokens is not None else DEFAULT_MAX_TOKENS,
             temperature=temperature,
             privacy_level=privacy_level,
             max_concurrent_requests=max_concurrent_requests,
-            reasoning=build_openrouter_reasoning_config(reasoning_effort),
+            reasoning=build_zai_reasoning_config(
+                reasoning_effort,
+                reasoning_required=variant.get("reasoning_required", False),
+            ),
         )
         return [
             {

--- a/inference/core/workflows/core_steps/models/foundation/zai_vlm/v1.py
+++ b/inference/core/workflows/core_steps/models/foundation/zai_vlm/v1.py
@@ -1,0 +1,669 @@
+"""Z.ai GLM vision-language block, v1.
+
+OpenRouter-only. Uses the vlm-exam request contract validated for
+GLM 5V Turbo: image-first user message, no system role, extended
+reasoning disabled by default, and the box_2d / 0-1000 xyxy detection
+prompt. Parse detection output with ``vlm_as_detector@v2`` using
+``model_type="zai"``.
+"""
+
+import base64
+import json
+from typing import Any, Dict, List, Literal, Optional, Type, Union
+
+import cv2
+import numpy as np
+from pydantic import ConfigDict, Field, field_validator, model_validator
+
+from inference.core.utils.image_utils import encode_image_to_jpeg_bytes
+from inference.core.workflows.core_steps.common.openrouter import (
+    PRIVACY_LEVEL_LITERAL,
+    PRIVACY_LEVEL_METADATA,
+    RECOMMENDED_PARSERS,
+    RELEVANT_TASKS_METADATA,
+    SUPPORTED_TASK_TYPES_LIST,
+    OpenRouterBlockManifestMixin,
+    OpenRouterWorkflowBlockBase,
+    validate_task_type_required_fields,
+)
+from inference.core.workflows.core_steps.common.reasoning import (
+    attach_reasoning_levels,
+    build_openrouter_reasoning_config,
+    validate_reasoning_level,
+)
+from inference.core.workflows.core_steps.common.token_usage import (
+    TOKEN_OUTPUT_DEFINITIONS,
+)
+from inference.core.workflows.core_steps.common.utils import (
+    scale_dimensions_to_max_edge,
+)
+from inference.core.workflows.execution_engine.entities.base import (
+    Batch,
+    OutputDefinition,
+    WorkflowImageData,
+)
+from inference.core.workflows.execution_engine.entities.types import (
+    FLOAT_KIND,
+    IMAGE_KIND,
+    LANGUAGE_MODEL_OUTPUT_KIND,
+    LIST_OF_VALUES_KIND,
+    ROBOFLOW_MANAGED_KEY,
+    SECRET_KIND,
+    STRING_KIND,
+    ImageInputField,
+    Selector,
+)
+from inference.core.workflows.prototypes.block import (
+    AirGappedAvailability,
+    BlockResult,
+    DependentResource,
+    WorkflowBlockManifest,
+    is_workflow_selector,
+    third_party_model,
+)
+
+# One row per model; add future Z.ai models (e.g. Ox Alpha) here. A row may
+# override `reasoning_levels` if a model diverges from the shared set.
+MODEL_VARIANTS: Dict[str, Dict[str, Any]] = {
+    "GLM 5V Turbo": {
+        "model_id": "z-ai/glm-5v-turbo",
+    },
+}
+
+MODEL_IDS = {label: variant["model_id"] for label, variant in MODEL_VARIANTS.items()}
+
+ModelVersion = Literal[tuple(MODEL_VARIANTS.keys())]
+DEFAULT_MODEL_VERSION = "GLM 5V Turbo"
+
+TaskType = Literal[tuple(SUPPORTED_TASK_TYPES_LIST)]
+
+REASONING_EFFORT_OPTIONS = ["none", "low", "medium", "high"]
+ReasoningEffort = Literal[tuple(REASONING_EFFORT_OPTIONS)]
+DEFAULT_REASONING_EFFORT = "none"
+
+REASONING_EFFORT_METADATA = {
+    "none": {
+        "name": "Disabled (recommended)",
+        "description": (
+            "Turns extended reasoning off. GLM models default to extended "
+            "reasoning on OpenRouter, which bloats latency and can consume "
+            "the whole token budget before a visible answer is produced. "
+            "This is the configuration validated in the vlm-exam benchmarks."
+        ),
+    },
+    "low": {
+        "name": "Low",
+        "description": "Small reasoning budget before answering.",
+    },
+    "medium": {
+        "name": "Medium",
+        "description": "Moderate reasoning budget before answering.",
+    },
+    "high": {
+        "name": "High",
+        "description": (
+            "Large reasoning budget. Slowest and most expensive; consider "
+            "raising `max_tokens` so reasoning does not crowd out the answer."
+        ),
+    },
+}
+
+MODEL_REASONING_LEVELS = {
+    label: variant.get("reasoning_levels", REASONING_EFFORT_OPTIONS)
+    for label, variant in MODEL_VARIANTS.items()
+}
+
+MODEL_VERSION_METADATA = attach_reasoning_levels(
+    {label: {"name": label} for label in MODEL_VARIANTS},
+    MODEL_REASONING_LEVELS,
+)
+
+DEFAULT_MAX_TOKENS = 2048
+OPENROUTER_MAX_BASE64_BYTES = 9_500_000
+OPENROUTER_JPEG_QUALITY = 90
+
+# Ported verbatim from vlm-exam's `_NORMALIZED_XYXY_PROMPT_TEMPLATE` — the
+# detection coordinate format pinned for GLM 5V Turbo in the benchmark
+# configs (`xyxy_normalized_0_to_1000`).
+ZAI_OBJECT_DETECTION_PROMPT_TEMPLATE = (
+    "Detect all objects in this image. "
+    "Output a JSON list where each entry contains the 2D bounding box "
+    'in the key "box_2d" and the text label in the key "label". '
+    'The "box_2d" value must be [x_min, y_min, x_max, y_max]: the '
+    "top-left and bottom-right corners as integers between 0 and 1000, "
+    "normalized to the image width (x) and height (y). "
+    "Return only the JSON list, with no extra text. "
+    "Only use these labels: {class_list}"
+)
+
+_TASK_CLASSIFICATION = (
+    "You act as single-class classification model. You must provide reasonable "
+    "predictions. You are only allowed to produce JSON document in Markdown "
+    "```json [...]``` markers. Expected structure of json: "
+    '{"class_name": "class-name", "confidence": 0.4}. `class-name` must be one '
+    "of the class names defined by user. You are only allowed to return single "
+    "JSON document, even if there are potentially multiple classes. You are not "
+    "allowed to return list. You cannot discuss the result, you are only "
+    "allowed to return JSON document."
+)
+
+_TASK_MULTI_LABEL = (
+    "You act as multi-label classification model. You must provide reasonable "
+    "predictions. You are only allowed to produce JSON document in Markdown "
+    '```json``` markers. Expected structure of json: {"predicted_classes": '
+    '[{"class": "class-name-1", "confidence": 0.9}, {"class": "class-name-2", '
+    '"confidence": 0.7}]}. `class-name-X` must be one of the class names '
+    "defined by user and `confidence` is a float value in range 0.0-1.0 that "
+    "represent how sure you are that the class is present in the image. Only "
+    "return class names that are visible. You cannot discuss the result, you "
+    "are only allowed to return JSON document."
+)
+
+_TASK_VQA = (
+    "You act as Visual Question Answering model. Your task is to provide "
+    "answer to question submitted by user. If this is open-question - answer "
+    "with few sentences, for ABCD question, return only the indicator of "
+    "the answer."
+)
+
+_TASK_OCR = (
+    "You act as OCR model. Your task is to read text from the image and "
+    "return it in paragraphs representing the structure of texts in the "
+    "image. You should only return recognised text, nothing else."
+)
+
+_TASK_STRUCTURED = (
+    "You are supposed to produce responses in JSON wrapped in Markdown "
+    "markers: ```json\nyour-response\n```. User is to provide you "
+    "dictionary with keys and values. Each key must be present in your "
+    "response. Values in user dictionary represent descriptions for JSON "
+    "fields to be generated. Provide only JSON Markdown in response."
+)
+
+
+def encode_image_for_zai_openrouter(numpy_image: np.ndarray) -> str:
+    """Encode a BGR image as base64 JPEG under the OpenRouter payload cap.
+
+    Encodes at fixed JPEG quality and, when the base64 payload exceeds
+    ``OPENROUTER_MAX_BASE64_BYTES``, iteratively downscales the longest
+    edge by 10% until it fits. Detection coordinates are normalized to
+    0-1000, so downscaling does not affect parsing.
+
+    Args:
+        numpy_image: Image in BGR channel order.
+
+    Returns:
+        Base64-encoded JPEG payload.
+    """
+    working = numpy_image
+    while True:
+        jpeg_bytes = encode_image_to_jpeg_bytes(
+            working, jpeg_quality=OPENROUTER_JPEG_QUALITY
+        )
+        base64_image = base64.b64encode(jpeg_bytes).decode("ascii")
+        if len(base64_image) <= OPENROUTER_MAX_BASE64_BYTES:
+            return base64_image
+
+        height, width = working.shape[:2]
+        if max(height, width) <= 1:
+            return base64_image
+
+        target_max_edge = max(int(max(height, width) * 0.9), 1)
+        target_width, target_height = scale_dimensions_to_max_edge(
+            width, height, target_max_edge
+        )
+        working = cv2.resize(
+            working, (target_width, target_height), interpolation=cv2.INTER_AREA
+        )
+
+
+def _user_message(base64_image: str, text: str) -> List[dict]:
+    return [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image_url",
+                    "image_url": {
+                        "url": f"data:image/jpeg;base64,{base64_image}",
+                    },
+                },
+                {"type": "text", "text": text},
+            ],
+        }
+    ]
+
+
+def _prepare_unconstrained_prompt(base64_image: str, prompt: str, **_) -> List[dict]:
+    return _user_message(base64_image=base64_image, text=prompt)
+
+
+def _prepare_ocr_prompt(base64_image: str, **_) -> List[dict]:
+    return _user_message(base64_image=base64_image, text=_TASK_OCR)
+
+
+def _prepare_vqa_prompt(base64_image: str, prompt: str, **_) -> List[dict]:
+    return _user_message(
+        base64_image=base64_image, text=f"{_TASK_VQA}\n\nQuestion: {prompt}"
+    )
+
+
+def _prepare_caption_prompt(
+    base64_image: str, short_description: bool, **_
+) -> List[dict]:
+    detail = (
+        "Caption should be short."
+        if short_description
+        else "Caption should be extensive."
+    )
+    text = (
+        "You act as image caption model. Your task is to provide "
+        f"description of the image. {detail}"
+    )
+    return _user_message(base64_image=base64_image, text=text)
+
+
+def _prepare_classification_prompt(
+    base64_image: str, classes: List[str], **_
+) -> List[dict]:
+    text = (
+        f"{_TASK_CLASSIFICATION}\n\n"
+        f"List of all classes to be recognised by model: {', '.join(classes)}"
+    )
+    return _user_message(base64_image=base64_image, text=text)
+
+
+def _prepare_multi_label_classification_prompt(
+    base64_image: str, classes: List[str], **_
+) -> List[dict]:
+    text = (
+        f"{_TASK_MULTI_LABEL}\n\n"
+        f"List of all classes to be recognised by model: {', '.join(classes)}"
+    )
+    return _user_message(base64_image=base64_image, text=text)
+
+
+def _prepare_structured_answering_prompt(
+    base64_image: str, output_structure: Dict[str, str], **_
+) -> List[dict]:
+    text = (
+        f"{_TASK_STRUCTURED}\n\n"
+        "Specification of requirements regarding output fields: \n"
+        f"{json.dumps(output_structure, indent=4)}"
+    )
+    return _user_message(base64_image=base64_image, text=text)
+
+
+def _prepare_object_detection_prompt(
+    base64_image: str, classes: List[str], **_
+) -> List[dict]:
+    text = ZAI_OBJECT_DETECTION_PROMPT_TEMPLATE.format(class_list=", ".join(classes))
+    return _user_message(base64_image=base64_image, text=text)
+
+
+PROMPT_BUILDERS = {
+    "unconstrained": _prepare_unconstrained_prompt,
+    "ocr": _prepare_ocr_prompt,
+    "visual-question-answering": _prepare_vqa_prompt,
+    "caption": lambda **kwargs: _prepare_caption_prompt(
+        short_description=True, **kwargs
+    ),
+    "detailed-caption": lambda **kwargs: _prepare_caption_prompt(
+        short_description=False, **kwargs
+    ),
+    "classification": _prepare_classification_prompt,
+    "multi-label-classification": _prepare_multi_label_classification_prompt,
+    "structured-answering": _prepare_structured_answering_prompt,
+    "object-detection": _prepare_object_detection_prompt,
+}
+
+
+def build_zai_openrouter_prompts(
+    images: List[np.ndarray],
+    task_type: str,
+    prompt: Optional[str],
+    output_structure: Optional[Dict[str, str]],
+    classes: Optional[List[str]],
+) -> List[List[dict]]:
+    """Build one OpenRouter ``messages`` array per input image, GLM-style.
+
+    Every task sends a single user message with the image part first and
+    the instruction text second, with no system role, matching the
+    vlm-exam GLM request contract.
+
+    Args:
+        images: BGR numpy images.
+        task_type: One of the supported VLM task types.
+        prompt: User prompt for unconstrained / VQA tasks.
+        output_structure: Output spec for structured-answering.
+        classes: Class list for classification / detection tasks.
+
+    Returns:
+        List of ``messages`` arrays, one per image.
+
+    Raises:
+        ValueError: If the task type is not supported.
+    """
+    if task_type not in PROMPT_BUILDERS:
+        raise ValueError(f"Task type: {task_type} not supported.")
+    builder = PROMPT_BUILDERS[task_type]
+    built: List[List[dict]] = []
+    for image in images:
+        built.append(
+            builder(
+                base64_image=encode_image_for_zai_openrouter(numpy_image=image),
+                prompt=prompt,
+                output_structure=output_structure,
+                classes=classes,
+            )
+        )
+    return built
+
+
+RELEVANT_TASKS_DOCS_DESCRIPTION = "\n\n".join(
+    f"* **{v['name']}** (`{k}`) - {v['description']}"
+    for k, v in RELEVANT_TASKS_METADATA.items()
+)
+
+LONG_DESCRIPTION = f"""
+Run Z.ai GLM vision-language models via [OpenRouter](https://openrouter.ai/).
+
+Supported model: GLM 5V Turbo.
+
+You can specify arbitrary text prompts or predefined ones. The block supports:
+
+{RELEVANT_TASKS_DOCS_DESCRIPTION}
+
+Object detection uses the format validated for GLM in the vlm-exam
+benchmarks: a JSON list of `box_2d`/`label` entries with
+`[x_min, y_min, x_max, y_max]` integer coordinates normalized to 0-1000.
+Parse the output with `VLM as Detector` (`vlm_as_detector@v2`) using
+`model_type="zai"`.
+
+Every request sends the image before the instruction text in a single user
+message. GLM models default to extended reasoning on OpenRouter; the block
+disables it by default (the benchmarked configuration) and exposes a
+`reasoning_effort` knob to turn it back on. `max_tokens` defaults to 2048;
+raise it (e.g. 8192) when you need a longer answer.
+
+By default the block uses the Roboflow-managed OpenRouter key and bills
+your Roboflow credits. Paste your own `sk-or-...` key to call OpenRouter
+directly.
+"""
+
+
+class BlockManifest(OpenRouterBlockManifestMixin):
+    model_config = ConfigDict(
+        json_schema_extra={
+            "name": "Z.ai",
+            "version": "v1",
+            "short_description": "Run Z.ai GLM vision models via OpenRouter.",
+            "long_description": LONG_DESCRIPTION,
+            "license": "MIT",
+            "block_type": "model",
+            "search_keywords": [
+                "LMM",
+                "VLM",
+                "GLM",
+                "GLM-5V",
+                "Z.ai",
+                "Zhipu",
+                "OpenRouter",
+            ],
+            "is_vlm_block": True,
+            "task_type_property": "task_type",
+            "ui_manifest": {
+                "section": "model",
+                "icon": "fal fa-atom",
+                "blockPriority": 5.56,
+            },
+        },
+        protected_namespaces=(),
+    )
+    type: Literal["roboflow_core/zai_vlm@v1"]
+    images: Selector(kind=[IMAGE_KIND]) = ImageInputField
+    model_version: Union[Selector(kind=[STRING_KIND]), ModelVersion] = Field(
+        default=DEFAULT_MODEL_VERSION,
+        description="Z.ai GLM model to run.",
+        examples=[DEFAULT_MODEL_VERSION],
+        json_schema_extra={
+            "values_metadata": MODEL_VERSION_METADATA,
+        },
+    )
+    task_type: TaskType = Field(
+        default="unconstrained",
+        description=(
+            "Task type to be performed by model. Value determines required "
+            "parameters and output response."
+        ),
+        json_schema_extra={
+            "values_metadata": RELEVANT_TASKS_METADATA,
+            "recommended_parsers": RECOMMENDED_PARSERS,
+            "always_visible": True,
+        },
+    )
+    prompt: Optional[Union[Selector(kind=[STRING_KIND]), str]] = Field(
+        default=None,
+        description="Text prompt to send to the model.",
+        examples=["my prompt", "$inputs.prompt"],
+        json_schema_extra={
+            "relevant_for": {
+                "task_type": {
+                    "values": ["unconstrained", "visual-question-answering"],
+                    "required": True,
+                },
+            },
+            "multiline": True,
+        },
+    )
+    output_structure: Optional[Dict[str, str]] = Field(
+        default=None,
+        description="Dictionary with structure of expected JSON response.",
+        examples=[{"my_key": "description"}, "$inputs.output_structure"],
+        json_schema_extra={
+            "relevant_for": {
+                "task_type": {"values": ["structured-answering"], "required": True},
+            },
+        },
+    )
+    classes: Optional[Union[Selector(kind=[LIST_OF_VALUES_KIND]), List[str]]] = Field(
+        default=None,
+        description="List of classes to be used.",
+        examples=[["class-a", "class-b"], "$inputs.classes"],
+        json_schema_extra={
+            "relevant_for": {
+                "task_type": {
+                    "values": [
+                        "classification",
+                        "multi-label-classification",
+                        "object-detection",
+                    ],
+                    "required": True,
+                },
+            },
+        },
+    )
+    reasoning_effort: ReasoningEffort = Field(
+        default=DEFAULT_REASONING_EFFORT,
+        description=(
+            "Extended-reasoning budget. GLM models default to extended "
+            "reasoning on OpenRouter; `none` (the default) disables it, "
+            "matching the configuration validated in the vlm-exam benches."
+        ),
+        json_schema_extra={"values_metadata": REASONING_EFFORT_METADATA},
+    )
+    max_tokens: Optional[int] = Field(
+        default=DEFAULT_MAX_TOKENS,
+        description=(
+            "Maximum number of tokens the model can generate in its response. "
+            f"Defaults to {DEFAULT_MAX_TOKENS}. Raise it explicitly "
+            "(e.g. 8192) when a task needs a longer answer. Billing is based "
+            "on tokens actually generated, not on this limit."
+        ),
+        gt=1,
+    )
+    temperature: Optional[Union[float, Selector(kind=[FLOAT_KIND])]] = Field(
+        default=None,
+        description=(
+            "Sampling temperature. Left unset by default so the provider "
+            "default applies. Range 0.0-2.0."
+        ),
+    )
+    api_key: Union[
+        Selector(kind=[STRING_KIND, SECRET_KIND, ROBOFLOW_MANAGED_KEY]), str
+    ] = Field(
+        default="rf_key:account",
+        description=(
+            "OpenRouter API key. Defaults to Roboflow's managed key. Provide "
+            "your own `sk-or-...` key to call OpenRouter directly without "
+            "Roboflow billing."
+        ),
+        examples=["rf_key:account", "sk-or-...", "$inputs.openrouter_api_key"],
+        private=True,
+    )
+    privacy_level: PRIVACY_LEVEL_LITERAL = Field(
+        default="deny",
+        description=(
+            "Provider privacy filter. Stricter levels reduce the pool of "
+            "providers and may increase per-call cost on the managed key."
+        ),
+        json_schema_extra={"values_metadata": PRIVACY_LEVEL_METADATA},
+    )
+
+    @model_validator(mode="after")
+    def validate(self) -> "BlockManifest":
+        validate_task_type_required_fields(
+            task_type=self.task_type,
+            prompt=self.prompt,
+            classes=self.classes,
+            output_structure=self.output_structure,
+        )
+        validate_reasoning_level(
+            model=self.model_version,
+            level=self.reasoning_effort,
+            levels_by_model=MODEL_REASONING_LEVELS,
+        )
+        return self
+
+    @field_validator("temperature")
+    @classmethod
+    def validate_temperature(
+        cls, value: Optional[Union[str, float]]
+    ) -> Optional[Union[str, float]]:
+        if value is None or isinstance(value, str):
+            return value
+        if value < 0.0 or value > 2.0:
+            raise ValueError(
+                "'temperature' parameter required to be in range [0.0, 2.0]"
+            )
+        return value
+
+    @classmethod
+    def get_air_gapped_availability(cls) -> AirGappedAvailability:
+        return AirGappedAvailability(available=False, reason="requires_internet")
+
+    @classmethod
+    def get_parameters_accepting_batches(cls) -> List[str]:
+        return ["images"]
+
+    @classmethod
+    def describe_outputs(cls) -> List[OutputDefinition]:
+        return [
+            OutputDefinition(
+                name="output", kind=[STRING_KIND, LANGUAGE_MODEL_OUTPUT_KIND]
+            ),
+            OutputDefinition(name="classes", kind=[LIST_OF_VALUES_KIND]),
+            OutputDefinition(
+                name="thinking",
+                kind=[STRING_KIND],
+                description=(
+                    "Reasoning trace from the model when OpenRouter returns "
+                    "one. Empty string otherwise."
+                ),
+            ),
+            *TOKEN_OUTPUT_DEFINITIONS,
+        ]
+
+    @classmethod
+    def get_execution_engine_compatibility(cls) -> Optional[str]:
+        return ">=1.3.0,<2.0.0"
+
+    def discover_dependent_resources(self) -> Optional[List[DependentResource]]:
+        if is_workflow_selector(self.model_version):
+            return [
+                third_party_model(
+                    provider="openrouter",
+                    model_id=self.model_version,
+                    model_id_resolver=lambda label: MODEL_IDS.get(label),
+                )
+            ]
+        return [
+            third_party_model(
+                provider="openrouter",
+                model_id=MODEL_IDS[self.model_version],
+            )
+        ]
+
+
+class ZaiVlmBlockV1(OpenRouterWorkflowBlockBase):
+    @classmethod
+    def get_manifest(cls) -> Type[WorkflowBlockManifest]:
+        return BlockManifest
+
+    @classmethod
+    def get_execution_engine_compatibility(cls) -> Optional[str]:
+        return ">=1.3.0,<2.0.0"
+
+    def run(
+        self,
+        images: Batch[WorkflowImageData],
+        model_version: str,
+        task_type: str,
+        prompt: Optional[str],
+        output_structure: Optional[Dict[str, str]],
+        classes: Optional[List[str]],
+        reasoning_effort: str,
+        api_key: str,
+        privacy_level: str,
+        max_tokens: Optional[int],
+        temperature: Optional[float],
+        max_concurrent_requests: Optional[int],
+    ) -> BlockResult:
+        model_id = MODEL_IDS.get(model_version)
+        if model_id is None:
+            raise ValueError(
+                f"Unknown Z.ai model '{model_version}'. "
+                f"Pick one of: {list(MODEL_VARIANTS)}"
+            )
+        validate_reasoning_level(
+            model=model_version,
+            level=reasoning_effort,
+            levels_by_model=MODEL_REASONING_LEVELS,
+        )
+        prompts = build_zai_openrouter_prompts(
+            images=[image.numpy_image for image in images],
+            task_type=task_type,
+            prompt=prompt,
+            output_structure=output_structure,
+            classes=classes,
+        )
+        results = self.execute_openrouter_batch_with_usage(
+            openrouter_api_key=api_key,
+            model=model_id,
+            prompts=prompts,
+            max_tokens=max_tokens if max_tokens is not None else DEFAULT_MAX_TOKENS,
+            temperature=temperature,
+            privacy_level=privacy_level,
+            max_concurrent_requests=max_concurrent_requests,
+            reasoning=build_openrouter_reasoning_config(reasoning_effort),
+        )
+        return [
+            {
+                "output": result.content,
+                "classes": classes,
+                "thinking": result.reasoning_trace,
+                "input_tokens": result.input_tokens,
+                "output_tokens": result.output_tokens,
+            }
+            for result in results
+        ]

--- a/tests/workflows/unit_tests/core_steps/common/test_reasoning_contract.py
+++ b/tests/workflows/unit_tests/core_steps/common/test_reasoning_contract.py
@@ -20,6 +20,9 @@ from inference.core.workflows.core_steps.models.foundation.qwen_vlm import (
 from inference.core.workflows.core_steps.models.foundation.spacexai import (
     v2 as spacexai_v2,
 )
+from inference.core.workflows.core_steps.models.foundation.zai_vlm import (
+    v1 as zai_vlm_v1,
+)
 
 _LEVELS = {"model-a": ["low", "high"], "model-b": []}
 
@@ -88,6 +91,12 @@ BLOCK_CONTRACTS = {
         qwen_vlm_v3.REASONING_EFFORT_OPTIONS,
         qwen_vlm_v3.OPENROUTER_MODEL_VERSION_METADATA,
         "none",
+    ),
+    "zai_vlm@v1": (
+        zai_vlm_v1.MODEL_REASONING_LEVELS,
+        zai_vlm_v1.REASONING_EFFORT_OPTIONS,
+        zai_vlm_v1.MODEL_VERSION_METADATA,
+        zai_vlm_v1.DEFAULT_REASONING_EFFORT,
     ),
 }
 

--- a/tests/workflows/unit_tests/core_steps/dependent_resources/test_zai_vlm.py
+++ b/tests/workflows/unit_tests/core_steps/dependent_resources/test_zai_vlm.py
@@ -1,0 +1,50 @@
+"""
+Dependent-resources discovery tests for ``roboflow_core/zai_vlm@v1``,
+served via OpenRouter. Friendly labels map through ``MODEL_IDS`` to
+OpenRouter slugs — the same mapping ``run()`` resolves before calling
+OpenRouter.
+"""
+
+from inference.core.workflows.core_steps.models.foundation.zai_vlm.v1 import (
+    MODEL_IDS,
+    BlockManifest,
+)
+from inference.core.workflows.prototypes.block import third_party_model
+
+
+def _build_payload(**overrides) -> dict:
+    payload = {
+        "type": "roboflow_core/zai_vlm@v1",
+        "name": "vlm",
+        "images": "$inputs.image",
+        "task_type": "caption",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_zai_vlm_v1_default_label_resolves_to_catalog_slug() -> None:
+    manifest = BlockManifest.model_validate(_build_payload())
+
+    # Default model_version is "GLM 5V Turbo"; cross-check the expected
+    # slug against the catalog itself.
+    assert MODEL_IDS["GLM 5V Turbo"] == "z-ai/glm-5v-turbo"
+    assert manifest.discover_dependent_resources() == [
+        third_party_model(provider="openrouter", model_id="z-ai/glm-5v-turbo"),
+    ]
+
+
+def test_zai_vlm_v1_selector_fed_label_is_returned_verbatim() -> None:
+    manifest = BlockManifest.model_validate(
+        _build_payload(model_version="$inputs.zai_model")
+    )
+
+    resources = manifest.discover_dependent_resources()
+
+    assert resources == [
+        third_party_model(provider="openrouter", model_id="$inputs.zai_model"),
+    ]
+    resolver = resources[0].metadata.model_id_resolver
+    assert resolver is not None
+    assert resolver("GLM 5V Turbo") == "z-ai/glm-5v-turbo"
+    assert resolver("not-a-model") is None

--- a/tests/workflows/unit_tests/core_steps/formatters/vlm_as_detector/test_v2.py
+++ b/tests/workflows/unit_tests/core_steps/formatters/vlm_as_detector/test_v2.py
@@ -441,6 +441,89 @@ def test_run_method_for_anthropic_claude_legacy_detections_output() -> None:
     assert np.allclose(result["predictions"].confidence, np.array([0.9]))
 
 
+def test_manifest_parsing_for_zai_model_type() -> None:
+    # given
+    raw_manifest = {
+        "type": "roboflow_core/vlm_as_detector@v2",
+        "name": "parser",
+        "image": "$inputs.image",
+        "vlm_output": "$steps.vlm.output",
+        "classes": ["cat", "dog"],
+        "model_type": "zai",
+        "task_type": "object-detection",
+    }
+
+    # when
+    result = BlockManifest.model_validate(raw_manifest)
+
+    # then
+    assert result.model_type == "zai"
+
+
+def test_run_method_for_zai_box_2d_output() -> None:
+    # given - the Z.ai GLM block prompts for the same box_2d contract as
+    # Qwen: [x_min, y_min, x_max, y_max] integers normalized to 0-1000
+    block = VLMAsDetectorBlockV2()
+    image = WorkflowImageData(
+        numpy_image=np.zeros((480, 640, 3), dtype=np.uint8),
+        parent_metadata=ImageParentMetadata(parent_id="parent"),
+    )
+    vlm_output = """
+[
+  {"box_2d": [100, 200, 500, 1000], "label": "cat"},
+  {"box_2d": [0, 0, 500, 500], "label": "unicorn"}
+]
+    """
+
+    # when
+    result = block.run(
+        image=image,
+        vlm_output=vlm_output,
+        classes=["cat", "dog"],
+        model_type="zai",
+        task_type="object-detection",
+    )
+
+    # then
+    assert result["error_status"] is False
+    assert isinstance(result["predictions"], sv.Detections)
+    assert result["predictions"].data["class_name"].tolist() == ["cat", "unicorn"]
+    assert np.allclose(result["predictions"].class_id, np.array([0, -1]))
+    assert np.allclose(
+        result["predictions"].xyxy,
+        np.array(
+            [
+                [64, 96, 320, 480],
+                [0, 0, 320, 240],
+            ]
+        ),
+        atol=1.0,
+    )
+    assert np.allclose(result["predictions"].confidence, np.array([1.0, 1.0]))
+
+
+def test_run_method_for_zai_unexpected_shape_sets_error_status() -> None:
+    # given - neither a JSON list nor a {"detections": [...]} object
+    block = VLMAsDetectorBlockV2()
+    image = WorkflowImageData(
+        numpy_image=np.zeros((480, 640, 3), dtype=np.uint8),
+        parent_metadata=ImageParentMetadata(parent_id="parent"),
+    )
+
+    # when
+    result = block.run(
+        image=image,
+        vlm_output='{"objects": []}',
+        classes=["cat"],
+        model_type="zai",
+        task_type="object-detection",
+    )
+
+    # then
+    assert result["error_status"] is True
+    assert result["predictions"] is None
+
+
 def test_run_method_for_invalid_claude_and_gemini_output() -> None:
     # given
     block = VLMAsDetectorBlockV2()

--- a/tests/workflows/unit_tests/core_steps/formatters/vlm_as_detector/test_v2.py
+++ b/tests/workflows/unit_tests/core_steps/formatters/vlm_as_detector/test_v2.py
@@ -502,6 +502,45 @@ def test_run_method_for_zai_box_2d_output() -> None:
     assert np.allclose(result["predictions"].confidence, np.array([1.0, 1.0]))
 
 
+def test_run_method_for_zai_bbox_2d_absolute_pixel_output() -> None:
+    # given - the GLM 5.3 Flash prompt pins bbox_2d entries in absolute
+    # pixels of the original image; out-of-range values are clamped
+    block = VLMAsDetectorBlockV2()
+    image = WorkflowImageData(
+        numpy_image=np.zeros((480, 640, 3), dtype=np.uint8),
+        parent_metadata=ImageParentMetadata(parent_id="parent"),
+    )
+    vlm_output = """
+[
+  {"bbox_2d": [64, 96, 320, 480], "label": "cat"},
+  {"bbox_2d": [-10, 0, 700, 240], "label": "dog"}
+]
+    """
+
+    # when
+    result = block.run(
+        image=image,
+        vlm_output=vlm_output,
+        classes=["cat", "dog"],
+        model_type="zai",
+        task_type="object-detection",
+    )
+
+    # then
+    assert result["error_status"] is False
+    assert result["predictions"].data["class_name"].tolist() == ["cat", "dog"]
+    assert np.allclose(
+        result["predictions"].xyxy,
+        np.array(
+            [
+                [64, 96, 320, 480],
+                [0, 0, 640, 240],
+            ]
+        ),
+        atol=1.0,
+    )
+
+
 def test_run_method_for_zai_unexpected_shape_sets_error_status() -> None:
     # given - neither a JSON list nor a {"detections": [...]} object
     block = VLMAsDetectorBlockV2()

--- a/tests/workflows/unit_tests/core_steps/formatters/vlm_as_detector/test_v2_tensor.py
+++ b/tests/workflows/unit_tests/core_steps/formatters/vlm_as_detector/test_v2_tensor.py
@@ -286,6 +286,50 @@ def test_run_method_for_qwen_unexpected_shape_sets_error_status_tensor_native() 
     assert result["predictions"] is None
 
 
+def test_run_method_for_zai_box_2d_output_tensor_native() -> None:
+    # given - the Z.ai GLM block prompts for the same box_2d contract as
+    # Qwen: [x_min, y_min, x_max, y_max] integers normalized to 0-1000
+    block = VLMAsDetectorBlockV2()
+    image = WorkflowImageData(
+        numpy_image=np.zeros((480, 640, 3), dtype=np.uint8),
+        parent_metadata=ImageParentMetadata(parent_id="parent"),
+    )
+    vlm_output = """
+[
+  {"box_2d": [100, 200, 500, 1000], "label": "cat"},
+  {"box_2d": [0, 0, 500, 500], "label": "unicorn"}
+]
+    """
+
+    # when
+    result = block.run(
+        image=image,
+        vlm_output=vlm_output,
+        classes=["cat", "dog"],
+        model_type="zai",
+        task_type="object-detection",
+    )
+
+    # then
+    assert result["error_status"] is False
+    assert isinstance(result["predictions"], Detections)
+    assert _class_names(result["predictions"]) == ["cat", "unicorn"]
+    assert np.allclose(result["predictions"].class_id.cpu().numpy(), np.array([0, -1]))
+    assert np.allclose(
+        result["predictions"].xyxy.cpu().numpy(),
+        np.array(
+            [
+                [64, 96, 320, 480],
+                [0, 0, 320, 240],
+            ]
+        ),
+        atol=1.0,
+    )
+    assert np.allclose(
+        result["predictions"].confidence.cpu().numpy(), np.array([1.0, 1.0])
+    )
+
+
 def test_run_method_for_muse_named_fields_output_tensor_native() -> None:
     # given - muse coordinates are named x_min/y_min/x_max/y_max fields
     # normalized to 0-1000 on both axes; out-of-range values are clamped

--- a/tests/workflows/unit_tests/core_steps/formatters/vlm_as_detector/test_v2_tensor.py
+++ b/tests/workflows/unit_tests/core_steps/formatters/vlm_as_detector/test_v2_tensor.py
@@ -330,6 +330,45 @@ def test_run_method_for_zai_box_2d_output_tensor_native() -> None:
     )
 
 
+def test_run_method_for_zai_bbox_2d_absolute_pixel_output_tensor_native() -> None:
+    # given - the GLM 5.3 Flash prompt pins bbox_2d entries in absolute
+    # pixels of the original image; out-of-range values are clamped
+    block = VLMAsDetectorBlockV2()
+    image = WorkflowImageData(
+        numpy_image=np.zeros((480, 640, 3), dtype=np.uint8),
+        parent_metadata=ImageParentMetadata(parent_id="parent"),
+    )
+    vlm_output = """
+[
+  {"bbox_2d": [64, 96, 320, 480], "label": "cat"},
+  {"bbox_2d": [-10, 0, 700, 240], "label": "dog"}
+]
+    """
+
+    # when
+    result = block.run(
+        image=image,
+        vlm_output=vlm_output,
+        classes=["cat", "dog"],
+        model_type="zai",
+        task_type="object-detection",
+    )
+
+    # then
+    assert result["error_status"] is False
+    assert _class_names(result["predictions"]) == ["cat", "dog"]
+    assert np.allclose(
+        result["predictions"].xyxy.cpu().numpy(),
+        np.array(
+            [
+                [64, 96, 320, 480],
+                [0, 0, 640, 240],
+            ]
+        ),
+        atol=1.0,
+    )
+
+
 def test_run_method_for_muse_named_fields_output_tensor_native() -> None:
     # given - muse coordinates are named x_min/y_min/x_max/y_max fields
     # normalized to 0-1000 on both axes; out-of-range values are clamped

--- a/tests/workflows/unit_tests/core_steps/models/foundation/test_zai_vlm_v1.py
+++ b/tests/workflows/unit_tests/core_steps/models/foundation/test_zai_vlm_v1.py
@@ -9,6 +9,7 @@ from inference.core.workflows.core_steps.models.foundation.zai_vlm.v1 import (
     DEFAULT_MAX_TOKENS,
     DEFAULT_MODEL_VERSION,
     DEFAULT_REASONING_EFFORT,
+    ZAI_BBOX_2D_PIXEL_DETECTION_PROMPT_TEMPLATE,
     BlockManifest,
     ZaiVlmBlockV1,
     build_zai_openrouter_prompts,
@@ -147,3 +148,53 @@ def test_run_maps_reasoning_effort_to_openrouter_config(mock_or):
     block.run(**_base_run_kwargs(reasoning_effort="high"))
 
     assert mock_or.call_args.kwargs["reasoning"] == {"effort": "high"}
+
+
+# Copied from vlm-exam `_BBOX_2D_PIXEL_PROMPT_TEMPLATE` so an edit to the
+# block constant fails this test.
+EXPECTED_FLASH_DETECTION_PROMPT = (
+    "Detect all objects in this image and return their locations in the "
+    "form of coordinates. The format of output should be like "
+    '{"bbox_2d": [x1, y1, x2, y2], "label": "<name>"}. '
+    "Only use these labels: cat, dog. Return a JSON array only."
+)
+
+
+def test_flash_detection_prompt_is_vlm_exam_bbox_2d_template():
+    messages = build_zai_openrouter_prompts(
+        images=[np.zeros((8, 8, 3), dtype=np.uint8)],
+        task_type="object-detection",
+        prompt=None,
+        output_structure=None,
+        classes=["cat", "dog"],
+        detection_prompt_template=(ZAI_BBOX_2D_PIXEL_DETECTION_PROMPT_TEMPLATE),
+    )
+    content = messages[0][0]["content"]
+    assert content[1]["text"] == EXPECTED_FLASH_DETECTION_PROMPT
+
+
+@patch(
+    "inference.core.workflows.core_steps.models.foundation.zai_vlm.v1."
+    "OpenRouterWorkflowBlockBase.execute_openrouter_batch_with_usage"
+)
+def test_run_flash_falls_back_to_low_effort_when_reasoning_disabled(mock_or):
+    mock_or.return_value = [
+        OpenRouterResult(
+            content="boxes", reasoning_trace="t", input_tokens=9, output_tokens=3
+        )
+    ]
+    block = ZaiVlmBlockV1(model_manager=MagicMock(), api_key="rf_key")
+
+    block.run(
+        **_base_run_kwargs(
+            model_version="GLM 5.3 Flash",
+            task_type="object-detection",
+            classes=["cat"],
+            reasoning_effort="none",
+        )
+    )
+
+    assert mock_or.call_args.kwargs["model"] == "z-ai/glm-5.3-flash"
+    assert mock_or.call_args.kwargs["reasoning"] == {"effort": "low"}
+    sent_text = mock_or.call_args.kwargs["prompts"][0][0]["content"][1]["text"]
+    assert '"bbox_2d"' in sent_text

--- a/tests/workflows/unit_tests/core_steps/models/foundation/test_zai_vlm_v1.py
+++ b/tests/workflows/unit_tests/core_steps/models/foundation/test_zai_vlm_v1.py
@@ -1,0 +1,149 @@
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+from pydantic import ValidationError
+
+from inference.core.workflows.core_steps.common.openrouter import OpenRouterResult
+from inference.core.workflows.core_steps.models.foundation.zai_vlm.v1 import (
+    DEFAULT_MAX_TOKENS,
+    DEFAULT_MODEL_VERSION,
+    DEFAULT_REASONING_EFFORT,
+    BlockManifest,
+    ZaiVlmBlockV1,
+    build_zai_openrouter_prompts,
+)
+from inference.core.workflows.execution_engine.entities.base import WorkflowImageData
+
+# Copied from vlm-exam `_NORMALIZED_XYXY_PROMPT_TEMPLATE` so an edit to the
+# block constant fails this test.
+EXPECTED_DETECTION_PROMPT = (
+    "Detect all objects in this image. "
+    "Output a JSON list where each entry contains the 2D bounding box "
+    'in the key "box_2d" and the text label in the key "label". '
+    'The "box_2d" value must be [x_min, y_min, x_max, y_max]: the '
+    "top-left and bottom-right corners as integers between 0 and 1000, "
+    "normalized to the image width (x) and height (y). "
+    "Return only the JSON list, with no extra text. "
+    "Only use these labels: cat, dog"
+)
+
+
+def _stub_image() -> WorkflowImageData:
+    return WorkflowImageData(
+        parent_metadata=MagicMock(
+            parent_id="root", workflow_root_ancestor_metadata=None
+        ),
+        numpy_image=np.zeros((10, 10, 3), dtype=np.uint8),
+    )
+
+
+def _base_run_kwargs(**overrides):
+    kwargs = dict(
+        images=[_stub_image()],
+        model_version=DEFAULT_MODEL_VERSION,
+        task_type="caption",
+        prompt=None,
+        output_structure=None,
+        classes=None,
+        reasoning_effort=DEFAULT_REASONING_EFFORT,
+        api_key="rf_key:account",
+        privacy_level="deny",
+        max_tokens=DEFAULT_MAX_TOKENS,
+        temperature=None,
+        max_concurrent_requests=None,
+    )
+    kwargs.update(overrides)
+    return kwargs
+
+
+def test_manifest_defaults():
+    manifest = BlockManifest.model_validate(
+        {
+            "type": "roboflow_core/zai_vlm@v1",
+            "name": "glm",
+            "images": "$inputs.image",
+            "task_type": "caption",
+        }
+    )
+    assert manifest.model_version == "GLM 5V Turbo"
+    assert manifest.max_tokens == 2048
+    assert manifest.temperature is None
+    assert manifest.reasoning_effort == "none"
+    assert manifest.privacy_level == "deny"
+
+
+def test_manifest_rejects_unknown_model_version():
+    with pytest.raises(ValidationError):
+        BlockManifest.model_validate(
+            {
+                "type": "roboflow_core/zai_vlm@v1",
+                "name": "glm",
+                "images": "$inputs.image",
+                "task_type": "caption",
+                "model_version": "GLM 4V",
+            }
+        )
+
+
+def test_detection_prompt_is_vlm_exam_normalized_xyxy_template():
+    messages = build_zai_openrouter_prompts(
+        images=[np.zeros((8, 8, 3), dtype=np.uint8)],
+        task_type="object-detection",
+        prompt=None,
+        output_structure=None,
+        classes=["cat", "dog"],
+    )
+    assert [message["role"] for message in messages[0]] == ["user"]
+    content = messages[0][0]["content"]
+    assert content[0]["type"] == "image_url"
+    assert content[1]["type"] == "text"
+    assert content[1]["text"] == EXPECTED_DETECTION_PROMPT
+
+
+@patch(
+    "inference.core.workflows.core_steps.models.foundation.zai_vlm.v1."
+    "OpenRouterWorkflowBlockBase.execute_openrouter_batch_with_usage"
+)
+def test_run_passes_slug_and_disables_reasoning_by_default(mock_or):
+    mock_or.return_value = [
+        OpenRouterResult(
+            content="boxes", reasoning_trace="", input_tokens=20, output_tokens=8
+        )
+    ]
+    block = ZaiVlmBlockV1(model_manager=MagicMock(), api_key="rf_key")
+
+    result = block.run(
+        **_base_run_kwargs(task_type="object-detection", classes=["cat"])
+    )
+
+    assert mock_or.call_args.kwargs["model"] == "z-ai/glm-5v-turbo"
+    assert mock_or.call_args.kwargs["reasoning"] == {"enabled": False}
+    assert mock_or.call_args.kwargs["max_tokens"] == 2048
+    assert mock_or.call_args.kwargs["temperature"] is None
+    assert result == [
+        {
+            "output": "boxes",
+            "classes": ["cat"],
+            "thinking": "",
+            "input_tokens": 20,
+            "output_tokens": 8,
+        }
+    ]
+
+
+@patch(
+    "inference.core.workflows.core_steps.models.foundation.zai_vlm.v1."
+    "OpenRouterWorkflowBlockBase.execute_openrouter_batch_with_usage"
+)
+def test_run_maps_reasoning_effort_to_openrouter_config(mock_or):
+    mock_or.return_value = [
+        OpenRouterResult(
+            content="answer", reasoning_trace="trace", input_tokens=5, output_tokens=2
+        )
+    ]
+    block = ZaiVlmBlockV1(model_manager=MagicMock(), api_key="rf_key")
+
+    block.run(**_base_run_kwargs(reasoning_effort="high"))
+
+    assert mock_or.call_args.kwargs["reasoning"] == {"effort": "high"}


### PR DESCRIPTION
## What

Adds a Z.ai block, the same way the Anthropic block was aligned in #2865. Two models, each with its vlm-exam winning detection format:

- **GLM 5V Turbo**: `xyxy_normalized_0_to_1000` (`box_2d`), reasoning off.
- **GLM 5.3 Flash** (released 2026-08-26): `xyxy_absolute_original_image_bbox_2d` (`bbox_2d`, absolute pixels), reasoning required. It ran on OpenRouter as the stealth model "Ox Alpha"; the retirement notice confirms it is the same model ("This model was ZAI's GLM-5.3 Flash"). A 20-image format probe on the released id confirms the format: bbox_2d pixels 0.241 mean mAP@50 vs ~0 for normalized prompts (vlm-exam PR: roboflow/vlm-exam#33).

## Changes

- New `zai_vlm@v1` block runs both models via OpenRouter, on the shared OpenRouter base (managed `rf_key:account` by default, own `sk-or-...` key supported). It follows the vlm-exam request contract: image-first user message, no system role, per-model detection prompt template, and a `reasoning_effort` knob that defaults to `none` (the benchmarked config). GLM 5.3 Flash rejects `reasoning: {enabled: false}` and falls back to `{"effort": "low"}`. Outputs include `thinking`, `input_tokens`, and `output_tokens`. Search keywords include `GLM` and `Zhipu`.
- `vlm_as_detector@v2` (and its tensor variant) gain `model_type="zai"`. The parser dispatches on the box key the response carries: `box_2d` entries reuse the Qwen parser unchanged (same 0-1000 contract), and `bbox_2d` entries are rescaled from absolute pixels into the 0-1000 space and then handed to the same Qwen parser, so no assembly code is duplicated.
- No image pre-resize beyond the shared OpenRouter JPEG cap (quality 90, 9.5MB base64, 10% iterative downscale, same as the Muse/Qwen blocks and vlm-exam). Coordinates are normalized, so downscaling does not affect parsing, unlike the Claude absolute-pixel path.
- No Roboflow platform change needed: the OpenRouter proxy validates models against OpenRouter's live catalog and bills from `usage.cost`.

## Testing

Unit tests cover manifest defaults and rejects, both exact vlm-exam prompt templates, reasoning config mapping (`none` -> `{"enabled": false}` for Turbo, `{"effort": "low"}` fallback for Flash, efforts pass through), token-usage outputs, parser dispatch for both box formats in both v2 variants (including clamping), dependent-resource discovery, and the shared reasoning contract. All affected suites pass (1857 tests).

E2E through the prod proxy with the managed key (block + `vlm_as_detector@v2`, `model_type="zai"`), on the same 20 vlm-exam detection images each model was benchmarked on, scored with the same per-image mAP@50:

| | this PR (block + parser) | vlm-exam eval |
|---|---|---|
| GLM 5V Turbo | 0.530 mean mAP@50 / 35% acc@0.8 | 0.487 / 30% |
| GLM 5.3 Flash | 0.229 mean mAP@50 / 10% acc@0.8 | 0.265 / 15% |

Both match within run-to-run sampling noise (GLM 5.3 Flash per-image scores vary a lot between runs; both directions of the gap appear per image). The run surfaced one recoverable failure mode: GLM sometimes wraps the JSON array in prose, which broke whole-string parsing. The parser now recovers the outermost `[...]` substring for `model_type="zai"`, the same fallback vlm-exam applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
