### PR TITLE
Add reasoning_effort to Anthropic Claude block (v5)

### DIFF
--- a/inference/core/version.py
+++ b/inference/core/version.py
@@ -1,4 +1,4 @@
-__version__ = "1.5.1-post1"
+__version__ = "1.5.1-post2"
 
 
 if __name__ == "__main__":

--- a/inference/core/version.py
+++ b/inference/core/version.py
@@ -1,4 +1,4 @@
-__version__ = "1.5.1-post2"
+__version__ = "1.5.1-post3"
 
 
 if __name__ == "__main__":

--- a/inference/core/version.py
+++ b/inference/core/version.py
@@ -1,4 +1,4 @@
-__version__ = "1.5.1"
+__version__ = "1.5.1-post1"
 
 
 if __name__ == "__main__":

--- a/inference/core/workflows/core_steps/common/openrouter.py
+++ b/inference/core/workflows/core_steps/common/openrouter.py
@@ -16,15 +16,28 @@ Two key paths are supported per call:
        proxy in the loop.
 
 Both paths honor a user-selected ``privacy_level`` of ``allow``, ``deny``, or
-``zdr`` (zero data retention). Full task-type prompt builders shared across
-the VLM blocks live here too so the per-block files stay small.
+``zdr`` (zero data retention). Both also attach a per-model provider
+``quantizations`` allowlist (:data:`MODEL_NATIVE_QUANTIZATIONS`) so OpenRouter
+only routes to providers serving the model at native precision or higher.
+Full task-type prompt builders shared across the VLM blocks live here too so
+the per-block files stay small.
 """
 
 import base64
 import json
 from dataclasses import dataclass
 from functools import partial
-from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+)
 
 from openai import APIStatusError, OpenAI
 from pydantic import ConfigDict, Field
@@ -89,20 +102,86 @@ PRIVACY_LEVEL_METADATA = {
 }
 
 
-def build_provider_routing(privacy_level: str) -> Optional[dict]:
-    """Translate a privacy level into OpenRouter's ``provider`` payload object.
+def build_provider_routing(
+    privacy_level: str,
+    quantizations: Optional[Sequence[str]] = None,
+) -> Optional[dict]:
+    """Build the ``provider`` object for an OpenRouter request.
 
-    Returns ``None`` for ``allow`` (no filter), an object with
-    ``data_collection: deny`` for ``deny``, and an object with both
-    ``data_collection`` and ``zdr`` set for ``zdr``.
+    Merges the ``privacy_level`` filter (``allow`` adds nothing, ``deny``
+    blocks data collection, ``zdr`` additionally requires zero data
+    retention) with an optional ``quantizations`` allowlist. Returns ``None``
+    when neither applies.
+
+    Raises:
+        ValueError: If ``privacy_level`` is not a known level.
     """
     if privacy_level == "allow":
-        return None
-    if privacy_level == "deny":
-        return {"data_collection": "deny"}
-    if privacy_level == "zdr":
-        return {"data_collection": "deny", "zdr": True}
-    raise ValueError(f"unknown privacy_level: {privacy_level}")
+        provider: Dict[str, Any] = {}
+    elif privacy_level == "deny":
+        provider = {"data_collection": "deny"}
+    elif privacy_level == "zdr":
+        provider = {"data_collection": "deny", "zdr": True}
+    else:
+        raise ValueError(f"unknown privacy_level: {privacy_level}")
+
+    if quantizations:
+        provider["quantizations"] = list(quantizations)
+
+    return provider or None
+
+
+# ---------------------------------------------------------------------------
+# Native model precision (provider quantization filter)
+# ---------------------------------------------------------------------------
+
+# Allowlists for OpenRouter's `provider.quantizations` filter, meaning "the
+# model's native precision or higher". Endpoints reporting any other
+# quantization (including `unknown`) are excluded from routing.
+BF16_NATIVE = ("bf16", "fp32")
+FP8_NATIVE = ("fp8", "bf16", "fp32")
+# BF16-native models with no BF16 endpoint on OpenRouter today; FP8 keeps
+# them routable at the highest precision actually served.
+BF16_NATIVE_FP8_FLOOR = FP8_NATIVE
+
+# OpenRouter model slug -> acceptable provider quantization labels, from the
+# model's native release precision and what OpenRouter providers serve today.
+#
+# Absent models get no filter, because a filter would leave them with zero
+# providers: single-provider hosted SKUs (Muse Spark 1.1/1.2, Qwen
+# Flash/Plus/Max, the Qwen 3.7 line, GLM-5V-Turbo, DeepSeek V4 Flash Vision
+# Exp) report `unknown` precision; DeepSeek V4 is natively FP4+FP8; the only
+# endpoints for Qwen3 VL 8B Thinking and 32B Instruct report `unknown`.
+MODEL_NATIVE_QUANTIZATIONS: Dict[str, Tuple[str, ...]] = {
+    "meta/muse-glimmer-30b": BF16_NATIVE,
+    "qwen/qwen3.5-9b": BF16_NATIVE,
+    "qwen/qwen3.5-27b": BF16_NATIVE,
+    "qwen/qwen3.5-35b-a3b": BF16_NATIVE_FP8_FLOOR,
+    "qwen/qwen3.5-122b-a10b": BF16_NATIVE,
+    "qwen/qwen3.5-397b-a17b": BF16_NATIVE_FP8_FLOOR,
+    "qwen/qwen3.6-27b": BF16_NATIVE_FP8_FLOOR,
+    "qwen/qwen3.6-35b-a3b": BF16_NATIVE_FP8_FLOOR,
+    "qwen/qwen3.8-27b": BF16_NATIVE_FP8_FLOOR,
+    "qwen/qwen3-vl-8b-instruct": BF16_NATIVE,
+    "qwen/qwen3-vl-30b-a3b-instruct": BF16_NATIVE,
+    "qwen/qwen3-vl-30b-a3b-thinking": BF16_NATIVE_FP8_FLOOR,
+    "qwen/qwen3-vl-235b-a22b-instruct": BF16_NATIVE,
+    "qwen/qwen3-vl-235b-a22b-thinking": BF16_NATIVE,
+    "z-ai/glm-5.3-flash": FP8_NATIVE,
+    "google/gemma-4-31b-it": BF16_NATIVE,
+    "google/gemma-4-26b-a4b-it": BF16_NATIVE,
+    "meta-llama/llama-3.2-11b-vision-instruct": BF16_NATIVE,
+}
+
+
+def get_native_quantizations(model: str) -> Optional[Tuple[str, ...]]:
+    """Return the quantization allowlist for an OpenRouter model slug.
+
+    Returns ``None`` for models absent from
+    :data:`MODEL_NATIVE_QUANTIZATIONS`; absence means the model must not
+    be filtered by quantization.
+    """
+    return MODEL_NATIVE_QUANTIZATIONS.get(model)
 
 
 # ---------------------------------------------------------------------------
@@ -264,7 +343,14 @@ class OpenRouterWorkflowBlockBase(WorkflowBlock):
         Roboflow platform proxy version that forwards the key upstream
         (older proxy versions strip it and the model applies its
         provider-default reasoning behavior).
+
+        Models registered in :data:`MODEL_NATIVE_QUANTIZATIONS` get a
+        provider ``quantizations`` allowlist on every request, restricting
+        routing to native precision or higher. On the proxied path the
+        Roboflow proxy must forward the field upstream.
         """
+        quantizations = get_native_quantizations(model=model)
+
         is_managed = openrouter_api_key.startswith(("rf_key:account", "rf_key:user:"))
         if is_managed:
             single = partial(
@@ -274,6 +360,7 @@ class OpenRouterWorkflowBlockBase(WorkflowBlock):
                 model=model,
                 privacy_level=privacy_level,
                 reasoning=reasoning,
+                quantizations=quantizations,
             )
         else:
             single = partial(
@@ -282,6 +369,7 @@ class OpenRouterWorkflowBlockBase(WorkflowBlock):
                 model=model,
                 privacy_level=privacy_level,
                 reasoning=reasoning,
+                quantizations=quantizations,
             )
         tasks = [
             partial(
@@ -392,6 +480,7 @@ def _execute_proxied_openrouter_request(
     temperature: Optional[float],
     privacy_level: str,
     reasoning: Optional[dict] = None,
+    quantizations: Optional[Sequence[str]] = None,
 ) -> OpenRouterResult:
     payload = {
         "openrouter_api_key": openrouter_api_key,
@@ -404,6 +493,8 @@ def _execute_proxied_openrouter_request(
         payload["temperature"] = temperature
     if reasoning is not None:
         payload["reasoning"] = reasoning
+    if quantizations is not None:
+        payload["quantizations"] = list(quantizations)
     try:
         response_data = post_to_roboflow_api(
             endpoint="apiproxy/openrouter",
@@ -478,10 +569,11 @@ def _execute_direct_openrouter_request(
     temperature: Optional[float],
     privacy_level: str,
     reasoning: Optional[dict] = None,
+    quantizations: Optional[Sequence[str]] = None,
 ) -> OpenRouterResult:
     client = OpenAI(base_url="https://openrouter.ai/api/v1", api_key=api_key)
     extra_body: Dict[str, Any] = {}
-    provider = build_provider_routing(privacy_level)
+    provider = build_provider_routing(privacy_level, quantizations=quantizations)
     if provider is not None:
         extra_body["provider"] = provider
     if reasoning is not None:

--- a/inference/core/workflows/core_steps/formatters/vlm_as_detector/v2.py
+++ b/inference/core/workflows/core_steps/formatters/vlm_as_detector/v2.py
@@ -255,7 +255,7 @@ class BlockManifest(WorkflowBlockManifest):
         "zai-flash",
         "florence-2",
     ] = Field(
-        description="Type of the VLM/LLM model that generated the prediction. Determines which parser is used to extract detection data from the JSON output. Supported models: 'openai' (GPT-4V), 'google-gemini' (Gemini Vision), 'anthropic-claude' (Claude Vision), 'spacexai' (Grok), 'qwen' (Qwen-VL via OpenRouter), 'zai' (Z.ai GLM 5V Turbo via OpenRouter, box_2d xyxy 0-1000), 'zai-flash' (Z.ai GLM 5.3 Flash via OpenRouter, box_2d yxyx 0-1000), 'muse' (Meta Muse via OpenRouter), 'florence-2' (Microsoft Florence-2). Each model type has different JSON output formats, so the correct model type must be specified for proper parsing.",
+        description="Type of the VLM/LLM model that generated the prediction. Determines which parser is used to extract detection data from the JSON output. Supported models: 'openai' (GPT-4V), 'google-gemini' (Gemini Vision), 'anthropic-claude' (Claude Vision), 'spacexai' (Grok), 'qwen' (Qwen-VL via OpenRouter), 'zai' (Z.ai GLM 5V Turbo via OpenRouter, box_2d xyxy 0-1000), 'zai-flash' (Z.ai GLM 5.3 Flash via OpenRouter, bbox_2d xyxy 0-1000), 'muse' (Meta Muse via OpenRouter), 'florence-2' (Microsoft Florence-2). Each model type has different JSON output formats, so the correct model type must be specified for proper parsing.",
         examples=[
             ["openai"],
             ["google-gemini"],
@@ -617,11 +617,12 @@ REGISTERED_PARSERS = {
     ("spacexai", "object-detection"): parse_spacexai_object_detection_response,
     ("qwen", "object-detection"): parse_qwen_object_detection_response,
     ("muse", "object-detection"): parse_muse_object_detection_response,
-    # GLM 5V Turbo prompts for the Qwen box_2d xyxy 0-1000 contract; GLM 5.3
-    # Flash prompts for the Gemini box_2d yxyx 0-1000 contract. Same key,
-    # different axis order, so each model gets its own model_type.
+    # Both GLM models emit xyxy 0-1000 boxes: GLM 5V Turbo under the
+    # "box_2d" key, GLM 5.3 Flash under "bbox_2d". The Qwen parser accepts
+    # both keys, so both model_types share it; the labels stay separate
+    # for saved-workflow compatibility.
     ("zai", "object-detection"): parse_qwen_object_detection_response,
-    ("zai-flash", "object-detection"): parse_gemini_object_detection_response,
+    ("zai-flash", "object-detection"): parse_qwen_object_detection_response,
     # Florence 2
     ("florence-2", "object-detection"): partial(
         parse_florence2_object_detection_response, florence_task_type="<OD>"

--- a/inference/core/workflows/core_steps/formatters/vlm_as_detector/v2_tensor.py
+++ b/inference/core/workflows/core_steps/formatters/vlm_as_detector/v2_tensor.py
@@ -272,7 +272,7 @@ class BlockManifest(WorkflowBlockManifest):
         "zai-flash",
         "florence-2",
     ] = Field(
-        description="Type of the VLM/LLM model that generated the prediction. Determines which parser is used to extract detection data from the JSON output. Supported models: 'openai' (GPT-4V), 'google-gemini' (Gemini Vision), 'anthropic-claude' (Claude Vision), 'spacexai' (Grok), 'qwen' (Qwen-VL via OpenRouter), 'zai' (Z.ai GLM 5V Turbo via OpenRouter, box_2d xyxy 0-1000), 'zai-flash' (Z.ai GLM 5.3 Flash via OpenRouter, box_2d yxyx 0-1000), 'muse' (Meta Muse via OpenRouter), 'florence-2' (Microsoft Florence-2). Each model type has different JSON output formats, so the correct model type must be specified for proper parsing.",
+        description="Type of the VLM/LLM model that generated the prediction. Determines which parser is used to extract detection data from the JSON output. Supported models: 'openai' (GPT-4V), 'google-gemini' (Gemini Vision), 'anthropic-claude' (Claude Vision), 'spacexai' (Grok), 'qwen' (Qwen-VL via OpenRouter), 'zai' (Z.ai GLM 5V Turbo via OpenRouter, box_2d xyxy 0-1000), 'zai-flash' (Z.ai GLM 5.3 Flash via OpenRouter, bbox_2d xyxy 0-1000), 'muse' (Meta Muse via OpenRouter), 'florence-2' (Microsoft Florence-2). Each model type has different JSON output formats, so the correct model type must be specified for proper parsing.",
         examples=[
             ["openai"],
             ["google-gemini"],
@@ -980,11 +980,12 @@ REGISTERED_PARSERS = {
     ("spacexai", "object-detection"): parse_spacexai_object_detection_response,
     ("qwen", "object-detection"): parse_qwen_object_detection_response,
     ("muse", "object-detection"): parse_muse_object_detection_response,
-    # GLM 5V Turbo prompts for the Qwen box_2d xyxy 0-1000 contract; GLM 5.3
-    # Flash prompts for the Gemini box_2d yxyx 0-1000 contract. Same key,
-    # different axis order, so each model gets its own model_type.
+    # Both GLM models emit xyxy 0-1000 boxes: GLM 5V Turbo under the
+    # "box_2d" key, GLM 5.3 Flash under "bbox_2d". The Qwen parser accepts
+    # both keys, so both model_types share it; the labels stay separate
+    # for saved-workflow compatibility.
     ("zai", "object-detection"): parse_qwen_object_detection_response,
-    ("zai-flash", "object-detection"): parse_gemini_object_detection_response,
+    ("zai-flash", "object-detection"): parse_qwen_object_detection_response,
     # Florence 2
     ("florence-2", "object-detection"): partial(
         parse_florence2_object_detection_response, florence_task_type="<OD>"

--- a/inference/core/workflows/core_steps/formatters/vlm_as_detector/zai_detection_parsing.py
+++ b/inference/core/workflows/core_steps/formatters/vlm_as_detector/zai_detection_parsing.py
@@ -1,11 +1,11 @@
 import json
 from typing import Optional
 
-# The Z.ai detection contracts, both "box_2d" lists normalized to 0-1000:
-# GLM 5V Turbo (model_type "zai") uses xyxy order and parses with the Qwen
-# parser; GLM 5.3 Flash (model_type "zai-flash") uses yxyx order and parses
-# with the Gemini parser. The axis order is not recoverable from the data,
-# so each model maps to its own model_type in the registry.
+# The Z.ai detection contracts, both xyxy lists normalized to 0-1000:
+# GLM 5V Turbo (model_type "zai") uses the "box_2d" key and GLM 5.3 Flash
+# (model_type "zai-flash") uses "bbox_2d". Both parse with the Qwen parser,
+# which accepts either key; the model_types stay separate so saved
+# workflows keep working if the contracts ever diverge again.
 
 
 def extract_zai_json_array(raw: str) -> Optional[list]:

--- a/inference/core/workflows/core_steps/loader.py
+++ b/inference/core/workflows/core_steps/loader.py
@@ -482,6 +482,9 @@ from inference.core.workflows.core_steps.models.foundation.anthropic_claude.v3 i
 from inference.core.workflows.core_steps.models.foundation.anthropic_claude.v4 import (
     AnthropicClaudeBlockV4,
 )
+from inference.core.workflows.core_steps.models.foundation.anthropic_claude.v5 import (
+    AnthropicClaudeBlockV5,
+)
 
 if not ENABLE_TENSOR_DATA_REPRESENTATION:
     from inference.core.workflows.core_steps.models.foundation.clip.v1 import (
@@ -1764,6 +1767,7 @@ def load_blocks() -> List[Type[WorkflowBlock]]:
         AnthropicClaudeBlockV2,
         AnthropicClaudeBlockV3,
         AnthropicClaudeBlockV4,
+        AnthropicClaudeBlockV5,
         SpaceXAIBlockV1,
         SpaceXAIBlockV2,
         CosineSimilarityBlockV1,

--- a/inference/core/workflows/core_steps/models/foundation/anthropic_claude/model_capabilities.py
+++ b/inference/core/workflows/core_steps/models/foundation/anthropic_claude/model_capabilities.py
@@ -38,6 +38,8 @@ _MODELS_WITH_LEGACY_CONTROLS: FrozenSet[str] = frozenset(
 TEMPERATURE_SUPPORTED_MODELS: FrozenSet[str] = _MODELS_WITH_LEGACY_CONTROLS
 """Models that still accept a non-default ``temperature``."""
 
+MIN_THINKING_BUDGET_TOKENS = 1024
+
 MANUAL_THINKING_SUPPORTED_MODELS: FrozenSet[str] = _MODELS_WITH_LEGACY_CONTROLS
 """Models that still accept ``thinking.type = "enabled"`` with a token budget."""
 
@@ -116,21 +118,23 @@ def build_thinking_config(
     extended_thinking: Optional[bool],
     thinking_budget_tokens: Optional[int],
     model_version: str,
-    model_max_output: int,
+    max_tokens: int,
 ) -> Optional[Dict[str, object]]:
     """Build the ``thinking`` request block appropriate for a Claude model.
 
     Models that still support manual extended thinking receive
     ``{"type": "enabled", "budget_tokens": N}`` where ``N`` defaults to half
-    of the model's output ceiling. Models whose thinking is adaptive only
-    receive ``{"type": "adaptive"}``; a configured budget is ignored there and
-    a warning is logged once per model per process.
+    of the request's ``max_tokens`` (Anthropic requires
+    ``1024 <= budget_tokens < max_tokens``), mirroring the Roboflow proxy.
+    Models whose thinking is adaptive only receive ``{"type": "adaptive"}``;
+    a configured budget is ignored there and a warning is logged once per
+    model per process.
 
     Args:
         extended_thinking: Whether the block requested thinking.
         thinking_budget_tokens: Budget configured on the block, or ``None``.
         model_version: Model label or wire id as configured on the block.
-        model_max_output: Output-token ceiling used to derive a default budget.
+        max_tokens: Output-token limit that will be sent on the request.
 
     Returns:
         The ``thinking`` payload, or ``None`` when thinking was not requested.
