### PR TITLE
Add Gemini 3.8 Flash to the Google Gemini v5 block

### DIFF
--- a/inference/core/version.py
+++ b/inference/core/version.py
@@ -1,4 +1,4 @@
-__version__ = "1.5.1-post2"
+__version__ = "1.5.1-post3"
 
 
 if __name__ == "__main__":

--- a/inference/core/workflows/core_steps/models/foundation/google_gemini/v5.py
+++ b/inference/core/workflows/core_steps/models/foundation/google_gemini/v5.py
@@ -59,9 +59,16 @@ MODEL_ALIASES = {
     "gemini-2.5-pro-preview-03-25": "gemini-2.5-pro",
 }
 
-# 3.7-flash probed 2026-08-25: API rejects `minimal`. 2.5 pages contradict
-# (`thinking_level` vs `thinking_budget` only); we keep 2.5 unsupported.
+# 3.7-flash probed 2026-08-25 and 3.8-flash probed 2026-09-02: API rejects
+# `minimal`. 2.5 pages contradict (`thinking_level` vs `thinking_budget` only);
+# we keep 2.5 unsupported.
 GEMINI_MODELS = [
+    {
+        "id": "gemini-3.8-flash",
+        "name": "Gemini 3.8 Flash",
+        "thinking_levels": ["low", "medium", "high"],
+        "supports_native_code_execution": True,
+    },
     {
         "id": "gemini-3.7-flash",
         "name": "Gemini 3.7 Flash",
@@ -322,8 +329,8 @@ class BlockManifest(WorkflowBlockManifest):
         description="Controls the depth of internal reasoning for Gemini 3+ models. "
         "'minimal' matches no-thinking for most queries, 'low' minimizes latency and cost, "
         "'medium' balances both, 'high' maximizes reasoning depth. Supported values differ "
-        "per model (see the model dropdown): Gemini 3.1 Pro and Gemini 3.7 Flash have no "
-        "'minimal'; Gemini 3.1 Pro also cannot disable thinking. When unset, the Google "
+        "per model (see the model dropdown): Gemini 3.1 Pro and Gemini 3.7/3.8 Flash have "
+        "no 'minimal'; Gemini 3.1 Pro also cannot disable thinking. When unset, the Google "
         "API default for the selected model is used (e.g. 'high' for Gemini 3.1 Pro, "
         "'medium' for Gemini 3.5/3.6 Flash). "
         "Not supported by the Gemini 2.5 series.",

--- a/tests/workflows/unit_tests/core_steps/common/test_reasoning_contract.py
+++ b/tests/workflows/unit_tests/core_steps/common/test_reasoning_contract.py
@@ -196,6 +196,10 @@ def test_manifest_accepts_edges_rejects_cannot_cover(block_type, overrides):
         ),
         (
             "google_gemini@v5",
+            {"model_version": "gemini-3.8-flash", "thinking_level": "minimal"},
+        ),
+        (
+            "google_gemini@v5",
             {"model_version": "gemini-2.5-pro", "thinking_level": "low"},
         ),
         ("spacexai@v2", {"model_version": "grok-4.5", "reasoning_effort": "xhigh"}),


### PR DESCRIPTION
## What does this PR do?

Linked issue: [INF-XXXX](https://linear.app/roboflow/issue/INF-XXXX/add-gemini-3-8-flash-to-the-google-gemini-block)

Google shipped Gemini 3.8 Flash (`gemini-3.8-flash`, generally available) on 2026-09-02. The Google Gemini workflow block had no entry for it, so workflows could not select the newest Flash model.

We add `gemini-3.8-flash` to the model catalog of `google_gemini@v5`. Only the latest block version gets the new model, following the convention set in #2907. Before writing the entry we probed the live Gemini API: `models/gemini-3.8-flash` is served with thinking enabled, `thinking_level=minimal` is rejected ("Thinking level MINIMAL is not supported for this model"), and `low`, `medium` and `high` are accepted. That is the same profile as Gemini 3.7 Flash, so the entry declares those three levels and keeps native code execution on, like the other Gemini 3.x models. The `thinking_level` field description and the probe comment above the catalog now mention 3.8 Flash. The block default stays `gemini-3.1-pro-preview`. No version bump: this branch is already at `1.5.1-post2`.

We also checked the API side in the `roboflow` repo (`master`). The managed proxy (`POST /apiproxy/gemini`) has no per-model allowlist; it accepts a Gemini model when the OpenRouter catalog lists it with non-zero pricing, and OpenRouter already lists `google/gemini-3.8-flash` at $0.75/M input and $3.75/M output. A proxied run through production succeeded with no API change, so nothing on that side blocks the release.

Main elements:
- `inference/core/workflows/core_steps/models/foundation/google_gemini/v5.py`: new `GEMINI_MODELS` entry, probe comment, `thinking_level` description
- `tests/workflows/unit_tests/core_steps/common/test_reasoning_contract.py`: the v5 manifest rejects `gemini-3.8-flash` with `thinking_level=minimal`

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other:

## Testing

### Unit tests

- `test_reasoning_contract.py`: one new case, the v5 manifest rejects `gemini-3.8-flash` combined with `thinking_level="minimal"`, mirroring the 3.7 Flash case. The existing contract tests already check catalog and dropdown metadata consistency for every entry, so we did not add a catalog-restating test (see #2794).

### Integration tests

- None for this PR.

### Other

- `pytest tests/workflows/unit_tests/core_steps/models/foundation/test_google_gemini_v5.py tests/workflows/unit_tests/core_steps/models/foundation/test_google_gemini.py tests/workflows/unit_tests/core_steps/common/test_reasoning_contract.py tests/workflows/unit_tests/core_steps/test_dependent_resources.py`: 115 passed
- black, isort and flake8 (the `check_code_quality` selection) clean on the touched files
- Live probe of `models/gemini-3.8-flash` via `generateContent` with `thinkingLevel` minimal, low, medium and high: minimal rejected, the rest accepted
- Two local workflows run end to end on a drone intersection image, each with `google_gemini@v5` on `gemini-3.8-flash` for object detection (`thinking_level=low`, parsed by `vlm_as_detector@v2`) plus an unconstrained caption (`thinking_level=high`):
  - direct Google API key: 14 detections (car, bus, tree), 1208 input and 510 output tokens on the detection call
  - Roboflow pass-through (`rf_key:account`, production `api.roboflow.com`): 17 detections, 1208 input and 576 output tokens, usage metadata returned by the proxy

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [ ] I have updated the documentation accordingly (if applicable)

## Additional Context

Only `google_gemini@v5` receives the new model; v1 to v4 stay unchanged. `docs/workflows/blocks/google_gemini.md` is regenerated at docs build time, so it is not edited here. The Linear link is a placeholder, please replace it with the real issue.
