### PR TITLE
Emit model-category usage rows for local in-infra models - code review

### DIFF
--- a/inference/core/workflows/core_steps/models/foundation/segment_anything3_video/v1.py
+++ b/inference/core/workflows/core_steps/models/foundation/segment_anything3_video/v1.py
@@ -372,7 +372,6 @@ class SegmentAnything3VideoBlockV1(WorkflowBlock):
             self._visual_sessions.clear()
         return self._model
 
-    @usage_collector("model")
     def run(
         self,
         images: Batch[WorkflowImageData],
@@ -388,8 +387,35 @@ class SegmentAnything3VideoBlockV1(WorkflowBlock):
     ) -> BlockResult:
         if self._step_execution_mode is not StepExecutionMode.LOCAL:
             raise NotImplementedError(self._REMOTE_EXECUTION_NOT_SUPPORTED_MESSAGE)
+        # The usage decorator reads `model_id` off the tracked call, so the
+        # dispatch happens out here where the mode-dependent model is picked.
         selected_model_id = model_id if tracking_mode == "concept" else visual_model_id
-        model = self._get_model(model_id=selected_model_id)
+        return self._tracked_run(
+            images=images,
+            class_names=class_names,
+            model_id=selected_model_id,
+            threshold=threshold,
+            tracking_mode=tracking_mode,
+            points=points,
+            boxes=boxes,
+            prompt_mode=prompt_mode,
+            prompt_interval=prompt_interval,
+        )
+
+    @usage_collector("model")
+    def _tracked_run(
+        self,
+        images: Batch[WorkflowImageData],
+        class_names: Optional[Union[List[str], str]],
+        model_id: str,
+        threshold: float,
+        tracking_mode: TrackingMode,
+        points: Optional[List[Any]],
+        boxes: Optional[Batch[sv.Detections]],
+        prompt_mode: PromptMode,
+        prompt_interval: int,
+    ) -> BlockResult:
+        model = self._get_model(model_id=model_id)
         if tracking_mode == "visual":
             return self._run_visual(
                 model=model,

--- a/inference/models/clip/clip_inference_models.py
+++ b/inference/models/clip/clip_inference_models.py
@@ -33,9 +33,6 @@ from inference.core.roboflow_api import get_extra_weights_provider_headers
 from inference.core.utils.image_utils import load_image_bgr
 from inference.core.utils.postprocess import cosine_similarity
 from inference.usage_tracking.collector import usage_collector
-from inference.usage_tracking.decorator_helpers import (
-    record_fixed_model_input_for_request,
-)
 from inference_models import AutoModel
 from inference_models.models.clip.clip_onnx import ClipOnnx
 from inference_models.models.clip.clip_pytorch import ClipTorch
@@ -84,13 +81,12 @@ class InferenceModelsClipAdapter(Model):
             backend=backend,
             **kwargs,
         )
