### PR TITLE
Switch GLM 5.3 Flash detection to the benchmarked yxyx 0-1000 format

### DIFF
--- a/inference/core/workflows/core_steps/formatters/vlm_as_detector/v2.py
+++ b/inference/core/workflows/core_steps/formatters/vlm_as_detector/v2.py
@@ -35,7 +35,7 @@ from inference.core.workflows.core_steps.formatters.vlm_as_detector.spacexai_det
     parse_spacexai_object_detection_response,
 )
 from inference.core.workflows.core_steps.formatters.vlm_as_detector.zai_detection_parsing import (
-    parse_zai_object_detection_response,
+    extract_zai_json_array,
 )
 from inference.core.workflows.execution_engine.constants import (
     DETECTION_ID_KEY,
@@ -161,7 +161,7 @@ This version (v2) includes the following enhancements over v1:
 
 ## Requirements
 
-This block requires an image input (for metadata and dimensions) and a VLM output string containing JSON detection data. The JSON can be raw JSON or wrapped in Markdown code blocks (```json ... ```). The block supports eight model types: "openai", "google-gemini", "anthropic-claude", "spacexai", "qwen", "muse", "zai", and "florence-2". It supports multiple task types: "object-detection", "open-vocabulary-object-detection", "object-detection-and-caption", "phrase-grounded-object-detection", "region-proposal", and "ocr-with-text-detection". The `classes` parameter is required for OpenAI, Gemini, Claude, SpaceXAI, Qwen, Muse, and Z.ai models (to map class names to IDs) but optional for Florence-2 (some tasks don't require it). Classes are mapped to IDs by index (first class = 0, second = 1, etc.). Classes not in the list get class_id = -1; the model's original label is kept as class_name and visualization blocks paint those detections in a neutral gray. The block outputs object detection predictions in standard format (compatible with detection blocks), error_status (boolean), and inference_id (INFERENCE_ID_KIND) for tracking.
+This block requires an image input (for metadata and dimensions) and a VLM output string containing JSON detection data. The JSON can be raw JSON or wrapped in Markdown code blocks (```json ... ```). The block supports nine model types: "openai", "google-gemini", "anthropic-claude", "spacexai", "qwen", "muse", "zai", "zai-flash", and "florence-2". It supports multiple task types: "object-detection", "open-vocabulary-object-detection", "object-detection-and-caption", "phrase-grounded-object-detection", "region-proposal", and "ocr-with-text-detection". The `classes` parameter is required for OpenAI, Gemini, Claude, SpaceXAI, Qwen, Muse, and Z.ai models (to map class names to IDs) but optional for Florence-2 (some tasks don't require it). Classes are mapped to IDs by index (first class = 0, second = 1, etc.). Classes not in the list get class_id = -1; the model's original label is kept as class_name and visualization blocks paint those detections in a neutral gray. The block outputs object detection predictions in standard format (compatible with detection blocks), error_status (boolean), and inference_id (INFERENCE_ID_KIND) for tracking.
 """
 
 SHORT_DESCRIPTION = "Parses raw string into object-detection prediction."
@@ -237,6 +237,7 @@ class BlockManifest(WorkflowBlockManifest):
                         "qwen",
                         "muse",
                         "zai",
+                        "zai-flash",
                     ],
                     "required": True,
                 },
@@ -251,9 +252,10 @@ class BlockManifest(WorkflowBlockManifest):
         "qwen",
         "muse",
         "zai",
+        "zai-flash",
         "florence-2",
     ] = Field(
-        description="Type of the VLM/LLM model that generated the prediction. Determines which parser is used to extract detection data from the JSON output. Supported models: 'openai' (GPT-4V), 'google-gemini' (Gemini Vision), 'anthropic-claude' (Claude Vision), 'spacexai' (Grok), 'qwen' (Qwen-VL via OpenRouter), 'muse' (Meta Muse via OpenRouter), 'zai' (Z.ai GLM via OpenRouter), 'florence-2' (Microsoft Florence-2). Each model type has different JSON output formats, so the correct model type must be specified for proper parsing.",
+        description="Type of the VLM/LLM model that generated the prediction. Determines which parser is used to extract detection data from the JSON output. Supported models: 'openai' (GPT-4V), 'google-gemini' (Gemini Vision), 'anthropic-claude' (Claude Vision), 'spacexai' (Grok), 'qwen' (Qwen-VL via OpenRouter), 'zai' (Z.ai GLM 5V Turbo via OpenRouter, box_2d xyxy 0-1000), 'zai-flash' (Z.ai GLM 5.3 Flash via OpenRouter, box_2d yxyx 0-1000), 'muse' (Meta Muse via OpenRouter), 'florence-2' (Microsoft Florence-2). Each model type has different JSON output formats, so the correct model type must be specified for proper parsing.",
         examples=[
             ["openai"],
             ["google-gemini"],
@@ -262,6 +264,7 @@ class BlockManifest(WorkflowBlockManifest):
             ["qwen"],
             ["muse"],
             ["zai"],
+            ["zai-flash"],
             ["florence-2"],
         ],
     )
@@ -323,6 +326,10 @@ class VLMAsDetectorBlockV2(WorkflowBlock):
             loose_entries = extract_flat_object_entries(vlm_output)
             if loose_entries:
                 error_status, parsed_data = False, loose_entries
+        if error_status and model_type in ("zai", "zai-flash"):
+            recovered_entries = extract_zai_json_array(vlm_output)
+            if recovered_entries is not None:
+                error_status, parsed_data = False, recovered_entries
         if error_status:
             return {
                 "error_status": True,
@@ -610,7 +617,11 @@ REGISTERED_PARSERS = {
     ("spacexai", "object-detection"): parse_spacexai_object_detection_response,
     ("qwen", "object-detection"): parse_qwen_object_detection_response,
     ("muse", "object-detection"): parse_muse_object_detection_response,
-    ("zai", "object-detection"): parse_zai_object_detection_response,
+    # GLM 5V Turbo prompts for the Qwen box_2d xyxy 0-1000 contract; GLM 5.3
+    # Flash prompts for the Gemini box_2d yxyx 0-1000 contract. Same key,
+    # different axis order, so each model gets its own model_type.
+    ("zai", "object-detection"): parse_qwen_object_detection_response,
+    ("zai-flash", "object-detection"): parse_gemini_object_detection_response,
     # Florence 2
     ("florence-2", "object-detection"): partial(
         parse_florence2_object_detection_response, florence_task_type="<OD>"

--- a/inference/core/workflows/core_steps/formatters/vlm_as_detector/v2_tensor.py
+++ b/inference/core/workflows/core_steps/formatters/vlm_as_detector/v2_tensor.py
@@ -41,8 +41,7 @@ from inference.core.workflows.core_steps.formatters.vlm_as_detector.spacexai_det
     extract_spacexai_detection_entries,
 )
 from inference.core.workflows.core_steps.formatters.vlm_as_detector.zai_detection_parsing import (
-    convert_zai_pixel_entries_to_normalized,
-    zai_entries_use_absolute_pixels,
+    extract_zai_json_array,
 )
 from inference.core.workflows.execution_engine.constants import (
     CLASS_NAME_KEY,
@@ -179,7 +178,7 @@ This version (v2) includes the following enhancements over v1:
 
 ## Requirements
 
-This block requires an image input (for metadata and dimensions) and a VLM output string containing JSON detection data. The JSON can be raw JSON or wrapped in Markdown code blocks (```json ... ```). The block supports eight model types: "openai", "google-gemini", "anthropic-claude", "spacexai", "qwen", "muse", "zai", and "florence-2". It supports multiple task types: "object-detection", "open-vocabulary-object-detection", "object-detection-and-caption", "phrase-grounded-object-detection", "region-proposal", and "ocr-with-text-detection". The `classes` parameter is required for OpenAI, Gemini, Claude, SpaceXAI, Qwen, Muse, and Z.ai models (to map class names to IDs) but optional for Florence-2 (some tasks don't require it). Classes are mapped to IDs by index (first class = 0, second = 1, etc.). Classes not in the list get class_id = -1; the model's original label is kept as class_name and visualization blocks paint those detections in a neutral gray. The block outputs object detection predictions in standard format (compatible with detection blocks), error_status (boolean), and inference_id (INFERENCE_ID_KIND) for tracking.
+This block requires an image input (for metadata and dimensions) and a VLM output string containing JSON detection data. The JSON can be raw JSON or wrapped in Markdown code blocks (```json ... ```). The block supports nine model types: "openai", "google-gemini", "anthropic-claude", "spacexai", "qwen", "muse", "zai", "zai-flash", and "florence-2". It supports multiple task types: "object-detection", "open-vocabulary-object-detection", "object-detection-and-caption", "phrase-grounded-object-detection", "region-proposal", and "ocr-with-text-detection". The `classes` parameter is required for OpenAI, Gemini, Claude, SpaceXAI, Qwen, Muse, and Z.ai models (to map class names to IDs) but optional for Florence-2 (some tasks don't require it). Classes are mapped to IDs by index (first class = 0, second = 1, etc.). Classes not in the list get class_id = -1; the model's original label is kept as class_name and visualization blocks paint those detections in a neutral gray. The block outputs object detection predictions in standard format (compatible with detection blocks), error_status (boolean), and inference_id (INFERENCE_ID_KIND) for tracking.
 """
 
 SHORT_DESCRIPTION = "Parses raw string into object-detection prediction."
@@ -255,6 +254,7 @@ class BlockManifest(WorkflowBlockManifest):
                         "qwen",
                         "muse",
                         "zai",
+                        "zai-flash",
                     ],
                     "required": True,
                 },
@@ -269,9 +269,10 @@ class BlockManifest(WorkflowBlockManifest):
         "qwen",
         "muse",
         "zai",
+        "zai-flash",
         "florence-2",
     ] = Field(
-        description="Type of the VLM/LLM model that generated the prediction. Determines which parser is used to extract detection data from the JSON output. Supported models: 'openai' (GPT-4V), 'google-gemini' (Gemini Vision), 'anthropic-claude' (Claude Vision), 'spacexai' (Grok), 'qwen' (Qwen-VL via OpenRouter), 'muse' (Meta Muse via OpenRouter), 'zai' (Z.ai GLM via OpenRouter), 'florence-2' (Microsoft Florence-2). Each model type has different JSON output formats, so the correct model type must be specified for proper parsing.",
+        description="Type of the VLM/LLM model that generated the prediction. Determines which parser is used to extract detection data from the JSON output. Supported models: 'openai' (GPT-4V), 'google-gemini' (Gemini Vision), 'anthropic-claude' (Claude Vision), 'spacexai' (Grok), 'qwen' (Qwen-VL via OpenRouter), 'zai' (Z.ai GLM 5V Turbo via OpenRouter, box_2d xyxy 0-1000), 'zai-flash' (Z.ai GLM 5.3 Flash via OpenRouter, box_2d yxyx 0-1000), 'muse' (Meta Muse via OpenRouter), 'florence-2' (Microsoft Florence-2). Each model type has different JSON output formats, so the correct model type must be specified for proper parsing.",
         examples=[
             ["openai"],
             ["google-gemini"],
@@ -280,6 +281,7 @@ class BlockManifest(WorkflowBlockManifest):
             ["qwen"],
             ["muse"],
             ["zai"],
+            ["zai-flash"],
             ["florence-2"],
         ],
     )
