### PR TITLE
Add RF-DETR implementation selection proof metadata

### DIFF
--- a/inference_models/docs/contributors/inference-path-optimization-architectures/rfdetr.md
+++ b/inference_models/docs/contributors/inference-path-optimization-architectures/rfdetr.md
@@ -209,3 +209,19 @@ TensorRT forward does not need to know which preprocessor produced its input.
   execution failures still propagate.
 - Target-device profiling and output-snapshot parity checks remain required before an
   optimized choice is promoted for automatic selection.
+
+## Runtime selection observability
+
+`optimization_runtime_metadata` is the production-facing source of truth for the
+resolved execution path. It exposes the canonical `InferenceExecutionPlan`, model-time
+selection resolutions, the latest request-time resolution for each stage, and bounded
+implementation metadata. Selection snapshots are retained as immutable objects and
+serialized only when the property is read; repeated requests do not append history or
+re-store an unchanged thread-local selection.
+
+Profiling uses the same `InferenceExecutionPlan` as production. Its boundary validator
+requires explicit IDs for all five stages, rejects `auto`, and requires both fallback
+flags to be false. An incompatible implementation or recoverable stage failure therefore
+fails the profiling workload instead of silently measuring a fallback. A future
+production log exporter should read this property after initialization and when a plan
+or fallback changes, rather than logging every request.