@@ -142,7 +146,7 @@ def build_thinking_config(
         effective_budget = (
             thinking_budget_tokens
             if thinking_budget_tokens is not None
-            else model_max_output // 2
+            else max(MIN_THINKING_BUDGET_TOKENS, max_tokens // 2)
         )
         return {"type": "enabled", "budget_tokens": effective_budget}
 
@@ -160,24 +164,3 @@ def build_thinking_config(
         )
 
     return {"type": "adaptive"}
-
-
-def build_output_config(
-    reasoning_effort: Optional[str],
-) -> Optional[Dict[str, object]]:
-    """Build the Anthropic ``output_config`` block for a selected effort.
-
-    Unset effort omits the field so the API keeps its default (``high`` on
-    models that support effort).
-
-    Args:
-        reasoning_effort: One of ``low``, ``medium``, ``high``, ``xhigh``,
-            ``max``, or ``None`` when the block left the control unset.
-
-    Returns:
-        ``{"effort": level}``, or ``None`` when effort was not requested.
-    """
-    if reasoning_effort is None:
-        return None
-
-    return {"effort": reasoning_effort}

--- a/inference/core/workflows/core_steps/models/foundation/anthropic_claude/model_capabilities.py
+++ b/inference/core/workflows/core_steps/models/foundation/anthropic_claude/model_capabilities.py
@@ -160,3 +160,24 @@ def build_thinking_config(
         )
 
     return {"type": "adaptive"}
+
+
+def build_output_config(
+    reasoning_effort: Optional[str],
+) -> Optional[Dict[str, object]]:
+    """Build the Anthropic ``output_config`` block for a selected effort.
+
+    Unset effort omits the field so the API keeps its default (``high`` on
+    models that support effort).
+
+    Args:
+        reasoning_effort: One of ``low``, ``medium``, ``high``, ``xhigh``,
+            ``max``, or ``None`` when the block left the control unset.
+
+    Returns:
+        ``{"effort": level}``, or ``None`` when effort was not requested.
+    """
+    if reasoning_effort is None:
+        return None
+
+    return {"effort": reasoning_effort}

--- a/inference/core/workflows/core_steps/models/foundation/anthropic_claude/model_capabilities.py
+++ b/inference/core/workflows/core_steps/models/foundation/anthropic_claude/model_capabilities.py
@@ -1,0 +1,162 @@
+"""Per-model request capabilities shared by the Anthropic Claude block versions.
+
+Starting with Claude Opus 4.7, Anthropic rejects ``temperature`` and manual
+extended thinking (``thinking.type = "enabled"``) with HTTP 400; thinking on
+those models is ``adaptive``. The allow-list below names the models that still
+accept the legacy controls, so unknown or future ids default to the new
+behaviour. Keep it in sync with ``TEMPERATURE_SUPPORTED_MODELS`` in the
+Roboflow API proxy (``app/functions/services/anthropicProxy``).
+"""
+
+import re
+from typing import Dict, FrozenSet, Optional, Set
+
+from inference.core import logger
+
+_MODELS_WITH_LEGACY_CONTROLS: FrozenSet[str] = frozenset(
+    {
+        "claude-opus-4-6",
+        "claude-opus-4-5",
+        "claude-opus-4-1",
+        "claude-opus-4",
+        "claude-sonnet-4-6",
+        "claude-sonnet-4-5",
+        "claude-sonnet-4",
+        "claude-haiku-4-5",
+        "claude-3-7-sonnet",
+        "claude-3-5-haiku",
+        "claude-3-opus",
+        "claude-3-haiku",
+        # v1 alias labels that resolve to Sonnet 4.5 on the wire
+        "claude-3-5-sonnet",
+        "claude-3-5-sonnet-v2",
+        "claude-4-5-sonnet",
+        "claude-4-5-sonnet-v2",
+    }
+)
+
+TEMPERATURE_SUPPORTED_MODELS: FrozenSet[str] = _MODELS_WITH_LEGACY_CONTROLS
+"""Models that still accept a non-default ``temperature``."""
+
+MANUAL_THINKING_SUPPORTED_MODELS: FrozenSet[str] = _MODELS_WITH_LEGACY_CONTROLS
+"""Models that still accept ``thinking.type = "enabled"`` with a token budget."""
+
+_DATED_SNAPSHOT_SUFFIX = re.compile(r"-\d{8}$")
+_LATEST_SUFFIX = re.compile(r"-latest$")
+_NON_ALPHANUMERIC = re.compile(r"[^a-z0-9]+")
+
+_TEMPERATURE_WARNINGS_EMITTED: Set[str] = set()
+_THINKING_BUDGET_WARNINGS_EMITTED: Set[str] = set()
+
+
+def normalize_anthropic_model_id(model_version: str) -> str:
+    """Strip dated snapshot / ``-latest`` suffixes and slugify, e.g.
+    ``claude-sonnet-4-5-20250929`` -> ``claude-sonnet-4-5``."""
+    slug = _NON_ALPHANUMERIC.sub("-", model_version.strip().lower()).strip("-")
+    slug = _LATEST_SUFFIX.sub("", slug)
+    return _DATED_SNAPSHOT_SUFFIX.sub("", slug)
+
+
+def anthropic_model_supports_temperature(model_version: str) -> bool:
+    """False for Claude Opus 4.7 and newer and for any unknown id."""
+    return normalize_anthropic_model_id(model_version) in TEMPERATURE_SUPPORTED_MODELS
+
+
+def anthropic_model_supports_manual_thinking(model_version: str) -> bool:
+    """False for Claude Opus 4.7 and newer and for any unknown id."""
+    return (
+        normalize_anthropic_model_id(model_version) in MANUAL_THINKING_SUPPORTED_MODELS
+    )
+
+
+def resolve_temperature(
+    temperature: Optional[float],
+    *,
+    model_version: str,
+    extended_thinking: Optional[bool] = None,
+) -> Optional[float]:
+    """Decide which ``temperature`` value, if any, to put on the request.
+
+    Mirrors the Roboflow proxy: the value is dropped when thinking is enabled
+    (Anthropic forbids the combination) and when the model no longer accepts
+    sampling parameters, so the same workflow behaves identically with a
+    customer key and with ``rf_key:account``. Dropping a user-provided value
+    logs a warning once per model per process.
+
+    Args:
+        temperature: Value configured on the block, or ``None``.
+        model_version: Model label or wire id as configured on the block.
+        extended_thinking: Whether the block requested thinking.
+
+    Returns:
+        The temperature to send, or ``None`` when it must be omitted.
+    """
+    if temperature is None or extended_thinking:
+        return None
+
+    if anthropic_model_supports_temperature(model_version):
+        return temperature
+
+    normalized_model = normalize_anthropic_model_id(model_version)
+    if normalized_model not in _TEMPERATURE_WARNINGS_EMITTED:
+        _TEMPERATURE_WARNINGS_EMITTED.add(normalized_model)
+        logger.warning(
+            "Anthropic model `%s` does not accept the `temperature` parameter "
+            "(Claude Opus 4.7 and newer, Sonnet 5, Opus 5 and Fable models reject "
+            "non-default sampling parameters); ignoring temperature=%s.",
+            model_version,
+            temperature,
+        )
+
+    return None
+
+
+def build_thinking_config(
+    *,
+    extended_thinking: Optional[bool],
+    thinking_budget_tokens: Optional[int],
+    model_version: str,
+    model_max_output: int,
+) -> Optional[Dict[str, object]]:
+    """Build the ``thinking`` request block appropriate for a Claude model.
+
+    Models that still support manual extended thinking receive
+    ``{"type": "enabled", "budget_tokens": N}`` where ``N`` defaults to half
+    of the model's output ceiling. Models whose thinking is adaptive only
+    receive ``{"type": "adaptive"}``; a configured budget is ignored there and
+    a warning is logged once per model per process.
+
+    Args:
+        extended_thinking: Whether the block requested thinking.
+        thinking_budget_tokens: Budget configured on the block, or ``None``.
+        model_version: Model label or wire id as configured on the block.
+        model_max_output: Output-token ceiling used to derive a default budget.
+
+    Returns:
+        The ``thinking`` payload, or ``None`` when thinking was not requested.
+    """
+    if not extended_thinking:
+        return None
+
+    if anthropic_model_supports_manual_thinking(model_version):
+        effective_budget = (
+            thinking_budget_tokens
+            if thinking_budget_tokens is not None
+            else model_max_output // 2
+        )
+        return {"type": "enabled", "budget_tokens": effective_budget}
+
+    normalized_model = normalize_anthropic_model_id(model_version)
+    if (
+        thinking_budget_tokens is not None
+        and normalized_model not in _THINKING_BUDGET_WARNINGS_EMITTED
+    ):
+        _THINKING_BUDGET_WARNINGS_EMITTED.add(normalized_model)
+        logger.warning(
+            "Anthropic model `%s` only supports adaptive thinking; ignoring "
+            "thinking_budget_tokens=%s and requesting `thinking.type=adaptive`.",
+            model_version,
+            thinking_budget_tokens,
+        )
+
+    return {"type": "adaptive"}

--- a/inference/core/workflows/core_steps/models/foundation/anthropic_claude/v1.py
+++ b/inference/core/workflows/core_steps/models/foundation/anthropic_claude/v1.py
@@ -14,6 +14,9 @@ from inference.core.utils.image_utils import encode_image_to_jpeg_bytes, load_im
 from inference.core.utils.preprocess import downscale_image_keeping_aspect_ratio
 from inference.core.workflows.core_steps.common.utils import run_in_parallel
 from inference.core.workflows.core_steps.common.vlms import VLM_TASKS_METADATA
+from inference.core.workflows.core_steps.models.foundation.anthropic_claude.model_capabilities import (
+    resolve_temperature,
+)
 from inference.core.workflows.execution_engine.entities.base import (
     Batch,
     OutputDefinition,
@@ -197,7 +200,8 @@ class BlockManifest(WorkflowBlockManifest):
     temperature: Optional[Union[float, Selector(kind=[FLOAT_KIND])]] = Field(
         default=None,
         description="Temperature to sample from the model - value in range 0.0-2.0, the higher - the more "
-        'random / "creative" the generations are.',
+        'random / "creative" the generations are. Ignored by models that no longer accept '
+        "sampling parameters (Claude Opus 4.7 and newer).",
         ge=0.0,
         le=2.0,
     )
@@ -433,6 +437,7 @@ def execute_claude_request(
     client = anthropic.Anthropic(api_key=api_key)
     if system_prompt is None:
         system_prompt = NOT_GIVEN
+    temperature = resolve_temperature(temperature, model_version=model_version)
     if temperature is None:
         temperature = NOT_GIVEN
     result = client.messages.create(

--- a/inference/core/workflows/core_steps/models/foundation/anthropic_claude/v2.py
+++ b/inference/core/workflows/core_steps/models/foundation/anthropic_claude/v2.py
@@ -548,7 +548,7 @@ def execute_claude_request(
         extended_thinking=extended_thinking,
         thinking_budget_tokens=thinking_budget_tokens,
         model_version=model_version,
-        model_max_output=model_max_output,
+        max_tokens=effective_max_tokens,
     )
     if thinking is not None:
         request_params["thinking"] = thinking

--- a/inference/core/workflows/core_steps/models/foundation/anthropic_claude/v2.py
+++ b/inference/core/workflows/core_steps/models/foundation/anthropic_claude/v2.py
@@ -13,6 +13,10 @@ from inference.core.utils.image_utils import encode_image_to_jpeg_bytes, load_im
 from inference.core.utils.preprocess import downscale_image_keeping_aspect_ratio
 from inference.core.workflows.core_steps.common.utils import run_in_parallel
 from inference.core.workflows.core_steps.common.vlms import VLM_TASKS_METADATA
+from inference.core.workflows.core_steps.models.foundation.anthropic_claude.model_capabilities import (
+    build_thinking_config,
+    resolve_temperature,
+)
 from inference.core.workflows.execution_engine.entities.base import (
     Batch,
     OutputDefinition,
@@ -251,13 +255,15 @@ class BlockManifest(WorkflowBlockManifest):
     extended_thinking: Optional[bool] = Field(
         default=None,
         description="Enable extended thinking for deeper reasoning on complex tasks. "
-        "Note: temperature cannot be used when extended thinking is enabled.",
+        "Note: temperature cannot be used when extended thinking is enabled. Models that "
+        "only support adaptive thinking (Claude Opus 4.7 and newer) ignore `thinking_budget_tokens`.",
     )
     thinking_budget_tokens: Optional[int] = Field(
         default=None,
         description="Maximum number of tokens for internal thinking when extended thinking is enabled. "
         "Higher values allow deeper reasoning but increase latency and cost. "
-        "Must be less than max_tokens. Minimum: 1024.",
+        "Must be less than max_tokens. Minimum: 1024. Ignored by models that only support "
+        "adaptive thinking (Claude Opus 4.7 and newer).",
         ge=1024,
         json_schema_extra={
             "relevant_for": {
@@ -275,7 +281,8 @@ class BlockManifest(WorkflowBlockManifest):
     temperature: Optional[Union[float, Selector(kind=[FLOAT_KIND])]] = Field(
         default=None,
         description="Temperature to sample from the model - value in range 0.0-1.0, the higher - the more "
-        'random / "creative" the generations are. Cannot be used when extended_thinking is enabled.',
+        'random / "creative" the generations are. Cannot be used when extended_thinking is enabled. '
+        "Ignored by models that no longer accept sampling parameters (Claude Opus 4.7 and newer).",
         ge=0.0,
         le=1.0,
     )
@@ -518,7 +525,12 @@ def execute_claude_request(
     if system_prompt is None:
         system_prompt = NOT_GIVEN
 
-    if temperature is None or extended_thinking:
+    temperature = resolve_temperature(
+        temperature,
+        model_version=model_version,
+        extended_thinking=extended_thinking,
+    )
+    if temperature is None:
         temperature = NOT_GIVEN
 
     model_max_output = MAX_OUTPUT_TOKENS.get(model_version, DEFAULT_MAX_OUTPUT_TOKENS)
@@ -532,16 +544,14 @@ def execute_claude_request(
         "temperature": temperature,
     }
 
-    if extended_thinking:
-        effective_budget = (
-            thinking_budget_tokens
-            if thinking_budget_tokens is not None
-            else model_max_output // 2
-        )
-        request_params["thinking"] = {
-            "type": "enabled",
-            "budget_tokens": effective_budget,
-        }
+    thinking = build_thinking_config(
+        extended_thinking=extended_thinking,
+        thinking_budget_tokens=thinking_budget_tokens,
+        model_version=model_version,
+        model_max_output=model_max_output,
+    )
+    if thinking is not None:
+        request_params["thinking"] = thinking
 
     # Stream response to avoid max_tokens limitation
     with client.messages.stream(**request_params) as stream:

--- a/inference/core/workflows/core_steps/models/foundation/anthropic_claude/v3.py
+++ b/inference/core/workflows/core_steps/models/foundation/anthropic_claude/v3.py
@@ -15,6 +15,10 @@ from inference.core.utils.image_utils import encode_image_to_jpeg_bytes, load_im
 from inference.core.utils.preprocess import downscale_image_keeping_aspect_ratio
 from inference.core.workflows.core_steps.common.utils import run_in_parallel
 from inference.core.workflows.core_steps.common.vlms import VLM_TASKS_METADATA
+from inference.core.workflows.core_steps.models.foundation.anthropic_claude.model_capabilities import (
+    build_thinking_config,
+    resolve_temperature,
+)
 from inference.core.workflows.execution_engine.entities.base import (
     Batch,
     OutputDefinition,
@@ -268,13 +272,15 @@ class BlockManifest(WorkflowBlockManifest):
     extended_thinking: Optional[bool] = Field(
         default=None,
         description="Enable extended thinking for deeper reasoning on complex tasks. "
-        "Note: temperature cannot be used when extended thinking is enabled.",
+        "Note: temperature cannot be used when extended thinking is enabled. Models that "
+        "only support adaptive thinking (Claude Opus 4.7 and newer) ignore `thinking_budget_tokens`.",
     )
     thinking_budget_tokens: Optional[int] = Field(
         default=None,
         description="Maximum number of tokens for internal thinking when extended thinking is enabled. "
         "Higher values allow deeper reasoning but increase latency and cost. "
-        "Must be less than max_tokens. Minimum: 1024.",
+        "Must be less than max_tokens. Minimum: 1024. Ignored by models that only support "
+        "adaptive thinking (Claude Opus 4.7 and newer).",
         ge=1024,
         json_schema_extra={
             "relevant_for": {
@@ -292,7 +298,8 @@ class BlockManifest(WorkflowBlockManifest):
     temperature: Optional[Union[float, Selector(kind=[FLOAT_KIND])]] = Field(
         default=None,
         description="Temperature to sample from the model - value in range 0.0-1.0, the higher - the more "
-        'random / "creative" the generations are. Cannot be used when extended_thinking is enabled.',
+        'random / "creative" the generations are. Cannot be used when extended_thinking is enabled. '
+        "Ignored by models that no longer accept sampling parameters (Claude Opus 4.7 and newer).",
         ge=0.0,
         le=1.0,
     )
@@ -586,19 +593,22 @@ def _execute_proxied_claude_request(
     if system_prompt is not None:
         payload["system"] = system_prompt
 
-    if temperature is not None and not extended_thinking:
+    temperature = resolve_temperature(
+        temperature,
+        model_version=model_version,
+        extended_thinking=extended_thinking,
+    )
+    if temperature is not None:
         payload["temperature"] = temperature
 
-    if extended_thinking:
-        effective_budget = (
-            thinking_budget_tokens
-            if thinking_budget_tokens is not None
-            else model_max_output // 2
-        )
-        payload["thinking"] = {
-            "type": "enabled",
-            "budget_tokens": effective_budget,
-        }
+    thinking = build_thinking_config(
+        extended_thinking=extended_thinking,
+        thinking_budget_tokens=thinking_budget_tokens,
+        model_version=model_version,
+        model_max_output=model_max_output,
+    )
+    if thinking is not None:
+        payload["thinking"] = thinking
 
     endpoint = "apiproxy/anthropic"
 
@@ -633,7 +643,12 @@ def _execute_direct_claude_request(
     if system_prompt is None:
         system_prompt = NOT_GIVEN
 
-    if temperature is None or extended_thinking:
+    temperature = resolve_temperature(
+        temperature,
+        model_version=model_version,
+        extended_thinking=extended_thinking,
+    )
+    if temperature is None:
         temperature = NOT_GIVEN
 
     model_max_output = MAX_OUTPUT_TOKENS.get(model_version, DEFAULT_MAX_OUTPUT_TOKENS)
@@ -647,16 +662,14 @@ def _execute_direct_claude_request(
         "temperature": temperature,
     }
 
-    if extended_thinking:
-        effective_budget = (
-            thinking_budget_tokens
-            if thinking_budget_tokens is not None
-            else model_max_output // 2
-        )
-        request_params["thinking"] = {
-            "type": "enabled",
-            "budget_tokens": effective_budget,
-        }
+    thinking = build_thinking_config(
+        extended_thinking=extended_thinking,
+        thinking_budget_tokens=thinking_budget_tokens,
+        model_version=model_version,
+        model_max_output=model_max_output,
+    )
+    if thinking is not None:
+        request_params["thinking"] = thinking
 
     # Stream response to avoid max_tokens limitation
     with client.messages.stream(**request_params) as stream:

--- a/inference/core/workflows/core_steps/models/foundation/anthropic_claude/v3.py
+++ b/inference/core/workflows/core_steps/models/foundation/anthropic_claude/v3.py
@@ -605,7 +605,7 @@ def _execute_proxied_claude_request(
         extended_thinking=extended_thinking,
         thinking_budget_tokens=thinking_budget_tokens,
         model_version=model_version,
-        model_max_output=model_max_output,
+        max_tokens=effective_max_tokens,
     )
     if thinking is not None:
         payload["thinking"] = thinking
@@ -666,7 +666,7 @@ def _execute_direct_claude_request(
         extended_thinking=extended_thinking,
         thinking_budget_tokens=thinking_budget_tokens,
         model_version=model_version,
-        model_max_output=model_max_output,
+        max_tokens=effective_max_tokens,
     )
     if thinking is not None:
         request_params["thinking"] = thinking

--- a/inference/core/workflows/core_steps/models/foundation/anthropic_claude/v4.py
+++ b/inference/core/workflows/core_steps/models/foundation/anthropic_claude/v4.py
@@ -757,7 +757,7 @@ def _execute_proxied_claude_request(
         extended_thinking=extended_thinking,
         thinking_budget_tokens=thinking_budget_tokens,
         model_version=model_version,
-        model_max_output=model_max_output,
+        max_tokens=effective_max_tokens,
     )
     if thinking is not None:
         payload["thinking"] = thinking
@@ -822,7 +822,7 @@ def _execute_direct_claude_request(
         extended_thinking=extended_thinking,
         thinking_budget_tokens=thinking_budget_tokens,
         model_version=model_version,
-        model_max_output=model_max_output,
+        max_tokens=effective_max_tokens,
     )
     if thinking is not None:
         request_params["thinking"] = thinking

--- a/inference/core/workflows/core_steps/models/foundation/anthropic_claude/v4.py
+++ b/inference/core/workflows/core_steps/models/foundation/anthropic_claude/v4.py
@@ -36,6 +36,10 @@ from inference.core.workflows.core_steps.common.utils import (
     run_in_parallel,
 )
 from inference.core.workflows.core_steps.common.vlms import VLM_TASKS_METADATA
+from inference.core.workflows.core_steps.models.foundation.anthropic_claude.model_capabilities import (
+    build_thinking_config,
+    resolve_temperature,
+)
 from inference.core.workflows.execution_engine.entities.base import (
     Batch,
     OutputDefinition,
@@ -64,6 +68,12 @@ from inference.core.workflows.prototypes.block import (
 )
 
 CLAUDE_MODELS = [
+    {
+        "id": "claude-fable-5-1",
+        "name": "Claude Fable 5.1",
+        "exact_version": "claude-fable-5-1",
+        "max_output_tokens": 128000,
+    },
     {
         "id": "claude-fable-5",
         "name": "Claude Fable 5",
@@ -339,13 +349,15 @@ class BlockManifest(WorkflowBlockManifest):
     extended_thinking: Optional[bool] = Field(
         default=None,
         description="Enable extended thinking for deeper reasoning on complex tasks. "
-        "Note: temperature cannot be used when extended thinking is enabled.",
+        "Note: temperature cannot be used when extended thinking is enabled. Models that "
+        "only support adaptive thinking (Claude Opus 4.7 and newer) ignore `thinking_budget_tokens`.",
     )
     thinking_budget_tokens: Optional[int] = Field(
         default=None,
         description="Maximum number of tokens for internal thinking when extended thinking is enabled. "
         "Higher values allow deeper reasoning but increase latency and cost. "
-        "Must be less than max_tokens. Minimum: 1024.",
+        "Must be less than max_tokens. Minimum: 1024. Ignored by models that only support "
+        "adaptive thinking (Claude Opus 4.7 and newer).",
         ge=1024,
         json_schema_extra={
             "relevant_for": {
@@ -363,7 +375,8 @@ class BlockManifest(WorkflowBlockManifest):
     temperature: Optional[Union[float, Selector(kind=[FLOAT_KIND])]] = Field(
         default=None,
         description="Temperature to sample from the model - value in range 0.0-1.0, the higher - the more "
-        'random / "creative" the generations are. Cannot be used when extended_thinking is enabled.',
+        'random / "creative" the generations are. Cannot be used when extended_thinking is enabled. '
+        "Ignored by models that no longer accept sampling parameters (Claude Opus 4.7 and newer).",
         ge=0.0,
         le=1.0,
     )
@@ -732,19 +745,22 @@ def _execute_proxied_claude_request(
     if system_prompt is not None:
         payload["system"] = system_prompt
 
-    if temperature is not None and not extended_thinking:
+    temperature = resolve_temperature(
+        temperature,
+        model_version=model_version,
+        extended_thinking=extended_thinking,
+    )
+    if temperature is not None:
         payload["temperature"] = temperature
 
-    if extended_thinking:
-        effective_budget = (
-            thinking_budget_tokens
-            if thinking_budget_tokens is not None
-            else model_max_output // 2
-        )
-        payload["thinking"] = {
-            "type": "enabled",
-            "budget_tokens": effective_budget,
-        }
+    thinking = build_thinking_config(
+        extended_thinking=extended_thinking,
+        thinking_budget_tokens=thinking_budget_tokens,
+        model_version=model_version,
+        model_max_output=model_max_output,
+    )
+    if thinking is not None:
+        payload["thinking"] = thinking
 
     endpoint = "apiproxy/anthropic"
 
@@ -783,7 +799,12 @@ def _execute_direct_claude_request(
     if system_prompt is None:
         system_prompt = NOT_GIVEN
 
-    if temperature is None or extended_thinking:
+    temperature = resolve_temperature(
+        temperature,
+        model_version=model_version,
+        extended_thinking=extended_thinking,
+    )
+    if temperature is None:
         temperature = NOT_GIVEN
 
     model_max_output = MAX_OUTPUT_TOKENS.get(model_version, DEFAULT_MAX_OUTPUT_TOKENS)
@@ -797,16 +818,14 @@ def _execute_direct_claude_request(
         "temperature": temperature,
     }
 
-    if extended_thinking:
-        effective_budget = (
-            thinking_budget_tokens
-            if thinking_budget_tokens is not None
-            else model_max_output // 2
-        )
-        request_params["thinking"] = {
-            "type": "enabled",
-            "budget_tokens": effective_budget,
-        }
+    thinking = build_thinking_config(
+        extended_thinking=extended_thinking,
+        thinking_budget_tokens=thinking_budget_tokens,
+        model_version=model_version,
+        model_max_output=model_max_output,
+    )
+    if thinking is not None:
+        request_params["thinking"] = thinking
 
     # Stream response to avoid max_tokens limitation
     with client.messages.stream(**request_params) as stream:

--- a/inference/core/workflows/core_steps/models/foundation/anthropic_claude/v5.py
+++ b/inference/core/workflows/core_steps/models/foundation/anthropic_claude/v5.py
@@ -1,0 +1,1281 @@
+"""Anthropic Claude workflow block (v5).
+
+Extends v4 with a ``reasoning_effort`` control that maps to Anthropic
+``output_config.effort`` (``low`` / ``medium`` / ``high`` / ``xhigh`` /
+``max``) on models that support it. Unset effort keeps the API default
+(``high``). Manual ``extended_thinking`` remains for models that still
+accept ``thinking.type=enabled``.
+"""
+
+import base64
+import json
+from functools import partial
+from typing import Any, Dict, List, Literal, Optional, Tuple, Type, Union
+
+import anthropic
+import cv2
+import numpy as np
+import requests
+from anthropic import NOT_GIVEN
+from pydantic import ConfigDict, Field, model_validator
+
+from inference.core.env import WORKFLOWS_REMOTE_EXECUTION_MAX_STEP_CONCURRENT_REQUESTS
+from inference.core.managers.base import ModelManager
+from inference.core.roboflow_api import post_to_roboflow_api
+from inference.core.utils.image_utils import encode_image_to_jpeg_bytes, load_image
+from inference.core.utils.preprocess import downscale_image_keeping_aspect_ratio
+from inference.core.workflows.core_steps.common.reasoning import (
+    attach_reasoning_levels,
+    models_supporting_reasoning,
+    validate_reasoning_level,
+)
+from inference.core.workflows.core_steps.common.token_usage import (
+    TOKEN_OUTPUT_DEFINITIONS,
+    parse_responses_api_usage,
+)
+from inference.core.workflows.core_steps.common.utils import (
+    compute_anthropic_upload_dimensions,
+    run_in_parallel,
+)
+from inference.core.workflows.core_steps.common.vlms import VLM_TASKS_METADATA
+from inference.core.workflows.core_steps.models.foundation.anthropic_claude.model_capabilities import (
+    anthropic_model_supports_manual_thinking,
+    build_output_config,
+    build_thinking_config,
+    resolve_temperature,
+)
+from inference.core.workflows.execution_engine.entities.base import (
+    Batch,
+    OutputDefinition,
+    WorkflowImageData,
+)
+from inference.core.workflows.execution_engine.entities.types import (
+    FLOAT_KIND,
+    IMAGE_KIND,
+    INTEGER_KIND,
+    LANGUAGE_MODEL_OUTPUT_KIND,
+    LIST_OF_VALUES_KIND,
+    ROBOFLOW_MANAGED_KEY,
+    SECRET_KIND,
+    STRING_KIND,
+    ImageInputField,
+    Selector,
+)
+from inference.core.workflows.prototypes.block import (
+    AirGappedAvailability,
+    BlockResult,
+    DependentResource,
+    WorkflowBlock,
+    WorkflowBlockManifest,
+    is_workflow_selector,
+    third_party_model,
+)
+
+REASONING_EFFORT_VALUES = ["low", "medium", "high", "xhigh", "max"]
+EFFORT_WITHOUT_XHIGH = ["low", "medium", "high", "max"]
+EFFORT_LOW_MEDIUM_HIGH = ["low", "medium", "high"]
+
+CLAUDE_MODELS = [
+    {
+        "id": "claude-fable-5-1",
+        "name": "Claude Fable 5.1",
+        "exact_version": "claude-fable-5-1",
+        "max_output_tokens": 128000,
+        "reasoning_effort_values": REASONING_EFFORT_VALUES,
+    },
+    {
+        "id": "claude-fable-5",
+        "name": "Claude Fable 5",
+        "exact_version": "claude-fable-5",
+        "max_output_tokens": 128000,
+        "reasoning_effort_values": REASONING_EFFORT_VALUES,
+    },
+    {
+        "id": "claude-opus-5",
+        "name": "Claude Opus 5",
+        "exact_version": "claude-opus-5",
+        "max_output_tokens": 128000,
+        "reasoning_effort_values": REASONING_EFFORT_VALUES,
+    },
+    {
+        "id": "claude-sonnet-5",
+        "name": "Claude Sonnet 5",
+        "exact_version": "claude-sonnet-5",
+        "max_output_tokens": 128000,
+        "reasoning_effort_values": REASONING_EFFORT_VALUES,
+    },
+    {
+        "id": "claude-opus-4-8",
+        "name": "Claude Opus 4.8",
+        "exact_version": "claude-opus-4-8",
+        "max_output_tokens": 128000,
+        "reasoning_effort_values": REASONING_EFFORT_VALUES,
+    },
+    {
+        "id": "claude-opus-4-7",
+        "name": "Claude Opus 4.7",
+        "exact_version": "claude-opus-4-7",
+        "max_output_tokens": 128000,
+        "reasoning_effort_values": REASONING_EFFORT_VALUES,
+    },
+    {
+        "id": "claude-opus-4-6",
+        "name": "Claude Opus 4.6",
+        "exact_version": "claude-opus-4-6",
+        "max_output_tokens": 128000,
+        "reasoning_effort_values": EFFORT_WITHOUT_XHIGH,
+    },
+    {
+        "id": "claude-sonnet-4-6",
+        "name": "Claude Sonnet 4.6",
+        "exact_version": "claude-sonnet-4-6",
+        "max_output_tokens": 64000,
+        "reasoning_effort_values": EFFORT_WITHOUT_XHIGH,
+    },
+    {
+        "id": "claude-sonnet-4-5",
+        "name": "Claude Sonnet 4.5",
+        "exact_version": "claude-sonnet-4-5-20250929",
+        "max_output_tokens": 64000,
+        "reasoning_effort_values": [],
+    },
+    {
+        "id": "claude-haiku-4-5",
+        "name": "Claude Haiku 4.5",
+        "exact_version": "claude-haiku-4-5-20251001",
+        "max_output_tokens": 64000,
+        "reasoning_effort_values": [],
+    },
+    {
+        "id": "claude-opus-4-5",
+        "name": "Claude Opus 4.5",
+        "exact_version": "claude-opus-4-5-20251101",
+        "max_output_tokens": 64000,
+        "reasoning_effort_values": EFFORT_LOW_MEDIUM_HIGH,
+    },
+    {
+        "id": "claude-sonnet-4",
+        "name": "Claude Sonnet 4",
+        "exact_version": "claude-sonnet-4-20250514",
+        "max_output_tokens": 64000,
+        "reasoning_effort_values": [],
+    },
+    {
+        "id": "claude-opus-4-1",
+        "name": "Claude Opus 4.1",
+        "exact_version": "claude-opus-4-1-20250805",
+        "max_output_tokens": 32000,
+        "reasoning_effort_values": [],
+    },
+    {
+        "id": "claude-opus-4",
+        "name": "Claude Opus 4",
+        "exact_version": "claude-opus-4-20250514",
+        "max_output_tokens": 32000,
+        "reasoning_effort_values": [],
+    },
+]
+
+MODEL_VERSION_IDS = [model["id"] for model in CLAUDE_MODELS]
+EXACT_MODEL_VERSIONS = {model["id"]: model["exact_version"] for model in CLAUDE_MODELS}
+
+MODEL_REASONING_EFFORT_VALUES = {
+    model["id"]: model["reasoning_effort_values"] for model in CLAUDE_MODELS
+}
+MODELS_SUPPORTING_REASONING_EFFORT = models_supporting_reasoning(
+    MODEL_REASONING_EFFORT_VALUES
+)
+MODELS_SUPPORTING_MANUAL_THINKING = [
+    model["id"]
+    for model in CLAUDE_MODELS
+    if anthropic_model_supports_manual_thinking(model["id"])
+]
+
+MODEL_VERSION_METADATA = attach_reasoning_levels(
+    {model["id"]: {"name": model["name"]} for model in CLAUDE_MODELS},
+    MODEL_REASONING_EFFORT_VALUES,
+)
+
+MAX_OUTPUT_TOKENS = {model["id"]: model["max_output_tokens"] for model in CLAUDE_MODELS}
+DEFAULT_MAX_OUTPUT_TOKENS = 64000
+
+DETECTION_MAX_PNG_PAYLOAD_BYTES = 2_500_000
+"""Largest PNG payload sent for object detection, before base64 growth.
+
+Lossless PNG of a large photographic upload can exceed the request body
+limits of the Roboflow proxy and Anthropic's per-image maximum. Above this
+size the block re-encodes the image as JPEG (quality 95) at the same
+resolution, which keeps the coordinate contract intact.
+"""
+
+DETECTION_JPEG_FALLBACK_QUALITY = 95
+
+OBJECT_DETECTION_PROMPT_TEMPLATE = (
+    "Detect all objects in this image. "
+    "Output a JSON list where each entry contains the 2D bounding box "
+    'in the key "box_2d" and the text label in the key "label". '
+    'The "box_2d" value must be [x_min, y_min, x_max, y_max]: the '
+    "top-left and bottom-right corners in absolute pixel coordinates "
+    "of the {width}x{height} pixel image. "
+    "Return only the JSON list, with no extra text. "
+    "Only use these labels: {class_list}"
+)
+
+SUPPORTED_TASK_TYPES_LIST = [
+    "unconstrained",
+    "ocr",
+    "structured-answering",
+    "classification",
+    "multi-label-classification",
+    "visual-question-answering",
+    "caption",
+    "detailed-caption",
+    "object-detection",
+]
+SUPPORTED_TASK_TYPES = set(SUPPORTED_TASK_TYPES_LIST)
+RELEVANT_TASKS_METADATA = {
+    k: v for k, v in VLM_TASKS_METADATA.items() if k in SUPPORTED_TASK_TYPES
+}
+RELEVANT_TASKS_DOCS_DESCRIPTION = "\n\n".join(
+    f"* **{v['name']}** (`{k}`) - {v['description']}"
+    for k, v in RELEVANT_TASKS_METADATA.items()
+)
+LONG_DESCRIPTION = f"""
+Ask a question to Anthropic Claude model with vision capabilities.
+
+You can specify arbitrary text prompts or predefined ones, the block supports the following types of prompt:
+
+{RELEVANT_TASKS_DOCS_DESCRIPTION}
+
+The `object-detection` task asks Claude for a JSON list of
+`{{"box_2d": [x_min, y_min, x_max, y_max], "label": ...}}` entries where
+coordinates are absolute pixels of the uploaded image. The image is
+pre-resized to the exact dimensions Claude's internal resize would produce
+and sent as lossless PNG, matching the vlm-exam benchmark setup for Claude
+models; the `max_image_size` parameter is not applied to this task. Use
+`roboflow_core/vlm_as_detector@v2` with `model_type="anthropic-claude"` to
+convert the output into predictions. Confidence scores are not requested;
+the parser assigns `1.0`.
+
+### API Key Options
+
+This block supports two API key modes:
+
+1. **Roboflow Managed API Key (Default)** - Use `rf_key:account` to proxy requests through Roboflow's API:
+   * **Simplified setup** - no Anthropic API key required
+   * **Secure** - your workflow API key is used for authentication
+   * **Usage-based billing** - charged per token based on the model used
+
+2. **Custom Anthropic API Key** - Provide your own Anthropic API key:
+   * Full control over API usage
+   * You pay Anthropic directly
+"""
+
+TaskType = Literal[tuple(SUPPORTED_TASK_TYPES_LIST)]
+
+TASKS_REQUIRING_PROMPT = {
+    "unconstrained",
+    "visual-question-answering",
+}
+
+TASKS_REQUIRING_CLASSES = {
+    "classification",
+    "multi-label-classification",
+    "object-detection",
+}
+
+TASKS_REQUIRING_OUTPUT_STRUCTURE = {
+    "structured-answering",
+}
+
+
+class BlockManifest(WorkflowBlockManifest):
+    model_config = ConfigDict(
+        json_schema_extra={
+            "name": "Anthropic Claude",
+            "version": "v5",
+            "short_description": "Run Anthropic Claude model with vision capabilities.",
+            "long_description": LONG_DESCRIPTION,
+            "license": "Apache-2.0",
+            "block_type": "model",
+            "search_keywords": ["LMM", "VLM", "Claude", "Anthropic"],
+            "is_vlm_block": True,
+            "task_type_property": "task_type",
+            "ui_manifest": {
+                "section": "model",
+                "icon": "far fa-a",
+                "blockPriority": 5,
+            },
+        },
+        protected_namespaces=(),
+    )
+    type: Literal["roboflow_core/anthropic_claude@v5"]
+    images: Selector(kind=[IMAGE_KIND]) = ImageInputField
+    task_type: TaskType = Field(
+        default="unconstrained",
+        description="Task type to be performed by model. Value determines required parameters and output response.",
+        json_schema_extra={
+            "values_metadata": RELEVANT_TASKS_METADATA,
+            "recommended_parsers": {
+                "structured-answering": "roboflow_core/json_parser@v1",
+                "classification": "roboflow_core/vlm_as_classifier@v2",
+                "multi-label-classification": "roboflow_core/vlm_as_classifier@v2",
+                "object-detection": "roboflow_core/vlm_as_detector@v2",
+            },
+            "always_visible": True,
+        },
+    )
+    prompt: Optional[Union[Selector(kind=[STRING_KIND]), str]] = Field(
+        default=None,
+        description="Text prompt to the Claude model",
+        examples=["my prompt", "$inputs.prompt"],
+        json_schema_extra={
+            "relevant_for": {
+                "task_type": {"values": TASKS_REQUIRING_PROMPT, "required": True},
+            },
+            "multiline": True,
+        },
+    )
+    output_structure: Optional[Dict[str, str]] = Field(
+        default=None,
+        description="Dictionary with structure of expected JSON response",
+        examples=[{"my_key": "description"}, "$inputs.output_structure"],
+        json_schema_extra={
+            "relevant_for": {
+                "task_type": {
+                    "values": TASKS_REQUIRING_OUTPUT_STRUCTURE,
+                    "required": True,
+                },
+            },
+        },
+    )
+    classes: Optional[Union[Selector(kind=[LIST_OF_VALUES_KIND]), List[str]]] = Field(
+        default=None,
+        description="List of classes to be used",
+        examples=[["class-a", "class-b"], "$inputs.classes"],
+        json_schema_extra={
+            "relevant_for": {
+                "task_type": {
+                    "values": TASKS_REQUIRING_CLASSES,
+                    "required": True,
+                },
+            },
+        },
+    )
+    api_key: Union[
+        Selector(kind=[STRING_KIND, SECRET_KIND, ROBOFLOW_MANAGED_KEY]), str
+    ] = Field(
+        default="rf_key:account",
+        description="Your Anthropic API key or 'rf_key:account' to use Roboflow's managed API key",
+        examples=["rf_key:account", "xxx-xxx", "$inputs.anthropic_api_key"],
+        private=True,
+    )
+    model_version: Union[
+        Selector(kind=[STRING_KIND]),
+        Literal[tuple(MODEL_VERSION_IDS)],
+    ] = Field(
+        default="claude-sonnet-4-5",
+        description="Model to be used",
+        examples=["claude-sonnet-4-5", "$inputs.claude_model"],
+        json_schema_extra={
+            "values_metadata": MODEL_VERSION_METADATA,
+        },
+    )
+    extended_thinking: Optional[bool] = Field(
+        default=None,
+        description="Enable extended thinking for deeper reasoning on complex tasks. "
+        "Note: temperature cannot be used when extended thinking is enabled. Models that "
+        "only support adaptive thinking (Claude Opus 4.7 and newer) ignore `thinking_budget_tokens`.",
+        json_schema_extra={
+            "relevant_for": {
+                "model_version": {
+                    "values": MODELS_SUPPORTING_MANUAL_THINKING,
+                    "required": False,
+                },
+            },
+        },
+    )
+    reasoning_effort: Optional[
+        Union[
+            Selector(kind=[STRING_KIND]),
+            Literal[tuple(REASONING_EFFORT_VALUES)],
+        ]
+    ] = Field(
+        default=None,
+        description="Controls how much work Claude puts into the response, including "
+        "thinking depth on models with adaptive thinking. Maps to Anthropic "
+        "`output_config.effort`. Supported values differ per model and are listed "
+        "next to each entry of the model dropdown. When unset, the Anthropic "
+        "default (high) is used.",
+        examples=["low", "$inputs.reasoning_effort"],
+        json_schema_extra={
+            "relevant_for": {
+                "model_version": {
+                    "values": MODELS_SUPPORTING_REASONING_EFFORT,
+                    "required": False,
+                },
+            },
+        },
+    )
+    thinking_budget_tokens: Optional[int] = Field(
+        default=None,
+        description="Maximum number of tokens for internal thinking when extended thinking is enabled. "
+        "Higher values allow deeper reasoning but increase latency and cost. "
+        "Must be less than max_tokens. Minimum: 1024. Ignored by models that only support "
+        "adaptive thinking (Claude Opus 4.7 and newer).",
+        ge=1024,
+        json_schema_extra={
+            "relevant_for": {
+                "extended_thinking": {
+                    "values": [True],
+                    "required": False,
+                },
+            },
+        },
+    )
+    max_tokens: Optional[int] = Field(
+        default=None,
+        description="Maximum number of tokens the model can generate in its response.",
+    )
+    temperature: Optional[Union[float, Selector(kind=[FLOAT_KIND])]] = Field(
+        default=None,
+        description="Temperature to sample from the model - value in range 0.0-1.0, the higher - the more "
+        'random / "creative" the generations are. Cannot be used when extended_thinking is enabled. '
+        "Ignored by models that no longer accept sampling parameters (Claude Opus 4.7 and newer).",
+        ge=0.0,
+        le=1.0,
+    )
+    max_image_size: Union[int, Selector(kind=[INTEGER_KIND])] = Field(
+        description="Maximum size of the image - if input has larger side, it will be downscaled, keeping aspect ratio. "
+        "Not applied to the `object-detection` task, which pre-resizes images to Claude's native resolution instead.",
+        default=1024,
+    )
+    max_concurrent_requests: Optional[int] = Field(
+        default=None,
+        description="Number of concurrent requests that can be executed by block when batch of input images provided. "
+        "If not given - block defaults to value configured globally in Workflows Execution Engine. "
+        "Please restrict if you hit Anthropic API limits.",
+    )
+
+    @model_validator(mode="after")
+    def validate(self) -> "BlockManifest":
+        if self.task_type in TASKS_REQUIRING_PROMPT and self.prompt is None:
+            raise ValueError(
+                f"`prompt` parameter required to be set for task `{self.task_type}`"
+            )
+        if self.task_type in TASKS_REQUIRING_CLASSES and self.classes is None:
+            raise ValueError(
+                f"`classes` parameter required to be set for task `{self.task_type}`"
+            )
+        if (
+            self.task_type in TASKS_REQUIRING_OUTPUT_STRUCTURE
+            and self.output_structure is None
+        ):
+            raise ValueError(
+                f"`output_structure` parameter required to be set for task `{self.task_type}`"
+            )
+        if self.extended_thinking:
+            if self.temperature is not None:
+                raise ValueError(
+                    "`temperature` cannot be used when `extended_thinking` is enabled"
+                )
+            budget_tokens = self.thinking_budget_tokens
+            max_tokens = self.max_tokens
+            if budget_tokens and max_tokens and budget_tokens >= max_tokens:
+                raise ValueError(
+                    f"`thinking_budget_tokens` ({budget_tokens}) must be less than `max_tokens` ({max_tokens})"
+                )
+        validate_reasoning_level(
+            model=self.model_version,
+            level=self.reasoning_effort,
+            levels_by_model=MODEL_REASONING_EFFORT_VALUES,
+        )
+        return self
+
+    @classmethod
+    def get_air_gapped_availability(cls) -> AirGappedAvailability:
+        return AirGappedAvailability(available=False, reason="requires_internet")
+
+    @classmethod
+    def get_parameters_accepting_batches(cls) -> List[str]:
+        return ["images"]
+
+    @classmethod
+    def describe_outputs(cls) -> List[OutputDefinition]:
+        return [
+            OutputDefinition(
+                name="output", kind=[STRING_KIND, LANGUAGE_MODEL_OUTPUT_KIND]
+            ),
+            OutputDefinition(name="classes", kind=[LIST_OF_VALUES_KIND]),
+            *TOKEN_OUTPUT_DEFINITIONS,
+        ]
+
+    @classmethod
+    def get_execution_engine_compatibility(cls) -> Optional[str]:
+        return ">=1.4.0,<2.0.0"
+
+    def discover_dependent_resources(self) -> Optional[List[DependentResource]]:
+        if is_workflow_selector(self.model_version):
+            # Selector returned verbatim; the attached resolver performs the
+            # EXACT_MODEL_VERSIONS lookup once the input value is substituted.
+            return [
+                third_party_model(
+                    provider="anthropic",
+                    model_id=self.model_version,
+                    model_id_resolver=lambda label: EXACT_MODEL_VERSIONS.get(
+                        label, label
+                    ),
+                )
+            ]
+        return [
+            third_party_model(
+                provider="anthropic",
+                model_id=EXACT_MODEL_VERSIONS.get(
+                    self.model_version, self.model_version
+                ),
+            )
+        ]
+
+
+class AnthropicClaudeBlockV5(WorkflowBlock):
+
+    def __init__(
+        self,
+        model_manager: ModelManager,
+        api_key: Optional[str],
+    ):
+        self._model_manager = model_manager
+        self._api_key = api_key
+
+    @classmethod
+    def get_init_parameters(cls) -> List[str]:
+        return ["model_manager", "api_key"]
+
+    @classmethod
+    def get_manifest(cls) -> Type[WorkflowBlockManifest]:
+        return BlockManifest
+
+    @classmethod
+    def get_execution_engine_compatibility(cls) -> Optional[str]:
+        return ">=1.4.0,<2.0.0"
+
+    def run(
+        self,
+        images: Batch[WorkflowImageData],
+        task_type: TaskType,
+        prompt: Optional[str],
+        output_structure: Optional[Dict[str, str]],
+        classes: Optional[List[str]],
+        model_version: str,
+        max_tokens: Optional[int],
+        temperature: Optional[float],
+        extended_thinking: Optional[bool],
+        thinking_budget_tokens: Optional[int],
+        reasoning_effort: Optional[str],
+        max_image_size: int,
+        max_concurrent_requests: Optional[int],
+        api_key: str = "rf_key:account",
+    ) -> BlockResult:
+        inference_images = [i.to_inference_format() for i in images]
+        raw_outputs = run_claude_prompting(
+            roboflow_api_key=self._api_key,
+            images=inference_images,
+            task_type=task_type,
+            prompt=prompt,
+            output_structure=output_structure,
+            classes=classes,
+            anthropic_api_key=api_key,
+            model_version=model_version,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            extended_thinking=extended_thinking,
+            thinking_budget_tokens=thinking_budget_tokens,
+            reasoning_effort=reasoning_effort,
+            max_image_size=max_image_size,
+            max_concurrent_requests=max_concurrent_requests,
+        )
+        return [
+            {
+                "output": content,
+                "classes": classes,
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+            }
+            for content, input_tokens, output_tokens in raw_outputs
+        ]
+
+
+def run_claude_prompting(
+    roboflow_api_key: Optional[str],
+    images: List[Dict[str, Any]],
+    task_type: TaskType,
+    prompt: Optional[str],
+    output_structure: Optional[Dict[str, str]],
+    classes: Optional[List[str]],
+    anthropic_api_key: str,
+    model_version: str,
+    max_tokens: Optional[int],
+    temperature: Optional[float],
+    extended_thinking: Optional[bool],
+    thinking_budget_tokens: Optional[int],
+    reasoning_effort: Optional[str],
+    max_image_size: int,
+    max_concurrent_requests: Optional[int],
+) -> List[Tuple[str, Optional[int], Optional[int]]]:
+    if task_type not in PROMPT_BUILDERS:
+        raise ValueError(f"Task type: {task_type} not supported.")
+    prompts = []
+    for image in images:
+        loaded_image, _ = load_image(image)
+        base64_image, media_type, image_width, image_height = encode_image_for_task(
+            loaded_image, task_type=task_type, max_image_size=max_image_size
+        )
+        generated_prompt = PROMPT_BUILDERS[task_type](
+            base64_image=base64_image,
+            prompt=prompt,
+            output_structure=output_structure,
+            classes=classes,
+            image_width=image_width,
+            image_height=image_height,
+            media_type=media_type,
+        )
+        prompts.append(generated_prompt)
+    return execute_claude_requests(
+        roboflow_api_key=roboflow_api_key,
+        anthropic_api_key=anthropic_api_key,
+        prompts=prompts,
+        model_version=model_version,
+        max_tokens=max_tokens,
+        temperature=temperature,
+        extended_thinking=extended_thinking,
+        thinking_budget_tokens=thinking_budget_tokens,
+        reasoning_effort=reasoning_effort,
+        max_concurrent_requests=max_concurrent_requests,
+    )
+
+
+def encode_image_for_task(
+    image: np.ndarray, *, task_type: TaskType, max_image_size: int
+) -> Tuple[str, int, int]:
+    """Encode an image as base64 using task-appropriate preprocessing.
+
+    The ``object-detection`` task pre-resizes the image to the exact
+    dimensions Claude's internal resize would produce (high-resolution tier)
+    and encodes it as lossless PNG, so pixel coordinates returned by the
+    model map one-to-one onto the uploaded image - matching the vlm-exam
+    benchmark setup the absolute-pixel contract was validated with. All other
+    tasks downscale to ``max_image_size`` and send JPEG, as previous block
+    versions did.
+
+    Args:
+        image: BGR image to be encoded.
+        task_type: Task type determining the preprocessing applied.
+        max_image_size: Maximum longest edge applied to non-detection tasks.
+
+    Returns:
+        Tuple of the base64-encoded image payload (without a data URL prefix),
+        its media type, and the ``(width, height)`` of the encoded image.
+    """
+    if task_type == "object-detection":
+        encoded_image = _resize_image_to_anthropic_upload_dimensions(image)
+        image_bytes = _encode_image_to_png_bytes(encoded_image)
+        media_type = "image/png"
+        if len(image_bytes) > DETECTION_MAX_PNG_PAYLOAD_BYTES:
+            image_bytes = _encode_image_to_jpeg_bytes_with_quality(
+                encoded_image, quality=DETECTION_JPEG_FALLBACK_QUALITY
+            )
+            media_type = "image/jpeg"
+    else:
+        encoded_image = downscale_image_keeping_aspect_ratio(
+            image=image, desired_size=(max_image_size, max_image_size)
+        )
+        image_bytes = encode_image_to_jpeg_bytes(encoded_image)
+        media_type = "image/jpeg"
+
+    base64_image = base64.b64encode(image_bytes).decode("ascii")
+    encoded_height, encoded_width = encoded_image.shape[:2]
+
+    return base64_image, media_type, encoded_width, encoded_height
+
+
+def _resize_image_to_anthropic_upload_dimensions(image: np.ndarray) -> np.ndarray:
+    height, width = image.shape[:2]
+    target_width, target_height = compute_anthropic_upload_dimensions(width, height)
+    if (target_width, target_height) == (width, height):
+        return image
+
+    return cv2.resize(
+        image, (target_width, target_height), interpolation=cv2.INTER_LANCZOS4
+    )
+
+
+def _encode_image_to_png_bytes(image: np.ndarray) -> bytes:
+    _, encoded_image = cv2.imencode(".png", image)
+    return encoded_image.tobytes()
+
+
+def _encode_image_to_jpeg_bytes_with_quality(
+    image: np.ndarray, *, quality: int
+) -> bytes:
+    _, encoded_image = cv2.imencode(".jpg", image, [cv2.IMWRITE_JPEG_QUALITY, quality])
+    return encoded_image.tobytes()
+
+
+def execute_claude_requests(
+    roboflow_api_key: Optional[str],
+    anthropic_api_key: str,
+    prompts: List[Tuple[Optional[str], List[dict]]],
+    model_version: str,
+    max_tokens: Optional[int],
+    temperature: Optional[float],
+    extended_thinking: Optional[bool],
+    thinking_budget_tokens: Optional[int],
+    reasoning_effort: Optional[str],
+    max_concurrent_requests: Optional[int],
+) -> List[Tuple[str, Optional[int], Optional[int]]]:
+    tasks = [
+        partial(
+            execute_claude_request,
+            roboflow_api_key=roboflow_api_key,
+            anthropic_api_key=anthropic_api_key,
+            system_prompt=prompt[0],
+            messages=prompt[1],
+            model_version=model_version,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            extended_thinking=extended_thinking,
+            thinking_budget_tokens=thinking_budget_tokens,
+            reasoning_effort=reasoning_effort,
+        )
+        for prompt in prompts
+    ]
+    max_workers = (
+        max_concurrent_requests
+        or WORKFLOWS_REMOTE_EXECUTION_MAX_STEP_CONCURRENT_REQUESTS
+    )
+    return run_in_parallel(
+        tasks=tasks,
+        max_workers=max_workers,
+    )
+
+
+def execute_claude_request(
+    roboflow_api_key: Optional[str],
+    anthropic_api_key: str,
+    system_prompt: Optional[str],
+    messages: List[dict],
+    model_version: str,
+    max_tokens: Optional[int],
+    temperature: Optional[float],
+    extended_thinking: Optional[bool],
+    thinking_budget_tokens: Optional[int],
+    reasoning_effort: Optional[str] = None,
+) -> Tuple[str, Optional[int], Optional[int]]:
+    """Route to proxied or direct execution based on API key format.
+
+    ``reasoning_effort`` is re-validated here because manifest validation
+    cannot see values that arrive through selectors at runtime.
+    """
+    validate_reasoning_level(
+        model=model_version,
+        level=reasoning_effort,
+        levels_by_model=MODEL_REASONING_EFFORT_VALUES,
+    )
+    if anthropic_api_key.startswith(("rf_key:account", "rf_key:user:")):
+        return _execute_proxied_claude_request(
+            roboflow_api_key=roboflow_api_key,
+            anthropic_api_key=anthropic_api_key,
+            system_prompt=system_prompt,
+            messages=messages,
+            model_version=model_version,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            extended_thinking=extended_thinking,
+            thinking_budget_tokens=thinking_budget_tokens,
+            reasoning_effort=reasoning_effort,
+        )
+    else:
+        return _execute_direct_claude_request(
+            anthropic_api_key=anthropic_api_key,
+            system_prompt=system_prompt,
+            messages=messages,
+            model_version=model_version,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            extended_thinking=extended_thinking,
+            thinking_budget_tokens=thinking_budget_tokens,
+            reasoning_effort=reasoning_effort,
+        )
+
+
+def _execute_proxied_claude_request(
+    roboflow_api_key: str,
+    anthropic_api_key: str,
+    system_prompt: Optional[str],
+    messages: List[dict],
+    model_version: str,
+    max_tokens: Optional[int],
+    temperature: Optional[float],
+    extended_thinking: Optional[bool],
+    thinking_budget_tokens: Optional[int],
+    reasoning_effort: Optional[str] = None,
+) -> Tuple[str, Optional[int], Optional[int]]:
+    """Execute Claude request via Roboflow proxy."""
+    model_max_output = MAX_OUTPUT_TOKENS.get(model_version, DEFAULT_MAX_OUTPUT_TOKENS)
+    effective_max_tokens = max_tokens if max_tokens is not None else model_max_output
+
+    payload = {
+        "model": model_version,
+        "anthropic_api_key": anthropic_api_key,
+        "messages": messages,
+        "max_tokens": effective_max_tokens,
+    }
+
+    if system_prompt is not None:
+        payload["system"] = system_prompt
+
+    temperature = resolve_temperature(
+        temperature,
+        model_version=model_version,
+        extended_thinking=extended_thinking,
+    )
+    if temperature is not None:
+        payload["temperature"] = temperature
+
+    thinking = build_thinking_config(
+        extended_thinking=extended_thinking,
+        thinking_budget_tokens=thinking_budget_tokens,
+        model_version=model_version,
+        model_max_output=model_max_output,
+    )
+    if thinking is not None:
+        payload["thinking"] = thinking
+
+    output_config = build_output_config(reasoning_effort)
+    if output_config is not None:
+        payload["output_config"] = output_config
+
+    endpoint = "apiproxy/anthropic"
+
+    try:
+        response_data = post_to_roboflow_api(
+            endpoint=endpoint,
+            api_key=roboflow_api_key,
+            payload=payload,
+        )
+        text = _extract_claude_response_text(response_data)
+        input_tokens, output_tokens = parse_responses_api_usage(
+            response_data.get("usage")
+        )
+        return text, input_tokens, output_tokens
+    except requests.exceptions.RequestException as e:
+        raise RuntimeError(f"Failed to connect to Roboflow proxy: {e}") from e
+    except (KeyError, IndexError) as e:
+        raise RuntimeError(
+            f"Invalid response structure from Roboflow proxy: {e}"
+        ) from e
+
+
+def _execute_direct_claude_request(
+    anthropic_api_key: str,
+    system_prompt: Optional[str],
+    messages: List[dict],
+    model_version: str,
+    max_tokens: Optional[int],
+    temperature: Optional[float],
+    extended_thinking: Optional[bool],
+    thinking_budget_tokens: Optional[int],
+    reasoning_effort: Optional[str] = None,
+) -> Tuple[str, Optional[int], Optional[int]]:
+    """Execute Claude request directly to Anthropic API.
+
+    ``output_config`` is sent through ``extra_body`` because the pinned
+    ``anthropic~=0.49.0`` SDK predates it as a first-class kwarg.
+    """
+    client = anthropic.Anthropic(api_key=anthropic_api_key)
+
+    if system_prompt is None:
+        system_prompt = NOT_GIVEN
+
+    temperature = resolve_temperature(
+        temperature,
+        model_version=model_version,
+        extended_thinking=extended_thinking,
+    )
+    if temperature is None:
+        temperature = NOT_GIVEN
+
+    model_max_output = MAX_OUTPUT_TOKENS.get(model_version, DEFAULT_MAX_OUTPUT_TOKENS)
+    effective_max_tokens = max_tokens if max_tokens is not None else model_max_output
+
+    request_params = {
+        "system": system_prompt,
+        "messages": messages,
+        "max_tokens": effective_max_tokens,
+        "model": EXACT_MODEL_VERSIONS.get(model_version, model_version),
+        "temperature": temperature,
+    }
+
+    thinking = build_thinking_config(
+        extended_thinking=extended_thinking,
+        thinking_budget_tokens=thinking_budget_tokens,
+        model_version=model_version,
+        model_max_output=model_max_output,
+    )
+    if thinking is not None:
+        request_params["thinking"] = thinking
+
+    output_config = build_output_config(reasoning_effort)
+    if output_config is not None:
+        request_params["extra_body"] = {"output_config": output_config}
+
+    # Stream response to avoid max_tokens limitation
+    with client.messages.stream(**request_params) as stream:
+        result = stream.get_final_message()
+
+    text = _validate_and_extract_direct_response(result)
+    input_tokens, output_tokens = parse_responses_api_usage(
+        getattr(result, "usage", None)
+    )
+    return text, input_tokens, output_tokens
+
+
+def _validate_and_extract_direct_response(result) -> str:
+    """Validate and extract text from direct Anthropic API response."""
+    stop_reason = result.stop_reason
+
+    if stop_reason == "max_tokens":
+        raise ValueError(
+            "Claude API stopped generation because the max_tokens limit was reached. "
+            "Please increase the max_tokens parameter to allow for a complete response."
+        )
+
+    if stop_reason not in ["end_turn", "stop_sequence"]:
+        raise ValueError(
+            f"Claude API stopped generation with unexpected stop reason: {stop_reason}."
+        )
+
+    # Ignore thinking blocks and return text content
+    for block in result.content:
+        if block.type == "text":
+            return block.text
+
+    raise ValueError("Claude API returned no text content in response.")
+
+
+def _extract_claude_response_text(response_data: dict) -> str:
+    """Extract text content from Claude API response (proxied)."""
+    stop_reason = response_data.get("stop_reason")
+
+    if stop_reason == "max_tokens":
+        raise ValueError(
+            "Claude API stopped generation because the max_tokens limit was reached. "
+            "Please increase the max_tokens parameter to allow for a complete response."
+        )
+
+    if stop_reason not in ["end_turn", "stop_sequence", None]:
+        raise ValueError(
+            f"Claude API stopped generation with unexpected stop reason: {stop_reason}."
+        )
+
+    content = response_data.get("content", [])
+    if not content:
+        raise ValueError("Claude API returned no content in response.")
+
+    # Ignore thinking blocks and return text content
+    for block in content:
+        if isinstance(block, dict) and block.get("type") == "text":
+            return block.get("text", "")
+
+    raise ValueError("Claude API returned no text content in response.")
+
+
+def prepare_unconstrained_prompt(
+    base64_image: str,
+    prompt: str,
+    **kwargs,
+) -> Tuple[Optional[str], List[dict]]:
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": "image/jpeg",
+                        "data": base64_image,
+                    },
+                },
+                {
+                    "type": "text",
+                    "text": prompt,
+                },
+            ],
+        }
+    ]
+    return None, messages
+
+
+def prepare_classification_prompt(
+    base64_image: str,
+    classes: List[str],
+    **kwargs,
+) -> Tuple[Optional[str], List[dict]]:
+    serialised_classes = ", ".join(classes)
+    system_prompt = (
+        "You act as single-class classification model. You must provide reasonable predictions. "
+        "You are only allowed to produce JSON document. "
+        'Expected structure of json: {"class_name": "class-name", "confidence": 0.4}. '
+        "`class-name` must be one of the class names defined by user. You are only allowed to return "
+        "single JSON document, even if there are potentially multiple classes. You are not allowed to "
+        "return list."
+    )
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": "image/jpeg",
+                        "data": base64_image,
+                    },
+                },
+                {
+                    "type": "text",
+                    "text": f"List of all classes to be recognised by model: {serialised_classes}",
+                },
+            ],
+        }
+    ]
+    return system_prompt, messages
+
+
+def prepare_multi_label_classification_prompt(
+    base64_image: str,
+    classes: List[str],
+    **kwargs,
+) -> Tuple[Optional[str], List[dict]]:
+    serialised_classes = ", ".join(classes)
+    system_prompt = (
+        "You act as multi-label classification model. You must provide reasonable predictions. "
+        "You are only allowed to produce JSON document. "
+        'Expected structure of json: {"predicted_classes": [{"class": "class-name-1", "confidence": 0.9}, '
+        '{"class": "class-name-2", "confidence": 0.7}]}.'
+        "`class-name-X` must be one of the class names defined by user and `confidence` is a float value "
+        "in range 0.0-1.0 that represents how sure you are that the class is present in the image. "
+        "Only return class names that are visible."
+    )
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": "image/jpeg",
+                        "data": base64_image,
+                    },
+                },
+                {
+                    "type": "text",
+                    "text": f"List of all classes to be recognised by model: {serialised_classes}",
+                },
+            ],
+        }
+    ]
+    return system_prompt, messages
+
+
+def prepare_vqa_prompt(
+    base64_image: str,
+    prompt: str,
+    **kwargs,
+) -> Tuple[Optional[str], List[dict]]:
+    system_prompt = (
+        "You act as Visual Question Answering model. Your task is to provide answer to question"
+        "submitted by user. If this is open-question - answer with few sentences, for ABCD question, "
+        "return only the indicator of the answer."
+    )
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": "image/jpeg",
+                        "data": base64_image,
+                    },
+                },
+                {
+                    "type": "text",
+                    "text": f"Question: {prompt}",
+                },
+            ],
+        }
+    ]
+    return system_prompt, messages
+
+
+def prepare_ocr_prompt(
+    base64_image: str,
+    **kwargs,
+) -> Tuple[Optional[str], List[dict]]:
+    system_prompt = (
+        "You act as OCR model. Your task is to read text from the image and return it in "
+        "paragraphs representing the structure of texts in the image. You should only return "
+        "recognised text, nothing else."
+    )
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": "image/jpeg",
+                        "data": base64_image,
+                    },
+                },
+            ],
+        }
+    ]
+    return system_prompt, messages
+
+
+def prepare_caption_prompt(
+    base64_image: str,
+    short_description: bool,
+    **kwargs,
+) -> Tuple[Optional[str], List[dict]]:
+    caption_detail_level = "Caption should be short."
+    if not short_description:
+        caption_detail_level = "Caption should be extensive."
+    system_prompt = (
+        f"You act as image caption model. Your task is to provide description of the image. "
+        f"{caption_detail_level}"
+    )
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": "image/jpeg",
+                        "data": base64_image,
+                    },
+                },
+            ],
+        }
+    ]
+    return system_prompt, messages
+
+
+def prepare_structured_answering_prompt(
+    base64_image: str,
+    output_structure: Dict[str, str],
+    **kwargs,
+) -> Tuple[Optional[str], List[dict]]:
+    output_structure_serialised = json.dumps(output_structure, indent=4)
+    system_prompt = (
+        "You are supposed to produce responses in JSON. User is to provide you dictionary with "
+        "keys and values. Each key must be present in your response. Values in user dictionary "
+        "represent descriptions for JSON fields to be generated. Provide only JSON in response."
+    )
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": "image/jpeg",
+                        "data": base64_image,
+                    },
+                },
+                {
+                    "type": "text",
+                    "text": f"Specification of requirements regarding output fields: \n"
+                    f"{output_structure_serialised}",
+                },
+            ],
+        }
+    ]
+    return system_prompt, messages
+
+
+def prepare_object_detection_prompt(
+    base64_image: str,
+    classes: List[str],
+    image_width: int,
+    image_height: int,
+    media_type: str = "image/png",
+    **kwargs,
+) -> Tuple[Optional[str], List[dict]]:
+    """Build the absolute-pixel detection request used by Claude models.
+
+    Matches the vlm-exam benchmark setup: the image placed before the text
+    prompt, no system prompt, and coordinates requested as absolute pixels of
+    the uploaded ``image_width`` x ``image_height`` image. The image is
+    lossless PNG unless its payload exceeded the size limit, in which case
+    it is JPEG at the same resolution.
+
+    Args:
+        base64_image: Base64-encoded image.
+        classes: Class names the model may predict.
+        image_width: Width of the uploaded image in pixels.
+        image_height: Height of the uploaded image in pixels.
+        media_type: Media type of the encoded image.
+        **kwargs: Ignored builder arguments shared across task types.
+
+    Returns:
+        Tuple of the system prompt (``None``) and the request messages.
+    """
+    class_list = ", ".join(classes)
+    prompt_text = OBJECT_DETECTION_PROMPT_TEMPLATE.format(
+        width=image_width,
+        height=image_height,
+        class_list=class_list,
+    )
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": media_type,
+                        "data": base64_image,
+                    },
+                },
+                {
+                    "type": "text",
+                    "text": prompt_text,
+                },
+            ],
+        }
+    ]
+    return None, messages
+
+
+PROMPT_BUILDERS = {
+    "unconstrained": prepare_unconstrained_prompt,
+    "ocr": prepare_ocr_prompt,
+    "visual-question-answering": prepare_vqa_prompt,
+    "caption": partial(prepare_caption_prompt, short_description=True),
+    "detailed-caption": partial(prepare_caption_prompt, short_description=False),
+    "classification": prepare_classification_prompt,
+    "multi-label-classification": prepare_multi_label_classification_prompt,
+    "structured-answering": prepare_structured_answering_prompt,
+    "object-detection": prepare_object_detection_prompt,
+}

