### PR TITLE
chore(logging): demote per-request serverless chatter and probe access logs to DEBUG

### DIFF
--- a/inference/core/interfaces/http/http_api.py
+++ b/inference/core/interfaces/http/http_api.py
@@ -391,6 +391,10 @@ class LambdaMiddleware(BaseHTTPMiddleware):
 AUTH_CACHE_TTL_SECONDS = 3600
 SHORT_AUTH_CACHE_TTL_SECONDS = 60
 REQUEST_RECEIVED_LOG_MESSAGE = "Request received"
+# Probe/health endpoints whose access-log lines are demoted to DEBUG.
+HEALTH_CHECK_LOG_PATHS = frozenset(
+    {"/", "/info", "/healthz", "/ready", "/readiness", "/live", "/liveness"}
+)
 
 
 if ALLOW_CUSTOM_PYTHON_EXECUTION_IN_WORKFLOWS:
@@ -563,7 +567,9 @@ def _log_serverless_request_received(
     }
     if execution_id_value is not None:
         log_fields["execution_id"] = execution_id_value
-    logger.info(REQUEST_RECEIVED_LOG_MESSAGE, **log_fields)
+    # Debug: one INFO line per request doubles serverless log volume; the
+    # structured access log already records every request with the same ids.
+    logger.debug(REQUEST_RECEIVED_LOG_MESSAGE, **log_fields)
 
 
 class HttpInterface(BaseInterface):
@@ -1395,7 +1401,17 @@ class HttpInterface(BaseInterface):
                     if len(parts) >= 3:
                         log_fields["trace_id"] = parts[1]
 
-                logger.info(
+                # Health/probe endpoints log at DEBUG: kube-probe and LB
+                # health traffic otherwise dominates access-log volume.
+                # Real request paths MUST stay at INFO — the dedicated
+                # deployment auto-pause daemon reads these lines as its
+                # activity signal (see GEV-28).
+                access_log = (
+                    logger.debug
+                    if request.url.path in HEALTH_CHECK_LOG_PATHS
+                    else logger.info
+                )
+                access_log(
                     f"{request.method} {request.url.path} {response.status_code}",
                     **log_fields,
                 )


### PR DESCRIPTION
# Description

Log-volume sampling of the async-serverless prod pods (2026-08-26) found the two chattiest inference-server log lines, and this PR demotes exactly those two emitters — no global log-level change:

1. **`Request received`** (`_log_serverless_request_received`, GCP_SERVERLESS middleware): INFO → DEBUG. It was the single most frequent line in the sample (74 of 600 sampled entries). The structured access log already records every request at completion with the same `request_id`/`execution_id`, so this line duplicates per-request coverage.
2. **`structured_access_log`**: health/probe paths (`/`, `/info`, `/healthz`, `/ready(-iness)`, `/live(-ness)`) now log at DEBUG; **all other paths stay at INFO**.

Why the access log is only path-scoped and not demoted wholesale: the dedicated-deployment auto-pause daemon consumes these access-log lines as its activity signal (GEV-28). Real-request lines must keep flowing at INFO or active machines would read as idle. Removing *probe* lines is strictly aligned with the GEV-28 fix (probe noise was what defeated the inactivity filter) and cannot create false-idle, since real requests keep logging.

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue) — log-noise/cost reduction

## How has this change been tested, please provide a testcase or example of how you tested the change?

- `python -m py_compile` on the modified module.
- Grep: no tests reference `Request received` or the new `HEALTH_CHECK_LOG_PATHS` constant.
- Behavior is unchanged apart from log level selection; both lines still emit at DEBUG for anyone running `LOG_LEVEL=DEBUG`.

## Any specific deployment considerations

- Serverless (async) pods lose the per-request `Request received` INFO line and `GET /info` probe lines; request-level visibility remains via the structured access log.
- Dedicated deployments: probe-path lines (`/readiness` etc.) stop appearing at INFO — expected to *reduce* false-activity input to the auto-pause filter, not affect real-activity detection.
- Anyone parsing `GET / …` or `GET /info …` INFO lines downstream would need `LOG_LEVEL=DEBUG`; no such consumer was found in roboflow-infra or async-serverless.

## Docs

-   [ ] Docs updated? No.

🤖 Generated with [Claude Code](https://claude.com/claude-code)