### PR TITLE
repair MQTT writer sink lifecycle

### DIFF
--- a/inference/enterprise/workflows/enterprise_blocks/sinks/mqtt_writer/v1.py
+++ b/inference/enterprise/workflows/enterprise_blocks/sinks/mqtt_writer/v1.py
@@ -26,9 +26,10 @@ LONG_DESCRIPTION = """
 MQTT Writer block for publishing messages to an MQTT broker.
 
 The first run connects synchronously: the TCP connect and the broker's
-session acknowledgement are each bounded by `timeout`, so a cold start may
-take up to twice `timeout` - raise it for remote brokers. Afterwards a
-background network loop maintains the connection and owns reconnects.
+session acknowledgement are each bounded by `timeout` (DNS resolution is
+bounded by the OS resolver instead), so a cold start may take up to twice
+`timeout` - raise it for remote brokers. Afterwards a background network
+loop maintains the connection and owns reconnects.
 
 A run that cannot connect reports the failure and leaves nothing behind; the
 next run on the same block instance (video pipelines) retries from scratch,
@@ -45,8 +46,9 @@ Outputs:
     - message (str): Status message describing the result of the operation.
                     Contains error details if error_status is True,
                     or success confirmation if error_status is False.
-                    A publish acknowledgement timeout is reported as
-                    delivery-unknown: the message may still be delivered.
+                    A publish acknowledgement timeout on QoS 1/2 is reported
+                    as delivery-unknown (the message may still be delivered);
+                    an unconfirmed QoS 0 send is reported as lost.
 
 By default failures are returned in the outputs and logged, and the workflow
 keeps running. Set fail_fast to True to raise the failure instead, stopping
@@ -253,6 +255,20 @@ class MQTTWriterSinkBlockV1(WorkflowBlock):
                 fail_fast=fail_fast,
             )
         port = port_number
+        try:
+            if isinstance(qos, bool) or (
+                isinstance(qos, float) and not qos.is_integer()
+            ):
+                raise ValueError
+            qos_number = int(qos)
+        except (TypeError, ValueError):
+            qos_number = -1
+        if qos_number not in (0, 1, 2):
+            return self._handle_failure(
+                f"Invalid qos: {qos!r}. QoS must be 0, 1 or 2.",
+                fail_fast=fail_fast,
+            )
+        qos = qos_number
         if password is not None and username is None:
             return self._handle_failure(
                 "Password provided without username. Set username to enable MQTT authentication.",
@@ -295,14 +311,17 @@ class MQTTWriterSinkBlockV1(WorkflowBlock):
                 client.on_connect = mqtt_on_connect
                 client.on_connect_fail = mqtt_on_connect_fail
                 client.on_disconnect = mqtt_on_disconnect
-                client.reconnect_delay_set(min_delay=timeout, max_delay=2 * timeout)
+                # min_delay stays below the readiness wait (= timeout) so the
+                # first reconnect attempt after a connection drop can finish
+                # within a single run's wait instead of starting as it expires
+                client.reconnect_delay_set(min_delay=timeout / 2, max_delay=2 * timeout)
                 # paho 1.6.1 has no public setter for its synchronous connect
-                # timeout; without this the DNS + TCP phase runs under paho's
-                # 5s default instead of the block's timeout
+                # timeout; without this the TCP phase runs under paho's 5s
+                # default instead of the block's timeout
                 client._connect_timeout = timeout
-                # DNS + TCP happen here, bounded by _connect_timeout, so the
-                # first run gets a real connect budget; the CONNACK wait below
-                # covers the rest of the handshake
+                # the TCP connect happens here, bounded by _connect_timeout
+                # (DNS resolution is not - it runs under the OS resolver
+                # timeout); the CONNACK wait below covers the handshake rest
                 client.connect(host, port)
                 client.loop_start()
             except OSError as e:
@@ -367,6 +386,15 @@ class MQTTWriterSinkBlockV1(WorkflowBlock):
                 "error_status": False,
                 "message": "Message published successfully",
             }
+        if qos == 0:
+            # an unconfirmed QoS 0 send is a real loss: paho never queues
+            # QoS 0 messages and reconnect() clears the pending out packet
+            return self._handle_failure(
+                "Publish confirmation timed out; the connection dropped before "
+                "the message was fully sent and QoS 0 messages are not "
+                "retransmitted, so the message is lost.",
+                fail_fast=fail_fast,
+            )
         return self._handle_failure(
             "Publish acknowledgement timed out; delivery status unknown "
             "and the message may still be delivered.",

--- a/inference/enterprise/workflows/enterprise_blocks/sinks/mqtt_writer/v1.py
+++ b/inference/enterprise/workflows/enterprise_blocks/sinks/mqtt_writer/v1.py
@@ -1,8 +1,10 @@
+import math
 import threading
-from typing import List, Literal, Optional, Type, Union
+from typing import List, Literal, Optional, Tuple, Type, Union
 
 import paho.mqtt.client as mqtt
 from pydantic import ConfigDict, Field
+from typing_extensions import Annotated
 
 from inference.core.logger import logger
 from inference.core.workflows.core_steps.sinks.noop import disabled_sink_response
@@ -23,7 +25,12 @@ from inference.core.workflows.prototypes.block import (
 LONG_DESCRIPTION = """
 MQTT Writer block for publishing messages to an MQTT broker.
 
-This block is blocking on connect and publish operations.
+The connection is established and maintained by a background network loop.
+The first run configures the connection and may return a connection-timeout
+error while the client keeps connecting in the background; a later run can
+then publish without re-creating the block. One block instance publishes to
+a single broker connection: changing host, port, credentials or timeout
+between runs is rejected as a configuration error.
 
 Outputs:
     - error_status (bool): Indicates if an error occurred during the MQTT publishing process.
@@ -31,7 +38,35 @@ Outputs:
     - message (str): Status message describing the result of the operation.
                     Contains error details if error_status is True,
                     or success confirmation if error_status is False.