@@ -342,6 +344,10 @@ class VLMAsDetectorBlockV2(WorkflowBlock):
             loose_entries = extract_flat_object_entries(vlm_output)
             if loose_entries:
                 error_status, parsed_data = False, loose_entries
+        if error_status and model_type in ("zai", "zai-flash"):
+            recovered_entries = extract_zai_json_array(vlm_output)
+            if recovered_entries is not None:
+                error_status, parsed_data = False, recovered_entries
         if error_status:
             return {
                 "error_status": True,
@@ -870,40 +876,6 @@ def parse_qwen_object_detection_response(
     )
 
 
-def parse_zai_object_detection_response(
-    image: WorkflowImageData,
-    parsed_data: Union[dict, list],
-    classes: List[str],
-    inference_id: str,
-) -> Detections:
-    """Parse Z.ai block object-detection output into native detections.
-
-    Dispatches on the box key the response carries: ``bbox_2d`` entries
-    (GLM 5.3 Flash) are rescaled from absolute pixels into the 0-1000
-    space first; either way the tensor-native Qwen parser does the parsing.
-    Tensor-native sibling of the numpy
-    ``zai_detection_parsing.parse_zai_object_detection_response``.
-
-    Raises:
-        ValueError: If the response is neither a JSON list nor a
-            ``{"detections": [...]}`` object.
-    """
-    entries = extract_qwen_detection_entries(parsed_data=parsed_data)
-    if zai_entries_use_absolute_pixels(entries):
-        image_height, image_width = image._read_shape_without_materialization()
-        parsed_data = convert_zai_pixel_entries_to_normalized(
-            entries=entries,
-            image_height=image_height,
-            image_width=image_width,
-        )
-    return parse_qwen_object_detection_response(
-        image=image,
-        parsed_data=parsed_data,
-        classes=classes,
-        inference_id=inference_id,
-    )
-
-
 def parse_muse_object_detection_response(
     image: WorkflowImageData,
     parsed_data: Union[dict, list],
@@ -1008,7 +980,11 @@ REGISTERED_PARSERS = {
     ("spacexai", "object-detection"): parse_spacexai_object_detection_response,
     ("qwen", "object-detection"): parse_qwen_object_detection_response,
     ("muse", "object-detection"): parse_muse_object_detection_response,
-    ("zai", "object-detection"): parse_zai_object_detection_response,
+    # GLM 5V Turbo prompts for the Qwen box_2d xyxy 0-1000 contract; GLM 5.3
+    # Flash prompts for the Gemini box_2d yxyx 0-1000 contract. Same key,
+    # different axis order, so each model gets its own model_type.
+    ("zai", "object-detection"): parse_qwen_object_detection_response,
+    ("zai-flash", "object-detection"): parse_gemini_object_detection_response,
     # Florence 2
     ("florence-2", "object-detection"): partial(
         parse_florence2_object_detection_response, florence_task_type="<OD>"

--- a/inference/core/workflows/core_steps/formatters/vlm_as_detector/zai_detection_parsing.py
+++ b/inference/core/workflows/core_steps/formatters/vlm_as_detector/zai_detection_parsing.py
@@ -1,125 +1,34 @@
-from typing import List, Union
+import json
+from typing import Optional
 
-import supervision as sv
-
-from inference.core.workflows.core_steps.formatters.vlm_as_detector.qwen_detection_parsing import (
-    QWEN_BOX_COORDINATE_SCALE,
-    extract_qwen_detection_entries,
-    get_qwen_detection_box,
-    parse_qwen_object_detection_response,
-)
-from inference.core.workflows.execution_engine.entities.base import WorkflowImageData
-
-# The two Z.ai detection contracts, keyed by the box field each prompt pins:
-# GLM 5V Turbo prompts for "box_2d" xyxy integers normalized to 0-1000 (the
-# Qwen contract), while GLM 5.3 Flash prompts for "bbox_2d" in absolute
-# pixels of the original image (the format that scored best for it in the
-# vlm-exam benchmarks; it scores ~0 mAP with normalized prompts). Rather
-# than duplicating the Qwen assembly, absolute-pixel entries are rescaled
-# into the 0-1000 space and handed to the Qwen parser, which scales them
-# back onto the image exactly.
-ZAI_ABSOLUTE_PIXEL_BOX_KEY = "bbox_2d"
+# The Z.ai detection contracts, both "box_2d" lists normalized to 0-1000:
+# GLM 5V Turbo (model_type "zai") uses xyxy order and parses with the Qwen
+# parser; GLM 5.3 Flash (model_type "zai-flash") uses yxyx order and parses
+# with the Gemini parser. The axis order is not recoverable from the data,
+# so each model maps to its own model_type in the registry.
 
 
-def zai_entries_use_absolute_pixels(entries: List[dict]) -> bool:
-    """Tell whether Z.ai detection entries carry absolute-pixel boxes.
+def extract_zai_json_array(raw: str) -> Optional[list]:
+    """Recover the outermost JSON array from prose-wrapped Z.ai output.
 
-    The GLM 5.3 Flash prompt pins the ``bbox_2d`` key for absolute-pixel
-    boxes; the GLM 5V Turbo prompt pins ``box_2d`` for 0-1000 normalized
-    boxes. The models echo the prompted key, so its presence selects the
-    coordinate space.
+    GLM models occasionally wrap the detection list in extra text that
+    breaks whole-string JSON parsing. Mirrors the vlm-exam fallback: take
+    the substring between the first ``[`` and the last ``]`` and parse it.
 
     Args:
-        entries: Raw detection entry dicts.
+        raw: Raw VLM output that failed regular JSON parsing.
 
     Returns:
-        True when any dict entry contains the ``bbox_2d`` key.
+        The recovered list, or ``None`` when nothing recoverable.
     """
-    return any(
-        isinstance(entry, dict) and ZAI_ABSOLUTE_PIXEL_BOX_KEY in entry
-        for entry in entries
-    )
-
-
-def convert_zai_pixel_entries_to_normalized(
-    entries: List[dict],
-    image_height: int,
-    image_width: int,
-) -> List[dict]:
-    """Rescale absolute-pixel ``bbox_2d`` entries into the 0-1000 space.
-
-    Coordinates are absolute pixels of the image the model saw. The block
-    only downscales uploads above the OpenRouter payload cap (extremely
-    large images), so the coordinates map onto the original image directly.
-    Entries without a well-formed box pass through untouched and are
-    skipped downstream.
-
-    Args:
-        entries: Raw detection entry dicts.
-        image_height: Original image height in pixels.
-        image_width: Original image width in pixels.
-
-    Returns:
-        Entries with ``box_2d`` normalized to 0-1000, consumable by the
-        Qwen parser.
-    """
-    scale = QWEN_BOX_COORDINATE_SCALE
-    normalized: List[dict] = []
-    for entry in entries:
-        box = (
-            get_qwen_detection_box(detection=entry) if isinstance(entry, dict) else None
-        )
-        if box is None:
-            normalized.append(entry)
-            continue
-        x_min, y_min, x_max, y_max = box
-        converted = {k: v for k, v in entry.items() if k != ZAI_ABSOLUTE_PIXEL_BOX_KEY}
-        converted["box_2d"] = [
-            x_min / image_width * scale,
-            y_min / image_height * scale,
-            x_max / image_width * scale,
-            y_max / image_height * scale,
-        ]
-        normalized.append(converted)
-    return normalized
-
-
-def parse_zai_object_detection_response(
-    image: WorkflowImageData,
-    parsed_data: Union[dict, list],
-    classes: List[str],
-    inference_id: str,
-) -> sv.Detections:
-    """Parse Z.ai block object-detection output into detections.
-
-    Dispatches on the box key the response carries: ``bbox_2d`` entries
-    (GLM 5.3 Flash) are rescaled from absolute pixels into the 0-1000
-    space first; either way the Qwen parser does the parsing.
-
-    Args:
-        image: Workflow image the detections refer to.
-        parsed_data: JSON payload extracted from the VLM output.
-        classes: Class names used to map labels onto class ids.
-        inference_id: Identifier attached to every parsed detection.
-
-    Returns:
-        Parsed detections in the original image's coordinate space.
-
-    Raises:
-        ValueError: If the response is neither a JSON list nor a
-            ``{"detections": [...]}`` object.
-    """
-    entries = extract_qwen_detection_entries(parsed_data=parsed_data)
-    if zai_entries_use_absolute_pixels(entries):
-        image_height, image_width = image.numpy_image.shape[:2]
-        parsed_data = convert_zai_pixel_entries_to_normalized(
-            entries=entries,
-            image_height=image_height,
-            image_width=image_width,
-        )
-    return parse_qwen_object_detection_response(
-        image=image,
-        parsed_data=parsed_data,
-        classes=classes,
-        inference_id=inference_id,
-    )
+    start = raw.find("[")
+    stop = raw.rfind("]")
+    if start == -1 or stop <= start:
+        return None
+    try:
+        recovered = json.loads(raw[start : stop + 1])
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(recovered, list):
+        return None
+    return recovered

--- a/inference/core/workflows/core_steps/models/foundation/zai_vlm/v1.py
+++ b/inference/core/workflows/core_steps/models/foundation/zai_vlm/v1.py
@@ -76,30 +76,39 @@ ZAI_OBJECT_DETECTION_PROMPT_TEMPLATE = (
     "Only use these labels: {class_list}"
 )
 
-# Ported verbatim from vlm-exam's `_BBOX_2D_PIXEL_PROMPT_TEMPLATE`, the
-# format pinned for GLM 5.3 Flash (`xyxy_absolute_original_image_bbox_2d`).
-# The model scores ~0 mAP with normalized 0-1000 prompts.
-ZAI_BBOX_2D_PIXEL_DETECTION_PROMPT_TEMPLATE = (
-    "Detect all objects in this image and return their locations in the "
-    "form of coordinates. The format of output should be like "
-    '{{"bbox_2d": [x1, y1, x2, y2], "label": "<name>"}}. '
-    "Only use these labels: {class_list}. Return a JSON array only."
+# Ported verbatim from vlm-exam's `_PROMPT_TEMPLATE`, the format pinned for
+# GLM 5.3 Flash (`yxyx_normalized_0_to_1000`). The full 250-image benchmark
+# scores it 0.331 dataset mAP@50 vs 0.219 for absolute-pixel bbox_2d
+# prompting, the next best format.
+ZAI_FLASH_OBJECT_DETECTION_PROMPT_TEMPLATE = (
+    "Detect all objects in this image. "
+    "Output a JSON list where each entry contains the 2D bounding box "
+    'in the key "box_2d" and the text label in the key "label". '
+    'The "box_2d" value must be [y_min, x_min, y_max, x_max]: integers '
+    "between 0 and 1000, normalized to the image height and width. "
+    "Return only the JSON list, with no extra text. "
+    "Only use these labels: {class_list}"
 )
 
 # One row per model; add future Z.ai models here. A row may override
 # `reasoning_levels` if a model diverges from the shared set;
 # `reasoning_required` marks models that reject `reasoning: {enabled:
 # false}` and fall back to low effort when the user disables reasoning.
+# `detection_model_type` is the `vlm_as_detector@v2` model_type that parses
+# the model's detection output; the two GLM models emit the same "box_2d"
+# key with different axis orders, so each needs its own parser entry.
 MODEL_VARIANTS: Dict[str, Dict[str, Any]] = {
     "GLM 5V Turbo": {
         "model_id": "z-ai/glm-5v-turbo",
         "detection_prompt_template": ZAI_OBJECT_DETECTION_PROMPT_TEMPLATE,
+        "detection_model_type": "zai",
     },
     # GLM 5.3 Flash ran as the OpenRouter stealth model "Ox Alpha"; the
     # retirement notice confirms they are the same model.
     "GLM 5.3 Flash": {
         "model_id": "z-ai/glm-5.3-flash",
-        "detection_prompt_template": ZAI_BBOX_2D_PIXEL_DETECTION_PROMPT_TEMPLATE,
+        "detection_prompt_template": ZAI_FLASH_OBJECT_DETECTION_PROMPT_TEMPLATE,
+        "detection_model_type": "zai-flash",
         "reasoning_required": True,
     },
 }
@@ -431,10 +440,12 @@ You can specify arbitrary text prompts or predefined ones. The block supports:
 {RELEVANT_TASKS_DOCS_DESCRIPTION}
 
 Object detection uses the per-model format validated in the vlm-exam
-benchmarks: GLM 5V Turbo emits `box_2d`/`label` entries with coordinates
-normalized to 0-1000, while GLM 5.3 Flash emits `bbox_2d`/`label` entries
-in absolute pixels. Parse either output with `VLM as Detector`
-(`vlm_as_detector@v2`) using `model_type="zai"`; it detects the format.
+benchmarks. Both models emit `box_2d`/`label` entries normalized to
+0-1000, but with different axis orders: GLM 5V Turbo uses
+`[x_min, y_min, x_max, y_max]` and GLM 5.3 Flash uses
+`[y_min, x_min, y_max, x_max]`. Parse with `VLM as Detector`
+(`vlm_as_detector@v2`) using `model_type="zai"` for GLM 5V Turbo and
+`model_type="zai-flash"` for GLM 5.3 Flash.
 
 Every request sends the image before the instruction text in a single user
 message. GLM models default to extended reasoning on OpenRouter; the block

--- a/tests/workflows/unit_tests/core_steps/formatters/vlm_as_detector/test_v2.py
+++ b/tests/workflows/unit_tests/core_steps/formatters/vlm_as_detector/test_v2.py
@@ -441,7 +441,8 @@ def test_run_method_for_anthropic_claude_legacy_detections_output() -> None:
     assert np.allclose(result["predictions"].confidence, np.array([0.9]))
 
 
-def test_manifest_parsing_for_zai_model_type() -> None:
+@pytest.mark.parametrize("model_type", ["zai", "zai-flash"])
+def test_manifest_parsing_for_zai_model_types(model_type: str) -> None:
     # given
     raw_manifest = {
         "type": "roboflow_core/vlm_as_detector@v2",
@@ -449,7 +450,7 @@ def test_manifest_parsing_for_zai_model_type() -> None:
         "image": "$inputs.image",
         "vlm_output": "$steps.vlm.output",
         "classes": ["cat", "dog"],
-        "model_type": "zai",
+        "model_type": model_type,
         "task_type": "object-detection",
     }
 
@@ -457,7 +458,7 @@ def test_manifest_parsing_for_zai_model_type() -> None:
     result = BlockManifest.model_validate(raw_manifest)
 
     # then
-    assert result.model_type == "zai"
+    assert result.model_type == model_type
 
 
 def test_run_method_for_zai_box_2d_output() -> None:
@@ -502,9 +503,10 @@ def test_run_method_for_zai_box_2d_output() -> None:
     assert np.allclose(result["predictions"].confidence, np.array([1.0, 1.0]))
 
 
-def test_run_method_for_zai_bbox_2d_absolute_pixel_output() -> None:
-    # given - the GLM 5.3 Flash prompt pins bbox_2d entries in absolute
-    # pixels of the original image; out-of-range values are clamped
+def test_run_method_for_zai_flash_yxyx_box_2d_output() -> None:
+    # given - the GLM 5.3 Flash prompt pins box_2d entries as
+    # [y_min, x_min, y_max, x_max] integers normalized to 0-1000
+    # (the Gemini contract)
     block = VLMAsDetectorBlockV2()
     image = WorkflowImageData(
         numpy_image=np.zeros((480, 640, 3), dtype=np.uint8),
@@ -512,8 +514,8 @@ def test_run_method_for_zai_bbox_2d_absolute_pixel_output() -> None:
     )
     vlm_output = """
 [
-  {"bbox_2d": [64, 96, 320, 480], "label": "cat"},
-  {"bbox_2d": [-10, 0, 700, 240], "label": "dog"}
+  {"box_2d": [100, 200, 500, 1000], "label": "cat"},
+  {"box_2d": [0, 0, 500, 500], "label": "unicorn"}
 ]
     """
 
@@ -522,22 +524,54 @@ def test_run_method_for_zai_bbox_2d_absolute_pixel_output() -> None:
         image=image,
         vlm_output=vlm_output,
         classes=["cat", "dog"],
-        model_type="zai",
+        model_type="zai-flash",
         task_type="object-detection",
     )
 
     # then
     assert result["error_status"] is False
-    assert result["predictions"].data["class_name"].tolist() == ["cat", "dog"]
+    assert result["predictions"].data["class_name"].tolist() == ["cat", "unicorn"]
+    assert np.allclose(result["predictions"].class_id, np.array([0, -1]))
     assert np.allclose(
         result["predictions"].xyxy,
         np.array(
             [
-                [64, 96, 320, 480],
-                [0, 0, 640, 240],
+                [128, 48, 640, 240],
+                [0, 0, 320, 240],
             ]
         ),
         atol=1.0,
+    )
+
+
+def test_run_method_for_zai_flash_recovers_array_from_prose_wrapped_output() -> None:
+    # given - GLM sometimes wraps the JSON array in extra text that breaks
+    # whole-string parsing; the zai paths recover the outermost [...] block
+    block = VLMAsDetectorBlockV2()
+    image = WorkflowImageData(
+        numpy_image=np.zeros((480, 640, 3), dtype=np.uint8),
+        parent_metadata=ImageParentMetadata(parent_id="parent"),
+    )
+    vlm_output = (
+        "Here are the detected objects: "
+        '[{"box_2d": [100, 200, 500, 1000], "label": "cat"}] '
+        "Let me know if you need anything else."
+    )
+
+    # when
+    result = block.run(
+        image=image,
+        vlm_output=vlm_output,
+        classes=["cat", "dog"],
+        model_type="zai-flash",
+        task_type="object-detection",
+    )
+
+    # then
+    assert result["error_status"] is False
+    assert result["predictions"].data["class_name"].tolist() == ["cat"]
+    assert np.allclose(
+        result["predictions"].xyxy, np.array([[128, 48, 640, 240]]), atol=1.0
     )
 
 

--- a/tests/workflows/unit_tests/core_steps/formatters/vlm_as_detector/test_v2_tensor.py
+++ b/tests/workflows/unit_tests/core_steps/formatters/vlm_as_detector/test_v2_tensor.py
@@ -330,9 +330,10 @@ def test_run_method_for_zai_box_2d_output_tensor_native() -> None:
     )
 
 
-def test_run_method_for_zai_bbox_2d_absolute_pixel_output_tensor_native() -> None:
-    # given - the GLM 5.3 Flash prompt pins bbox_2d entries in absolute
-    # pixels of the original image; out-of-range values are clamped
+def test_run_method_for_zai_flash_yxyx_box_2d_output_tensor_native() -> None:
+    # given - the GLM 5.3 Flash prompt pins box_2d entries as
+    # [y_min, x_min, y_max, x_max] integers normalized to 0-1000
+    # (the Gemini contract)
     block = VLMAsDetectorBlockV2()
     image = WorkflowImageData(
         numpy_image=np.zeros((480, 640, 3), dtype=np.uint8),
@@ -340,8 +341,8 @@ def test_run_method_for_zai_bbox_2d_absolute_pixel_output_tensor_native() -> Non
     )
     vlm_output = """
 [
-  {"bbox_2d": [64, 96, 320, 480], "label": "cat"},
-  {"bbox_2d": [-10, 0, 700, 240], "label": "dog"}
+  {"box_2d": [100, 200, 500, 1000], "label": "cat"},
+  {"box_2d": [0, 0, 500, 500], "label": "unicorn"}
 ]
     """
 
@@ -350,19 +351,20 @@ def test_run_method_for_zai_bbox_2d_absolute_pixel_output_tensor_native() -> Non
         image=image,
         vlm_output=vlm_output,
         classes=["cat", "dog"],
-        model_type="zai",
+        model_type="zai-flash",
         task_type="object-detection",
     )
 
     # then
     assert result["error_status"] is False
-    assert _class_names(result["predictions"]) == ["cat", "dog"]
+    assert _class_names(result["predictions"]) == ["cat", "unicorn"]
+    assert np.allclose(result["predictions"].class_id.cpu().numpy(), np.array([0, -1]))
     assert np.allclose(
         result["predictions"].xyxy.cpu().numpy(),
         np.array(
             [
-                [64, 96, 320, 480],
-                [0, 0, 640, 240],
+                [128, 48, 640, 240],
+                [0, 0, 320, 240],
             ]
         ),
         atol=1.0,

--- a/tests/workflows/unit_tests/core_steps/models/foundation/test_zai_vlm_v1.py
+++ b/tests/workflows/unit_tests/core_steps/models/foundation/test_zai_vlm_v1.py
@@ -9,7 +9,7 @@ from inference.core.workflows.core_steps.models.foundation.zai_vlm.v1 import (
     DEFAULT_MAX_TOKENS,
     DEFAULT_MODEL_VERSION,
     DEFAULT_REASONING_EFFORT,
-    ZAI_BBOX_2D_PIXEL_DETECTION_PROMPT_TEMPLATE,
+    ZAI_FLASH_OBJECT_DETECTION_PROMPT_TEMPLATE,
     BlockManifest,
     ZaiVlmBlockV1,
     build_zai_openrouter_prompts,
@@ -150,24 +150,27 @@ def test_run_maps_reasoning_effort_to_openrouter_config(mock_or):
     assert mock_or.call_args.kwargs["reasoning"] == {"effort": "high"}
 
 
-# Copied from vlm-exam `_BBOX_2D_PIXEL_PROMPT_TEMPLATE` so an edit to the
-# block constant fails this test.
+# Copied from vlm-exam `_PROMPT_TEMPLATE` so an edit to the block constant
+# fails this test.
 EXPECTED_FLASH_DETECTION_PROMPT = (
-    "Detect all objects in this image and return their locations in the "
-    "form of coordinates. The format of output should be like "
-    '{"bbox_2d": [x1, y1, x2, y2], "label": "<name>"}. '
-    "Only use these labels: cat, dog. Return a JSON array only."
+    "Detect all objects in this image. "
+    "Output a JSON list where each entry contains the 2D bounding box "
+    'in the key "box_2d" and the text label in the key "label". '
+    'The "box_2d" value must be [y_min, x_min, y_max, x_max]: integers '
+    "between 0 and 1000, normalized to the image height and width. "
+    "Return only the JSON list, with no extra text. "
+    "Only use these labels: cat, dog"
 )
 
 
-def test_flash_detection_prompt_is_vlm_exam_bbox_2d_template():
+def test_flash_detection_prompt_is_vlm_exam_yxyx_template():
     messages = build_zai_openrouter_prompts(
         images=[np.zeros((8, 8, 3), dtype=np.uint8)],
         task_type="object-detection",
         prompt=None,
         output_structure=None,
         classes=["cat", "dog"],
-        detection_prompt_template=(ZAI_BBOX_2D_PIXEL_DETECTION_PROMPT_TEMPLATE),
+        detection_prompt_template=(ZAI_FLASH_OBJECT_DETECTION_PROMPT_TEMPLATE),
     )
     content = messages[0][0]["content"]
     assert content[1]["text"] == EXPECTED_FLASH_DETECTION_PROMPT
@@ -197,4 +200,4 @@ def test_run_flash_falls_back_to_low_effort_when_reasoning_disabled(mock_or):
     assert mock_or.call_args.kwargs["model"] == "z-ai/glm-5.3-flash"
     assert mock_or.call_args.kwargs["reasoning"] == {"effort": "low"}
     sent_text = mock_or.call_args.kwargs["prompts"][0][0]["content"][1]["text"]
-    assert '"bbox_2d"' in sent_text
+    assert "[y_min, x_min, y_max, x_max]" in sent_text


### PR DESCRIPTION
## What

Fixes the GLM 5.3 Flash detection format shipped in #2873. The 20-image probe behind #2873 picked `bbox_2d` absolute pixels, but the full 250-image vlm-exam benchmark is clear: `yxyx_normalized_0_to_1000` wins with 0.331 dataset mAP@50 / 0.266 mean per-image vs 0.219 / 0.195 for bbox_2d. The probe result was sampling noise.

Branched from `82836c454` (post3 version bump), no syncs with `main`, single commit on top.

## Changes

- `zai_vlm@v1`: GLM 5.3 Flash now prompts with vlm-exam's yxyx template (`box_2d` as `[y_min, x_min, y_max, x_max]` integers 0-1000). GLM 5V Turbo is unchanged (xyxy 0-1000, its benchmarked winner).
- `vlm_as_detector@v2` (both variants): both GLM models now emit the same `box_2d` key with different axis orders, which cannot be told apart from the data. The single dispatching `zai` entry is replaced by two model types: `zai` (Turbo, xyxy, reuses the Qwen parser) and `zai-flash` (Flash, yxyx, reuses the Gemini parser; it is byte-for-byte the Gemini contract). No new parsing code.
- Re-applies the prose-wrapped JSON recovery (outermost `[...]` substring, the vlm-exam fallback) for both zai model types; that commit missed the #2873 squash. GLM wraps the array in prose occasionally (seen 1/20 in e2e).

## Testing

Unit tests updated: yxyx prompt template contract, `zai-flash` parser dispatch and coordinate conversion in both v2 variants, prose recovery, manifest acceptance. Full affected sweep passes (1859 tests).

Live e2e through the prod proxy (block + parser, `model_type="zai-flash"`): Flash returns `box_2d` yxyx lists, parsed into detections with no errors; scores on dense first images match the pattern of the official yxyx benchmark run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
