### PR TITLE
Keep the OWLv2 cache test off torch.compile (torch 2.14 rejects the mocked model)

### DIFF
--- a/tests/inference/unit_tests/models/test_hugging_face_dependency_cache.py
+++ b/tests/inference/unit_tests/models/test_hugging_face_dependency_cache.py
@@ -36,6 +36,9 @@ def test_owlv2_singleton_uses_explicit_hugging_face_cache_path(
 
     expected_cache_path = "/mounted/inference-cache/hf_home/hub"
     monkeypatch.setattr(owlv2, "HF_HUB_CACHE", expected_cache_path)
+    # The singleton is asked about the cache path, not compilation: torch>=2.14
+    # validates what torch.compile is handed and rejects the MagicMock model.
+    monkeypatch.setattr(owlv2, "OWLV2_COMPILE_MODEL", False)
     owlv2.Owlv2Singleton._instances.clear()
 
     model = MagicMock()


### PR DESCRIPTION
## What does this PR do?

Unbreaks `UNIT TESTS - inference` on `main`. Since the runners started resolving torch 2.14.0 (2026-09-02), `tests/inference/unit_tests/models/test_hugging_face_dependency_cache.py::test_owlv2_singleton_uses_explicit_hugging_face_cache_path` fails on every branch, `main` included (e.g. run 33658688716):

```
TypeError: dynamic spec expects a dict, ShapesSpec, or ParamsSpec, got MagicMock
```

torch 2.14 validates what `torch.compile` is handed, and the test stands the model in with a `MagicMock`, which `Owlv2Singleton` then compiles (`OWLV2_COMPILE_MODEL` defaults on). The test is about the HF cache path, not compilation, so it turns `OWLV2_COMPILE_MODEL` off for its duration. One line, test-only.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- The two tests in the file pass locally (torch 2.7.1, where the compile call happened to tolerate the mock); CI on this PR is the torch 2.14 check.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQph9P2Cis9MV9xT382qL4