+                    A publish acknowledgement timeout is reported as
+                    delivery-unknown: the message may still be delivered.
+
+By default failures are returned in the outputs and logged, and the workflow
+keeps running. Set fail_fast to True to raise the failure instead, stopping
+the workflow run - intended for one-shot requests, not streaming pipelines.
 """
+
+
+def mqtt_on_connect(client, userdata, flags, reason_code, properties=None):
+    # paho invokes on_connect for accepted and rejected CONNACK alike;
+    # only reason_code 0 means an established MQTT session
+    if reason_code == 0:
+        logger.info("MQTT client connected")
+        userdata.set()
+    else:
+        logger.error("MQTT connection refused, result code %s", reason_code)
+        userdata.clear()
+
+
+def mqtt_on_connect_fail(client, userdata):
+    # paho 1.6.1 invokes this callback with exactly (client, userdata)
+    logger.error("MQTT client failed to establish connection with broker")
+    userdata.clear()
+
+
+def mqtt_on_disconnect(client, userdata, reason_code, properties=None):
+    logger.info("MQTT client disconnected, result code %s", reason_code)
+    userdata.clear()
 
 
 class BlockManifest(WorkflowBlockManifest):
@@ -57,8 +92,11 @@ class BlockManifest(WorkflowBlockManifest):
         description="Host of the MQTT broker.",
         examples=["localhost", "$inputs.mqtt_host"],
     )
-    port: Union[int, Selector(kind=[INTEGER_KIND])] = Field(
-        description="Port of the MQTT broker.",
+    port: Union[
+        Annotated[int, Field(ge=1, le=65535)],
+        Selector(kind=[INTEGER_KIND]),
+    ] = Field(
+        description="Port of the MQTT broker (1-65535).",
         examples=[1883, "$inputs.mqtt_port"],
     )
     topic: Union[Selector(kind=[STRING_KIND]), str] = Field(
@@ -79,9 +117,13 @@ class BlockManifest(WorkflowBlockManifest):
         description="Whether the message should be retained by the broker.",
         examples=[True, False],
     )
-    timeout: Union[float, Selector(kind=[FLOAT_KIND])] = Field(
+    timeout: Union[
+        Annotated[float, Field(gt=0, allow_inf_nan=False)],
+        Selector(kind=[FLOAT_KIND]),
+    ] = Field(
         default=0.5,
-        description="Timeout for connecting to the MQTT broker and for sending MQTT messages.",
+        description="Timeout for connecting to the MQTT broker and for sending MQTT messages. "
+        "Must be a finite number greater than 0.",
         examples=[0.5],
     )
     username: Union[Selector(kind=[STRING_KIND]), str] = Field(
@@ -93,6 +135,13 @@ class BlockManifest(WorkflowBlockManifest):
         default=None,
         description="Password for MQTT broker authentication.",
         examples=["$inputs.mqtt_password"],
+    )
+    fail_fast: Union[bool, Selector(kind=[BOOLEAN_KIND])] = Field(
+        default=False,
+        description="If True, MQTT failures raise an error stopping the workflow run "
+        "instead of being returned in the block outputs. Intended for one-shot "
+        "requests; in streaming pipelines it stops processing.",
+        examples=[False],
     )
 
     @classmethod
@@ -111,15 +160,35 @@ class MQTTWriterSinkBlockV1(WorkflowBlock):
     def __init__(self, disable_sinks: bool = False):
         self.mqtt_client: Optional[mqtt.Client] = None
         self._connected = threading.Event()
+        self._connection_identity: Optional[Tuple] = None
+        self._lifecycle_lock = threading.Lock()
         self._disable_sinks = disable_sinks
+
+    def close(self) -> None:
+        with self._lifecycle_lock:
+            client = self.mqtt_client
+            if client is None:
+                return
+            self.mqtt_client = None
+            self._connection_identity = None
+            try:
+                client.disconnect()
+            except Exception as e:
+                logger.error("Failed to disconnect MQTT client: %s", e)
+            finally:
+                try:
+                    # loop_stop() joins the network thread without a timeout;
+                    # accepted so the thread never outlives the block
+                    client.loop_stop()
+                finally:
+                    # only after the join can no callback re-set the event
+                    self._connected.clear()
 
     def __del__(self):
         try:
-            if self.mqtt_client is not None:
-                self.mqtt_client.disconnect()
-                self.mqtt_client.loop_stop()
+            self.close()
         except Exception as e:
-            logger.error("Failed to disconnect MQTT client: %s", e)
+            logger.error("Failed to close MQTT client: %s", e)
 
     @classmethod
     def get_manifest(cls) -> Type[WorkflowBlockManifest]:
@@ -140,70 +209,137 @@ class MQTTWriterSinkBlockV1(WorkflowBlock):
         qos: int = 0,
         retain: bool = False,
         timeout: float = 0.5,
+        fail_fast: bool = False,
     ) -> BlockResult:
         if self._disable_sinks:
             return disabled_sink_response()
-        if self.mqtt_client is None:
-            self.mqtt_client = mqtt.Client()
-            if username and password:
-                self.mqtt_client.username_pw_set(username, password)
-            self.mqtt_client.on_connect = self.mqtt_on_connect
-            self.mqtt_client.on_connect_fail = self.mqtt_on_connect_fail
-            self.mqtt_client.reconnect_delay_set(
-                min_delay=timeout, max_delay=2 * timeout
+        # selector-resolved values bypass manifest constraints, so validate here
+        try:
+            timeout_seconds = float(timeout)
+        except (TypeError, ValueError, OverflowError):
+            timeout_seconds = math.nan
+        if (
+            not math.isfinite(timeout_seconds)
+            or not 0 < timeout_seconds <= threading.TIMEOUT_MAX
+        ):
+            return self._handle_failure(
+                f"Invalid timeout: {timeout!r}. Timeout must be a positive finite "
+                "number of seconds within the platform limit.",
+                fail_fast=fail_fast,
             )
+        timeout = timeout_seconds
+        # paho validates only port <= 0; above 65535 the socket call raises
+        # OverflowError inside the network loop, silently killing it
+        if not isinstance(port, int) or not 1 <= port <= 65535:
+            return self._handle_failure(
+                f"Invalid port: {port!r}. Port must be an integer between 1 and 65535.",
+                fail_fast=fail_fast,
+            )
+        if password is not None and username is None:
+            return self._handle_failure(
+                "Password provided without username. Set username to enable MQTT authentication.",
+                fail_fast=fail_fast,
+            )
+        with self._lifecycle_lock:
+            return self._connect_and_publish(
+                host=host,
+                port=port,
+                topic=topic,
+                message=message,
+                username=username,
+                password=password,
+                qos=qos,
+                retain=retain,
+                timeout=timeout,
+                fail_fast=fail_fast,
+            )
+
+    def _connect_and_publish(
+        self,
+        host: str,
+        port: int,
+        topic: str,
+        message: str,
+        username: Optional[str],
+        password: Optional[str],
+        qos: int,
+        retain: bool,
+        timeout: float,
+        fail_fast: bool,
+    ) -> BlockResult:
+        connection_identity = (host, port, username, password, timeout)
+        if self.mqtt_client is None:
+            client = None
             try:
-                # TODO: blocking, consider adding fire_and_forget like in OPC writer
-                print("Connecting")
-                self.mqtt_client.connect(host, port)
-                self.mqtt_client.loop_start()
-
-                if not self._connected.wait(timeout=timeout):
-                    raise Exception("Connection timeout")
+                client = mqtt.Client(userdata=self._connected)
+                if username is not None:
+                    client.username_pw_set(username, password)
+                client.on_connect = mqtt_on_connect
+                client.on_connect_fail = mqtt_on_connect_fail
+                client.on_disconnect = mqtt_on_disconnect
+                client.reconnect_delay_set(min_delay=timeout, max_delay=2 * timeout)
+                client.connect_async(host, port)
+                client.loop_start()
             except Exception as e:
-                logger.error("Failed to connect to MQTT broker: %s", e)
-                return {
-                    "error_status": True,
-                    "message": f"Failed to connect to MQTT broker: {e}",
-                }
-
-        if not self.mqtt_client.is_connected():
-            try:
-                # TODO: blocking
-                print("Reconnecting")
-                self.mqtt_client.reconnect()
-                if not self._connected.wait(timeout=timeout):
-                    raise Exception("Connection timeout")
-            except Exception as e:
-                logger.error("Failed to connect to MQTT broker: %s", e)
-                return {
-                    "error_status": True,
-                    "message": f"Failed to connect to MQTT broker: {e}",
-                }
-
+                if client is not None:
+                    try:
+                        client.loop_stop()
+                    except Exception:
+                        pass
+                return self._handle_failure(
+                    f"Failed to initialize MQTT client: {e}", fail_fast=fail_fast
+                )
+            self.mqtt_client = client
+            self._connection_identity = connection_identity
+        elif connection_identity != self._connection_identity:
+            return self._handle_failure(
+                "MQTT connection parameters (host, port, credentials or timeout) changed "
+                "between runs; this block publishes only to the connection configured "
+                "on its first run.",
+                fail_fast=fail_fast,
+            )
+        # the background loop owns (re)connecting; runs only wait for readiness
+        if not self._connected.wait(timeout=timeout):
+            return self._handle_failure(
+                "MQTT broker not connected (connection was not established within timeout); "
+                "the client keeps retrying in the background.",
+                fail_fast=fail_fast,
+            )
         try:
             res: mqtt.MQTTMessageInfo = self.mqtt_client.publish(
                 topic, message, qos=qos, retain=retain
             )
-            # TODO: this is blocking
-            res.wait_for_publish(timeout=timeout)
-            if res.is_published():
-                return {
-                    "error_status": False,
-                    "message": "Message published successfully",
-                }
-            else:
-                return {"error_status": True, "message": "Failed to publish payload"}
         except Exception as e:
-            logger.error("Failed to publish message: %s", e)
-            return {"error_status": True, "message": f"Unhandled error - {e}"}
+            return self._handle_failure(
+                f"Failed to publish message: {e}", fail_fast=fail_fast
+            )
+        if res.rc == mqtt.MQTT_ERR_NO_CONN and qos > 0:
+            # paho keeps QoS 1/2 messages queued for delivery after reconnect
+            return self._handle_failure(
+                "Connection lost before publish; the message is queued by the client, "
+                "delivery status unknown and the message may still be delivered.",
+                fail_fast=fail_fast,
+            )
+        try:
+            res.wait_for_publish(timeout=timeout)
+            published = res.is_published()
+        except Exception as e:
+            return self._handle_failure(
+                f"Failed to publish message: {e}", fail_fast=fail_fast
+            )
+        if published:
+            return {
+                "error_status": False,
+                "message": "Message published successfully",
+            }
+        return self._handle_failure(
+            "Publish acknowledgement timed out; delivery status unknown "
+            "and the message may still be delivered.",
+            fail_fast=fail_fast,
+        )
 
-    def mqtt_on_connect(self, client, userdata, flags, reason_code, properties=None):
-        logger.info("Connected with result code %s", reason_code)
-        self._connected.set()
-
-    def mqtt_on_connect_fail(
-        self, client, userdata, flags, reason_code, properties=None
-    ):
-        logger.error(f"Failed to connect with result code %s", reason_code)
-        self._connected.clear()
+    def _handle_failure(self, message: str, fail_fast: bool) -> BlockResult:
+        logger.error("MQTT Writer failure: %s", message)
+        if fail_fast:
+            raise RuntimeError(message)
+        return {"error_status": True, "message": message}

--- a/inference/enterprise/workflows/enterprise_blocks/sinks/mqtt_writer/v1.py
+++ b/inference/enterprise/workflows/enterprise_blocks/sinks/mqtt_writer/v1.py
@@ -30,10 +30,10 @@ session acknowledgement are each bounded by `timeout`, so a cold start may
 take up to twice `timeout` - raise it for remote brokers. Afterwards a
 background network loop maintains the connection and owns reconnects.
 
-Recovery across runs applies only where the same block instance serves many
-runs (video pipelines): a run that finds the broker unavailable reports the
-failure while the background loop keeps retrying, and a later run can publish
-without reconnecting. Over the HTTP API every request builds a fresh block
+A run that cannot connect reports the failure and leaves nothing behind; the
+next run on the same block instance (video pipelines) retries from scratch,
+while an established connection that later drops is re-established by the
+background loop. Over the HTTP API every request builds a fresh block
 instance, so each request pays the bounded connect and a failed request is
 final for that request. One block instance publishes to a single broker
 connection: changing host, port, credentials or timeout between runs is
@@ -288,7 +288,6 @@ class MQTTWriterSinkBlockV1(WorkflowBlock):
         connection_identity = (host, port, username, password, timeout)
         if self.mqtt_client is None:
             client = None
-            connect_error: Optional[OSError] = None
             try:
                 client = mqtt.Client(userdata=self._connected)
                 if username is not None:
@@ -301,17 +300,20 @@ class MQTTWriterSinkBlockV1(WorkflowBlock):
                 # timeout; without this the DNS + TCP phase runs under paho's
                 # 5s default instead of the block's timeout
                 client._connect_timeout = timeout
-                try:
-                    # DNS + TCP happen here, bounded by _connect_timeout, so
-                    # the first run gets a real connect budget; the CONNACK
-                    # wait below covers the rest of the handshake
-                    client.connect(host, port)
-                except OSError as e:
-                    # broker unreachable right now; keep the client so the
-                    # background loop retries and a later run on this
-                    # instance can publish
-                    connect_error = e
+                # DNS + TCP happen here, bounded by _connect_timeout, so the
+                # first run gets a real connect budget; the CONNACK wait below
+                # covers the rest of the handshake
+                client.connect(host, port)
                 client.loop_start()
+            except OSError as e:
+                # broker unreachable: nothing is kept and no loop was started,
+                # so a failed one-shot run leaves no background thread behind;
+                # the next run on this instance retries with a fresh client
+                return self._handle_failure(
+                    f"MQTT broker not connected ({e}). Raise 'timeout' if the "
+                    "broker needs longer to connect.",
+                    fail_fast=fail_fast,
+                )
             except Exception as e:
                 if client is not None:
                     try:
@@ -323,13 +325,6 @@ class MQTTWriterSinkBlockV1(WorkflowBlock):
                 )
             self.mqtt_client = client
             self._connection_identity = connection_identity
-            if connect_error is not None:
-                return self._handle_failure(
-                    f"MQTT broker not connected ({connect_error}); the client keeps "
-                    "retrying in the background. Raise 'timeout' if the broker "
-                    "needs longer to connect.",
-                    fail_fast=fail_fast,
-                )
         elif connection_identity != self._connection_identity:
             return self._handle_failure(
                 "MQTT connection parameters (host, port, credentials or timeout) changed "

--- a/inference/enterprise/workflows/enterprise_blocks/sinks/mqtt_writer/v1.py
+++ b/inference/enterprise/workflows/enterprise_blocks/sinks/mqtt_writer/v1.py
@@ -235,13 +235,24 @@ class MQTTWriterSinkBlockV1(WorkflowBlock):
                 fail_fast=fail_fast,
             )
         timeout = timeout_seconds
-        # paho validates only port <= 0; above 65535 the socket call raises
+        # selector-supplied ports arrive uncoerced (numeric strings, floats
+        # from JSON), so coerce like the manifest would before range-checking;
+        # paho validates only port <= 0 and above 65535 the socket call raises
         # OverflowError inside the network loop, silently killing it
-        if not isinstance(port, int) or not 1 <= port <= 65535:
+        try:
+            if isinstance(port, bool) or (
+                isinstance(port, float) and not port.is_integer()
+            ):
+                raise ValueError
+            port_number = int(port)
+        except (TypeError, ValueError):
+            port_number = 0
+        if not 1 <= port_number <= 65535:
             return self._handle_failure(
                 f"Invalid port: {port!r}. Port must be an integer between 1 and 65535.",
                 fail_fast=fail_fast,
             )
+        port = port_number
         if password is not None and username is None:
             return self._handle_failure(
                 "Password provided without username. Set username to enable MQTT authentication.",

--- a/inference/enterprise/workflows/enterprise_blocks/sinks/mqtt_writer/v1.py
+++ b/inference/enterprise/workflows/enterprise_blocks/sinks/mqtt_writer/v1.py
@@ -25,12 +25,19 @@ from inference.core.workflows.prototypes.block import (
 LONG_DESCRIPTION = """
 MQTT Writer block for publishing messages to an MQTT broker.
 