-        # ClipOnnx stores the square canvas as `_image_size`; ClipTorch only
-        # keeps it on the inner CLIP visual tower. Usage telemetry reads
-        # `resolution` the same way the legacy ONNX Clip class does.
-        self.resolution = getattr(self._model, "_image_size", None)
-        if self.resolution is None:
-            visual = getattr(getattr(self._model, "_model", None), "visual", None)
-            self.resolution = getattr(visual, "input_resolution", None)
+        # Usage telemetry reads the fixed canvas from `image_size`. ClipOnnx
+        # keeps it as `_image_size`; ClipTorch only on the inner visual tower.
+        if isinstance(self._model, ClipTorch):
+            self.image_size = self._model._model.visual.input_resolution
+        else:
+            self.image_size = self._model._image_size
 
     def run_tensor_native_inference(
         self, action: Literal["compare", "embed-image", "embed-text"], **kwargs
@@ -326,7 +322,6 @@ class InferenceModelsClipAdapter(Model):
         Returns:
             ClipEmbeddingResponse: The response object containing the embeddings.
         """
-        record_fixed_model_input_for_request(self, request)
         t1 = perf_counter()
         if isinstance(request, ClipImageEmbeddingRequest):
             infer_func = self.embed_image

--- a/inference/models/clip/clip_model.py
+++ b/inference/models/clip/clip_model.py
@@ -33,9 +33,6 @@ from inference.core.utils.image_utils import load_image_rgb
 from inference.core.utils.onnx import get_onnxruntime_execution_providers
 from inference.core.utils.postprocess import cosine_similarity
 from inference.usage_tracking.collector import usage_collector
-from inference.usage_tracking.decorator_helpers import (
-    record_fixed_model_input_for_request,
-)
 
 
 class Clip(OnnxRoboflowCoreModel):
@@ -85,6 +82,8 @@ class Clip(OnnxRoboflowCoreModel):
                     )
 
         self.resolution = self.visual_onnx_session.get_inputs()[0].shape[2]
+        # Usage telemetry reads the fixed canvas from `image_size`.
+        self.image_size = self.resolution
 
         self.clip_preprocess = clip.clip._transform(self.resolution)
         self.log(f"CLIP model loaded in {perf_counter() - t1:.2f} seconds")
@@ -319,7 +318,6 @@ class Clip(OnnxRoboflowCoreModel):
         Returns:
             ClipEmbeddingResponse: The response object containing the embeddings.
         """
-        record_fixed_model_input_for_request(self, request)
         t1 = perf_counter()
         if isinstance(request, ClipImageEmbeddingRequest):
             infer_func = self.embed_image

--- a/inference/models/perception_encoder/perception_encoder.py
+++ b/inference/models/perception_encoder/perception_encoder.py
@@ -27,9 +27,6 @@ from inference.core.models.utils.batching import create_batches
 from inference.core.utils.image_utils import load_image_rgb
 from inference.core.utils.postprocess import cosine_similarity
 from inference.usage_tracking.collector import usage_collector
-from inference.usage_tracking.decorator_helpers import (
-    record_fixed_model_input_for_request,
-)
 
 if DEVICE is None:
     if torch.cuda.is_available():
@@ -287,7 +284,6 @@ class PerceptionEncoder(RoboflowCoreModel):
         self, request: PerceptionEncoderInferenceRequest
     ) -> PerceptionEncoderEmbeddingResponse:
         """Routes the request to the appropriate inference function."""
-        record_fixed_model_input_for_request(self, request)
         t1 = perf_counter()
         if isinstance(request, PerceptionEncoderImageEmbeddingRequest):
             infer_func = self.embed_image

--- a/inference/models/perception_encoder/perception_encoder_inference_models.py
+++ b/inference/models/perception_encoder/perception_encoder_inference_models.py
@@ -33,9 +33,6 @@ from inference.core.roboflow_api import get_extra_weights_provider_headers
 from inference.core.utils.image_utils import load_image_bgr
 from inference.core.utils.postprocess import cosine_similarity
 from inference.usage_tracking.collector import usage_collector
-from inference.usage_tracking.decorator_helpers import (
-    record_fixed_model_input_for_request,
-)
 from inference_models import AutoModel
 from inference_models.models.perception_encoder.perception_encoder_pytorch import (
     PerceptionEncoderTorch,
@@ -80,8 +77,8 @@ class InferenceModelsPerceptionEncoderAdapter(Model):
             backend=backend,
             **kwargs,
         )
-        inner = getattr(self._model, "model", None)
-        self.image_size = getattr(inner, "image_size", None)
+        # Usage telemetry reads the fixed canvas from `image_size`.
+        self.image_size = self._model.model.image_size
 
     def preproc_image(self, image: InferenceRequestImage) -> np.ndarray:
         """Preprocesses an inference request image."""
@@ -271,7 +268,6 @@ class InferenceModelsPerceptionEncoderAdapter(Model):
         self, request: PerceptionEncoderInferenceRequest
     ) -> PerceptionEncoderEmbeddingResponse:
         """Routes the request to the appropriate inference function."""
-        record_fixed_model_input_for_request(self, request)
         t1 = perf_counter()
         if isinstance(request, PerceptionEncoderImageEmbeddingRequest):
             infer_func = self.embed_image

--- a/inference/models/sam/segment_anything.py
+++ b/inference/models/sam/segment_anything.py
@@ -26,9 +26,6 @@ from inference.core.models.roboflow import RoboflowCoreModel
 from inference.core.utils.image_utils import load_image_rgb
 from inference.core.utils.postprocess import masks2poly
 from inference.usage_tracking.collector import usage_collector
