### PR TITLE
Add optional custom file name to Write Vision Event Bundle sink

### DIFF
--- a/inference/core/workflows/core_steps/sinks/roboflow/vision_events_bundle/v1.py
+++ b/inference/core/workflows/core_steps/sinks/roboflow/vision_events_bundle/v1.py
@@ -1,7 +1,10 @@
+import errno
 import io
 import json
 import os
+import re
 import tarfile
+import tempfile
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
 from functools import partial
@@ -10,11 +13,16 @@ from uuid import uuid4
 
 import supervision as sv
 from fastapi import BackgroundTasks
-from pydantic import ConfigDict, Field, NonNegativeFloat, NonNegativeInt
+from pydantic import (
+    ConfigDict,
+    Field,
+    NonNegativeFloat,
+    NonNegativeInt,
+    field_validator,
+)
 
 from inference.core.env import ALLOW_WORKFLOW_BLOCKS_ACCESSING_LOCAL_STORAGE
 from inference.core.logger import logger
-from inference.core.utils.file_system import dump_bytes_atomic
 from inference.core.utils.image_utils import encode_image_to_jpeg_bytes
 from inference.core.workflows.core_steps.sinks.local_file.v1 import (
     path_is_within_specified_directory,
@@ -55,6 +63,7 @@ from inference.core.workflows.prototypes.block import (
     Severity,
     WorkflowBlock,
     WorkflowBlockManifest,
+    is_workflow_selector,
 )
 
 BUNDLE_FORMAT_VERSION = 1
@@ -68,6 +77,19 @@ MAX_BUNDLE_SIZE_BYTES = 25 * 1024 * 1024  # 25 MiB
 # more entries trigger a consumer-side fallback that silently drops *all*
 # images, so we enforce the cap before attaching annotations to the payload.
 MAX_ANNOTATIONS_PER_LIST = 1000
+
+DEFAULT_FILE_NAME_PREFIX = "event_"
+BUNDLE_FILE_NAME_SUFFIX = ".tar.gz"
+
+# A custom file name replaces the generated one wholesale, so it must not be
+# able to redirect the write (path separators, `..`) nor collide with the
+# dot-prefixed temporary files that file movers are told to skip.  Matched with
+# `fullmatch` - `$` alone would also accept a trailing newline.
+BUNDLE_FILE_NAME_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+# `AtomicPath` writes through a `.tmp_<random>_<file name>` sibling, so the
+# name must stay clear of the 255-byte path-segment limit with that padding.
+MAX_FILE_NAME_LENGTH = 200
 
 SHORT_DESCRIPTION = (
     "Write vision events as self-contained tarball bundles to a local directory."
@@ -85,7 +107,7 @@ to Roboflow's `POST /vision-events/bundle` endpoint without unpacking it.
 One tarball per event, written to `target_directory`:
 
 ```
-event_<UTC timestamp>_<eventId>.tar.gz
+event_<UTC timestamp>_<eventId>.tar.gz    # or your own `file_name`
 ├── payload.json               # the event payload (versioned contract, camelCase)
 └── images/<file_id>.jpg       # image members, file_id is a uuid4
 ```
@@ -106,9 +128,25 @@ use sibling directories, so consumers should ignore unknown top-level directorie
 ## Atomic Writes
 
 Bundles are written to a dot-prefixed temporary file in the target directory, fsynced, and
-atomically renamed to their final `event_*.tar.gz` name (the directory is fsynced after the
-rename). A file-mover service that matches `event_*.tar.gz` (or skips dotfiles) can never
-pick up a partially written bundle.
+atomically renamed to their final `*.tar.gz` name (the directory is fsynced after the
+rename). A file-mover service that matches `*.tar.gz` (or skips dotfiles) can never pick
+up a partially written bundle.
+
+## Output Routing
+
+By default the file name is `event_<UTC timestamp>_<eventId>.tar.gz`. Set **File Name** to
+replace it outright - typically wired from another step that composes the name - so no part
+of Roboflow's naming is imposed on the output. `.tar.gz` is appended when absent.
+
+Because `target_directory` is per-block too, several bundle blocks in one workflow can own
+their output completely: a person-detection block writing `person_*.tar.gz` into
+`/media/person` alongside an episode block writing the default `event_*.tar.gz` into
+`/media/event`, letting a downstream file mover route purely by folder and name. The upload
+endpoint ignores the file name entirely, so it is free to carry deployment-specific meaning.
+
+The generated name embeds a uuid4 and is unique by construction. A custom name is not: if
+the target file already exists the block raises rather than overwriting it, so a name that
+repeats across events will fail the workflow run. Compose something unique per event.
 
 ## Rate Limiting
 
@@ -169,6 +207,21 @@ class BlockManifest(WorkflowBlockManifest):
         "automatically if it does not exist. If WORKFLOW_BLOCKS_WRITE_DIRECTORY is "
         "set, this path must be a subdirectory of the allowed directory.",
         examples=["/data/vision-event-bundles"],
+        json_schema_extra={"always_visible": True},
+    )
+    file_name: Optional[Union[Selector(kind=[STRING_KIND]), str]] = Field(
+        default=None,
+        title="File Name",
+        description="Optional file name for the bundle, replacing the generated "
+        "`event_<UTC timestamp>_<eventId>.tar.gz` name entirely. Usually wired "
+        "from another step that composes the name, so nothing of Roboflow's "
+        "naming is imposed. `.tar.gz` is appended when absent. May contain "
+        "letters, digits, `.`, `_` and `-`, must start with a letter or digit, "
+        "and must be at most 200 characters. The block errors if the "
+        "resulting file already exists, so a "
+        "custom name must be unique per event. Leave unset for the default "
+        "name, which is unique by construction.",
+        examples=["$steps.compose_name.output", "person_batch7.tar.gz"],
         json_schema_extra={"always_visible": True},
     )
     input_image: Optional[Selector(kind=[IMAGE_KIND])] = Field(
@@ -406,6 +459,13 @@ class BlockManifest(WorkflowBlockManifest):
         json_schema_extra={"always_visible": True},
     )
 
+    @field_validator("file_name")
+    @classmethod
+    def ensure_file_name_is_safe(cls, value: Any) -> Any:
+        if isinstance(value, str) and not is_workflow_selector(value):
+            validate_bundle_file_name(value)
+        return value
+
     @classmethod
     def describe_outputs(cls) -> List[OutputDefinition]:
         return [
@@ -519,6 +579,9 @@ class VisionEventBundleSinkBlockV1(WorkflowBlock):
         custom_value: Optional[str] = None,
         related_event_id: Optional[str] = None,
         feedback: Optional[str] = None,
+        # Appended last on purpose: inserting it earlier would silently
+        # rebind any positional caller's event-data arguments.
+        file_name: Optional[str] = None,
     ) -> BlockResult:
         if self._disable_sinks or disable_sink:
             return {
@@ -555,12 +618,17 @@ class VisionEventBundleSinkBlockV1(WorkflowBlock):
                 "message": "Sink cooldown applies",
             }
 
+        # Selector-resolved values bypass manifest validation, so an unsafe
+        # name would otherwise reach the path unchecked.
+        if file_name is not None:
+            validate_bundle_file_name(file_name)
         event_id = str(uuid4())
         timestamp = datetime.now(timezone.utc)
         target_path = _generate_bundle_path(
             target_directory=target_directory,
             timestamp=timestamp,
             event_id=event_id,
+            file_name=file_name,
         )
         # Misconfiguration should fail loudly here, not vanish into a
         # fire-and-forget background task.
@@ -572,7 +640,17 @@ class VisionEventBundleSinkBlockV1(WorkflowBlock):
                 f"`roboflow_core/vision_event_bundle@v1` block cannot write to "
                 f"`{target_directory}` - the directory is not writable."
             )