-The connection is established and maintained by a background network loop.
-The first run configures the connection and may return a connection-timeout
-error while the client keeps connecting in the background; a later run can
-then publish without re-creating the block. One block instance publishes to
-a single broker connection: changing host, port, credentials or timeout
-between runs is rejected as a configuration error.
+The first run connects synchronously: the TCP connect and the broker's
+session acknowledgement are each bounded by `timeout`, so a cold start may
+take up to twice `timeout` - raise it for remote brokers. Afterwards a
+background network loop maintains the connection and owns reconnects.
+
+Recovery across runs applies only where the same block instance serves many
+runs (video pipelines): a run that finds the broker unavailable reports the
+failure while the background loop keeps retrying, and a later run can publish
+without reconnecting. Over the HTTP API every request builds a fresh block
+instance, so each request pays the bounded connect and a failed request is
+final for that request. One block instance publishes to a single broker
+connection: changing host, port, credentials or timeout between runs is
+rejected as a configuration error.
 
 Outputs:
     - error_status (bool): Indicates if an error occurred during the MQTT publishing process.
@@ -270,6 +277,7 @@ class MQTTWriterSinkBlockV1(WorkflowBlock):
         connection_identity = (host, port, username, password, timeout)
         if self.mqtt_client is None:
             client = None
+            connect_error: Optional[OSError] = None
             try:
                 client = mqtt.Client(userdata=self._connected)
                 if username is not None:
@@ -278,7 +286,20 @@ class MQTTWriterSinkBlockV1(WorkflowBlock):
                 client.on_connect_fail = mqtt_on_connect_fail
                 client.on_disconnect = mqtt_on_disconnect
                 client.reconnect_delay_set(min_delay=timeout, max_delay=2 * timeout)
-                client.connect_async(host, port)
+                # paho 1.6.1 has no public setter for its synchronous connect
+                # timeout; without this the DNS + TCP phase runs under paho's
+                # 5s default instead of the block's timeout
+                client._connect_timeout = timeout
+                try:
+                    # DNS + TCP happen here, bounded by _connect_timeout, so
+                    # the first run gets a real connect budget; the CONNACK
+                    # wait below covers the rest of the handshake
+                    client.connect(host, port)
+                except OSError as e:
+                    # broker unreachable right now; keep the client so the
+                    # background loop retries and a later run on this
+                    # instance can publish
+                    connect_error = e
                 client.loop_start()
             except Exception as e:
                 if client is not None:
@@ -291,6 +312,13 @@ class MQTTWriterSinkBlockV1(WorkflowBlock):
                 )
             self.mqtt_client = client
             self._connection_identity = connection_identity
