### PR TITLE
Fix SAM streaming visual tracking when prompts arrive mid-stream, add…

### DIFF
--- a/inference/core/workflows/core_steps/models/foundation/segment_anything2_video/v1.py
+++ b/inference/core/workflows/core_steps/models/foundation/segment_anything2_video/v1.py
@@ -324,7 +324,6 @@ class SegmentAnything2VideoBlockV1(WorkflowBlock):
                     state_dict=session.state_dict,
                     # clear old points is implied by our own reset gating
                     clear_old_prompts=True,
-                    frame_idx=frame_number,
                 )
                 session.obj_id_metadata = build_obj_id_metadata_from_boxes(
                     obj_ids=obj_ids, box_metas=per_box_meta

--- a/inference/core/workflows/core_steps/models/foundation/segment_anything2_video/v1_tensor.py
+++ b/inference/core/workflows/core_steps/models/foundation/segment_anything2_video/v1_tensor.py
@@ -339,7 +339,6 @@ class SegmentAnything2VideoBlockV1(WorkflowBlock):
                     bboxes=boxes_xyxy,
                     state_dict=session.state_dict,
                     clear_old_prompts=True,
-                    frame_idx=frame_number,
                 )
                 session.obj_id_metadata = build_obj_id_metadata_from_boxes(
                     obj_ids=obj_ids, box_metas=per_box_meta

--- a/inference/core/workflows/core_steps/models/foundation/segment_anything3_video/v1.py
+++ b/inference/core/workflows/core_steps/models/foundation/segment_anything3_video/v1.py
@@ -257,6 +257,19 @@ class BlockManifest(WorkflowBlockManifest):
         examples=[30],
         json_schema_extra={"relevant_for": {"tracking_mode": {"values": ["visual"]}}},
     )
+    prompt_frame_number: Optional[Union[int, Selector(kind=[INTEGER_KIND])]] = Field(
+        default=None,
+        title="Prompt Frame Number",
+        description=(
+            "Visual mode only. Hold the visual prompts until the stream "
+            "reaches this frame number. Earlier frames emit no detections "
+            "and leave the session untouched; the first frame at or past "
+            "this number becomes the prompt frame and tracking continues "
+            "from there."
+        ),
+        examples=[120],
+        json_schema_extra={"relevant_for": {"tracking_mode": {"values": ["visual"]}}},
+    )
     threshold: Union[
         Selector(kind=[FLOAT_KIND]),
         float,
@@ -387,6 +400,7 @@ class SegmentAnything3VideoBlockV1(WorkflowBlock):
         boxes: Optional[Batch[sv.Detections]] = None,
         prompt_mode: PromptMode = "first_frame",
         prompt_interval: int = 30,
+        prompt_frame_number: Optional[int] = None,
     ) -> BlockResult:
         if self._step_execution_mode is not StepExecutionMode.LOCAL:
             raise NotImplementedError(self._REMOTE_EXECUTION_NOT_SUPPORTED_MESSAGE)
@@ -403,6 +417,7 @@ class SegmentAnything3VideoBlockV1(WorkflowBlock):
             boxes=boxes,
             prompt_mode=prompt_mode,
             prompt_interval=prompt_interval,
+            prompt_frame_number=prompt_frame_number,
         )
 
     @usage_collector("model")
@@ -417,6 +432,7 @@ class SegmentAnything3VideoBlockV1(WorkflowBlock):
         boxes: Optional[Batch[sv.Detections]],
         prompt_mode: PromptMode,
         prompt_interval: int,
+        prompt_frame_number: Optional[int],
     ) -> BlockResult:
         model = self._get_model(model_id=model_id)
         if tracking_mode == "visual":
@@ -427,6 +443,7 @@ class SegmentAnything3VideoBlockV1(WorkflowBlock):
                 boxes=boxes,
                 prompt_mode=prompt_mode,
                 prompt_interval=prompt_interval,
+                prompt_frame_number=prompt_frame_number,
                 threshold=threshold,
             )
         return self._run_concept(
@@ -517,6 +534,7 @@ class SegmentAnything3VideoBlockV1(WorkflowBlock):
         boxes: Optional[Batch[sv.Detections]],
         prompt_mode: PromptMode,
         prompt_interval: int,
+        prompt_frame_number: Optional[int],
         threshold: float,
     ) -> BlockResult:
         point_prompts = normalise_labeled_points(points)
