### PR TITLE
Cosmos AnomalyGen: package runtime, packaging tool, workflow-block productionization

### DIFF
--- a/inference/core/workflows/core_steps/loader.py
+++ b/inference/core/workflows/core_steps/loader.py
@@ -512,6 +512,9 @@ from inference.core.workflows.core_steps.models.foundation.cog_vlm.v1 import (
 from inference.core.workflows.core_steps.models.foundation.cosmos3.v1 import (
     Cosmos3EdgeBlockV1,
 )
+from inference.core.workflows.core_steps.models.foundation.cosmos_anomalygen.v1 import (
+    CosmosAnomalyGenBlockV1,
+)
 
 if not ENABLE_TENSOR_DATA_REPRESENTATION:
     from inference.core.workflows.core_steps.models.foundation.depth_estimation.v1 import (
@@ -1932,6 +1935,7 @@ def load_blocks() -> List[Type[WorkflowBlock]]:
         GoogleGemmaBlockV3,
         ImageSlicerBlockV2,
         Cosmos3EdgeBlockV1,
+        CosmosAnomalyGenBlockV1,
         Qwen25VLBlockV1,
         Qwen3VLBlockV1,
         Qwen35VLBlockV1,

--- a/inference/core/workflows/core_steps/models/foundation/cosmos_anomalygen/v1.py
+++ b/inference/core/workflows/core_steps/models/foundation/cosmos_anomalygen/v1.py
@@ -1,0 +1,231 @@
+from typing import List, Literal, Optional, Type, Union
+
+import cv2
+import numpy as np
+import supervision as sv
+from pydantic import ConfigDict, Field
+from supervision.draw.color import Color
+
+from inference.core.env import (
+    ALLOW_INFERENCE_MODELS_DIRECTLY_ACCESS_LOCAL_PACKAGES,
+    ALLOW_INFERENCE_MODELS_UNTRUSTED_PACKAGES,
+)
+from inference.core.roboflow_api import get_extra_weights_provider_headers
+from inference.core.workflows.core_steps.common.entities import StepExecutionMode
+from inference.core.workflows.execution_engine.entities.base import (
+    OutputDefinition,
+    WorkflowImageData,
+)
+from inference.core.workflows.execution_engine.entities.types import (
+    FLOAT_KIND,
+    IMAGE_KIND,
+    INSTANCE_SEGMENTATION_PREDICTION_KIND,
+    INTEGER_KIND,
+    ROBOFLOW_MODEL_ID_KIND,
+    STRING_KIND,
+    Selector,
+)
+from inference.core.workflows.prototypes.block import (
+    BlockResult,
+    Runtime,
+    RuntimeRestriction,
+    Severity,
+    WorkflowBlock,
+    WorkflowBlockManifest,
+)
+
+LONG_DESCRIPTION = """
+Generate synthetic defect images with NVIDIA Cosmos AnomalyGen.
+
+Given a clean (defect-free) image, a placement mask, and an anomaly type
+(e.g. `wood+crack`), the model inpaints a realistic defect into the mask's
+region. Fine-tuned per-defect checkpoints load through the same model id /
+local package path as the base model. Useful for bootstrapping defect
+detection datasets where real defect data is scarce.
+
+The placement mask comes in as an instance segmentation prediction - draw it
+upstream (e.g. a polygon zone converted to detections) or chain a
+segmentation model.
+"""
+
+
+class BlockManifest(WorkflowBlockManifest):
+    model_config = ConfigDict(
+        json_schema_extra={
+            "name": "Cosmos AnomalyGen",
+            "version": "v1",
+            "short_description": "Inpaint realistic synthetic defects into clean images.",
+            "long_description": LONG_DESCRIPTION,
+            "license": "Other",
+            "block_type": "model",
+            "search_keywords": [
+                "Cosmos",
+                "AnomalyGen",
+                "NVIDIA",
+                "defect",
+                "synthetic data",
+                "inpainting",
+                "anomaly",
+            ],
+            "ui_manifest": {
+                "section": "model",
+                "icon": "fal fa-hammer-crash",
+                "blockPriority": 5.9,
+            },
+        },
+        protected_namespaces=(),
+    )
+    type: Literal["roboflow_core/cosmos_anomalygen@v1"]
+
+    image: Selector(kind=[IMAGE_KIND]) = Field(
+        description="The clean (defect-free) image to inpaint a defect into.",
+        examples=["$inputs.image"],
+    )
+    segmentation_mask: Selector(kind=[INSTANCE_SEGMENTATION_PREDICTION_KIND]) = Field(
+        name="Placement Mask",
+        description="Segmentation prediction marking where the defect should appear.",
+        examples=["$steps.model.predictions"],
+    )
+    anomaly_type: Union[Selector(kind=[STRING_KIND]), str] = Field(
+        description="The trained anomaly type to generate, as `<texture>+<defect_class>`.",
+        examples=["wood+crack", "$inputs.anomaly_type"],
+    )
+    model_version: Union[Selector(kind=[ROBOFLOW_MODEL_ID_KIND]), str] = Field(
+        default="cosmos-anomalygen",
+        description="The Cosmos AnomalyGen checkpoint to use (model id or local package path).",
+        examples=["cosmos-anomalygen"],
+    )
+    guidance: Union[Selector(kind=[FLOAT_KIND]), float] = Field(
+        default=7.0,
+        description="Anomaly conditioning strength.",
+        examples=[7.0],
+    )
+    num_steps: Union[Selector(kind=[INTEGER_KIND]), int] = Field(
+        default=35,
+        description="Number of denoising steps.",
+        examples=[35],
+    )
+    seed: Union[Selector(kind=[INTEGER_KIND]), int] = Field(
+        default=0,
+        description="Random seed for reproducible generation.",
+        examples=[0],
+    )
+
+    @classmethod
+    def describe_outputs(cls) -> List[OutputDefinition]:
+        return [
+            OutputDefinition(
+                name="image",
+                kind=[IMAGE_KIND],
+                description="The clean image with the synthetic defect inpainted.",
+            ),
+        ]
+
+    @classmethod
+    def get_execution_engine_compatibility(cls) -> Optional[str]:
+        return ">=1.3.0,<2.0.0"
+
+    @classmethod
+    def get_restrictions(cls) -> List[RuntimeRestriction]:
+        return [
+            RuntimeRestriction(
+                severity=Severity.HARD,
+                note="Requires a GPU; the diffusion model needs CUDA.",
+                applies_to_runtimes=[Runtime.SELF_HOSTED_CPU],
+                applies_to_step_execution_modes=[StepExecutionMode.LOCAL],
+            ),
+            RuntimeRestriction(
+                severity=Severity.HARD,
+                note=(
+                    "Cosmos AnomalyGen has no remote endpoint - the block loads "
+                    "the model in-process and only supports local execution."
+                ),
+                applies_to_runtimes=[Runtime.HOSTED_SERVERLESS],
+                applies_to_step_execution_modes=[StepExecutionMode.REMOTE],
+            ),
+        ]
+
+    @classmethod
+    def get_supported_model_variants(cls) -> Optional[List[str]]:
+        return ["cosmos-anomalygen"]
+
+
+class CosmosAnomalyGenBlockV1(WorkflowBlock):
+    def __init__(
+        self,
+        api_key: Optional[str],
+        step_execution_mode: StepExecutionMode,
+    ):
+        self._api_key = api_key
+        self._step_execution_mode = step_execution_mode
+        self._model = None
+        self._current_model_id: Optional[str] = None
+
+    @classmethod
+    def get_init_parameters(cls) -> List[str]:
+        return ["api_key", "step_execution_mode"]
+
+    @classmethod
+    def get_manifest(cls) -> Type[WorkflowBlockManifest]:
+        return BlockManifest
+
+    def run(
+        self,
+        image: WorkflowImageData,
+        segmentation_mask: sv.Detections,
+        anomaly_type: str,
+        model_version: str,
+        guidance: float,
+        num_steps: int,
+        seed: int,
+    ) -> BlockResult:
+        if self._step_execution_mode is not StepExecutionMode.LOCAL:
+            raise NotImplementedError(
+                "Cosmos AnomalyGen only supports local execution - there is no "
+                "remote endpoint for this model."
+            )
+        model = self._resolve_model(model_id=model_version)
+        numpy_image = image.numpy_image
+        mask = rasterize_placement_mask(
+            image=numpy_image, segmentation_mask=segmentation_mask
+        )
+        generated = model.generate(
+            image=numpy_image,
+            mask=mask,
+            anomaly_type=anomaly_type,
+            guidance=guidance,
+            num_steps=num_steps,
+            seed=seed,
+            num_images=1,
+        )
+        return {
+            "image": WorkflowImageData.copy_and_replace(
+                origin_image_data=image,
+                numpy_image=generated[0],
+            ),
+        }
+
+    def _resolve_model(self, model_id: str):
+        if self._model is None or self._current_model_id != model_id:
+            from inference_models import AutoModel
+
+            extra_weights_provider_headers = get_extra_weights_provider_headers()
+            self._model = AutoModel.from_pretrained(
+                model_id_or_path=model_id,
+                api_key=self._api_key,
+                allow_untrusted_packages=ALLOW_INFERENCE_MODELS_UNTRUSTED_PACKAGES,
+                allow_direct_local_storage_loading=ALLOW_INFERENCE_MODELS_DIRECTLY_ACCESS_LOCAL_PACKAGES,
+                weights_provider_extra_headers=extra_weights_provider_headers,
+            )
+            self._current_model_id = model_id
+        return self._model
+
+
+def rasterize_placement_mask(
+    image: np.ndarray,
+    segmentation_mask: sv.Detections,
+) -> np.ndarray:
+    black_image = np.zeros_like(image)
+    mask_annotator = sv.MaskAnnotator(color=Color.WHITE, opacity=1.0)
+    mask = mask_annotator.annotate(black_image, segmentation_mask)
+    return cv2.cvtColor(mask, cv2.COLOR_BGR2GRAY)

--- a/inference/core/workflows/core_steps/models/foundation/cosmos_anomalygen/v1.py
+++ b/inference/core/workflows/core_steps/models/foundation/cosmos_anomalygen/v1.py
@@ -17,6 +17,7 @@ from inference.core.workflows.execution_engine.entities.base import (
     WorkflowImageData,
 )
 from inference.core.workflows.execution_engine.entities.types import (
+    BOOLEAN_KIND,
     FLOAT_KIND,
     IMAGE_KIND,
     INSTANCE_SEGMENTATION_PREDICTION_KIND,
@@ -46,6 +47,12 @@ detection datasets where real defect data is scarce.
 The placement mask comes in as an instance segmentation prediction - draw it
 upstream (e.g. a polygon zone converted to detections) or chain a
 segmentation model.
+
+Alongside the generated image the block reports `visibility` - the mean
+absolute pixel change inside the placement mask (0-255 gray levels). The
+model sometimes returns the canvas unchanged; filter or regenerate when
+visibility is low (>=15 separated real defects from empty generations in
+practice).
 """
 
 
@@ -96,9 +103,14 @@ class BlockManifest(WorkflowBlockManifest):
         examples=["cosmos-anomalygen"],
     )
     guidance: Union[Selector(kind=[FLOAT_KIND]), float] = Field(
-        default=7.0,
-        description="Anomaly conditioning strength.",
-        examples=[7.0],
+        default=1.5,
+        description=(
+            "Anomaly conditioning strength (upstream extrapolation scale; 1.5 "
+            "corresponds to a standard classifier-free-guidance scale of 2.5 and "
+            "is NVIDIA's production default). Higher values make defects more "
+            "pronounced."
+        ),
+        examples=[1.5],
     )
     num_steps: Union[Selector(kind=[INTEGER_KIND]), int] = Field(
         default=35,
@@ -110,6 +122,21 @@ class BlockManifest(WorkflowBlockManifest):
         description="Random seed for reproducible generation.",
         examples=[0],
     )
+    crop_ratio: Union[Selector(kind=[FLOAT_KIND]), float] = Field(
+        default=4.0,
+        description=(
+            "Size of the generation window relative to the mask's bounding box. "
+            "Larger values give the model more context but resample a larger "
+            "region; for defects bigger than ~1/4 of the frame a smaller ratio "
+            "keeps the surrounding image sharp."
+        ),
+        examples=[4.0],
+    )
+    poisson_blend: Union[Selector(kind=[BOOLEAN_KIND]), bool] = Field(
+        default=False,
+        description="Poisson-blend the generated region into the original image.",
+        examples=[False],
+    )
 
     @classmethod
     def describe_outputs(cls) -> List[OutputDefinition]:
@@ -118,6 +145,16 @@ class BlockManifest(WorkflowBlockManifest):
                 name="image",
                 kind=[IMAGE_KIND],
                 description="The clean image with the synthetic defect inpainted.",
+            ),
+            OutputDefinition(
+                name="visibility",
+                kind=[FLOAT_KIND],
+                description=(
+                    "Mean absolute pixel change inside the placement mask "
+                    "(0-255). Low values mean the model returned the canvas "
+                    "nearly unchanged; >=15 separated real defects from empty "
+                    "generations in practice."
+                ),
             ),
         ]
 
@@ -156,6 +193,11 @@ class CosmosAnomalyGenBlockV1(WorkflowBlock):
         api_key: Optional[str],
         step_execution_mode: StepExecutionMode,
     ):
+        if step_execution_mode is not StepExecutionMode.LOCAL:
+            raise NotImplementedError(
+                "Cosmos AnomalyGen only supports local execution - there is no "
+                "remote endpoint for this model."
+            )
         self._api_key = api_key
         self._step_execution_mode = step_execution_mode
         self._model = None
@@ -178,12 +220,9 @@ class CosmosAnomalyGenBlockV1(WorkflowBlock):
         guidance: float,
         num_steps: int,
         seed: int,
+        crop_ratio: float,
+        poisson_blend: bool,
     ) -> BlockResult:
-        if self._step_execution_mode is not StepExecutionMode.LOCAL:
-            raise NotImplementedError(
-                "Cosmos AnomalyGen only supports local execution - there is no "
-                "remote endpoint for this model."
-            )
         model = self._resolve_model(model_id=model_version)
         numpy_image = image.numpy_image
         mask = rasterize_placement_mask(
@@ -197,11 +236,16 @@ class CosmosAnomalyGenBlockV1(WorkflowBlock):
             num_steps=num_steps,
             seed=seed,
             num_images=1,
+            crop_ratio=crop_ratio,
+            poisson_blend=poisson_blend,
         )
         return {
             "image": WorkflowImageData.copy_and_replace(
                 origin_image_data=image,
                 numpy_image=generated[0],
+            ),
+            "visibility": compute_visibility(
+                original=numpy_image, generated=generated[0], mask=mask
             ),
         }
 
@@ -229,3 +273,21 @@ def rasterize_placement_mask(
     mask_annotator = sv.MaskAnnotator(color=Color.WHITE, opacity=1.0)
     mask = mask_annotator.annotate(black_image, segmentation_mask)
     return cv2.cvtColor(mask, cv2.COLOR_BGR2GRAY)
+
+
+def compute_visibility(
+    original: np.ndarray,
+    generated: np.ndarray,
+    mask: np.ndarray,
+) -> float:
+    """Mean absolute gray-level change (0-255) inside the placement mask.
+
+    The model sometimes returns the canvas unchanged; this is the measure
+    callers filter or regenerate on.
+    """
+    original_gray = cv2.cvtColor(original, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    generated_gray = cv2.cvtColor(generated, cv2.COLOR_BGR2GRAY).astype(np.float32)
+    inside = mask >= 128
+    if not inside.any():
+        return 0.0
+    return float(np.abs(generated_gray - original_gray)[inside].mean())

--- a/inference/core/workflows/core_steps/models/foundation/cosmos_anomalygen/v1.py
+++ b/inference/core/workflows/core_steps/models/foundation/cosmos_anomalygen/v1.py
@@ -28,11 +28,13 @@ from inference.core.workflows.execution_engine.entities.types import (
 )
 from inference.core.workflows.prototypes.block import (
     BlockResult,
+    DependentResource,
     Runtime,
     RuntimeRestriction,
     Severity,
     WorkflowBlock,
     WorkflowBlockManifest,
+    roboflow_platform_model,
 )
 
 LONG_DESCRIPTION = """
@@ -185,6 +187,9 @@ class BlockManifest(WorkflowBlockManifest):
     @classmethod
     def get_supported_model_variants(cls) -> Optional[List[str]]:
         return ["cosmos-anomalygen"]
+
+    def discover_dependent_resources(self) -> Optional[List[DependentResource]]:
+        return [roboflow_platform_model(model_id=self.model_version)]
 
 
 class CosmosAnomalyGenBlockV1(WorkflowBlock):

--- a/inference_models/development/cosmos3/cosmos_anomalygen_runtime.py
+++ b/inference_models/development/cosmos3/cosmos_anomalygen_runtime.py
@@ -1,0 +1,247 @@
+"""Reference `cosmos_anomalygen_runtime.py` for the Cosmos AnomalyGen package.
+
+This is the self-contained runtime module that ships INSIDE the
+`cosmos-anomalygen` model package (injected by pull_anomalygen_weights.py
+--runtime-module). `CosmosAnomalyGen.from_pretrained` imports the
+`CosmosAnomalyGenRuntime` class from it via `import_class_from_file`.
+
+Unlike the world tower (which rides diffusers), AnomalyGen has no released
+pipeline: this runtime drives NVIDIA's GA `paidf-anomalygen` stack directly
+(`cosmos_predict2` + `imaginaire`), so it must run inside an environment where
+that repo is importable - in practice a container built on the published GA
+image (`paidf-anomalygen:ga`). The heavy imports are lazy so the module itself
+imports anywhere.
+
+Package layout expected at `load(package_dir)` (all paths package-relative):
+
+    cosmos_anomalygen_runtime.py       this file
+    inference_config.json              {"experiment": ..., "guidance": ..., "anomaly_types": [...]}
+    class_names.txt                    one trained "<category>+<class>" anomaly type per line
+    ag_config.yaml                     frozen training config (the run dir's copy)
+    checkpoints/model/iter_XXXXXXXXX.pt        trained adapter + anomaly embeddings (~14 MB)
+    checkpoints/nvidia/Cosmos-Predict2-2B-Text2Image/model.pt          frozen DiT
+    checkpoints/nvidia/Cosmos-Predict2-2B-Text2Image/tokenizer/tokenizer.pth   frozen VAE
+    checkpoints/google-t5/t5-large/...          frozen text encoder
+    checkpoints/NVDINOV2/nv_dinov2_classification_model.ckpt           frozen mask encoder
+
+The trained artifact and the frozen base towers share one `checkpoints/` tree
+on purpose: the GA loader reads `<ckpt_dir>/checkpoints/model/iter_*.pt` for
+the adapter while the base-weight paths are overridden here to absolute
+package paths, so the package needs no particular working directory.
+
+Contract expected by CosmosAnomalyGen (images RGB numpy arrays, masks uint8
+0/255 at image resolution):
+- load(package_dir, device) -> runtime
+- generate(image, mask, anomaly_type, guidance, num_steps, seed, num_images,
+  crop_and_paste, crop_ratio, poisson_blend) -> [RGB arrays]
+
+Generation reuses the GA SDG entry path 1:1 (temp one-line JSONL ->
+`AnomalyInpaintDataset` -> `AnomalyInpaintCondition` -> `inpaint_image`), so
+preprocessing, RePaint-style latent replacement, crop/paste and PSNR reporting
+stay byte-compatible with `scripts.anomaly_gen.synthetic_dataset_generation`.
+"""
+
+import glob
+import importlib
+import json
+import os
+import re
+import tempfile
+from typing import List, Optional
+
+import numpy as np
+import torch
+
+DEFAULT_EXPERIMENT = "predict2_anomaly_gen_ddp_2b"
+_DIT_PATH = "checkpoints/nvidia/Cosmos-Predict2-2B-Text2Image/model.pt"
+_VAE_PATH = "checkpoints/nvidia/Cosmos-Predict2-2B-Text2Image/tokenizer/tokenizer.pth"
+_T5_PATH = "checkpoints/google-t5/t5-large"
+_NVDINOV2_PATH = "checkpoints/NVDINOV2/nv_dinov2_classification_model.ckpt"
+
+
+class CosmosAnomalyGenRuntime:
+
+    @classmethod
+    def load(cls, package_dir: str, device: torch.device) -> "CosmosAnomalyGenRuntime":
+        try:
+            import yaml
+            from cosmos_predict2.inference.anomaly_gen.initialize import (
+                initialize_anomaly_diffusion_model,
+            )
+            from imaginaire.utils.config_helper import get_config_module, override
+            from scripts.anomaly_gen.ag_train import set_nested_attributes
+        except ImportError as exc:
+            raise RuntimeError(
+                "Cosmos AnomalyGen requires NVIDIA's paidf-anomalygen stack "
+                "(cosmos_predict2 + imaginaire) on the python path. Run inside "
+                "a container built on the paidf-anomalygen:ga base image."
+            ) from exc
+
+        package_dir = os.path.abspath(package_dir)
+        inference_config = _read_optional_json(
+            os.path.join(package_dir, "inference_config.json")
+        )
+        anomaly_types = _read_anomaly_types(package_dir, inference_config)
+        step = _find_checkpoint_step(package_dir)
+
+        config_module = get_config_module("cosmos_predict2/configs/base/ag_config.py")
+        config = importlib.import_module(config_module).make_config()
+        experiment = inference_config.get("experiment", DEFAULT_EXPERIMENT)
+        config = override(config, [f"experiment={experiment}"])
+
+        ag_config_path = os.path.join(package_dir, "ag_config.yaml")
+        with open(ag_config_path) as fp:
+            ag_config = yaml.safe_load(fp)
+        set_nested_attributes(config, ag_config)
+
+        # The GA configs address every frozen tower relative to the repo
+        # checkout; repoint them into the package so no working directory or
+        # repo-local `checkpoints/` tree is assumed.
+        set_nested_attributes(
+            config,
+            {
+                "model": {
+                    "config": {
+                        "model_manager_config": {
+                            "dit_path": os.path.join(package_dir, _DIT_PATH),
+                        },
+                        "pipe_config": {
+                            "tokenizer": {
+                                "vae_pth": os.path.join(package_dir, _VAE_PATH),
+                            },
+                            "guardrail_config": {
+                                "checkpoint_dir": os.path.join(
+                                    package_dir, "checkpoints"
+                                ),
+                            },
+                        },
+                        "ag_config": {
+                            "t5_model_name": os.path.join(package_dir, _T5_PATH),
+                            "mask_encoder": {
+                                "encoder_config": {
+                                    "init_cfg": {
+                                        "checkpoint": os.path.join(
+                                            package_dir, _NVDINOV2_PATH
+                                        ),
+                                    }
+                                }
+                            },
+                        },
+                    }
+                }
+            },
+        )
+        if getattr(config.model.config, "fsdp_shard_size", 0) != 0:
+            config.model.config.fsdp_shard_size = 0
+
+        if device.type == "cuda":
+            torch.cuda.set_device(device)
+        torch.backends.cudnn.allow_tf32 = True
+        torch.backends.cuda.matmul.allow_tf32 = True
+        model = initialize_anomaly_diffusion_model(config, package_dir, step)
+        return cls(model=model, device=device, anomaly_types=anomaly_types)
+
+    def __init__(self, model, device: torch.device, anomaly_types: List[str]):
+        self._model = model
+        self._device = device
+        self._anomaly_types = anomaly_types
+
+    @property
+    def anomaly_types(self) -> List[str]:
+        return list(self._anomaly_types)
+
+    def generate(
+        self,
+        image: np.ndarray,
+        mask: np.ndarray,
+        anomaly_type: str,
+        guidance: float,
+        num_steps: int,
+        seed: int,
+        num_images: int,
+        crop_and_paste: bool,
+        crop_ratio: Optional[float],
+        poisson_blend: bool,
+    ) -> List[np.ndarray]:
+        from cosmos_predict2.data.anomaly_gen.anomaly_dataset import (
+            AnomalyInpaintDataset,
+        )
+        from cosmos_predict2.inference.anomaly_gen.inference_anomaly_diffusion_utils import (
+            inpaint_image,
+        )
+        from cosmos_predict2.inference.anomaly_gen.inpaint_condition import (
+            AnomalyInpaintCondition,
+        )
+        from imaginaire.utils import misc
+        from PIL import Image
+
+        if self._anomaly_types and anomaly_type not in self._anomaly_types:
+            raise ValueError(
+                f"Unknown anomaly type {anomaly_type!r}; this package was "
+                f"trained on: {', '.join(self._anomaly_types)}"
+            )
+
+        with tempfile.TemporaryDirectory(prefix="anomalygen-") as workdir:
+            image_path = os.path.join(workdir, "image.png")
+            mask_path = os.path.join(workdir, "mask.png")
+            Image.fromarray(image).save(image_path)
+            Image.fromarray(mask).save(mask_path)
+            entry = {
+                "image_filename": image_path,
+                "mask_filename": mask_path,
+                "anomaly_type": anomaly_type,
+                "guidance": guidance,
+                "num_steps": num_steps,
+                "crop_and_paste": crop_and_paste,
+                "num_generated_images": num_images,
+                "poisson_blend": poisson_blend,
+                "iteration_generation_max_instance": 1,
+                "index": 0,
+            }
+            if crop_and_paste and crop_ratio is not None:
+                entry["crop_ratio"] = crop_ratio
+            jsonl_path = os.path.join(workdir, "testcase.jsonl")
+            with open(jsonl_path, "w") as fp:
+                fp.write(json.dumps(entry) + "\n")
+
+            # The dataset applies the same defaulting / mask handling as the
+            # SDG script, so one JSONL entry here behaves exactly like one
+            # line fed to `synthetic_dataset_generation`.
+            dataset = AnomalyInpaintDataset(jsonl_path)
+            batch = dataset._collate_fn([dataset[0]])
+            batch["seed"] = seed
+            condition = AnomalyInpaintCondition(**batch)
+
+            misc.set_random_seed(seed, by_rank=False)
+            with torch.no_grad():
+                inpainting_result, _, _ = inpaint_image(condition, self._model)
+
+        reconstructed = inpainting_result["reconstructed_image"]
+        return [np.asarray(item.convert("RGB")) for item in reconstructed]
+
+
+def _read_optional_json(path: str) -> dict:
+    if not os.path.exists(path):
+        return {}
+    with open(path) as fp:
+        return json.load(fp)
+
+
+def _read_anomaly_types(package_dir: str, inference_config: dict) -> List[str]:
+    class_names_path = os.path.join(package_dir, "class_names.txt")
+    if os.path.exists(class_names_path):
+        with open(class_names_path) as fp:
+            return [line.strip() for line in fp if line.strip()]
+    return list(inference_config.get("anomaly_types", []))
+
+
+def _find_checkpoint_step(package_dir: str) -> int:
+    pattern = os.path.join(package_dir, "checkpoints", "model", "iter_*.pt")
+    candidates = sorted(glob.glob(pattern))
+    if not candidates:
+        raise FileNotFoundError(
+            f"No trained checkpoint found under {pattern}; the package must "
+            "contain the fine-tuned adapter as checkpoints/model/iter_<step>.pt"
+        )
+    match = re.search(r"iter_(\d+)\.pt$", candidates[-1])
+    return int(match.group(1))

--- a/inference_models/development/cosmos3/cosmos_anomalygen_runtime.py
+++ b/inference_models/development/cosmos3/cosmos_anomalygen_runtime.py
@@ -23,6 +23,7 @@ Package layout expected at `load(package_dir)` (all paths package-relative):
     checkpoints/nvidia/Cosmos-Predict2-2B-Text2Image/tokenizer/tokenizer.pth   frozen VAE
     checkpoints/google-t5/t5-large/...          frozen text encoder
     checkpoints/NVDINOV2/nv_dinov2_classification_model.ckpt           frozen mask encoder
+    checkpoints/facebook/dinov2-large/...       correspondence backbone (prefetched at init)
 
 The trained artifact and the frozen base towers share one `checkpoints/` tree
 on purpose: the GA loader reads `<ckpt_dir>/checkpoints/model/iter_*.pt` for
@@ -57,6 +58,7 @@ _DIT_PATH = "checkpoints/nvidia/Cosmos-Predict2-2B-Text2Image/model.pt"
 _VAE_PATH = "checkpoints/nvidia/Cosmos-Predict2-2B-Text2Image/tokenizer/tokenizer.pth"
 _T5_PATH = "checkpoints/google-t5/t5-large"
 _NVDINOV2_PATH = "checkpoints/NVDINOV2/nv_dinov2_classification_model.ckpt"
+_CORRESPONDENCE_PATH = "checkpoints/facebook/dinov2-large"
 
 
 class CosmosAnomalyGenRuntime:
@@ -102,6 +104,12 @@ class CosmosAnomalyGenRuntime:
             {
                 "model": {
                     "config": {
+                        # The GA model __init__ prefetches the correspondence
+                        # backbone unconditionally (early-stop metric), so it
+                        # must resolve inside the package too.
+                        "correspondence_backbone": os.path.join(
+                            package_dir, _CORRESPONDENCE_PATH
+                        ),
                         "model_manager_config": {
                             "dit_path": os.path.join(package_dir, _DIT_PATH),
                         },

--- a/inference_models/development/cosmos3/cosmos_anomalygen_runtime.py
+++ b/inference_models/development/cosmos3/cosmos_anomalygen_runtime.py
@@ -87,7 +87,7 @@ class CosmosAnomalyGenRuntime:
         config_module = get_config_module("cosmos_predict2/configs/base/ag_config.py")
         config = importlib.import_module(config_module).make_config()
         experiment = inference_config.get("experiment", DEFAULT_EXPERIMENT)
-        config = override(config, [f"experiment={experiment}"])
+        config = override(config, ["--", f"experiment={experiment}"])
 
         ag_config_path = os.path.join(package_dir, "ag_config.yaml")
         with open(ag_config_path) as fp:
@@ -134,7 +134,7 @@ class CosmosAnomalyGenRuntime:
         if getattr(config.model.config, "fsdp_shard_size", 0) != 0:
             config.model.config.fsdp_shard_size = 0
 
-        if device.type == "cuda":
+        if device.type == "cuda" and device.index is not None:
             torch.cuda.set_device(device)
         torch.backends.cudnn.allow_tf32 = True
         torch.backends.cuda.matmul.allow_tf32 = True

--- a/inference_models/development/cosmos3/pull_anomalygen_weights.py
+++ b/inference_models/development/cosmos3/pull_anomalygen_weights.py
@@ -1,0 +1,229 @@
+"""Assemble a Cosmos AnomalyGen model package from a paidf-anomalygen checkout.
+
+Sibling of pull_weights.py for the anomalygen tower. The base weights do not
+live in one HF repo - they are the frozen towers that NVIDIA's
+`scripts.download_checkpoints` materializes under the GA repo's `checkpoints/`
+tree - so this tool assembles the package from:
+
+- ``--checkpoints-dir``: a GA ``checkpoints/`` tree holding the frozen towers
+  (Cosmos-Predict2-2B-Text2Image DiT + VAE tokenizer, google-t5/t5-large,
+  NVDINOV2). Optionally also ``nvidia/Cosmos-Guardrail1`` if the package
+  should ship the image content-safety guardrail.
+- ``--run-dir``: a finished training run directory
+  (``.../anomaly_gen/<category>/<run_name>``) holding ``ag_config.yaml`` and
+  ``checkpoints/model/iter_*.pt``; the newest iteration is packaged.
+- ``--runtime-module``: the self-contained runtime file, copied in as
+  ``cosmos_anomalygen_runtime.py`` (see that file for the package layout and
+  load contract).
+
+Files are hardlinked when possible (copy fallback), never overwritten.
+``class_names.txt`` and ``inference_config.json`` are derived from the run's
+``ag_config.yaml`` (anomaly types = the trained ``<category>+<class>`` pairs;
+generation defaults = the production recipe: guidance 1.5, 35 steps,
+crop_ratio 4.0, crop-and-paste on, Poisson off).
+
+Usage:
+    python pull_anomalygen_weights.py \\
+        --checkpoints-dir /workspace/paidf-anomalygen/checkpoints \\
+        --run-dir /workspace/paidf-anomalygen/checkpoints/anomaly_gen/tube/tube_hole_webapp_7a6f33a9 \\
+        --runtime-module cosmos_anomalygen_runtime.py \\
+        --output-dir checkpoints/packages \\
+        [--gcs-dest gs://bucket/prefix] [--dry-run]
+"""
+
+import argparse
+import glob
+import json
+import os
+import shutil
+import subprocess
+import sys
+
+PACKAGE_NAME = "cosmos-anomalygen"
+RUNTIME_MODULE_NAME = "cosmos_anomalygen_runtime.py"
+
+# Frozen base towers, relative to --checkpoints-dir, packaged under
+# checkpoints/<same path>. Guardrail files are optional (see docstring).
+BASE_FILES = [
+    "nvidia/Cosmos-Predict2-2B-Text2Image/model.pt",
+    "nvidia/Cosmos-Predict2-2B-Text2Image/tokenizer/tokenizer.pth",
+    "google-t5/t5-large/config.json",
+    "google-t5/t5-large/model.safetensors",
+    "google-t5/t5-large/spiece.model",
+    "google-t5/t5-large/tokenizer.json",
+    "NVDINOV2/nv_dinov2_classification_model.ckpt",
+]
+OPTIONAL_BASE_PATTERNS = [
+    "nvidia/Cosmos-Guardrail1/*",
+]
+
+INFERENCE_DEFAULTS = {
+    "architecture": "cosmos-anomalygen",
+    "variant": "cosmos-anomalygen-2b",
+    "task_type": "image-generation",
+    "experiment": "predict2_anomaly_gen_ddp_2b",
+    "guidance": 1.5,
+    "num_steps": 35,
+    "crop_ratio": 4.0,
+    "crop_and_paste": True,
+    "poisson_blend": False,
+}
+
+
+def main() -> int:
+    args = _parse_args()
+    package_dir = os.path.join(args.output_dir, PACKAGE_NAME)
+    print(f"Assembling {PACKAGE_NAME} package -> {package_dir}")
+
+    anomaly_types = _read_anomaly_types(args.run_dir)
+    adapter_path = _find_latest_adapter(args.run_dir)
+    print(f"  adapter: {adapter_path}")
+    print(f"  anomaly types: {anomaly_types}")
+
+    base_files = list(BASE_FILES)
+    for pattern in OPTIONAL_BASE_PATTERNS:
+        matches = glob.glob(os.path.join(args.checkpoints_dir, pattern))
+        base_files.extend(
+            os.path.relpath(m, args.checkpoints_dir)
+            for m in matches
+            if os.path.isfile(m)
+        )
+    missing = [
+        rel
+        for rel in BASE_FILES
+        if not os.path.isfile(os.path.join(args.checkpoints_dir, rel))
+    ]
+    if missing:
+        raise SystemExit(
+            f"Missing base weights under {args.checkpoints_dir}: {missing}"
+        )
+
+    plan = [
+        (os.path.join(args.checkpoints_dir, rel), os.path.join("checkpoints", rel))
+        for rel in base_files
+    ]
+    plan.append(
+        (
+            adapter_path,
+            os.path.join("checkpoints", "model", os.path.basename(adapter_path)),
+        )
+    )
+    plan.append((os.path.join(args.run_dir, "ag_config.yaml"), "ag_config.yaml"))
+    plan.append((args.runtime_module, RUNTIME_MODULE_NAME))
+
+    for src, rel in plan:
+        print(f"  {rel}")
+        if not args.dry_run:
+            _materialize(src, os.path.join(package_dir, rel))
+
+    if not args.dry_run:
+        os.makedirs(package_dir, exist_ok=True)
+        with open(os.path.join(package_dir, "class_names.txt"), "w") as fp:
+            fp.write("\n".join(anomaly_types) + "\n")
+        inference_config = dict(INFERENCE_DEFAULTS)
+        inference_config["anomaly_types"] = anomaly_types
+        with open(os.path.join(package_dir, "inference_config.json"), "w") as fp:
+            json.dump(inference_config, fp, indent=2)
+            fp.write("\n")
+
+    if args.gcs_dest:
+        _upload_to_gcs(
+            package_dir=package_dir,
+            gcs_dest=f"{args.gcs_dest.rstrip('/')}/{PACKAGE_NAME}",
+            dry_run=args.dry_run,
+        )
+    return 0
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument(
+        "--checkpoints-dir",
+        required=True,
+        help="A GA checkpoints/ tree holding the frozen base towers.",
+    )
+    parser.add_argument(
+        "--run-dir",
+        required=True,
+        help="Training run dir with ag_config.yaml and checkpoints/model/iter_*.pt.",
+    )
+    parser.add_argument(
+        "--runtime-module",
+        default=os.path.join(os.path.dirname(__file__), RUNTIME_MODULE_NAME),
+        help=f"Python file copied into the package as {RUNTIME_MODULE_NAME}.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="checkpoints/packages",
+        help="Directory receiving the package subdirectory.",
+    )
+    parser.add_argument(
+        "--gcs-dest",
+        default=None,
+        help="gs://bucket/prefix - the package is mirrored to <dest>/cosmos-anomalygen/.",
+    )
+    parser.add_argument("--dry-run", action="store_true")
+    return parser.parse_args()
+
+
+def _read_anomaly_types(run_dir: str) -> list:
+    import yaml
+
+    ag_config_path = os.path.join(run_dir, "ag_config.yaml")
+    with open(ag_config_path) as fp:
+        ag_config = yaml.safe_load(fp)
+    try:
+        pairs = ag_config["dataloader_train"]["dataset"]["anomaly_types"]
+    except (KeyError, TypeError):
+        raise SystemExit(f"{ag_config_path} has no dataloader_train anomaly_types")
+    return [f"{category}+{name}" for category, name in pairs]
+
+
+def _find_latest_adapter(run_dir: str) -> str:
+    candidates = sorted(
+        glob.glob(os.path.join(run_dir, "checkpoints", "model", "iter_*.pt"))
+    )
+    if not candidates:
+        raise SystemExit(f"No iter_*.pt under {run_dir}/checkpoints/model/")
+    return candidates[-1]
+
+
+def _materialize(src: str, dst: str) -> None:
+    os.makedirs(os.path.dirname(dst), exist_ok=True)
+    if os.path.exists(dst):
+        return
+    try:
+        os.link(os.path.realpath(src), dst)
+    except OSError:
+        shutil.copy2(src, dst)
+
+
+def _upload_to_gcs(package_dir: str, gcs_dest: str, dry_run: bool) -> None:
+    tool = shutil.which("gcloud")
+    if tool:
+        cmd = [
+            "gcloud",
+            "storage",
+            "cp",
+            "-r",
+            f"{package_dir.rstrip('/')}/*",
+            gcs_dest + "/",
+        ]
+    elif shutil.which("gsutil"):
+        cmd = [
+            "gsutil",
+            "-m",
+            "cp",
+            "-r",
+            f"{package_dir.rstrip('/')}/*",
+            gcs_dest + "/",
+        ]
+    else:
+        raise SystemExit("Neither gcloud nor gsutil found on PATH for --gcs-dest.")
+    print(f"  upload: {' '.join(cmd)}")
+    if not dry_run:
+        subprocess.run(" ".join(cmd), shell=True, check=True)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/inference_models/development/cosmos3/pull_anomalygen_weights.py
+++ b/inference_models/development/cosmos3/pull_anomalygen_weights.py
@@ -52,6 +52,11 @@ BASE_FILES = [
     "google-t5/t5-large/spiece.model",
     "google-t5/t5-large/tokenizer.json",
     "NVDINOV2/nv_dinov2_classification_model.ckpt",
+    # Correspondence backbone: the GA model's __init__ prefetches it
+    # unconditionally, so loading fails without it in the package.
+    "facebook/dinov2-large/config.json",
+    "facebook/dinov2-large/preprocessor_config.json",
+    "facebook/dinov2-large/model.safetensors",
 ]
 OPTIONAL_BASE_PATTERNS = [
     "nvidia/Cosmos-Guardrail1/*",

--- a/inference_models/docs/changelog.md
+++ b/inference_models/docs/changelog.md
@@ -7,9 +7,15 @@
 - NVIDIA Cosmos AnomalyGen (`cosmos-anomalygen`, new task `image-generation`, backend
   `custom`): mask-conditioned defect inpainting via `generate(image, mask,
   anomaly_type, ...)`, mirroring the upstream SDG generation-entry contract
-  (guidance / num_steps / seed / crop-and-paste) so JSONL-driven pipelines map one
-  entry to one call. Runtime ships inside the model package, like the Cosmos 3 Edge
-  generator.
+  (guidance / num_steps / seed / crop-and-paste / crop_ratio / poisson_blend) so
+  JSONL-driven pipelines map one entry to one call. Defaults follow NVIDIA's
+  production recipe (guidance 1.5, 35 steps, crop ratio 4.0). The runtime ships
+  inside the model package (`cosmos_anomalygen_runtime.py`, reference
+  implementation and packaging tool under `development/cosmos3/`) and drives the
+  GA `paidf-anomalygen` stack, so serving requires a container built on that base
+  image. The `roboflow_core/cosmos_anomalygen@v1` workflow block also reports
+  `visibility` - the mean absolute pixel change inside the placement mask - so
+  callers can filter or regenerate empty generations.
 
 ---
 

--- a/inference_models/docs/changelog.md
+++ b/inference_models/docs/changelog.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+### Added
+
+- NVIDIA Cosmos AnomalyGen (`cosmos-anomalygen`, new task `image-generation`, backend
+  `custom`): mask-conditioned defect inpainting via `generate(image, mask,
+  anomaly_type, ...)`, mirroring the upstream SDG generation-entry contract
+  (guidance / num_steps / seed / crop-and-paste) so JSONL-driven pipelines map one
+  entry to one call. Runtime ships inside the model package, like the Cosmos 3 Edge
+  generator.
+
 ---
 
 ## `0.36.0`

--- a/inference_models/docs/models/cosmos-anomalygen.md
+++ b/inference_models/docs/models/cosmos-anomalygen.md
@@ -1,0 +1,104 @@
+# Cosmos AnomalyGen - Synthetic Defect Generation
+
+Cosmos AnomalyGen (NVIDIA `paidf-anomalygen`) is a generative defect-inpainting model: given a
+clean image, a binary placement mask, and a trained anomaly type, it inpaints a realistic defect
+inside the mask. It is fine-tuned per dataset on a handful of labeled defect images
+(instance-segmentation data) and then used to manufacture synthetic training images.
+
+## Overview
+
+- **Mask-Conditioned Inpainting** - defects appear only where the placement mask says
+- **Few-Shot Fine-Tuning** - a trained checkpoint is a ~14 MB adapter + per-class anomaly
+  embeddings on top of a frozen Cosmos-Predict2-2B-Text2Image base
+- **SDG-Compatible Parameters** - `guidance`, `num_steps`, `seed`, `crop_and_paste`,
+  `crop_ratio`, `poisson_blend` mirror NVIDIA's `synthetic_dataset_generation` JSONL contract
+  one entry to one call
+
+!!! info "License & Attribution"
+    **License**: NVIDIA OSPA / Apache-2.0 components - licensing review pending<br>
+    **Source**: [NVIDIA/paidf-anomalygen](https://github.com/NVIDIA/paidf-anomalygen)<br>
+    **Base model**: [Cosmos-Predict2-2B-Text2Image](https://huggingface.co/nvidia/Cosmos-Predict2-2B-Text2Image)
+
+!!! note "Runtime Requirements"
+    The model runs through NVIDIA's GA stack (`cosmos_predict2` + `imaginaire`), which is **not**
+    installable from PyPI. Serve it inside a container built on the `paidf-anomalygen:ga` base
+    image with `inference` installed on top. The runtime module ships inside the weight package
+    (`cosmos_anomalygen_runtime.py`), so loading it requires either a package marked as trusted or
+    `ALLOW_INFERENCE_MODELS_UNTRUSTED_PACKAGES=True`. Needs a GPU with >=16 GB VRAM
+    (~14 GB in use during generation, ~10 s/image on an L4).
+
+## Model IDs
+
+Checkpoints are fine-tuned per dataset; there is no useful zero-shot checkpoint. Each trained
+model is registered as architecture `cosmos-anomalygen` (task `image-generation`, backend
+`custom`), variant `cosmos-anomalygen-2b`.
+
+## Supported Backends
+
+| Backend | Extras Required |
+|---------|----------------|
+| `custom` | none installable - requires the `paidf-anomalygen:ga` container environment |
+
+## Roboflow Platform Compatibility
+
+| Feature | Supported |
+|---------|-----------|
+| **Training** | ✅ Fine-tune on instance-segmentation projects (COCO polygon export) |
+| **Upload Weights** | ❌ Not supported |
+| **Serverless API (v2)** | ❌ Not available |
+| **Workflows** | ✅ `roboflow_core/cosmos_anomalygen@v1` block (local GPU execution only) |
+| **Edge Deployment (Jetson)** | ❌ Not supported |
+| **Self-Hosting** | ⚠️ GA-based container only (see Runtime Requirements) |
+
+## Usage Examples
+
+### Generate a synthetic defect
+
+```python
+import cv2
+import numpy as np
+from inference_models import AutoModel
+
+model = AutoModel.from_pretrained(
+    "path/to/cosmos-anomalygen-package",  # or a registered model id
+    api_key="your_roboflow_api_key",
+)
+
+image = cv2.imread("clean_part.png")
+mask = np.zeros(image.shape[:2], dtype=np.uint8)
+mask[200:320, 180:300] = 255  # where the defect should appear
+
+generated = model.generate(
+    image=image,
+    mask=mask,
+    anomaly_type="tube+hole",  # a trained "<category>+<class>" pair
+    guidance=1.5,
+    num_steps=35,
+    seed=0,
+)
+cv2.imwrite("synthetic_defect.png", generated[0])
+```
+
+### Filtering empty generations
+
+The model sometimes returns the canvas unchanged (more often at low guidance). Measure
+visibility - the mean absolute gray-level change inside the mask - and regenerate with a new
+seed when it is low; `>=15` separated real defects from empty generations in practice:
+
+```python
+gray_before = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY).astype(np.float32)
+gray_after = cv2.cvtColor(generated[0], cv2.COLOR_BGR2GRAY).astype(np.float32)
+visibility = np.abs(gray_after - gray_before)[mask >= 128].mean()
+```
+
+The workflow block reports this as its `visibility` output.
+
+### Practical notes
+
+- `guidance` is an extrapolation scale (`x0 = cond + g*(cond - uncond)`); the production default
+  `1.5` corresponds to a standard classifier-free-guidance scale of `2.5`.
+- `crop_ratio` sizes the 512 px generation window relative to the mask's bounding box. With the
+  default `4.0`, defects larger than ~1/4 of the frame make the crop exceed the frame and the
+  whole image gets resampled through the VAE - lower the ratio for large defects.
+- The generated defect can bleed up to one 8 px latent cell past the input mask. If you
+  auto-annotate generated images, derive labels from the changed region, not the input polygon.

--- a/inference_models/docs/models/index.md
+++ b/inference_models/docs/models/index.md
@@ -14,6 +14,7 @@ The `inference-models` library supports a wide range of computer vision models a
 - **Interactive Segmentation**: Interactive and automatic segmentation
 - **Vision-Language Models**: Multi-modal understanding and generation
 - **Depth Estimation**: Predict depth maps from images
+- **Image Generation**: Generate synthetic training images
 - **Specialized**: Gaze detection, face detection, and more
 
 ## Model Catalog
@@ -120,6 +121,12 @@ The `inference-models` library supports a wide range of computer vision models a
 | [YOLO26 Depth](yolo26-depth-estimation.md) | `onnx`, `torch-script`, `trt` | AGPL-3.0 | ✅ | ✅ | ❌ |
 | [Depth Anything V2](depth-anything-v2.md) | `torch` | Apache 2.0 | N/A | 🔑 | ❌ |
 | [Depth Anything V3](depth-anything-v3.md) | `torch` | Apache 2.0 | N/A | 🔑 | ❌ |
+
+### Image Generation
+
+| Model | Backends | License | Commercial License in RF Plan | Pre-trained Weights | Trainable at RF |
+|-------|----------|---------|-------------------------------|---------------------|-----------------|
+| [Cosmos AnomalyGen](cosmos-anomalygen.md) | `custom` | NVIDIA (review pending) | N/A | ❌ | ✅ |
 
 ### Specialized Models
 

--- a/inference_models/inference_models/models/auto_loaders/models_registry.py
+++ b/inference_models/inference_models/models/auto_loaders/models_registry.py
@@ -24,6 +24,7 @@ GAZE_DETECTION_TASK = "gaze-detection"
 OPEN_VOCABULARY_OBJECT_DETECTION_TASK = "open-vocabulary-object-detection"
 INTERACTIVE_INSTANCE_SEGMENTATION_TASK = "interactive-instance-segmentation"
 WORLD_MODEL_TASK = "world-model"
+IMAGE_GENERATION_TASK = "image-generation"
 
 
 @dataclass(frozen=True)
@@ -314,6 +315,10 @@ REGISTERED_MODELS: Dict[
     ("cosmos-3-edge-world", WORLD_MODEL_TASK, BackendType.CUSTOM): LazyClass(
         module_name="inference_models.models.cosmos3.cosmos3_world",
         class_name="Cosmos3EdgeWorldModel",
+    ),
+    ("cosmos-anomalygen", IMAGE_GENERATION_TASK, BackendType.CUSTOM): LazyClass(
+        module_name="inference_models.models.cosmos3.cosmos_anomalygen",
+        class_name="CosmosAnomalyGen",
     ),
     ("mage-vl", VLM_TASK, BackendType.HF): LazyClass(
         module_name="inference_models.models.mage_vl.mage_vl_hf",

--- a/inference_models/inference_models/models/cosmos3/cosmos_anomalygen.py
+++ b/inference_models/inference_models/models/cosmos3/cosmos_anomalygen.py
@@ -1,0 +1,120 @@
+from threading import Lock
+from typing import List, Optional, Union
+
+import numpy as np
+import torch
+
+from inference_models.configuration import DEFAULT_DEVICE
+from inference_models.entities import ColorFormat
+from inference_models.errors import ModelInputError
+from inference_models.models.cosmos3.runtime_loading import load_runtime_from_package
+
+RUNTIME_MODULE_FILE = "cosmos_anomalygen_runtime.py"
+RUNTIME_CLASS_NAME = "CosmosAnomalyGenRuntime"
+
+DEFAULT_GUIDANCE = 7.0
+DEFAULT_NUM_STEPS = 35
+
+
+class CosmosAnomalyGen:
+    """NVIDIA Cosmos AnomalyGen - mask-conditioned defect inpainting.
+
+    Given a clean image, a binary placement mask, and an anomaly type, the
+    model inpaints a realistic defect into the mask's region. Fine-tuned
+    per-defect checkpoints load through the same weight-package path as the
+    base model. Parameters mirror the upstream SDG generation-entry contract
+    (guidance / num_steps / crop-and-paste), so callers currently driving
+    NVIDIA's `synthetic_dataset_generation` script via JSONL can map each
+    entry onto one `generate()` call.
+    """
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        model_name_or_path: str,
+        device: torch.device = DEFAULT_DEVICE,
+        **kwargs,
+    ) -> "CosmosAnomalyGen":
+        runtime_class = load_runtime_from_package(
+            model_name_or_path=model_name_or_path,
+            runtime_module_file=RUNTIME_MODULE_FILE,
+            runtime_class_name=RUNTIME_CLASS_NAME,
+        )
+        runtime = runtime_class.load(model_name_or_path, device=device)
+        return cls(runtime=runtime, device=device)
+
+    def __init__(self, runtime, device: torch.device):
+        self._runtime = runtime
+        self._device = device
+        self._lock = Lock()
+
+    def generate(
+        self,
+        image: np.ndarray,
+        mask: np.ndarray,
+        anomaly_type: str,
+        guidance: float = DEFAULT_GUIDANCE,
+        num_steps: int = DEFAULT_NUM_STEPS,
+        seed: int = 0,
+        num_images: int = 1,
+        crop_and_paste: bool = True,
+        crop_ratio: float = 2.0,
+        poisson_blend: bool = False,
+        input_color_format: ColorFormat = None,
+        **kwargs,
+    ) -> List[np.ndarray]:
+        """Inpaint `anomaly_type` into the white region of `mask` on `image`.
+
+        Returns `num_images` generated BGR images at the input resolution.
+        """
+        if not isinstance(image, np.ndarray) or image.ndim != 3:
+            raise ModelInputError(
+                message="generate() expects a single HxWx3 numpy image.",
+                help_url="https://inference-models.roboflow.com/errors/models-input/#modelinputerror",
+            )
+        binary_mask = _normalize_mask(mask=mask, image=image)
+        if input_color_format != "rgb":
+            image = image[:, :, ::-1]
+        image = np.ascontiguousarray(image)
+        with self._lock:
+            generated = self._runtime.generate(
+                image=image,
+                mask=binary_mask,
+                anomaly_type=anomaly_type,
+                guidance=guidance,
+                num_steps=num_steps,
+                seed=seed,
+                num_images=num_images,
+                crop_and_paste=crop_and_paste,
+                crop_ratio=crop_ratio,
+                poisson_blend=poisson_blend,
+            )
+        return [
+            np.ascontiguousarray(np.asarray(result)[:, :, ::-1]) for result in generated
+        ]
+
+
+def _normalize_mask(mask: Union[np.ndarray, None], image: np.ndarray) -> np.ndarray:
+    if not isinstance(mask, np.ndarray) or mask.ndim not in (2, 3):
+        raise ModelInputError(
+            message="generate() expects a HxW binary placement mask.",
+            help_url="https://inference-models.roboflow.com/errors/models-input/#modelinputerror",
+        )
+    if mask.ndim == 3:
+        mask = mask[:, :, 0]
+    if mask.shape[:2] != image.shape[:2]:
+        raise ModelInputError(
+            message=f"Mask resolution {mask.shape[:2]} does not match image "
+            f"resolution {image.shape[:2]}.",
+            help_url="https://inference-models.roboflow.com/errors/models-input/#modelinputerror",
+        )
+    binary_mask = (mask.astype(np.uint8) >= 128) if mask.dtype == np.uint8 else (
+        mask.astype(bool)
+    )
+    if not binary_mask.any():
+        raise ModelInputError(
+            message="Placement mask is empty - draw or place at least one "
+            "defect region before generating.",
+            help_url="https://inference-models.roboflow.com/errors/models-input/#modelinputerror",
+        )
+    return binary_mask.astype(np.uint8) * 255

--- a/inference_models/inference_models/models/cosmos3/cosmos_anomalygen.py
+++ b/inference_models/inference_models/models/cosmos3/cosmos_anomalygen.py
@@ -12,8 +12,12 @@ from inference_models.models.cosmos3.runtime_loading import load_runtime_from_pa
 RUNTIME_MODULE_FILE = "cosmos_anomalygen_runtime.py"
 RUNTIME_CLASS_NAME = "CosmosAnomalyGenRuntime"
 
-DEFAULT_GUIDANCE = 7.0
+# NVIDIA's production recipe: guidance 1.5 (an extrapolation scale; equals a
+# standard classifier-free-guidance scale of 2.5), 35 steps, crop window 4x
+# the mask bbox, crop-and-paste on, Poisson blend off.
+DEFAULT_GUIDANCE = 1.5
 DEFAULT_NUM_STEPS = 35
+DEFAULT_CROP_RATIO = 4.0
 
 
 class CosmosAnomalyGen:
@@ -58,7 +62,7 @@ class CosmosAnomalyGen:
         seed: int = 0,
         num_images: int = 1,
         crop_and_paste: bool = True,
-        crop_ratio: float = 2.0,
+        crop_ratio: float = DEFAULT_CROP_RATIO,
         poisson_blend: bool = False,
         input_color_format: ColorFormat = None,
         **kwargs,

--- a/inference_models/mkdocs.yml
+++ b/inference_models/mkdocs.yml
@@ -104,6 +104,8 @@ nav:
           - Depth Anything V3: models/depth-anything-v3.md
       - Gaze Detection:
           - L2CS-Net: models/l2cs.md
+      - Image Generation:
+          - Cosmos AnomalyGen: models/cosmos-anomalygen.md
   - How-To:
       - Understand Core Concepts: how-to/understand-core-concepts.md
       - Choose the Right Backend: how-to/choose-backend.md

--- a/inference_models/tests/integration_tests/models/test_cosmos_anomalygen_predictions.py
+++ b/inference_models/tests/integration_tests/models/test_cosmos_anomalygen_predictions.py
@@ -1,0 +1,60 @@
+"""Integration test for Cosmos AnomalyGen on real weights.
+
+Loads from a local package directory (the layout produced by
+`development/cosmos3/pull_anomalygen_weights.py`) pointed to by an env var, so
+it can run before the package is published to the weights provider:
+
+    COSMOS_ANOMALYGEN_PACKAGE_DIR=checkpoints/packages/cosmos-anomalygen \
+    COSMOS_ANOMALYGEN_ANOMALY_TYPE=tube+hole \
+    python -m pytest tests/integration_tests/models/test_cosmos_anomalygen_predictions.py -m slow
+
+The anomaly type must be one the package was trained on (first line of the
+package's class_names.txt when the env var is unset). Requires the NVIDIA
+paidf-anomalygen stack on the python path (a container built on the
+`paidf-anomalygen:ga` base image) and a >=16GB GPU.
+
+Once the package is registered, a conftest fixture downloading the published
+zip should replace the env-var indirection (matching the other model suites).
+"""
+
+import os
+
+import numpy as np
+import pytest
+import torch
+
+PACKAGE_DIR = os.environ.get("COSMOS_ANOMALYGEN_PACKAGE_DIR")
+CUDA_AVAILABLE = torch.cuda.is_available()
+
+
+def _first_trained_anomaly_type(package_dir: str) -> str:
+    configured = os.environ.get("COSMOS_ANOMALYGEN_ANOMALY_TYPE")
+    if configured:
+        return configured
+    with open(os.path.join(package_dir, "class_names.txt")) as fp:
+        return next(line.strip() for line in fp if line.strip())
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(
+    not PACKAGE_DIR or not CUDA_AVAILABLE,
+    reason="COSMOS_ANOMALYGEN_PACKAGE_DIR not set or CUDA unavailable",
+)
+def test_cosmos_anomalygen_inpaints_a_defect() -> None:
+    from inference_models.models.cosmos3.cosmos_anomalygen import CosmosAnomalyGen
+
+    model = CosmosAnomalyGen.from_pretrained(PACKAGE_DIR, device=torch.device("cuda"))
+    image = np.full((512, 512, 3), 180, dtype=np.uint8)
+    mask = np.zeros((512, 512), dtype=np.uint8)
+    mask[200:312, 200:312] = 255
+
+    generated = model.generate(
+        image=image,
+        mask=mask,
+        anomaly_type=_first_trained_anomaly_type(PACKAGE_DIR),
+        seed=0,
+    )
+
+    assert len(generated) == 1
+    assert generated[0].shape == image.shape
+    assert generated[0].dtype == np.uint8

--- a/inference_models/tests/unit_tests/models/test_cosmos_anomalygen.py
+++ b/inference_models/tests/unit_tests/models/test_cosmos_anomalygen.py
@@ -1,0 +1,96 @@
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+import torch
+
+from inference_models.errors import ModelInputError
+from inference_models.models.cosmos3.cosmos_anomalygen import CosmosAnomalyGen
+
+
+def _model() -> CosmosAnomalyGen:
+    return CosmosAnomalyGen(runtime=MagicMock(), device=torch.device("cpu"))
+
+
+def _image() -> np.ndarray:
+    return np.full((8, 8, 3), 128, dtype=np.uint8)
+
+
+def _mask() -> np.ndarray:
+    mask = np.zeros((8, 8), dtype=np.uint8)
+    mask[2:6, 2:6] = 255
+    return mask
+
+
+def test_generate_passes_sdg_parameters_to_runtime() -> None:
+    model = _model()
+    model._runtime.generate.return_value = [np.zeros((8, 8, 3), dtype=np.uint8)]
+
+    result = model.generate(
+        image=_image(),
+        mask=_mask(),
+        anomaly_type="wood+crack",
+        guidance=5.5,
+        num_steps=20,
+        seed=7,
+        num_images=1,
+    )
+
+    kwargs = model._runtime.generate.call_args.kwargs
+    assert kwargs["anomaly_type"] == "wood+crack"
+    assert kwargs["guidance"] == 5.5
+    assert kwargs["num_steps"] == 20
+    assert kwargs["seed"] == 7
+    assert kwargs["crop_and_paste"] is True
+    assert len(result) == 1
+
+
+def test_generate_binarizes_uint8_mask_with_128_threshold() -> None:
+    model = _model()
+    model._runtime.generate.return_value = []
+    mask = np.zeros((8, 8), dtype=np.uint8)
+    mask[0, 0] = 127  # below threshold
+    mask[1, 1] = 200  # above threshold
+
+    model.generate(image=_image(), mask=mask, anomaly_type="wood+crack")
+
+    sent = model._runtime.generate.call_args.kwargs["mask"]
+    assert sent[0, 0] == 0
+    assert sent[1, 1] == 255
+
+
+def test_generate_rejects_empty_mask() -> None:
+    model = _model()
+
+    with pytest.raises(ModelInputError):
+        model.generate(
+            image=_image(),
+            mask=np.zeros((8, 8), dtype=np.uint8),
+            anomaly_type="wood+crack",
+        )
+
+
+def test_generate_rejects_mismatched_mask_resolution() -> None:
+    model = _model()
+
+    with pytest.raises(ModelInputError):
+        model.generate(
+            image=_image(),
+            mask=np.full((4, 4), 255, dtype=np.uint8),
+            anomaly_type="wood+crack",
+        )
+
+
+def test_generate_converts_colors_both_ways() -> None:
+    model = _model()
+    rgb_out = np.zeros((8, 8, 3), dtype=np.uint8)
+    rgb_out[..., 0] = 255  # red in RGB
+    model._runtime.generate.return_value = [rgb_out]
+    bgr_in = np.zeros((8, 8, 3), dtype=np.uint8)
+    bgr_in[..., 0] = 255  # blue in BGR
+
+    result = model.generate(image=bgr_in, mask=_mask(), anomaly_type="wood+crack")
+
+    sent = model._runtime.generate.call_args.kwargs["image"]
+    assert sent[0, 0].tolist() == [0, 0, 255]  # runtime sees RGB
+    assert result[0][0, 0].tolist() == [0, 0, 255]  # caller gets BGR

--- a/inference_models/tests/unit_tests/models/test_cosmos_anomalygen.py
+++ b/inference_models/tests/unit_tests/models/test_cosmos_anomalygen.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 import torch
 
-from inference_models.errors import ModelInputError
+from inference_models.errors import ModelInputError, ModelRuntimeError
 from inference_models.models.cosmos3.cosmos_anomalygen import CosmosAnomalyGen
 
 
@@ -43,6 +43,25 @@ def test_generate_passes_sdg_parameters_to_runtime() -> None:
     assert kwargs["seed"] == 7
     assert kwargs["crop_and_paste"] is True
     assert len(result) == 1
+
+
+def test_generate_defaults_match_the_production_recipe() -> None:
+    model = _model()
+    model._runtime.generate.return_value = []
+
+    model.generate(image=_image(), mask=_mask(), anomaly_type="wood+crack")
+
+    kwargs = model._runtime.generate.call_args.kwargs
+    assert kwargs["guidance"] == 1.5
+    assert kwargs["num_steps"] == 35
+    assert kwargs["crop_ratio"] == 4.0
+    assert kwargs["crop_and_paste"] is True
+    assert kwargs["poisson_blend"] is False
+
+
+def test_from_pretrained_rejects_package_without_runtime_module(tmp_path) -> None:
+    with pytest.raises(ModelRuntimeError):
+        CosmosAnomalyGen.from_pretrained(str(tmp_path), device=torch.device("cpu"))
 
 
 def test_generate_binarizes_uint8_mask_with_128_threshold() -> None:

--- a/tests/workflows/unit_tests/core_steps/models/foundation/test_cosmos_anomalygen.py
+++ b/tests/workflows/unit_tests/core_steps/models/foundation/test_cosmos_anomalygen.py
@@ -1,0 +1,89 @@
+"""Unit tests for the Cosmos AnomalyGen v1 block."""
+
+import numpy as np
+import pytest
+import supervision as sv
+from pydantic import ValidationError
+
+from inference.core.workflows.core_steps.common.entities import StepExecutionMode
+from inference.core.workflows.core_steps.models.foundation.cosmos_anomalygen.v1 import (
+    BlockManifest,
+    CosmosAnomalyGenBlockV1,
+    rasterize_placement_mask,
+)
+
+BASE = {
+    "type": "roboflow_core/cosmos_anomalygen@v1",
+    "name": "my_anomalygen_step",
+    "image": "$inputs.image",
+    "segmentation_mask": "$steps.model.predictions",
+    "anomaly_type": "wood+crack",
+}
+
+
+def test_manifest_parses_with_defaults():
+    result = BlockManifest.model_validate(BASE)
+    assert result.anomaly_type == "wood+crack"
+    assert result.model_version == "cosmos-anomalygen"
+    assert result.guidance == 7.0
+    assert result.num_steps == 35
+    assert result.seed == 0
+
+
+def test_manifest_accepts_selectors():
+    result = BlockManifest.model_validate(
+        {
+            **BASE,
+            "anomaly_type": "$inputs.anomaly_type",
+            "model_version": "$inputs.model_version",
+            "guidance": "$inputs.guidance",
+        }
+    )
+    assert result.anomaly_type == "$inputs.anomaly_type"
+    assert result.model_version == "$inputs.model_version"
+    assert result.guidance == "$inputs.guidance"
+
+
+def test_manifest_requires_segmentation_mask():
+    payload = dict(BASE)
+    del payload["segmentation_mask"]
+    with pytest.raises(ValidationError):
+        BlockManifest.model_validate(payload)
+
+
+def test_manifest_declares_image_output():
+    outputs = BlockManifest.describe_outputs()
+    assert [o.name for o in outputs] == ["image"]
+
+
+def test_remote_execution_raises():
+    block = CosmosAnomalyGenBlockV1(
+        api_key=None, step_execution_mode=StepExecutionMode.REMOTE
+    )
+    with pytest.raises(NotImplementedError):
+        block.run(
+            image=None,
+            segmentation_mask=None,
+            anomaly_type="wood+crack",
+            model_version="cosmos-anomalygen",
+            guidance=7.0,
+            num_steps=35,
+            seed=0,
+        )
+
+
+def test_rasterize_placement_mask_marks_masked_region_white():
+    image = np.zeros((10, 10, 3), dtype=np.uint8)
+    mask = np.zeros((1, 10, 10), dtype=bool)
+    mask[0, 2:6, 2:6] = True
+    detections = sv.Detections(
+        xyxy=np.array([[2.0, 2.0, 6.0, 6.0]]),
+        mask=mask,
+        class_id=np.array([0]),
+    )
+
+    result = rasterize_placement_mask(image=image, segmentation_mask=detections)
+
+    assert result.shape == (10, 10)
+    assert result[3, 3] == 255
+    assert result[0, 0] == 0

--- a/tests/workflows/unit_tests/core_steps/models/foundation/test_cosmos_anomalygen.py
+++ b/tests/workflows/unit_tests/core_steps/models/foundation/test_cosmos_anomalygen.py
@@ -9,6 +9,7 @@ from inference.core.workflows.core_steps.common.entities import StepExecutionMod
 from inference.core.workflows.core_steps.models.foundation.cosmos_anomalygen.v1 import (
     BlockManifest,
     CosmosAnomalyGenBlockV1,
+    compute_visibility,
     rasterize_placement_mask,
 )
 
@@ -21,13 +22,15 @@ BASE = {
 }
 
 
-def test_manifest_parses_with_defaults():
+def test_manifest_parses_with_production_recipe_defaults():
     result = BlockManifest.model_validate(BASE)
     assert result.anomaly_type == "wood+crack"
     assert result.model_version == "cosmos-anomalygen"
-    assert result.guidance == 7.0
+    assert result.guidance == 1.5
     assert result.num_steps == 35
     assert result.seed == 0
+    assert result.crop_ratio == 4.0
+    assert result.poisson_blend is False
 
 
 def test_manifest_accepts_selectors():
@@ -37,11 +40,13 @@ def test_manifest_accepts_selectors():
             "anomaly_type": "$inputs.anomaly_type",
             "model_version": "$inputs.model_version",
             "guidance": "$inputs.guidance",
+            "crop_ratio": "$inputs.crop_ratio",
         }
     )
     assert result.anomaly_type == "$inputs.anomaly_type"
     assert result.model_version == "$inputs.model_version"
     assert result.guidance == "$inputs.guidance"
+    assert result.crop_ratio == "$inputs.crop_ratio"
 
 
 def test_manifest_requires_segmentation_mask():
@@ -51,24 +56,15 @@ def test_manifest_requires_segmentation_mask():
         BlockManifest.model_validate(payload)
 
 
-def test_manifest_declares_image_output():
+def test_manifest_declares_image_and_visibility_outputs():
     outputs = BlockManifest.describe_outputs()
-    assert [o.name for o in outputs] == ["image"]
+    assert [o.name for o in outputs] == ["image", "visibility"]
 
 
-def test_remote_execution_raises():
-    block = CosmosAnomalyGenBlockV1(
-        api_key=None, step_execution_mode=StepExecutionMode.REMOTE
-    )
+def test_remote_execution_raises_at_init():
     with pytest.raises(NotImplementedError):
-        block.run(
-            image=None,
-            segmentation_mask=None,
-            anomaly_type="wood+crack",
-            model_version="cosmos-anomalygen",
-            guidance=7.0,
-            num_steps=35,
-            seed=0,
+        CosmosAnomalyGenBlockV1(
+            api_key=None, step_execution_mode=StepExecutionMode.REMOTE
         )
 
 
@@ -87,3 +83,28 @@ def test_rasterize_placement_mask_marks_masked_region_white():
     assert result.shape == (10, 10)
     assert result[3, 3] == 255
     assert result[0, 0] == 0
+
+
+def test_compute_visibility_measures_change_inside_mask_only():
+    original = np.zeros((10, 10, 3), dtype=np.uint8)
+    generated = original.copy()
+    generated[2:6, 2:6] = 100  # change inside the mask
+    generated[8, 8] = 255  # change outside the mask - must not count
+    mask = np.zeros((10, 10), dtype=np.uint8)
+    mask[2:6, 2:6] = 255
+
+    visibility = compute_visibility(original=original, generated=generated, mask=mask)
+
+    assert visibility == pytest.approx(100.0)
+
+
+def test_compute_visibility_is_zero_for_unchanged_canvas():
+    original = np.full((10, 10, 3), 50, dtype=np.uint8)
+    mask = np.zeros((10, 10), dtype=np.uint8)
+    mask[2:6, 2:6] = 255
+
+    visibility = compute_visibility(
+        original=original, generated=original.copy(), mask=mask
+    )
+
+    assert visibility == 0.0


### PR DESCRIPTION
Successor to #2676 (closed when its base stack #2675 squash-merged); the branch was rebuilt on latest `main` as the anomalygen delta only.

## ⚠️ Human-blocked open items (called out per the integration plan)

1. **Task-type ratification**: `"image-generation"` for `cosmos-anomalygen` must be what `/models/v1/external/stat` returns — needs the models-service (GOAT) enum addition; confirm with Inference Core. (On the platform, `image-generation` is also a billing-meter name in a different namespace — do not reuse it as a meter.)
2. **Trust marking**: the package ships executable Python (`cosmos_anomalygen_runtime.py`); it must be registered `trusted_source` server-side, or callers need `ALLOW_INFERENCE_MODELS_UNTRUSTED_PACKAGES=True`.
3. **NVIDIA license review** for paidf-anomalygen-derived packaging (docs page marks it "review pending").
4. **Packaging/registration** (surface 2) is Core-team tooling; `development/cosmos3/pull_anomalygen_weights.py` produces the package + `--gcs-dest` mirror.

## What this adds

- **`cosmos_anomalygen_runtime.py`** (reference, `inference_models/development/cosmos3/`) — the self-contained runtime that ships inside the package. Builds the GA config (`predict2_anomaly_gen_ddp_2b` + the run's frozen `ag_config.yaml`), repoints every frozen-tower path into the package (DiT, VAE tokenizer, t5-large, NV-DINOv2, guardrail dir), and reuses NVIDIA's SDG entry path 1:1 for generation (temp one-line JSONL → `AnomalyInpaintDataset` → `inpaint_image`), so preprocessing/RePaint/crop-paste stay byte-compatible with `synthetic_dataset_generation`. Requires the `paidf-anomalygen:ga` container environment (lazy imports; clear error otherwise).
- **`pull_anomalygen_weights.py`** — assembles the flat package (base towers + trained adapter + runtime + `class_names.txt` + `inference_config.json`) with hardlinks, optional `--gcs-dest`.
- **Production-recipe defaults**: guidance 1.5 (≈ CFG 2.5), 35 steps, `crop_ratio` 4.0, crop-and-paste on, Poisson off — model class + workflow block.
- **Workflow block**: exposes `crop_ratio` / `poisson_blend`; new `visibility` output (mean abs pixel change inside the placement mask, 0–255) so callers can filter/regenerate empty generations (≥15 worked in the Corning CV study); REMOTE now rejected at construction (compile time); `discover_dependent_resources()` declared.
- **Tests**: defaults + missing-runtime-module coverage; block manifest/visibility tests; env-gated integration test (`COSMOS_ANOMALYGEN_PACKAGE_DIR`).
- **Docs**: `inference_models/docs/models/cosmos-anomalygen.md` + nav ("Image Generation" group) + index rows; changelog.

## Test evidence

- **E2E on real weights** (L4 23 GB, GA container, real Corning `tube+hole` checkpoint @ iter 35k): package assembled by the tool → runtime `load()` 27 s → `generate()` 10.1 s/image at 35 steps, output at native input resolution, visibility 49.3 (≥15 threshold), PSNR 12.8.
- `inference_models` unit suite: 1552 passed (4 pre-existing `runtime_introspection` failures reproduce on pristine `main` in the same env).
- Workflows unit suite: 6103 passed, 1 pre-existing-convention failure (`test_dependent_resources`) fixed by this PR.
- `black`/`isort`/`flake8` (CI-pinned versions) clean on `check_dirs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015qKkor5AsgasrsFz3j7TA2