+            if connect_error is not None:
+                return self._handle_failure(
+                    f"MQTT broker not connected ({connect_error}); the client keeps "
+                    "retrying in the background. Raise 'timeout' if the broker "
+                    "needs longer to connect.",
+                    fail_fast=fail_fast,
+                )
         elif connection_identity != self._connection_identity:
             return self._handle_failure(
                 "MQTT connection parameters (host, port, credentials or timeout) changed "
@@ -302,7 +330,8 @@ class MQTTWriterSinkBlockV1(WorkflowBlock):
         if not self._connected.wait(timeout=timeout):
             return self._handle_failure(
                 "MQTT broker not connected (connection was not established within timeout); "
-                "the client keeps retrying in the background.",
+                "the client keeps retrying in the background. Raise 'timeout' if the "
+                "broker needs longer to connect.",
                 fail_fast=fail_fast,
             )
         try:

--- a/tests/workflows/integration_tests/execution/conftest.py
+++ b/tests/workflows/integration_tests/execution/conftest.py
@@ -149,7 +149,7 @@ def face_image() -> np.ndarray:
 
 # Below taken from https://github.com/eclipse-paho/paho.mqtt.python/blob/d45de3737879cfe7a6acc361631fa5cb1ef584bb/tests/testsupport/broker.py
 class FakeMQTTBroker:
-    def __init__(self):
+    def __init__(self, connack_reason_code: int = 0, listening: bool = True):
         # Bind to "localhost" for maximum performance, as described in:
         # http://docs.python.org/howto/sockets.html#ipc
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -159,12 +159,18 @@ class FakeMQTTBroker:
         self.port = sock.getsockname()[1]
         self.messages = []
         self.messages_count_to_wait_for = 2
+        self.connack_reason_code = connack_reason_code
 
         sock.settimeout(5)
-        sock.listen(1)
 
         self._sock = sock
         self._conn = None
+        # bound but not listening: connection attempts are refused until listen()
+        if listening:
+            self.listen()
+
+    def listen(self):
+        self._sock.listen(1)
 
     def start(self):
         if self._sock is None:
@@ -175,14 +181,16 @@ class FakeMQTTBroker:
         conn, address = self._sock.accept()
         conn.settimeout(1)
         self._conn = conn
-        while len(self.messages) < self.messages_count_to_wait_for:
+        connack_sent = False
+        while len(self.messages) < self.messages_count_to_wait_for or not connack_sent:
             packet = self.receive_packet(1000)
             print(f"Received {packet}")
             if not packet:
-                continue
+                break
             if packet.startswith(b"\x10"):
                 print("sending CONNACK")
-                self._conn.send(b"\x20\x02\x00\x00")
+                self._conn.send(b"\x20\x02\x00" + bytes([self.connack_reason_code]))
+                connack_sent = True
                 continue
             self.messages.append(packet)
 

--- a/tests/workflows/integration_tests/execution/test_workflow_with_mqtt_writer.py
+++ b/tests/workflows/integration_tests/execution/test_workflow_with_mqtt_writer.py
@@ -277,6 +277,9 @@ MQTT_SINK_WORKFLOW = {
 @pytest.fixture
 def enterprise_blocks_enabled():
     from inference.core.workflows.execution_engine.introspection import blocks_loader
+    from inference.core.workflows.execution_engine.v1.compiler.core import (
+        COMPILATION_CACHE,
+    )
 
     previous_value = blocks_loader.LOAD_ENTERPRISE_BLOCKS
     blocks_loader.LOAD_ENTERPRISE_BLOCKS = True
@@ -284,6 +287,10 @@ def enterprise_blocks_enabled():
     yield
     blocks_loader.LOAD_ENTERPRISE_BLOCKS = previous_value
     blocks_loader.load_core_workflow_blocks.cache_clear()
+    # drop graphs compiled with enterprise blocks from the process-wide cache
+    with COMPILATION_CACHE._cache_lock:
+        COMPILATION_CACHE._cache.clear()
+        COMPILATION_CACHE._keys_buffer.clear()
 
 
 @pytest.mark.timeout(15)

--- a/tests/workflows/integration_tests/execution/test_workflow_with_mqtt_writer.py
+++ b/tests/workflows/integration_tests/execution/test_workflow_with_mqtt_writer.py
@@ -96,7 +96,7 @@ def test_rejected_connack_is_not_treated_as_connected():
 @pytest.mark.timeout(15)
 def test_block_recovers_when_broker_becomes_available_after_first_run():
     # given - the port is bound but refuses connections, so the first TCP
-    # attempt fails and the background loop has to recover on its own
+    # attempt fails; the failed run must leave no client or thread behind
     broker = FakeMQTTBroker(listening=False)
     broker.messages_count_to_wait_for = 1
     block = MQTTWriterSinkBlockV1()
@@ -111,18 +111,19 @@ def test_block_recovers_when_broker_becomes_available_after_first_run():
             timeout=0.3,
         )
 
-        # broker becomes available, background loop finishes connecting
+        assert block.mqtt_client is None
+
+        # broker becomes available, the next run connects from scratch
         broker.listen()
         broker_thread = threading.Thread(target=broker.start)
         broker_thread.start()
-        assert wait_until(block._connected.is_set)
 
         second_result = block.run(
             host=broker.host,
             port=broker.port,
             topic="RoboflowTopic",
             message="second message",
-            timeout=0.3,
+            timeout=2.0,
         )
         broker_thread.join(timeout=2)
 

--- a/tests/workflows/integration_tests/execution/test_workflow_with_mqtt_writer.py
+++ b/tests/workflows/integration_tests/execution/test_workflow_with_mqtt_writer.py
@@ -1,13 +1,38 @@
+import copy
+import socket
 import threading
+import time
+from unittest.mock import patch
 
 import pytest
 
+from inference.core.env import WORKFLOWS_MAX_CONCURRENT_STEPS
+from inference.core.workflows.execution_engine.core import ExecutionEngine
+from inference.enterprise.workflows.enterprise_blocks.sinks.mqtt_writer import v1
 from inference.enterprise.workflows.enterprise_blocks.sinks.mqtt_writer.v1 import (
     MQTTWriterSinkBlockV1,
 )
+from tests.workflows.integration_tests.execution.conftest import FakeMQTTBroker
 
 
-@pytest.mark.timeout(5)
+def wait_until(predicate, timeout: float = 5.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.05)
+    return False
+
+
+def closed_port() -> int:
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind(("localhost", 0))
+    port = sock.getsockname()[1]
+    sock.close()
+    return port
+
+
+@pytest.mark.timeout(10)
 def test_successful_connection_and_publishing(fake_mqtt_broker):
     # given
     block = MQTTWriterSinkBlockV1()
@@ -18,18 +43,332 @@ def test_successful_connection_and_publishing(fake_mqtt_broker):
     broker_thread = threading.Thread(target=fake_mqtt_broker.start)
     broker_thread.start()
 
-    # when
-    result = block.run(
-        host=fake_mqtt_broker.host,
-        port=fake_mqtt_broker.port,
-        topic="RoboflowTopic",
-        message=published_message,
-    )
+    try:
+        # when
+        result = block.run(
+            host=fake_mqtt_broker.host,
+            port=fake_mqtt_broker.port,
+            topic="RoboflowTopic",
+            message=published_message,
+            timeout=2.0,
+        )
 
-    broker_thread.join(timeout=2)
+        broker_thread.join(timeout=2)
+
+        # then
+        assert result["error_status"] is False, "No error expected"
+        assert result["message"] == expected_message
+
+        assert published_message.encode() in fake_mqtt_broker.messages[-1]
+    finally:
+        block.close()
+
+
+@pytest.mark.timeout(10)
+def test_rejected_connack_is_not_treated_as_connected():
+    # given
+    broker = FakeMQTTBroker(connack_reason_code=5)
+    broker.messages_count_to_wait_for = 0
+    broker_thread = threading.Thread(target=broker.start)
+    broker_thread.start()
+    block = MQTTWriterSinkBlockV1()
+
+    try:
+        # when
+        result = block.run(
+            host=broker.host,
+            port=broker.port,
+            topic="RoboflowTopic",
+            message="should not be delivered",
+            timeout=1.0,
+        )
+        broker_thread.join(timeout=2)
+
+        # then
+        assert result["error_status"] is True
+        assert not block._connected.is_set()
+        assert broker.messages == []
+    finally:
+        block.close()
+        broker.finish()
+
+
+@pytest.mark.timeout(15)
+def test_block_recovers_when_broker_becomes_available_after_first_run():
+    # given - the port is bound but refuses connections, so the first TCP
+    # attempt fails and the background loop has to recover on its own
+    broker = FakeMQTTBroker(listening=False)
+    broker.messages_count_to_wait_for = 1
+    block = MQTTWriterSinkBlockV1()
+
+    try:
+        # when - broker is not accepting connections yet
+        first_result = block.run(
+            host=broker.host,
+            port=broker.port,
+            topic="RoboflowTopic",
+            message="first message",
+            timeout=0.3,
+        )
+
+        # broker becomes available, background loop finishes connecting
+        broker.listen()
+        broker_thread = threading.Thread(target=broker.start)
+        broker_thread.start()
+        assert wait_until(block._connected.is_set)
+
+        second_result = block.run(
+            host=broker.host,
+            port=broker.port,
+            topic="RoboflowTopic",
+            message="second message",
+            timeout=0.3,
+        )
+        broker_thread.join(timeout=2)
+
+        # then
+        assert first_result["error_status"] is True
+        assert second_result["error_status"] is False
+        assert b"second message" in broker.messages[-1]
+    finally:
+        block.close()
+        broker.finish()
+
+
+@pytest.mark.timeout(15)
+def test_lost_connection_clears_readiness_and_run_reports_it(fake_mqtt_broker):
+    # given
+    block = MQTTWriterSinkBlockV1()
+    fake_mqtt_broker.messages_count_to_wait_for = 1
+    broker_thread = threading.Thread(target=fake_mqtt_broker.start)
+    broker_thread.start()
+
+    try:
+        # when
+        first_result = block.run(
+            host=fake_mqtt_broker.host,
+            port=fake_mqtt_broker.port,
+            topic="RoboflowTopic",
+            message="delivered",
+            timeout=2.0,
+        )
+        broker_thread.join(timeout=2)
+        fake_mqtt_broker.finish()
+
+        assert wait_until(lambda: not block._connected.is_set())
+
+        second_result = block.run(
+            host=fake_mqtt_broker.host,
+            port=fake_mqtt_broker.port,
+            topic="RoboflowTopic",
+            message="lost",
+            timeout=2.0,
+        )
+
+        # then
+        assert first_result["error_status"] is False
+        assert second_result["error_status"] is True
+        assert "not connected" in second_result["message"].lower()
+    finally:
+        block.close()
+
+
+@pytest.mark.timeout(10)
+def test_missing_puback_reported_as_delivery_unknown_not_final_failure(
+    fake_mqtt_broker,
+):
+    # given - broker accepts the PUBLISH but never sends PUBACK
+    block = MQTTWriterSinkBlockV1()
+    published_message = "qos1 message"
+    fake_mqtt_broker.messages_count_to_wait_for = 1
+    broker_thread = threading.Thread(target=fake_mqtt_broker.start)
+    broker_thread.start()
+
+    try:
+        # when
+        result = block.run(
+            host=fake_mqtt_broker.host,
+            port=fake_mqtt_broker.port,
+            topic="RoboflowTopic",
+            message=published_message,
+            qos=1,
+            timeout=1.0,
+        )
+        broker_thread.join(timeout=2)
+
+        # then - the block reports delivery-unknown, yet the broker received it
+        assert result["error_status"] is True
+        assert "delivery status unknown" in result["message"].lower()
+        assert published_message.encode() in fake_mqtt_broker.messages[-1]
+    finally:
+        block.close()
+
+
+@pytest.mark.timeout(10)
+def test_second_broker_is_rejected_instead_of_publishing_to_first(fake_mqtt_broker):
+    # given
+    block = MQTTWriterSinkBlockV1()
+    other_broker = FakeMQTTBroker()
+    fake_mqtt_broker.messages_count_to_wait_for = 1
+    broker_thread = threading.Thread(target=fake_mqtt_broker.start)
+    broker_thread.start()
+
+    try:
+        # when
+        first_result = block.run(
+            host=fake_mqtt_broker.host,
+            port=fake_mqtt_broker.port,
+            topic="RoboflowTopic",
+            message="for broker A",
+            timeout=2.0,
+        )
+        broker_thread.join(timeout=2)
+
+        second_result = block.run(
+            host=other_broker.host,
+            port=other_broker.port,
+            topic="RoboflowTopic",
+            message="for broker B",
+            timeout=2.0,
+        )
+
+        # then
+        assert first_result["error_status"] is False
+        assert second_result["error_status"] is True
+        assert "parameters" in second_result["message"].lower()
+        assert other_broker.messages == []
+        assert all(
+            b"for broker B" not in message for message in fake_mqtt_broker.messages
+        )
+    finally:
+        block.close()
+        other_broker.finish()
+
+
+MQTT_SINK_WORKFLOW = {
+    "version": "1.0",
+    "inputs": [
+        {"type": "WorkflowParameter", "name": "host"},
+        {"type": "WorkflowParameter", "name": "port"},
+        {"type": "WorkflowParameter", "name": "message"},
+    ],
+    "steps": [
+        {
+            "type": "roboflow_enterprise/mqtt_writer_sink@v1",
+            "name": "mqtt_sink",
+            "host": "$inputs.host",
+            "port": "$inputs.port",
+            "topic": "RoboflowTopic",
+            "message": "$inputs.message",
+            "timeout": 0.2,
+        }
+    ],
+    "outputs": [
+        {
+            "type": "JsonField",
+            "name": "status",
+            "selector": "$steps.mqtt_sink.error_status",
+        },
+    ],
+}
+
+
+@pytest.fixture
+def enterprise_blocks_enabled():
+    from inference.core.workflows.execution_engine.introspection import blocks_loader
+
+    previous_value = blocks_loader.LOAD_ENTERPRISE_BLOCKS
+    blocks_loader.LOAD_ENTERPRISE_BLOCKS = True
+    blocks_loader.load_core_workflow_blocks.cache_clear()
+    yield
+    blocks_loader.LOAD_ENTERPRISE_BLOCKS = previous_value
+    blocks_loader.load_core_workflow_blocks.cache_clear()
+
+
+@pytest.mark.timeout(15)
+def test_workflow_with_failing_mqtt_sink_logs_and_continues(
+    enterprise_blocks_enabled,
+):
+    # given - nothing listens on the port, so every sink run fails
+    execution_engine = ExecutionEngine.init(
+        workflow_definition=MQTT_SINK_WORKFLOW,
+        max_concurrent_steps=WORKFLOWS_MAX_CONCURRENT_STEPS,
+    )
+    runtime_parameters = {
+        "host": "localhost",
+        "port": closed_port(),
+        "message": "frame payload",
+    }
+
+    # when - two consecutive frames
+    with patch.object(v1, "logger") as mock_logger:
+        first_frame_result = execution_engine.run(runtime_parameters=runtime_parameters)
+        second_frame_result = execution_engine.run(
+            runtime_parameters=runtime_parameters
+        )
+
+    # then - failures are surfaced in logs and outputs, execution continues
+    assert any(
+        call.args[0].startswith("MQTT Writer failure")
+        for call in mock_logger.error.call_args_list
+    )
+    assert first_frame_result[0]["status"] is True
+    assert second_frame_result[0]["status"] is True
+
+
+@pytest.mark.timeout(15)
+def test_workflow_with_unwired_failing_mqtt_sink_still_logs_and_continues(
+    enterprise_blocks_enabled,
+):
+    # given - no MQTT outputs are wired, so logs are the only failure signal
+    workflow_definition = copy.deepcopy(MQTT_SINK_WORKFLOW)
+    workflow_definition["outputs"] = [
+        {"type": "JsonField", "name": "echo", "selector": "$inputs.message"},
+    ]
+    execution_engine = ExecutionEngine.init(
+        workflow_definition=workflow_definition,
+        max_concurrent_steps=WORKFLOWS_MAX_CONCURRENT_STEPS,
+    )
+    runtime_parameters = {
+        "host": "localhost",
+        "port": closed_port(),
+        "message": "frame payload",
+    }
+
+    # when
+    with patch.object(v1, "logger") as mock_logger:
+        first_frame_result = execution_engine.run(runtime_parameters=runtime_parameters)
+        second_frame_result = execution_engine.run(
+            runtime_parameters=runtime_parameters
+        )
 
     # then
-    assert result["error_status"] is False, "No error expected"
-    assert result["message"] == expected_message
+    assert any(
+        call.args[0].startswith("MQTT Writer failure")
+        for call in mock_logger.error.call_args_list
+    )
+    assert first_frame_result[0]["echo"] == "frame payload"
+    assert second_frame_result[0]["echo"] == "frame payload"
 
-    assert published_message.encode() in fake_mqtt_broker.messages[-1]
+
+@pytest.mark.timeout(15)
+def test_workflow_with_failing_mqtt_sink_and_fail_fast_raises(
+    enterprise_blocks_enabled,
+):
+    # given
+    workflow_definition = copy.deepcopy(MQTT_SINK_WORKFLOW)
+    workflow_definition["steps"][0]["fail_fast"] = True
+    execution_engine = ExecutionEngine.init(
+        workflow_definition=workflow_definition,
+        max_concurrent_steps=WORKFLOWS_MAX_CONCURRENT_STEPS,
+    )
+
+    # when / then
+    with pytest.raises(Exception, match="not connected"):
+        execution_engine.run(
+            runtime_parameters={
+                "host": "localhost",
+                "port": closed_port(),
+                "message": "frame payload",
+            }
+        )

--- a/tests/workflows/unit_tests/core_steps/sinks/test_mqtt_writer.py
+++ b/tests/workflows/unit_tests/core_steps/sinks/test_mqtt_writer.py
@@ -208,6 +208,29 @@ class TestRunValidation:
         assert result["error_status"] is False
         mock_client_cls.return_value.connect.assert_called_once_with("localhost", 1883)
 
+    @pytest.mark.parametrize("qos", [-1, 3, "abc", 1.5, True, None])
+    def test_invalid_qos_rejected_before_client_construction(
+        self, mock_client_cls, block, qos
+    ):
+        result = block.run(**run_kwargs(qos=qos))
+
+        assert result["error_status"] is True
+        assert "qos" in result["message"].lower()
+        mock_client_cls.assert_not_called()
+
+    @pytest.mark.parametrize("qos, expected", [("1", 1), (2.0, 2), (0, 0)])
+    def test_selector_supplied_qos_coerced_like_other_parameters(
+        self, mock_client_cls, block, qos, expected
+    ):
+        block._connected.set()
+
+        result = block.run(**run_kwargs(qos=qos))
+
+        assert result["error_status"] is False
+        mock_client_cls.return_value.publish.assert_called_once_with(
+            "test/topic", "Hello, MQTT!", qos=expected, retain=False
+        )
+
     def test_password_without_username_rejected(self, mock_client_cls, block):
         result = block.run(**run_kwargs(password="secret"))
 
@@ -270,13 +293,18 @@ class TestClientSetup:
         ):
             assert getattr(callback, "__self__", None) is not block
 