@@ -527,6 +545,20 @@ class SegmentAnything3VideoBlockV1(WorkflowBlock):
             metadata = single_image.video_metadata
             video_id = metadata.video_identifier
             frame_number = metadata.frame_number or 0
+            if prompt_frame_number is not None and frame_number < prompt_frame_number:
+                height, width = single_image._read_shape_without_materialization()
+                batch_detections.append(
+                    masks_to_sv_detections(
+                        masks=np.zeros((0, height, width), dtype=bool),
+                        obj_ids=np.zeros((0,), dtype=np.int64),
+                        image=single_image,
+                        obj_id_metadata={},
+                        threshold=threshold,
+                        fallback_class_id=SYNTHETIC_POINT_PROMPT_CLASS_ID,
+                        fallback_class_name=SYNTHETIC_POINT_PROMPT_CLASS_NAME,
+                    )
+                )
+                continue
             session = self._visual_sessions.setdefault(
                 video_id, VideoSessionBookkeeping()
             )
@@ -552,7 +584,6 @@ class SegmentAnything3VideoBlockV1(WorkflowBlock):
                     bboxes=boxes_xyxy,
                     points=point_prompts,
                     clear_old_prompts=True,
-                    frame_idx=frame_number,
                 )
                 session.obj_id_metadata = build_obj_id_metadata_from_visual_prompts(
                     obj_ids=obj_ids,

--- a/inference/core/workflows/core_steps/models/foundation/segment_anything3_video/v1_tensor.py
+++ b/inference/core/workflows/core_steps/models/foundation/segment_anything3_video/v1_tensor.py
@@ -301,6 +301,19 @@ class BlockManifest(WorkflowBlockManifest):
         examples=[30],
         json_schema_extra={"relevant_for": {"tracking_mode": {"values": ["visual"]}}},
     )
+    prompt_frame_number: Optional[Union[int, Selector(kind=[INTEGER_KIND])]] = Field(
+        default=None,
+        title="Prompt Frame Number",
+        description=(
+            "Visual mode only. Hold the visual prompts until the stream "
+            "reaches this frame number. Earlier frames emit no detections "
+            "and leave the session untouched; the first frame at or past "
+            "this number becomes the prompt frame and tracking continues "
+            "from there."
+        ),
+        examples=[120],
+        json_schema_extra={"relevant_for": {"tracking_mode": {"values": ["visual"]}}},
+    )
     threshold: Union[
         Selector(kind=[FLOAT_KIND]),
         float,
@@ -430,6 +443,7 @@ class SegmentAnything3VideoBlockV1(WorkflowBlock):
         boxes: Optional[Batch] = None,
         prompt_mode: PromptMode = "first_frame",
         prompt_interval: int = 30,
+        prompt_frame_number: Optional[int] = None,
     ) -> BlockResult:
         if self._step_execution_mode is not StepExecutionMode.LOCAL:
             raise NotImplementedError(self._REMOTE_EXECUTION_NOT_SUPPORTED_MESSAGE)
@@ -443,6 +457,7 @@ class SegmentAnything3VideoBlockV1(WorkflowBlock):
                 boxes=boxes,
                 prompt_mode=prompt_mode,
                 prompt_interval=prompt_interval,
+                prompt_frame_number=prompt_frame_number,
                 threshold=threshold,
             )
         return self._run_concept(
@@ -519,6 +534,7 @@ class SegmentAnything3VideoBlockV1(WorkflowBlock):
         boxes: Optional[Batch],
         prompt_mode: PromptMode,
         prompt_interval: int,
+        prompt_frame_number: Optional[int],
         threshold: float,
     ) -> BlockResult:
         mask_representation = _resolve_mask_representation()
@@ -530,6 +546,23 @@ class SegmentAnything3VideoBlockV1(WorkflowBlock):
             metadata = single_image.video_metadata
             video_id = metadata.video_identifier
             frame_number = metadata.frame_number or 0