-
+        # A generated name carries a uuid4 and cannot collide; a custom one
+        # repeats as often as its author repeats it.  Checked here so the
+        # ordinary repeated-name case fails loudly and synchronously, before a
+        # fire-and-forget dispatch can swallow it.  The publish below is what
+        # actually guarantees no bundle is ever overwritten.
+        if os.path.exists(target_path):
+            raise ValueError(
+                f"`roboflow_core/vision_event_bundle@v1` block cannot write "
+                f"`{target_path}` - the file already exists. A custom "
+                f"`file_name` must be unique for every event."
+            )
         event_data = _build_event_data(
             event_type=event_type,
             external_id=external_id,
@@ -646,12 +724,115 @@ class VisionEventBundleSinkBlockV1(WorkflowBlock):
             )
 
 
+def validate_bundle_file_name(file_name: str) -> None:
+    if not file_name:
+        raise ValueError(
+            "`file_name` must not be empty - leave it unset for the default "
+            "generated name."
+        )
+    if len(file_name) > MAX_FILE_NAME_LENGTH:
+        raise ValueError(
+            f"`file_name` must be at most {MAX_FILE_NAME_LENGTH} characters "
+            f"long, got {len(file_name)}."
+        )
+    if not BUNDLE_FILE_NAME_PATTERN.fullmatch(file_name):
+        raise ValueError(
+            f"`file_name` must start with a letter or digit and may only "
+            f"contain letters, digits, `.`, `_` and `-`, got `{file_name}`."
+        )
+
+
+# Only these mean "this filesystem cannot do hard links".  Every other OSError
+# is a real write failure and must not silently reach the replacing fallback.
+_LINK_UNSUPPORTED_ERRNOS = frozenset(
+    {errno.EPERM, errno.EOPNOTSUPP, errno.ENOSYS, errno.EXDEV, errno.EMLINK}
+)
+
+
+def _publish_bundle(target_path: str, content: bytes) -> None:
+    """Write `content` and publish it at `target_path` without replacing.
+
+    `os.link` fails atomically when the destination already exists, so two
+    concurrent events that pass the foreground collision check cannot both
+    believe they won - and unlike a reservation marker, an interrupted process
+    leaves only the dot-prefixed temporary file that file movers already skip.
+
+    On filesystems with no hard-link support (FAT-family removable media, the
+    usual way bundles leave an air-gapped network) this degrades to a checked
+    replacing rename: repeated names are still caught, but two genuinely
+    concurrent events with the same name can race.
+    """
+    directory = os.path.dirname(os.path.abspath(target_path))
+    temp_file = tempfile.NamedTemporaryFile(
+        dir=directory,
+        prefix=".tmp_",
+        suffix=f"_{os.path.basename(target_path)}",
+        delete=False,
+    )
+    temp_path = temp_file.name
+    try:
+        temp_file.write(content)
+        temp_file.flush()
+        os.fsync(temp_file.fileno())
+        temp_file.close()
+        try:
+            os.link(temp_path, target_path)
+        except FileExistsError:
+            raise ValueError(
+                f"`roboflow_core/vision_event_bundle@v1` block cannot write "
+                f"`{target_path}` - the file already exists. A custom "
+                f"`file_name` must be unique for every event."
+            )
+        except OSError as error:
+            if error.errno not in _LINK_UNSUPPORTED_ERRNOS:
+                raise
+            # FAT-family removable media - the way bundles physically leave an
+            # air-gapped network - cannot do hard links.  Falling back keeps
+            # those targets working, at the cost of the atomic guarantee: the
+            # re-check below narrows the window but cannot close it.
+            if os.path.exists(target_path):
+                raise ValueError(
+                    f"`roboflow_core/vision_event_bundle@v1` block cannot write "
+                    f"`{target_path}` - the file already exists. A custom "
+                    f"`file_name` must be unique for every event."
+                )
+            logger.warning(
+                "Hard links unsupported under %s - publishing vision event "
+                "bundle with a replacing rename, which cannot guarantee that "
+                "a concurrent event with the same file name is not "
+                "overwritten.",
+                directory,
+            )
+            os.replace(temp_path, target_path)
+    finally:
+        # Cleanup must never turn a published bundle into a reported failure,
+        # nor mask the original write error.
+        try:
+            os.unlink(temp_path)
+        except FileNotFoundError:
+            pass
+        except OSError as error:
+            logger.warning(
+                "Failed to remove vision event bundle temporary file %s: %s",
+                temp_path,
+                error,
+            )
+
+
 def _generate_bundle_path(
     target_directory: str,
     timestamp: datetime,
     event_id: str,
+    file_name: Optional[str] = None,
 ) -> str:
-    file_name = f"event_{timestamp.strftime('%Y%m%dT%H%M%S_%f')}_{event_id}.tar.gz"
+    if file_name:
+        if not file_name.endswith(BUNDLE_FILE_NAME_SUFFIX):
+            file_name = f"{file_name}{BUNDLE_FILE_NAME_SUFFIX}"
+    else:
+        file_name = (
+            f"{DEFAULT_FILE_NAME_PREFIX}{timestamp.strftime('%Y%m%dT%H%M%S_%f')}"
+            f"_{event_id}{BUNDLE_FILE_NAME_SUFFIX}"
+        )
     return os.path.abspath(os.path.join(target_directory, file_name))
 
 
@@ -712,7 +893,7 @@ def _write_event_bundle(
                 f"limit of {MAX_BUNDLE_SIZE_BYTES:,} bytes (25 MiB). Reduce the "
                 "number or size of images in this event."
             )
-        dump_bytes_atomic(target_path, tar_bytes)
+        _publish_bundle(target_path=target_path, content=tar_bytes)
         _fsync_directory(target_directory)
         return False, "Vision event bundle written successfully", event_id, target_path
     except Exception as error:

--- a/inference/core/workflows/core_steps/sinks/roboflow/vision_events_bundle/v1_tensor.py
+++ b/inference/core/workflows/core_steps/sinks/roboflow/vision_events_bundle/v1_tensor.py
@@ -9,10 +9,13 @@ tensor-native ``vision_events.v1_tensor`` helpers exactly as the numpy block
 delegates to ``vision_events.v1``.
 """
 
+import errno
 import io
 import json
 import os
+import re
 import tarfile
+import tempfile
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
 from functools import partial
@@ -20,11 +23,16 @@ from typing import Any, Dict, List, Literal, Optional, Tuple, Type, Union
 from uuid import uuid4
 
 from fastapi import BackgroundTasks
-from pydantic import ConfigDict, Field, NonNegativeFloat, NonNegativeInt
+from pydantic import (
+    ConfigDict,
+    Field,
+    NonNegativeFloat,
+    NonNegativeInt,
+    field_validator,
+)
 
 from inference.core.env import ALLOW_WORKFLOW_BLOCKS_ACCESSING_LOCAL_STORAGE
 from inference.core.logger import logger
-from inference.core.utils.file_system import dump_bytes_atomic
 from inference.core.utils.image_utils import encode_image_to_jpeg_bytes
 from inference.core.workflows.core_steps.sinks.local_file.v1 import (
     path_is_within_specified_directory,
@@ -68,6 +76,7 @@ from inference.core.workflows.prototypes.block import (
     Severity,
     WorkflowBlock,
     WorkflowBlockManifest,
+    is_workflow_selector,
 )
 
 BUNDLE_FORMAT_VERSION = 1
@@ -81,6 +90,19 @@ MAX_BUNDLE_SIZE_BYTES = 25 * 1024 * 1024  # 25 MiB
 # more entries trigger a consumer-side fallback that silently drops *all*
 # images, so we enforce the cap before attaching annotations to the payload.
 MAX_ANNOTATIONS_PER_LIST = 1000
+
+DEFAULT_FILE_NAME_PREFIX = "event_"
+BUNDLE_FILE_NAME_SUFFIX = ".tar.gz"
+
+# A custom file name replaces the generated one wholesale, so it must not be
+# able to redirect the write (path separators, `..`) nor collide with the
+# dot-prefixed temporary files that file movers are told to skip.  Matched with
+# `fullmatch` - `$` alone would also accept a trailing newline.
+BUNDLE_FILE_NAME_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+# `AtomicPath` writes through a `.tmp_<random>_<file name>` sibling, so the
+# name must stay clear of the 255-byte path-segment limit with that padding.
+MAX_FILE_NAME_LENGTH = 200
 
 SHORT_DESCRIPTION = (
     "Write vision events as self-contained tarball bundles to a local directory."
@@ -98,7 +120,7 @@ to Roboflow's `POST /vision-events/bundle` endpoint without unpacking it.
 One tarball per event, written to `target_directory`:
 
 ```
-event_<UTC timestamp>_<eventId>.tar.gz
+event_<UTC timestamp>_<eventId>.tar.gz    # or your own `file_name`
 ├── payload.json               # the event payload (versioned contract, camelCase)
 └── images/<file_id>.jpg       # image members, file_id is a uuid4
 ```
@@ -119,9 +141,25 @@ use sibling directories, so consumers should ignore unknown top-level directorie
 ## Atomic Writes
 
 Bundles are written to a dot-prefixed temporary file in the target directory, fsynced, and
-atomically renamed to their final `event_*.tar.gz` name (the directory is fsynced after the
-rename). A file-mover service that matches `event_*.tar.gz` (or skips dotfiles) can never
-pick up a partially written bundle.
+atomically renamed to their final `*.tar.gz` name (the directory is fsynced after the
+rename). A file-mover service that matches `*.tar.gz` (or skips dotfiles) can never pick
+up a partially written bundle.
+
+## Output Routing
+
+By default the file name is `event_<UTC timestamp>_<eventId>.tar.gz`. Set **File Name** to
+replace it outright - typically wired from another step that composes the name - so no part
+of Roboflow's naming is imposed on the output. `.tar.gz` is appended when absent.
+
+Because `target_directory` is per-block too, several bundle blocks in one workflow can own
+their output completely: a person-detection block writing `person_*.tar.gz` into
+`/media/person` alongside an episode block writing the default `event_*.tar.gz` into
+`/media/event`, letting a downstream file mover route purely by folder and name. The upload
+endpoint ignores the file name entirely, so it is free to carry deployment-specific meaning.
+
+The generated name embeds a uuid4 and is unique by construction. A custom name is not: if
+the target file already exists the block raises rather than overwriting it, so a name that
+repeats across events will fail the workflow run. Compose something unique per event.
 
 ## Rate Limiting
 
@@ -182,6 +220,21 @@ class BlockManifest(WorkflowBlockManifest):
         "automatically if it does not exist. If WORKFLOW_BLOCKS_WRITE_DIRECTORY is "
         "set, this path must be a subdirectory of the allowed directory.",
         examples=["/data/vision-event-bundles"],
+        json_schema_extra={"always_visible": True},
+    )
+    file_name: Optional[Union[Selector(kind=[STRING_KIND]), str]] = Field(
+        default=None,
+        title="File Name",
+        description="Optional file name for the bundle, replacing the generated "
+        "`event_<UTC timestamp>_<eventId>.tar.gz` name entirely. Usually wired "
+        "from another step that composes the name, so nothing of Roboflow's "
+        "naming is imposed. `.tar.gz` is appended when absent. May contain "
+        "letters, digits, `.`, `_` and `-`, must start with a letter or digit, "
+        "and must be at most 200 characters. The block errors if the "
+        "resulting file already exists, so a "
+        "custom name must be unique per event. Leave unset for the default "
+        "name, which is unique by construction.",
+        examples=["$steps.compose_name.output", "person_batch7.tar.gz"],
         json_schema_extra={"always_visible": True},
     )
     input_image: Optional[Selector(kind=[IMAGE_KIND])] = Field(
@@ -419,6 +472,13 @@ class BlockManifest(WorkflowBlockManifest):
         json_schema_extra={"always_visible": True},
     )
 
+    @field_validator("file_name")
+    @classmethod
+    def ensure_file_name_is_safe(cls, value: Any) -> Any:
+        if isinstance(value, str) and not is_workflow_selector(value):
+            validate_bundle_file_name(value)
+        return value
+
     @classmethod
     def describe_outputs(cls) -> List[OutputDefinition]:
         return [
@@ -532,6 +592,9 @@ class VisionEventBundleSinkBlockV1(WorkflowBlock):
         custom_value: Optional[str] = None,
         related_event_id: Optional[str] = None,
         feedback: Optional[str] = None,
+        # Appended last on purpose: inserting it earlier would silently
+        # rebind any positional caller's event-data arguments.
+        file_name: Optional[str] = None,
     ) -> BlockResult:
         if self._disable_sinks or disable_sink:
             return {
@@ -568,12 +631,17 @@ class VisionEventBundleSinkBlockV1(WorkflowBlock):
                 "message": "Sink cooldown applies",
             }
 
+        # Selector-resolved values bypass manifest validation, so an unsafe
+        # name would otherwise reach the path unchecked.
+        if file_name is not None:
+            validate_bundle_file_name(file_name)
         event_id = str(uuid4())
         timestamp = datetime.now(timezone.utc)
         target_path = _generate_bundle_path(
             target_directory=target_directory,
             timestamp=timestamp,
             event_id=event_id,
+            file_name=file_name,
         )
         # Misconfiguration should fail loudly here, not vanish into a
         # fire-and-forget background task.
@@ -585,7 +653,17 @@ class VisionEventBundleSinkBlockV1(WorkflowBlock):
                 f"`roboflow_core/vision_event_bundle@v1` block cannot write to "
                 f"`{target_directory}` - the directory is not writable."
             )
-
+        # A generated name carries a uuid4 and cannot collide; a custom one
+        # repeats as often as its author repeats it.  Checked here so the
+        # ordinary repeated-name case fails loudly and synchronously, before a
+        # fire-and-forget dispatch can swallow it.  The publish below is what
+        # actually guarantees no bundle is ever overwritten.
+        if os.path.exists(target_path):
+            raise ValueError(
+                f"`roboflow_core/vision_event_bundle@v1` block cannot write "
+                f"`{target_path}` - the file already exists. A custom "
+                f"`file_name` must be unique for every event."
+            )
         event_data = _build_event_data(
             event_type=event_type,
             external_id=external_id,
@@ -659,12 +737,115 @@ class VisionEventBundleSinkBlockV1(WorkflowBlock):
             )
 
 
+def validate_bundle_file_name(file_name: str) -> None:
+    if not file_name:
+        raise ValueError(
+            "`file_name` must not be empty - leave it unset for the default "
+            "generated name."
+        )
+    if len(file_name) > MAX_FILE_NAME_LENGTH:
+        raise ValueError(
+            f"`file_name` must be at most {MAX_FILE_NAME_LENGTH} characters "
+            f"long, got {len(file_name)}."
+        )
+    if not BUNDLE_FILE_NAME_PATTERN.fullmatch(file_name):
+        raise ValueError(
+            f"`file_name` must start with a letter or digit and may only "
+            f"contain letters, digits, `.`, `_` and `-`, got `{file_name}`."
+        )
+
+
+# Only these mean "this filesystem cannot do hard links".  Every other OSError
+# is a real write failure and must not silently reach the replacing fallback.
+_LINK_UNSUPPORTED_ERRNOS = frozenset(
+    {errno.EPERM, errno.EOPNOTSUPP, errno.ENOSYS, errno.EXDEV, errno.EMLINK}
+)
+
+
+def _publish_bundle(target_path: str, content: bytes) -> None:
+    """Write `content` and publish it at `target_path` without replacing.
+
+    `os.link` fails atomically when the destination already exists, so two
+    concurrent events that pass the foreground collision check cannot both
+    believe they won - and unlike a reservation marker, an interrupted process
+    leaves only the dot-prefixed temporary file that file movers already skip.
+
+    On filesystems with no hard-link support (FAT-family removable media, the
+    usual way bundles leave an air-gapped network) this degrades to a checked
+    replacing rename: repeated names are still caught, but two genuinely
+    concurrent events with the same name can race.
+    """
+    directory = os.path.dirname(os.path.abspath(target_path))
+    temp_file = tempfile.NamedTemporaryFile(
+        dir=directory,
+        prefix=".tmp_",
+        suffix=f"_{os.path.basename(target_path)}",
+        delete=False,
+    )
+    temp_path = temp_file.name
+    try:
+        temp_file.write(content)
+        temp_file.flush()
+        os.fsync(temp_file.fileno())
+        temp_file.close()
+        try:
+            os.link(temp_path, target_path)
+        except FileExistsError:
+            raise ValueError(
+                f"`roboflow_core/vision_event_bundle@v1` block cannot write "
+                f"`{target_path}` - the file already exists. A custom "
+                f"`file_name` must be unique for every event."
+            )
+        except OSError as error:
+            if error.errno not in _LINK_UNSUPPORTED_ERRNOS:
+                raise
+            # FAT-family removable media - the way bundles physically leave an
+            # air-gapped network - cannot do hard links.  Falling back keeps
+            # those targets working, at the cost of the atomic guarantee: the
+            # re-check below narrows the window but cannot close it.
+            if os.path.exists(target_path):
+                raise ValueError(
+                    f"`roboflow_core/vision_event_bundle@v1` block cannot write "
+                    f"`{target_path}` - the file already exists. A custom "
+                    f"`file_name` must be unique for every event."
+                )
+            logger.warning(
+                "Hard links unsupported under %s - publishing vision event "
+                "bundle with a replacing rename, which cannot guarantee that "
+                "a concurrent event with the same file name is not "
+                "overwritten.",
+                directory,
+            )
+            os.replace(temp_path, target_path)
+    finally:
+        # Cleanup must never turn a published bundle into a reported failure,
+        # nor mask the original write error.
+        try:
+            os.unlink(temp_path)
+        except FileNotFoundError:
+            pass
+        except OSError as error:
+            logger.warning(
+                "Failed to remove vision event bundle temporary file %s: %s",
+                temp_path,
+                error,
+            )
+
+
 def _generate_bundle_path(
     target_directory: str,
     timestamp: datetime,
     event_id: str,
+    file_name: Optional[str] = None,
 ) -> str:
-    file_name = f"event_{timestamp.strftime('%Y%m%dT%H%M%S_%f')}_{event_id}.tar.gz"
+    if file_name:
+        if not file_name.endswith(BUNDLE_FILE_NAME_SUFFIX):
+            file_name = f"{file_name}{BUNDLE_FILE_NAME_SUFFIX}"
+    else:
+        file_name = (
+            f"{DEFAULT_FILE_NAME_PREFIX}{timestamp.strftime('%Y%m%dT%H%M%S_%f')}"
+            f"_{event_id}{BUNDLE_FILE_NAME_SUFFIX}"
+        )
     return os.path.abspath(os.path.join(target_directory, file_name))
 
 
@@ -725,7 +906,7 @@ def _write_event_bundle(
                 f"limit of {MAX_BUNDLE_SIZE_BYTES:,} bytes (25 MiB). Reduce the "
                 "number or size of images in this event."
             )
-        dump_bytes_atomic(target_path, tar_bytes)
+        _publish_bundle(target_path=target_path, content=tar_bytes)
         _fsync_directory(target_directory)
         return False, "Vision event bundle written successfully", event_id, target_path
     except Exception as error:

--- a/tests/workflows/unit_tests/core_steps/sinks/roboflow/vision_events_bundle/test_v1.py
+++ b/tests/workflows/unit_tests/core_steps/sinks/roboflow/vision_events_bundle/test_v1.py
@@ -1,4 +1,6 @@
+import errno
 import json
+import os
 import re
 import tarfile
 import time
@@ -9,6 +11,7 @@ import cv2
 import numpy as np
 import pytest
 import supervision as sv
+from pydantic import ValidationError
 
 from inference.core.workflows.core_steps.sinks.roboflow import vision_events_bundle
 from inference.core.workflows.core_steps.sinks.roboflow.vision_events.v1 import (
@@ -31,6 +34,10 @@ from inference.core.workflows.execution_engine.entities.base import (
 BUNDLE_FILE_NAME_PATTERN = re.compile(
     r"^event_\d{8}T\d{6}_\d{6}_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.tar\.gz$"
 )
+
+
+def files_in(directory) -> list:
+    return sorted(p.name for p in directory.iterdir() if not p.name.startswith("."))
 
 
 def _make_workflow_image(width: int = 100, height: int = 100) -> WorkflowImageData:
@@ -144,6 +151,71 @@ def test_manifest_accepts_optional_solution() -> None:
     }
     manifest = BlockManifest.model_validate(raw_manifest)
     assert manifest.solution == "my-use-case"
+
+
+def test_manifest_defaults_file_name_to_none() -> None:
+    raw_manifest = {
+        "type": "roboflow_core/vision_event_bundle@v1",
+        "name": "test_step",
+        "event_type": "quality_check",
+        "target_directory": "/data/bundles",
+    }
+    manifest = BlockManifest.model_validate(raw_manifest)
+    assert manifest.file_name is None
+
+
+@pytest.mark.parametrize(
+    "file_name", ["person_batch7", "person_batch7.tar.gz", "cam-01.2026", "a"]
+)
+def test_manifest_accepts_valid_file_name(file_name: str) -> None:
+    raw_manifest = {
+        "type": "roboflow_core/vision_event_bundle@v1",
+        "name": "test_step",
+        "event_type": "quality_check",
+        "target_directory": "/data/bundles",
+        "file_name": file_name,
+    }
+    manifest = BlockManifest.model_validate(raw_manifest)
+    assert manifest.file_name == file_name
+
+
+@pytest.mark.parametrize(
+    "file_name",
+    [
+        "",
+        "../escape",
+        "nested/bundle",
+        ".hidden",
+        "-leading-dash",
+        "with space",
+        "unicode_\u00e9",
+        "trailing_newline\n",
+        "embedded\nnewline",
+        "x" * 201,
+    ],
+)
+def test_manifest_rejects_unsafe_file_name(file_name: str) -> None:
+    raw_manifest = {
+        "type": "roboflow_core/vision_event_bundle@v1",
+        "name": "test_step",
+        "event_type": "quality_check",
+        "target_directory": "/data/bundles",
+        "file_name": file_name,
+    }
+    with pytest.raises(ValidationError):
+        BlockManifest.model_validate(raw_manifest)
+
+
+def test_manifest_accepts_selector_as_file_name() -> None:
+    raw_manifest = {
+        "type": "roboflow_core/vision_event_bundle@v1",
+        "name": "test_step",
+        "event_type": "quality_check",
+        "target_directory": "/data/bundles",
+        "file_name": "$steps.compose.output",
+    }
+    manifest = BlockManifest.model_validate(raw_manifest)
+    assert manifest.file_name == "$steps.compose.output"
 
 
 # === Happy path (sync) ===
@@ -436,7 +508,7 @@ def test_failed_write_leaves_no_partial_bundle(tmp_path, monkeypatch) -> None:
     def _explode(*args, **kwargs):
         raise OSError("disk full")
 
-    monkeypatch.setattr(vision_events_bundle.v1, "dump_bytes_atomic", _explode)
+    monkeypatch.setattr(vision_events_bundle.v1, "_publish_bundle", _explode)
 
     result = _run_block(block, str(tmp_path), output_image=_make_workflow_image())
 
@@ -449,25 +521,24 @@ def test_failed_write_leaves_no_partial_bundle(tmp_path, monkeypatch) -> None:
 
 
 def test_temp_files_are_dot_prefixed(tmp_path, monkeypatch) -> None:
+    # a file mover matching *.tar.gz must never see a partially written bundle,
+    # so whatever the publish writes first has to be a dotfile
     observed_temp_names = []
-    original_dump = vision_events_bundle.v1.dump_bytes_atomic
+    real_link = os.link
 
-    def _spy(path, content, **kwargs):
-        from inference.core.utils.file_system import AtomicPath
+    def _spy(source, destination, **kwargs):
+        observed_temp_names.append(os.path.basename(source))
+        return real_link(source, destination, **kwargs)
 
-        with AtomicPath(path) as temp_path:
-            observed_temp_names.append(temp_path.split("/")[-1])
-            with open(temp_path, "wb") as f:
-                f.write(content)
-
-    monkeypatch.setattr(vision_events_bundle.v1, "dump_bytes_atomic", _spy)
+    monkeypatch.setattr(vision_events_bundle.v1.os, "link", _spy)
 
     result = _run_block(block=_make_block(tmp_path), target_directory=str(tmp_path))
 
     assert result["error_status"] is False
     assert len(observed_temp_names) == 1
     assert observed_temp_names[0].startswith(".")
-    assert original_dump is not None
+    # and nothing dot-prefixed survives the publish
+    assert not [p for p in tmp_path.iterdir() if p.name.startswith(".")]
 
 
 # === P1 regression: 25 MiB bundle size limit ===
@@ -636,6 +707,255 @@ def test_valid_float_in_payload_is_serialized_correctly(tmp_path) -> None:
     assert payload["images"][0]["objectDetections"][0]["confidence"] == pytest.approx(
         0.9
     )
+
+
+# === Custom file name ===
+
+
+def test_default_name_used_when_file_name_unset(tmp_path) -> None:
+    block = _make_block(tmp_path)
+
+    result = _run_block(block, str(tmp_path))
+
+    assert result["error_status"] is False
+    assert BUNDLE_FILE_NAME_PATTERN.match(os.path.basename(result["bundle_path"]))
+
+
+def test_custom_file_name_replaces_generated_name(tmp_path) -> None:
+    block = _make_block(tmp_path)
+
+    result = _run_block(block, str(tmp_path), file_name="person_batch7")
+
+    assert result["error_status"] is False
+    # nothing of the generated name survives - no timestamp, no event id
+    assert os.path.basename(result["bundle_path"]) == "person_batch7.tar.gz"
+    assert files_in(tmp_path) == ["person_batch7.tar.gz"]
+
+
+def test_custom_file_name_keeps_existing_suffix(tmp_path) -> None:
+    block = _make_block(tmp_path)
+
+    result = _run_block(block, str(tmp_path), file_name="person_batch7.tar.gz")
+
+    assert os.path.basename(result["bundle_path"]) == "person_batch7.tar.gz"
+
+
+def test_custom_file_name_bundle_contents_are_valid(tmp_path) -> None:
+    block = _make_block(tmp_path)
+
+    result = _run_block(
+        block,
+        str(tmp_path),
+        file_name="custom_name",
+        input_image=_make_workflow_image(),
+    )
+
+    payload, members = _read_bundle(result["bundle_path"])
+    assert payload["bundleFormatVersion"] == BUNDLE_FORMAT_VERSION
+    # the event id still lives in the payload even though the name omits it
+    assert payload["eventId"]
+    assert any(m.startswith("images/") for m in members)
+
+
+def test_two_blocks_route_by_directory_and_name(tmp_path) -> None:
+    # each block owns its own directory and file name, so a downstream file
+    # mover can route purely by folder and name
+    person_directory = tmp_path / "person"
+    event_directory = tmp_path / "event"
+
+    person_result = _run_block(
+        _make_block(tmp_path), str(person_directory), file_name="person_001"
+    )
+    event_result = _run_block(_make_block(tmp_path), str(event_directory))
+
+    assert person_result["error_status"] is False
+    assert event_result["error_status"] is False
+    assert files_in(person_directory) == ["person_001.tar.gz"]
+    assert BUNDLE_FILE_NAME_PATTERN.match(files_in(event_directory)[0])
+
+
+def test_repeated_custom_file_name_raises_and_preserves_original(tmp_path) -> None:
+    block = _make_block(tmp_path)
+    first = _run_block(block, str(tmp_path), file_name="collides")
+    original_bytes = (tmp_path / "collides.tar.gz").read_bytes()
+
+    with pytest.raises(ValueError, match="already exists"):
+        _run_block(block, str(tmp_path), file_name="collides")
+
+    assert first["error_status"] is False
+    assert files_in(tmp_path) == ["collides.tar.gz"]
+    assert (tmp_path / "collides.tar.gz").read_bytes() == original_bytes
+
+
+def test_collision_raises_before_background_dispatch(tmp_path) -> None:
+    # fire_and_forget returns before the write happens, so the guard has to run
+    # in the foreground - otherwise a clobbering write is reported as success
+    (tmp_path / "collides.tar.gz").write_bytes(b"existing bundle")
+    background_tasks = MagicMock()
+    block = _make_block(tmp_path, background_tasks=background_tasks)
+
+    with pytest.raises(ValueError, match="already exists"):
+        _run_block(block, str(tmp_path), file_name="collides", fire_and_forget=True)
+
+    background_tasks.add_task.assert_not_called()
+    assert (tmp_path / "collides.tar.gz").read_bytes() == b"existing bundle"
+
+
+def test_concurrent_writes_of_one_name_never_overwrite(tmp_path) -> None:
+    # a plain exists() check lets both threads through and the later write
+    # clobbers the earlier one; the reservation makes exactly one win
+    from concurrent.futures import ThreadPoolExecutor
+
+    def attempt(_):
+        try:
+            result = _run_block(
+                _make_block(tmp_path), str(tmp_path), file_name="shared"
+            )
+        except ValueError:
+            # lost the foreground check
+            return "rejected"
+        # lost the publish race: reported through error_status, not an exception
+        return "rejected" if result["error_status"] else "written"
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        outcomes = list(pool.map(attempt, range(8)))
+
+    assert outcomes.count("written") == 1
+    assert outcomes.count("rejected") == 7
+    assert files_in(tmp_path) == ["shared.tar.gz"]
+    # the single winner's bundle is intact, not a half-written loser's
+    payload, _ = _read_bundle(str(tmp_path / "shared.tar.gz"))
+    assert payload["bundleFormatVersion"] == BUNDLE_FORMAT_VERSION
+
+
+def test_interrupted_write_leaves_no_marker_blocking_the_name(
+    tmp_path, monkeypatch
+) -> None:
+    # a durable reservation would survive the failure and poison the name for
+    # every later event; only dot-prefixed temporaries may be left behind
+    monkeypatch.setattr(
+        vision_events_bundle.v1,
+        "_publish_bundle",
+        MagicMock(side_effect=OSError("disk on fire")),
+    )
+    block = _make_block(tmp_path)
+
+    result = _run_block(block, str(tmp_path), file_name="retryable")
+
+    assert result["error_status"] is True
+    assert files_in(tmp_path) == []
+
+    monkeypatch.undo()
+    retry = _run_block(block, str(tmp_path), file_name="retryable")
+    assert retry["error_status"] is False
+    assert files_in(tmp_path) == ["retryable.tar.gz"]
+
+
+def test_publish_never_replaces_an_existing_bundle(tmp_path) -> None:
+    # the foreground check is skipped here on purpose, so this exercises the
+    # publish itself - the guarantee that survives a lost race
+    from inference.core.workflows.core_steps.sinks.roboflow.vision_events_bundle.v1 import (
+        _publish_bundle,
+    )
+
+    target = tmp_path / "taken.tar.gz"
+    target.write_bytes(b"original")
+
+    with pytest.raises(ValueError, match="already exists"):
+        _publish_bundle(target_path=str(target), content=b"replacement")
+
+    assert target.read_bytes() == b"original"
+    # the temporary file is cleaned up rather than left for a file mover
+    assert files_in(tmp_path) == ["taken.tar.gz"]
+    assert not [p for p in tmp_path.iterdir() if p.name.startswith(".")]
+
+
+def test_publish_falls_back_when_hard_links_are_unavailable(
+    tmp_path, monkeypatch
+) -> None:
+    # FAT-family removable media is how bundles leave an air-gapped network, so
+    # the block must still write there rather than failing outright
+    monkeypatch.setattr(
+        vision_events_bundle.v1.os,
+        "link",
+        MagicMock(side_effect=OSError(errno.EOPNOTSUPP, "not supported")),
+    )
+    result = _run_block(_make_block(tmp_path), str(tmp_path), file_name="fallback")
+
+    assert result["error_status"] is False
+    assert files_in(tmp_path) == ["fallback.tar.gz"]
+
+
+def test_fallback_still_refuses_an_existing_bundle(tmp_path, monkeypatch) -> None:
+    from inference.core.workflows.core_steps.sinks.roboflow.vision_events_bundle.v1 import (
+        _publish_bundle,
+    )
+
+    monkeypatch.setattr(
+        vision_events_bundle.v1.os,
+        "link",
+        MagicMock(side_effect=OSError(errno.EOPNOTSUPP, "not supported")),
+    )
+    target = tmp_path / "taken.tar.gz"
+    target.write_bytes(b"original")
+
+    with pytest.raises(ValueError, match="already exists"):
+        _publish_bundle(target_path=str(target), content=b"replacement")
+
+    assert target.read_bytes() == b"original"
+
+
+def test_publish_does_not_fall_back_on_a_real_write_error(
+    tmp_path, monkeypatch
+) -> None:
+    # only "this filesystem cannot do hard links" may reach the fallback; a
+    # genuine failure must surface instead of being papered over by a rename
+    replace = MagicMock()
+    monkeypatch.setattr(
+        vision_events_bundle.v1.os,
+        "link",
+        MagicMock(side_effect=OSError(errno.EIO, "disk on fire")),
+    )
+    monkeypatch.setattr(vision_events_bundle.v1.os, "replace", replace)
+
+    result = _run_block(_make_block(tmp_path), str(tmp_path), file_name="broken")
+
+    assert result["error_status"] is True
+    replace.assert_not_called()
+    assert files_in(tmp_path) == []
+
+
+def test_default_names_do_not_collide_across_events(tmp_path) -> None:
+    block = _make_block(tmp_path)
+
+    for _ in range(5):
+        assert _run_block(block, str(tmp_path))["error_status"] is False
+
+    assert len(files_in(tmp_path)) == 5
+
+
+@pytest.mark.parametrize(
+    "file_name", ["../escape", "nested/bundle", ".hidden", "", "x" * 201]
+)
+def test_run_rejects_unsafe_file_name_resolved_from_selector(
+    tmp_path, file_name: str
+) -> None:
+    # selector-resolved values bypass manifest validation, so run() must guard
+    block = _make_block(tmp_path)
+
+    with pytest.raises(ValueError):
+        _run_block(block, str(tmp_path), file_name=file_name)
+
+    assert files_in(tmp_path) == []
+
+
+def test_disabled_sink_does_not_validate_file_name(tmp_path) -> None:
+    block = _make_block(tmp_path)
+
+    result = _run_block(block, str(tmp_path), disable_sink=True, file_name="../escape")
+
+    assert result["error_status"] is False
+    assert result["bundle_path"] == ""
 
 
 # === Tensor-native sibling smoke coverage ===


### PR DESCRIPTION
## What

Adds an optional `file_name` field to the `roboflow_core/vision_event_bundle@v1` sink.

Left unset, nothing changes: bundles are still named `event_<UTC timestamp>_<eventId>.tar.gz`. Set, it **replaces** the generated name entirely rather than composing with it, so a workflow can build whatever name it needs in an upstream step and have none of the block's own naming imposed on the output. `.tar.gz` is appended only when absent, so `"batch7"` and `"batch7.tar.gz"` both produce `batch7.tar.gz`.

## Why

The file name was fixed. Deployments running several bundle blocks in one workflow could already separate their output by `target_directory`, but not by name, so a downstream file mover could not route on name alone. With both per-block, one workflow can write `person_*.tar.gz` into `/media/person` alongside the default `event_*.tar.gz` in `/media/event`, and the mover routes purely by folder and name.

The upload endpoint reads only the raw request body and never inspects a file name, so this is a block-side change with no server counterpart.

## Never overwriting an existing bundle

A generated name embeds a uuid4 and cannot collide. A custom one repeats whenever its author repeats it, so collision handling had to become real rather than incidental:

- Bundles are published with `os.link`, which fails atomically when the destination exists, replacing the previous replacing-rename publish. Two concurrent events with the same name cannot both believe they won.
- A foreground existence check reports the ordinary repeated-name case synchronously, so a `fire_and_forget` dispatch cannot swallow it. That path raises and fails the run.
- An interrupted process leaves only the dot-prefixed temporary file that file movers already skip, so a crash never poisons a name.

On filesystems with no hard-link support (FAT-family removable media, a realistic way bundles leave an air-gapped network) publishing falls back to a checked replacing rename. That still refuses a name already on disk, but cannot rule out a genuinely concurrent writer. The fallback triggers only on errnos that mean "unsupported" — a real write error surfaces instead — and it logs a warning. This limitation is documented on the helper.

## Validation

A custom name must be a single safe path segment: it must start with a letter or digit, may contain only letters, digits, `.`, `_` and `-`, and is capped at 200 characters (the publish writes through a `.tmp_<random>_<name>` sibling, which has to stay clear of the 255-byte limit). That rejects path separators, parent traversal, leading dots that would collide with the temporary-file convention, and trailing newlines.

Validated in the manifest and again at runtime, since selector-resolved values bypass manifest validation.

## Compatibility

Additive. Existing workflows are unaffected and produce byte-identical file names. Applied to both `v1.py` and its tensor-native sibling.

## Testing

- 70 unit tests for the block, covering default naming, custom naming, suffix handling, repeated names, concurrent writers, the hard-link fallback and its errno narrowing, temp-file cleanup, and validation of both literal and selector-supplied names.
- Exercised end to end against a local server: multi-block routing, `fire_and_forget`, selector-supplied names from a workflow input, and rejection paths.
- Bundles written with custom names ingest successfully through the bundle upload endpoint, confirming the endpoint is name-agnostic in practice.