### PR TITLE
Add Claude Fable 5.1 to the Anthropic Claude blocks (1.5.1-post2)

### DIFF
--- a/inference/core/version.py
+++ b/inference/core/version.py
@@ -1,4 +1,4 @@
-__version__ = "1.5.1-post1"
+__version__ = "1.5.1-post2"
 
 
 if __name__ == "__main__":

--- a/inference/core/workflows/core_steps/models/foundation/anthropic_claude/model_capabilities.py
+++ b/inference/core/workflows/core_steps/models/foundation/anthropic_claude/model_capabilities.py
@@ -97,8 +97,9 @@ def resolve_temperature(
     if anthropic_model_supports_temperature(model_version):
         return temperature
 
-    if model_version not in _TEMPERATURE_WARNINGS_EMITTED:
-        _TEMPERATURE_WARNINGS_EMITTED.add(model_version)
+    normalized_model = normalize_anthropic_model_id(model_version)
+    if normalized_model not in _TEMPERATURE_WARNINGS_EMITTED:
+        _TEMPERATURE_WARNINGS_EMITTED.add(normalized_model)
         logger.warning(
             "Anthropic model `%s` does not accept the `temperature` parameter "
             "(Claude Opus 4.7 and newer, Sonnet 5, Opus 5 and Fable models reject "
@@ -145,11 +146,12 @@ def build_thinking_config(
         )
         return {"type": "enabled", "budget_tokens": effective_budget}
 
+    normalized_model = normalize_anthropic_model_id(model_version)
     if (
         thinking_budget_tokens is not None
-        and model_version not in _THINKING_BUDGET_WARNINGS_EMITTED
+        and normalized_model not in _THINKING_BUDGET_WARNINGS_EMITTED
     ):
-        _THINKING_BUDGET_WARNINGS_EMITTED.add(model_version)
+        _THINKING_BUDGET_WARNINGS_EMITTED.add(normalized_model)
         logger.warning(
             "Anthropic model `%s` only supports adaptive thinking; ignoring "
             "thinking_budget_tokens=%s and requesting `thinking.type=adaptive`.",

--- a/inference/core/workflows/core_steps/models/foundation/anthropic_claude/model_capabilities.py
+++ b/inference/core/workflows/core_steps/models/foundation/anthropic_claude/model_capabilities.py
@@ -1,0 +1,204 @@
+"""Per-model request capabilities shared by the Anthropic Claude block versions.
+
+Starting with Claude Opus 4.7, Anthropic removed the sampling parameters
+(``temperature``, ``top_p``, ``top_k``) and manual extended thinking
+(``thinking: {"type": "enabled", "budget_tokens": N}``). Sending either to
+such a model returns HTTP 400. Thinking on those models is adaptive
+(``thinking: {"type": "adaptive"}``), while models up to the 4.6 generation
+still take the manual controls and Sonnet 4.5 / Haiku 4.5 / Opus 4.5 reject
+the adaptive form.
+
+The allow-lists below name the models that still accept the legacy controls,
+so unknown or future ids default to the current behaviour. They mirror
+``TEMPERATURE_SUPPORTED_MODELS`` in the Roboflow API proxy
+(``app/functions/services/anthropicProxy/anthropicProxyService.ts``) and the
+``capabilities.thinking.types`` flags returned by Anthropic's Models API; keep
+them in sync when a new model generation ships.
+"""
+
+import re
+from typing import Dict, FrozenSet, Optional, Set
+
+from inference.core import logger
+
+_MODELS_WITH_LEGACY_CONTROLS: FrozenSet[str] = frozenset(
+    {
+        "claude-opus-4-6",
+        "claude-opus-4-5",
+        "claude-opus-4-1",
+        "claude-opus-4",
+        "claude-sonnet-4-6",
+        "claude-sonnet-4-5",
+        "claude-sonnet-4",
+        "claude-haiku-4-5",
+        "claude-3-7-sonnet",
+        "claude-3-5-haiku",
+        "claude-3-opus",
+        "claude-3-haiku",
+        # v1 alias labels that resolve to Sonnet 4.5 on the wire
+        "claude-3-5-sonnet",
+        "claude-3-5-sonnet-v2",
+        "claude-4-5-sonnet",
+        "claude-4-5-sonnet-v2",
+    }
+)
+
+TEMPERATURE_SUPPORTED_MODELS: FrozenSet[str] = _MODELS_WITH_LEGACY_CONTROLS
+"""Models that still accept a non-default ``temperature``."""
+
+MANUAL_THINKING_SUPPORTED_MODELS: FrozenSet[str] = _MODELS_WITH_LEGACY_CONTROLS
+"""Models that still accept ``thinking.type = "enabled"`` with a token budget."""
+
+_DATED_SNAPSHOT_SUFFIX = re.compile(r"-\d{8}$")
+_LATEST_SUFFIX = re.compile(r"-latest$")
+_NON_ALPHANUMERIC = re.compile(r"[^a-z0-9]+")
+
+_TEMPERATURE_WARNINGS_EMITTED: Set[str] = set()
+_THINKING_BUDGET_WARNINGS_EMITTED: Set[str] = set()
+
+
+def normalize_anthropic_model_id(model_version: str) -> str:
+    """Reduce a Claude model reference to the bare family slug.
+
+    Accepts friendly block labels, dated snapshot ids and ``-latest`` aliases
+    and returns the lower-case dash-separated slug used by the allow-lists,
+    e.g. ``claude-sonnet-4-5-20250929`` -> ``claude-sonnet-4-5`` and
+    ``anthropic.claude-fable-5-1`` -> ``anthropic-claude-fable-5-1``.
+
+    Args:
+        model_version: Model label or wire id as configured on the block.
+
+    Returns:
+        Normalised slug suitable for membership checks.
+    """
+    slug = _NON_ALPHANUMERIC.sub("-", model_version.strip().lower()).strip("-")
+    slug = _LATEST_SUFFIX.sub("", slug)
+    slug = _DATED_SNAPSHOT_SUFFIX.sub("", slug)
+
+    return slug
+
+
+def anthropic_model_supports_temperature(model_version: str) -> bool:
+    """Tell whether a Claude model still accepts a non-default ``temperature``.
+
+    Args:
+        model_version: Model label or wire id as configured on the block.
+
+    Returns:
+        ``True`` for models up to the 4.6 generation, ``False`` for Opus 4.7
+        and newer, Sonnet 5, Opus 5, the Fable line and any unknown id.
+    """
+    supported = normalize_anthropic_model_id(model_version) in (
+        TEMPERATURE_SUPPORTED_MODELS
+    )
+
+    return supported
+
+
+def anthropic_model_supports_manual_thinking(model_version: str) -> bool:
+    """Tell whether a Claude model accepts ``thinking.type = "enabled"``.
+
+    Args:
+        model_version: Model label or wire id as configured on the block.
+
+    Returns:
+        ``True`` for models up to the 4.6 generation, ``False`` for models
+        whose thinking is adaptive only (Opus 4.7 and newer, Sonnet 5,
+        Opus 5, the Fable line) and for any unknown id.
+    """
+    supported = normalize_anthropic_model_id(model_version) in (
+        MANUAL_THINKING_SUPPORTED_MODELS
+    )
+
+    return supported
+
+
+def resolve_temperature(
+    temperature: Optional[float],
+    *,
+    model_version: str,
+    extended_thinking: Optional[bool] = None,
+) -> Optional[float]:
+    """Decide which ``temperature`` value, if any, to put on the request.
+
+    Mirrors the Roboflow proxy: the value is dropped when thinking is enabled
+    (Anthropic forbids the combination) and when the model no longer accepts
+    sampling parameters, so the same workflow behaves identically with a
+    customer key and with ``rf_key:account``. Dropping a user-provided value
+    logs a warning once per model per process.
+
+    Args:
+        temperature: Value configured on the block, or ``None``.
+        model_version: Model label or wire id as configured on the block.
+        extended_thinking: Whether the block requested thinking.
+
+    Returns:
+        The temperature to send, or ``None`` when it must be omitted.
+    """
+    if temperature is None or extended_thinking:
+        return None
+
+    if anthropic_model_supports_temperature(model_version):
+        return temperature
+
+    if model_version not in _TEMPERATURE_WARNINGS_EMITTED:
+        _TEMPERATURE_WARNINGS_EMITTED.add(model_version)
+        logger.warning(
+            "Anthropic model `%s` does not accept the `temperature` parameter "
+            "(Claude Opus 4.7 and newer, Sonnet 5, Opus 5 and Fable models reject "
+            "non-default sampling parameters); ignoring temperature=%s.",
+            model_version,
+            temperature,
+        )
+
+    return None
+
+
+def build_thinking_config(
+    *,
+    extended_thinking: Optional[bool],
+    thinking_budget_tokens: Optional[int],
+    model_version: str,
+    model_max_output: int,
+) -> Optional[Dict[str, object]]:
+    """Build the ``thinking`` request block appropriate for a Claude model.
+
+    Models that still support manual extended thinking receive
+    ``{"type": "enabled", "budget_tokens": N}`` where ``N`` defaults to half
+    of the model's output ceiling. Models whose thinking is adaptive only
+    receive ``{"type": "adaptive"}``; a configured budget is ignored there and
+    a warning is logged once per model per process.
+
+    Args:
+        extended_thinking: Whether the block requested thinking.
+        thinking_budget_tokens: Budget configured on the block, or ``None``.
+        model_version: Model label or wire id as configured on the block.
+        model_max_output: Output-token ceiling used to derive a default budget.
+
+    Returns:
+        The ``thinking`` payload, or ``None`` when thinking was not requested.
+    """
+    if not extended_thinking:
+        return None
+
+    if anthropic_model_supports_manual_thinking(model_version):
+        effective_budget = (
+            thinking_budget_tokens
+            if thinking_budget_tokens is not None
+            else model_max_output // 2
+        )
+        return {"type": "enabled", "budget_tokens": effective_budget}
+
+    if (
+        thinking_budget_tokens is not None
+        and model_version not in _THINKING_BUDGET_WARNINGS_EMITTED
+    ):
+        _THINKING_BUDGET_WARNINGS_EMITTED.add(model_version)
+        logger.warning(
+            "Anthropic model `%s` only supports adaptive thinking; ignoring "
+            "thinking_budget_tokens=%s and requesting `thinking.type=adaptive`.",
+            model_version,
+            thinking_budget_tokens,
+        )
+
+    return {"type": "adaptive"}

--- a/inference/core/workflows/core_steps/models/foundation/anthropic_claude/model_capabilities.py
+++ b/inference/core/workflows/core_steps/models/foundation/anthropic_claude/model_capabilities.py
@@ -1,19 +1,11 @@
 """Per-model request capabilities shared by the Anthropic Claude block versions.
 
-Starting with Claude Opus 4.7, Anthropic removed the sampling parameters
-(``temperature``, ``top_p``, ``top_k``) and manual extended thinking
-(``thinking: {"type": "enabled", "budget_tokens": N}``). Sending either to
-such a model returns HTTP 400. Thinking on those models is adaptive
-(``thinking: {"type": "adaptive"}``), while models up to the 4.6 generation
-still take the manual controls and Sonnet 4.5 / Haiku 4.5 / Opus 4.5 reject
-the adaptive form.
-
-The allow-lists below name the models that still accept the legacy controls,
-so unknown or future ids default to the current behaviour. They mirror
-``TEMPERATURE_SUPPORTED_MODELS`` in the Roboflow API proxy
-(``app/functions/services/anthropicProxy/anthropicProxyService.ts``) and the
-``capabilities.thinking.types`` flags returned by Anthropic's Models API; keep
-them in sync when a new model generation ships.
+Starting with Claude Opus 4.7, Anthropic rejects ``temperature`` and manual
+extended thinking (``thinking.type = "enabled"``) with HTTP 400; thinking on
+those models is ``adaptive``. The allow-list below names the models that still
+accept the legacy controls, so unknown or future ids default to the new
+behaviour. Keep it in sync with ``TEMPERATURE_SUPPORTED_MODELS`` in the
+Roboflow API proxy (``app/functions/services/anthropicProxy``).
 """
 
 import re
@@ -58,59 +50,23 @@ _THINKING_BUDGET_WARNINGS_EMITTED: Set[str] = set()
 
 
 def normalize_anthropic_model_id(model_version: str) -> str:
-    """Reduce a Claude model reference to the bare family slug.
-
-    Accepts friendly block labels, dated snapshot ids and ``-latest`` aliases
-    and returns the lower-case dash-separated slug used by the allow-lists,
-    e.g. ``claude-sonnet-4-5-20250929`` -> ``claude-sonnet-4-5`` and
-    ``anthropic.claude-fable-5-1`` -> ``anthropic-claude-fable-5-1``.
-
-    Args:
-        model_version: Model label or wire id as configured on the block.
-
-    Returns:
-        Normalised slug suitable for membership checks.
-    """
+    """Strip dated snapshot / ``-latest`` suffixes and slugify, e.g.
+    ``claude-sonnet-4-5-20250929`` -> ``claude-sonnet-4-5``."""
     slug = _NON_ALPHANUMERIC.sub("-", model_version.strip().lower()).strip("-")
     slug = _LATEST_SUFFIX.sub("", slug)
-    slug = _DATED_SNAPSHOT_SUFFIX.sub("", slug)
-
-    return slug
+    return _DATED_SNAPSHOT_SUFFIX.sub("", slug)
 
 
 def anthropic_model_supports_temperature(model_version: str) -> bool:
-    """Tell whether a Claude model still accepts a non-default ``temperature``.
-
-    Args:
-        model_version: Model label or wire id as configured on the block.
-
-    Returns:
-        ``True`` for models up to the 4.6 generation, ``False`` for Opus 4.7
-        and newer, Sonnet 5, Opus 5, the Fable line and any unknown id.
-    """
-    supported = normalize_anthropic_model_id(model_version) in (
-        TEMPERATURE_SUPPORTED_MODELS
-    )
-
-    return supported
+    """False for Claude Opus 4.7 and newer and for any unknown id."""
+    return normalize_anthropic_model_id(model_version) in TEMPERATURE_SUPPORTED_MODELS
 
 
 def anthropic_model_supports_manual_thinking(model_version: str) -> bool:
-    """Tell whether a Claude model accepts ``thinking.type = "enabled"``.
-
-    Args:
-        model_version: Model label or wire id as configured on the block.
-
-    Returns:
-        ``True`` for models up to the 4.6 generation, ``False`` for models
-        whose thinking is adaptive only (Opus 4.7 and newer, Sonnet 5,
-        Opus 5, the Fable line) and for any unknown id.
-    """
-    supported = normalize_anthropic_model_id(model_version) in (
-        MANUAL_THINKING_SUPPORTED_MODELS
+    """False for Claude Opus 4.7 and newer and for any unknown id."""
+    return (
+        normalize_anthropic_model_id(model_version) in MANUAL_THINKING_SUPPORTED_MODELS
     )
-
-    return supported
 
 
 def resolve_temperature(

--- a/inference/core/workflows/core_steps/models/foundation/anthropic_claude/v1.py
+++ b/inference/core/workflows/core_steps/models/foundation/anthropic_claude/v1.py
@@ -168,7 +168,11 @@ class BlockManifest(WorkflowBlockManifest):
     model_version: Union[
         Selector(kind=[STRING_KIND]),
         Literal[
+            "claude-fable-5-1",
             "claude-fable-5",
+            "claude-opus-5",
+            "claude-sonnet-5",
+            "claude-opus-4-8",
             "claude-opus-4-7",
             "claude-opus-4-6",
             "claude-sonnet-4-6",
@@ -401,7 +405,11 @@ def execute_claude_requests(
 
 
 EXACT_MODELS_VERSIONS_MAPPING = {
+    "claude-fable-5-1": "claude-fable-5-1",
     "claude-fable-5": "claude-fable-5",
+    "claude-opus-5": "claude-opus-5",
+    "claude-sonnet-5": "claude-sonnet-5",
+    "claude-opus-4-8": "claude-opus-4-8",
     "claude-opus-4-7": "claude-opus-4-7",
     "claude-opus-4-6": "claude-opus-4-6",
     "claude-sonnet-4-6": "claude-sonnet-4-6",

--- a/inference/core/workflows/core_steps/models/foundation/anthropic_claude/v1.py
+++ b/inference/core/workflows/core_steps/models/foundation/anthropic_claude/v1.py
@@ -171,11 +171,7 @@ class BlockManifest(WorkflowBlockManifest):
     model_version: Union[
         Selector(kind=[STRING_KIND]),
         Literal[
-            "claude-fable-5-1",
             "claude-fable-5",
-            "claude-opus-5",
-            "claude-sonnet-5",
-            "claude-opus-4-8",
             "claude-opus-4-7",
             "claude-opus-4-6",
             "claude-sonnet-4-6",
@@ -409,11 +405,7 @@ def execute_claude_requests(
 
 
 EXACT_MODELS_VERSIONS_MAPPING = {
-    "claude-fable-5-1": "claude-fable-5-1",
     "claude-fable-5": "claude-fable-5",
-    "claude-opus-5": "claude-opus-5",
-    "claude-sonnet-5": "claude-sonnet-5",
-    "claude-opus-4-8": "claude-opus-4-8",
     "claude-opus-4-7": "claude-opus-4-7",
     "claude-opus-4-6": "claude-opus-4-6",
     "claude-sonnet-4-6": "claude-sonnet-4-6",

--- a/inference/core/workflows/core_steps/models/foundation/anthropic_claude/v1.py
+++ b/inference/core/workflows/core_steps/models/foundation/anthropic_claude/v1.py
@@ -14,6 +14,9 @@ from inference.core.utils.image_utils import encode_image_to_jpeg_bytes, load_im
 from inference.core.utils.preprocess import downscale_image_keeping_aspect_ratio
 from inference.core.workflows.core_steps.common.utils import run_in_parallel
 from inference.core.workflows.core_steps.common.vlms import VLM_TASKS_METADATA
+from inference.core.workflows.core_steps.models.foundation.anthropic_claude.model_capabilities import (
+    resolve_temperature,
+)
 from inference.core.workflows.execution_engine.entities.base import (
     Batch,
     OutputDefinition,
@@ -201,7 +204,8 @@ class BlockManifest(WorkflowBlockManifest):
     temperature: Optional[Union[float, Selector(kind=[FLOAT_KIND])]] = Field(
         default=None,
         description="Temperature to sample from the model - value in range 0.0-2.0, the higher - the more "
-        'random / "creative" the generations are.',
+        'random / "creative" the generations are. Ignored (with a warning) for Claude Opus 4.7 and '
+        "newer, Sonnet 5, Opus 5 and Fable models, which no longer accept sampling parameters.",
         ge=0.0,
         le=2.0,
     )
@@ -441,6 +445,7 @@ def execute_claude_request(
     client = anthropic.Anthropic(api_key=api_key)
     if system_prompt is None:
         system_prompt = NOT_GIVEN
+    temperature = resolve_temperature(temperature, model_version=model_version)
     if temperature is None:
         temperature = NOT_GIVEN
     result = client.messages.create(

--- a/inference/core/workflows/core_steps/models/foundation/anthropic_claude/v1.py
+++ b/inference/core/workflows/core_steps/models/foundation/anthropic_claude/v1.py
@@ -204,8 +204,8 @@ class BlockManifest(WorkflowBlockManifest):
     temperature: Optional[Union[float, Selector(kind=[FLOAT_KIND])]] = Field(
         default=None,
         description="Temperature to sample from the model - value in range 0.0-2.0, the higher - the more "
-        'random / "creative" the generations are. Ignored (with a warning) for Claude Opus 4.7 and '
-        "newer, Sonnet 5, Opus 5 and Fable models, which no longer accept sampling parameters.",
+        'random / "creative" the generations are. Ignored by models that no longer accept '
+        "sampling parameters (Claude Opus 4.7 and newer).",
         ge=0.0,
         le=2.0,
     )

--- a/inference/core/workflows/core_steps/models/foundation/anthropic_claude/v2.py
+++ b/inference/core/workflows/core_steps/models/foundation/anthropic_claude/v2.py
@@ -45,33 +45,9 @@ from inference.core.workflows.prototypes.block import (
 
 CLAUDE_MODELS = [
     {
-        "id": "claude-fable-5-1",
-        "name": "Claude Fable 5.1",
-        "exact_version": "claude-fable-5-1",
-        "max_output_tokens": 128000,
-    },
-    {
         "id": "claude-fable-5",
         "name": "Claude Fable 5",
         "exact_version": "claude-fable-5",
-        "max_output_tokens": 128000,
-    },
-    {
-        "id": "claude-opus-5",
-        "name": "Claude Opus 5",
-        "exact_version": "claude-opus-5",
-        "max_output_tokens": 128000,
-    },
-    {
-        "id": "claude-sonnet-5",
-        "name": "Claude Sonnet 5",
-        "exact_version": "claude-sonnet-5",
-        "max_output_tokens": 128000,
-    },
-    {
-        "id": "claude-opus-4-8",
-        "name": "Claude Opus 4.8",
-        "exact_version": "claude-opus-4-8",
         "max_output_tokens": 128000,
     },
     {

--- a/inference/core/workflows/core_steps/models/foundation/anthropic_claude/v2.py
+++ b/inference/core/workflows/core_steps/models/foundation/anthropic_claude/v2.py
@@ -90,7 +90,7 @@ CLAUDE_MODELS = [
         "id": "claude-sonnet-4-6",
         "name": "Claude Sonnet 4.6",
         "exact_version": "claude-sonnet-4-6",
-        "max_output_tokens": 128000,
+        "max_output_tokens": 64000,
     },
     {
         "id": "claude-sonnet-4-5",
@@ -279,16 +279,15 @@ class BlockManifest(WorkflowBlockManifest):
     extended_thinking: Optional[bool] = Field(
         default=None,
         description="Enable extended thinking for deeper reasoning on complex tasks. "
-        "Note: temperature cannot be used when extended thinking is enabled. "
-        "On Claude Opus 4.7 and newer, Sonnet 5, Opus 5 and Fable models thinking is "
-        "adaptive: the model decides how much to think and `thinking_budget_tokens` is ignored.",
+        "Note: temperature cannot be used when extended thinking is enabled. Models that "
+        "only support adaptive thinking (Claude Opus 4.7 and newer) ignore `thinking_budget_tokens`.",
     )
     thinking_budget_tokens: Optional[int] = Field(
         default=None,
         description="Maximum number of tokens for internal thinking when extended thinking is enabled. "
         "Higher values allow deeper reasoning but increase latency and cost. "
-        "Must be less than max_tokens. Minimum: 1024. Ignored (with a warning) by models "
-        "that only support adaptive thinking (Claude Opus 4.7 and newer, Sonnet 5, Opus 5, Fable).",
+        "Must be less than max_tokens. Minimum: 1024. Ignored by models that only support "
+        "adaptive thinking (Claude Opus 4.7 and newer).",
         ge=1024,
         json_schema_extra={
             "relevant_for": {
@@ -307,8 +306,7 @@ class BlockManifest(WorkflowBlockManifest):
         default=None,
         description="Temperature to sample from the model - value in range 0.0-1.0, the higher - the more "
         'random / "creative" the generations are. Cannot be used when extended_thinking is enabled. '
-        "Ignored (with a warning) for Claude Opus 4.7 and newer, Sonnet 5, Opus 5 and Fable models, "
-        "which no longer accept sampling parameters.",
+        "Ignored by models that no longer accept sampling parameters (Claude Opus 4.7 and newer).",
         ge=0.0,
         le=1.0,
     )

--- a/inference/core/workflows/core_steps/models/foundation/anthropic_claude/v2.py
+++ b/inference/core/workflows/core_steps/models/foundation/anthropic_claude/v2.py
@@ -41,9 +41,33 @@ from inference.core.workflows.prototypes.block import (
 
 CLAUDE_MODELS = [
     {
+        "id": "claude-fable-5-1",
+        "name": "Claude Fable 5.1",
+        "exact_version": "claude-fable-5-1",
+        "max_output_tokens": 128000,
+    },
+    {
         "id": "claude-fable-5",
         "name": "Claude Fable 5",
         "exact_version": "claude-fable-5",
+        "max_output_tokens": 128000,
+    },
+    {
+        "id": "claude-opus-5",
+        "name": "Claude Opus 5",
+        "exact_version": "claude-opus-5",
+        "max_output_tokens": 128000,
+    },
+    {
+        "id": "claude-sonnet-5",
+        "name": "Claude Sonnet 5",
+        "exact_version": "claude-sonnet-5",
+        "max_output_tokens": 128000,
+    },
+    {
+        "id": "claude-opus-4-8",
+        "name": "Claude Opus 4.8",
+        "exact_version": "claude-opus-4-8",
         "max_output_tokens": 128000,
     },
     {

--- a/inference/core/workflows/core_steps/models/foundation/anthropic_claude/v2.py
+++ b/inference/core/workflows/core_steps/models/foundation/anthropic_claude/v2.py
@@ -13,6 +13,10 @@ from inference.core.utils.image_utils import encode_image_to_jpeg_bytes, load_im
 from inference.core.utils.preprocess import downscale_image_keeping_aspect_ratio
 from inference.core.workflows.core_steps.common.utils import run_in_parallel
 from inference.core.workflows.core_steps.common.vlms import VLM_TASKS_METADATA
+from inference.core.workflows.core_steps.models.foundation.anthropic_claude.model_capabilities import (
+    build_thinking_config,
+    resolve_temperature,
+)
 from inference.core.workflows.execution_engine.entities.base import (
     Batch,
     OutputDefinition,
@@ -86,7 +90,7 @@ CLAUDE_MODELS = [
         "id": "claude-sonnet-4-6",
         "name": "Claude Sonnet 4.6",
         "exact_version": "claude-sonnet-4-6",
-        "max_output_tokens": 64000,
+        "max_output_tokens": 128000,
     },
     {
         "id": "claude-sonnet-4-5",
@@ -275,13 +279,16 @@ class BlockManifest(WorkflowBlockManifest):
     extended_thinking: Optional[bool] = Field(
         default=None,
         description="Enable extended thinking for deeper reasoning on complex tasks. "
-        "Note: temperature cannot be used when extended thinking is enabled.",
+        "Note: temperature cannot be used when extended thinking is enabled. "
+        "On Claude Opus 4.7 and newer, Sonnet 5, Opus 5 and Fable models thinking is "
+        "adaptive: the model decides how much to think and `thinking_budget_tokens` is ignored.",
     )
     thinking_budget_tokens: Optional[int] = Field(
         default=None,
         description="Maximum number of tokens for internal thinking when extended thinking is enabled. "
         "Higher values allow deeper reasoning but increase latency and cost. "
-        "Must be less than max_tokens. Minimum: 1024.",
+        "Must be less than max_tokens. Minimum: 1024. Ignored (with a warning) by models "
+        "that only support adaptive thinking (Claude Opus 4.7 and newer, Sonnet 5, Opus 5, Fable).",
         ge=1024,
         json_schema_extra={
             "relevant_for": {
@@ -299,7 +306,9 @@ class BlockManifest(WorkflowBlockManifest):
     temperature: Optional[Union[float, Selector(kind=[FLOAT_KIND])]] = Field(
         default=None,
         description="Temperature to sample from the model - value in range 0.0-1.0, the higher - the more "
-        'random / "creative" the generations are. Cannot be used when extended_thinking is enabled.',
+        'random / "creative" the generations are. Cannot be used when extended_thinking is enabled. '
+        "Ignored (with a warning) for Claude Opus 4.7 and newer, Sonnet 5, Opus 5 and Fable models, "
+        "which no longer accept sampling parameters.",
         ge=0.0,
         le=1.0,
     )
@@ -542,7 +551,12 @@ def execute_claude_request(
     if system_prompt is None:
         system_prompt = NOT_GIVEN
 
-    if temperature is None or extended_thinking:
+    temperature = resolve_temperature(
+        temperature,
+        model_version=model_version,
+        extended_thinking=extended_thinking,
+    )
+    if temperature is None:
         temperature = NOT_GIVEN
 
     model_max_output = MAX_OUTPUT_TOKENS.get(model_version, DEFAULT_MAX_OUTPUT_TOKENS)
@@ -556,16 +570,14 @@ def execute_claude_request(
         "temperature": temperature,
     }
 
-    if extended_thinking:
-        effective_budget = (
-            thinking_budget_tokens
-            if thinking_budget_tokens is not None
-            else model_max_output // 2
-        )
-        request_params["thinking"] = {
-            "type": "enabled",
-            "budget_tokens": effective_budget,
-        }
+    thinking = build_thinking_config(
+        extended_thinking=extended_thinking,
+        thinking_budget_tokens=thinking_budget_tokens,
+        model_version=model_version,
+        model_max_output=model_max_output,
+    )
+    if thinking is not None:
+        request_params["thinking"] = thinking
 
     # Stream response to avoid max_tokens limitation
     with client.messages.stream(**request_params) as stream:

--- a/inference/core/workflows/core_steps/models/foundation/anthropic_claude/v3.py
+++ b/inference/core/workflows/core_steps/models/foundation/anthropic_claude/v3.py
@@ -48,33 +48,9 @@ from inference.core.workflows.prototypes.block import (
 
 CLAUDE_MODELS = [
     {
-        "id": "claude-fable-5-1",
-        "name": "Claude Fable 5.1",
-        "exact_version": "claude-fable-5-1",
-        "max_output_tokens": 128000,
-    },
-    {
         "id": "claude-fable-5",
         "name": "Claude Fable 5",
         "exact_version": "claude-fable-5",
-        "max_output_tokens": 128000,
-    },
-    {
-        "id": "claude-opus-5",
-        "name": "Claude Opus 5",
-        "exact_version": "claude-opus-5",
-        "max_output_tokens": 128000,
-    },
-    {
-        "id": "claude-sonnet-5",
-        "name": "Claude Sonnet 5",
-        "exact_version": "claude-sonnet-5",
-        "max_output_tokens": 128000,
-    },
-    {
-        "id": "claude-opus-4-8",
-        "name": "Claude Opus 4.8",
-        "exact_version": "claude-opus-4-8",
         "max_output_tokens": 128000,
     },
     {

--- a/inference/core/workflows/core_steps/models/foundation/anthropic_claude/v3.py
+++ b/inference/core/workflows/core_steps/models/foundation/anthropic_claude/v3.py
@@ -44,9 +44,33 @@ from inference.core.workflows.prototypes.block import (
 
 CLAUDE_MODELS = [
     {
+        "id": "claude-fable-5-1",
+        "name": "Claude Fable 5.1",
+        "exact_version": "claude-fable-5-1",
+        "max_output_tokens": 128000,
+    },
+    {
         "id": "claude-fable-5",
         "name": "Claude Fable 5",
         "exact_version": "claude-fable-5",
+        "max_output_tokens": 128000,
+    },
+    {
+        "id": "claude-opus-5",
+        "name": "Claude Opus 5",
+        "exact_version": "claude-opus-5",
+        "max_output_tokens": 128000,
+    },
+    {
+        "id": "claude-sonnet-5",
+        "name": "Claude Sonnet 5",
+        "exact_version": "claude-sonnet-5",
+        "max_output_tokens": 128000,
+    },
+    {
+        "id": "claude-opus-4-8",
+        "name": "Claude Opus 4.8",
+        "exact_version": "claude-opus-4-8",
         "max_output_tokens": 128000,
     },
     {

--- a/inference/core/workflows/core_steps/models/foundation/anthropic_claude/v3.py
+++ b/inference/core/workflows/core_steps/models/foundation/anthropic_claude/v3.py
@@ -15,6 +15,10 @@ from inference.core.utils.image_utils import encode_image_to_jpeg_bytes, load_im
 from inference.core.utils.preprocess import downscale_image_keeping_aspect_ratio
 from inference.core.workflows.core_steps.common.utils import run_in_parallel
 from inference.core.workflows.core_steps.common.vlms import VLM_TASKS_METADATA
+from inference.core.workflows.core_steps.models.foundation.anthropic_claude.model_capabilities import (
+    build_thinking_config,
+    resolve_temperature,
+)
 from inference.core.workflows.execution_engine.entities.base import (
     Batch,
     OutputDefinition,
@@ -89,7 +93,7 @@ CLAUDE_MODELS = [
         "id": "claude-sonnet-4-6",
         "name": "Claude Sonnet 4.6",
         "exact_version": "claude-sonnet-4-6",
-        "max_output_tokens": 64000,
+        "max_output_tokens": 128000,
     },
     {
         "id": "claude-sonnet-4-5",
@@ -292,13 +296,16 @@ class BlockManifest(WorkflowBlockManifest):
     extended_thinking: Optional[bool] = Field(
         default=None,
         description="Enable extended thinking for deeper reasoning on complex tasks. "
-        "Note: temperature cannot be used when extended thinking is enabled.",
+        "Note: temperature cannot be used when extended thinking is enabled. "
+        "On Claude Opus 4.7 and newer, Sonnet 5, Opus 5 and Fable models thinking is "
+        "adaptive: the model decides how much to think and `thinking_budget_tokens` is ignored.",
     )
     thinking_budget_tokens: Optional[int] = Field(
         default=None,
         description="Maximum number of tokens for internal thinking when extended thinking is enabled. "
         "Higher values allow deeper reasoning but increase latency and cost. "
-        "Must be less than max_tokens. Minimum: 1024.",
+        "Must be less than max_tokens. Minimum: 1024. Ignored (with a warning) by models "
+        "that only support adaptive thinking (Claude Opus 4.7 and newer, Sonnet 5, Opus 5, Fable).",
         ge=1024,
         json_schema_extra={
             "relevant_for": {
@@ -316,7 +323,9 @@ class BlockManifest(WorkflowBlockManifest):
     temperature: Optional[Union[float, Selector(kind=[FLOAT_KIND])]] = Field(
         default=None,
         description="Temperature to sample from the model - value in range 0.0-1.0, the higher - the more "
-        'random / "creative" the generations are. Cannot be used when extended_thinking is enabled.',
+        'random / "creative" the generations are. Cannot be used when extended_thinking is enabled. '
+        "Ignored (with a warning) for Claude Opus 4.7 and newer, Sonnet 5, Opus 5 and Fable models, "
+        "which no longer accept sampling parameters.",
         ge=0.0,
         le=1.0,
     )
@@ -610,19 +619,22 @@ def _execute_proxied_claude_request(
     if system_prompt is not None:
         payload["system"] = system_prompt
 
-    if temperature is not None and not extended_thinking:
+    temperature = resolve_temperature(
+        temperature,
+        model_version=model_version,
+        extended_thinking=extended_thinking,
+    )
+    if temperature is not None:
         payload["temperature"] = temperature
 
-    if extended_thinking:
-        effective_budget = (
-            thinking_budget_tokens
-            if thinking_budget_tokens is not None
-            else model_max_output // 2
-        )
-        payload["thinking"] = {
-            "type": "enabled",
-            "budget_tokens": effective_budget,
-        }
+    thinking = build_thinking_config(
+        extended_thinking=extended_thinking,
+        thinking_budget_tokens=thinking_budget_tokens,
+        model_version=model_version,
+        model_max_output=model_max_output,
+    )
+    if thinking is not None:
+        payload["thinking"] = thinking
 
     endpoint = "apiproxy/anthropic"
 
@@ -657,7 +669,12 @@ def _execute_direct_claude_request(
     if system_prompt is None:
         system_prompt = NOT_GIVEN
 
-    if temperature is None or extended_thinking:
+    temperature = resolve_temperature(
+        temperature,
+        model_version=model_version,
+        extended_thinking=extended_thinking,
+    )
+    if temperature is None:
         temperature = NOT_GIVEN
 
     model_max_output = MAX_OUTPUT_TOKENS.get(model_version, DEFAULT_MAX_OUTPUT_TOKENS)
@@ -671,16 +688,14 @@ def _execute_direct_claude_request(
         "temperature": temperature,
     }
 
-    if extended_thinking:
-        effective_budget = (
-            thinking_budget_tokens
-            if thinking_budget_tokens is not None
-            else model_max_output // 2
-        )
-        request_params["thinking"] = {
-            "type": "enabled",
-            "budget_tokens": effective_budget,
-        }
+    thinking = build_thinking_config(
+        extended_thinking=extended_thinking,
+        thinking_budget_tokens=thinking_budget_tokens,
+        model_version=model_version,
+        model_max_output=model_max_output,
+    )
+    if thinking is not None:
+        request_params["thinking"] = thinking
 
     # Stream response to avoid max_tokens limitation
     with client.messages.stream(**request_params) as stream:

--- a/inference/core/workflows/core_steps/models/foundation/anthropic_claude/v3.py
+++ b/inference/core/workflows/core_steps/models/foundation/anthropic_claude/v3.py
@@ -93,7 +93,7 @@ CLAUDE_MODELS = [
         "id": "claude-sonnet-4-6",
         "name": "Claude Sonnet 4.6",
         "exact_version": "claude-sonnet-4-6",
-        "max_output_tokens": 128000,
+        "max_output_tokens": 64000,
     },
     {
         "id": "claude-sonnet-4-5",
@@ -296,16 +296,15 @@ class BlockManifest(WorkflowBlockManifest):
     extended_thinking: Optional[bool] = Field(
         default=None,
         description="Enable extended thinking for deeper reasoning on complex tasks. "
-        "Note: temperature cannot be used when extended thinking is enabled. "
-        "On Claude Opus 4.7 and newer, Sonnet 5, Opus 5 and Fable models thinking is "
-        "adaptive: the model decides how much to think and `thinking_budget_tokens` is ignored.",
+        "Note: temperature cannot be used when extended thinking is enabled. Models that "
+        "only support adaptive thinking (Claude Opus 4.7 and newer) ignore `thinking_budget_tokens`.",
     )
     thinking_budget_tokens: Optional[int] = Field(
         default=None,
         description="Maximum number of tokens for internal thinking when extended thinking is enabled. "
         "Higher values allow deeper reasoning but increase latency and cost. "
-        "Must be less than max_tokens. Minimum: 1024. Ignored (with a warning) by models "
-        "that only support adaptive thinking (Claude Opus 4.7 and newer, Sonnet 5, Opus 5, Fable).",
+        "Must be less than max_tokens. Minimum: 1024. Ignored by models that only support "
+        "adaptive thinking (Claude Opus 4.7 and newer).",
         ge=1024,
         json_schema_extra={
             "relevant_for": {
@@ -324,8 +323,7 @@ class BlockManifest(WorkflowBlockManifest):
         default=None,
         description="Temperature to sample from the model - value in range 0.0-1.0, the higher - the more "
         'random / "creative" the generations are. Cannot be used when extended_thinking is enabled. '
-        "Ignored (with a warning) for Claude Opus 4.7 and newer, Sonnet 5, Opus 5 and Fable models, "
-        "which no longer accept sampling parameters.",
+        "Ignored by models that no longer accept sampling parameters (Claude Opus 4.7 and newer).",
         ge=0.0,
         le=1.0,
     )

--- a/inference/core/workflows/core_steps/models/foundation/anthropic_claude/v4.py
+++ b/inference/core/workflows/core_steps/models/foundation/anthropic_claude/v4.py
@@ -65,6 +65,12 @@ from inference.core.workflows.prototypes.block import (
 
 CLAUDE_MODELS = [
     {
+        "id": "claude-fable-5-1",
+        "name": "Claude Fable 5.1",
+        "exact_version": "claude-fable-5-1",
+        "max_output_tokens": 128000,
+    },
+    {
         "id": "claude-fable-5",
         "name": "Claude Fable 5",
         "exact_version": "claude-fable-5",

--- a/inference/core/workflows/core_steps/models/foundation/anthropic_claude/v4.py
+++ b/inference/core/workflows/core_steps/models/foundation/anthropic_claude/v4.py
@@ -114,7 +114,7 @@ CLAUDE_MODELS = [
         "id": "claude-sonnet-4-6",
         "name": "Claude Sonnet 4.6",
         "exact_version": "claude-sonnet-4-6",
-        "max_output_tokens": 128000,
+        "max_output_tokens": 64000,
     },
     {
         "id": "claude-sonnet-4-5",
@@ -349,16 +349,15 @@ class BlockManifest(WorkflowBlockManifest):
     extended_thinking: Optional[bool] = Field(
         default=None,
         description="Enable extended thinking for deeper reasoning on complex tasks. "
-        "Note: temperature cannot be used when extended thinking is enabled. "
-        "On Claude Opus 4.7 and newer, Sonnet 5, Opus 5 and Fable models thinking is "
-        "adaptive: the model decides how much to think and `thinking_budget_tokens` is ignored.",
+        "Note: temperature cannot be used when extended thinking is enabled. Models that "
+        "only support adaptive thinking (Claude Opus 4.7 and newer) ignore `thinking_budget_tokens`.",
     )
     thinking_budget_tokens: Optional[int] = Field(
         default=None,
         description="Maximum number of tokens for internal thinking when extended thinking is enabled. "
         "Higher values allow deeper reasoning but increase latency and cost. "
-        "Must be less than max_tokens. Minimum: 1024. Ignored (with a warning) by models "
-        "that only support adaptive thinking (Claude Opus 4.7 and newer, Sonnet 5, Opus 5, Fable).",
+        "Must be less than max_tokens. Minimum: 1024. Ignored by models that only support "
+        "adaptive thinking (Claude Opus 4.7 and newer).",
         ge=1024,
         json_schema_extra={
             "relevant_for": {
@@ -377,8 +376,7 @@ class BlockManifest(WorkflowBlockManifest):
         default=None,
         description="Temperature to sample from the model - value in range 0.0-1.0, the higher - the more "
         'random / "creative" the generations are. Cannot be used when extended_thinking is enabled. '
-        "Ignored (with a warning) for Claude Opus 4.7 and newer, Sonnet 5, Opus 5 and Fable models, "
-        "which no longer accept sampling parameters.",
+        "Ignored by models that no longer accept sampling parameters (Claude Opus 4.7 and newer).",
         ge=0.0,
         le=1.0,
     )

--- a/inference/core/workflows/core_steps/models/foundation/anthropic_claude/v4.py
+++ b/inference/core/workflows/core_steps/models/foundation/anthropic_claude/v4.py
@@ -36,6 +36,10 @@ from inference.core.workflows.core_steps.common.utils import (
     run_in_parallel,
 )
 from inference.core.workflows.core_steps.common.vlms import VLM_TASKS_METADATA
+from inference.core.workflows.core_steps.models.foundation.anthropic_claude.model_capabilities import (
+    build_thinking_config,
+    resolve_temperature,
+)
 from inference.core.workflows.execution_engine.entities.base import (
     Batch,
     OutputDefinition,
@@ -110,7 +114,7 @@ CLAUDE_MODELS = [
         "id": "claude-sonnet-4-6",
         "name": "Claude Sonnet 4.6",
         "exact_version": "claude-sonnet-4-6",
-        "max_output_tokens": 64000,
+        "max_output_tokens": 128000,
     },
     {
         "id": "claude-sonnet-4-5",
@@ -345,13 +349,16 @@ class BlockManifest(WorkflowBlockManifest):
     extended_thinking: Optional[bool] = Field(
         default=None,
         description="Enable extended thinking for deeper reasoning on complex tasks. "
-        "Note: temperature cannot be used when extended thinking is enabled.",
+        "Note: temperature cannot be used when extended thinking is enabled. "
+        "On Claude Opus 4.7 and newer, Sonnet 5, Opus 5 and Fable models thinking is "
+        "adaptive: the model decides how much to think and `thinking_budget_tokens` is ignored.",
     )
     thinking_budget_tokens: Optional[int] = Field(
         default=None,
         description="Maximum number of tokens for internal thinking when extended thinking is enabled. "
         "Higher values allow deeper reasoning but increase latency and cost. "
-        "Must be less than max_tokens. Minimum: 1024.",
+        "Must be less than max_tokens. Minimum: 1024. Ignored (with a warning) by models "
+        "that only support adaptive thinking (Claude Opus 4.7 and newer, Sonnet 5, Opus 5, Fable).",
         ge=1024,
         json_schema_extra={
             "relevant_for": {
@@ -369,7 +376,9 @@ class BlockManifest(WorkflowBlockManifest):
     temperature: Optional[Union[float, Selector(kind=[FLOAT_KIND])]] = Field(
         default=None,
         description="Temperature to sample from the model - value in range 0.0-1.0, the higher - the more "
-        'random / "creative" the generations are. Cannot be used when extended_thinking is enabled.',
+        'random / "creative" the generations are. Cannot be used when extended_thinking is enabled. '
+        "Ignored (with a warning) for Claude Opus 4.7 and newer, Sonnet 5, Opus 5 and Fable models, "
+        "which no longer accept sampling parameters.",
         ge=0.0,
         le=1.0,
     )
@@ -738,19 +747,22 @@ def _execute_proxied_claude_request(
     if system_prompt is not None:
         payload["system"] = system_prompt
 
-    if temperature is not None and not extended_thinking:
+    temperature = resolve_temperature(
+        temperature,
+        model_version=model_version,
+        extended_thinking=extended_thinking,
+    )
+    if temperature is not None:
         payload["temperature"] = temperature
 
-    if extended_thinking:
-        effective_budget = (
-            thinking_budget_tokens
-            if thinking_budget_tokens is not None
-            else model_max_output // 2
-        )
-        payload["thinking"] = {
-            "type": "enabled",
-            "budget_tokens": effective_budget,
-        }
+    thinking = build_thinking_config(
+        extended_thinking=extended_thinking,
+        thinking_budget_tokens=thinking_budget_tokens,
+        model_version=model_version,
+        model_max_output=model_max_output,
+    )
+    if thinking is not None:
+        payload["thinking"] = thinking
 
     endpoint = "apiproxy/anthropic"
 
@@ -789,7 +801,12 @@ def _execute_direct_claude_request(
     if system_prompt is None:
         system_prompt = NOT_GIVEN
 
-    if temperature is None or extended_thinking:
+    temperature = resolve_temperature(
+        temperature,
+        model_version=model_version,
+        extended_thinking=extended_thinking,
+    )
+    if temperature is None:
         temperature = NOT_GIVEN
 
     model_max_output = MAX_OUTPUT_TOKENS.get(model_version, DEFAULT_MAX_OUTPUT_TOKENS)
@@ -803,16 +820,14 @@ def _execute_direct_claude_request(
         "temperature": temperature,
     }
 
-    if extended_thinking:
-        effective_budget = (
-            thinking_budget_tokens
-            if thinking_budget_tokens is not None
-            else model_max_output // 2
-        )
-        request_params["thinking"] = {
-            "type": "enabled",
-            "budget_tokens": effective_budget,
-        }
+    thinking = build_thinking_config(
+        extended_thinking=extended_thinking,
+        thinking_budget_tokens=thinking_budget_tokens,
+        model_version=model_version,
+        model_max_output=model_max_output,
+    )
+    if thinking is not None:
+        request_params["thinking"] = thinking
 
     # Stream response to avoid max_tokens limitation
     with client.messages.stream(**request_params) as stream:

--- a/tests/workflows/unit_tests/core_steps/dependent_resources/test_anthropic_claude.py
+++ b/tests/workflows/unit_tests/core_steps/dependent_resources/test_anthropic_claude.py
@@ -178,47 +178,6 @@ def test_anthropic_claude_v3_discovery_maps_labels_to_exact_model_versions() -> 
         ]
 
 
-def test_anthropic_claude_fable_5_1_declares_undated_wire_id_in_every_version() -> None:
-    # Fable 5.1 has no dated snapshot alias, so every block version must
-    # declare the exact id the request will carry on both auth paths.
-    manifests = [
-        AnthropicClaudeV1Manifest.model_validate(
-            {
-                "type": "roboflow_core/anthropic_claude@v1",
-                "name": "vlm",
-                "images": "$inputs.image",
-                "prompt": "What is in the image?",
-                "api_key": "$inputs.anthropic_api_key",
-                "model_version": "claude-fable-5-1",
-            }
-        ),
-        AnthropicClaudeV2Manifest.model_validate(
-            {
-                "type": "roboflow_core/anthropic_claude@v2",
-                "name": "vlm",
-                "images": "$inputs.image",
-                "prompt": "What is in the image?",
-                "api_key": "$inputs.anthropic_api_key",
-                "model_version": "claude-fable-5-1",
-            }
-        ),
-        AnthropicClaudeV3Manifest.model_validate(
-            {
-                "type": "roboflow_core/anthropic_claude@v3",
-                "name": "vlm",
-                "images": "$inputs.image",
-                "prompt": "What is in the image?",
-                "model_version": "claude-fable-5-1",
-            }
-        ),
-    ]
-
-    for manifest in manifests:
-        assert manifest.discover_dependent_resources() == [
-            third_party_model(provider="anthropic", model_id="claude-fable-5-1"),
-        ]
-
-
 def test_anthropic_claude_v3_selector_declaration_attaches_resolver() -> None:
     manifest = AnthropicClaudeV3Manifest.model_validate(
         {

--- a/tests/workflows/unit_tests/core_steps/dependent_resources/test_anthropic_claude.py
+++ b/tests/workflows/unit_tests/core_steps/dependent_resources/test_anthropic_claude.py
@@ -178,6 +178,47 @@ def test_anthropic_claude_v3_discovery_maps_labels_to_exact_model_versions() -> 
         ]
 
 
+def test_anthropic_claude_fable_5_1_declares_undated_wire_id_in_every_version() -> None:
+    # Fable 5.1 has no dated snapshot alias, so every block version must
+    # declare the exact id the request will carry on both auth paths.
+    manifests = [
+        AnthropicClaudeV1Manifest.model_validate(
+            {
+                "type": "roboflow_core/anthropic_claude@v1",
+                "name": "vlm",
+                "images": "$inputs.image",
+                "prompt": "What is in the image?",
+                "api_key": "$inputs.anthropic_api_key",
+                "model_version": "claude-fable-5-1",
+            }
+        ),
+        AnthropicClaudeV2Manifest.model_validate(
+            {
+                "type": "roboflow_core/anthropic_claude@v2",
+                "name": "vlm",
+                "images": "$inputs.image",
+                "prompt": "What is in the image?",
+                "api_key": "$inputs.anthropic_api_key",
+                "model_version": "claude-fable-5-1",
+            }
+        ),
+        AnthropicClaudeV3Manifest.model_validate(
+            {
+                "type": "roboflow_core/anthropic_claude@v3",
+                "name": "vlm",
+                "images": "$inputs.image",
+                "prompt": "What is in the image?",
+                "model_version": "claude-fable-5-1",
+            }
+        ),
+    ]
+
+    for manifest in manifests:
+        assert manifest.discover_dependent_resources() == [
+            third_party_model(provider="anthropic", model_id="claude-fable-5-1"),
+        ]
+
+
 def test_anthropic_claude_v3_selector_declaration_attaches_resolver() -> None:
     manifest = AnthropicClaudeV3Manifest.model_validate(
         {

--- a/tests/workflows/unit_tests/core_steps/models/foundation/test_anthropic_claude.py
+++ b/tests/workflows/unit_tests/core_steps/models/foundation/test_anthropic_claude.py
@@ -4,6 +4,12 @@ from unittest.mock import MagicMock, Mock, patch
 import pytest
 from pydantic import ValidationError
 
+from inference.core.workflows.core_steps.models.foundation.anthropic_claude.v1 import (
+    EXACT_MODELS_VERSIONS_MAPPING as EXACT_MODEL_VERSIONS_V1,
+)
+from inference.core.workflows.core_steps.models.foundation.anthropic_claude.v1 import (
+    BlockManifest as BlockManifestV1,
+)
 from inference.core.workflows.core_steps.models.foundation.anthropic_claude.v2 import (
     DEFAULT_MAX_OUTPUT_TOKENS,
     EXACT_MODEL_VERSIONS,
@@ -17,6 +23,29 @@ from inference.core.workflows.core_steps.models.foundation.anthropic_claude.v3 i
 from inference.core.workflows.core_steps.models.foundation.anthropic_claude.v3 import (
     MAX_OUTPUT_TOKENS as MAX_OUTPUT_TOKENS_V3,
 )
+from inference.core.workflows.core_steps.models.foundation.anthropic_claude.v3 import (
+    BlockManifest as BlockManifestV3,
+)
+from inference.core.workflows.core_steps.models.foundation.anthropic_claude.v4 import (
+    EXACT_MODEL_VERSIONS as EXACT_MODEL_VERSIONS_V4,
+)
+from inference.core.workflows.core_steps.models.foundation.anthropic_claude.v4 import (
+    MAX_OUTPUT_TOKENS as MAX_OUTPUT_TOKENS_V4,
+)
+from inference.core.workflows.core_steps.models.foundation.anthropic_claude.v4 import (
+    BlockManifest as BlockManifestV4,
+)
+
+# Claude 5-generation models that must be selectable in every block version,
+# together with the wire id sent to Anthropic and the max output tokens the
+# block falls back to when `max_tokens` is not set.
+CLAUDE_5_GENERATION_MODELS = {
+    "claude-fable-5-1": ("claude-fable-5-1", 128000),
+    "claude-fable-5": ("claude-fable-5", 128000),
+    "claude-opus-5": ("claude-opus-5", 128000),
+    "claude-sonnet-5": ("claude-sonnet-5", 128000),
+    "claude-opus-4-8": ("claude-opus-4-8", 128000),
+}
 
 
 def test_claude_step_validation_when_input_is_valid() -> None:
@@ -80,7 +109,11 @@ def test_claude_step_validation_when_prompt_is_given_directly() -> None:
 @pytest.mark.parametrize(
     "model_version",
     [
+        "claude-fable-5-1",
         "claude-fable-5",
+        "claude-opus-5",
+        "claude-sonnet-5",
+        "claude-opus-4-8",
         "claude-opus-4-7",
         "claude-sonnet-4-5",
         "claude-haiku-4-5",
@@ -344,7 +377,11 @@ def test_claude_step_validation_with_structured_answering() -> None:
 
 def test_max_output_tokens_mapping() -> None:
     # then - verify all models have max_output_tokens defined
+    assert MAX_OUTPUT_TOKENS["claude-fable-5-1"] == 128000
     assert MAX_OUTPUT_TOKENS["claude-fable-5"] == 128000
+    assert MAX_OUTPUT_TOKENS["claude-opus-5"] == 128000
+    assert MAX_OUTPUT_TOKENS["claude-sonnet-5"] == 128000
+    assert MAX_OUTPUT_TOKENS["claude-opus-4-8"] == 128000
     assert MAX_OUTPUT_TOKENS["claude-opus-4-7"] == 128000
     assert MAX_OUTPUT_TOKENS["claude-sonnet-4-5"] == 64000
     assert MAX_OUTPUT_TOKENS["claude-haiku-4-5"] == 64000
@@ -357,7 +394,11 @@ def test_max_output_tokens_mapping() -> None:
 
 def test_exact_model_versions_mapping() -> None:
     # then - verify all models have exact versions defined
+    assert EXACT_MODEL_VERSIONS["claude-fable-5-1"] == "claude-fable-5-1"
     assert EXACT_MODEL_VERSIONS["claude-fable-5"] == "claude-fable-5"
+    assert EXACT_MODEL_VERSIONS["claude-opus-5"] == "claude-opus-5"
+    assert EXACT_MODEL_VERSIONS["claude-sonnet-5"] == "claude-sonnet-5"
+    assert EXACT_MODEL_VERSIONS["claude-opus-4-8"] == "claude-opus-4-8"
     assert EXACT_MODEL_VERSIONS["claude-opus-4-7"] == "claude-opus-4-7"
     assert EXACT_MODEL_VERSIONS["claude-sonnet-4-5"] == "claude-sonnet-4-5-20250929"
     assert EXACT_MODEL_VERSIONS["claude-haiku-4-5"] == "claude-haiku-4-5-20251001"
@@ -371,6 +412,85 @@ def test_v3_claude_fable_model_metadata() -> None:
     # then
     assert MAX_OUTPUT_TOKENS_V3["claude-fable-5"] == 128000
     assert EXACT_MODEL_VERSIONS_V3["claude-fable-5"] == "claude-fable-5"
+
+
+@pytest.mark.parametrize(
+    "model_version, expected_exact_version, expected_max_output_tokens",
+    [
+        (model_version, exact_version, max_output_tokens)
+        for model_version, (
+            exact_version,
+            max_output_tokens,
+        ) in CLAUDE_5_GENERATION_MODELS.items()
+    ],
+)
+def test_claude_5_generation_models_share_metadata_across_v2_v3_v4(
+    model_version: str,
+    expected_exact_version: str,
+    expected_max_output_tokens: int,
+) -> None:
+    # then - every block version that owns a metadata table must agree on
+    # the wire id and the output budget, so switching block versions never
+    # silently changes which model is called or how much it may generate
+    for exact_versions, max_output_tokens in [
+        (EXACT_MODEL_VERSIONS, MAX_OUTPUT_TOKENS),
+        (EXACT_MODEL_VERSIONS_V3, MAX_OUTPUT_TOKENS_V3),
+        (EXACT_MODEL_VERSIONS_V4, MAX_OUTPUT_TOKENS_V4),
+    ]:
+        assert exact_versions[model_version] == expected_exact_version
+        assert max_output_tokens[model_version] == expected_max_output_tokens
+    assert EXACT_MODEL_VERSIONS_V1[model_version] == expected_exact_version
+
+
+@pytest.mark.parametrize("model_version", list(CLAUDE_5_GENERATION_MODELS.keys()))
+@pytest.mark.parametrize(
+    "block_type, manifest_class",
+    [
+        ("roboflow_core/anthropic_claude@v1", BlockManifestV1),
+        ("roboflow_core/anthropic_claude@v2", BlockManifest),
+        ("roboflow_core/anthropic_claude@v3", BlockManifestV3),
+        ("roboflow_core/anthropic_claude@v4", BlockManifestV4),
+    ],
+)
+def test_claude_5_generation_models_accepted_by_every_block_version(
+    model_version: str,
+    block_type: str,
+    manifest_class: type,
+) -> None:
+    # given
+    specification = {
+        "type": block_type,
+        "name": "step_1",
+        "images": "$inputs.image",
+        "task_type": "unconstrained",
+        "prompt": "This is my prompt",
+        "api_key": "$inputs.anthropic_api_key",
+        "model_version": model_version,
+    }
+
+    # when
+    result = manifest_class.model_validate(specification)
+
+    # then
+    assert result.model_version == model_version
+
+
+def test_v1_rejects_unknown_model_version_literal() -> None:
+    # given - v1 pins `model_version` to a Literal, so a typo of the new id
+    # must fail validation instead of being sent to Anthropic verbatim
+    specification = {
+        "type": "roboflow_core/anthropic_claude@v1",
+        "name": "step_1",
+        "images": "$inputs.image",
+        "task_type": "unconstrained",
+        "prompt": "This is my prompt",
+        "api_key": "$inputs.anthropic_api_key",
+        "model_version": "claude-fable-5.1",
+    }
+
+    # when
+    with pytest.raises(ValidationError):
+        _ = BlockManifestV1.model_validate(specification)
 
 
 @patch(

--- a/tests/workflows/unit_tests/core_steps/models/foundation/test_anthropic_claude.py
+++ b/tests/workflows/unit_tests/core_steps/models/foundation/test_anthropic_claude.py
@@ -2,6 +2,7 @@ from typing import Any
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
+from anthropic import NOT_GIVEN
 from pydantic import ValidationError
 
 from inference.core.workflows.core_steps.models.foundation.anthropic_claude.v1 import (
@@ -9,6 +10,9 @@ from inference.core.workflows.core_steps.models.foundation.anthropic_claude.v1 i
 )
 from inference.core.workflows.core_steps.models.foundation.anthropic_claude.v1 import (
     BlockManifest as BlockManifestV1,
+)
+from inference.core.workflows.core_steps.models.foundation.anthropic_claude.v1 import (
+    execute_claude_request as execute_claude_request_v1,
 )
 from inference.core.workflows.core_steps.models.foundation.anthropic_claude.v2 import (
     DEFAULT_MAX_OUTPUT_TOKENS,
@@ -26,6 +30,9 @@ from inference.core.workflows.core_steps.models.foundation.anthropic_claude.v3 i
 from inference.core.workflows.core_steps.models.foundation.anthropic_claude.v3 import (
     BlockManifest as BlockManifestV3,
 )
+from inference.core.workflows.core_steps.models.foundation.anthropic_claude.v3 import (
+    execute_claude_request as execute_claude_request_v3,
+)
 from inference.core.workflows.core_steps.models.foundation.anthropic_claude.v4 import (
     EXACT_MODEL_VERSIONS as EXACT_MODEL_VERSIONS_V4,
 )
@@ -34,6 +41,9 @@ from inference.core.workflows.core_steps.models.foundation.anthropic_claude.v4 i
 )
 from inference.core.workflows.core_steps.models.foundation.anthropic_claude.v4 import (
     BlockManifest as BlockManifestV4,
+)
+from inference.core.workflows.core_steps.models.foundation.anthropic_claude.v4 import (
+    execute_claude_request as execute_claude_request_v4,
 )
 
 # Claude 5-generation models that must be selectable in every block version,
@@ -383,6 +393,7 @@ def test_max_output_tokens_mapping() -> None:
     assert MAX_OUTPUT_TOKENS["claude-sonnet-5"] == 128000
     assert MAX_OUTPUT_TOKENS["claude-opus-4-8"] == 128000
     assert MAX_OUTPUT_TOKENS["claude-opus-4-7"] == 128000
+    assert MAX_OUTPUT_TOKENS["claude-sonnet-4-6"] == 128000
     assert MAX_OUTPUT_TOKENS["claude-sonnet-4-5"] == 64000
     assert MAX_OUTPUT_TOKENS["claude-haiku-4-5"] == 64000
     assert MAX_OUTPUT_TOKENS["claude-opus-4-5"] == 64000
@@ -811,3 +822,351 @@ def test_execute_claude_request_stop_sequence_is_valid(
 
     # then - stop_sequence is a valid stop reason
     assert result == "Response before stop sequence"
+
+
+# --- temperature / thinking handling per model generation -------------------
+#
+# Claude Opus 4.7+, Sonnet 5, Opus 5 and the Fable line reject `temperature`
+# and `thinking.type=enabled`; older models still take both. The request that
+# leaves the block must differ accordingly on every code path (v1 direct, v2
+# direct, v3/v4 direct and v3/v4 Roboflow proxy).
+
+LEGACY_MODEL = "claude-sonnet-4-5"
+NEW_GENERATION_MODEL = "claude-fable-5-1"
+
+
+def _mock_streaming_client(mock_anthropic_class: Mock, text: str = "ok") -> MagicMock:
+    mock_client = MagicMock()
+    mock_anthropic_class.return_value = mock_client
+
+    mock_text_block = Mock()
+    mock_text_block.type = "text"
+    mock_text_block.text = text
+
+    mock_result = Mock()
+    mock_result.stop_reason = "end_turn"
+    mock_result.content = [mock_text_block]
+    mock_result.usage = Mock(input_tokens=11, output_tokens=7)
+
+    mock_stream = MagicMock()
+    mock_stream.__enter__ = Mock(return_value=mock_stream)
+    mock_stream.__exit__ = Mock(return_value=False)
+    mock_stream.get_final_message.return_value = mock_result
+    mock_client.messages.stream.return_value = mock_stream
+    mock_client.messages.create.return_value = mock_result
+    return mock_client
+
+
+def _is_not_given(value: Any) -> bool:
+    return value is NOT_GIVEN
+
+
+@patch(
+    "inference.core.workflows.core_steps.models.foundation.anthropic_claude.v1.anthropic.Anthropic"
+)
+def test_v1_forwards_temperature_for_legacy_model(mock_anthropic_class: Mock) -> None:
+    # given
+    mock_client = _mock_streaming_client(mock_anthropic_class)
+
+    # when
+    execute_claude_request_v1(
+        system_prompt=None,
+        messages=[{"role": "user", "content": "Hello"}],
+        model_version=LEGACY_MODEL,
+        max_tokens=100,
+        temperature=0.4,
+        api_key="test-key",
+    )
+
+    # then
+    assert mock_client.messages.create.call_args.kwargs["temperature"] == 0.4
+
+
+@patch(
+    "inference.core.workflows.core_steps.models.foundation.anthropic_claude.v1.anthropic.Anthropic"
+)
+def test_v1_drops_temperature_for_new_generation_model(
+    mock_anthropic_class: Mock,
+) -> None:
+    # given
+    mock_client = _mock_streaming_client(mock_anthropic_class)
+
+    # when
+    execute_claude_request_v1(
+        system_prompt=None,
+        messages=[{"role": "user", "content": "Hello"}],
+        model_version=NEW_GENERATION_MODEL,
+        max_tokens=100,
+        temperature=0.4,
+        api_key="test-key",
+    )
+
+    # then
+    call_kwargs = mock_client.messages.create.call_args.kwargs
+    assert _is_not_given(call_kwargs["temperature"])
+    assert call_kwargs["model"] == "claude-fable-5-1"
+
+
+@patch(
+    "inference.core.workflows.core_steps.models.foundation.anthropic_claude.v2.anthropic.Anthropic"
+)
+def test_v2_direct_request_drops_temperature_for_new_generation_model(
+    mock_anthropic_class: Mock,
+) -> None:
+    # given
+    mock_client = _mock_streaming_client(mock_anthropic_class)
+
+    # when
+    execute_claude_request(
+        system_prompt=None,
+        messages=[{"role": "user", "content": "Hello"}],
+        model_version=NEW_GENERATION_MODEL,
+        max_tokens=100,
+        temperature=0.4,
+        extended_thinking=None,
+        thinking_budget_tokens=None,
+        api_key="test-key",
+    )
+
+    # then
+    call_kwargs = mock_client.messages.stream.call_args.kwargs
+    assert _is_not_given(call_kwargs["temperature"])
+    assert "thinking" not in call_kwargs
+
+
+@patch(
+    "inference.core.workflows.core_steps.models.foundation.anthropic_claude.v2.anthropic.Anthropic"
+)
+def test_v2_direct_request_uses_adaptive_thinking_for_new_generation_model(
+    mock_anthropic_class: Mock,
+) -> None:
+    # given
+    mock_client = _mock_streaming_client(mock_anthropic_class)
+
+    # when - a budget is configured but the model cannot take one
+    execute_claude_request(
+        system_prompt=None,
+        messages=[{"role": "user", "content": "Think"}],
+        model_version=NEW_GENERATION_MODEL,
+        max_tokens=None,
+        temperature=None,
+        extended_thinking=True,
+        thinking_budget_tokens=5000,
+        api_key="test-key",
+    )
+
+    # then
+    call_kwargs = mock_client.messages.stream.call_args.kwargs
+    assert call_kwargs["thinking"] == {"type": "adaptive"}
+    assert call_kwargs["max_tokens"] == 128000
+
+
+@pytest.mark.parametrize(
+    "execute_request, module",
+    [
+        (execute_claude_request_v3, "v3"),
+        (execute_claude_request_v4, "v4"),
+    ],
+)
+def test_direct_request_keeps_legacy_controls_for_legacy_model(
+    execute_request: Any, module: str
+) -> None:
+    with patch(
+        f"inference.core.workflows.core_steps.models.foundation.anthropic_claude.{module}.anthropic.Anthropic"
+    ) as mock_anthropic_class:
+        # given
+        mock_client = _mock_streaming_client(mock_anthropic_class)
+
+        # when - thinking off, temperature on
+        execute_request(
+            roboflow_api_key=None,
+            anthropic_api_key="sk-ant-test",
+            system_prompt=None,
+            messages=[{"role": "user", "content": "Hello"}],
+            model_version=LEGACY_MODEL,
+            max_tokens=100,
+            temperature=0.4,
+            extended_thinking=None,
+            thinking_budget_tokens=None,
+        )
+        no_thinking_kwargs = mock_client.messages.stream.call_args.kwargs
+
+        # when - thinking on with an explicit budget
+        execute_request(
+            roboflow_api_key=None,
+            anthropic_api_key="sk-ant-test",
+            system_prompt=None,
+            messages=[{"role": "user", "content": "Think"}],
+            model_version=LEGACY_MODEL,
+            max_tokens=10000,
+            temperature=0.4,
+            extended_thinking=True,
+            thinking_budget_tokens=5000,
+        )
+        thinking_kwargs = mock_client.messages.stream.call_args.kwargs
+
+    # then
+    assert no_thinking_kwargs["temperature"] == 0.4
+    assert "thinking" not in no_thinking_kwargs
+    assert _is_not_given(thinking_kwargs["temperature"])
+    assert thinking_kwargs["thinking"] == {"type": "enabled", "budget_tokens": 5000}
+
+
+@pytest.mark.parametrize(
+    "execute_request, module",
+    [
+        (execute_claude_request_v3, "v3"),
+        (execute_claude_request_v4, "v4"),
+    ],
+)
+def test_direct_request_translates_controls_for_new_generation_model(
+    execute_request: Any, module: str
+) -> None:
+    with patch(
+        f"inference.core.workflows.core_steps.models.foundation.anthropic_claude.{module}.anthropic.Anthropic"
+    ) as mock_anthropic_class:
+        # given
+        mock_client = _mock_streaming_client(mock_anthropic_class)
+
+        # when - temperature configured, thinking off
+        execute_request(
+            roboflow_api_key=None,
+            anthropic_api_key="sk-ant-test",
+            system_prompt=None,
+            messages=[{"role": "user", "content": "Hello"}],
+            model_version=NEW_GENERATION_MODEL,
+            max_tokens=100,
+            temperature=0.4,
+            extended_thinking=None,
+            thinking_budget_tokens=None,
+        )
+        no_thinking_kwargs = mock_client.messages.stream.call_args.kwargs
+
+        # when - thinking on with a budget the model cannot take
+        execute_request(
+            roboflow_api_key=None,
+            anthropic_api_key="sk-ant-test",
+            system_prompt=None,
+            messages=[{"role": "user", "content": "Think"}],
+            model_version=NEW_GENERATION_MODEL,
+            max_tokens=None,
+            temperature=None,
+            extended_thinking=True,
+            thinking_budget_tokens=5000,
+        )
+        thinking_kwargs = mock_client.messages.stream.call_args.kwargs
+
+    # then
+    assert _is_not_given(no_thinking_kwargs["temperature"])
+    assert "thinking" not in no_thinking_kwargs
+    assert no_thinking_kwargs["model"] == "claude-fable-5-1"
+    assert thinking_kwargs["thinking"] == {"type": "adaptive"}
+    assert thinking_kwargs["max_tokens"] == 128000
+
+
+PROXY_RESPONSE = {
+    "stop_reason": "end_turn",
+    "content": [{"type": "text", "text": "proxied"}],
+    "usage": {"input_tokens": 3, "output_tokens": 2},
+}
+
+
+@pytest.mark.parametrize(
+    "execute_request, module",
+    [
+        (execute_claude_request_v3, "v3"),
+        (execute_claude_request_v4, "v4"),
+    ],
+)
+def test_proxied_request_keeps_legacy_controls_for_legacy_model(
+    execute_request: Any, module: str
+) -> None:
+    with patch(
+        f"inference.core.workflows.core_steps.models.foundation.anthropic_claude.{module}.post_to_roboflow_api",
+        return_value=PROXY_RESPONSE,
+    ) as post_mock:
+        # when
+        execute_request(
+            roboflow_api_key="rf-key",
+            anthropic_api_key="rf_key:account",
+            system_prompt="sys",
+            messages=[{"role": "user", "content": "Hello"}],
+            model_version=LEGACY_MODEL,
+            max_tokens=100,
+            temperature=0.4,
+            extended_thinking=None,
+            thinking_budget_tokens=None,
+        )
+        plain_payload = post_mock.call_args.kwargs["payload"]
+
+        execute_request(
+            roboflow_api_key="rf-key",
+            anthropic_api_key="rf_key:account",
+            system_prompt=None,
+            messages=[{"role": "user", "content": "Think"}],
+            model_version=LEGACY_MODEL,
+            max_tokens=None,
+            temperature=0.4,
+            extended_thinking=True,
+            thinking_budget_tokens=None,
+        )
+        thinking_payload = post_mock.call_args.kwargs["payload"]
+
+    # then
+    assert plain_payload["model"] == LEGACY_MODEL
+    assert plain_payload["temperature"] == 0.4
+    assert plain_payload["system"] == "sys"
+    assert "thinking" not in plain_payload
+    assert "temperature" not in thinking_payload
+    assert thinking_payload["thinking"] == {"type": "enabled", "budget_tokens": 32000}
+    assert thinking_payload["max_tokens"] == 64000
+
+
+@pytest.mark.parametrize(
+    "execute_request, module",
+    [
+        (execute_claude_request_v3, "v3"),
+        (execute_claude_request_v4, "v4"),
+    ],
+)
+def test_proxied_request_translates_controls_for_new_generation_model(
+    execute_request: Any, module: str
+) -> None:
+    with patch(
+        f"inference.core.workflows.core_steps.models.foundation.anthropic_claude.{module}.post_to_roboflow_api",
+        return_value=PROXY_RESPONSE,
+    ) as post_mock:
+        # when
+        execute_request(
+            roboflow_api_key="rf-key",
+            anthropic_api_key="rf_key:account",
+            system_prompt=None,
+            messages=[{"role": "user", "content": "Hello"}],
+            model_version=NEW_GENERATION_MODEL,
+            max_tokens=100,
+            temperature=0.4,
+            extended_thinking=None,
+            thinking_budget_tokens=None,
+        )
+        plain_payload = post_mock.call_args.kwargs["payload"]
+
+        execute_request(
+            roboflow_api_key="rf-key",
+            anthropic_api_key="rf_key:account",
+            system_prompt=None,
+            messages=[{"role": "user", "content": "Think"}],
+            model_version=NEW_GENERATION_MODEL,
+            max_tokens=None,
+            temperature=None,
+            extended_thinking=True,
+            thinking_budget_tokens=5000,
+        )
+        thinking_payload = post_mock.call_args.kwargs["payload"]
+
+    # then - the payload matches what the direct path sends, so the proxy does
+    # not have to repair it
+    assert plain_payload["model"] == NEW_GENERATION_MODEL
+    assert "temperature" not in plain_payload
+    assert "thinking" not in plain_payload
+    assert thinking_payload["thinking"] == {"type": "adaptive"}
+    assert thinking_payload["max_tokens"] == 128000

--- a/tests/workflows/unit_tests/core_steps/models/foundation/test_anthropic_claude.py
+++ b/tests/workflows/unit_tests/core_steps/models/foundation/test_anthropic_claude.py
@@ -393,7 +393,6 @@ def test_max_output_tokens_mapping() -> None:
     assert MAX_OUTPUT_TOKENS["claude-sonnet-5"] == 128000
     assert MAX_OUTPUT_TOKENS["claude-opus-4-8"] == 128000
     assert MAX_OUTPUT_TOKENS["claude-opus-4-7"] == 128000
-    assert MAX_OUTPUT_TOKENS["claude-sonnet-4-6"] == 128000
     assert MAX_OUTPUT_TOKENS["claude-sonnet-4-5"] == 64000
     assert MAX_OUTPUT_TOKENS["claude-haiku-4-5"] == 64000
     assert MAX_OUTPUT_TOKENS["claude-opus-4-5"] == 64000
@@ -484,24 +483,6 @@ def test_claude_5_generation_models_accepted_by_every_block_version(
 
     # then
     assert result.model_version == model_version
-
-
-def test_v1_rejects_unknown_model_version_literal() -> None:
-    # given - v1 pins `model_version` to a Literal, so a typo of the new id
-    # must fail validation instead of being sent to Anthropic verbatim
-    specification = {
-        "type": "roboflow_core/anthropic_claude@v1",
-        "name": "step_1",
-        "images": "$inputs.image",
-        "task_type": "unconstrained",
-        "prompt": "This is my prompt",
-        "api_key": "$inputs.anthropic_api_key",
-        "model_version": "claude-fable-5.1",
-    }
-
-    # when
-    with pytest.raises(ValidationError):
-        _ = BlockManifestV1.model_validate(specification)
 
 
 @patch(
@@ -910,46 +891,19 @@ def test_v1_drops_temperature_for_new_generation_model(
 @patch(
     "inference.core.workflows.core_steps.models.foundation.anthropic_claude.v2.anthropic.Anthropic"
 )
-def test_v2_direct_request_drops_temperature_for_new_generation_model(
+def test_v2_direct_request_translates_controls_for_new_generation_model(
     mock_anthropic_class: Mock,
 ) -> None:
     # given
     mock_client = _mock_streaming_client(mock_anthropic_class)
 
-    # when
-    execute_claude_request(
-        system_prompt=None,
-        messages=[{"role": "user", "content": "Hello"}],
-        model_version=NEW_GENERATION_MODEL,
-        max_tokens=100,
-        temperature=0.4,
-        extended_thinking=None,
-        thinking_budget_tokens=None,
-        api_key="test-key",
-    )
-
-    # then
-    call_kwargs = mock_client.messages.stream.call_args.kwargs
-    assert _is_not_given(call_kwargs["temperature"])
-    assert "thinking" not in call_kwargs
-
-
-@patch(
-    "inference.core.workflows.core_steps.models.foundation.anthropic_claude.v2.anthropic.Anthropic"
-)
-def test_v2_direct_request_uses_adaptive_thinking_for_new_generation_model(
-    mock_anthropic_class: Mock,
-) -> None:
-    # given
-    mock_client = _mock_streaming_client(mock_anthropic_class)
-
-    # when - a budget is configured but the model cannot take one
+    # when - a budget and a temperature are configured but the model takes neither
     execute_claude_request(
         system_prompt=None,
         messages=[{"role": "user", "content": "Think"}],
         model_version=NEW_GENERATION_MODEL,
         max_tokens=None,
-        temperature=None,
+        temperature=0.4,
         extended_thinking=True,
         thinking_budget_tokens=5000,
         api_key="test-key",
@@ -958,6 +912,7 @@ def test_v2_direct_request_uses_adaptive_thinking_for_new_generation_model(
     # then
     call_kwargs = mock_client.messages.stream.call_args.kwargs
     assert call_kwargs["thinking"] == {"type": "adaptive"}
+    assert _is_not_given(call_kwargs["temperature"])
     assert call_kwargs["max_tokens"] == 128000
 
 

--- a/tests/workflows/unit_tests/core_steps/models/foundation/test_anthropic_claude.py
+++ b/tests/workflows/unit_tests/core_steps/models/foundation/test_anthropic_claude.py
@@ -6,12 +6,6 @@ from anthropic import NOT_GIVEN
 from pydantic import ValidationError
 
 from inference.core.workflows.core_steps.models.foundation.anthropic_claude.v1 import (
-    EXACT_MODELS_VERSIONS_MAPPING as EXACT_MODEL_VERSIONS_V1,
-)
-from inference.core.workflows.core_steps.models.foundation.anthropic_claude.v1 import (
-    BlockManifest as BlockManifestV1,
-)
-from inference.core.workflows.core_steps.models.foundation.anthropic_claude.v1 import (
     execute_claude_request as execute_claude_request_v1,
 )
 from inference.core.workflows.core_steps.models.foundation.anthropic_claude.v2 import (
@@ -28,9 +22,6 @@ from inference.core.workflows.core_steps.models.foundation.anthropic_claude.v3 i
     MAX_OUTPUT_TOKENS as MAX_OUTPUT_TOKENS_V3,
 )
 from inference.core.workflows.core_steps.models.foundation.anthropic_claude.v3 import (
-    BlockManifest as BlockManifestV3,
-)
-from inference.core.workflows.core_steps.models.foundation.anthropic_claude.v3 import (
     execute_claude_request as execute_claude_request_v3,
 )
 from inference.core.workflows.core_steps.models.foundation.anthropic_claude.v4 import (
@@ -45,17 +36,6 @@ from inference.core.workflows.core_steps.models.foundation.anthropic_claude.v4 i
 from inference.core.workflows.core_steps.models.foundation.anthropic_claude.v4 import (
     execute_claude_request as execute_claude_request_v4,
 )
-
-# Claude 5-generation models that must be selectable in every block version,
-# together with the wire id sent to Anthropic and the max output tokens the
-# block falls back to when `max_tokens` is not set.
-CLAUDE_5_GENERATION_MODELS = {
-    "claude-fable-5-1": ("claude-fable-5-1", 128000),
-    "claude-fable-5": ("claude-fable-5", 128000),
-    "claude-opus-5": ("claude-opus-5", 128000),
-    "claude-sonnet-5": ("claude-sonnet-5", 128000),
-    "claude-opus-4-8": ("claude-opus-4-8", 128000),
-}
 
 
 def test_claude_step_validation_when_input_is_valid() -> None:
@@ -119,11 +99,7 @@ def test_claude_step_validation_when_prompt_is_given_directly() -> None:
 @pytest.mark.parametrize(
     "model_version",
     [
-        "claude-fable-5-1",
         "claude-fable-5",
-        "claude-opus-5",
-        "claude-sonnet-5",
-        "claude-opus-4-8",
         "claude-opus-4-7",
         "claude-sonnet-4-5",
         "claude-haiku-4-5",
@@ -387,11 +363,7 @@ def test_claude_step_validation_with_structured_answering() -> None:
 
 def test_max_output_tokens_mapping() -> None:
     # then - verify all models have max_output_tokens defined
-    assert MAX_OUTPUT_TOKENS["claude-fable-5-1"] == 128000
     assert MAX_OUTPUT_TOKENS["claude-fable-5"] == 128000
-    assert MAX_OUTPUT_TOKENS["claude-opus-5"] == 128000
-    assert MAX_OUTPUT_TOKENS["claude-sonnet-5"] == 128000
-    assert MAX_OUTPUT_TOKENS["claude-opus-4-8"] == 128000
     assert MAX_OUTPUT_TOKENS["claude-opus-4-7"] == 128000
     assert MAX_OUTPUT_TOKENS["claude-sonnet-4-5"] == 64000
     assert MAX_OUTPUT_TOKENS["claude-haiku-4-5"] == 64000
@@ -404,11 +376,7 @@ def test_max_output_tokens_mapping() -> None:
 
 def test_exact_model_versions_mapping() -> None:
     # then - verify all models have exact versions defined
-    assert EXACT_MODEL_VERSIONS["claude-fable-5-1"] == "claude-fable-5-1"
     assert EXACT_MODEL_VERSIONS["claude-fable-5"] == "claude-fable-5"
-    assert EXACT_MODEL_VERSIONS["claude-opus-5"] == "claude-opus-5"
-    assert EXACT_MODEL_VERSIONS["claude-sonnet-5"] == "claude-sonnet-5"
-    assert EXACT_MODEL_VERSIONS["claude-opus-4-8"] == "claude-opus-4-8"
     assert EXACT_MODEL_VERSIONS["claude-opus-4-7"] == "claude-opus-4-7"
     assert EXACT_MODEL_VERSIONS["claude-sonnet-4-5"] == "claude-sonnet-4-5-20250929"
     assert EXACT_MODEL_VERSIONS["claude-haiku-4-5"] == "claude-haiku-4-5-20251001"
@@ -424,65 +392,25 @@ def test_v3_claude_fable_model_metadata() -> None:
     assert EXACT_MODEL_VERSIONS_V3["claude-fable-5"] == "claude-fable-5"
 
 
-@pytest.mark.parametrize(
-    "model_version, expected_exact_version, expected_max_output_tokens",
-    [
-        (model_version, exact_version, max_output_tokens)
-        for model_version, (
-            exact_version,
-            max_output_tokens,
-        ) in CLAUDE_5_GENERATION_MODELS.items()
-    ],
-)
-def test_claude_5_generation_models_share_metadata_across_v2_v3_v4(
-    model_version: str,
-    expected_exact_version: str,
-    expected_max_output_tokens: int,
-) -> None:
-    # then - every block version that owns a metadata table must agree on
-    # the wire id and the output budget, so switching block versions never
-    # silently changes which model is called or how much it may generate
-    for exact_versions, max_output_tokens in [
-        (EXACT_MODEL_VERSIONS, MAX_OUTPUT_TOKENS),
-        (EXACT_MODEL_VERSIONS_V3, MAX_OUTPUT_TOKENS_V3),
-        (EXACT_MODEL_VERSIONS_V4, MAX_OUTPUT_TOKENS_V4),
-    ]:
-        assert exact_versions[model_version] == expected_exact_version
-        assert max_output_tokens[model_version] == expected_max_output_tokens
-    assert EXACT_MODEL_VERSIONS_V1[model_version] == expected_exact_version
-
-
-@pytest.mark.parametrize("model_version", list(CLAUDE_5_GENERATION_MODELS.keys()))
-@pytest.mark.parametrize(
-    "block_type, manifest_class",
-    [
-        ("roboflow_core/anthropic_claude@v1", BlockManifestV1),
-        ("roboflow_core/anthropic_claude@v2", BlockManifest),
-        ("roboflow_core/anthropic_claude@v3", BlockManifestV3),
-        ("roboflow_core/anthropic_claude@v4", BlockManifestV4),
-    ],
-)
-def test_claude_5_generation_models_accepted_by_every_block_version(
-    model_version: str,
-    block_type: str,
-    manifest_class: type,
-) -> None:
+def test_v4_claude_fable_5_1_model_metadata() -> None:
     # given
     specification = {
-        "type": block_type,
+        "type": "roboflow_core/anthropic_claude@v4",
         "name": "step_1",
         "images": "$inputs.image",
         "task_type": "unconstrained",
         "prompt": "This is my prompt",
         "api_key": "$inputs.anthropic_api_key",
-        "model_version": model_version,
+        "model_version": "claude-fable-5-1",
     }
 
     # when
-    result = manifest_class.model_validate(specification)
+    result = BlockManifestV4.model_validate(specification)
 
     # then
-    assert result.model_version == model_version
+    assert result.model_version == "claude-fable-5-1"
+    assert EXACT_MODEL_VERSIONS_V4["claude-fable-5-1"] == "claude-fable-5-1"
+    assert MAX_OUTPUT_TOKENS_V4["claude-fable-5-1"] == 128000
 
 
 @patch(
@@ -813,7 +741,7 @@ def test_execute_claude_request_stop_sequence_is_valid(
 # direct, v3/v4 direct and v3/v4 Roboflow proxy).
 
 LEGACY_MODEL = "claude-sonnet-4-5"
-NEW_GENERATION_MODEL = "claude-fable-5-1"
+NEW_GENERATION_MODEL = "claude-opus-4-7"
 
 
 def _mock_streaming_client(mock_anthropic_class: Mock, text: str = "ok") -> MagicMock:
@@ -885,7 +813,7 @@ def test_v1_drops_temperature_for_new_generation_model(
     # then
     call_kwargs = mock_client.messages.create.call_args.kwargs
     assert _is_not_given(call_kwargs["temperature"])
-    assert call_kwargs["model"] == "claude-fable-5-1"
+    assert call_kwargs["model"] == NEW_GENERATION_MODEL
 
 
 @patch(
@@ -1014,7 +942,7 @@ def test_direct_request_translates_controls_for_new_generation_model(
     # then
     assert _is_not_given(no_thinking_kwargs["temperature"])
     assert "thinking" not in no_thinking_kwargs
-    assert no_thinking_kwargs["model"] == "claude-fable-5-1"
+    assert no_thinking_kwargs["model"] == NEW_GENERATION_MODEL
     assert thinking_kwargs["thinking"] == {"type": "adaptive"}
     assert thinking_kwargs["max_tokens"] == 128000
 

--- a/tests/workflows/unit_tests/core_steps/models/foundation/test_anthropic_claude.py
+++ b/tests/workflows/unit_tests/core_steps/models/foundation/test_anthropic_claude.py
@@ -1118,8 +1118,7 @@ def test_proxied_request_translates_controls_for_new_generation_model(
         )
         thinking_payload = post_mock.call_args.kwargs["payload"]
 
-    # then - the payload matches what the direct path sends, so the proxy does
-    # not have to repair it
+    # then
     assert plain_payload["model"] == NEW_GENERATION_MODEL
     assert "temperature" not in plain_payload
     assert "thinking" not in plain_payload

--- a/tests/workflows/unit_tests/core_steps/models/foundation/test_anthropic_claude_model_capabilities.py
+++ b/tests/workflows/unit_tests/core_steps/models/foundation/test_anthropic_claude_model_capabilities.py
@@ -19,26 +19,6 @@ from inference.core.workflows.core_steps.models.foundation.anthropic_claude.v4 i
     EXACT_MODEL_VERSIONS as EXACT_MODEL_VERSIONS_V4,
 )
 
-LEGACY_CONTROL_MODELS = [
-    "claude-opus-4-6",
-    "claude-sonnet-4-6",
-    "claude-opus-4-5",
-    "claude-sonnet-4-5",
-    "claude-haiku-4-5",
-    "claude-opus-4-1",
-    "claude-opus-4",
-    "claude-sonnet-4",
-]
-
-ADAPTIVE_ONLY_MODELS = [
-    "claude-fable-5-1",
-    "claude-fable-5",
-    "claude-opus-5",
-    "claude-sonnet-5",
-    "claude-opus-4-8",
-    "claude-opus-4-7",
-]
-
 
 @pytest.fixture(autouse=True)
 def reset_warning_dedup() -> None:
@@ -57,28 +37,11 @@ def reset_warning_dedup() -> None:
         ("claude-opus-4-5-latest", "claude-opus-4-5"),
         ("  Claude-Fable-5-1 ", "claude-fable-5-1"),
         ("claude_sonnet_4_5", "claude-sonnet-4-5"),
-        ("anthropic.claude-fable-5-1", "anthropic-claude-fable-5-1"),
         ("claude-3-5-sonnet-v2", "claude-3-5-sonnet-v2"),
     ],
 )
 def test_normalize_anthropic_model_id(raw: str, expected: str) -> None:
     assert normalize_anthropic_model_id(raw) == expected
-
-
-@pytest.mark.parametrize("model_version", LEGACY_CONTROL_MODELS)
-def test_legacy_models_keep_temperature_and_manual_thinking(
-    model_version: str,
-) -> None:
-    assert anthropic_model_supports_temperature(model_version) is True
-    assert anthropic_model_supports_manual_thinking(model_version) is True
-
-
-@pytest.mark.parametrize("model_version", ADAPTIVE_ONLY_MODELS)
-def test_new_generation_models_reject_temperature_and_manual_thinking(
-    model_version: str,
-) -> None:
-    assert anthropic_model_supports_temperature(model_version) is False
-    assert anthropic_model_supports_manual_thinking(model_version) is False
 
 
 def test_unknown_model_defaults_to_new_generation_behaviour() -> None:
@@ -98,141 +61,38 @@ def test_dated_wire_ids_used_by_block_versions_are_classified_like_labels() -> N
         ) == anthropic_model_supports_temperature(wire_id), (label, wire_id)
 
 
-def test_v1_legacy_labels_that_alias_sonnet_4_5_keep_temperature() -> None:
-    for label in [
-        "claude-3-5-sonnet",
-        "claude-3-5-sonnet-v2",
-        "claude-4-5-sonnet",
-        "claude-4-5-sonnet-v2",
-        "claude-3-7-sonnet",
-        "claude-3-opus",
-    ]:
-        assert anthropic_model_supports_temperature(label) is True, label
-
-
-def test_resolve_temperature_passes_value_through_for_legacy_model(
+def test_resolve_temperature_drops_value_for_new_generation_and_warns_once(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     with caplog.at_level(logging.WARNING):
-        result = resolve_temperature(0.3, model_version="claude-sonnet-4-5")
+        assert resolve_temperature(0.3, model_version="claude-sonnet-4-5") == 0.3
+        assert resolve_temperature(0.3, model_version="claude-fable-5-1") is None
+        assert resolve_temperature(0.9, model_version="claude-fable-5-1") is None
+        assert resolve_temperature(0.3, model_version="claude-opus-5") is None
 
-    assert result == 0.3
-    assert caplog.records == []
-
-
-def test_resolve_temperature_returns_none_when_not_configured() -> None:
-    assert resolve_temperature(None, model_version="claude-sonnet-4-5") is None
-    assert resolve_temperature(None, model_version="claude-fable-5-1") is None
-
-
-def test_resolve_temperature_drops_value_when_thinking_enabled_on_legacy_model(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    with caplog.at_level(logging.WARNING):
-        result = resolve_temperature(
-            0.3, model_version="claude-sonnet-4-5", extended_thinking=True
-        )
-
-    # Anthropic forbids temperature with thinking; this is not a model
-    # capability gap so no warning is expected.
-    assert result is None
-    assert caplog.records == []
-
-
-def test_resolve_temperature_drops_value_and_warns_for_new_generation_model(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    with caplog.at_level(logging.WARNING):
-        result = resolve_temperature(0.3, model_version="claude-fable-5-1")
-
-    assert result is None
-    assert len(caplog.records) == 1
-    assert "claude-fable-5-1" in caplog.records[0].getMessage()
+    warned_models = [record.args[0] for record in caplog.records]
+    assert warned_models == ["claude-fable-5-1", "claude-opus-5"]
     assert "temperature" in caplog.records[0].getMessage()
 
 
-def test_resolve_temperature_warns_once_per_model(
+def test_build_thinking_config_uses_adaptive_and_ignores_budget_with_single_warning(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     with caplog.at_level(logging.WARNING):
-        resolve_temperature(0.3, model_version="claude-fable-5-1")
-        resolve_temperature(0.9, model_version="claude-fable-5-1")
-        resolve_temperature(0.3, model_version="claude-opus-5")
-
-    warned_models = [r.args[0] for r in caplog.records]
-    assert warned_models == ["claude-fable-5-1", "claude-opus-5"]
-
-
-def test_build_thinking_config_returns_none_when_thinking_disabled() -> None:
-    for extended_thinking in (None, False):
-        assert (
-            build_thinking_config(
-                extended_thinking=extended_thinking,
-                thinking_budget_tokens=4096,
-                model_version="claude-sonnet-4-5",
-                model_max_output=64000,
-            )
-            is None
-        )
-
-
-def test_build_thinking_config_uses_manual_budget_for_legacy_model() -> None:
-    result = build_thinking_config(
-        extended_thinking=True,
-        thinking_budget_tokens=5000,
-        model_version="claude-sonnet-4-5",
-        model_max_output=64000,
-    )
-
-    assert result == {"type": "enabled", "budget_tokens": 5000}
-
-
-def test_build_thinking_config_defaults_budget_to_half_of_output_ceiling() -> None:
-    result = build_thinking_config(
-        extended_thinking=True,
-        thinking_budget_tokens=None,
-        model_version="claude-sonnet-4-5",
-        model_max_output=64000,
-    )
-
-    assert result == {"type": "enabled", "budget_tokens": 32000}
-
-
-@pytest.mark.parametrize("model_version", ADAPTIVE_ONLY_MODELS)
-def test_build_thinking_config_requests_adaptive_thinking_for_new_generation(
-    model_version: str, caplog: pytest.LogCaptureFixture
-) -> None:
-    with caplog.at_level(logging.WARNING):
-        result = build_thinking_config(
-            extended_thinking=True,
-            thinking_budget_tokens=None,
-            model_version=model_version,
-            model_max_output=128000,
-        )
-
-    assert result == {"type": "adaptive"}
-    # no budget was configured, so nothing was silently dropped
-    assert caplog.records == []
-
-
-def test_build_thinking_config_ignores_budget_with_warning_for_adaptive_model(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    with caplog.at_level(logging.WARNING):
-        result = build_thinking_config(
+        first = build_thinking_config(
             extended_thinking=True,
             thinking_budget_tokens=5000,
             model_version="claude-fable-5-1",
             model_max_output=128000,
         )
-        build_thinking_config(
+        second = build_thinking_config(
             extended_thinking=True,
             thinking_budget_tokens=7000,
             model_version="claude-fable-5-1",
             model_max_output=128000,
         )
 
-    assert result == {"type": "adaptive"}
-    assert "budget_tokens" not in result
+    assert first == {"type": "adaptive"}
+    assert second == {"type": "adaptive"}
     assert len(caplog.records) == 1
     assert "thinking_budget_tokens=5000" in caplog.records[0].getMessage()

--- a/tests/workflows/unit_tests/core_steps/models/foundation/test_anthropic_claude_model_capabilities.py
+++ b/tests/workflows/unit_tests/core_steps/models/foundation/test_anthropic_claude_model_capabilities.py
@@ -1,0 +1,238 @@
+import logging
+
+import pytest
+
+from inference.core.workflows.core_steps.models.foundation.anthropic_claude import (
+    model_capabilities,
+)
+from inference.core.workflows.core_steps.models.foundation.anthropic_claude.model_capabilities import (
+    anthropic_model_supports_manual_thinking,
+    anthropic_model_supports_temperature,
+    build_thinking_config,
+    normalize_anthropic_model_id,
+    resolve_temperature,
+)
+from inference.core.workflows.core_steps.models.foundation.anthropic_claude.v1 import (
+    EXACT_MODELS_VERSIONS_MAPPING as EXACT_MODEL_VERSIONS_V1,
+)
+from inference.core.workflows.core_steps.models.foundation.anthropic_claude.v4 import (
+    EXACT_MODEL_VERSIONS as EXACT_MODEL_VERSIONS_V4,
+)
+
+LEGACY_CONTROL_MODELS = [
+    "claude-opus-4-6",
+    "claude-sonnet-4-6",
+    "claude-opus-4-5",
+    "claude-sonnet-4-5",
+    "claude-haiku-4-5",
+    "claude-opus-4-1",
+    "claude-opus-4",
+    "claude-sonnet-4",
+]
+
+ADAPTIVE_ONLY_MODELS = [
+    "claude-fable-5-1",
+    "claude-fable-5",
+    "claude-opus-5",
+    "claude-sonnet-5",
+    "claude-opus-4-8",
+    "claude-opus-4-7",
+]
+
+
+@pytest.fixture(autouse=True)
+def reset_warning_dedup() -> None:
+    model_capabilities._TEMPERATURE_WARNINGS_EMITTED.clear()
+    model_capabilities._THINKING_BUDGET_WARNINGS_EMITTED.clear()
+    yield
+    model_capabilities._TEMPERATURE_WARNINGS_EMITTED.clear()
+    model_capabilities._THINKING_BUDGET_WARNINGS_EMITTED.clear()
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        ("claude-sonnet-4-5", "claude-sonnet-4-5"),
+        ("claude-sonnet-4-5-20250929", "claude-sonnet-4-5"),
+        ("claude-opus-4-5-latest", "claude-opus-4-5"),
+        ("  Claude-Fable-5-1 ", "claude-fable-5-1"),
+        ("claude_sonnet_4_5", "claude-sonnet-4-5"),
+        ("anthropic.claude-fable-5-1", "anthropic-claude-fable-5-1"),
+        ("claude-3-5-sonnet-v2", "claude-3-5-sonnet-v2"),
+    ],
+)
+def test_normalize_anthropic_model_id(raw: str, expected: str) -> None:
+    assert normalize_anthropic_model_id(raw) == expected
+
+
+@pytest.mark.parametrize("model_version", LEGACY_CONTROL_MODELS)
+def test_legacy_models_keep_temperature_and_manual_thinking(
+    model_version: str,
+) -> None:
+    assert anthropic_model_supports_temperature(model_version) is True
+    assert anthropic_model_supports_manual_thinking(model_version) is True
+
+
+@pytest.mark.parametrize("model_version", ADAPTIVE_ONLY_MODELS)
+def test_new_generation_models_reject_temperature_and_manual_thinking(
+    model_version: str,
+) -> None:
+    assert anthropic_model_supports_temperature(model_version) is False
+    assert anthropic_model_supports_manual_thinking(model_version) is False
+
+
+def test_unknown_model_defaults_to_new_generation_behaviour() -> None:
+    assert anthropic_model_supports_temperature("claude-something-9") is False
+    assert anthropic_model_supports_manual_thinking("claude-something-9") is False
+
+
+def test_dated_wire_ids_used_by_block_versions_are_classified_like_labels() -> None:
+    # The block may hand the helper either the friendly label or the exact wire
+    # id; both spellings must agree for every model shipped in the blocks.
+    for label, wire_id in {
+        **EXACT_MODEL_VERSIONS_V1,
+        **EXACT_MODEL_VERSIONS_V4,
+    }.items():
+        assert anthropic_model_supports_temperature(
+            label
+        ) == anthropic_model_supports_temperature(wire_id), (label, wire_id)
+
+
+def test_v1_legacy_labels_that_alias_sonnet_4_5_keep_temperature() -> None:
+    for label in [
+        "claude-3-5-sonnet",
+        "claude-3-5-sonnet-v2",
+        "claude-4-5-sonnet",
+        "claude-4-5-sonnet-v2",
+        "claude-3-7-sonnet",
+        "claude-3-opus",
+    ]:
+        assert anthropic_model_supports_temperature(label) is True, label
+
+
+def test_resolve_temperature_passes_value_through_for_legacy_model(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with caplog.at_level(logging.WARNING):
+        result = resolve_temperature(0.3, model_version="claude-sonnet-4-5")
+
+    assert result == 0.3
+    assert caplog.records == []
+
+
+def test_resolve_temperature_returns_none_when_not_configured() -> None:
+    assert resolve_temperature(None, model_version="claude-sonnet-4-5") is None
+    assert resolve_temperature(None, model_version="claude-fable-5-1") is None
+
+
+def test_resolve_temperature_drops_value_when_thinking_enabled_on_legacy_model(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with caplog.at_level(logging.WARNING):
+        result = resolve_temperature(
+            0.3, model_version="claude-sonnet-4-5", extended_thinking=True
+        )
+
+    # Anthropic forbids temperature with thinking; this is not a model
+    # capability gap so no warning is expected.
+    assert result is None
+    assert caplog.records == []
+
+
+def test_resolve_temperature_drops_value_and_warns_for_new_generation_model(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with caplog.at_level(logging.WARNING):
+        result = resolve_temperature(0.3, model_version="claude-fable-5-1")
+
+    assert result is None
+    assert len(caplog.records) == 1
+    assert "claude-fable-5-1" in caplog.records[0].getMessage()
+    assert "temperature" in caplog.records[0].getMessage()
+
+
+def test_resolve_temperature_warns_once_per_model(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with caplog.at_level(logging.WARNING):
+        resolve_temperature(0.3, model_version="claude-fable-5-1")
+        resolve_temperature(0.9, model_version="claude-fable-5-1")
+        resolve_temperature(0.3, model_version="claude-opus-5")
+
+    warned_models = [r.args[0] for r in caplog.records]
+    assert warned_models == ["claude-fable-5-1", "claude-opus-5"]
+
+
+def test_build_thinking_config_returns_none_when_thinking_disabled() -> None:
+    for extended_thinking in (None, False):
+        assert (
+            build_thinking_config(
+                extended_thinking=extended_thinking,
+                thinking_budget_tokens=4096,
+                model_version="claude-sonnet-4-5",
+                model_max_output=64000,
+            )
+            is None
+        )
+
+
+def test_build_thinking_config_uses_manual_budget_for_legacy_model() -> None:
+    result = build_thinking_config(
+        extended_thinking=True,
+        thinking_budget_tokens=5000,
+        model_version="claude-sonnet-4-5",
+        model_max_output=64000,
+    )
+
+    assert result == {"type": "enabled", "budget_tokens": 5000}
+
+
+def test_build_thinking_config_defaults_budget_to_half_of_output_ceiling() -> None:
+    result = build_thinking_config(
+        extended_thinking=True,
+        thinking_budget_tokens=None,
+        model_version="claude-sonnet-4-5",
+        model_max_output=64000,
+    )
+
+    assert result == {"type": "enabled", "budget_tokens": 32000}
+
+
+@pytest.mark.parametrize("model_version", ADAPTIVE_ONLY_MODELS)
+def test_build_thinking_config_requests_adaptive_thinking_for_new_generation(
+    model_version: str, caplog: pytest.LogCaptureFixture
+) -> None:
+    with caplog.at_level(logging.WARNING):
+        result = build_thinking_config(
+            extended_thinking=True,
+            thinking_budget_tokens=None,
+            model_version=model_version,
+            model_max_output=128000,
+        )
+
+    assert result == {"type": "adaptive"}
+    # no budget was configured, so nothing was silently dropped
+    assert caplog.records == []
+
+
+def test_build_thinking_config_ignores_budget_with_warning_for_adaptive_model(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with caplog.at_level(logging.WARNING):
+        result = build_thinking_config(
+            extended_thinking=True,
+            thinking_budget_tokens=5000,
+            model_version="claude-fable-5-1",
+            model_max_output=128000,
+        )
+        build_thinking_config(
+            extended_thinking=True,
+            thinking_budget_tokens=7000,
+            model_version="claude-fable-5-1",
+            model_max_output=128000,
+        )
+
+    assert result == {"type": "adaptive"}
+    assert "budget_tokens" not in result
+    assert len(caplog.records) == 1
+    assert "thinking_budget_tokens=5000" in caplog.records[0].getMessage()

--- a/tests/workflows/unit_tests/core_steps/models/foundation/test_anthropic_claude_model_capabilities.py
+++ b/tests/workflows/unit_tests/core_steps/models/foundation/test_anthropic_claude_model_capabilities.py
@@ -68,6 +68,9 @@ def test_resolve_temperature_drops_value_for_new_generation_and_warns_once(
         assert resolve_temperature(0.3, model_version="claude-sonnet-4-5") == 0.3
         assert resolve_temperature(0.3, model_version="claude-fable-5-1") is None
         assert resolve_temperature(0.9, model_version="claude-fable-5-1") is None
+        assert (
+            resolve_temperature(0.9, model_version="claude-fable-5-1-20260901") is None
+        )
         assert resolve_temperature(0.3, model_version="claude-opus-5") is None
 
     warned_models = [record.args[0] for record in caplog.records]
@@ -88,7 +91,7 @@ def test_build_thinking_config_uses_adaptive_and_ignores_budget_with_single_warn
         second = build_thinking_config(
             extended_thinking=True,
             thinking_budget_tokens=7000,
-            model_version="claude-fable-5-1",
+            model_version="claude-fable-5-1-20260901",
             model_max_output=128000,
         )
 


### PR DESCRIPTION
## What does this PR do?

Linked issue: n/a (fast-track patch for the Claude Fable 5.1 release)

Anthropic released Claude Fable 5.1 (`claude-fable-5-1`) on 2026-09-01. The Anthropic Claude workflow blocks pin `model_version` to a fixed list, so the new model could not be selected from the UI or from a static workflow definition. While verifying the new model live, we also found that the blocks still send request parameters that the Claude 4.7+ generation rejects with HTTP 400, so the same workflow could succeed via `rf_key:account` and fail with a customer's own key.

This patch adds `claude-fable-5-1` (128k max output, undated wire id) to `anthropic_claude@v4`, the latest block version. Following the maintainers' rule, new models are not added to older block versions; v1-v3 keep their existing model lists. It also introduces a small shared `model_capabilities` helper used by v1-v4 on both the direct and the proxied path: `temperature` is omitted (with a one-time warning) for models that no longer accept sampling parameters, and `extended_thinking` is sent as `thinking.type=adaptive` for models that no longer accept a manual `budget_tokens`. Older models (Sonnet/Opus/Haiku 4.x up to 4.6, Claude 3.x) keep the previous behaviour byte-for-byte. The proxied path is changed to send the same payload the direct path sends, so the Roboflow proxy no longer has to repair requests. No model-specific pricing configuration is introduced on purpose (see below). The package version is bumped to `1.5.1-post2` for the next fast-track release.

**Main elements:**
- `inference/core/workflows/core_steps/models/foundation/anthropic_claude/v4.py` - `claude-fable-5-1` added to `CLAUDE_MODELS`
- `inference/core/workflows/core_steps/models/foundation/anthropic_claude/v{1,2,3,4}.py` - request builders now go through the capability helper (bug fix: v1-v3 already list Claude Opus 4.7 and Fable 5, which reject the old parameters); `temperature` / `extended_thinking` / `thinking_budget_tokens` field descriptions note that Claude Opus 4.7 and newer ignore them
- `inference/core/workflows/core_steps/models/foundation/anthropic_claude/model_capabilities.py` (new) - allow-lists of models that still accept `temperature` / manual thinking (mirrors `TEMPERATURE_SUPPORTED_MODELS` in the Roboflow proxy), id normalisation, `resolve_temperature`, `build_thinking_config`
- `inference/core/version.py` - `1.5.1-post1` -> `1.5.1-post2`
- Unit tests for model metadata, manifest validation, dependent-resource discovery, the capability helper, and the outgoing request shape on every code path

### Roboflow-side pricing (checked against `roboflow` `master` @ `959cd626`)

Model-specific pricing config is **no longer needed**. Since roboflow#14749 (`1215a8c4`, "price LLM proxy models from the OpenRouter catalog") `anthropicProxyService.ts` resolves pricing via `getProxyModelPricing("anthropic", model)`, which maps `claude-fable-5-1` -> `anthropic/claude-fable-5.1` (dash-to-dot candidate ids) and reads live rates from the cached OpenRouter catalog. `anthropicPricing.ts` is now a frozen legacy table explicitly marked "Do not add new models here". `MODEL_VERSIONS[model] || model` passes the id through unchanged. OpenRouter already lists `anthropic/claude-fable-5.1` ($10 / $50 per Mtok, $0.25 cache read). The live pass-through run below confirms prod already prices Fable 5.1 correctly, so this PR relies on that mechanism and adds no config.

### Why `temperature` / manual thinking are dropped for new models

Verified live against the Anthropic API (2026-09-02):

| Model | `temperature=0.2` | `thinking: {type: enabled, budget_tokens}` | `thinking: {type: adaptive}` |
| --- | --- | --- | --- |
| `claude-fable-5-1`, `claude-fable-5`, `claude-opus-5`, `claude-sonnet-5`, `claude-opus-4-8`, `claude-opus-4-7` | 400 `temperature is deprecated for this model` | 400 `"thinking.type.enabled" is not supported for this model. Use "thinking.type.adaptive"` | OK |
| `claude-sonnet-4-6`, `claude-opus-4-6`, `claude-sonnet-4-5`, `claude-haiku-4-5`, `claude-opus-4-5`, `claude-opus-4-1`, `claude-opus-4`, `claude-sonnet-4` | OK | OK | 400 (4.5 family) / OK (4.6 family) |

The helper keeps an explicit allow-list of the second row, so any unknown or future id gets the new-generation treatment by default, which matches what the Roboflow proxy does for `temperature`. See Anthropic's [Opus 4.7 migration notes](https://docs.anthropic.com/en/docs/about-claude/models/migrating-to-claude-4-7) and the [adaptive thinking docs](https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking#adaptive-thinking).

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other:

The PR also carries a bug fix (400s on `temperature` / manual thinking for Claude 4.7+ on the direct path). Per the inference maintainers, the bug fix is applied to every block version while the new model is only added to v4.

## Testing

### Unit tests

- `test_anthropic_claude.py`: v4 manifest accepts `claude-fable-5-1` and v4 maps it to the undated wire id with a 128k output ceiling.
- `test_anthropic_claude.py` (request shape): for `claude-sonnet-4-5` vs `claude-opus-4-7` (present in every block version, so the same test runs against v1-v4), asserts what actually leaves the block on v1 direct, v2 direct, v3/v4 direct (`anthropic.Anthropic` mocked) and v3/v4 proxied (`post_to_roboflow_api` mocked): legacy model keeps `temperature` and `thinking.type=enabled` + budget (default budget = half of output ceiling); new model gets `temperature` omitted, `thinking.type=adaptive` with no `budget_tokens`, and the exact wire id.
- `test_anthropic_claude_model_capabilities.py` (new, 5 tests): id normalisation (dated snapshots, `-latest`, casing, underscores); unknown ids default to new-generation behaviour; label vs wire id agreement for every model shipped in the blocks; `resolve_temperature` drops for new models and warns once per model; `build_thinking_config` sends `adaptive` and ignores the budget with a single warning. Membership and pass-through cases are covered by the request-shape tests above instead.

### Integration tests

- None added. Live end-to-end runs below were done locally against real APIs.

### Live verification (local, `claude-fable-5-1`, `dogs.jpg`)

Workflow: `anthropic_claude@v4` `unconstrained` caption + `anthropic_claude@v4` `object-detection` -> `vlm_as_detector@v2` (`model_type=anthropic-claude`), run through `ExecutionEngine` in `StepExecutionMode.LOCAL`.

| Path | Result |
| --- | --- |
| Direct Anthropic API key (v4) | OK - caption returned (391 in / 46 out tokens); detection returned 2 `dog` boxes, parsed to 2 detections (516 in / 59 out tokens); 9.4 s |
| Roboflow pass-through `rf_key:account` (v4) | OK - caption returned (391 / 47 tokens); detection 2 `dog` boxes -> 2 detections (516 / 59 tokens); 12.6 s; no "Unsupported model" from `apiproxy/anthropic`, so catalog pricing is live in prod |
| Direct key (v3) with `claude-opus-4-7`, `temperature=0.3` | OK (`temperature` dropped with one warning) |
| Direct key (v3) with `claude-opus-4-7`, `extended_thinking=True`, budget 2048 | OK (`thinking.type=adaptive`, budget ignored with one warning) |
| Direct key (v2) with `claude-opus-4-7`, both cases above | OK |
| Direct key (v1) with `claude-opus-4-7`, `temperature=0.3` | OK (`temperature` dropped) |
| Roboflow pass-through (v2, v1) | 401 `invalid x-api-key` - expected: v1/v2 predate managed keys and have no `rf_key` routing; the literal string is sent to Anthropic. Pre-existing, not changed here. |

v1-v3 cannot select `claude-fable-5-1`, so the old-version rows exercise the same 4.7+ request fix with `claude-opus-4-7`, which those versions already list.

### Live verification of the `temperature` / thinking fix (v4 `execute_claude_request`, after this change)

| Case | Before this PR | After this PR |
| --- | --- | --- |
| direct / `claude-fable-5-1` / `temperature=0.2` | 400 `temperature is deprecated for this model` | OK (`temperature` omitted, warning logged once) |
| proxy / `claude-fable-5-1` / `temperature=0.2` | OK (proxy dropped it) | OK (block no longer sends it) |
| direct / `claude-fable-5-1` / `extended_thinking=True`, budget 4096 | 400 `"thinking.type.enabled" is not supported for this model` | OK (`thinking.type=adaptive`, budget ignored with warning) |
| proxy / `claude-fable-5-1` / `extended_thinking=True` | 502 (proxy forwarded `enabled`, Anthropic 400'd) | prod: 400 `Parameter 'thinking.type' must be 'enabled'` until roboflow/roboflow#15031 ships; **staging (proxy PR deployed): OK** - see the staging table below |
| direct / `claude-sonnet-4-5` / `temperature=0.2` | OK | OK (unchanged) |
| direct / `claude-sonnet-4-5` / `extended_thinking=True`, budget 2048 | OK | OK (`thinking.type=enabled`, unchanged) |
| proxy / `claude-sonnet-4-5` / `extended_thinking=True`, budget 2048 | OK | OK (unchanged) |

### Staging verification against the deployed proxy (2026-09-02, `PROJECT=roboflow-staging`, `api.roboflow.one`)

Run after roboflow/roboflow#15031 was deployed to staging (`heavy-v2-passthrough`, `heavy-v2-api`), with this branch's blocks, a real Anthropic key for the direct path and a staging Roboflow key for `rf_key:account`.

| Path | Version | Model | Controls | Result |
| --- | --- | --- | --- | --- |
| direct | v4 | `claude-fable-5-1` | workflow: caption + object-detection -> `vlm_as_detector@v2` | OK - 2 `dog` detections, caption returned, 5.0 s |
| pass-through | v4 | `claude-fable-5-1` | same workflow | OK - 2 `dog` detections, caption returned, 6.2 s; staging catalog pricing accepts Fable 5.1 |
| pass-through | v4 | `claude-fable-5-1` | `extended_thinking=True`, budget 4096 (block sends `adaptive`) | OK - previously 400 on the proxy validator |
| pass-through | v4 | `claude-fable-5-1` | `temperature=0.2` (block omits it) | OK |
| pass-through | v4 | `claude-sonnet-4-5` | `extended_thinking=True`, budget 2048 (block sends `enabled`) | OK, unchanged |
| pass-through | v3 | `claude-opus-4-7` | `extended_thinking=True`, budget 2048 (block sends `adaptive`) | OK - the 4.7+ fix in an older block version through the proxy |
| direct | v4 | `claude-fable-5-1` | `temperature=0.2` / `extended_thinking=True` | OK / OK |
| raw proxy (old `inference` client shape) | - | `claude-fable-5-1` | `thinking: {enabled, budget_tokens: 4096}` | OK - proxy rewrote to `adaptive`; already-deployed inference versions keep working |
| raw proxy | - | `claude-sonnet-4-5` | `thinking: {adaptive}`, `max_tokens: 1000` | 400 `Parameter 'max_tokens' must be greater than 1024 when thinking is requested for model 'claude-sonnet-4-5'` (intended) |
| raw proxy | - | `claude-sonnet-4-5` | `thinking: {adaptive}`, `max_tokens: 1500` | OK - proxy derived a manual budget |

### Other

- `uv run pytest tests/workflows/unit_tests/core_steps/models/foundation/test_anthropic_claude.py tests/workflows/unit_tests/core_steps/models/foundation/test_anthropic_claude_model_capabilities.py tests/workflows/unit_tests/core_steps/dependent_resources/test_anthropic_claude.py` -> 71 passed
- `uv run pytest tests/workflows/unit_tests/execution_engine/introspection tests/workflows/unit_tests/core_steps/common` -> 556 passed, 45 skipped
- `black --check` / `isort --check-only` / `flake8 --select=E9,F63,F7,F82` on touched files -> clean

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [ ] I have updated the documentation accordingly (if applicable)

## Additional Context

**Follow-up required in `roboflow` (proxy):** `anthropicProxyEndpoints.ts` validates `thinking.type === "enabled"` and requires `budget_tokens`, so with this PR `extended_thinking=True` on a Claude 4.7+ model through `rf_key:account` fails fast with 400 `Parameter 'thinking.type' must be 'enabled'` (previously it failed with a 502 after Anthropic rejected `enabled`). Companion PR [roboflow/roboflow#15031](https://github.com/roboflow/roboflow/pull/15031) relaxes the validator to accept `thinking.type` in `{"enabled", "adaptive"}` (budget only required for `enabled`) and translates `enabled` -> `adaptive` server-side for models that no longer support manual thinking, so older `inference` versions keep working too. `extended_thinking` on Claude 4.7+ via the proxy stays broken in prod until that ships (verified working on staging, see table above); the direct path and all pre-4.7 models are unaffected.

**Allow-list maintenance:** the allow-lists in `model_capabilities.py` name the models that still accept the legacy controls; anything unknown defaults to the new-generation behaviour. When a new model ships that *does* accept `temperature` / manual thinking it must be added there (and to the proxy's `TEMPERATURE_SUPPORTED_MODELS`).

**Not changed on purpose:** retired v1 model labels (`claude-3-opus`, `claude-3-haiku`, `claude-3-5-haiku` now return 404 from Anthropic) are left in the lists; removing them is a breaking change for existing workflow definitions and out of scope for a fast-track patch.

Working tree also contained unrelated untracked scratch files; none were committed.

Made with [Cursor](https://cursor.com)




