### PR TITLE
Add Qwen 3.8 Flash OpenRouter variant to the Qwen block

### DIFF
--- a/inference/core/workflows/core_steps/models/foundation/qwen_vlm/v3.py
+++ b/inference/core/workflows/core_steps/models/foundation/qwen_vlm/v3.py
@@ -128,6 +128,10 @@ MODEL_VARIANTS: Dict[str, Dict[str, Any]] = {
         "model_id": "qwen/qwen3.8-max",
         "reasoning_required": True,
     },
+    "Qwen 3.8 Flash": {
+        "backend": "openrouter",
+        "model_id": "qwen/qwen3.8-flash",
+    },
     "Qwen 3.7 Plus": {
         "backend": "openrouter",
         "model_id": "qwen/qwen3.7-plus",

--- a/tests/workflows/unit_tests/core_steps/models/foundation/test_qwen_vlm_v3.py
+++ b/tests/workflows/unit_tests/core_steps/models/foundation/test_qwen_vlm_v3.py
@@ -13,6 +13,7 @@ from inference.core.workflows.core_steps.common.entities import StepExecutionMod
 from inference.core.workflows.core_steps.common.openrouter import OpenRouterResult
 from inference.core.workflows.core_steps.models.foundation.qwen_vlm.v3 import (
     DEFAULT_OPENROUTER_MODEL_VERSION,
+    BlockManifest,
     QwenVlmBlockV3,
 )
 from inference.core.workflows.execution_engine.entities.base import WorkflowImageData
@@ -74,6 +75,49 @@ def test_run_openrouter_surfaces_token_usage(mock_or):
             "output_tokens": 7,
         }
     ]
+
+
+def test_manifest_accepts_qwen_3_8_flash_variant():
+    manifest = BlockManifest(
+        type="roboflow_core/qwen_vlm@v3",
+        name="qwen",
+        images="$inputs.image",
+        backend="openrouter",
+        openrouter_model_version="Qwen 3.8 Flash",
+        task_type="unconstrained",
+        prompt="What is in this image?",
+    )
+
+    assert manifest.openrouter_model_version == "Qwen 3.8 Flash"
+
+
+@patch.object(QwenVlmBlockV3, "execute_openrouter_batch_with_usage")
+def test_run_openrouter_qwen_3_8_flash_maps_slug_and_disables_reasoning(mock_or):
+    # OpenRouter reports reasoning as non-mandatory for qwen/qwen3.8-flash,
+    # so the default effort ("none") must translate to `enabled: false`
+    # instead of the low-effort fallback used by reasoning-required models.
+    mock_or.return_value = [
+        OpenRouterResult(
+            content="resp", reasoning_trace="", input_tokens=5, output_tokens=3
+        )
+    ]
+    block = QwenVlmBlockV3(
+        model_manager=MagicMock(),
+        api_key="ws-key",
+        step_execution_mode=StepExecutionMode.LOCAL,
+    )
+
+    result = block.run(
+        **_base_run_kwargs(
+            backend="openrouter",
+            openrouter_model_version="Qwen 3.8 Flash",
+        )
+    )
+
+    call_kwargs = mock_or.call_args.kwargs
+    assert call_kwargs["model"] == "qwen/qwen3.8-flash"
+    assert call_kwargs["reasoning"] == {"enabled": False}
+    assert result[0]["output"] == "resp"
 
 
 def test_run_native_reports_none_token_usage():

--- a/tests/workflows/unit_tests/core_steps/models/foundation/test_qwen_vlm_v3.py
+++ b/tests/workflows/unit_tests/core_steps/models/foundation/test_qwen_vlm_v3.py
@@ -13,7 +13,6 @@ from inference.core.workflows.core_steps.common.entities import StepExecutionMod
 from inference.core.workflows.core_steps.common.openrouter import OpenRouterResult
 from inference.core.workflows.core_steps.models.foundation.qwen_vlm.v3 import (
     DEFAULT_OPENROUTER_MODEL_VERSION,
-    BlockManifest,
     QwenVlmBlockV3,
 )
 from inference.core.workflows.execution_engine.entities.base import WorkflowImageData
