### PR TITLE
Enable websocket transport in custom python block Modal deploy

### DIFF
--- a/.github/workflows/modal.custom_python_block.deploy.yml
+++ b/.github/workflows/modal.custom_python_block.deploy.yml
@@ -85,5 +85,6 @@ jobs:
           WEBEXEC_MODAL_CLOUD: ${{ matrix.cloud }}
           WEBEXEC_MODAL_REGION: ${{ matrix.region }}
           WEBEXEC_MODAL_ROUTING_REGION: ${{ matrix.routing_region }}
+          WEBEXEC_TRANSPORT: "websocket"
         working-directory: modal
         run: python3 deploy_modal_app.py


### PR DESCRIPTION
## What

Sets `WEBEXEC_TRANSPORT: "websocket"` in the `modal.custom_python_block.deploy.yml` workflow env so deployed webexec Modal apps use the websocket transport.

Single-line change, no other modifications.