--- a/inference_models/docs/how-to/environment-variables.md
+++ b/inference_models/docs/how-to/environment-variables.md
@@ -699,7 +699,7 @@ plan = RFDetrExecutionPlan(
 model = AutoModel.from_pretrained(
     "rfdetr-small",
     backend="trt",
-    rfdetr_execution_plan=plan,
+    execution_plan=plan,
 )
 ```
 
@@ -710,7 +710,7 @@ independent `forward()` call without relying on model-owned readiness state:
 model = AutoModel.from_pretrained(
     "rfdetr-small",
     backend="trt",
-    rfdetr_execution_plan=plan,
+    execution_plan=plan,
 )
 preprocessed, metadata = model.pre_process(image)
 raw_predictions = model.forward(preprocessed)

--- a/inference_models/inference_models/models/optimization/execution_plan.py
+++ b/inference_models/inference_models/models/optimization/execution_plan.py
@@ -1,9 +1,24 @@
 """Reusable composed inference execution-plan representation."""
 
+import re
 from dataclasses import dataclass
-from typing import Any, Dict
+from typing import Any, Dict, Mapping
 
-from inference_models.models.optimization.ids import BASE_IMPLEMENTATION_ID
+from inference_models.models.optimization.ids import (
+    AUTO_IMPLEMENTATION_ID,
+    BASE_IMPLEMENTATION_ID,
+)
+
+_IMPLEMENTATION_ID = re.compile(r"^[a-z0-9][a-z0-9._-]{0,95}$")
+_SERIALIZED_FIELDS = {
+    "preprocessor",
+    "buffer_strategy",
+    "scheduler",
+    "postprocessor",
+    "engine_plugin",
+    "allow_compatibility_fallback",
+    "allow_runtime_failure_fallback",
+}
 
 
 @dataclass(frozen=True)
@@ -39,3 +54,80 @@ class InferenceExecutionPlan:
         }
 
         return serialized
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> "InferenceExecutionPlan":
+        """Parse the canonical representation emitted by :meth:`to_dict`.
+
+        Args:
+            value: Serialized stage selections and fallback policy.
+
+        Returns:
+            Parsed immutable execution plan.
+
+        Raises:
+            ValueError: If fields, implementation IDs, or fallback values are invalid.
+        """
+        if not isinstance(value, Mapping):
+            raise ValueError("Execution plan must be an object.")
+
+        if set(value) != _SERIALIZED_FIELDS:
+            raise ValueError(
+                "Execution plan must contain exactly: "
+                f"{sorted(_SERIALIZED_FIELDS)!r}."
+            )
+        implementation_fields = {
+            "preprocessor": "preprocessor_id",
+            "buffer_strategy": "buffer_strategy_id",
+            "scheduler": "scheduler_id",
+            "postprocessor": "postprocessor_id",
+            "engine_plugin": "engine_plugin_id",
+        }
+        parsed: Dict[str, Any] = {}
+        for serialized_name, attribute_name in implementation_fields.items():
+            implementation_id = value[serialized_name]
+            if not isinstance(implementation_id, str):
+                raise ValueError("Execution plan implementation IDs must be strings.")
+
+            parsed[attribute_name] = implementation_id
+        for fallback_name in (
+            "allow_compatibility_fallback",
+            "allow_runtime_failure_fallback",
+        ):
+            fallback_value = value[fallback_name]
+            if not isinstance(fallback_value, bool):
+                raise ValueError("Execution plan fallback values must be booleans.")
+
+            parsed[fallback_name] = fallback_value
+
+        execution_plan = cls(**parsed)
+
+        return execution_plan
+
+    def validate_for_profiling(self) -> "InferenceExecutionPlan":
+        """Require an attributable, fully explicit plan with fallback disabled.
+
+        Returns:
+            This execution plan after successful validation.
+
+        Raises:
+            ValueError: If an ID is invalid or automatic/fallback selection is enabled.
+        """
+        for stage, implementation_id in self.to_dict().items():
+            if stage.startswith("allow_"):
+                continue
+
+            if not _IMPLEMENTATION_ID.fullmatch(implementation_id):
+                raise ValueError(f"Invalid {stage} implementation ID.")
+
+            if implementation_id == AUTO_IMPLEMENTATION_ID:
+                raise ValueError(
+                    f"Profiling execution plan {stage} must not use 'auto'."
+                )
+
+        if self.allow_compatibility_fallback or self.allow_runtime_failure_fallback:
+            raise ValueError(
+                "Profiling execution plans must disable both fallback modes."
+            )
+
+        return self

--- a/inference_models/inference_models/models/optimization/runtime_metadata.py
+++ b/inference_models/inference_models/models/optimization/runtime_metadata.py
@@ -1,0 +1,104 @@
+"""Compact runtime-selection metadata shared by optimized model paths."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Iterator, Mapping, Optional, Protocol
+
+OPTIMIZATION_RUNTIME_METADATA_SCHEMA_VERSION = "1.0"
+
+
+class SupportsOptimizationRuntimeMetadata(Protocol):
+    """Model exposing its resolved optimization path for diagnostics."""
+
+    @property
+    def optimization_runtime_metadata(self) -> Mapping[str, Any]:
+        """Return versioned requested, selected, and last-executed stage data.
+
+        Returns:
+            Bounded runtime selection metadata for diagnostics and profiling proof.
+        """
+
+
+@dataclass(frozen=True)
+class SelectionSnapshot(Mapping[str, Any]):
+    """Immutable requested/effective selection retained on the hot path."""
+
+    requested_id: str
+    effective_id: str
+    fallback_reason: Optional[str] = None
+
+    @property
+    def fallback_occurred(self) -> bool:
+        """Report whether this resolution selected a fallback.
+
+        Returns:
+            True when the selection includes a fallback reason.
+        """
+        return self.fallback_reason is not None
+
+    def __getitem__(self, key: str) -> Any:
+        """Expose the immutable snapshot through the legacy mapping interface.
+
+        Args:
+            key: Selection field to read.
+
+        Returns:
+            The requested selection value.
+
+        Raises:
+            KeyError: If the field is not present in this snapshot.
+        """
+        if key == "requested_id":
+            value: Any = self.requested_id
+        elif key == "effective_id":
+            value = self.effective_id
+        elif key == "fallback_occurred":
+            value = self.fallback_occurred
+        elif key == "fallback_reason":
+            value = self.fallback_reason
+        else:
+            raise KeyError(key)
+
+        return value
+
+    def __iter__(self) -> Iterator[str]:
+        """Iterate over fields available in this snapshot.
+
+        Returns:
+            Iterator over the mapping keys.
+        """
+        keys = [
+            "requested_id",
+            "effective_id",
+            "fallback_occurred",
+            "fallback_reason",
+        ]
+        iterator = iter(keys)
+
+        return iterator
+
+    def __len__(self) -> int:
+        """Return the number of fields available in this snapshot.
+
+        Returns:
+            Number of mapping keys.
+        """
+        value = 4
+        return value
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize only when metadata is explicitly requested.
+
+        Returns:
+            Requested/effective IDs and bounded fallback information.
+        """
+        value: Dict[str, Any] = {
+            "requested_id": self.requested_id,
+            "effective_id": self.effective_id,
+            "fallback_occurred": self.fallback_occurred,
+        }
+        if self.fallback_reason is not None:
+            value["fallback_reason"] = self.fallback_reason
+
+        return value

--- a/inference_models/inference_models/models/rfdetr/optimization/execution_plan.py
+++ b/inference_models/inference_models/models/rfdetr/optimization/execution_plan.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
-from typing import Any, Mapping, Optional, Union
+from typing import Optional
 
 from inference_models.models.optimization.execution_plan import InferenceExecutionPlan
 from inference_models.models.optimization.ids import AUTO_IMPLEMENTATION_ID
@@ -25,43 +25,19 @@ class RFDetrExecutionPlan(InferenceExecutionPlan):
     def resolve(
         cls,
         *,
-        execution_plan: Optional[
-            Union[InferenceExecutionPlan, Mapping[str, Any]]
-        ] = None,
+        execution_plan: Optional["RFDetrExecutionPlan"] = None,
     ) -> "RFDetrExecutionPlan":
         """Resolve a plan from an explicit plan or RF-DETR environment values.
 
         Args:
-            execution_plan: Existing typed or canonical serialized composed plan.
+            execution_plan: Explicit composed plan. When omitted, stage IDs are read
+                from the RF-DETR environment variables.
 
         Returns:
             Immutable requested execution plan.
-
-        Raises:
-            ValueError: If a serialized execution plan is invalid.
         """
         if execution_plan is not None:
-            if isinstance(execution_plan, cls):
-                return execution_plan
-
-            generic_plan = (
-                execution_plan
-                if isinstance(execution_plan, InferenceExecutionPlan)
-                else InferenceExecutionPlan.from_dict(execution_plan)
-            )
-            plan = cls(
-                preprocessor_id=generic_plan.preprocessor_id,
-                buffer_strategy_id=generic_plan.buffer_strategy_id,
-                scheduler_id=generic_plan.scheduler_id,
-                postprocessor_id=generic_plan.postprocessor_id,
-                engine_plugin_id=generic_plan.engine_plugin_id,
-                allow_compatibility_fallback=(
-                    generic_plan.allow_compatibility_fallback
-                ),
-                allow_runtime_failure_fallback=(
-                    generic_plan.allow_runtime_failure_fallback
-                ),
-            )
+            plan = execution_plan
         else:
             plan = cls(
                 preprocessor_id=os.getenv(

--- a/inference_models/inference_models/models/rfdetr/optimization/execution_plan.py
+++ b/inference_models/inference_models/models/rfdetr/optimization/execution_plan.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
-from typing import Optional
+from typing import Any, Mapping, Optional, Union
 
 from inference_models.models.optimization.execution_plan import InferenceExecutionPlan
 from inference_models.models.optimization.ids import AUTO_IMPLEMENTATION_ID
@@ -25,20 +25,43 @@ class RFDetrExecutionPlan(InferenceExecutionPlan):
     def resolve(
         cls,
         *,
-        execution_plan: Optional["RFDetrExecutionPlan"] = None,
+        execution_plan: Optional[
+            Union[InferenceExecutionPlan, Mapping[str, Any]]
+        ] = None,
     ) -> "RFDetrExecutionPlan":
         """Resolve a plan from an explicit plan or RF-DETR environment values.
 
         Args:
-            execution_plan: Explicit composed plan. When omitted, stage IDs are read
-                from the RF-DETR environment variables.
+            execution_plan: Existing typed or canonical serialized composed plan.
 
         Returns:
             Immutable requested execution plan.
 
+        Raises:
+            ValueError: If a serialized execution plan is invalid.
         """
         if execution_plan is not None:
-            plan = execution_plan
+            if isinstance(execution_plan, cls):
+                return execution_plan
+
+            generic_plan = (
+                execution_plan
+                if isinstance(execution_plan, InferenceExecutionPlan)
+                else InferenceExecutionPlan.from_dict(execution_plan)
+            )
+            plan = cls(
+                preprocessor_id=generic_plan.preprocessor_id,
+                buffer_strategy_id=generic_plan.buffer_strategy_id,
+                scheduler_id=generic_plan.scheduler_id,
+                postprocessor_id=generic_plan.postprocessor_id,
+                engine_plugin_id=generic_plan.engine_plugin_id,
+                allow_compatibility_fallback=(
+                    generic_plan.allow_compatibility_fallback
+                ),
+                allow_runtime_failure_fallback=(
+                    generic_plan.allow_runtime_failure_fallback
+                ),
+            )
         else:
             plan = cls(
                 preprocessor_id=os.getenv(

--- a/inference_models/inference_models/models/rfdetr/rfdetr_object_detection_trt.py
+++ b/inference_models/inference_models/models/rfdetr/rfdetr_object_detection_trt.py
@@ -142,6 +142,37 @@ class RFDetrForObjectDetectionTRT(
 ):
     """Run RF-DETR object detection through TensorRT with selectable path stages."""
 
+    @staticmethod
+    def _resolve_requested_execution_plan(
+        *,
+        rfdetr_execution_plan: Optional[RFDetrExecutionPlan],
+        execution_plan: Optional[
+            Union[InferenceExecutionPlan, Mapping[str, Any]]
+        ],
+    ) -> RFDetrExecutionPlan:
+        """Normalize the generic loader contract into a typed RF-DETR plan."""
+        if rfdetr_execution_plan is not None and execution_plan is not None:
+            raise ValueError(
+                "Pass either rfdetr_execution_plan or execution_plan, not both."
+            )
+
+        if execution_plan is None:
+            resolved_plan = RFDetrExecutionPlan.resolve(
+                execution_plan=rfdetr_execution_plan,
+            )
+
+            return resolved_plan
+
+        serialized_plan = (
+            execution_plan.to_dict()
+            if isinstance(execution_plan, InferenceExecutionPlan)
+            else execution_plan
+        )
+        parsed_plan = RFDetrExecutionPlan.from_dict(serialized_plan)
+        resolved_plan = cast(RFDetrExecutionPlan, parsed_plan)
+
+        return resolved_plan
+
     @classmethod
     def from_pretrained(
         cls,
@@ -181,6 +212,8 @@ class RFDetrForObjectDetectionTRT(
             Loaded RF-DETR TensorRT model.
 
         Raises:
+            ValueError: If execution-plan arguments conflict or a serialized plan is
+                invalid.
             ModelRuntimeError: If the target or implementation selection is invalid.
             CorruptedModelPackageError: If required package contents are inconsistent.
         """
@@ -314,12 +347,9 @@ class RFDetrForObjectDetectionTRT(
         self._rfdetr_preprocessor_max_workers = resolve_rfdetr_preprocessor_max_workers(
             max_workers=rfdetr_preprocessor_max_workers
         )
-        if rfdetr_execution_plan is not None and execution_plan is not None:
-            raise ValueError(
-                "Pass either rfdetr_execution_plan or execution_plan, not both."
-            )
-        requested_plan = RFDetrExecutionPlan.resolve(
-            execution_plan=execution_plan or rfdetr_execution_plan,
+        requested_plan = self._resolve_requested_execution_plan(
+            rfdetr_execution_plan=rfdetr_execution_plan,
+            execution_plan=execution_plan,
         )
         self._implementation_registry = build_rfdetr_implementation_registry(
             device=self._device,

--- a/inference_models/inference_models/models/rfdetr/rfdetr_object_detection_trt.py
+++ b/inference_models/inference_models/models/rfdetr/rfdetr_object_detection_trt.py
@@ -138,21 +138,13 @@ class RFDetrForObjectDetectionTRT(
     @staticmethod
     def _resolve_requested_execution_plan(
         *,
-        rfdetr_execution_plan: Optional[RFDetrExecutionPlan],
         execution_plan: Optional[
             Union[RFDetrExecutionPlan, Mapping[str, Any]]
         ],
     ) -> RFDetrExecutionPlan:
         """Normalize loader input into a typed RF-DETR execution plan."""
-        if rfdetr_execution_plan is not None and execution_plan is not None:
-            raise ValueError(
-                "Pass either rfdetr_execution_plan or execution_plan, not both."
-            )
-
         if execution_plan is None:
-            resolved_plan = RFDetrExecutionPlan.resolve(
-                execution_plan=rfdetr_execution_plan,
-            )
+            resolved_plan = RFDetrExecutionPlan.resolve()
 
             return resolved_plan
 
@@ -174,7 +166,6 @@ class RFDetrForObjectDetectionTRT(
         default_trt_cuda_graph_cache_size: int = 8,
         rf_detr_max_input_resolution: Optional[Union[int, Tuple[int, int]]] = None,
         rfdetr_preprocessor_max_workers: Optional[int] = None,
-        rfdetr_execution_plan: Optional[RFDetrExecutionPlan] = None,
         execution_plan: Optional[
             Union[RFDetrExecutionPlan, Mapping[str, Any]]
         ] = None,
@@ -192,10 +183,8 @@ class RFDetrForObjectDetectionTRT(
             rf_detr_max_input_resolution: Optional maximum accepted input resolution.
             rfdetr_preprocessor_max_workers: Explicit threaded preprocessing worker
                 limit. When omitted, the corresponding environment value is used.
-            rfdetr_execution_plan: Explicit composed execution plan. When omitted,
-                RF-DETR implementation environment variables are used.
-            execution_plan: Canonical generic execution plan. It cannot be
-                combined with ``rfdetr_execution_plan``.
+            execution_plan: Explicit RF-DETR execution plan or its canonical mapping.
+                When omitted, RF-DETR implementation environment variables are used.
             recommended_parameters: Optional model-specific recommended parameters.
             **kwargs: Additional loader arguments accepted for API compatibility.
 
@@ -203,8 +192,7 @@ class RFDetrForObjectDetectionTRT(
             Loaded RF-DETR TensorRT model.
 
         Raises:
-            ValueError: If execution-plan arguments conflict or a serialized plan is
-                invalid.
+            ValueError: If a serialized execution plan is invalid.
             ModelRuntimeError: If the target or implementation selection is invalid.
             CorruptedModelPackageError: If required package contents are inconsistent.
         """
@@ -297,7 +285,6 @@ class RFDetrForObjectDetectionTRT(
             trt_execution_context=trt_execution_context,
             trt_cuda_graph_cache=trt_cuda_graph_cache,
             rfdetr_preprocessor_max_workers=rfdetr_preprocessor_max_workers,
-            rfdetr_execution_plan=rfdetr_execution_plan,
             execution_plan=execution_plan,
             recommended_parameters=recommended_parameters,
         )
@@ -318,7 +305,6 @@ class RFDetrForObjectDetectionTRT(
         trt_execution_context: trt.IExecutionContext,
         trt_cuda_graph_cache: Optional[TRTCudaGraphCache],
         rfdetr_preprocessor_max_workers: Optional[int] = None,
-        rfdetr_execution_plan: Optional[RFDetrExecutionPlan] = None,
         execution_plan: Optional[
             Union[RFDetrExecutionPlan, Mapping[str, Any]]
         ] = None,
@@ -339,7 +325,6 @@ class RFDetrForObjectDetectionTRT(
             max_workers=rfdetr_preprocessor_max_workers
         )
         requested_plan = self._resolve_requested_execution_plan(
-            rfdetr_execution_plan=rfdetr_execution_plan,
             execution_plan=execution_plan,
         )
         self._implementation_registry = build_rfdetr_implementation_registry(
@@ -408,10 +393,10 @@ class RFDetrForObjectDetectionTRT(
             ),
         )
         model_selections = {
-            "preprocess": preprocessor_selection,
+            "preprocessor": preprocessor_selection,
             "buffer_strategy": buffer_strategy_selection,
             "scheduler": scheduler_selection,
-            "postprocess": postprocessor_selection,
+            "postprocessor": postprocessor_selection,
             "engine_plugin": engine_plugin_selection,
         }
         self._model_selections = {
@@ -508,12 +493,12 @@ class RFDetrForObjectDetectionTRT(
     def optimization_runtime_metadata(self) -> Dict[str, Any]:
         """Return machine-readable selected implementation metadata."""
         implementation_metadata = {
-            "preprocess": self.preprocessor_implementation_metadata.to_dict(),
+            "preprocessor": self.preprocessor_implementation_metadata.to_dict(),
             "buffer_strategy": (
                 self.buffer_strategy_implementation_metadata.to_dict()
             ),
             "scheduler": self.scheduler_implementation_metadata.to_dict(),
-            "postprocess": self.postprocessor_implementation_metadata.to_dict(),
+            "postprocessor": self.postprocessor_implementation_metadata.to_dict(),
             "engine_plugin": self.engine_plugin_implementation_metadata.to_dict(),
         }
         plan = self.rfdetr_execution_plan
@@ -528,10 +513,10 @@ class RFDetrForObjectDetectionTRT(
         }
         last_execution = {}
         for stage in (
-            "preprocess",
+            "preprocessor",
             "buffer_strategy",
             "scheduler",
-            "postprocess",
+            "postprocessor",
             "engine_plugin",
         ):
             selection = getattr(
@@ -626,7 +611,7 @@ class RFDetrForObjectDetectionTRT(
                 allow_fallback=allow_runtime_failure_fallback,
             )
             self._record_runtime_selection(
-                stage="preprocess",
+                stage="preprocessor",
                 requested_id=selection.requested_id,
                 effective_id=selection.effective_id,
                 fallback_reason=selection.fallback_reason,
@@ -650,7 +635,7 @@ class RFDetrForObjectDetectionTRT(
                     raise
                 selection = fallback_selection
                 self._record_runtime_selection(
-                    stage="preprocess",
+                    stage="preprocessor",
                     requested_id=selection.requested_id,
                     effective_id=selection.effective_id,
                     fallback_reason=selection.fallback_reason,
@@ -802,7 +787,7 @@ class RFDetrForObjectDetectionTRT(
                     allow_fallback=allow_runtime_failure_fallback,
                 )
                 self._record_runtime_selection(
-                    stage="postprocess",
+                    stage="postprocessor",
                     requested_id=selection.requested_id,
                     effective_id=selection.effective_id,
                     fallback_reason=selection.fallback_reason,
@@ -826,7 +811,7 @@ class RFDetrForObjectDetectionTRT(
                         raise
                     selection = fallback_selection
                     self._record_runtime_selection(
-                        stage="postprocess",
+                        stage="postprocessor",
                         requested_id=selection.requested_id,
                         effective_id=selection.effective_id,
                         fallback_reason=selection.fallback_reason,
@@ -879,10 +864,12 @@ class RFDetrForObjectDetectionTRT(
         return context
 
     def _record_static_stage_execution(self, *, stage: str) -> None:
-        self._record_last_execution(
-            stage=stage,
-            selection=self._model_selections[stage],
-        )
+        selection = self._model_selections[stage]
+        attribute = f"last_{stage}_selection"
+        if getattr(self._thread_local_storage, attribute, None) == selection:
+            return
+
+        setattr(self._thread_local_storage, attribute, selection)
 
     def _record_runtime_selection(
         self,
@@ -908,19 +895,3 @@ class RFDetrForObjectDetectionTRT(
             fallback_reason=fallback_reason,
         )
         setattr(self._thread_local_storage, attribute, selection)
-
-    def _record_last_execution(
-        self,
-        *,
-        stage: str,
-        selection: SelectionSnapshot,
-    ) -> None:
-        attribute = f"last_{stage}_selection"
-        if getattr(self._thread_local_storage, attribute, None) == selection:
-            return
-
-        setattr(
-            self._thread_local_storage,
-            attribute,
-            selection,
-        )

--- a/inference_models/inference_models/models/rfdetr/rfdetr_object_detection_trt.py
+++ b/inference_models/inference_models/models/rfdetr/rfdetr_object_detection_trt.py
@@ -44,7 +44,6 @@ from inference_models.models.optimization.contracts import (
     OptimizationStage,
 )
 from inference_models.models.optimization.errors import RecoverableStageExecutionError
-from inference_models.models.optimization.execution_plan import InferenceExecutionPlan
 from inference_models.models.optimization.fallback_warnings import (
     FallbackWarningTracker,
 )
@@ -118,12 +117,6 @@ except ImportError as import_error:
 _MODEL_RUNTIME_ERROR_HELP_URL = (
     "https://inference-models.roboflow.com/errors/models-runtime/#modelruntimeerror"
 )
-_SELECTION_STORAGE_STAGE = {
-    "preprocess": "preprocessor",
-    "postprocess": "postprocessor",
-}
-
-
 def _as_model_runtime_error(
     error: RecoverableStageExecutionError,
 ) -> ModelRuntimeError:
@@ -147,10 +140,10 @@ class RFDetrForObjectDetectionTRT(
         *,
         rfdetr_execution_plan: Optional[RFDetrExecutionPlan],
         execution_plan: Optional[
-            Union[InferenceExecutionPlan, Mapping[str, Any]]
+            Union[RFDetrExecutionPlan, Mapping[str, Any]]
         ],
     ) -> RFDetrExecutionPlan:
-        """Normalize the generic loader contract into a typed RF-DETR plan."""
+        """Normalize loader input into a typed RF-DETR execution plan."""
         if rfdetr_execution_plan is not None and execution_plan is not None:
             raise ValueError(
                 "Pass either rfdetr_execution_plan or execution_plan, not both."
@@ -163,12 +156,10 @@ class RFDetrForObjectDetectionTRT(
 
             return resolved_plan
 
-        serialized_plan = (
-            execution_plan.to_dict()
-            if isinstance(execution_plan, InferenceExecutionPlan)
-            else execution_plan
-        )
-        parsed_plan = RFDetrExecutionPlan.from_dict(serialized_plan)
+        if isinstance(execution_plan, RFDetrExecutionPlan):
+            return execution_plan
+
+        parsed_plan = RFDetrExecutionPlan.from_dict(execution_plan)
         resolved_plan = cast(RFDetrExecutionPlan, parsed_plan)
 
         return resolved_plan
@@ -185,7 +176,7 @@ class RFDetrForObjectDetectionTRT(
         rfdetr_preprocessor_max_workers: Optional[int] = None,
         rfdetr_execution_plan: Optional[RFDetrExecutionPlan] = None,
         execution_plan: Optional[
-            Union[InferenceExecutionPlan, Mapping[str, Any]]
+            Union[RFDetrExecutionPlan, Mapping[str, Any]]
         ] = None,
         recommended_parameters: Optional[RecommendedParameters] = None,
         **kwargs,
@@ -329,7 +320,7 @@ class RFDetrForObjectDetectionTRT(
         rfdetr_preprocessor_max_workers: Optional[int] = None,
         rfdetr_execution_plan: Optional[RFDetrExecutionPlan] = None,
         execution_plan: Optional[
-            Union[InferenceExecutionPlan, Mapping[str, Any]]
+            Union[RFDetrExecutionPlan, Mapping[str, Any]]
         ] = None,
         recommended_parameters=None,
     ):
@@ -543,10 +534,9 @@ class RFDetrForObjectDetectionTRT(
             "postprocess",
             "engine_plugin",
         ):
-            storage_stage = _SELECTION_STORAGE_STAGE.get(stage, stage)
             selection = getattr(
                 self._thread_local_storage,
-                f"last_{storage_stage}_selection",
+                f"last_{stage}_selection",
                 None,
             )
             if selection is not None:
@@ -902,8 +892,7 @@ class RFDetrForObjectDetectionTRT(
         effective_id: str,
         fallback_reason: Optional[str],
     ) -> None:
-        storage_stage = _SELECTION_STORAGE_STAGE.get(stage, stage)
-        attribute = f"last_{storage_stage}_selection"
+        attribute = f"last_{stage}_selection"
         previous = getattr(self._thread_local_storage, attribute, None)
         if (
             previous is not None
@@ -926,8 +915,7 @@ class RFDetrForObjectDetectionTRT(
         stage: str,
         selection: SelectionSnapshot,
     ) -> None:
-        storage_stage = _SELECTION_STORAGE_STAGE.get(stage, stage)
-        attribute = f"last_{storage_stage}_selection"
+        attribute = f"last_{stage}_selection"
         if getattr(self._thread_local_storage, attribute, None) == selection:
             return
 

--- a/inference_models/inference_models/models/rfdetr/rfdetr_object_detection_trt.py
+++ b/inference_models/inference_models/models/rfdetr/rfdetr_object_detection_trt.py
@@ -44,10 +44,15 @@ from inference_models.models.optimization.contracts import (
     OptimizationStage,
 )
 from inference_models.models.optimization.errors import RecoverableStageExecutionError
+from inference_models.models.optimization.execution_plan import InferenceExecutionPlan
 from inference_models.models.optimization.fallback_warnings import (
     FallbackWarningTracker,
 )
 from inference_models.models.optimization.ids import BASE_IMPLEMENTATION_ID
+from inference_models.models.optimization.runtime_metadata import (
+    OPTIMIZATION_RUNTIME_METADATA_SCHEMA_VERSION,
+    SelectionSnapshot,
+)
 from inference_models.models.optimization.runtime_components import (
     get_runtime_components,
 )
@@ -113,6 +118,10 @@ except ImportError as import_error:
 _MODEL_RUNTIME_ERROR_HELP_URL = (
     "https://inference-models.roboflow.com/errors/models-runtime/#modelruntimeerror"
 )
+_SELECTION_STORAGE_STAGE = {
+    "preprocess": "preprocessor",
+    "postprocess": "postprocessor",
+}
 
 
 def _as_model_runtime_error(
@@ -144,6 +153,9 @@ class RFDetrForObjectDetectionTRT(
         rf_detr_max_input_resolution: Optional[Union[int, Tuple[int, int]]] = None,
         rfdetr_preprocessor_max_workers: Optional[int] = None,
         rfdetr_execution_plan: Optional[RFDetrExecutionPlan] = None,
+        execution_plan: Optional[
+            Union[InferenceExecutionPlan, Mapping[str, Any]]
+        ] = None,
         recommended_parameters: Optional[RecommendedParameters] = None,
         **kwargs,
     ) -> "RFDetrForObjectDetectionTRT":
@@ -160,6 +172,8 @@ class RFDetrForObjectDetectionTRT(
                 limit. When omitted, the corresponding environment value is used.
             rfdetr_execution_plan: Explicit composed execution plan. When omitted,
                 RF-DETR implementation environment variables are used.
+            execution_plan: Canonical generic execution plan. It cannot be
+                combined with ``rfdetr_execution_plan``.
             recommended_parameters: Optional model-specific recommended parameters.
             **kwargs: Additional loader arguments accepted for API compatibility.
 
@@ -246,7 +260,7 @@ class RFDetrForObjectDetectionTRT(
             default_cuda_graph_cache_size=default_trt_cuda_graph_cache_size,
             cuda_graph_cache=trt_cuda_graph_cache,
         )
-        return cls(
+        model = cls(
             engine=engine,
             input_name=inputs[0],
             output_names=["dets", "labels"],
@@ -260,8 +274,11 @@ class RFDetrForObjectDetectionTRT(
             trt_cuda_graph_cache=trt_cuda_graph_cache,
             rfdetr_preprocessor_max_workers=rfdetr_preprocessor_max_workers,
             rfdetr_execution_plan=rfdetr_execution_plan,
+            execution_plan=execution_plan,
             recommended_parameters=recommended_parameters,
         )
+
+        return model
 
     def __init__(
         self,
@@ -278,6 +295,9 @@ class RFDetrForObjectDetectionTRT(
         trt_cuda_graph_cache: Optional[TRTCudaGraphCache],
         rfdetr_preprocessor_max_workers: Optional[int] = None,
         rfdetr_execution_plan: Optional[RFDetrExecutionPlan] = None,
+        execution_plan: Optional[
+            Union[InferenceExecutionPlan, Mapping[str, Any]]
+        ] = None,
         recommended_parameters=None,
     ):
         self._engine = engine
@@ -294,8 +314,12 @@ class RFDetrForObjectDetectionTRT(
         self._rfdetr_preprocessor_max_workers = resolve_rfdetr_preprocessor_max_workers(
             max_workers=rfdetr_preprocessor_max_workers
         )
+        if rfdetr_execution_plan is not None and execution_plan is not None:
+            raise ValueError(
+                "Pass either rfdetr_execution_plan or execution_plan, not both."
+            )
         requested_plan = RFDetrExecutionPlan.resolve(
-            execution_plan=rfdetr_execution_plan,
+            execution_plan=execution_plan or rfdetr_execution_plan,
         )
         self._implementation_registry = build_rfdetr_implementation_registry(
             device=self._device,
@@ -363,14 +387,19 @@ class RFDetrForObjectDetectionTRT(
             ),
         )
         model_selections = {
-            "preprocessor": preprocessor_selection,
+            "preprocess": preprocessor_selection,
             "buffer_strategy": buffer_strategy_selection,
             "scheduler": scheduler_selection,
-            "postprocessor": postprocessor_selection,
+            "postprocess": postprocessor_selection,
             "engine_plugin": engine_plugin_selection,
         }
         self._model_selections = {
-            stage: selection.to_dict() for stage, selection in model_selections.items()
+            stage: SelectionSnapshot(
+                requested_id=selection.requested_id,
+                effective_id=selection.effective_id,
+                fallback_reason=selection.fallback_reason,
+            )
+            for stage, selection in model_selections.items()
         }
         for stage, selection in model_selections.items():
             if selection.used_fallback:
@@ -457,33 +486,41 @@ class RFDetrForObjectDetectionTRT(
     @property
     def optimization_runtime_metadata(self) -> Dict[str, Any]:
         """Return machine-readable selected implementation metadata."""
-        metadata = {
-            "execution_plan": self.rfdetr_execution_plan.to_dict(),
-            "preprocessor": self.preprocessor_implementation_metadata.to_dict(),
-            "buffer_strategy": (self.buffer_strategy_implementation_metadata.to_dict()),
+        implementation_metadata = {
+            "preprocess": self.preprocessor_implementation_metadata.to_dict(),
+            "buffer_strategy": (
+                self.buffer_strategy_implementation_metadata.to_dict()
+            ),
             "scheduler": self.scheduler_implementation_metadata.to_dict(),
-            "postprocessor": self.postprocessor_implementation_metadata.to_dict(),
+            "postprocess": self.postprocessor_implementation_metadata.to_dict(),
             "engine_plugin": self.engine_plugin_implementation_metadata.to_dict(),
+        }
+        plan = self.rfdetr_execution_plan
+        metadata = {
+            "schema_version": OPTIMIZATION_RUNTIME_METADATA_SCHEMA_VERSION,
+            "execution_plan": plan.to_dict(),
+            "implementation_metadata": implementation_metadata,
             "model_selection": {
-                stage: dict(selection)
+                stage: selection.to_dict()
                 for stage, selection in self._model_selections.items()
             },
         }
         last_execution = {}
         for stage in (
-            "preprocessor",
+            "preprocess",
             "buffer_strategy",
             "scheduler",
-            "postprocessor",
+            "postprocess",
             "engine_plugin",
         ):
+            storage_stage = _SELECTION_STORAGE_STAGE.get(stage, stage)
             selection = getattr(
                 self._thread_local_storage,
-                f"last_{stage}_selection",
+                f"last_{storage_stage}_selection",
                 None,
             )
             if selection is not None:
-                last_execution[stage] = dict(selection)
+                last_execution[stage] = selection.to_dict()
         if last_execution:
             metadata["last_execution"] = last_execution
 
@@ -568,9 +605,11 @@ class RFDetrForObjectDetectionTRT(
                 context=context,
                 allow_fallback=allow_runtime_failure_fallback,
             )
-            self._record_last_execution(
-                stage="preprocessor",
-                selection=selection.to_dict(),
+            self._record_runtime_selection(
+                stage="preprocess",
+                requested_id=selection.requested_id,
+                effective_id=selection.effective_id,
+                fallback_reason=selection.fallback_reason,
             )
             try:
                 result = selection.implementation.preprocess(
@@ -590,9 +629,11 @@ class RFDetrForObjectDetectionTRT(
                 if fallback_selection.implementation is selection.implementation:
                     raise
                 selection = fallback_selection
-                self._record_last_execution(
-                    stage="preprocessor",
-                    selection=selection.to_dict(),
+                self._record_runtime_selection(
+                    stage="preprocess",
+                    requested_id=selection.requested_id,
+                    effective_id=selection.effective_id,
+                    fallback_reason=selection.fallback_reason,
                 )
                 result = selection.implementation.preprocess(
                     request=request,
@@ -740,9 +781,11 @@ class RFDetrForObjectDetectionTRT(
                     context=context,
                     allow_fallback=allow_runtime_failure_fallback,
                 )
-                self._record_last_execution(
-                    stage="postprocessor",
-                    selection=selection.to_dict(),
+                self._record_runtime_selection(
+                    stage="postprocess",
+                    requested_id=selection.requested_id,
+                    effective_id=selection.effective_id,
+                    fallback_reason=selection.fallback_reason,
                 )
                 try:
                     results = selection.implementation.postprocess(
@@ -762,9 +805,11 @@ class RFDetrForObjectDetectionTRT(
                     if fallback_selection.implementation is selection.implementation:
                         raise
                     selection = fallback_selection
-                    self._record_last_execution(
-                        stage="postprocessor",
-                        selection=selection.to_dict(),
+                    self._record_runtime_selection(
+                        stage="postprocess",
+                        requested_id=selection.requested_id,
+                        effective_id=selection.effective_id,
+                        fallback_reason=selection.fallback_reason,
                     )
                     results = selection.implementation.postprocess(
                         request=request,
@@ -819,14 +864,45 @@ class RFDetrForObjectDetectionTRT(
             selection=self._model_selections[stage],
         )
 
+    def _record_runtime_selection(
+        self,
+        *,
+        stage: str,
+        requested_id: str,
+        effective_id: str,
+        fallback_reason: Optional[str],
+    ) -> None:
+        storage_stage = _SELECTION_STORAGE_STAGE.get(stage, stage)
+        attribute = f"last_{storage_stage}_selection"
+        previous = getattr(self._thread_local_storage, attribute, None)
+        if (
+            previous is not None
+            and previous.requested_id == requested_id
+            and previous.effective_id == effective_id
+            and previous.fallback_reason == fallback_reason
+        ):
+            return
+
+        selection = SelectionSnapshot(
+            requested_id=requested_id,
+            effective_id=effective_id,
+            fallback_reason=fallback_reason,
+        )
+        setattr(self._thread_local_storage, attribute, selection)
+
     def _record_last_execution(
         self,
         *,
         stage: str,
-        selection: Mapping[str, Optional[str]],
+        selection: SelectionSnapshot,
     ) -> None:
+        storage_stage = _SELECTION_STORAGE_STAGE.get(stage, stage)
+        attribute = f"last_{storage_stage}_selection"
+        if getattr(self._thread_local_storage, attribute, None) == selection:
+            return
+
         setattr(
             self._thread_local_storage,
-            f"last_{stage}_selection",
-            dict(selection),
+            attribute,
+            selection,
         )

--- a/inference_models/tests/unit_tests/models/optimization/test_execution_plan_profiling.py
+++ b/inference_models/tests/unit_tests/models/optimization/test_execution_plan_profiling.py
@@ -1,0 +1,62 @@
+import pytest
+
+from inference_models.models.optimization.execution_plan import InferenceExecutionPlan
+from inference_models.models.optimization.runtime_metadata import SelectionSnapshot
+
+
+def _payload():
+    return {
+        "preprocessor": "threaded-exact-v1",
+        "buffer_strategy": "base",
+        "scheduler": "base",
+        "postprocessor": "base",
+        "engine_plugin": "base",
+        "allow_compatibility_fallback": False,
+        "allow_runtime_failure_fallback": False,
+    }
+
+
+def test_execution_plan_round_trips_and_validates_for_profiling() -> None:
+    payload = _payload()
+
+    plan = InferenceExecutionPlan.from_dict(payload).validate_for_profiling()
+
+    assert plan.to_dict() == payload
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    [
+        (lambda value: value.pop("scheduler"), "exactly"),
+        (lambda value: value.update(extra="base"), "exactly"),
+        (lambda value: value.update(preprocessor="auto"), "must not"),
+        (lambda value: value.update(preprocessor=None), "strings"),
+        (
+            lambda value: value.update(allow_compatibility_fallback=True),
+            "disable both fallback",
+        ),
+    ],
+)
+def test_profiling_execution_plan_rejects_invalid_payloads(mutation, message) -> None:
+    payload = _payload()
+    mutation(payload)
+
+    with pytest.raises(ValueError, match=message):
+        InferenceExecutionPlan.from_dict(payload).validate_for_profiling()
+
+
+def test_selection_snapshot_serializes_fallback_only_when_present() -> None:
+    selected = SelectionSnapshot(requested_id="base", effective_id="base")
+    fallback = SelectionSnapshot(
+        requested_id="candidate",
+        effective_id="base",
+        fallback_reason="incompatible input",
+    )
+
+    assert selected.to_dict() == {
+        "requested_id": "base",
+        "effective_id": "base",
+        "fallback_occurred": False,
+    }
+    assert fallback.to_dict()["fallback_reason"] == "incompatible input"
+    assert fallback.to_dict()["fallback_occurred"]

--- a/inference_models/tests/unit_tests/models/rfdetr/test_optimization_contracts.py
+++ b/inference_models/tests/unit_tests/models/rfdetr/test_optimization_contracts.py
@@ -256,8 +256,9 @@ def test_profiling_execution_plan_is_explicit_and_forbids_fallback(
         allow_runtime_failure_fallback=False,
     )
 
-    resolved = RFDetrExecutionPlan.resolve(execution_plan=profiling_plan)
+    resolved = RFDetrExecutionPlan.from_dict(profiling_plan.to_dict())
 
+    assert isinstance(resolved, RFDetrExecutionPlan)
     assert resolved.preprocessor_id == RFDETR_PREPROCESSOR_THREADED_EXACT_V1
     assert resolved.buffer_strategy_id == "base"
     assert resolved.scheduler_id == "base"

--- a/inference_models/tests/unit_tests/models/rfdetr/test_optimization_contracts.py
+++ b/inference_models/tests/unit_tests/models/rfdetr/test_optimization_contracts.py
@@ -24,7 +24,6 @@ from inference_models.models.optimization.contracts import (
 )
 from inference_models.models.optimization.errors import RecoverableStageExecutionError
 from inference_models.models.optimization.ids import AUTO_IMPLEMENTATION_ID
-from inference_models.models.optimization.execution_plan import InferenceExecutionPlan
 from inference_models.models.optimization.registry import ImplementationRegistry
 from inference_models.models.rfdetr.optimization.catalog import (
     RFDETR_BUFFER_STRATEGY_IMPLEMENTATIONS,
@@ -246,7 +245,7 @@ def test_profiling_execution_plan_is_explicit_and_forbids_fallback(
         "INFERENCE_MODELS_RFDETR_PREPROCESSOR",
         RFDETR_PREPROCESSOR_TRITON_UNIVERSAL_V1,
     )
-    profiling_plan = InferenceExecutionPlan(
+    profiling_plan = RFDetrExecutionPlan(
         preprocessor_id=RFDETR_PREPROCESSOR_THREADED_EXACT_V1,
         buffer_strategy_id="base",
         scheduler_id="base",

--- a/inference_models/tests/unit_tests/models/rfdetr/test_optimization_contracts.py
+++ b/inference_models/tests/unit_tests/models/rfdetr/test_optimization_contracts.py
@@ -24,6 +24,7 @@ from inference_models.models.optimization.contracts import (
 )
 from inference_models.models.optimization.errors import RecoverableStageExecutionError
 from inference_models.models.optimization.ids import AUTO_IMPLEMENTATION_ID
+from inference_models.models.optimization.execution_plan import InferenceExecutionPlan
 from inference_models.models.optimization.registry import ImplementationRegistry
 from inference_models.models.rfdetr.optimization.catalog import (
     RFDETR_BUFFER_STRATEGY_IMPLEMENTATIONS,
@@ -236,6 +237,34 @@ def test_execution_plan_preserves_all_explicit_stage_ids() -> None:
     assert resolved.engine_plugin_id == "future-plugin"
     assert not resolved.allow_compatibility_fallback
     assert resolved.allow_runtime_failure_fallback
+
+
+def test_profiling_execution_plan_is_explicit_and_forbids_fallback(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv(
+        "INFERENCE_MODELS_RFDETR_PREPROCESSOR",
+        RFDETR_PREPROCESSOR_TRITON_UNIVERSAL_V1,
+    )
+    profiling_plan = InferenceExecutionPlan(
+        preprocessor_id=RFDETR_PREPROCESSOR_THREADED_EXACT_V1,
+        buffer_strategy_id="base",
+        scheduler_id="base",
+        postprocessor_id=RFDETR_POSTPROCESSOR_BASE,
+        engine_plugin_id="base",
+        allow_compatibility_fallback=False,
+        allow_runtime_failure_fallback=False,
+    )
+
+    resolved = RFDetrExecutionPlan.resolve(execution_plan=profiling_plan)
+
+    assert resolved.preprocessor_id == RFDETR_PREPROCESSOR_THREADED_EXACT_V1
+    assert resolved.buffer_strategy_id == "base"
+    assert resolved.scheduler_id == "base"
+    assert resolved.postprocessor_id == RFDETR_POSTPROCESSOR_BASE
+    assert resolved.engine_plugin_id == "base"
+    assert not resolved.allow_compatibility_fallback
+    assert not resolved.allow_runtime_failure_fallback
 
 
 def test_registry_resolves_explicit_and_auto_base() -> None:

--- a/inference_models/tests/unit_tests/models/rfdetr/test_rfdetr_trt_runtime_fallback.py
+++ b/inference_models/tests/unit_tests/models/rfdetr/test_rfdetr_trt_runtime_fallback.py
@@ -122,7 +122,6 @@ def test_model_boundary_parses_serialized_rfdetr_execution_plan(
     )
 
     resolved_plan = rfdetr_trt_model_class._resolve_requested_execution_plan(
-        rfdetr_execution_plan=None,
         execution_plan=execution_plan.to_dict(),
     )
 
@@ -133,19 +132,20 @@ def test_model_boundary_parses_serialized_rfdetr_execution_plan(
     assert not resolved_plan.allow_runtime_failure_fallback
 
 
-def test_model_boundary_rejects_invalid_or_conflicting_execution_plans(
+def test_model_boundary_accepts_typed_plan_and_rejects_invalid_mapping(
     rfdetr_trt_model_class,
 ) -> None:
+    execution_plan = RFDetrExecutionPlan()
+
+    resolved_plan = rfdetr_trt_model_class._resolve_requested_execution_plan(
+        execution_plan=execution_plan,
+    )
+
+    assert resolved_plan is execution_plan
+
     with pytest.raises(ValueError, match="must contain exactly"):
         rfdetr_trt_model_class._resolve_requested_execution_plan(
-            rfdetr_execution_plan=None,
             execution_plan={},
-        )
-
-    with pytest.raises(ValueError, match="either rfdetr_execution_plan"):
-        rfdetr_trt_model_class._resolve_requested_execution_plan(
-            rfdetr_execution_plan=RFDetrExecutionPlan(),
-            execution_plan=RFDetrExecutionPlan(),
         )
 
 
@@ -406,7 +406,7 @@ def test_preprocess_retries_base_then_short_circuits_recorded_failure(
     first_tensor, first_metadata = model.pre_process(
         images=np.zeros((2, 2, 3), dtype=np.uint8)
     )
-    first_selection = model._thread_local_storage.last_preprocess_selection
+    first_selection = model._thread_local_storage.last_preprocessor_selection
     second_tensor, second_metadata = model.pre_process(
         images=np.zeros((2, 2, 3), dtype=np.uint8)
     )
@@ -490,7 +490,7 @@ def test_preprocess_nonrecoverable_failure_records_attempted_selection(
     with pytest.raises(ValueError, match="non-recoverable failure"):
         model.pre_process(images=np.zeros((2, 2, 3), dtype=np.uint8))
 
-    selection = model._thread_local_storage.last_preprocess_selection
+    selection = model._thread_local_storage.last_preprocessor_selection
     assert selection["requested_id"] == RFDETR_PREPROCESSOR_TRITON_UNIVERSAL_V1
     assert selection["effective_id"] == RFDETR_PREPROCESSOR_TRITON_UNIVERSAL_V1
     assert selection["fallback_reason"] is None
@@ -517,7 +517,7 @@ def test_postprocess_retries_base_then_short_circuits_recorded_failure(
         pre_processing_meta=[],
         confidence=0.5,
     )
-    first_selection = model._thread_local_storage.last_postprocess_selection
+    first_selection = model._thread_local_storage.last_postprocessor_selection
     second_results = model.post_process(
         model_results=model_results,
         pre_processing_meta=[],
@@ -593,7 +593,7 @@ def test_postprocess_nonrecoverable_failure_records_attempted_selection(
             confidence=0.5,
         )
 
-    selection = model._thread_local_storage.last_postprocess_selection
+    selection = model._thread_local_storage.last_postprocessor_selection
     assert selection["requested_id"] == RFDETR_POSTPROCESSOR_TRITON_FUSED_V1
     assert selection["effective_id"] == RFDETR_POSTPROCESSOR_TRITON_FUSED_V1
     assert selection["fallback_reason"] is None

--- a/inference_models/tests/unit_tests/models/rfdetr/test_rfdetr_trt_runtime_fallback.py
+++ b/inference_models/tests/unit_tests/models/rfdetr/test_rfdetr_trt_runtime_fallback.py
@@ -19,11 +19,15 @@ from inference_models.models.optimization.contracts import (
     OptimizationStage,
 )
 from inference_models.models.optimization.errors import RecoverableStageExecutionError
+from inference_models.models.optimization.execution_plan import InferenceExecutionPlan
 from inference_models.models.optimization.registry import ImplementationRegistry
 from inference_models.models.rfdetr.optimization.contracts import (
     PostprocessRequest,
     PreprocessRequest,
     PreprocessResult,
+)
+from inference_models.models.rfdetr.optimization.execution_plan import (
+    RFDetrExecutionPlan,
 )
 from inference_models.models.rfdetr.optimization.ids import (
     RFDETR_POSTPROCESSOR_BASE,
@@ -106,6 +110,44 @@ def rfdetr_trt_model_class(monkeypatch):
                     delattr(parent, attribute)
             else:
                 setattr(parent, attribute, previous_attribute)
+
+
+def test_model_boundary_parses_serialized_generic_execution_plan(
+    rfdetr_trt_model_class,
+) -> None:
+    execution_plan = InferenceExecutionPlan(
+        preprocessor_id=RFDETR_PREPROCESSOR_TRITON_UNIVERSAL_V1,
+        postprocessor_id=RFDETR_POSTPROCESSOR_BASE,
+        allow_compatibility_fallback=False,
+        allow_runtime_failure_fallback=False,
+    )
+
+    resolved_plan = rfdetr_trt_model_class._resolve_requested_execution_plan(
+        rfdetr_execution_plan=None,
+        execution_plan=execution_plan.to_dict(),
+    )
+
+    assert isinstance(resolved_plan, RFDetrExecutionPlan)
+    assert resolved_plan.preprocessor_id == RFDETR_PREPROCESSOR_TRITON_UNIVERSAL_V1
+    assert resolved_plan.postprocessor_id == RFDETR_POSTPROCESSOR_BASE
+    assert not resolved_plan.allow_compatibility_fallback
+    assert not resolved_plan.allow_runtime_failure_fallback
+
+
+def test_model_boundary_rejects_invalid_or_conflicting_execution_plans(
+    rfdetr_trt_model_class,
+) -> None:
+    with pytest.raises(ValueError, match="must contain exactly"):
+        rfdetr_trt_model_class._resolve_requested_execution_plan(
+            rfdetr_execution_plan=None,
+            execution_plan={},
+        )
+
+    with pytest.raises(ValueError, match="either rfdetr_execution_plan"):
+        rfdetr_trt_model_class._resolve_requested_execution_plan(
+            rfdetr_execution_plan=RFDetrExecutionPlan(),
+            execution_plan=InferenceExecutionPlan(),
+        )
 
 
 class _RuntimeStage:

--- a/inference_models/tests/unit_tests/models/rfdetr/test_rfdetr_trt_runtime_fallback.py
+++ b/inference_models/tests/unit_tests/models/rfdetr/test_rfdetr_trt_runtime_fallback.py
@@ -19,7 +19,6 @@ from inference_models.models.optimization.contracts import (
     OptimizationStage,
 )
 from inference_models.models.optimization.errors import RecoverableStageExecutionError
-from inference_models.models.optimization.execution_plan import InferenceExecutionPlan
 from inference_models.models.optimization.registry import ImplementationRegistry
 from inference_models.models.rfdetr.optimization.contracts import (
     PostprocessRequest,
@@ -112,10 +111,10 @@ def rfdetr_trt_model_class(monkeypatch):
                 setattr(parent, attribute, previous_attribute)
 
 
-def test_model_boundary_parses_serialized_generic_execution_plan(
+def test_model_boundary_parses_serialized_rfdetr_execution_plan(
     rfdetr_trt_model_class,
 ) -> None:
-    execution_plan = InferenceExecutionPlan(
+    execution_plan = RFDetrExecutionPlan(
         preprocessor_id=RFDETR_PREPROCESSOR_TRITON_UNIVERSAL_V1,
         postprocessor_id=RFDETR_POSTPROCESSOR_BASE,
         allow_compatibility_fallback=False,
@@ -146,7 +145,7 @@ def test_model_boundary_rejects_invalid_or_conflicting_execution_plans(
     with pytest.raises(ValueError, match="either rfdetr_execution_plan"):
         rfdetr_trt_model_class._resolve_requested_execution_plan(
             rfdetr_execution_plan=RFDetrExecutionPlan(),
-            execution_plan=InferenceExecutionPlan(),
+            execution_plan=RFDetrExecutionPlan(),
         )
 
 
@@ -407,7 +406,7 @@ def test_preprocess_retries_base_then_short_circuits_recorded_failure(
     first_tensor, first_metadata = model.pre_process(
         images=np.zeros((2, 2, 3), dtype=np.uint8)
     )
-    first_selection = model._thread_local_storage.last_preprocessor_selection
+    first_selection = model._thread_local_storage.last_preprocess_selection
     second_tensor, second_metadata = model.pre_process(
         images=np.zeros((2, 2, 3), dtype=np.uint8)
     )
@@ -491,7 +490,7 @@ def test_preprocess_nonrecoverable_failure_records_attempted_selection(
     with pytest.raises(ValueError, match="non-recoverable failure"):
         model.pre_process(images=np.zeros((2, 2, 3), dtype=np.uint8))
 
-    selection = model._thread_local_storage.last_preprocessor_selection
+    selection = model._thread_local_storage.last_preprocess_selection
     assert selection["requested_id"] == RFDETR_PREPROCESSOR_TRITON_UNIVERSAL_V1
     assert selection["effective_id"] == RFDETR_PREPROCESSOR_TRITON_UNIVERSAL_V1
     assert selection["fallback_reason"] is None
@@ -518,7 +517,7 @@ def test_postprocess_retries_base_then_short_circuits_recorded_failure(
         pre_processing_meta=[],
         confidence=0.5,
     )
-    first_selection = model._thread_local_storage.last_postprocessor_selection
+    first_selection = model._thread_local_storage.last_postprocess_selection
     second_results = model.post_process(
         model_results=model_results,
         pre_processing_meta=[],
@@ -594,7 +593,7 @@ def test_postprocess_nonrecoverable_failure_records_attempted_selection(
             confidence=0.5,
         )
 
-    selection = model._thread_local_storage.last_postprocessor_selection
+    selection = model._thread_local_storage.last_postprocess_selection
     assert selection["requested_id"] == RFDETR_POSTPROCESSOR_TRITON_FUSED_V1
     assert selection["effective_id"] == RFDETR_POSTPROCESSOR_TRITON_FUSED_V1
     assert selection["fallback_reason"] is None


### PR DESCRIPTION
## What does this PR do?

Linked issue: None.

Optimization profiling needs durable proof of the implementation stages that RF-DETR TensorRT actually selected, including whether compatibility or runtime-failure fallback occurred. Previously, the runtime metadata was unversioned and the execution-plan contract did not provide profiling-specific validation.

This PR formalizes the existing `optimization_runtime_metadata` property as a versioned runtime-selection contract. It extends the existing execution plan with canonical serialization, parsing, and profiling validation instead of introducing a parallel strict-plan type. RF-DETR accepts either its typed execution plan or a mapping through the single `execution_plan` loader argument while preserving environment-based production selection when the argument is omitted. Model-time and latest request-time selections retain the established `preprocessor` and `postprocessor` stage names and expose requested IDs, effective IDs, and fallback reasons. Profiling validation requires explicit implementations for every stage, rejects `auto`, and requires both fallback modes to be disabled. Runtime selection snapshots are serialized only when metadata is read, and unchanged request selections avoid repeated thread-local writes.

**Main elements:**
- Canonical parsing and profiling validation on the existing inference execution plan
- Versioned optimization runtime metadata protocol and immutable selection snapshots
- RF-DETR TensorRT loader and runtime-selection instrumentation
- Unit coverage for strict profiling behavior, metadata, and runtime fallback
- RF-DETR optimization and environment-variable documentation

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other:

## Testing

### Unit tests

- Execution-plan serialization, parsing, identifier validation, explicit stage requirements, and fallback prohibition for profiling
- RF-DETR runtime metadata initialization and request-time selection behavior
- Production-configurable compatibility and runtime-failure fallback evidence

### Integration tests

- RF-DETR TensorRT base and large workloads on `orin-agx-jp62`, covering snapshots, latency, memory, Nsight Systems, and optimization handoff with all five stages observed and no fallback

### Other

- `PYTHONPATH=. UV_CACHE_DIR=/private/tmp/inference-pr3-uv-cache uv run pytest tests/unit_tests/models/optimization tests/unit_tests/models/rfdetr` — 195 passed, 15 skipped
- `git diff --check codex/agent-instructions...codex/implementation-selection-proof`

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where necessary, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have updated the documentation accordingly (if applicable)

## Additional Context

This PR is stacked on `codex/agent-instructions`. The Jetson campaign validated implementation commit `1ba219708`; subsequent commits simplify the public loader API and preserve the established runtime metadata stage names, with the current tip covered by the unit suite. The matching inference-profiler work is on its own `codex/implementation-selection-proof` branch. There is no Linear issue associated with this work.