-from inference.usage_tracking.decorator_helpers import (
-    record_fixed_model_input_for_request,
-)
 
 
 class SegmentAnything(RoboflowCoreModel):
@@ -58,6 +55,8 @@ class SegmentAnything(RoboflowCoreModel):
         )
         self.sam.to(device="cuda" if torch.cuda.is_available() else "cpu")
         self.predictor = SamPredictor(self.sam)
+        # Usage telemetry reads the fixed canvas from `image_size`.
+        self.image_size = self.sam.image_encoder.img_size
         self.ort_session = onnxruntime.InferenceSession(
             self.cache_file("decoder.onnx"),
             providers=[
@@ -136,7 +135,6 @@ class SegmentAnything(RoboflowCoreModel):
         Returns:
             Union[SamEmbeddingResponse, SamSegmentationResponse]: The inference response.
         """
-        record_fixed_model_input_for_request(self, request)
         with self._state_lock:
             t1 = perf_counter()
             if isinstance(request, SamEmbeddingRequest):

--- a/inference/models/sam/segment_anything_inference_models.py
+++ b/inference/models/sam/segment_anything_inference_models.py
@@ -31,9 +31,6 @@ from inference.core.roboflow_api import get_extra_weights_provider_headers
 from inference.core.utils.image_utils import load_image_bgr
 from inference.core.utils.postprocess import masks2poly
 from inference.usage_tracking.collector import usage_collector
-from inference.usage_tracking.decorator_helpers import (
-    record_fixed_model_input_for_request,
-)
 from inference_models import AutoModel
 from inference_models.models.sam.cache import (
     SamImageEmbeddingsInMemoryCache,
@@ -89,6 +86,9 @@ class InferenceModelsSAMAdapter(Model):
             backend=backend,
             **kwargs,
         )
+        # Usage telemetry reads the fixed canvas from `image_size`; SAMTorch
+        # only keeps it on the wrapped encoder.
+        self.image_size = self._model._model.image_encoder.img_size
 
     def map_inference_kwargs(self, kwargs: dict) -> dict:
         return kwargs
@@ -103,7 +103,6 @@ class InferenceModelsSAMAdapter(Model):
 
     @usage_collector("model")
     def infer_from_request(self, request: SamInferenceRequest):
-        record_fixed_model_input_for_request(self, request)
         t1 = perf_counter()
         if isinstance(request, SamEmbeddingRequest):
             embedding, _ = self.embed_image(**request.dict())

--- a/inference/models/sam3_3d/segment_anything_3d.py
+++ b/inference/models/sam3_3d/segment_anything_3d.py
@@ -33,9 +33,6 @@ from inference.core.roboflow_api import (
 )
 from inference.core.utils.image_utils import load_image_rgb
 from inference.usage_tracking.collector import usage_collector
-from inference.usage_tracking.decorator_helpers import (
-    record_fixed_model_input_for_request,
-)
 
 try:
     import pycocotools.mask as mask_utils
@@ -366,7 +363,6 @@ class SegmentAnything3_3D_Objects(RoboflowCoreModel):
     def infer_from_request(
         self, request: Sam3_3D_Objects_InferenceRequest
     ) -> Sam3_3D_Objects_Response:
-        record_fixed_model_input_for_request(self, request)
         with self._state_lock:
             t1 = perf_counter()
             raw_result = self.create_3d(**request.model_dump())

--- a/inference/usage_tracking/decorator_helpers.py
+++ b/inference/usage_tracking/decorator_helpers.py
@@ -4,6 +4,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 from inference.core.env import SAM3_EXEC_MODE
 from inference.core.logger import logger
 from inference.core.roboflow_api import service_secret_is_valid
+from inference.core.workflows.execution_engine.entities.base import Batch
 from inference.core.workflows.execution_engine.v1.compiler.entities import (
     CompiledWorkflow,
 )
@@ -342,9 +343,31 @@ def _as_image_sequence(value: Any) -> Any:
     ``count_inference_images`` would otherwise treat a multi-image batch as
     a single frame.
     """
-    if value is not None and hasattr(value, "iter_with_indices"):
+    if isinstance(value, Batch):
         return list(value)
     return value
+
+
+def _compare_request_images(request: Any) -> Optional[List[Any]]:
+    """Imagery carried by a CLIP/PE compare request, which has no ``image``.
+
+    Compare requests hold their images under ``subject`` / ``prompt``; each
+    side participates only when its ``*_type`` says it is an image.
+    """
+    images = []
+    if getattr(request, "subject_type", None) == "image":
+        subject = getattr(request, "subject", None)
+        if subject is not None:
+            images.append(subject)
+    if getattr(request, "prompt_type", None) == "image":
+        prompt = getattr(request, "prompt", None)
+        if isinstance(prompt, dict):
+            images.extend(prompt.values())
+        elif isinstance(prompt, (list, tuple)):
+            images.extend(prompt)
+        elif prompt is not None:
+            images.append(prompt)
+    return images or None
 
 
 def get_model_image_from_kwargs(func_kwargs: Dict[str, Any]) -> Any:
@@ -362,6 +385,9 @@ def get_model_image_from_kwargs(func_kwargs: Dict[str, Any]) -> Any:
         image = getattr(request, "image", None)
         if image is not None:
             return image
+        compare_images = _compare_request_images(request)
+        if compare_images is not None:
+            return compare_images
     return None
 
 
@@ -384,7 +410,10 @@ def get_model_frames_and_input_hw(
     if frames <= 0 and measured_frames:
         frames = measured_frames
     if frames <= 0:
-        frames = 1
+        # No imagery anywhere in the call (text-only embeds). One frame is
+        # still billed, but crediting the model's visual canvas to it would
+        # fabricate image-resolution telemetry - leave the bucket unknown.
+        return 1, None
 
     return frames, resolve_model_input_hw(model, measured_hw=measured_hw)
 

--- a/tests/inference/unit_tests/usage_tracking/test_collector.py
+++ b/tests/inference/unit_tests/usage_tracking/test_collector.py
@@ -17,10 +17,7 @@ from inference.core.env import LAMBDA
 from inference.core.version import __version__ as inference_version
 from inference.core.workflows.errors import ClientCausedStepExecutionError
 from inference.usage_tracking import payload_helpers
-from inference.usage_tracking.decorator_helpers import (
-    record_fixed_model_input_for_request,
-    usage_billing_suppressed,
-)
+from inference.usage_tracking.decorator_helpers import usage_billing_suppressed
 from inference.usage_tracking.megapixel_buckets import (
     clear_measured_model_input,
     record_measured_model_input,
@@ -2596,7 +2593,6 @@ def test_clip_shaped_infer_from_request_records_model_row(
 
         @usage_collector(category="model")
         def infer_from_request(self, request):
-            record_fixed_model_input_for_request(self, request)
             return {"ok": True}
 
     request = SimpleNamespace(

--- a/tests/inference/unit_tests/usage_tracking/test_decorator_helpers.py
+++ b/tests/inference/unit_tests/usage_tracking/test_decorator_helpers.py
@@ -5,6 +5,7 @@ import pytest
 
 from inference.core.entities.requests.sam2 import Sam2InferenceRequest
 from inference.core.env import SAM2_VERSION_ID, SAM3_EXEC_MODE
+from inference.core.workflows.execution_engine.entities.base import Batch
 from inference.usage_tracking import decorator_helpers
 from inference.usage_tracking.decorator_helpers import (
     call_carries_authenticated_non_billable_intent,
@@ -529,24 +530,35 @@ def test_model_frames_count_images_kwarg_used_by_video_blocks():
 
 
 def test_model_frames_count_workflow_batch_used_by_video_blocks():
-    class FakeWorkflowBatch:
-        def __init__(self, items):
-            self._content = items
+    batch = Batch(content=[object(), object(), object()], indices=None)
 
-        def __len__(self):
-            return len(self._content)
-
-        def __iter__(self):
-            return iter(self._content)
-
-        def iter_with_indices(self):
-            return enumerate(self._content)
-
-    frames, _ = get_model_frames_and_input_hw(
-        {"images": FakeWorkflowBatch([object(), object(), object()])}
-    )
+    frames, _ = get_model_frames_and_input_hw({"images": batch})
 
     assert frames == 3
+
+
+def test_model_frames_count_compare_request_subject_and_prompt_images():
+    request = SimpleNamespace(
+        subject=object(),
+        subject_type="image",
+        prompt=[object(), object()],
+        prompt_type="image",
+    )
+
+    frames, _ = get_model_frames_and_input_hw({"request": request})
+
+    assert frames == 3
+
+
+def test_text_only_embedding_bills_one_frame_without_visual_canvas():
+    model = SimpleNamespace(image_size=224)
+
+    frames, input_hw = get_model_frames_and_input_hw(
+        {"self": model, "request": SimpleNamespace()}
+    )
+
+    assert frames == 1
+    assert input_hw is None
 
 
 def test_model_api_key_from_workflow_block_private_attr():

--- a/tests/inference/unit_tests/usage_tracking/test_model_usage_coverage.py
+++ b/tests/inference/unit_tests/usage_tracking/test_model_usage_coverage.py
@@ -85,15 +85,19 @@ MODELS_DECORATING_INFER_FROM_REQUEST = [
 ]
 
 # Video trackers load ``AutoModel`` in the block and never go through
-# ModelManager, so ``run()`` itself must emit the model-category row.
+# ModelManager, so the block's tracked entrypoint must emit the model-category
+# row. SAM3 tracks ``_tracked_run`` so that ``run()`` can first swap in the
+# visual model id the decorator should attribute usage to.
 BLOCKS_DECORATING_RUN = [
     (
         "inference.core.workflows.core_steps.models.foundation.segment_anything2_video.v1",
         "SegmentAnything2VideoBlockV1",
+        "run",
     ),
     (
         "inference.core.workflows.core_steps.models.foundation.segment_anything3_video.v1",
         "SegmentAnything3VideoBlockV1",
+        "_tracked_run",
     ),
 ]
 
@@ -128,14 +132,15 @@ def test_model_infer_from_request_is_usage_collected(module_path, class_name):
     )
 
 
-@pytest.mark.parametrize("module_path, class_name", BLOCKS_DECORATING_RUN)
-def test_video_block_run_is_usage_collected(module_path, class_name):
+@pytest.mark.parametrize("module_path, class_name, method_name", BLOCKS_DECORATING_RUN)
+def test_video_block_run_is_usage_collected(module_path, class_name, method_name):
     module = pytest.importorskip(module_path)
     block_class = getattr(module, class_name)
 
-    assert _is_usage_collected(
-        block_class.run
-    ), f"{class_name}.run() must be decorated with @usage_collector('model')"
+    assert _is_usage_collected(getattr(block_class, method_name)), (
+        f"{class_name}.{method_name}() must be decorated with "
+        "@usage_collector('model')"
+    )
 
 
 def test_detection_helper_rejects_undecorated_function():


### PR DESCRIPTION
## What does this PR do?

  - CLIP dead resolution — legacy Clip gets self.image_size = self.resolution (clip_model.py:89); adapter sets self.image_size via isinstance(ClipTorch) branch (_model.visual.input_resolution) else ClipOnnx _image_size. Both backends now hit the probe's image_size branch.
  - Compare undercount — new _compare_request_images() in decorator_helpers: counts subject + prompt when *_type == image (handles list/dict/single). 1 subject + 32 prompts = 33 frames.
  - Text-only phantom bucket — get_model_frames_and_input_hw returns (1, None) when call carries zero imagery: one frame still billed, bucket unknown instead of fabricated visual canvas.
  - SAM3 visual-mode attribution — run() now undecorated dispatcher picking selected_model_id, calls decorated _tracked_run(model_id=selected_model_id, ...). Visual mode rows attribute to the visual model. Coverage test parametrized with method name.
  - SAM1 unknown bucket — legacy: self.image_size = self.sam.image_encoder.img_size; adapter: self._model._model.image_encoder.img_size (SAMTorch wraps Meta Sam, single backend).
  - Redundant record_fixed_model_input_for_request — removed from all 7 new call sites + imports (wrapper recomputes identical values). Helper itself kept.
  - _as_image_sequence — isinstance(value, Batch) instead of hasattr(iter_with_indices) duck-typing.
  - PE adapter getattr chain — direct self._model.model.image_size.
  - Tests — FakeWorkflowBatch replaced with real Batch; ClipLike no longer calls removed helper; new tests for compare counting and text-only behavior.

## Type of Change

- Other: code review

## Testing

CI - unit tests passing

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)

## Additional Context

N/A