-    def test_reconnect_delay_derived_from_timeout(self, mock_client_cls, block):
+    def test_reconnect_delay_lets_first_retry_finish_within_one_run(
+        self, mock_client_cls, block
+    ):
+        # min_delay must be below the readiness wait (= timeout), otherwise
+        # the first reconnect attempt after a connection drop starts exactly
+        # as the waiting run's timeout expires and that run always fails
         block._connected.set()
 
         block.run(**run_kwargs(timeout=0.5))
 
         mock_client_cls.return_value.reconnect_delay_set.assert_called_once_with(
-            min_delay=0.5, max_delay=1.0
+            min_delay=0.25, max_delay=1.0
         )
 
     def test_paho_connect_timeout_bound_to_block_timeout(self, mock_client_cls, block):
@@ -435,7 +463,24 @@ class TestPublishing:
             "test/topic", "Hello, MQTT!", qos=1, retain=True
         )
 
-    def test_publish_ack_timeout_reported_as_delivery_unknown(
+    def test_qos0_publish_confirmation_timeout_reported_as_lost(
+        self, mock_client_cls, block
+    ):
+        # paho never retransmits QoS 0: reconnect() clears _out_packet and
+        # QoS 0 messages are not queued, so an unconfirmed send is a real loss
+        block._connected.set()
+        mock_client = mock_client_cls.return_value
+        mock_client.publish.return_value.is_published.return_value = False
+
+        with patch.object(v1, "logger") as mock_logger:
+            result = block.run(**run_kwargs(qos=0))
+
+        assert result["error_status"] is True
+        assert "lost" in result["message"].lower()
+        assert "delivery status unknown" not in result["message"].lower()
+        assert mock_logger.error.called
+
+    def test_qos1_publish_ack_timeout_reported_as_delivery_unknown(
         self, mock_client_cls, block
     ):
         block._connected.set()
@@ -443,7 +488,7 @@ class TestPublishing:
         mock_client.publish.return_value.is_published.return_value = False
 
         with patch.object(v1, "logger") as mock_logger:
-            result = block.run(**run_kwargs())
+            result = block.run(**run_kwargs(qos=1))
 
         assert result["error_status"] is True
         assert "delivery status unknown" in result["message"].lower()
@@ -530,7 +575,7 @@ class TestFailFast:
         )
 
         with patch.object(v1, "logger") as mock_logger:
-            with pytest.raises(RuntimeError, match="^Publish acknowledgement"):
+            with pytest.raises(RuntimeError, match="^Publish confirmation"):
                 block.run(**run_kwargs(fail_fast=True))
 
         assert mock_logger.error.call_count == 1

--- a/tests/workflows/unit_tests/core_steps/sinks/test_mqtt_writer.py
+++ b/tests/workflows/unit_tests/core_steps/sinks/test_mqtt_writer.py
@@ -183,7 +183,9 @@ class TestRunValidation:
         assert "timeout" in result["message"].lower()
         mock_client_cls.assert_not_called()
 
-    @pytest.mark.parametrize("port", [0, -1, 65536, "1883"])
+    @pytest.mark.parametrize(
+        "port", [0, -1, 65536, "abc", "1883.5", 1883.7, True, None]
+    )
     def test_invalid_port_rejected_before_client_construction(
         self, mock_client_cls, block, port
     ):