+            if prompt_frame_number is not None and frame_number < prompt_frame_number:
+                height, width = single_image._read_shape_without_materialization()
+                results.append(
+                    {
+                        "predictions": masks_to_instance_detections(
+                            masks=np.zeros((0, height, width), dtype=bool),
+                            obj_ids=np.zeros((0,), dtype=np.int64),
+                            image=single_image,
+                            obj_id_metadata={},
+                            threshold=threshold,
+                            mask_representation=mask_representation,
+                            fallback_class_id=SYNTHETIC_POINT_PROMPT_CLASS_ID,
+                            fallback_class_name=SYNTHETIC_POINT_PROMPT_CLASS_NAME,
+                        )
+                    }
+                )
+                continue
             session = self._visual_sessions.setdefault(
                 video_id, VideoSessionBookkeeping()
             )
@@ -555,7 +588,6 @@ class SegmentAnything3VideoBlockV1(WorkflowBlock):
                     bboxes=boxes_xyxy,
                     points=point_prompts,
                     clear_old_prompts=True,
-                    frame_idx=frame_number,
                 )
                 session.obj_id_metadata = build_obj_id_metadata_from_visual_prompts(
                     obj_ids=obj_ids,

--- a/inference_models/inference_models/models/common/hf_streaming_video.py
+++ b/inference_models/inference_models/models/common/hf_streaming_video.py
@@ -172,7 +172,7 @@ class HFStreamingVideoBase(HFVideoModelBase):
         text: Optional[str] = None,
         state_dict: Optional[dict] = None,
         clear_old_prompts: bool = True,
-        frame_idx: int = 0,
+        frame_idx: Optional[int] = None,
         points: Optional[List[Tuple[float, float, bool]]] = None,
     ) -> Tuple[np.ndarray, np.ndarray, dict]:
         """Seed a session and run one streaming step.
@@ -180,6 +180,13 @@ class HFStreamingVideoBase(HFVideoModelBase):
         ``clear_old_prompts=True`` starts a fresh session (discarding
         any prior state).  Pass ``False`` along with ``state_dict`` to
         append prompts to an ongoing session.
+
+        ``frame_idx`` is deprecated and ignored.  Prompts always attach
+        to the frame passed in ``image``: the session numbers streamed
+        frames internally from 0, so prompts registered at any other
+        index leave the streamed frames unconditioned and the tracker
+        emits empty masks (the caller's stream frame number is not the
+        session's frame index).
         """
         if text is not None and not self._supports_text_prompts:
             raise ModelRuntimeError(
@@ -197,6 +204,10 @@ class HFStreamingVideoBase(HFVideoModelBase):
             session = self._resolve_session(
                 state_dict=state_dict, reset=clear_old_prompts
             )
+            # The index `add_new_frame` will assign to `image` when the model
+            # processes it below. Prompt inputs must be registered under the
+            # same index or the model treats the frame as unconditioned.
+            prompt_frame_idx = _next_streaming_frame_idx(session)
 
             inputs = self._processor(
                 images=image_np, device=self._device, return_tensors="pt"
@@ -221,7 +232,7 @@ class HFStreamingVideoBase(HFVideoModelBase):
                 point_labels = [1 if positive else 0 for _x, _y, positive in point_list]
                 self._processor.add_inputs_to_inference_session(
                     inference_session=session,
-                    frame_idx=frame_idx,
+                    frame_idx=prompt_frame_idx,
                     obj_ids=list(range(len(box_list) + 1)),
                     input_points=[[*box_points, point_coordinates]],
                     input_labels=[[*[[2, 3] for _box in box_list], point_labels]],
@@ -230,7 +241,7 @@ class HFStreamingVideoBase(HFVideoModelBase):
             elif box_list:
                 self._processor.add_inputs_to_inference_session(
                     inference_session=session,
-                    frame_idx=frame_idx,
+                    frame_idx=prompt_frame_idx,
                     obj_ids=list(range(len(box_list))),
                     input_boxes=[[[float(v) for v in xyxy] for xyxy in box_list]],
                     original_size=original_sizes[0],
@@ -239,7 +250,7 @@ class HFStreamingVideoBase(HFVideoModelBase):
             elif point_list:
                 self._processor.add_inputs_to_inference_session(
                     inference_session=session,
-                    frame_idx=frame_idx,
+                    frame_idx=prompt_frame_idx,
                     obj_ids=[0],
                     input_points=[[[[x, y] for x, y, _positive in point_list]]],
                     input_labels=[
@@ -339,6 +350,18 @@ class HFStreamingVideoBase(HFVideoModelBase):
 # ---------------------------------------------------------------------------
 # Module-level helpers (pure, easy to unit-test)
 # ---------------------------------------------------------------------------
+
+
+def _next_streaming_frame_idx(session: Any) -> int:
+    """Return the index the session's ``add_new_frame`` will assign next.
+
+    Mirrors the HF implementation: ``len(processed_frames)`` with ``None``
+    (no frame streamed yet) counting as 0.
+    """
+    processed_frames = getattr(session, "processed_frames", None)
+    if not processed_frames:
+        return 0
+    return len(processed_frames)
 
 
 def _ensure_numpy_image(image: Union[np.ndarray, torch.Tensor]) -> np.ndarray:

--- a/inference_models/tests/unit_tests/models/test_sam3_tracker_video.py
+++ b/inference_models/tests/unit_tests/models/test_sam3_tracker_video.py
@@ -27,6 +27,9 @@ class _FakeSession:
     def __init__(self):
         self.obj_ids: List[int] = []
         self.boxes_added: List[List[float]] = []
+        # Real sessions start with no streamed frames; the model's
+        # ``add_new_frame`` fills this dict as frames arrive.
+        self.processed_frames: Optional[dict] = None
 
 
 class _FakeBatchEncoding:
@@ -197,6 +200,38 @@ def test_sam3_tracker_video_keeps_boxes_and_points_as_separate_objects():
         ]
     ]
     assert processor.last_add_inputs_kwargs["input_labels"] == [[[2, 3], [2, 3], [1]]]
+
+
+def test_sam3_tracker_video_prompt_anchors_inputs_to_first_streamed_frame():
+    """A fresh session numbers frames from 0, whatever the caller passes.
+
+    Registering prompts at the caller's stream frame number (e.g. an
+    InferencePipeline ``frame_number``) left every streamed frame
+    unconditioned and the tracker emitted empty masks."""
+    tracker, processor, _ = _build_model()
+    frame = np.zeros((32, 48, 3), dtype=np.uint8)
+
+    tracker.prompt(image=frame, bboxes=[(1, 2, 10, 12)], frame_idx=41)
+
+    assert processor.last_add_inputs_kwargs["frame_idx"] == 0
+
+
+def test_sam3_tracker_video_prompt_anchors_inputs_to_next_frame_of_ongoing_session():
+    tracker, processor, _ = _build_model()
+    frame = np.zeros((32, 48, 3), dtype=np.uint8)
+
+    _, _, state = tracker.prompt(image=frame, bboxes=[(1, 2, 10, 12)])
+    state[SESSION_KEY].processed_frames = {0: object(), 1: object()}
+
+    tracker.prompt(
+        image=frame,
+        bboxes=[(3, 4, 11, 13)],
+        state_dict=state,
+        clear_old_prompts=False,
+        frame_idx=99,
+    )
+
+    assert processor.last_add_inputs_kwargs["frame_idx"] == 2
 
 
 def test_sam3_tracker_video_track_without_state_raises():

--- a/tests/workflows/unit_tests/core_steps/models/foundation/test_segment_anything3_video.py
+++ b/tests/workflows/unit_tests/core_steps/models/foundation/test_segment_anything3_video.py
@@ -154,7 +154,7 @@ class _FakeVisualModel:
         points,
         state_dict=None,
         clear_old_prompts=True,
-        frame_idx=0,
+        frame_idx=None,
     ):
         self.calls.append(
             (
@@ -773,9 +773,13 @@ def test_visual_stream_restart_reprompts(block_factory):
         )
 
     assert [call[0] for call in fake.calls] == ["prompt", "track", "prompt"]
-    assert [
-        call[1]["frame_idx"] for call in fake.calls if call[0] == "prompt"
-    ] == [5, 0]
+    # The block must NOT forward the stream frame number as the model's
+    # frame_idx: a fresh session numbers frames internally from 0, and a
+    # mismatched index leaves every streamed frame unconditioned.
+    assert [call[1]["frame_idx"] for call in fake.calls if call[0] == "prompt"] == [
+        None,
+        None,
+    ]
     assert [
         call[1]["had_prior_state"] for call in fake.calls if call[0] == "prompt"
     ] == [False, False]
@@ -802,8 +806,77 @@ def test_visual_every_frame_mode_prompts_each_frame(block_factory):
         )
 
     assert [call[0] for call in fake.calls] == ["prompt", "prompt", "prompt"]
-    assert [call[1]["frame_idx"] for call in fake.calls] == [0, 1, 2]
+    assert [call[1]["frame_idx"] for call in fake.calls] == [None, None, None]
     assert [call[1]["had_prior_state"] for call in fake.calls] == [False] * 3
+
+
+@pytest.mark.parametrize("manifest_type", [BlockManifest, TensorBlockManifest])
+def test_manifest_accepts_prompt_frame_number(manifest_type):
+    manifest = manifest_type.model_validate(
+        {
+            "type": "roboflow_core/sam3_video@v1",
+            "name": "sam3_video_step",
+            "images": "$inputs.image",
+            "tracking_mode": "visual",
+            "points": [{"x": 10, "y": 20, "positive": True}],
+            "prompt_frame_number": 120,
+        }
+    )
+
+    assert manifest.prompt_frame_number == 120
+
+    properties = manifest_type.model_json_schema()["properties"]
+    assert properties["prompt_frame_number"]["relevant_for"]["tracking_mode"] == {
+        "values": ["visual"]
+    }
+
+
+@pytest.mark.parametrize(
+    "block_factory",
+    [_make_visual_block_with_fake_model, _make_tensor_visual_block_with_fake_model],
+    ids=["numpy", "tensor"],
+)
+def test_visual_prompt_frame_number_holds_prompt_until_target_frame(block_factory):
+    block, fake = block_factory()
+
+    results = []
+    for frame_number in range(4):
+        results.append(
+            block.run(
+                images=[_make_frame(frame_number=frame_number)],
+                class_names=None,
+                model_id="sam3video",
+                visual_model_id="sam3trackervideo",
+                threshold=0.0,
+                tracking_mode="visual",
+                points=[{"x": 10, "y": 12, "positive": True}],
+                prompt_frame_number=2,
+            )
+        )
+
+    assert [call[0] for call in fake.calls] == ["prompt", "track"]
+    assert len(results[0][0]["predictions"]) == 0
+    assert len(results[1][0]["predictions"]) == 0
+    assert len(results[2][0]["predictions"]) == 1
+    assert len(results[3][0]["predictions"]) == 1
+
+
+def test_visual_prompt_frame_number_leaves_session_untouched_before_target():
+    block, fake = _make_visual_block_with_fake_model()
+
+    block.run(
+        images=[_make_frame(frame_number=0), _make_frame(frame_number=1)],
+        class_names=None,
+        model_id="sam3video",
+        visual_model_id="sam3trackervideo",
+        threshold=0.0,
+        tracking_mode="visual",
+        points=[{"x": 10, "y": 12, "positive": True}],
+        prompt_frame_number=2,
+    )
+
+    assert fake.calls == []
+    assert block._visual_sessions == {}
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
… prompt_frame_number to SAM3 video block.

The HF streaming session numbers frames internally from 0, but the video blocks registered visual prompts at the pipeline frame number. Whenever the two disagreed (pipeline numbering starts at 1), every streamed frame ran as an unprompted conditioning frame and the tracker emitted empty masks. Anchor prompt registration to the index the session assigns to the prompted image and stop forwarding the stream frame number from the blocks.

prompt_frame_number lets visual mode hold its prompts until the stream reaches a chosen frame: earlier frames emit no detections and leave the session untouched, so a track correction can prompt mid-clip without a trimmed upload.

## What does this PR do?

<!-- Provide a clear and concise description of the changes -->

**Related Issue(s):** <!-- Link to related issues, e.g., Fixes #123 or Related to #456 -->

## Type of Change

<!-- Please select one and delete the others, or describe if Other -->

- Bug fix (non-breaking change that fixes an issue)
- New feature (non-breaking change that adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
- Refactoring (no functional changes)
- Other:

## Testing

<!-- Describe how you tested your changes -->

- [ ] I have tested this change locally
- [ ] I have added/updated tests for this change

**Test details:**
<!-- Describe what tests were added/updated and what they cover -->

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where necessary, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have updated the documentation accordingly (if applicable)

## Additional Context

<!-- Add any other context, screenshots, or notes about the PR here -->