--- a/inference/core/workflows/core_steps/models/foundation/anthropic_claude/v5.py
+++ b/inference/core/workflows/core_steps/models/foundation/anthropic_claude/v5.py
@@ -40,7 +40,6 @@ from inference.core.workflows.core_steps.common.utils import (
 from inference.core.workflows.core_steps.common.vlms import VLM_TASKS_METADATA
 from inference.core.workflows.core_steps.models.foundation.anthropic_claude.model_capabilities import (
     anthropic_model_supports_manual_thinking,
-    build_output_config,
     build_thinking_config,
     resolve_temperature,
 )
@@ -846,14 +845,13 @@ def _execute_proxied_claude_request(
         extended_thinking=extended_thinking,
         thinking_budget_tokens=thinking_budget_tokens,
         model_version=model_version,
-        model_max_output=model_max_output,
+        max_tokens=effective_max_tokens,
     )
     if thinking is not None:
         payload["thinking"] = thinking
 
-    output_config = build_output_config(reasoning_effort)
-    if output_config is not None:
-        payload["output_config"] = output_config
+    if reasoning_effort is not None:
+        payload["output_config"] = {"effort": reasoning_effort}
 
     endpoint = "apiproxy/anthropic"
 
@@ -920,14 +918,13 @@ def _execute_direct_claude_request(
         extended_thinking=extended_thinking,
         thinking_budget_tokens=thinking_budget_tokens,
         model_version=model_version,
-        model_max_output=model_max_output,
+        max_tokens=effective_max_tokens,
     )
     if thinking is not None:
         request_params["thinking"] = thinking
 
-    output_config = build_output_config(reasoning_effort)
-    if output_config is not None:
-        request_params["extra_body"] = {"output_config": output_config}
+    if reasoning_effort is not None:
+        request_params["extra_body"] = {"output_config": {"effort": reasoning_effort}}
 
     # Stream response to avoid max_tokens limitation
     with client.messages.stream(**request_params) as stream:

--- a/inference/core/workflows/core_steps/models/foundation/google_gemini/v5.py
+++ b/inference/core/workflows/core_steps/models/foundation/google_gemini/v5.py
@@ -59,9 +59,16 @@ MODEL_ALIASES = {
     "gemini-2.5-pro-preview-03-25": "gemini-2.5-pro",
 }
 
-# 3.7-flash probed 2026-08-25: API rejects `minimal`. 2.5 pages contradict
-# (`thinking_level` vs `thinking_budget` only); we keep 2.5 unsupported.
+# 3.7-flash probed 2026-08-25 and 3.8-flash probed 2026-09-02: API rejects
+# `minimal`. 2.5 pages contradict (`thinking_level` vs `thinking_budget` only);
+# we keep 2.5 unsupported.
 GEMINI_MODELS = [
+    {
+        "id": "gemini-3.8-flash",
+        "name": "Gemini 3.8 Flash",
+        "thinking_levels": ["low", "medium", "high"],
+        "supports_native_code_execution": True,
+    },
     {
         "id": "gemini-3.7-flash",
         "name": "Gemini 3.7 Flash",
@@ -322,8 +329,8 @@ class BlockManifest(WorkflowBlockManifest):
         description="Controls the depth of internal reasoning for Gemini 3+ models. "
         "'minimal' matches no-thinking for most queries, 'low' minimizes latency and cost, "
         "'medium' balances both, 'high' maximizes reasoning depth. Supported values differ "
-        "per model (see the model dropdown): Gemini 3.1 Pro and Gemini 3.7 Flash have no "
-        "'minimal'; Gemini 3.1 Pro also cannot disable thinking. When unset, the Google "
+        "per model (see the model dropdown): Gemini 3.1 Pro and Gemini 3.7/3.8 Flash have "
+        "no 'minimal'; Gemini 3.1 Pro also cannot disable thinking. When unset, the Google "
         "API default for the selected model is used (e.g. 'high' for Gemini 3.1 Pro, "
         "'medium' for Gemini 3.5/3.6 Flash). "
         "Not supported by the Gemini 2.5 series.",

--- a/inference/core/workflows/core_steps/models/foundation/llama_vision/v1.py
+++ b/inference/core/workflows/core_steps/models/foundation/llama_vision/v1.py
@@ -147,7 +147,11 @@ class BlockManifest(WorkflowBlockManifest):
             "name": "Llama 3.2 Vision",
             "version": "v1",
             "deprecated": True,
-            "deprecation_message": "Use the Llama 3.2 Vision v2 block, which adds a Roboflow-managed API key option and user-selectable privacy controls.",
+            "deprecation_message": (
+                "OpenRouter no longer hosts Llama 3.2 Vision. Use the Meta "
+                "block (`roboflow_core/meta_vlm@v2`) for Muse Spark and Muse "
+                "Glimmer."
+            ),
             "short_description": "Run Llama model with Vision capabilities",
             "long_description": LONG_DESCRIPTION,
             "license": "Llama 3.2 Community",

--- a/inference/core/workflows/core_steps/models/foundation/llama_vision/v2.py
+++ b/inference/core/workflows/core_steps/models/foundation/llama_vision/v2.py
@@ -33,10 +33,7 @@ from inference.core.workflows.prototypes.block import (
     third_party_model,
 )
 
-# OpenRouter currently only ships one Llama 3.2 vision variant (the paid 11B).
-# The :free tier and the 90B variant that the v1 block listed have all been
-# removed from OpenRouter's catalog (verified against /api/v1/models on the
-# branch's E2E test). We only ship the variant that actually responds.
+# Deprecated: OpenRouter has no live Llama 3.2 Vision endpoints left.
 MODEL_VERSION_MAPPING = {
     "11B - OpenRouter": "meta-llama/llama-3.2-11b-vision-instruct",
 }
@@ -83,6 +80,12 @@ class BlockManifest(OpenRouterBlockManifestMixin):
         json_schema_extra={
             "name": "Llama 3.2 Vision",
             "version": "v2",
+            "deprecated": True,
+            "deprecation_message": (
+                "OpenRouter no longer hosts Llama 3.2 Vision; the last 11B "
+                "endpoint has no live providers. Use the Meta block "
+                "(`roboflow_core/meta_vlm@v2`) for Muse Spark and Muse Glimmer."
+            ),
             "short_description": "Run Llama 3.2 Vision via OpenRouter.",
             "long_description": LONG_DESCRIPTION,
             "license": "Llama 3.2 Community License",

--- a/inference/core/workflows/core_steps/models/foundation/zai_vlm/v1.py
+++ b/inference/core/workflows/core_steps/models/foundation/zai_vlm/v1.py
@@ -1,10 +1,11 @@
 """Z.ai GLM vision-language block, v1.
 
-OpenRouter-only. Uses the vlm-exam request contract validated for
-GLM 5V Turbo: image-first user message, no system role, extended
-reasoning disabled by default, and the box_2d / 0-1000 xyxy detection
-prompt. Parse detection output with ``vlm_as_detector@v2`` using
-``model_type="zai"``.
+OpenRouter-only. Uses the vlm-exam request contract: image-first user
+message, no system role, extended reasoning disabled by default, and
+per-model xyxy / 0-1000 detection prompts (``box_2d`` key for GLM 5V
+Turbo, ``bbox_2d`` for GLM 5.3 Flash). Parse detection output with
+``vlm_as_detector@v2`` using ``model_type="zai"`` for Turbo and
+``model_type="zai-flash"`` for Flash.
 """
 
 import base64
@@ -76,18 +77,21 @@ ZAI_OBJECT_DETECTION_PROMPT_TEMPLATE = (
     "Only use these labels: {class_list}"
 )
 
-# Ported verbatim from vlm-exam's `_PROMPT_TEMPLATE`, the format pinned for
-# GLM 5.3 Flash (`yxyx_normalized_0_to_1000`). The full 250-image benchmark
-# scores it 0.331 dataset mAP@50 vs 0.219 for absolute-pixel bbox_2d
-# prompting, the next best format.
+# Ported verbatim from vlm-exam's `_BBOX_2D_NORMALIZED_PROMPT_TEMPLATE`,
+# the format pinned for GLM 5.3 Flash
+# (`xyxy_normalized_0_to_1000_bbox_2d`). Re-selected during the fp8-pinned
+# re-evaluation (the earlier yxyx box_2d pick came from runs that hit
+# quantized OpenRouter providers) and confirmed by a prompt-format sweep:
+# alternative containers and key names (bullets, "box", absolute pixels)
+# all score 36-70% below this Qwen-style template on the 250-image
+# benchmark.
 ZAI_FLASH_OBJECT_DETECTION_PROMPT_TEMPLATE = (
-    "Detect all objects in this image. "
-    "Output a JSON list where each entry contains the 2D bounding box "
-    'in the key "box_2d" and the text label in the key "label". '
-    'The "box_2d" value must be [y_min, x_min, y_max, x_max]: integers '
-    "between 0 and 1000, normalized to the image height and width. "
-    "Return only the JSON list, with no extra text. "
-    "Only use these labels: {class_list}"
+    "Detect all objects in this image and return their locations in the "
+    "form of coordinates. The format of output should be like "
+    '{{"bbox_2d": [x1, y1, x2, y2], "label": "<name>"}}. '
+    "bbox_2d is [xmin, ymin, xmax, ymax] as integers between 0 and 1000, "
+    "normalized to image width and height. "
+    "Only use these labels: {class_list}. Return a JSON array only."
 )
 
 # One row per model; add future Z.ai models here. A row may override
@@ -95,8 +99,9 @@ ZAI_FLASH_OBJECT_DETECTION_PROMPT_TEMPLATE = (
 # `reasoning_required` marks models that reject `reasoning: {enabled:
 # false}` and fall back to low effort when the user disables reasoning.
 # `detection_model_type` is the `vlm_as_detector@v2` model_type that parses
-# the model's detection output; the two GLM models emit the same "box_2d"
-# key with different axis orders, so each needs its own parser entry.
+# the model's detection output; both GLM models emit xyxy 0-1000 boxes but
+# with different key names ("box_2d" for Turbo, "bbox_2d" for Flash), so
+# each keeps its own model_type.
 MODEL_VARIANTS: Dict[str, Dict[str, Any]] = {
     "GLM 5V Turbo": {
         "model_id": "z-ai/glm-5v-turbo",
@@ -440,12 +445,11 @@ You can specify arbitrary text prompts or predefined ones. The block supports:
 {RELEVANT_TASKS_DOCS_DESCRIPTION}
 
 Object detection uses the per-model format validated in the vlm-exam
-benchmarks. Both models emit `box_2d`/`label` entries normalized to
-0-1000, but with different axis orders: GLM 5V Turbo uses
-`[x_min, y_min, x_max, y_max]` and GLM 5.3 Flash uses
-`[y_min, x_min, y_max, x_max]`. Parse with `VLM as Detector`
-(`vlm_as_detector@v2`) using `model_type="zai"` for GLM 5V Turbo and
-`model_type="zai-flash"` for GLM 5.3 Flash.
+benchmarks. Both models emit `[x_min, y_min, x_max, y_max]` boxes as
+integers normalized to 0-1000, but with different key names: GLM 5V
+Turbo uses `box_2d` and GLM 5.3 Flash uses `bbox_2d`. Parse with
+`VLM as Detector` (`vlm_as_detector@v2`) using `model_type="zai"` for
+GLM 5V Turbo and `model_type="zai-flash"` for GLM 5.3 Flash.
 
 Every request sends the image before the instruction text in a single user
 message. GLM models default to extended reasoning on OpenRouter; the block

--- a/tests/workflows/unit_tests/core_steps/common/test_openrouter.py
+++ b/tests/workflows/unit_tests/core_steps/common/test_openrouter.py
@@ -12,6 +12,7 @@ from inference.core.exceptions import (
     RoboflowAPIUnsuccessfulRequestError,
 )
 from inference.core.workflows.core_steps.common.openrouter import (
+    MODEL_NATIVE_QUANTIZATIONS,
     OpenRouterResult,
     OpenRouterWorkflowBlockBase,
     _execute_direct_openrouter_request,
@@ -19,6 +20,7 @@ from inference.core.workflows.core_steps.common.openrouter import (
     _is_unsupported_reasoning_error,
     build_prompts_from_images,
     build_provider_routing,
+    get_native_quantizations,
     validate_task_type_required_fields,
 )
 
@@ -70,6 +72,44 @@ def test_build_provider_routing_zdr_returns_zdr_and_deny():
 def test_build_provider_routing_unknown_raises():
     with pytest.raises(ValueError, match="unknown privacy_level"):
         build_provider_routing("nope")
+
+
+def test_build_provider_routing_merges_quantizations_with_privacy_filter():
+    assert build_provider_routing("allow", quantizations=["bf16", "fp32"]) == {
+        "quantizations": ["bf16", "fp32"]
+    }
+    assert build_provider_routing("deny", quantizations=["fp8", "bf16", "fp32"]) == {
+        "data_collection": "deny",
+        "quantizations": ["fp8", "bf16", "fp32"],
+    }
+
+
+# ---------------------------------------------------------------------------
+# get_native_quantizations
+# ---------------------------------------------------------------------------
+
+
+def test_get_native_quantizations_returns_none_for_unregistered_model():
+    # Deliberate: registering these `unknown`-precision SKUs would make them
+    # unroutable.
+    for slug in (
+        "meta/muse-spark-1.1",
+        "meta/muse-spark-1.2",
+        "qwen/qwen3.8-max",
+        "qwen/qwen3.8-flash",
+        "qwen/qwen3.7-plus",
+        "qwen/qwen3.5-flash-02-23",
+        "z-ai/glm-5v-turbo",
+        "deepseek/deepseek-v4-flash-vision-exp",
+        "moonshotai/kimi-k2.6",
+    ):
+        assert get_native_quantizations(model=slug) is None, slug
+
+
+def test_native_quantization_registry_never_allows_below_fp8():
+    # Sub-FP8 labels would break the registry's native-or-higher guarantee.
+    for slug, allowlist in MODEL_NATIVE_QUANTIZATIONS.items():
+        assert not {"int4", "int8", "fp4", "fp6", "unknown"} & set(allowlist), slug
 
 
 # ---------------------------------------------------------------------------
@@ -188,6 +228,42 @@ def test_execute_openrouter_batch_routes_to_direct_for_user_key(
     kwargs = mock_direct.call_args.kwargs
     assert kwargs["api_key"] == "sk-or-v1-abcdef"
     assert kwargs["privacy_level"] == "zdr"
+
+
+@patch(
+    "inference.core.workflows.core_steps.common.openrouter._execute_proxied_openrouter_request"
+)
+@patch(
+    "inference.core.workflows.core_steps.common.openrouter._execute_direct_openrouter_request"
+)
+def test_execute_openrouter_batch_attaches_native_quantizations(
+    mock_direct, mock_proxied
+):
+    """Registered models get the central allowlist on both routing paths."""
+    mock_direct.side_effect = [OpenRouterResult(content="d")]
+    mock_proxied.side_effect = [OpenRouterResult(content="p")]
+    block = _FakeBlock(model_manager=MagicMock(), api_key="ws-key")
+    common = dict(
+        prompts=[[{"role": "user", "content": "hi"}]],
+        max_tokens=50,
+        temperature=0.1,
+        privacy_level="deny",
+        max_concurrent_requests=1,
+    )
+
+    block.execute_openrouter_batch(
+        openrouter_api_key="sk-or-v1-abcdef",
+        model="google/gemma-4-31b-it",
+        **common,
+    )
+    block.execute_openrouter_batch(
+        openrouter_api_key="rf_key:account",
+        model="z-ai/glm-5.3-flash",
+        **common,
+    )
+
+    assert mock_direct.call_args.kwargs["quantizations"] == ("bf16", "fp32")
+    assert mock_proxied.call_args.kwargs["quantizations"] == ("fp8", "bf16", "fp32")
 
 
 # ---------------------------------------------------------------------------
@@ -420,6 +496,74 @@ def test_direct_request_omits_provider_when_allow(mock_openai_cls):
 
 
 @patch("inference.core.workflows.core_steps.common.openrouter.OpenAI")
+def test_direct_request_injects_quantizations_into_provider(mock_openai_cls):
+    client = MagicMock()
+    client.chat.completions.create.return_value = _stub_openai_response("ok")
+    mock_openai_cls.return_value = client
+
+    _execute_direct_openrouter_request(
+        api_key="sk-or-v1-test",
+        model="google/gemma-4-31b-it",
+        messages=[],
+        max_tokens=1,
+        temperature=0.0,
+        privacy_level="deny",
+        quantizations=["bf16", "fp32"],
+    )
+
+    create_kwargs = client.chat.completions.create.call_args.kwargs
+    assert create_kwargs["extra_body"] == {
+        "provider": {
+            "data_collection": "deny",
+            "quantizations": ["bf16", "fp32"],
+        },
+    }
+
+
+@patch("inference.core.workflows.core_steps.common.openrouter.OpenAI")
+def test_direct_request_sends_quantizations_even_when_privacy_allows(mock_openai_cls):
+    """`allow` normally omits the provider object entirely; the quantization
+    allowlist must still be delivered."""
+    client = MagicMock()
+    client.chat.completions.create.return_value = _stub_openai_response("ok")
+    mock_openai_cls.return_value = client
+
+    _execute_direct_openrouter_request(
+        api_key="sk-or-v1-test",
+        model="google/gemma-4-31b-it",
+        messages=[],
+        max_tokens=1,
+        temperature=0.0,
+        privacy_level="allow",
+        quantizations=["bf16", "fp32"],
+    )
+
+    create_kwargs = client.chat.completions.create.call_args.kwargs
+    assert create_kwargs["extra_body"] == {
+        "provider": {"quantizations": ["bf16", "fp32"]},
+    }
+
+
+@patch("inference.core.workflows.core_steps.common.openrouter.post_to_roboflow_api")
+def test_proxied_request_forwards_quantizations_in_payload(mock_post):
+    mock_post.return_value = {"choices": [{"message": {"content": "ok"}}]}
+
+    _execute_proxied_openrouter_request(
+        roboflow_api_key="ws-key",
+        openrouter_api_key="rf_key:account",
+        model="z-ai/glm-5.3-flash",
+        messages=[{"role": "user", "content": "hi"}],
+        max_tokens=10,
+        temperature=0.1,
+        privacy_level="deny",
+        quantizations=["fp8", "bf16", "fp32"],
+    )
+
+    payload = mock_post.call_args.kwargs["payload"]
+    assert payload["quantizations"] == ["fp8", "bf16", "fp32"]
+
+
+@patch("inference.core.workflows.core_steps.common.openrouter.OpenAI")
 def test_direct_request_raises_when_choices_none(mock_openai_cls):
     response = MagicMock()
     response.choices = None
@@ -582,6 +726,32 @@ def test_proxied_request_retries_without_reasoning_on_rejection(mock_post, mock_
     assert "reasoning" in mock_post.call_args_list[0].kwargs["payload"]
     assert "reasoning" not in mock_post.call_args_list[1].kwargs["payload"]
     assert mock_logger.warning.call_count == 1
+
+
+@patch("inference.core.workflows.core_steps.common.openrouter.logger")
+@patch("inference.core.workflows.core_steps.common.openrouter.post_to_roboflow_api")
+def test_proxied_retry_without_reasoning_keeps_quantizations(mock_post, mock_logger):
+    """Dropping a rejected reasoning config must not drop the precision filter."""
+    mock_post.side_effect = [
+        _proxy_error(MANDATORY_REASONING_ERROR, status_code=400),
+        {"choices": [{"message": {"content": "ok"}}]},
+    ]
+
+    _execute_proxied_openrouter_request(
+        roboflow_api_key="ws-key",
+        openrouter_api_key="rf_key:account",
+        model="z-ai/glm-5.3-flash",
+        messages=[{"role": "user", "content": "hi"}],
+        max_tokens=100,
+        temperature=None,
+        privacy_level="deny",
+        reasoning={"enabled": False},
+        quantizations=["fp8", "bf16", "fp32"],
+    )
+
+    retry_payload = mock_post.call_args_list[1].kwargs["payload"]
+    assert "reasoning" not in retry_payload
+    assert retry_payload["quantizations"] == ["fp8", "bf16", "fp32"]
 
 
 @patch("inference.core.workflows.core_steps.common.openrouter.post_to_roboflow_api")

--- a/tests/workflows/unit_tests/core_steps/common/test_reasoning_contract.py
+++ b/tests/workflows/unit_tests/core_steps/common/test_reasoning_contract.py
@@ -7,6 +7,9 @@ from inference.core.workflows.core_steps.common.reasoning import (
     REASONING_EFFORT_OPTIONS,
     validate_reasoning_level,
 )
+from inference.core.workflows.core_steps.models.foundation.anthropic_claude import (
+    v5 as anthropic_v5,
+)
 from inference.core.workflows.core_steps.models.foundation.google_gemini import (
     v5 as gemini_v5,
 )
@@ -98,6 +101,12 @@ BLOCK_CONTRACTS = {
         zai_vlm_v1.MODEL_VERSION_METADATA,
         zai_vlm_v1.DEFAULT_REASONING_EFFORT,
     ),
+    "anthropic_claude@v5": (
+        anthropic_v5.MODEL_REASONING_EFFORT_VALUES,
+        anthropic_v5.REASONING_EFFORT_VALUES,
+        anthropic_v5.MODEL_VERSION_METADATA,
+        None,
+    ),
 }
 
 
@@ -152,6 +161,7 @@ _MANIFESTS = {
     "spacexai@v2": spacexai_v2.BlockManifest,
     "meta_vlm@v2": meta_vlm_v2.BlockManifest,
     "qwen_vlm@v3": qwen_vlm_v3.BlockManifest,
+    "anthropic_claude@v5": anthropic_v5.BlockManifest,
 }
 
 
@@ -175,6 +185,14 @@ def _manifest(block_type: str, **overrides):
         ("open_ai@v6", {"model_version": "$inputs.model", "reasoning_effort": "xhigh"}),
         ("open_ai@v6", {"model_version": "gpt-4o"}),
         ("qwen_vlm@v3", {"backend": "native"}),
+        (
+            "anthropic_claude@v5",
+            {"model_version": "claude-fable-5-1", "reasoning_effort": "medium"},
+        ),
+        (
+            "anthropic_claude@v5",
+            {"model_version": "$inputs.model", "reasoning_effort": "xhigh"},
+        ),
     ],
 )
 def test_manifest_accepts_edges_rejects_cannot_cover(block_type, overrides):
@@ -206,6 +224,14 @@ def test_manifest_accepts_edges_rejects_cannot_cover(block_type, overrides):
         (
             "meta_vlm@v2",
             {"model_version": "Muse Glimmer", "reasoning_effort": "minimal"},
+        ),
+        (
+            "anthropic_claude@v5",
+            {"model_version": "claude-sonnet-4-5", "reasoning_effort": "high"},
+        ),
+        (
+            "anthropic_claude@v5",
+            {"model_version": "claude-opus-4-6", "reasoning_effort": "xhigh"},
         ),
     ],
 )

--- a/tests/workflows/unit_tests/core_steps/common/test_reasoning_contract.py
+++ b/tests/workflows/unit_tests/core_steps/common/test_reasoning_contract.py
@@ -196,6 +196,10 @@ def test_manifest_accepts_edges_rejects_cannot_cover(block_type, overrides):
         ),
         (
             "google_gemini@v5",
+            {"model_version": "gemini-3.8-flash", "thinking_level": "minimal"},
+        ),
+        (
+            "google_gemini@v5",
             {"model_version": "gemini-2.5-pro", "thinking_level": "low"},
         ),
         ("spacexai@v2", {"model_version": "grok-4.5", "reasoning_effort": "xhigh"}),

--- a/tests/workflows/unit_tests/core_steps/common/test_token_usage.py
+++ b/tests/workflows/unit_tests/core_steps/common/test_token_usage.py
@@ -20,6 +20,7 @@ NEW_BLOCK_MODULES = [
     f"{_FOUNDATION}.meta_vlm.v2",
     f"{_FOUNDATION}.qwen_vlm.v3",
     f"{_FOUNDATION}.anthropic_claude.v4",
+    f"{_FOUNDATION}.anthropic_claude.v5",
     f"{_FOUNDATION}.google_gemini.v5",
     f"{_FOUNDATION}.openai.v6",
     f"{_FOUNDATION}.spacexai.v2",

--- a/tests/workflows/unit_tests/core_steps/formatters/vlm_as_detector/test_v2.py
+++ b/tests/workflows/unit_tests/core_steps/formatters/vlm_as_detector/test_v2.py
@@ -503,10 +503,10 @@ def test_run_method_for_zai_box_2d_output() -> None:
     assert np.allclose(result["predictions"].confidence, np.array([1.0, 1.0]))
 
 
-def test_run_method_for_zai_flash_yxyx_box_2d_output() -> None:
-    # given - the GLM 5.3 Flash prompt pins box_2d entries as
-    # [y_min, x_min, y_max, x_max] integers normalized to 0-1000
-    # (the Gemini contract)
+def test_run_method_for_zai_flash_xyxy_bbox_2d_output() -> None:
+    # given - the GLM 5.3 Flash prompt pins bbox_2d entries as
+    # [x_min, y_min, x_max, y_max] integers normalized to 0-1000
+    # (the Qwen contract)
     block = VLMAsDetectorBlockV2()
     image = WorkflowImageData(
         numpy_image=np.zeros((480, 640, 3), dtype=np.uint8),
@@ -514,8 +514,8 @@ def test_run_method_for_zai_flash_yxyx_box_2d_output() -> None:
     )
     vlm_output = """
 [
-  {"box_2d": [100, 200, 500, 1000], "label": "cat"},
-  {"box_2d": [0, 0, 500, 500], "label": "unicorn"}
+  {"bbox_2d": [200, 100, 1000, 500], "label": "cat"},
+  {"bbox_2d": [0, 0, 500, 500], "label": "unicorn"}
 ]
     """
 
@@ -554,7 +554,7 @@ def test_run_method_for_zai_flash_recovers_array_from_prose_wrapped_output() -> 
     )
     vlm_output = (
         "Here are the detected objects: "
-        '[{"box_2d": [100, 200, 500, 1000], "label": "cat"}] '
+        '[{"bbox_2d": [200, 100, 1000, 500], "label": "cat"}] '
         "Let me know if you need anything else."
     )
 

--- a/tests/workflows/unit_tests/core_steps/formatters/vlm_as_detector/test_v2_tensor.py
+++ b/tests/workflows/unit_tests/core_steps/formatters/vlm_as_detector/test_v2_tensor.py
@@ -330,10 +330,10 @@ def test_run_method_for_zai_box_2d_output_tensor_native() -> None:
     )
 
 
-def test_run_method_for_zai_flash_yxyx_box_2d_output_tensor_native() -> None:
-    # given - the GLM 5.3 Flash prompt pins box_2d entries as
-    # [y_min, x_min, y_max, x_max] integers normalized to 0-1000
-    # (the Gemini contract)
+def test_run_method_for_zai_flash_xyxy_bbox_2d_output_tensor_native() -> None:
+    # given - the GLM 5.3 Flash prompt pins bbox_2d entries as
+    # [x_min, y_min, x_max, y_max] integers normalized to 0-1000
+    # (the Qwen contract)
     block = VLMAsDetectorBlockV2()
     image = WorkflowImageData(
         numpy_image=np.zeros((480, 640, 3), dtype=np.uint8),
@@ -341,8 +341,8 @@ def test_run_method_for_zai_flash_yxyx_box_2d_output_tensor_native() -> None:
     )
     vlm_output = """
 [
-  {"box_2d": [100, 200, 500, 1000], "label": "cat"},
-  {"box_2d": [0, 0, 500, 500], "label": "unicorn"}
+  {"bbox_2d": [200, 100, 1000, 500], "label": "cat"},
+  {"bbox_2d": [0, 0, 500, 500], "label": "unicorn"}
 ]
     """
 

--- a/tests/workflows/unit_tests/core_steps/models/foundation/test_anthropic_claude.py
+++ b/tests/workflows/unit_tests/core_steps/models/foundation/test_anthropic_claude.py
@@ -36,6 +36,9 @@ from inference.core.workflows.core_steps.models.foundation.anthropic_claude.v4 i
 from inference.core.workflows.core_steps.models.foundation.anthropic_claude.v4 import (
     execute_claude_request as execute_claude_request_v4,
 )
+from inference.core.workflows.core_steps.models.foundation.anthropic_claude.v5 import (
+    execute_claude_request as execute_claude_request_v5,
+)
 
 
 def test_claude_step_validation_when_input_is_valid() -> None:
@@ -849,6 +852,7 @@ def test_v2_direct_request_translates_controls_for_new_generation_model(
     [
         (execute_claude_request_v3, "v3"),
         (execute_claude_request_v4, "v4"),
+        (execute_claude_request_v5, "v5"),
     ],
 )
 def test_direct_request_keeps_legacy_controls_for_legacy_model(
@@ -900,6 +904,7 @@ def test_direct_request_keeps_legacy_controls_for_legacy_model(
     [
         (execute_claude_request_v3, "v3"),
         (execute_claude_request_v4, "v4"),
+        (execute_claude_request_v5, "v5"),
     ],
 )
 def test_direct_request_translates_controls_for_new_generation_model(
@@ -959,6 +964,7 @@ PROXY_RESPONSE = {
     [
         (execute_claude_request_v3, "v3"),
         (execute_claude_request_v4, "v4"),
+        (execute_claude_request_v5, "v5"),
     ],
 )
 def test_proxied_request_keeps_legacy_controls_for_legacy_model(
@@ -1010,6 +1016,7 @@ def test_proxied_request_keeps_legacy_controls_for_legacy_model(
     [
         (execute_claude_request_v3, "v3"),
         (execute_claude_request_v4, "v4"),
+        (execute_claude_request_v5, "v5"),
     ],
 )
 def test_proxied_request_translates_controls_for_new_generation_model(

--- a/tests/workflows/unit_tests/core_steps/models/foundation/test_anthropic_claude.py
+++ b/tests/workflows/unit_tests/core_steps/models/foundation/test_anthropic_claude.py
@@ -2,8 +2,12 @@ from typing import Any
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
+from anthropic import NOT_GIVEN
 from pydantic import ValidationError
 
+from inference.core.workflows.core_steps.models.foundation.anthropic_claude.v1 import (
+    execute_claude_request as execute_claude_request_v1,
+)
 from inference.core.workflows.core_steps.models.foundation.anthropic_claude.v2 import (
     DEFAULT_MAX_OUTPUT_TOKENS,
     EXACT_MODEL_VERSIONS,
@@ -16,6 +20,21 @@ from inference.core.workflows.core_steps.models.foundation.anthropic_claude.v3 i
 )
 from inference.core.workflows.core_steps.models.foundation.anthropic_claude.v3 import (
     MAX_OUTPUT_TOKENS as MAX_OUTPUT_TOKENS_V3,
+)
+from inference.core.workflows.core_steps.models.foundation.anthropic_claude.v3 import (
+    execute_claude_request as execute_claude_request_v3,
+)
+from inference.core.workflows.core_steps.models.foundation.anthropic_claude.v4 import (
+    EXACT_MODEL_VERSIONS as EXACT_MODEL_VERSIONS_V4,
+)
+from inference.core.workflows.core_steps.models.foundation.anthropic_claude.v4 import (
+    MAX_OUTPUT_TOKENS as MAX_OUTPUT_TOKENS_V4,
+)
+from inference.core.workflows.core_steps.models.foundation.anthropic_claude.v4 import (
+    BlockManifest as BlockManifestV4,
+)
+from inference.core.workflows.core_steps.models.foundation.anthropic_claude.v4 import (
+    execute_claude_request as execute_claude_request_v4,
 )
 
 
@@ -373,6 +392,27 @@ def test_v3_claude_fable_model_metadata() -> None:
     assert EXACT_MODEL_VERSIONS_V3["claude-fable-5"] == "claude-fable-5"
 
 
+def test_v4_claude_fable_5_1_model_metadata() -> None:
+    # given
+    specification = {
+        "type": "roboflow_core/anthropic_claude@v4",
+        "name": "step_1",
+        "images": "$inputs.image",
+        "task_type": "unconstrained",
+        "prompt": "This is my prompt",
+        "api_key": "$inputs.anthropic_api_key",
+        "model_version": "claude-fable-5-1",
+    }
+
+    # when
+    result = BlockManifestV4.model_validate(specification)
+
+    # then
+    assert result.model_version == "claude-fable-5-1"
+    assert EXACT_MODEL_VERSIONS_V4["claude-fable-5-1"] == "claude-fable-5-1"
+    assert MAX_OUTPUT_TOKENS_V4["claude-fable-5-1"] == 128000
+
+
 @patch(
     "inference.core.workflows.core_steps.models.foundation.anthropic_claude.v2.anthropic.Anthropic"
 )
@@ -691,3 +731,324 @@ def test_execute_claude_request_stop_sequence_is_valid(
 
     # then - stop_sequence is a valid stop reason
     assert result == "Response before stop sequence"
+
+
+# --- temperature / thinking handling per model generation -------------------
+#
+# Claude Opus 4.7+, Sonnet 5, Opus 5 and the Fable line reject `temperature`
+# and `thinking.type=enabled`; older models still take both. The request that
+# leaves the block must differ accordingly on every code path (v1 direct, v2
+# direct, v3/v4 direct and v3/v4 Roboflow proxy).
+
+LEGACY_MODEL = "claude-sonnet-4-5"
+NEW_GENERATION_MODEL = "claude-opus-4-7"
+
+
+def _mock_streaming_client(mock_anthropic_class: Mock, text: str = "ok") -> MagicMock:
+    mock_client = MagicMock()
+    mock_anthropic_class.return_value = mock_client
+
+    mock_text_block = Mock()
+    mock_text_block.type = "text"
+    mock_text_block.text = text
+
+    mock_result = Mock()
+    mock_result.stop_reason = "end_turn"
+    mock_result.content = [mock_text_block]
+    mock_result.usage = Mock(input_tokens=11, output_tokens=7)
+
+    mock_stream = MagicMock()
+    mock_stream.__enter__ = Mock(return_value=mock_stream)
+    mock_stream.__exit__ = Mock(return_value=False)
+    mock_stream.get_final_message.return_value = mock_result
+    mock_client.messages.stream.return_value = mock_stream
+    mock_client.messages.create.return_value = mock_result
+    return mock_client
+
+
+def _is_not_given(value: Any) -> bool:
+    return value is NOT_GIVEN
+
+
+@patch(
+    "inference.core.workflows.core_steps.models.foundation.anthropic_claude.v1.anthropic.Anthropic"
+)
+def test_v1_forwards_temperature_for_legacy_model(mock_anthropic_class: Mock) -> None:
+    # given
+    mock_client = _mock_streaming_client(mock_anthropic_class)
+
+    # when
+    execute_claude_request_v1(
+        system_prompt=None,
+        messages=[{"role": "user", "content": "Hello"}],
+        model_version=LEGACY_MODEL,
+        max_tokens=100,
+        temperature=0.4,
+        api_key="test-key",
+    )
+
+    # then
+    assert mock_client.messages.create.call_args.kwargs["temperature"] == 0.4
+
+
+@patch(
+    "inference.core.workflows.core_steps.models.foundation.anthropic_claude.v1.anthropic.Anthropic"
+)
+def test_v1_drops_temperature_for_new_generation_model(
+    mock_anthropic_class: Mock,
+) -> None:
+    # given
+    mock_client = _mock_streaming_client(mock_anthropic_class)
+
+    # when
+    execute_claude_request_v1(
+        system_prompt=None,
+        messages=[{"role": "user", "content": "Hello"}],
+        model_version=NEW_GENERATION_MODEL,
+        max_tokens=100,
+        temperature=0.4,
+        api_key="test-key",
+    )
+
+    # then
+    call_kwargs = mock_client.messages.create.call_args.kwargs
+    assert _is_not_given(call_kwargs["temperature"])
+    assert call_kwargs["model"] == NEW_GENERATION_MODEL
+
+
+@patch(
+    "inference.core.workflows.core_steps.models.foundation.anthropic_claude.v2.anthropic.Anthropic"
+)
+def test_v2_direct_request_translates_controls_for_new_generation_model(
+    mock_anthropic_class: Mock,
+) -> None:
+    # given
+    mock_client = _mock_streaming_client(mock_anthropic_class)
+
+    # when - a budget and a temperature are configured but the model takes neither
+    execute_claude_request(
+        system_prompt=None,
+        messages=[{"role": "user", "content": "Think"}],
+        model_version=NEW_GENERATION_MODEL,
+        max_tokens=None,
+        temperature=0.4,
+        extended_thinking=True,
+        thinking_budget_tokens=5000,
+        api_key="test-key",
+    )
+
+    # then
+    call_kwargs = mock_client.messages.stream.call_args.kwargs
+    assert call_kwargs["thinking"] == {"type": "adaptive"}
+    assert _is_not_given(call_kwargs["temperature"])
+    assert call_kwargs["max_tokens"] == 128000
+
+
+@pytest.mark.parametrize(
+    "execute_request, module",
+    [
+        (execute_claude_request_v3, "v3"),
+        (execute_claude_request_v4, "v4"),
+    ],
+)
+def test_direct_request_keeps_legacy_controls_for_legacy_model(
+    execute_request: Any, module: str
+) -> None:
+    with patch(
+        f"inference.core.workflows.core_steps.models.foundation.anthropic_claude.{module}.anthropic.Anthropic"
+    ) as mock_anthropic_class:
+        # given
+        mock_client = _mock_streaming_client(mock_anthropic_class)
+
+        # when - thinking off, temperature on
+        execute_request(
+            roboflow_api_key=None,
+            anthropic_api_key="sk-ant-test",
+            system_prompt=None,
+            messages=[{"role": "user", "content": "Hello"}],
+            model_version=LEGACY_MODEL,
+            max_tokens=100,
+            temperature=0.4,
+            extended_thinking=None,
+            thinking_budget_tokens=None,
+        )
+        no_thinking_kwargs = mock_client.messages.stream.call_args.kwargs
+
+        # when - thinking on with an explicit budget
+        execute_request(
+            roboflow_api_key=None,
+            anthropic_api_key="sk-ant-test",
+            system_prompt=None,
+            messages=[{"role": "user", "content": "Think"}],
+            model_version=LEGACY_MODEL,
+            max_tokens=10000,
+            temperature=0.4,
+            extended_thinking=True,
+            thinking_budget_tokens=5000,
+        )
+        thinking_kwargs = mock_client.messages.stream.call_args.kwargs
+
+    # then
+    assert no_thinking_kwargs["temperature"] == 0.4
+    assert "thinking" not in no_thinking_kwargs
+    assert _is_not_given(thinking_kwargs["temperature"])
+    assert thinking_kwargs["thinking"] == {"type": "enabled", "budget_tokens": 5000}
+
+
+@pytest.mark.parametrize(
+    "execute_request, module",
+    [
+        (execute_claude_request_v3, "v3"),
+        (execute_claude_request_v4, "v4"),
+    ],
+)
+def test_direct_request_translates_controls_for_new_generation_model(
+    execute_request: Any, module: str
+) -> None:
+    with patch(
+        f"inference.core.workflows.core_steps.models.foundation.anthropic_claude.{module}.anthropic.Anthropic"
+    ) as mock_anthropic_class:
+        # given
+        mock_client = _mock_streaming_client(mock_anthropic_class)
+
+        # when - temperature configured, thinking off
+        execute_request(
+            roboflow_api_key=None,
+            anthropic_api_key="sk-ant-test",
+            system_prompt=None,
+            messages=[{"role": "user", "content": "Hello"}],
+            model_version=NEW_GENERATION_MODEL,
+            max_tokens=100,
+            temperature=0.4,
+            extended_thinking=None,
+            thinking_budget_tokens=None,
+        )
+        no_thinking_kwargs = mock_client.messages.stream.call_args.kwargs
+
+        # when - thinking on with a budget the model cannot take
+        execute_request(
+            roboflow_api_key=None,
+            anthropic_api_key="sk-ant-test",
+            system_prompt=None,
+            messages=[{"role": "user", "content": "Think"}],
+            model_version=NEW_GENERATION_MODEL,
+            max_tokens=None,
+            temperature=None,
+            extended_thinking=True,
+            thinking_budget_tokens=5000,
+        )
+        thinking_kwargs = mock_client.messages.stream.call_args.kwargs
+
+    # then
+    assert _is_not_given(no_thinking_kwargs["temperature"])
+    assert "thinking" not in no_thinking_kwargs
+    assert no_thinking_kwargs["model"] == NEW_GENERATION_MODEL
+    assert thinking_kwargs["thinking"] == {"type": "adaptive"}
+    assert thinking_kwargs["max_tokens"] == 128000
+
+
+PROXY_RESPONSE = {
+    "stop_reason": "end_turn",
+    "content": [{"type": "text", "text": "proxied"}],
+    "usage": {"input_tokens": 3, "output_tokens": 2},
+}
+
+
+@pytest.mark.parametrize(
+    "execute_request, module",
+    [
+        (execute_claude_request_v3, "v3"),
+        (execute_claude_request_v4, "v4"),
+    ],
+)
+def test_proxied_request_keeps_legacy_controls_for_legacy_model(
+    execute_request: Any, module: str
+) -> None:
+    with patch(
+        f"inference.core.workflows.core_steps.models.foundation.anthropic_claude.{module}.post_to_roboflow_api",
+        return_value=PROXY_RESPONSE,
+    ) as post_mock:
+        # when
+        execute_request(
+            roboflow_api_key="rf-key",
+            anthropic_api_key="rf_key:account",
+            system_prompt="sys",
+            messages=[{"role": "user", "content": "Hello"}],
+            model_version=LEGACY_MODEL,
+            max_tokens=100,
+            temperature=0.4,
+            extended_thinking=None,
+            thinking_budget_tokens=None,
+        )
+        plain_payload = post_mock.call_args.kwargs["payload"]
+
+        execute_request(
+            roboflow_api_key="rf-key",
+            anthropic_api_key="rf_key:account",
+            system_prompt=None,
+            messages=[{"role": "user", "content": "Think"}],
+            model_version=LEGACY_MODEL,
+            max_tokens=None,
+            temperature=0.4,
+            extended_thinking=True,
+            thinking_budget_tokens=None,
+        )
+        thinking_payload = post_mock.call_args.kwargs["payload"]
+
+    # then
+    assert plain_payload["model"] == LEGACY_MODEL
+    assert plain_payload["temperature"] == 0.4
+    assert plain_payload["system"] == "sys"
+    assert "thinking" not in plain_payload
+    assert "temperature" not in thinking_payload
+    assert thinking_payload["thinking"] == {"type": "enabled", "budget_tokens": 32000}
+    assert thinking_payload["max_tokens"] == 64000
+
+
+@pytest.mark.parametrize(
+    "execute_request, module",
+    [
+        (execute_claude_request_v3, "v3"),
+        (execute_claude_request_v4, "v4"),
+    ],
+)
+def test_proxied_request_translates_controls_for_new_generation_model(
+    execute_request: Any, module: str
+) -> None:
+    with patch(
+        f"inference.core.workflows.core_steps.models.foundation.anthropic_claude.{module}.post_to_roboflow_api",
+        return_value=PROXY_RESPONSE,
+    ) as post_mock:
+        # when
+        execute_request(
+            roboflow_api_key="rf-key",
+            anthropic_api_key="rf_key:account",
+            system_prompt=None,
+            messages=[{"role": "user", "content": "Hello"}],
+            model_version=NEW_GENERATION_MODEL,
+            max_tokens=100,
+            temperature=0.4,
+            extended_thinking=None,
+            thinking_budget_tokens=None,
+        )
+        plain_payload = post_mock.call_args.kwargs["payload"]
+
+        execute_request(
+            roboflow_api_key="rf-key",
+            anthropic_api_key="rf_key:account",
+            system_prompt=None,
+            messages=[{"role": "user", "content": "Think"}],
+            model_version=NEW_GENERATION_MODEL,
+            max_tokens=None,
+            temperature=None,
+            extended_thinking=True,
+            thinking_budget_tokens=5000,
+        )
+        thinking_payload = post_mock.call_args.kwargs["payload"]
+
+    # then
+    assert plain_payload["model"] == NEW_GENERATION_MODEL
+    assert "temperature" not in plain_payload
+    assert "thinking" not in plain_payload
+    assert thinking_payload["thinking"] == {"type": "adaptive"}
+    assert thinking_payload["max_tokens"] == 128000

--- a/tests/workflows/unit_tests/core_steps/models/foundation/test_anthropic_claude_model_capabilities.py
+++ b/tests/workflows/unit_tests/core_steps/models/foundation/test_anthropic_claude_model_capabilities.py
@@ -8,7 +8,6 @@ from inference.core.workflows.core_steps.models.foundation.anthropic_claude impo
 from inference.core.workflows.core_steps.models.foundation.anthropic_claude.model_capabilities import (
     anthropic_model_supports_manual_thinking,
     anthropic_model_supports_temperature,
-    build_output_config,
     build_thinking_config,
     normalize_anthropic_model_id,
     resolve_temperature,
@@ -87,13 +86,13 @@ def test_build_thinking_config_uses_adaptive_and_ignores_budget_with_single_warn
             extended_thinking=True,
             thinking_budget_tokens=5000,
             model_version="claude-fable-5-1",
-            model_max_output=128000,
+            max_tokens=128000,
         )
         second = build_thinking_config(
             extended_thinking=True,
             thinking_budget_tokens=7000,
             model_version="claude-fable-5-1-20260901",
-            model_max_output=128000,
+            max_tokens=128000,
         )
 
     assert first == {"type": "adaptive"}
@@ -102,10 +101,22 @@ def test_build_thinking_config_uses_adaptive_and_ignores_budget_with_single_warn
     assert "thinking_budget_tokens=5000" in caplog.records[0].getMessage()
 
 
-def test_build_output_config_omits_when_effort_unset() -> None:
-    assert build_output_config(None) is None
+@pytest.mark.parametrize(
+    "max_tokens, expected_budget",
+    [
+        (64000, 32000),
+        (6000, 3000),
+        (1500, 1024),
+    ],
+)
+def test_build_thinking_config_derives_default_budget_below_request_max_tokens(
+    max_tokens: int, expected_budget: int
+) -> None:
+    result = build_thinking_config(
+        extended_thinking=True,
+        thinking_budget_tokens=None,
+        model_version="claude-opus-4-6",
+        max_tokens=max_tokens,
+    )
 
-
-def test_build_output_config_passes_through_effort() -> None:
-    assert build_output_config("medium") == {"effort": "medium"}
-    assert build_output_config("xhigh") == {"effort": "xhigh"}
+    assert result == {"type": "enabled", "budget_tokens": expected_budget}

--- a/tests/workflows/unit_tests/core_steps/models/foundation/test_anthropic_claude_model_capabilities.py
+++ b/tests/workflows/unit_tests/core_steps/models/foundation/test_anthropic_claude_model_capabilities.py
@@ -1,0 +1,101 @@
+import logging
+
+import pytest
+
+from inference.core.workflows.core_steps.models.foundation.anthropic_claude import (
+    model_capabilities,
+)
+from inference.core.workflows.core_steps.models.foundation.anthropic_claude.model_capabilities import (
+    anthropic_model_supports_manual_thinking,
+    anthropic_model_supports_temperature,
+    build_thinking_config,
+    normalize_anthropic_model_id,
+    resolve_temperature,
+)
+from inference.core.workflows.core_steps.models.foundation.anthropic_claude.v1 import (
+    EXACT_MODELS_VERSIONS_MAPPING as EXACT_MODEL_VERSIONS_V1,
+)
+from inference.core.workflows.core_steps.models.foundation.anthropic_claude.v4 import (
+    EXACT_MODEL_VERSIONS as EXACT_MODEL_VERSIONS_V4,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_warning_dedup() -> None:
+    model_capabilities._TEMPERATURE_WARNINGS_EMITTED.clear()
+    model_capabilities._THINKING_BUDGET_WARNINGS_EMITTED.clear()
+    yield
+    model_capabilities._TEMPERATURE_WARNINGS_EMITTED.clear()
+    model_capabilities._THINKING_BUDGET_WARNINGS_EMITTED.clear()
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        ("claude-sonnet-4-5", "claude-sonnet-4-5"),
+        ("claude-sonnet-4-5-20250929", "claude-sonnet-4-5"),
+        ("claude-opus-4-5-latest", "claude-opus-4-5"),
+        ("  Claude-Fable-5-1 ", "claude-fable-5-1"),
+        ("claude_sonnet_4_5", "claude-sonnet-4-5"),
+        ("claude-3-5-sonnet-v2", "claude-3-5-sonnet-v2"),
+    ],
+)
+def test_normalize_anthropic_model_id(raw: str, expected: str) -> None:
+    assert normalize_anthropic_model_id(raw) == expected
+
+
+def test_unknown_model_defaults_to_new_generation_behaviour() -> None:
+    assert anthropic_model_supports_temperature("claude-something-9") is False
+    assert anthropic_model_supports_manual_thinking("claude-something-9") is False
+
+
+def test_dated_wire_ids_used_by_block_versions_are_classified_like_labels() -> None:
+    # The block may hand the helper either the friendly label or the exact wire
+    # id; both spellings must agree for every model shipped in the blocks.
+    for label, wire_id in {
+        **EXACT_MODEL_VERSIONS_V1,
+        **EXACT_MODEL_VERSIONS_V4,
+    }.items():
+        assert anthropic_model_supports_temperature(
+            label
+        ) == anthropic_model_supports_temperature(wire_id), (label, wire_id)
+
+
+def test_resolve_temperature_drops_value_for_new_generation_and_warns_once(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with caplog.at_level(logging.WARNING):
+        assert resolve_temperature(0.3, model_version="claude-sonnet-4-5") == 0.3
+        assert resolve_temperature(0.3, model_version="claude-fable-5-1") is None
+        assert resolve_temperature(0.9, model_version="claude-fable-5-1") is None
+        assert (
+            resolve_temperature(0.9, model_version="claude-fable-5-1-20260901") is None
+        )
+        assert resolve_temperature(0.3, model_version="claude-opus-5") is None
+
+    warned_models = [record.args[0] for record in caplog.records]
+    assert warned_models == ["claude-fable-5-1", "claude-opus-5"]
+    assert "temperature" in caplog.records[0].getMessage()
+
+
+def test_build_thinking_config_uses_adaptive_and_ignores_budget_with_single_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with caplog.at_level(logging.WARNING):
+        first = build_thinking_config(
+            extended_thinking=True,
+            thinking_budget_tokens=5000,
+            model_version="claude-fable-5-1",
+            model_max_output=128000,
+        )
+        second = build_thinking_config(
+            extended_thinking=True,
+            thinking_budget_tokens=7000,
+            model_version="claude-fable-5-1-20260901",
+            model_max_output=128000,
+        )
+
+    assert first == {"type": "adaptive"}
+    assert second == {"type": "adaptive"}
+    assert len(caplog.records) == 1
+    assert "thinking_budget_tokens=5000" in caplog.records[0].getMessage()

--- a/tests/workflows/unit_tests/core_steps/models/foundation/test_anthropic_claude_model_capabilities.py
+++ b/tests/workflows/unit_tests/core_steps/models/foundation/test_anthropic_claude_model_capabilities.py
@@ -8,6 +8,7 @@ from inference.core.workflows.core_steps.models.foundation.anthropic_claude impo
 from inference.core.workflows.core_steps.models.foundation.anthropic_claude.model_capabilities import (
     anthropic_model_supports_manual_thinking,
     anthropic_model_supports_temperature,
+    build_output_config,
     build_thinking_config,
     normalize_anthropic_model_id,
     resolve_temperature,
@@ -99,3 +100,12 @@ def test_build_thinking_config_uses_adaptive_and_ignores_budget_with_single_warn
     assert second == {"type": "adaptive"}
     assert len(caplog.records) == 1
     assert "thinking_budget_tokens=5000" in caplog.records[0].getMessage()
+
+
+def test_build_output_config_omits_when_effort_unset() -> None:
+    assert build_output_config(None) is None
+
+
+def test_build_output_config_passes_through_effort() -> None:
+    assert build_output_config("medium") == {"effort": "medium"}
+    assert build_output_config("xhigh") == {"effort": "xhigh"}

--- a/tests/workflows/unit_tests/core_steps/models/foundation/test_anthropic_claude_v5.py
+++ b/tests/workflows/unit_tests/core_steps/models/foundation/test_anthropic_claude_v5.py
@@ -32,14 +32,6 @@ def _spec(**overrides: Any) -> dict:
     return specification
 
 
-def test_v5_accepts_fable_with_medium_effort() -> None:
-    result = BlockManifest.model_validate(
-        _spec(model_version="claude-fable-5-1", reasoning_effort="medium")
-    )
-
-    assert result.reasoning_effort == "medium"
-
-
 def test_v5_accepts_effort_alongside_extended_thinking_on_opus_4_5() -> None:
     result = BlockManifest.model_validate(
         _spec(
@@ -55,21 +47,7 @@ def test_v5_accepts_effort_alongside_extended_thinking_on_opus_4_5() -> None:
     assert result.extended_thinking is True
 
 
-def test_v5_rejects_effort_on_legacy_model() -> None:
-    with pytest.raises(ValidationError, match="support"):
-        BlockManifest.model_validate(
-            _spec(model_version="claude-sonnet-4-5", reasoning_effort="high")
-        )
-
-
-def test_v5_rejects_xhigh_on_opus_4_6() -> None:
-    with pytest.raises(ValidationError, match="support"):
-        BlockManifest.model_validate(
-            _spec(model_version="claude-opus-4-6", reasoning_effort="xhigh")
-        )
-
-
-def test_v5_rejects_none_effort() -> None:
+def test_v5_does_not_offer_none_because_claude_thinking_cannot_be_disabled() -> None:
     with pytest.raises(ValidationError):
         BlockManifest.model_validate(
             _spec(model_version="claude-fable-5-1", reasoning_effort="none")

--- a/tests/workflows/unit_tests/core_steps/models/foundation/test_anthropic_claude_v5.py
+++ b/tests/workflows/unit_tests/core_steps/models/foundation/test_anthropic_claude_v5.py
@@ -1,0 +1,338 @@
+"""Tests for the Anthropic Claude v5 block (v4 + reasoning_effort)."""
+
+from typing import Any
+from unittest.mock import MagicMock, Mock, patch
+
+import numpy as np
+import pytest
+from pydantic import ValidationError
+
+from inference.core.workflows.core_steps.models.foundation.anthropic_claude.v5 import (
+    AnthropicClaudeBlockV5,
+    BlockManifest,
+    execute_claude_request,
+)
+from inference.core.workflows.execution_engine.entities.base import (
+    Batch,
+    ImageParentMetadata,
+    WorkflowImageData,
+)
+
+
+def _spec(**overrides: Any) -> dict:
+    specification = {
+        "type": "roboflow_core/anthropic_claude@v5",
+        "name": "step_1",
+        "images": "$inputs.image",
+        "task_type": "unconstrained",
+        "prompt": "This is my prompt",
+        "api_key": "$inputs.anthropic_api_key",
+    }
+    specification.update(overrides)
+    return specification
+
+
+def test_v5_accepts_fable_with_medium_effort() -> None:
+    result = BlockManifest.model_validate(
+        _spec(model_version="claude-fable-5-1", reasoning_effort="medium")
+    )
+
+    assert result.reasoning_effort == "medium"
+
+
+def test_v5_accepts_effort_alongside_extended_thinking_on_opus_4_5() -> None:
+    result = BlockManifest.model_validate(
+        _spec(
+            model_version="claude-opus-4-5",
+            reasoning_effort="low",
+            extended_thinking=True,
+            thinking_budget_tokens=2048,
+            max_tokens=8000,
+        )
+    )
+
+    assert result.reasoning_effort == "low"
+    assert result.extended_thinking is True
+
+
+def test_v5_rejects_effort_on_legacy_model() -> None:
+    with pytest.raises(ValidationError, match="support"):
+        BlockManifest.model_validate(
+            _spec(model_version="claude-sonnet-4-5", reasoning_effort="high")
+        )
+
+
+def test_v5_rejects_xhigh_on_opus_4_6() -> None:
+    with pytest.raises(ValidationError, match="support"):
+        BlockManifest.model_validate(
+            _spec(model_version="claude-opus-4-6", reasoning_effort="xhigh")
+        )
+
+
+def test_v5_rejects_none_effort() -> None:
+    with pytest.raises(ValidationError):
+        BlockManifest.model_validate(
+            _spec(model_version="claude-fable-5-1", reasoning_effort="none")
+        )
+
+
+@pytest.mark.parametrize(
+    "model_version, reasoning_effort",
+    [
+        ("claude-opus-4-6", "xhigh"),
+        ("claude-sonnet-4-5", "high"),
+        ("claude-fable-5-1", "turbo"),
+    ],
+)
+@patch(
+    "inference.core.workflows.core_steps.models.foundation.anthropic_claude.v5.post_to_roboflow_api"
+)
+@patch(
+    "inference.core.workflows.core_steps.models.foundation.anthropic_claude.v5.anthropic.Anthropic"
+)
+def test_runtime_rejects_effort_the_model_cannot_take_before_any_request(
+    mock_anthropic_class: Mock,
+    post_mock: Mock,
+    model_version: str,
+    reasoning_effort: str,
+) -> None:
+    for anthropic_api_key in ("sk-ant-test", "rf_key:account"):
+        with pytest.raises(ValueError, match="support"):
+            execute_claude_request(
+                roboflow_api_key="rf-key",
+                anthropic_api_key=anthropic_api_key,
+                system_prompt=None,
+                messages=[{"role": "user", "content": "Hello"}],
+                model_version=model_version,
+                max_tokens=100,
+                temperature=None,
+                extended_thinking=None,
+                thinking_budget_tokens=None,
+                reasoning_effort=reasoning_effort,
+            )
+
+    assert mock_anthropic_class.call_count == 0
+    assert post_mock.call_count == 0
+
+
+def _mock_streaming_client(mock_anthropic_class: Mock, text: str = "ok") -> MagicMock:
+    mock_client = MagicMock()
+    mock_anthropic_class.return_value = mock_client
+
+    mock_text_block = Mock()
+    mock_text_block.type = "text"
+    mock_text_block.text = text
+
+    mock_result = Mock()
+    mock_result.stop_reason = "end_turn"
+    mock_result.content = [mock_text_block]
+    mock_result.usage = Mock(input_tokens=11, output_tokens=7)
+
+    mock_stream = MagicMock()
+    mock_stream.__enter__ = Mock(return_value=mock_stream)
+    mock_stream.__exit__ = Mock(return_value=False)
+    mock_stream.get_final_message.return_value = mock_result
+    mock_client.messages.stream.return_value = mock_stream
+    return mock_client
+
+
+PROXY_RESPONSE = {
+    "stop_reason": "end_turn",
+    "content": [{"type": "text", "text": "proxied"}],
+    "usage": {"input_tokens": 3, "output_tokens": 2},
+}
+
+
+@patch(
+    "inference.core.workflows.core_steps.models.foundation.anthropic_claude.v5.anthropic.Anthropic"
+)
+def test_direct_request_sends_effort_without_thinking_for_fable(
+    mock_anthropic_class: Mock,
+) -> None:
+    mock_client = _mock_streaming_client(mock_anthropic_class)
+
+    execute_claude_request(
+        roboflow_api_key=None,
+        anthropic_api_key="sk-ant-test",
+        system_prompt=None,
+        messages=[{"role": "user", "content": "Hello"}],
+        model_version="claude-fable-5-1",
+        max_tokens=100,
+        temperature=None,
+        extended_thinking=None,
+        thinking_budget_tokens=None,
+        reasoning_effort="medium",
+    )
+
+    call_kwargs = mock_client.messages.stream.call_args.kwargs
+    assert "thinking" not in call_kwargs
+    assert call_kwargs["extra_body"] == {"output_config": {"effort": "medium"}}
+
+
+@patch(
+    "inference.core.workflows.core_steps.models.foundation.anthropic_claude.v5.anthropic.Anthropic"
+)
+def test_direct_request_sends_adaptive_thinking_and_effort_for_fable(
+    mock_anthropic_class: Mock,
+) -> None:
+    mock_client = _mock_streaming_client(mock_anthropic_class)
+
+    execute_claude_request(
+        roboflow_api_key=None,
+        anthropic_api_key="sk-ant-test",
+        system_prompt=None,
+        messages=[{"role": "user", "content": "Think"}],
+        model_version="claude-fable-5-1",
+        max_tokens=None,
+        temperature=None,
+        extended_thinking=True,
+        thinking_budget_tokens=5000,
+        reasoning_effort="high",
+    )
+
+    call_kwargs = mock_client.messages.stream.call_args.kwargs
+    assert call_kwargs["thinking"] == {"type": "adaptive"}
+    assert call_kwargs["extra_body"] == {"output_config": {"effort": "high"}}
+
+
+@patch(
+    "inference.core.workflows.core_steps.models.foundation.anthropic_claude.v5.anthropic.Anthropic"
+)
+def test_direct_request_keeps_legacy_thinking_without_output_config(
+    mock_anthropic_class: Mock,
+) -> None:
+    mock_client = _mock_streaming_client(mock_anthropic_class)
+
+    execute_claude_request(
+        roboflow_api_key=None,
+        anthropic_api_key="sk-ant-test",
+        system_prompt=None,
+        messages=[{"role": "user", "content": "Think"}],
+        model_version="claude-sonnet-4-5",
+        max_tokens=10000,
+        temperature=None,
+        extended_thinking=True,
+        thinking_budget_tokens=5000,
+        reasoning_effort=None,
+    )
+
+    call_kwargs = mock_client.messages.stream.call_args.kwargs
+    assert call_kwargs["thinking"] == {"type": "enabled", "budget_tokens": 5000}
+    assert "extra_body" not in call_kwargs
+
+
+@patch(
+    "inference.core.workflows.core_steps.models.foundation.anthropic_claude.v5.post_to_roboflow_api",
+    return_value=PROXY_RESPONSE,
+)
+def test_proxied_request_sends_effort_without_thinking_for_fable(
+    post_mock: Mock,
+) -> None:
+    execute_claude_request(
+        roboflow_api_key="rf-key",
+        anthropic_api_key="rf_key:account",
+        system_prompt=None,
+        messages=[{"role": "user", "content": "Hello"}],
+        model_version="claude-fable-5-1",
+        max_tokens=100,
+        temperature=None,
+        extended_thinking=None,
+        thinking_budget_tokens=None,
+        reasoning_effort="medium",
+    )
+
+    payload = post_mock.call_args.kwargs["payload"]
+    assert "thinking" not in payload
+    assert payload["output_config"] == {"effort": "medium"}
+
+
+@patch(
+    "inference.core.workflows.core_steps.models.foundation.anthropic_claude.v5.post_to_roboflow_api",
+    return_value=PROXY_RESPONSE,
+)
+def test_proxied_request_sends_adaptive_thinking_and_effort_for_fable(
+    post_mock: Mock,
+) -> None:
+    execute_claude_request(
+        roboflow_api_key="rf-key",
+        anthropic_api_key="rf_key:account",
+        system_prompt=None,
+        messages=[{"role": "user", "content": "Think"}],
+        model_version="claude-fable-5-1",
+        max_tokens=None,
+        temperature=None,
+        extended_thinking=True,
+        thinking_budget_tokens=5000,
+        reasoning_effort="low",
+    )
+
+    payload = post_mock.call_args.kwargs["payload"]
+    assert payload["thinking"] == {"type": "adaptive"}
+    assert payload["output_config"] == {"effort": "low"}
+
+
+@patch(
+    "inference.core.workflows.core_steps.models.foundation.anthropic_claude.v5.post_to_roboflow_api",
+    return_value=PROXY_RESPONSE,
+)
+def test_proxied_request_keeps_legacy_thinking_without_output_config(
+    post_mock: Mock,
+) -> None:
+    execute_claude_request(
+        roboflow_api_key="rf-key",
+        anthropic_api_key="rf_key:account",
+        system_prompt=None,
+        messages=[{"role": "user", "content": "Think"}],
+        model_version="claude-sonnet-4-5",
+        max_tokens=10000,
+        temperature=None,
+        extended_thinking=True,
+        thinking_budget_tokens=5000,
+        reasoning_effort=None,
+    )
+
+    payload = post_mock.call_args.kwargs["payload"]
+    assert payload["thinking"] == {"type": "enabled", "budget_tokens": 5000}
+    assert "output_config" not in payload
+
+
+@patch(
+    "inference.core.workflows.core_steps.models.foundation.anthropic_claude.v5.post_to_roboflow_api",
+    return_value=PROXY_RESPONSE,
+)
+def test_block_run_threads_reasoning_effort_to_the_request(post_mock: Mock) -> None:
+    block = AnthropicClaudeBlockV5(model_manager=MagicMock(), api_key="rf-key")
+    image = WorkflowImageData(
+        parent_metadata=ImageParentMetadata(parent_id="parent"),
+        numpy_image=np.zeros((16, 16, 3), dtype=np.uint8),
+    )
+
+    result = block.run(
+        images=Batch(content=[image], indices=[(0,)]),
+        task_type="unconstrained",
+        prompt="Describe the image",
+        output_structure=None,
+        classes=None,
+        model_version="claude-fable-5-1",
+        max_tokens=None,
+        temperature=None,
+        extended_thinking=None,
+        thinking_budget_tokens=None,
+        reasoning_effort="low",
+        max_image_size=1024,
+        max_concurrent_requests=None,
+        api_key="rf_key:account",
+    )
+
+    payload = post_mock.call_args.kwargs["payload"]
+    assert payload["model"] == "claude-fable-5-1"
+    assert payload["output_config"] == {"effort": "low"}
+    assert "thinking" not in payload
+    assert result == [
+        {
+            "output": "proxied",
+            "classes": None,
+            "input_tokens": 3,
+            "output_tokens": 2,
+        }
+    ]

--- a/tests/workflows/unit_tests/core_steps/models/foundation/test_zai_vlm_v1.py
+++ b/tests/workflows/unit_tests/core_steps/models/foundation/test_zai_vlm_v1.py
@@ -150,20 +150,19 @@ def test_run_maps_reasoning_effort_to_openrouter_config(mock_or):
     assert mock_or.call_args.kwargs["reasoning"] == {"effort": "high"}
 
 
-# Copied from vlm-exam `_PROMPT_TEMPLATE` so an edit to the block constant
-# fails this test.
+# Copied from vlm-exam `_BBOX_2D_NORMALIZED_PROMPT_TEMPLATE` so an edit to
+# the block constant fails this test.
 EXPECTED_FLASH_DETECTION_PROMPT = (
-    "Detect all objects in this image. "
-    "Output a JSON list where each entry contains the 2D bounding box "
-    'in the key "box_2d" and the text label in the key "label". '
-    'The "box_2d" value must be [y_min, x_min, y_max, x_max]: integers '
-    "between 0 and 1000, normalized to the image height and width. "
-    "Return only the JSON list, with no extra text. "
-    "Only use these labels: cat, dog"
+    "Detect all objects in this image and return their locations in the "
+    "form of coordinates. The format of output should be like "
+    '{"bbox_2d": [x1, y1, x2, y2], "label": "<name>"}. '
+    "bbox_2d is [xmin, ymin, xmax, ymax] as integers between 0 and 1000, "
+    "normalized to image width and height. "
+    "Only use these labels: cat, dog. Return a JSON array only."
 )
 
 
-def test_flash_detection_prompt_is_vlm_exam_yxyx_template():
+def test_flash_detection_prompt_is_vlm_exam_bbox_2d_template():
     messages = build_zai_openrouter_prompts(
         images=[np.zeros((8, 8, 3), dtype=np.uint8)],
         task_type="object-detection",
@@ -200,4 +199,4 @@ def test_run_flash_falls_back_to_low_effort_when_reasoning_disabled(mock_or):
     assert mock_or.call_args.kwargs["model"] == "z-ai/glm-5.3-flash"
     assert mock_or.call_args.kwargs["reasoning"] == {"effort": "low"}
     sent_text = mock_or.call_args.kwargs["prompts"][0][0]["content"][1]["text"]
-    assert "[y_min, x_min, y_max, x_max]" in sent_text
+    assert '"bbox_2d"' in sent_text


### PR DESCRIPTION
## What does this PR do?

Linked issue: [INF-XXXX](https://linear.app/roboflow/issue/INF-XXXX/i-anthropic-claude-v5-reasoning-effort)

Claude Fable 5.1 and the rest of the Opus 4.7+ generation run adaptive thinking that cannot be switched off; the depth of that thinking is controlled by Anthropic's `output_config.effort`. The existing `anthropic_claude@v4` block only exposes the legacy `extended_thinking` on/off toggle plus a token budget, so in Playgrounds a Fable user sees a switch that does nothing beyond sending `thinking.type=adaptive`, while OpenAI, Gemini and other VLM blocks already offer a per-model effort dropdown.

`anthropic_claude@v5` copies v4 and adds a `reasoning_effort` control (`low` / `medium` / `high` / `xhigh` / `max`). Each entry in `CLAUDE_MODELS` declares the effort values Anthropic accepts for it, and that table drives everything else: `values_metadata[model].reasoning_levels` for the Playground dropdown, `relevant_for.model_version` so the field only appears for models that take it, manifest validation, and a second validation inside `execute_claude_request` for values that arrive through selectors at runtime. When set, the value is sent as `output_config.effort` on both the direct Anthropic path (through `extra_body`, since the pinned `anthropic~=0.49.0` SDK predates the kwarg) and the Roboflow proxy payload. Unset leaves the request untouched so Anthropic's default (`high`) applies. `extended_thinking` and `thinking_budget_tokens` remain for the Claude 4.x models that still accept `thinking.type=enabled`, and are now hidden for models that do not.

**Main elements:**
- `anthropic_claude/v5.py`: new block version with per-model effort table, `reasoning_effort` field, `relevant_for` gating on both `reasoning_effort` and `extended_thinking`, runtime re-validation, `output_config` wiring on direct and proxied paths
- `anthropic_claude/model_capabilities.py`: `build_thinking_config` now derives the default `budget_tokens` from the request's `max_tokens` (`max(1024, max_tokens // 2)`) instead of half the model ceiling, matching the Roboflow proxy. Found during the live matrix: Opus 4.6 with `extended_thinking` and `max_tokens: 6000` returned 400 `max_tokens must be greater than thinking.budget_tokens` because the block sent a 32000 budget. The helper is shared, so v2-v4 receive the same fix; behaviour is unchanged when `max_tokens` is left unset
- `core_steps/loader.py`: registers `AnthropicClaudeBlockV5`
- Shared reasoning contract (`common/reasoning.py`) reused for validation and metadata, no new dependencies

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other:

## Testing

### Unit tests

- `test_anthropic_claude_v5.py`: manifest accepts effort alongside manual thinking on Opus 4.5 and does not offer `none` (Claude thinking cannot be disabled); per-model accept/reject cases live in the shared contract test; runtime validation raises before any HTTP call for selector-fed bad values on both key types; direct and proxied request shapes with effort only, adaptive thinking plus effort, and legacy thinking without `output_config`; block-level `run()` threads `reasoning_effort` into the proxy payload and returns token outputs
- `test_anthropic_claude.py`: v5 added to the parametrized v3/v4 legacy vs new-generation control tests (temperature drop, adaptive thinking translation)
- `test_anthropic_claude_model_capabilities.py`: default thinking budget is derived from request `max_tokens` and floored at 1024
- `test_reasoning_contract.py`: `anthropic_claude@v5` registered in the shared contract (table/literal drift, selector acceptance, per-model rejection)
- `test_token_usage.py`: v5 added to blocks that must declare token outputs

### Integration tests

- None added in this PR. Live runs below were done locally against real keys.

### Other

- `uv run pytest tests/workflows/unit_tests/core_steps/models/foundation/test_anthropic_claude*.py tests/workflows/unit_tests/core_steps/common/test_reasoning_contract.py tests/workflows/unit_tests/core_steps/common/test_token_usage.py` (149 passed, including v4 suites)
- `uv run pytest tests/workflows/unit_tests/execution_engine/introspection tests/workflows/unit_tests/core_steps/common` (565 passed)
- black / isort / flake8 (E9,F63,F7,F82) clean on all touched files
- Live, direct Anthropic key, Fable 5.1, same image and prompt, 4 runs each: `effort=low` 402-491 output tokens, `effort=max` 789-905 output tokens. Adaptive thinking plus `effort=medium` accepted.
- Live raw API checks confirming the per-model table: Opus 4.6 `xhigh` returns 400 "Supported levels: high, low, max, medium"; Sonnet 4.5 with any effort returns 400 "does not support the effort parameter"; Opus 4.6 `max` and Opus 4.5 `low` succeed.
- Live `ExecutionEngine` run of a v5 workflow with `reasoning_effort: "$inputs.effort"`: `low` and `max` both succeed; an out-of-enum value is rejected by the engine before any request.
- Live `ExecutionEngine` matrix on the final code, 7 configurations x 2 auth paths, all succeed: Fable 5.1 (effort unset / `low` / `max`), Opus 4.6 (`low` + adaptive thinking), Sonnet 4.6 (`low` + manual thinking, budget 2048), Opus 4.5 (`low` + manual thinking), Sonnet 4.5 (legacy manual thinking, no effort). Direct Anthropic key and `rf_key:account` through `apiproxy/anthropic`.
- Schema comparison against `open_ai@v6`: `reasoning_effort.relevant_for` and `model_version.values_metadata[*].reasoning_levels` have the same shape, so Playgrounds renders the dropdown the same way.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [ ] I have updated the documentation accordingly (if applicable)

## Additional Context

**Roboflow proxy does not forward `output_config` yet.** Through `apiproxy/anthropic` with `rf_key:account`, Fable 5.1 produced the same output-token count for `low`, `max` and unset alike, while the direct path shows a stable gap. The block sends the field correctly; the production proxy drops it. roboflow/roboflow#15116 makes `apiproxy/anthropic` validate and forward `output_config`; until it deploys, proxied requests silently run at Anthropic's default effort.

**Playgrounds.** The workflow editor shows a field when `relevant_for.model_version.values` contains the selected (or default) model and labels enum options from `values_metadata`; `reasoning_effort` on v5 uses exactly the mechanism `open_ai@v6` and `google_gemini@v5` rely on, so the dropdown appears for Fable / Opus 4.6 / Sonnet 4.6 / Opus 4.5 and stays hidden for 4.5-and-older models where `extended_thinking` is shown instead. The block default stays `claude-sonnet-4-5`, so the effort control appears once a supporting model is picked.

The Linear link is a placeholder; replace with the real issue ID.

Made with [Cursor](https://cursor.com)
