### PR TITLE
Serve Roboflow Cosmos 3 Edge fine-tunes (LoRA packages, clips over HTTP)

### DIFF
--- a/inference/core/entities/requests/inference.py
+++ b/inference/core/entities/requests/inference.py
@@ -394,6 +394,13 @@ class LMMInferenceRequest(CVInferenceRequest):
         default=None,
         description="Maximum number of tokens to generate. If not set, the model's default will be used.",
     )
+    video_fps: Optional[float] = Field(
+        default=None,
+        examples=[4.0],
+        description="When `image` is a list, the frames per second it was sampled at: the list is then one clip, "
+        "in order, for video-language models that reason over time (e.g. Cosmos 3). Not set means the list is "
+        "a batch of independent images.",
+    )
 
 
 def request_from_type(model_type, request_dict):

--- a/inference/models/cosmos3/cosmos3_reasoner_inference_models.py
+++ b/inference/models/cosmos3/cosmos3_reasoner_inference_models.py
@@ -60,17 +60,46 @@ class InferenceModelsCosmos3ReasonerAdapter(Model):
         return kwargs
 
     def preprocess(self, image: Any, prompt: str = "", **kwargs):
-        is_batch = isinstance(image, list)
-        if is_batch:
-            raise ValueError("This model does not support batched-inference.")
+        """One image, or a list of images that is one clip.
+
+        The model does not batch independent images; a list is the consecutive frames of a
+        video window, and ``video_fps`` (the rate they were sampled at) says how far apart
+        they are in time. The response dims are those of the first frame.
+        """
+        disable_preproc_auto_orient = kwargs.get("disable_preproc_auto_orient", False)
+        video_fps = kwargs.pop("video_fps", None)
+        mapped_kwargs = self.map_inference_kwargs(kwargs)
+        if isinstance(image, list):
+            if video_fps is None:
+                raise ValueError(
+                    "A list of images is the frames of one clip for this model; pass "
+                    "video_fps, the rate the frames were sampled at."
+                )
+            if len(image) == 0:
+                raise ValueError("A clip needs at least one frame.")
+            frames = [
+                load_image_bgr(
+                    frame, disable_preproc_auto_orient=disable_preproc_auto_orient
+                )
+                for frame in image
+            ]
+            input_shape = PreprocessReturnMetadata(
+                {"image_dims": frames[0].shape[:2][::-1]}
+            )
+            return (
+                self._model.pre_process_generation(
+                    frames,
+                    prompt,
+                    as_video=True,
+                    video_fps=video_fps,
+                    **mapped_kwargs,
+                ),
+                input_shape,
+            )
         np_image = load_image_bgr(
-            image,
-            disable_preproc_auto_orient=kwargs.get(
-                "disable_preproc_auto_orient", False
-            ),
+            image, disable_preproc_auto_orient=disable_preproc_auto_orient
         )
         input_shape = PreprocessReturnMetadata({"image_dims": np_image.shape[:2][::-1]})
-        mapped_kwargs = self.map_inference_kwargs(kwargs)
         return (
             self._model.pre_process_generation(np_image, prompt, **mapped_kwargs),
             input_shape,

--- a/inference/models/utils.py
+++ b/inference/models/utils.py
@@ -511,6 +511,17 @@ try:
                 "cosmos-3-edge",
             ): InferenceModelsCosmos3ReasonerAdapter,
             ("vlm", "cosmos-3-edge"): InferenceModelsCosmos3ReasonerAdapter,
+            # Roboflow action-recognition fine-tunes: the platform's model type id is
+            # cosmos3-edge (what a versioned project/version id resolves to), the model
+            # package's architecture is cosmos-3-edge.
+            (
+                "action-recognition",
+                "cosmos3-edge",
+            ): InferenceModelsCosmos3ReasonerAdapter,
+            (
+                "action-recognition",
+                "cosmos-3-edge",
+            ): InferenceModelsCosmos3ReasonerAdapter,
         }
         ROBOFLOW_MODEL_TYPES.update(cosmos3_models)
 except:

--- a/inference_models/inference_models/models/cosmos3/cosmos3_reasoner_hf.py
+++ b/inference_models/inference_models/models/cosmos3/cosmos3_reasoner_hf.py
@@ -3,14 +3,18 @@ This is inference-models wrapper for the reasoner tower of NVIDIA Cosmos 3 Edge,
 originally published in https://huggingface.co/nvidia/Cosmos3-Edge
 """
 
+import json
+import os
 import re
 from threading import Lock
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import torch
+from peft import PeftModel
 from transformers import AutoModelForImageTextToText, AutoProcessor
 from transformers.utils import is_flash_attn_2_available
+from transformers.video_utils import VideoMetadata
 
 from inference_models.configuration import (
     DEFAULT_DEVICE,
@@ -21,7 +25,15 @@ from inference_models.configuration import (
 from inference_models.entities import ColorFormat
 
 DEFAULT_PROMPT = "Describe what's in this image."
+DEFAULT_SYSTEM_PROMPT = (
+    "You are Cosmos, a helpful assistant that understands physical scenes "
+    "and answers questions about images and videos."
+)
 SYSTEM_PROMPT_SENTINEL = "<system_prompt>"
+ADAPTER_CONFIG_FILE = "adapter_config.json"
+BASE_MODEL_DIR = "base"
+INFERENCE_CONFIG_FILE = "inference_config.json"
+CLASS_NAMES_FILE = "class_names.txt"
 THINK_BLOCK_PATTERN = re.compile(r"<think>.*?</think>\s*", flags=re.DOTALL)
 THINK_EXTRACT_PATTERN = re.compile(r"<think>(.*?)</think>", flags=re.DOTALL)
 
@@ -81,36 +93,68 @@ class Cosmos3EdgeReasoner:
     ) -> "Cosmos3EdgeReasoner":
         dtype = _resolve_default_dtype(device)
         attn_implementation = _get_cosmos3_attn_implementation(device)
-        model = AutoModelForImageTextToText.from_pretrained(
+        # A Roboflow fine-tune is a LoRA package: the adapter (and the processor, whose
+        # tokenizer carries the fine-tune's added class tokens) at the root, the base
+        # reasoner under base/. The pretrained package is the base reasoner itself.
+        adapter_config_path = os.path.join(model_name_or_path, ADAPTER_CONFIG_FILE)
+        is_adapter_package = os.path.exists(adapter_config_path)
+        base_model_path = (
+            os.path.join(model_name_or_path, BASE_MODEL_DIR)
+            if is_adapter_package
+            else model_name_or_path
+        )
+        processor = AutoProcessor.from_pretrained(
             model_name_or_path,
+            trust_remote_code=trust_remote_code,
+            local_files_only=local_files_only,
+        )
+        model = AutoModelForImageTextToText.from_pretrained(
+            base_model_path,
             device_map=device,
             dtype=dtype,
             trust_remote_code=trust_remote_code,
             local_files_only=local_files_only,
             quantization_config=quantization_config,
             attn_implementation=attn_implementation,
-        ).eval()
-        processor = AutoProcessor.from_pretrained(
-            model_name_or_path,
-            trust_remote_code=trust_remote_code,
-            local_files_only=local_files_only,
         )
-        return cls(model=model, processor=processor, device=device)
+        if is_adapter_package:
+            # The fine-tune added one special token per class; their embedding and head
+            # rows live in the adapter (PEFT trainable tokens), so the base only needs the
+            # rows to exist before the adapter is applied.
+            model.resize_token_embeddings(len(processor.tokenizer))
+            model = PeftModel.from_pretrained(model, model_name_or_path)
+            model = model.merge_and_unload()
+        model = model.eval()
+        generation = _load_generation_defaults(model_name_or_path)
+        return cls(
+            model=model,
+            processor=processor,
+            device=device,
+            default_prompt=generation.get("prompt", DEFAULT_PROMPT),
+            default_system_prompt=generation.get(
+                "system_prompt", DEFAULT_SYSTEM_PROMPT
+            ),
+            class_names=_load_class_names(model_name_or_path),
+        )
 
     def __init__(
         self,
         model,
         processor,
         device: torch.device,
+        default_prompt: str = DEFAULT_PROMPT,
+        default_system_prompt: str = DEFAULT_SYSTEM_PROMPT,
+        class_names: Optional[List[str]] = None,
     ):
         self._model = model
         self._processor = processor
         self._device = device
         self._torch_dtype = next(model.parameters()).dtype
-        self.default_system_prompt = (
-            "You are Cosmos, a helpful assistant that understands physical scenes "
-            "and answers questions about images and videos."
-        )
+        self.default_prompt = default_prompt
+        self.default_system_prompt = default_system_prompt
+        # A fine-tune answers in the special class tokens it was trained with, so decoding
+        # must keep special tokens for its answers to survive.
+        self.class_names = list(class_names) if class_names else []
         self._lock = Lock()
 
     def prompt(
@@ -147,6 +191,7 @@ class Cosmos3EdgeReasoner:
         do_sample: bool = INFERENCE_MODELS_COSMOS3_DEFAULT_DO_SAMPLE,
         skip_special_tokens: bool = True,
         return_thinking: bool = False,
+        video_fps: Optional[float] = None,
         **kwargs,
     ) -> Union[str, Dict[str, str]]:
         inputs = self.pre_process_generation(
@@ -154,6 +199,7 @@ class Cosmos3EdgeReasoner:
             prompt=prompt,
             input_color_format=input_color_format,
             as_video=True,
+            video_fps=video_fps,
         )
         generated_ids = self.generate(
             inputs=inputs,
@@ -172,8 +218,16 @@ class Cosmos3EdgeReasoner:
         prompt: str = None,
         input_color_format: ColorFormat = None,
         as_video: bool = False,
+        video_fps: Optional[float] = None,
         **kwargs,
     ) -> dict:
+        """Tokenize a prompt around an image, or around a clip when ``as_video``.
+
+        ``video_fps`` is the rate the frames were sampled at. With it, frame ``i`` is stamped
+        ``i / video_fps`` seconds into the clip - the timestamps a temporal fine-tune answers
+        in - and the processor is told not to resample. Without it the processor applies its
+        own frame sampling and timing.
+        """
         if isinstance(images, np.ndarray):
             if input_color_format != "rgb":
                 images = images[:, :, ::-1]
@@ -206,6 +260,17 @@ class Cosmos3EdgeReasoner:
             conversation, tokenize=False, add_generation_prompt=True
         )
         processor_kwargs = {"videos": [images]} if as_video else {"images": images}
+        if as_video and video_fps is not None:
+            if video_fps <= 0:
+                raise ValueError(f"video_fps must be positive, got {video_fps}")
+            processor_kwargs["video_metadata"] = [
+                VideoMetadata(
+                    total_num_frames=len(images),
+                    fps=video_fps,
+                    frames_indices=list(range(len(images))),
+                )
+            ]
+            processor_kwargs["do_sample_frames"] = False
         model_inputs = self._processor(
             text=text_input,
             return_tensors="pt",
@@ -253,10 +318,31 @@ class Cosmos3EdgeReasoner:
         return_thinking: bool = False,
         **kwargs,
     ) -> Union[List[str], List[Dict[str, str]]]:
-        decoded = self._processor.batch_decode(
-            generated_ids,
-            skip_special_tokens=skip_special_tokens,
-        )
+        if self.class_names:
+            # The answer is made of the fine-tune's class tokens, which are special
+            # tokens; only the turn/pad control tokens are dropped.
+            tokenizer = self._processor.tokenizer
+            control_tokens = [
+                token
+                for token in (
+                    tokenizer.eos_token,
+                    tokenizer.pad_token,
+                    tokenizer.bos_token,
+                )
+                if token
+            ]
+            decoded = []
+            for text in self._processor.batch_decode(
+                generated_ids, skip_special_tokens=False
+            ):
+                for token in control_tokens:
+                    text = text.replace(token, "")
+                decoded.append(text)
+        else:
+            decoded = self._processor.batch_decode(
+                generated_ids,
+                skip_special_tokens=skip_special_tokens,
+            )
         result = []
         for text in decoded:
             text = text.replace("assistant\n", "")
@@ -287,9 +373,38 @@ class Cosmos3EdgeReasoner:
 
     def _parse_prompt(self, prompt: Optional[str]) -> Tuple[str, str]:
         if prompt is None:
-            return DEFAULT_PROMPT, self.default_system_prompt
+            return self.default_prompt, self.default_system_prompt
         split_prompt = prompt.split(SYSTEM_PROMPT_SENTINEL)
-        parsed_prompt = split_prompt[0] or DEFAULT_PROMPT
+        parsed_prompt = split_prompt[0] or self.default_prompt
         if len(split_prompt) == 1:
             return parsed_prompt, self.default_system_prompt
         return parsed_prompt, split_prompt[1] or self.default_system_prompt
+
+
+def _load_generation_defaults(model_name_or_path: str) -> Dict[str, str]:
+    """The prompt a fine-tune was trained with, from the package's inference_config.json.
+
+    Roboflow's Cosmos trainers record it under ``generation`` so a request without a prompt
+    asks the model exactly what it learned to answer.
+    """
+    config_path = os.path.join(model_name_or_path, INFERENCE_CONFIG_FILE)
+    if not os.path.exists(config_path):
+        return {}
+    with open(config_path, "r") as config_file:
+        config = json.load(config_file)
+    generation = config.get("generation") or {}
+    for key in ("prompt", "system_prompt"):
+        if key in generation and not isinstance(generation[key], str):
+            raise ValueError(
+                f"{config_path}: generation.{key} must be a string, got {type(generation[key]).__name__}"
+            )
+    return generation
+
+
+def _load_class_names(model_name_or_path: str) -> List[str]:
+    """The class list a fine-tune answers with (one per line), when the package carries one."""
+    class_names_path = os.path.join(model_name_or_path, CLASS_NAMES_FILE)
+    if not os.path.exists(class_names_path):
+        return []
+    with open(class_names_path, "r") as class_names_file:
+        return [line.rstrip("\n") for line in class_names_file if line.strip()]

--- a/inference_models/tests/unit_tests/models/test_cosmos3_reasoner_hf.py
+++ b/inference_models/tests/unit_tests/models/test_cosmos3_reasoner_hf.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock
 
 import numpy as np
+import pytest
 import torch
 
 from inference_models.configuration import (
@@ -149,3 +150,115 @@ def test_prompt_video_returns_single_string() -> None:
     )
 
     assert result == "a robot arm"
+
+
+def test_pre_process_generation_video_with_fps_stamps_frames_without_resampling() -> (
+    None
+):
+    reasoner = _model_with_processor()
+    frames = [np.zeros((8, 8, 3), dtype=np.uint8) for _ in range(4)]
+
+    reasoner.pre_process_generation(images=frames, as_video=True, video_fps=2.0)
+
+    kwargs = reasoner._processor.call_args.kwargs
+    assert kwargs["do_sample_frames"] is False
+    metadata = kwargs["video_metadata"][0]
+    assert metadata.total_num_frames == 4
+    assert metadata.fps == 2.0
+    assert list(metadata.frames_indices) == [0, 1, 2, 3]
+
+
+def test_pre_process_generation_video_without_fps_leaves_sampling_to_processor() -> (
+    None
+):
+    reasoner = _model_with_processor()
+    frames = [np.zeros((8, 8, 3), dtype=np.uint8) for _ in range(4)]
+
+    reasoner.pre_process_generation(images=frames, as_video=True)
+
+    kwargs = reasoner._processor.call_args.kwargs
+    assert "video_metadata" not in kwargs
+    assert "do_sample_frames" not in kwargs
+
+
+def test_pre_process_generation_rejects_non_positive_fps() -> None:
+    reasoner = _model_with_processor()
+    frames = [np.zeros((8, 8, 3), dtype=np.uint8) for _ in range(4)]
+
+    with pytest.raises(ValueError):
+        reasoner.pre_process_generation(images=frames, as_video=True, video_fps=0)
+
+
+def test_package_prompt_defaults_are_used_when_request_has_none() -> None:
+    reasoner = _model_with_processor()
+    reasoner.default_prompt = "Find every clap."
+    reasoner.default_system_prompt = "You are a clap finder."
+
+    reasoner.pre_process_generation(images=np.zeros((8, 8, 3), dtype=np.uint8))
+
+    conversation = reasoner._processor.apply_chat_template.call_args.args[0]
+    assert conversation[0]["content"][0]["text"] == "You are a clap finder."
+    assert conversation[1]["content"][1]["text"] == "Find every clap."
+
+
+def test_post_process_generation_keeps_class_tokens_for_a_fine_tune() -> None:
+    reasoner = _model_with_processor()
+    reasoner.class_names = ["clap"]
+    tokenizer = reasoner._processor.tokenizer
+    tokenizer.eos_token = "<|im_end|>"
+    tokenizer.pad_token = "<|im_end|>"
+    tokenizer.bos_token = None
+    reasoner._processor.batch_decode.return_value = [
+        "<|cls:clap|> <0.10> <0.50><|im_end|>"
+    ]
+
+    result = reasoner.post_process_generation(torch.tensor([[1, 2]]))
+
+    assert result == ["<|cls:clap|> <0.10> <0.50>"]
+    assert (
+        reasoner._processor.batch_decode.call_args.kwargs["skip_special_tokens"]
+        is False
+    )
+
+
+def test_post_process_generation_skips_special_tokens_without_class_tokens() -> None:
+    reasoner = _model_with_processor()
+    reasoner._processor.batch_decode.return_value = ["a clap"]
+
+    result = reasoner.post_process_generation(torch.tensor([[1, 2]]))
+
+    assert result == ["a clap"]
+    assert (
+        reasoner._processor.batch_decode.call_args.kwargs["skip_special_tokens"] is True
+    )
+
+
+def test_load_generation_defaults_and_class_names_from_package(tmp_path) -> None:
+    from inference_models.models.cosmos3.cosmos3_reasoner_hf import (
+        _load_class_names,
+        _load_generation_defaults,
+    )
+
+    (tmp_path / "inference_config.json").write_text(
+        '{"generation": {"prompt": "Find claps.", "system_prompt": "Be exact."}}'
+    )
+    (tmp_path / "class_names.txt").write_text("clap\nwave\n")
+
+    assert _load_generation_defaults(str(tmp_path)) == {
+        "prompt": "Find claps.",
+        "system_prompt": "Be exact.",
+    }
+    assert _load_class_names(str(tmp_path)) == ["clap", "wave"]
+    assert _load_generation_defaults(str(tmp_path / "missing")) == {}
+    assert _load_class_names(str(tmp_path / "missing")) == []
+
+
+def test_load_generation_defaults_rejects_non_string_prompt(tmp_path) -> None:
+    from inference_models.models.cosmos3.cosmos3_reasoner_hf import (
+        _load_generation_defaults,
+    )
+
+    (tmp_path / "inference_config.json").write_text('{"generation": {"prompt": 3}}')
+
+    with pytest.raises(ValueError):
+        _load_generation_defaults(str(tmp_path))

--- a/tests/inference/unit_tests/models/test_cosmos3_inference_models.py
+++ b/tests/inference/unit_tests/models/test_cosmos3_inference_models.py
@@ -1,0 +1,59 @@
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+from inference.models.cosmos3.cosmos3_reasoner_inference_models import (
+    InferenceModelsCosmos3ReasonerAdapter,
+)
+
+
+def _adapter() -> InferenceModelsCosmos3ReasonerAdapter:
+    adapter = InferenceModelsCosmos3ReasonerAdapter.__new__(
+        InferenceModelsCosmos3ReasonerAdapter
+    )
+    adapter._model = MagicMock()
+    adapter._model.pre_process_generation.return_value = {"input_ids": "encoded"}
+    return adapter
+
+
+def test_preprocess_single_image_is_an_image_prompt() -> None:
+    adapter = _adapter()
+    image = np.zeros((6, 9, 3), dtype=np.uint8)
+
+    inputs, metadata = adapter.preprocess(image, prompt="What happens?")
+
+    assert inputs == {"input_ids": "encoded"}
+    assert metadata["image_dims"] == (9, 6)
+    call = adapter._model.pre_process_generation.call_args
+    assert call.args[1] == "What happens?"
+    assert "as_video" not in call.kwargs
+
+
+def test_preprocess_list_of_images_is_one_clip_at_video_fps() -> None:
+    adapter = _adapter()
+    frames = [np.zeros((6, 9, 3), dtype=np.uint8) for _ in range(3)]
+
+    inputs, metadata = adapter.preprocess(frames, prompt="", video_fps=4.0)
+
+    assert inputs == {"input_ids": "encoded"}
+    assert metadata["image_dims"] == (9, 6)
+    call = adapter._model.pre_process_generation.call_args
+    assert len(call.args[0]) == 3
+    assert call.kwargs["as_video"] is True
+    assert call.kwargs["video_fps"] == 4.0
+
+
+def test_preprocess_list_of_images_requires_video_fps() -> None:
+    adapter = _adapter()
+    frames = [np.zeros((6, 9, 3), dtype=np.uint8)]
+
+    with pytest.raises(ValueError):
+        adapter.preprocess(frames, prompt="")
+
+
+def test_preprocess_rejects_an_empty_clip() -> None:
+    adapter = _adapter()
+
+    with pytest.raises(ValueError):
+        adapter.preprocess([], prompt="", video_fps=4.0)


### PR DESCRIPTION
## Summary

Roboflow's Cosmos 3 Edge action-recognition fine-tunes (roboflow-train `cosmos3edge`) could not be served: the Cosmos loader only knew the base package, the HTTP adapter took one image, and the registry did not know the platform's task/type keys.

- **LoRA packages**: `Cosmos3EdgeReasoner.from_pretrained` loads the base reasoner from `base/`, resizes embeddings to the fine-tuned tokenizer (one special token per class, PEFT trainable tokens), applies and merges the adapter. The package's `inference_config.json` `generation` block provides the prompt the model was trained with when a request sends none; `class_names.txt` switches decoding to keep the class tokens the answer is made of.
- **Clips over HTTP**: a list of images on `LMMInferenceRequest` is one clip when `video_fps` is set; frames are stamped at that rate without resampling, so a temporal fine-tune answers in the seconds it was trained on.
- **Registry**: `(action-recognition, cosmos3-edge)` (platform model type id) and `(action-recognition, cosmos-3-edge)` (package architecture).

Companion changes: roboflow-train registers the architecture as `cosmos-3-edge` and writes the `generation` block; the platform's model eval sends windows to `/infer/lmm/{model}` with `video_fps`.

## Testing

- `inference_models/tests/unit_tests/models/test_cosmos3_reasoner_hf.py` (19 passed) and new `tests/inference/unit_tests/models/test_cosmos3_inference_models.py` (4 passed).
- `black`/`isort` clean on touched files.
- Not exercised on a GPU here; needs a hosted-inference deploy to verify against a real fine-tune package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y6nqgixT37XFq5wkWLbqLe