@@ -192,6 +194,19 @@ class TestRunValidation:
         assert result["error_status"] is True
         assert "port" in result["message"].lower()
         mock_client_cls.assert_not_called()
+
+    @pytest.mark.parametrize("port", ["1883", 1883.0])
+    def test_selector_supplied_port_coerced_like_manifest(
+        self, mock_client_cls, block, port
+    ):
+        # runtime validation coerces on a discarded manifest copy, so run()
+        # receives the raw selector value and must coerce it itself
+        block._connected.set()
+
+        result = block.run(**run_kwargs(port=port))
+
+        assert result["error_status"] is False
+        mock_client_cls.return_value.connect.assert_called_once_with("localhost", 1883)
 
     def test_password_without_username_rejected(self, mock_client_cls, block):
         result = block.run(**run_kwargs(password="secret"))

--- a/tests/workflows/unit_tests/core_steps/sinks/test_mqtt_writer.py
+++ b/tests/workflows/unit_tests/core_steps/sinks/test_mqtt_writer.py
@@ -291,7 +291,7 @@ class TestClientSetup:
 
         assert connect_timeout_at_connect_call == [0.25]
 
-    def test_unreachable_broker_on_first_run_reports_failure_and_keeps_retrying(
+    def test_unreachable_broker_on_first_run_leaves_no_background_thread(
         self, mock_client_cls, block
     ):
         mock_client = mock_client_cls.return_value
@@ -302,17 +302,21 @@ class TestClientSetup:
         mock_client.connect.assert_called_once()
         assert first_result["error_status"] is True
         assert "not connected" in first_result["message"].lower()
-        assert block.mqtt_client is not None
-        mock_client.loop_start.assert_called_once()
+        # no client kept and no loop started: a failed one-shot run must not
+        # leave a reconnecting background thread behind
+        assert block.mqtt_client is None
+        mock_client.loop_start.assert_not_called()
         mock_client.publish.assert_not_called()
 
-        # background loop establishes the connection later
+        # broker becomes reachable, the next run retries with a fresh client
+        mock_client.connect.side_effect = None
         block._connected.set()
 
         second_result = block.run(**run_kwargs())
 
         assert second_result["error_status"] is False
-        mock_client_cls.assert_called_once()
+        assert mock_client_cls.call_count == 2
+        mock_client.loop_start.assert_called_once()
 
     def test_unreachable_broker_with_fail_fast_raises(self, mock_client_cls, block):
         mock_client = mock_client_cls.return_value
@@ -322,6 +326,8 @@ class TestClientSetup:
             block.run(**run_kwargs(fail_fast=True))
 
         mock_client.connect.assert_called_once()
+        mock_client.loop_start.assert_not_called()
+        assert block.mqtt_client is None
 
     def test_setup_failure_resets_client_so_next_run_can_retry(
         self, mock_client_cls, block

--- a/tests/workflows/unit_tests/core_steps/sinks/test_mqtt_writer.py
+++ b/tests/workflows/unit_tests/core_steps/sinks/test_mqtt_writer.py
@@ -1,4 +1,3 @@
-import math
 import threading
 from typing import get_args
 from unittest.mock import MagicMock, patch
@@ -225,7 +224,7 @@ class TestRunValidation:
 
 
 class TestClientSetup:
-    def test_client_uses_connect_async_and_background_loop(
+    def test_client_connects_synchronously_before_background_loop(
         self, mock_client_cls, block
     ):
         block._connected.set()
@@ -235,12 +234,10 @@ class TestClientSetup:
 
         assert result["error_status"] is False
         mock_client_cls.assert_called_once_with(userdata=block._connected)
-        mock_client.connect_async.assert_called_once_with("localhost", 1883)
-        mock_client.connect.assert_not_called()
+        mock_client.connect.assert_called_once_with("localhost", 1883)
+        mock_client.connect_async.assert_not_called()
         called_methods = [call[0] for call in mock_client.method_calls]
-        assert called_methods.index("connect_async") < called_methods.index(
-            "loop_start"
-        )
+        assert called_methods.index("connect") < called_methods.index("loop_start")
 
     def test_client_registers_static_callbacks(self, mock_client_cls, block):
         block._connected.set()
@@ -266,6 +263,50 @@ class TestClientSetup:
         mock_client_cls.return_value.reconnect_delay_set.assert_called_once_with(
             min_delay=0.5, max_delay=1.0
         )
+
+    def test_paho_connect_timeout_bound_to_block_timeout(self, mock_client_cls, block):
+        block._connected.set()
+        mock_client = mock_client_cls.return_value
+        connect_timeout_at_connect_call = []
+        mock_client.connect.side_effect = lambda *args, **kwargs: (
+            connect_timeout_at_connect_call.append(mock_client._connect_timeout)
+        )
+
+        block.run(**run_kwargs(timeout=0.25))
+
+        assert connect_timeout_at_connect_call == [0.25]
+
+    def test_unreachable_broker_on_first_run_reports_failure_and_keeps_retrying(
+        self, mock_client_cls, block
+    ):
+        mock_client = mock_client_cls.return_value
+        mock_client.connect.side_effect = ConnectionRefusedError("refused")
+
+        first_result = block.run(**run_kwargs())
+
+        mock_client.connect.assert_called_once()
+        assert first_result["error_status"] is True
+        assert "not connected" in first_result["message"].lower()
+        assert block.mqtt_client is not None
+        mock_client.loop_start.assert_called_once()
+        mock_client.publish.assert_not_called()
+
+        # background loop establishes the connection later
+        block._connected.set()
+
+        second_result = block.run(**run_kwargs())
+
+        assert second_result["error_status"] is False
+        mock_client_cls.assert_called_once()
+
+    def test_unreachable_broker_with_fail_fast_raises(self, mock_client_cls, block):
+        mock_client = mock_client_cls.return_value
+        mock_client.connect.side_effect = OSError("no route to host")
+
+        with pytest.raises(RuntimeError, match="not connected"):
+            block.run(**run_kwargs(fail_fast=True))
+
+        mock_client.connect.assert_called_once()
 
     def test_setup_failure_resets_client_so_next_run_can_retry(
         self, mock_client_cls, block
@@ -305,7 +346,7 @@ class TestClientSetup:
 
         assert second_result["error_status"] is False
         mock_client_cls.assert_called_once()
-        mock_client.connect_async.assert_called_once()
+        mock_client.connect.assert_called_once()
         mock_client.publish.assert_called_once()
 
 
@@ -334,7 +375,7 @@ class TestConnectionOwnership:
 
         assert result["error_status"] is True
         assert "parameters" in result["message"].lower()
-        mock_client.connect_async.assert_called_once_with("broker-a", 1883)
+        mock_client.connect.assert_called_once_with("broker-a", 1883)
         mock_client.publish.assert_called_once()
 
     def test_changed_credentials_rejected(self, mock_client_cls, block):

--- a/tests/workflows/unit_tests/core_steps/sinks/test_mqtt_writer.py
+++ b/tests/workflows/unit_tests/core_steps/sinks/test_mqtt_writer.py
@@ -1,99 +1,54 @@
-import unittest
+import math
+import threading
 from typing import get_args
 from unittest.mock import MagicMock, patch
 
+import pytest
+from pydantic import ValidationError
+
+from inference.enterprise.workflows.enterprise_blocks.sinks.mqtt_writer import v1
 from inference.enterprise.workflows.enterprise_blocks.sinks.mqtt_writer.v1 import (
     BlockManifest,
     MQTTWriterSinkBlockV1,
+    mqtt_on_connect,
+    mqtt_on_connect_fail,
+    mqtt_on_disconnect,
+)
+
+CLIENT_CLASS_PATH = (
+    "inference.enterprise.workflows.enterprise_blocks.sinks.mqtt_writer.v1.mqtt.Client"
 )
 
 
-class TestMQTTWriterSinkBlockV1(unittest.TestCase):
-    @patch(
-        "inference.enterprise.workflows.enterprise_blocks.sinks.mqtt_writer.v1.mqtt.Client"
-    )
-    def test_successful_connection_and_publishing(self, MockMQTTClient):
-        # Arrange
-        mock_client = MockMQTTClient.return_value
-        mock_client.is_connected.return_value = False
-        mock_client.publish.return_value.is_published.return_value = True
-
-        block = MQTTWriterSinkBlockV1()
-        block._connected = MagicMock()
-        block._connected.wait.return_value = True
-
-        # Act
-        result = block.run(
-            host="localhost",
-            port=1883,
-            topic="test/topic",
-            message="Hello, MQTT!",
-            username="lenny",
-            password="roboflow",
-        )
-
-        # Assert
-        self.assertFalse(result["error_status"])
-        self.assertEqual(result["message"], "Message published successfully")
-
-    @patch(
-        "inference.enterprise.workflows.enterprise_blocks.sinks.mqtt_writer.v1.mqtt.Client"
-    )
-    def test_connection_failure(self, MockMQTTClient):
-        # Arrange
-        mock_client = MockMQTTClient.return_value
-        mock_client.is_connected.return_value = False
-        mock_client.connect.side_effect = Exception("Connection failed")
-
-        block = MQTTWriterSinkBlockV1()
-
-        # Act
-        result = block.run(
-            host="localhost",
-            port=1883,
-            topic="test/topic",
-            message="Hello, MQTT!",
-            username="lenny",
-            password="roboflow",
-        )
-
-        # Assert
-        self.assertTrue(result["error_status"])
-        self.assertIn("Failed to connect to MQTT broker", result["message"])
-
-    @patch(
-        "inference.enterprise.workflows.enterprise_blocks.sinks.mqtt_writer.v1.mqtt.Client"
-    )
-    def test_publishing_failure(self, MockMQTTClient):
-        # Arrange
-        mock_client = MockMQTTClient.return_value
-        mock_client.is_connected.return_value = True
-        mock_client.publish.return_value.is_published.return_value = False
-
-        block = MQTTWriterSinkBlockV1()
-        block._connected = MagicMock()
-        block._connected.wait.return_value = True
-
-        # Act
-        result = block.run(
-            host="localhost",
-            port=1883,
-            topic="test/topic",
-            message="Hello, MQTT!",
-            username="lenny",
-            password="roboflow",
-        )
-
-        # Assert
-        self.assertTrue(result["error_status"])
-        self.assertEqual(result["message"], "Failed to publish payload")
+def run_kwargs(**overrides) -> dict:
+    kwargs = {
+        "host": "localhost",
+        "port": 1883,
+        "topic": "test/topic",
+        "message": "Hello, MQTT!",
+        "timeout": 0.01,
+    }
+    kwargs.update(overrides)
+    return kwargs
 
 
-class TestMQTTWriterSinkBlockV1Manifest(unittest.TestCase):
+@pytest.fixture
+def mock_client_cls():
+    with patch(CLIENT_CLASS_PATH) as client_cls:
+        client_cls.return_value.publish.return_value.is_published.return_value = True
+        yield client_cls
+
+
+@pytest.fixture
+def block() -> MQTTWriterSinkBlockV1:
+    return MQTTWriterSinkBlockV1()
+
+
+class TestManifest:
     def test_primary_identifier_is_namespaced(self):
         identifiers = get_args(BlockManifest.model_fields["type"].annotation)
 
-        self.assertEqual(identifiers[0], "roboflow_enterprise/mqtt_writer_sink@v1")
+        assert identifiers[0] == "roboflow_enterprise/mqtt_writer_sink@v1"
 
     def test_legacy_identifier_still_accepted(self):
         manifest = BlockManifest.model_validate(
@@ -107,8 +62,462 @@ class TestMQTTWriterSinkBlockV1Manifest(unittest.TestCase):
             }
         )
 
-        self.assertEqual(manifest.type, "mqtt_writer_sink@v1")
+        assert manifest.type == "mqtt_writer_sink@v1"
+
+    @pytest.mark.parametrize(
+        "timeout", [0, -1, float("nan"), float("inf"), float("-inf")]
+    )
+    def test_literal_timeout_must_be_finite_and_positive(self, timeout):
+        with pytest.raises(ValidationError):
+            BlockManifest.model_validate(
+                {
+                    "type": "mqtt_writer_sink@v1",
+                    "name": "mqtt",
+                    "host": "localhost",
+                    "port": 1883,
+                    "topic": "test/topic",
+                    "message": "Hello, MQTT!",
+                    "timeout": timeout,
+                }
+            )
+
+    @pytest.mark.parametrize("timeout", [0.5, "$inputs.timeout"])
+    def test_valid_timeouts_accepted(self, timeout):
+        manifest = BlockManifest.model_validate(
+            {
+                "type": "mqtt_writer_sink@v1",
+                "name": "mqtt",
+                "host": "localhost",
+                "port": 1883,
+                "topic": "test/topic",
+                "message": "Hello, MQTT!",
+                "timeout": timeout,
+            }
+        )
+
+        assert manifest.timeout == timeout
+
+    @pytest.mark.parametrize("port", [0, -1, 65536])
+    def test_literal_port_must_be_within_tcp_range(self, port):
+        with pytest.raises(ValidationError):
+            BlockManifest.model_validate(
+                {
+                    "type": "mqtt_writer_sink@v1",
+                    "name": "mqtt",
+                    "host": "localhost",
+                    "port": port,
+                    "topic": "test/topic",
+                    "message": "Hello, MQTT!",
+                }
+            )
+
+    @pytest.mark.parametrize("port", [1883, "$inputs.port"])
+    def test_valid_ports_accepted(self, port):
+        manifest = BlockManifest.model_validate(
+            {
+                "type": "mqtt_writer_sink@v1",
+                "name": "mqtt",
+                "host": "localhost",
+                "port": port,
+                "topic": "test/topic",
+                "message": "Hello, MQTT!",
+            }
+        )
+
+        assert manifest.port == port
 
 
-if __name__ == "__main__":
-    unittest.main()
+class TestCallbacks:
+    def test_on_connect_sets_event_only_for_accepted_connack(self):
+        event = threading.Event()
+
+        mqtt_on_connect(MagicMock(), event, {}, 0)
+
+        assert event.is_set()
+
+    @pytest.mark.parametrize("reason_code", [1, 2, 3, 4, 5])
+    def test_on_connect_clears_event_for_rejected_connack(self, reason_code):
+        event = threading.Event()
+        event.set()
+
+        mqtt_on_connect(MagicMock(), event, {}, reason_code)
+
+        assert not event.is_set()
+
+    def test_on_connect_fail_matches_paho_two_argument_signature(self):
+        event = threading.Event()
+        event.set()
+
+        # paho 1.6.1 invokes on_connect_fail with exactly (client, userdata)
+        mqtt_on_connect_fail(MagicMock(), event)
+
+        assert not event.is_set()
+
+    def test_on_disconnect_clears_event(self):
+        event = threading.Event()
+        event.set()
+
+        mqtt_on_disconnect(MagicMock(), event, 1)
+
+        assert not event.is_set()
+
+    def test_on_disconnect_accepts_mqtt5_properties_argument(self):
+        event = threading.Event()
+        event.set()
+
+        mqtt_on_disconnect(MagicMock(), event, 1, properties=None)
+
+        assert not event.is_set()
+
+
+class TestRunValidation:
+    @pytest.mark.parametrize(
+        "timeout",
+        [0, -1, float("nan"), float("inf"), float("-inf"), 10**400, 1e308],
+    )
+    def test_invalid_timeout_rejected_before_client_construction(
+        self, mock_client_cls, block, timeout
+    ):
+        result = block.run(**run_kwargs(timeout=timeout))
+
+        assert result["error_status"] is True
+        assert "timeout" in result["message"].lower()
+        mock_client_cls.assert_not_called()
+
+    @pytest.mark.parametrize("port", [0, -1, 65536, "1883"])
+    def test_invalid_port_rejected_before_client_construction(
+        self, mock_client_cls, block, port
+    ):
+        result = block.run(**run_kwargs(port=port))
+
+        assert result["error_status"] is True
+        assert "port" in result["message"].lower()
+        mock_client_cls.assert_not_called()
+
+    def test_password_without_username_rejected(self, mock_client_cls, block):
+        result = block.run(**run_kwargs(password="secret"))
+
+        assert result["error_status"] is True
+        assert "username" in result["message"].lower()
+        mock_client_cls.assert_not_called()
+
+    def test_username_without_password_configures_authentication(
+        self, mock_client_cls, block
+    ):
+        block._connected.set()
+
+        block.run(**run_kwargs(username="lenny"))
+
+        mock_client_cls.return_value.username_pw_set.assert_called_once_with(
+            "lenny", None
+        )
+
+    def test_username_with_empty_password_configures_authentication(
+        self, mock_client_cls, block
+    ):
+        block._connected.set()
+
+        block.run(**run_kwargs(username="lenny", password=""))
+
+        mock_client_cls.return_value.username_pw_set.assert_called_once_with(
+            "lenny", ""
+        )
+
+
+class TestClientSetup:
+    def test_client_uses_connect_async_and_background_loop(
+        self, mock_client_cls, block
+    ):
+        block._connected.set()
+        mock_client = mock_client_cls.return_value
+
+        result = block.run(**run_kwargs())
+
+        assert result["error_status"] is False
+        mock_client_cls.assert_called_once_with(userdata=block._connected)
+        mock_client.connect_async.assert_called_once_with("localhost", 1883)
+        mock_client.connect.assert_not_called()
+        called_methods = [call[0] for call in mock_client.method_calls]
+        assert called_methods.index("connect_async") < called_methods.index(
+            "loop_start"
+        )
+
+    def test_client_registers_static_callbacks(self, mock_client_cls, block):
+        block._connected.set()
+        mock_client = mock_client_cls.return_value
+
+        block.run(**run_kwargs())
+
+        assert mock_client.on_connect is mqtt_on_connect
+        assert mock_client.on_connect_fail is mqtt_on_connect_fail
+        assert mock_client.on_disconnect is mqtt_on_disconnect
+        for callback in (
+            mock_client.on_connect,
+            mock_client.on_connect_fail,
+            mock_client.on_disconnect,
+        ):
+            assert getattr(callback, "__self__", None) is not block
+
+    def test_reconnect_delay_derived_from_timeout(self, mock_client_cls, block):
+        block._connected.set()
+
+        block.run(**run_kwargs(timeout=0.5))
+
+        mock_client_cls.return_value.reconnect_delay_set.assert_called_once_with(
+            min_delay=0.5, max_delay=1.0
+        )
+
+    def test_setup_failure_resets_client_so_next_run_can_retry(
+        self, mock_client_cls, block
+    ):
+        mock_client = mock_client_cls.return_value
+        mock_client.loop_start.side_effect = Exception("boom")
+
+        first_result = block.run(**run_kwargs())
+
+        assert first_result["error_status"] is True
+        assert block.mqtt_client is None
+        mock_client.loop_stop.assert_called_once()
+
+        mock_client.loop_start.side_effect = None
+        block._connected.set()
+
+        second_result = block.run(**run_kwargs())
+
+        assert second_result["error_status"] is False
+        assert mock_client_cls.call_count == 2
+
+    def test_first_run_connection_timeout_does_not_poison_client(
+        self, mock_client_cls, block
+    ):
+        mock_client = mock_client_cls.return_value
+
+        first_result = block.run(**run_kwargs())
+
+        assert first_result["error_status"] is True
+        assert "not connected" in first_result["message"].lower()
+        mock_client.publish.assert_not_called()
+
+        # simulates the background loop establishing the connection later
+        block._connected.set()
+
+        second_result = block.run(**run_kwargs())
+
+        assert second_result["error_status"] is False
+        mock_client_cls.assert_called_once()
+        mock_client.connect_async.assert_called_once()
+        mock_client.publish.assert_called_once()
+
+
+class TestConnectionOwnership:
+    def test_disconnected_run_never_calls_manual_reconnect(
+        self, mock_client_cls, block
+    ):
+        block._connected.set()
+        mock_client = mock_client_cls.return_value
+        block.run(**run_kwargs())
+
+        block._connected.clear()
+        result = block.run(**run_kwargs())
+
+        assert result["error_status"] is True
+        assert "not connected" in result["message"].lower()
+        mock_client.reconnect.assert_not_called()
+        mock_client.publish.assert_called_once()
+
+    def test_changed_connection_parameters_rejected(self, mock_client_cls, block):
+        block._connected.set()
+        mock_client = mock_client_cls.return_value
+        block.run(**run_kwargs(host="broker-a"))
+
+        result = block.run(**run_kwargs(host="broker-b"))
+
+        assert result["error_status"] is True
+        assert "parameters" in result["message"].lower()
+        mock_client.connect_async.assert_called_once_with("broker-a", 1883)
+        mock_client.publish.assert_called_once()
+
+    def test_changed_credentials_rejected(self, mock_client_cls, block):
+        block._connected.set()
+        mock_client = mock_client_cls.return_value
+        block.run(**run_kwargs(username="lenny", password="old"))
+
+        result = block.run(**run_kwargs(username="lenny", password="new"))
+
+        assert result["error_status"] is True
+        mock_client.publish.assert_called_once()
+
+    def test_changed_timeout_rejected(self, mock_client_cls, block):
+        # the first timeout permanently configures the reconnect schedule
+        block._connected.set()
+        mock_client = mock_client_cls.return_value
+        block.run(**run_kwargs(timeout=0.5))
+
+        result = block.run(**run_kwargs(timeout=1.0))
+
+        assert result["error_status"] is True
+        assert "parameters" in result["message"].lower()
+        mock_client.publish.assert_called_once()
+
+
+class TestPublishing:
+    def test_successful_publish(self, mock_client_cls, block):
+        block._connected.set()
+        mock_client = mock_client_cls.return_value
+
+        result = block.run(**run_kwargs(qos=1, retain=True))
+
+        assert result["error_status"] is False
+        assert result["message"] == "Message published successfully"
+        mock_client.publish.assert_called_once_with(
+            "test/topic", "Hello, MQTT!", qos=1, retain=True
+        )
+
+    def test_publish_ack_timeout_reported_as_delivery_unknown(
+        self, mock_client_cls, block
+    ):
+        block._connected.set()
+        mock_client = mock_client_cls.return_value
+        mock_client.publish.return_value.is_published.return_value = False
+
+        with patch.object(v1, "logger") as mock_logger:
+            result = block.run(**run_kwargs())
+
+        assert result["error_status"] is True
+        assert "delivery status unknown" in result["message"].lower()
+        assert mock_logger.error.called
+
+    def test_qos1_publish_with_lost_connection_reported_as_delivery_unknown(
+        self, mock_client_cls, block
+    ):
+        # paho queues QoS 1/2 messages for redelivery when publish() returns
+        # MQTT_ERR_NO_CONN - not a final failure
+        import paho.mqtt.client as mqtt
+
+        block._connected.set()
+        mock_client = mock_client_cls.return_value
+        mock_client.publish.return_value.rc = mqtt.MQTT_ERR_NO_CONN
+
+        result = block.run(**run_kwargs(qos=1))
+
+        assert result["error_status"] is True
+        assert "delivery status unknown" in result["message"].lower()
+        mock_client.publish.return_value.wait_for_publish.assert_not_called()
+
+    def test_qos0_publish_with_lost_connection_reported_as_final_failure(
+        self, mock_client_cls, block
+    ):
+        # paho drops QoS 0 messages on MQTT_ERR_NO_CONN - final failure is honest
+        import paho.mqtt.client as mqtt
+
+        block._connected.set()
+        mock_client = mock_client_cls.return_value
+        publish_result = mock_client.publish.return_value
+        publish_result.rc = mqtt.MQTT_ERR_NO_CONN
+        publish_result.wait_for_publish.side_effect = RuntimeError(
+            "Message publish failed: The client is not currently connected."
+        )
+
+        result = block.run(**run_kwargs(qos=0))
+
+        assert result["error_status"] is True
+        assert "failed to publish" in result["message"].lower()
+
+    def test_publish_exception_returned_as_error(self, mock_client_cls, block):
+        block._connected.set()
+        mock_client = mock_client_cls.return_value
+        mock_client.publish.side_effect = ValueError("Invalid topic")
+
+        result = block.run(**run_kwargs())
+
+        assert result["error_status"] is True
+        assert "Invalid topic" in result["message"]
+
+    def test_no_raw_prints_in_any_code_path(self, mock_client_cls, block):
+        with patch("builtins.print") as mock_print:
+            block._connected.set()
+            block.run(**run_kwargs())
+            block._connected.clear()
+            block.run(**run_kwargs())
+
+        mock_print.assert_not_called()
+
+
+class TestFailFast:
+    def test_fail_fast_raises_on_connection_failure(self, mock_client_cls, block):
+        with pytest.raises(Exception, match="not connected"):
+            block.run(**run_kwargs(fail_fast=True))
+
+    def test_fail_fast_raises_on_invalid_timeout(self, mock_client_cls, block):
+        with pytest.raises(Exception, match="[Tt]imeout"):
+            block.run(**run_kwargs(timeout=-1, fail_fast=True))
+
+    def test_fail_fast_does_not_affect_success(self, mock_client_cls, block):
+        block._connected.set()
+
+        result = block.run(**run_kwargs(fail_fast=True))
+
+        assert result["error_status"] is False
+
+    def test_fail_fast_ack_timeout_raises_once_with_clean_message(
+        self, mock_client_cls, block
+    ):
+        block._connected.set()
+        mock_client_cls.return_value.publish.return_value.is_published.return_value = (
+            False
+        )
+
+        with patch.object(v1, "logger") as mock_logger:
+            with pytest.raises(RuntimeError, match="^Publish acknowledgement"):
+                block.run(**run_kwargs(fail_fast=True))
+
+        assert mock_logger.error.call_count == 1
+
+
+class TestCleanup:
+    def test_close_disconnects_and_stops_loop_once(self, mock_client_cls, block):
+        block._connected.set()
+        mock_client = mock_client_cls.return_value
+        block.run(**run_kwargs())
+
+        block.close()
+        block.close()
+        block.__del__()
+
+        mock_client.disconnect.assert_called_once()
+        mock_client.loop_stop.assert_called_once()
+        assert block.mqtt_client is None
+        assert not block._connected.is_set()
+
+    def test_close_stops_loop_even_when_disconnect_raises(self, mock_client_cls, block):
+        block._connected.set()
+        mock_client = mock_client_cls.return_value
+        mock_client.disconnect.side_effect = Exception("socket already dead")
+        block.run(**run_kwargs())
+
+        block.close()
+
+        mock_client.loop_stop.assert_called_once()
+
+    def test_close_on_uninitialized_block_is_noop(self, block):
+        block.close()
+
+        assert block.mqtt_client is None
+
+    def test_close_clears_readiness_only_after_loop_thread_joined(
+        self, mock_client_cls, block
+    ):
+        # clearing before loop_stop() lets the dying loop's on_connect re-set
+        # the event; the event must stay authoritative until the join returns
+        block._connected.set()
+        mock_client = mock_client_cls.return_value
+        event_state_at_loop_stop = []
+        mock_client.loop_stop.side_effect = lambda: event_state_at_loop_stop.append(
+            block._connected.is_set()
+        )
+        block.run(**run_kwargs())
+
+        block.close()
+
+        assert event_state_at_loop_stop == [True]
+        assert not block._connected.is_set()


### PR DESCRIPTION
## What does this PR do?

  Rewrite of the enterprise MQTT Writer sink, which had a broken client lifecycle
  (13 confirmed defects vs paho-mqtt 1.6.1): a failed first connect poisoned the
  client forever, rejected CONNACKs logged "Connected", `on_connect_fail` had the
  wrong arity and always raised, manual `reconnect()` raced paho's auto-reconnect,
  changed host/credentials silently published to the first broker, username-only
  auth was skipped, ack timeouts were reported as final failure, and invalid
  timeout/port values could hang, busy-spin, or kill the network thread.

  ## How

  Connection owned by `connect_async()` + background loop; runs just wait on a
  readiness Event maintained by correct static callbacks. Connection identity cached
  on first run, changes rejected. Timeout/port/auth validated up front. Ack timeout
  and QoS 1/2 disconnect now report "delivery status unknown". All failures log and
  return `error_status=True` without stopping the workflow; new opt-in `fail_fast`
  field raises instead. Idempotent `close()` + lifecycle lock.

## Type of Change

- Bug fix (non-breaking change that fixes an issue)

## Testing

All MQTT tests in CI passing

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)

## Additional Context

N/A