### PR TITLE
Switch GLM 5.3 Flash detection to the validated bbox_2d prompt

### DIFF
--- a/inference/core/workflows/core_steps/formatters/vlm_as_detector/v2.py
+++ b/inference/core/workflows/core_steps/formatters/vlm_as_detector/v2.py
@@ -255,7 +255,7 @@ class BlockManifest(WorkflowBlockManifest):
         "zai-flash",
         "florence-2",
     ] = Field(
-        description="Type of the VLM/LLM model that generated the prediction. Determines which parser is used to extract detection data from the JSON output. Supported models: 'openai' (GPT-4V), 'google-gemini' (Gemini Vision), 'anthropic-claude' (Claude Vision), 'spacexai' (Grok), 'qwen' (Qwen-VL via OpenRouter), 'zai' (Z.ai GLM 5V Turbo via OpenRouter, box_2d xyxy 0-1000), 'zai-flash' (Z.ai GLM 5.3 Flash via OpenRouter, box_2d yxyx 0-1000), 'muse' (Meta Muse via OpenRouter), 'florence-2' (Microsoft Florence-2). Each model type has different JSON output formats, so the correct model type must be specified for proper parsing.",
+        description="Type of the VLM/LLM model that generated the prediction. Determines which parser is used to extract detection data from the JSON output. Supported models: 'openai' (GPT-4V), 'google-gemini' (Gemini Vision), 'anthropic-claude' (Claude Vision), 'spacexai' (Grok), 'qwen' (Qwen-VL via OpenRouter), 'zai' (Z.ai GLM 5V Turbo via OpenRouter, box_2d xyxy 0-1000), 'zai-flash' (Z.ai GLM 5.3 Flash via OpenRouter, bbox_2d xyxy 0-1000), 'muse' (Meta Muse via OpenRouter), 'florence-2' (Microsoft Florence-2). Each model type has different JSON output formats, so the correct model type must be specified for proper parsing.",
         examples=[
             ["openai"],
             ["google-gemini"],
@@ -617,11 +617,12 @@ REGISTERED_PARSERS = {
     ("spacexai", "object-detection"): parse_spacexai_object_detection_response,
     ("qwen", "object-detection"): parse_qwen_object_detection_response,
     ("muse", "object-detection"): parse_muse_object_detection_response,
-    # GLM 5V Turbo prompts for the Qwen box_2d xyxy 0-1000 contract; GLM 5.3
-    # Flash prompts for the Gemini box_2d yxyx 0-1000 contract. Same key,
-    # different axis order, so each model gets its own model_type.
+    # Both GLM models emit xyxy 0-1000 boxes: GLM 5V Turbo under the
+    # "box_2d" key, GLM 5.3 Flash under "bbox_2d". The Qwen parser accepts
+    # both keys, so both model_types share it; the labels stay separate
+    # for saved-workflow compatibility.
     ("zai", "object-detection"): parse_qwen_object_detection_response,
-    ("zai-flash", "object-detection"): parse_gemini_object_detection_response,
+    ("zai-flash", "object-detection"): parse_qwen_object_detection_response,
     # Florence 2
     ("florence-2", "object-detection"): partial(
         parse_florence2_object_detection_response, florence_task_type="<OD>"

--- a/inference/core/workflows/core_steps/formatters/vlm_as_detector/v2_tensor.py
+++ b/inference/core/workflows/core_steps/formatters/vlm_as_detector/v2_tensor.py
@@ -272,7 +272,7 @@ class BlockManifest(WorkflowBlockManifest):
         "zai-flash",
         "florence-2",
     ] = Field(
-        description="Type of the VLM/LLM model that generated the prediction. Determines which parser is used to extract detection data from the JSON output. Supported models: 'openai' (GPT-4V), 'google-gemini' (Gemini Vision), 'anthropic-claude' (Claude Vision), 'spacexai' (Grok), 'qwen' (Qwen-VL via OpenRouter), 'zai' (Z.ai GLM 5V Turbo via OpenRouter, box_2d xyxy 0-1000), 'zai-flash' (Z.ai GLM 5.3 Flash via OpenRouter, box_2d yxyx 0-1000), 'muse' (Meta Muse via OpenRouter), 'florence-2' (Microsoft Florence-2). Each model type has different JSON output formats, so the correct model type must be specified for proper parsing.",
+        description="Type of the VLM/LLM model that generated the prediction. Determines which parser is used to extract detection data from the JSON output. Supported models: 'openai' (GPT-4V), 'google-gemini' (Gemini Vision), 'anthropic-claude' (Claude Vision), 'spacexai' (Grok), 'qwen' (Qwen-VL via OpenRouter), 'zai' (Z.ai GLM 5V Turbo via OpenRouter, box_2d xyxy 0-1000), 'zai-flash' (Z.ai GLM 5.3 Flash via OpenRouter, bbox_2d xyxy 0-1000), 'muse' (Meta Muse via OpenRouter), 'florence-2' (Microsoft Florence-2). Each model type has different JSON output formats, so the correct model type must be specified for proper parsing.",
         examples=[
             ["openai"],
             ["google-gemini"],
@@ -980,11 +980,12 @@ REGISTERED_PARSERS = {
     ("spacexai", "object-detection"): parse_spacexai_object_detection_response,
     ("qwen", "object-detection"): parse_qwen_object_detection_response,
     ("muse", "object-detection"): parse_muse_object_detection_response,
-    # GLM 5V Turbo prompts for the Qwen box_2d xyxy 0-1000 contract; GLM 5.3
-    # Flash prompts for the Gemini box_2d yxyx 0-1000 contract. Same key,
-    # different axis order, so each model gets its own model_type.
+    # Both GLM models emit xyxy 0-1000 boxes: GLM 5V Turbo under the
+    # "box_2d" key, GLM 5.3 Flash under "bbox_2d". The Qwen parser accepts
+    # both keys, so both model_types share it; the labels stay separate
+    # for saved-workflow compatibility.
     ("zai", "object-detection"): parse_qwen_object_detection_response,
-    ("zai-flash", "object-detection"): parse_gemini_object_detection_response,
+    ("zai-flash", "object-detection"): parse_qwen_object_detection_response,
     # Florence 2
     ("florence-2", "object-detection"): partial(
         parse_florence2_object_detection_response, florence_task_type="<OD>"

--- a/inference/core/workflows/core_steps/formatters/vlm_as_detector/zai_detection_parsing.py
+++ b/inference/core/workflows/core_steps/formatters/vlm_as_detector/zai_detection_parsing.py
@@ -1,11 +1,11 @@
 import json
 from typing import Optional
 
-# The Z.ai detection contracts, both "box_2d" lists normalized to 0-1000:
-# GLM 5V Turbo (model_type "zai") uses xyxy order and parses with the Qwen
-# parser; GLM 5.3 Flash (model_type "zai-flash") uses yxyx order and parses
-# with the Gemini parser. The axis order is not recoverable from the data,
-# so each model maps to its own model_type in the registry.
+# The Z.ai detection contracts, both xyxy lists normalized to 0-1000:
+# GLM 5V Turbo (model_type "zai") uses the "box_2d" key and GLM 5.3 Flash
+# (model_type "zai-flash") uses "bbox_2d". Both parse with the Qwen parser,
+# which accepts either key; the model_types stay separate so saved
+# workflows keep working if the contracts ever diverge again.
 
 
 def extract_zai_json_array(raw: str) -> Optional[list]:

--- a/inference/core/workflows/core_steps/models/foundation/zai_vlm/v1.py
+++ b/inference/core/workflows/core_steps/models/foundation/zai_vlm/v1.py
@@ -1,10 +1,11 @@
 """Z.ai GLM vision-language block, v1.
 
-OpenRouter-only. Uses the vlm-exam request contract validated for
-GLM 5V Turbo: image-first user message, no system role, extended
-reasoning disabled by default, and the box_2d / 0-1000 xyxy detection
-prompt. Parse detection output with ``vlm_as_detector@v2`` using
-``model_type="zai"``.
+OpenRouter-only. Uses the vlm-exam request contract: image-first user
+message, no system role, extended reasoning disabled by default, and
+per-model xyxy / 0-1000 detection prompts (``box_2d`` key for GLM 5V
+Turbo, ``bbox_2d`` for GLM 5.3 Flash). Parse detection output with
+``vlm_as_detector@v2`` using ``model_type="zai"`` for Turbo and
+``model_type="zai-flash"`` for Flash.
 """
 
 import base64
@@ -76,18 +77,21 @@ ZAI_OBJECT_DETECTION_PROMPT_TEMPLATE = (
     "Only use these labels: {class_list}"
 )
 
-# Ported verbatim from vlm-exam's `_PROMPT_TEMPLATE`, the format pinned for
-# GLM 5.3 Flash (`yxyx_normalized_0_to_1000`). The full 250-image benchmark
-# scores it 0.331 dataset mAP@50 vs 0.219 for absolute-pixel bbox_2d
-# prompting, the next best format.
+# Ported verbatim from vlm-exam's `_BBOX_2D_NORMALIZED_PROMPT_TEMPLATE`,
+# the format pinned for GLM 5.3 Flash
+# (`xyxy_normalized_0_to_1000_bbox_2d`). Re-selected during the fp8-pinned
+# re-evaluation (the earlier yxyx box_2d pick came from runs that hit
+# quantized OpenRouter providers) and confirmed by a prompt-format sweep:
+# alternative containers and key names (bullets, "box", absolute pixels)
+# all score 36-70% below this Qwen-style template on the 250-image
+# benchmark.
 ZAI_FLASH_OBJECT_DETECTION_PROMPT_TEMPLATE = (
-    "Detect all objects in this image. "
-    "Output a JSON list where each entry contains the 2D bounding box "
-    'in the key "box_2d" and the text label in the key "label". '
-    'The "box_2d" value must be [y_min, x_min, y_max, x_max]: integers '
-    "between 0 and 1000, normalized to the image height and width. "
-    "Return only the JSON list, with no extra text. "
-    "Only use these labels: {class_list}"
+    "Detect all objects in this image and return their locations in the "
+    "form of coordinates. The format of output should be like "
+    '{{"bbox_2d": [x1, y1, x2, y2], "label": "<name>"}}. '
+    "bbox_2d is [xmin, ymin, xmax, ymax] as integers between 0 and 1000, "
+    "normalized to image width and height. "
+    "Only use these labels: {class_list}. Return a JSON array only."
 )
 
 # One row per model; add future Z.ai models here. A row may override
@@ -95,8 +99,9 @@ ZAI_FLASH_OBJECT_DETECTION_PROMPT_TEMPLATE = (
 # `reasoning_required` marks models that reject `reasoning: {enabled:
 # false}` and fall back to low effort when the user disables reasoning.
 # `detection_model_type` is the `vlm_as_detector@v2` model_type that parses
-# the model's detection output; the two GLM models emit the same "box_2d"
-# key with different axis orders, so each needs its own parser entry.
+# the model's detection output; both GLM models emit xyxy 0-1000 boxes but
+# with different key names ("box_2d" for Turbo, "bbox_2d" for Flash), so
+# each keeps its own model_type.
 MODEL_VARIANTS: Dict[str, Dict[str, Any]] = {
     "GLM 5V Turbo": {
         "model_id": "z-ai/glm-5v-turbo",
@@ -440,12 +445,11 @@ You can specify arbitrary text prompts or predefined ones. The block supports:
 {RELEVANT_TASKS_DOCS_DESCRIPTION}
 
 Object detection uses the per-model format validated in the vlm-exam
-benchmarks. Both models emit `box_2d`/`label` entries normalized to
-0-1000, but with different axis orders: GLM 5V Turbo uses
-`[x_min, y_min, x_max, y_max]` and GLM 5.3 Flash uses
-`[y_min, x_min, y_max, x_max]`. Parse with `VLM as Detector`
-(`vlm_as_detector@v2`) using `model_type="zai"` for GLM 5V Turbo and
-`model_type="zai-flash"` for GLM 5.3 Flash.
+benchmarks. Both models emit `[x_min, y_min, x_max, y_max]` boxes as
+integers normalized to 0-1000, but with different key names: GLM 5V
+Turbo uses `box_2d` and GLM 5.3 Flash uses `bbox_2d`. Parse with
+`VLM as Detector` (`vlm_as_detector@v2`) using `model_type="zai"` for
+GLM 5V Turbo and `model_type="zai-flash"` for GLM 5.3 Flash.
 
 Every request sends the image before the instruction text in a single user
 message. GLM models default to extended reasoning on OpenRouter; the block

--- a/tests/workflows/unit_tests/core_steps/formatters/vlm_as_detector/test_v2.py
+++ b/tests/workflows/unit_tests/core_steps/formatters/vlm_as_detector/test_v2.py
@@ -503,10 +503,10 @@ def test_run_method_for_zai_box_2d_output() -> None:
     assert np.allclose(result["predictions"].confidence, np.array([1.0, 1.0]))
 
 
-def test_run_method_for_zai_flash_yxyx_box_2d_output() -> None:
-    # given - the GLM 5.3 Flash prompt pins box_2d entries as
-    # [y_min, x_min, y_max, x_max] integers normalized to 0-1000
-    # (the Gemini contract)
+def test_run_method_for_zai_flash_xyxy_bbox_2d_output() -> None:
+    # given - the GLM 5.3 Flash prompt pins bbox_2d entries as
+    # [x_min, y_min, x_max, y_max] integers normalized to 0-1000
+    # (the Qwen contract)
     block = VLMAsDetectorBlockV2()
     image = WorkflowImageData(
         numpy_image=np.zeros((480, 640, 3), dtype=np.uint8),
@@ -514,8 +514,8 @@ def test_run_method_for_zai_flash_yxyx_box_2d_output() -> None:
     )
     vlm_output = """
 [
-  {"box_2d": [100, 200, 500, 1000], "label": "cat"},
-  {"box_2d": [0, 0, 500, 500], "label": "unicorn"}
+  {"bbox_2d": [200, 100, 1000, 500], "label": "cat"},
+  {"bbox_2d": [0, 0, 500, 500], "label": "unicorn"}
 ]
     """
 
@@ -554,7 +554,7 @@ def test_run_method_for_zai_flash_recovers_array_from_prose_wrapped_output() -> 
     )
     vlm_output = (
         "Here are the detected objects: "
-        '[{"box_2d": [100, 200, 500, 1000], "label": "cat"}] '
+        '[{"bbox_2d": [200, 100, 1000, 500], "label": "cat"}] '
         "Let me know if you need anything else."
     )
 

--- a/tests/workflows/unit_tests/core_steps/formatters/vlm_as_detector/test_v2_tensor.py
+++ b/tests/workflows/unit_tests/core_steps/formatters/vlm_as_detector/test_v2_tensor.py
@@ -330,10 +330,10 @@ def test_run_method_for_zai_box_2d_output_tensor_native() -> None:
     )
 
 
-def test_run_method_for_zai_flash_yxyx_box_2d_output_tensor_native() -> None:
-    # given - the GLM 5.3 Flash prompt pins box_2d entries as
-    # [y_min, x_min, y_max, x_max] integers normalized to 0-1000
-    # (the Gemini contract)
+def test_run_method_for_zai_flash_xyxy_bbox_2d_output_tensor_native() -> None:
+    # given - the GLM 5.3 Flash prompt pins bbox_2d entries as
+    # [x_min, y_min, x_max, y_max] integers normalized to 0-1000
+    # (the Qwen contract)
     block = VLMAsDetectorBlockV2()
     image = WorkflowImageData(
         numpy_image=np.zeros((480, 640, 3), dtype=np.uint8),
@@ -341,8 +341,8 @@ def test_run_method_for_zai_flash_yxyx_box_2d_output_tensor_native() -> None:
     )
     vlm_output = """
 [
-  {"box_2d": [100, 200, 500, 1000], "label": "cat"},
-  {"box_2d": [0, 0, 500, 500], "label": "unicorn"}
+  {"bbox_2d": [200, 100, 1000, 500], "label": "cat"},
+  {"bbox_2d": [0, 0, 500, 500], "label": "unicorn"}
 ]
     """
 

--- a/tests/workflows/unit_tests/core_steps/models/foundation/test_zai_vlm_v1.py
+++ b/tests/workflows/unit_tests/core_steps/models/foundation/test_zai_vlm_v1.py
@@ -150,20 +150,19 @@ def test_run_maps_reasoning_effort_to_openrouter_config(mock_or):
     assert mock_or.call_args.kwargs["reasoning"] == {"effort": "high"}
 
 
-# Copied from vlm-exam `_PROMPT_TEMPLATE` so an edit to the block constant
-# fails this test.
+# Copied from vlm-exam `_BBOX_2D_NORMALIZED_PROMPT_TEMPLATE` so an edit to
+# the block constant fails this test.
 EXPECTED_FLASH_DETECTION_PROMPT = (
-    "Detect all objects in this image. "
-    "Output a JSON list where each entry contains the 2D bounding box "
-    'in the key "box_2d" and the text label in the key "label". '
-    'The "box_2d" value must be [y_min, x_min, y_max, x_max]: integers '
-    "between 0 and 1000, normalized to the image height and width. "
-    "Return only the JSON list, with no extra text. "
-    "Only use these labels: cat, dog"
+    "Detect all objects in this image and return their locations in the "
+    "form of coordinates. The format of output should be like "
+    '{"bbox_2d": [x1, y1, x2, y2], "label": "<name>"}. '
+    "bbox_2d is [xmin, ymin, xmax, ymax] as integers between 0 and 1000, "
+    "normalized to image width and height. "
+    "Only use these labels: cat, dog. Return a JSON array only."
 )
 
 
-def test_flash_detection_prompt_is_vlm_exam_yxyx_template():
+def test_flash_detection_prompt_is_vlm_exam_bbox_2d_template():
     messages = build_zai_openrouter_prompts(
         images=[np.zeros((8, 8, 3), dtype=np.uint8)],
         task_type="object-detection",
@@ -200,4 +199,4 @@ def test_run_flash_falls_back_to_low_effort_when_reasoning_disabled(mock_or):
     assert mock_or.call_args.kwargs["model"] == "z-ai/glm-5.3-flash"
     assert mock_or.call_args.kwargs["reasoning"] == {"effort": "low"}
     sent_text = mock_or.call_args.kwargs["prompts"][0][0]["content"][1]["text"]
-    assert "[y_min, x_min, y_max, x_max]" in sent_text
+    assert '"bbox_2d"' in sent_text


### PR DESCRIPTION
## What does this PR do?

The GLM 5.3 Flash block was asking the model for yxyx `box_2d` boxes. That format came from the first detection benchmark, which was almost certainly hitting quantized OpenRouter providers.

We pinned OpenRouter to native fp8 and re-ran the 250-image detection set. The format that actually wins is Qwen-style: a JSON array of `{"bbox_2d": [xmin, ymin, xmax, ymax], "label": "..."}` with integers from 0 to 1000. We also tried bullets, a `box` key, and absolute pixels. Those all scored 36–70% worse than this prompt.

This PR updates the Flash detection prompt to that template and points `vlm_as_detector@v2` `model_type="zai-flash"` at the Qwen parser. That parser already accepts both `box_2d` and `bbox_2d`. The `zai-flash` label stays so saved workflows keep compiling. GLM 5V Turbo is unchanged.

If someone wrote a custom prompt that still emits yxyx `box_2d` and parses it as `zai-flash`, those boxes will be axis-swapped. Default block users are fine: the new prompt and the new parser ship together.

## Benchmark

Same 250-image detection set, OpenRouter fp8, two reasoning levels. Old = current yxyx `box_2d` prompt. New = this `bbox_2d` prompt.

Dataset mAP:

| Run | Incomplete | mAP@50 | mAP@75 | mAP@50:95 |
|---|---|---|---|---|
| Old, low | 0 | 0.3024 | 0.1413 | 0.1537 |
| New, low | 0 | **0.3725** | **0.2137** | **0.2131** |
| Old, max | 1 | **0.3388** | 0.1729 | 0.1884 |
| New, max | 0 | 0.3292 | **0.1912** | **0.1903** |

At low reasoning the new prompt is clearly better: +7.0 mAP@50, +7.2 mAP@75, +5.9 mAP@50:95. At max reasoning the picture is mixed: old is +1.0 on dataset mAP@50, new is ahead on mAP@75 and mean per-image mAP. The old-max run still has one empty response (`Lego_122_low`).

Tokens and latency (mean / median):

| Run | Output tokens | Latency (s) |
|---|---|---|
| Old, low | 973 / 522 | 27.4 / 15.7 |
| New, low | 1108 / 473 | 27.6 / 15.1 |
| Old, max | 3951 / 2165 | 58.9 / 29.9 |
| New, max | 4789 / 2399 | 85.0 / 30.4 |

At low effort the new prompt costs about the same time and a similar token budget. At max effort it uses more tokens and wall time, mostly because max reasoning often burns the output budget on thinking before it writes boxes.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other:

## Testing

### Unit tests

- Flash detection prompt matches the vlm-exam `bbox_2d` template exactly
- `zai-flash` parses xyxy `bbox_2d` JSON, including an unknown-class label
- Prose-wrapped `bbox_2d` arrays still recover
- Tensor-native path matches the same contract
- Reasoning-disabled Flash fallback still sends the new prompt

Qwen-parser edge cases (malformed boxes, empty arrays, label aliases, both key names) stay in the existing `test_qwen_detection_parsing.py`.

### Integration tests

None in CI.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)


Made with [Cursor](https://cursor.com)