@@ -75,49 +74,6 @@ def test_run_openrouter_surfaces_token_usage(mock_or):
             "output_tokens": 7,
         }
     ]
-
-
-def test_manifest_accepts_qwen_3_8_flash_variant():
-    manifest = BlockManifest(
-        type="roboflow_core/qwen_vlm@v3",
-        name="qwen",
-        images="$inputs.image",
-        backend="openrouter",
-        openrouter_model_version="Qwen 3.8 Flash",
-        task_type="unconstrained",
-        prompt="What is in this image?",
-    )
-
-    assert manifest.openrouter_model_version == "Qwen 3.8 Flash"
-
-
-@patch.object(QwenVlmBlockV3, "execute_openrouter_batch_with_usage")
-def test_run_openrouter_qwen_3_8_flash_maps_slug_and_disables_reasoning(mock_or):
-    # OpenRouter reports reasoning as non-mandatory for qwen/qwen3.8-flash,
-    # so the default effort ("none") must translate to `enabled: false`
-    # instead of the low-effort fallback used by reasoning-required models.
-    mock_or.return_value = [
-        OpenRouterResult(
-            content="resp", reasoning_trace="", input_tokens=5, output_tokens=3
-        )
-    ]
-    block = QwenVlmBlockV3(
-        model_manager=MagicMock(),
-        api_key="ws-key",
-        step_execution_mode=StepExecutionMode.LOCAL,
-    )
-
-    result = block.run(
-        **_base_run_kwargs(
-            backend="openrouter",
-            openrouter_model_version="Qwen 3.8 Flash",
-        )
-    )
-
-    call_kwargs = mock_or.call_args.kwargs
-    assert call_kwargs["model"] == "qwen/qwen3.8-flash"
-    assert call_kwargs["reasoning"] == {"enabled": False}
-    assert result[0]["output"] == "resp"
 
 
 def test_run_native_reports_none_token_usage():


### PR DESCRIPTION
## What does this PR do?

Alibaba released Qwen 3.8 Flash (`qwen/qwen3.8-flash`) on OpenRouter on 2026-08-26. The unified Qwen block (`roboflow_core/qwen_vlm@v3`) had no entry for it, so workflows could not select the model.

The change is one entry in `MODEL_VARIANTS` mapping the "Qwen 3.8 Flash" label to the OpenRouter slug. The dropdown literal, reasoning-level metadata, and dependent-resource discovery all derive from that dict, so nothing else changes. OpenRouter's models API reports reasoning as optional for this model, while Qwen 3.8 Max reports it as mandatory, so the entry carries no `reasoning_required` flag. Requests therefore default to reasoning disabled, matching Qwen 3.7 Flash. A live request with `reasoning: {"enabled": false}` confirmed the provider accepts it.

Main elements:
- `inference/core/workflows/core_steps/models/foundation/qwen_vlm/v3.py`: new `MODEL_VARIANTS` entry

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other:

## Testing

### Unit tests

- No new unit tests. Existing Qwen block tests still pass (`pytest tests/workflows/unit_tests/core_steps/models/foundation/test_qwen_vlm_v3.py test_qwen_vlm_v2.py test_qwen_vlm.py`).

### Integration tests

- None for this PR. Live validation below covers the end-to-end path.

### Other

- Live requests through the Workflows Execution Engine against OpenRouter for four task types: unconstrained, classification, OCR, and object detection. All returned correct responses with token usage populated.
- Object detection output parsed cleanly by `vlm_as_detector@v2` with `model_type="qwen"`: 28 detections (14 car, 11 person, 3 tree) on an aerial intersection image, `error_status` False.
- The upstream Alibaba pool rate-limits intermittently since the model is one day old; requests succeed on retry and this does not affect the block.
- black and isort clean on the changed file.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code where necessary, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have updated the documentation accordingly (if applicable)