### PR TITLE
Fix any-size VLM preprocessing without dense-batch distortion

### DIFF
--- a/inference_models/docs/changelog.md
+++ b/inference_models/docs/changelog.md
@@ -22,8 +22,9 @@
   PaliGemma, Qwen2.5-VL, Gemma 4, and Florence 2 instead of distorting a tensor batch to its first
   image or failing to concatenate heterogeneous NumPy inputs. Callers that require a dense batch
   still receive one for uniform images and now get a clear `ModelInputError` for heterogeneous
-  sizes. Invalid Cosmos package configurations are no longer silently ignored, and an input-size
-  restriction rejects packages that omit the size needed to enforce it.
+  sizes, while already-dense 4D tensor inputs retain vectorized preprocessing. Invalid Cosmos
+  package configurations are no longer silently ignored, and an input-size restriction rejects
+  packages that omit the size needed to enforce it.
 
 ---
 

--- a/inference_models/docs/changelog.md
+++ b/inference_models/docs/changelog.md
@@ -16,6 +16,15 @@
   each image at its own size (or the size requested) while still applying the version's
   photometric steps.
 
+### Fixed
+
+- Any-size VLM preprocessing now returns independently sized images to Cosmos 3, SmolVLM,
+  PaliGemma, Qwen2.5-VL, Gemma 4, and Florence 2 instead of distorting a tensor batch to its first
+  image or failing to concatenate heterogeneous NumPy inputs. Callers that require a dense batch
+  still receive one for uniform images and now get a clear `ModelInputError` for heterogeneous
+  sizes. Invalid Cosmos package configurations are no longer silently ignored, and an input-size
+  restriction rejects packages that omit the size needed to enforce it.
+
 ---
 
 ## `0.36.0`

--- a/inference_models/inference_models/models/common/roboflow/model_packages.py
+++ b/inference_models/inference_models/models/common/roboflow/model_packages.py
@@ -3,13 +3,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Annotated, Dict, List, Literal, Optional, Set, Tuple, Union
 
-from pydantic import (
-    BaseModel,
-    BeforeValidator,
-    Field,
-    ValidationError,
-    model_validator,
-)
+from pydantic import BaseModel, BeforeValidator, Field, ValidationError, model_validator
 
 from inference_models.errors import (
     CorruptedModelPackageError,
@@ -377,6 +371,25 @@ def parse_inference_config(
     ] = None,
     max_allowed_input_size: Optional[Union[int, Tuple[int, int]]] = None,
 ) -> InferenceConfig:
+    """Load and validate a Roboflow model package inference configuration.
+
+    Args:
+        config_path: Path to the package's inference configuration JSON file.
+        allowed_resize_modes: Resize modes supported by the model implementation.
+        implicit_resize_mode_substitutions: Optional mapping from package resize
+            modes to supported substitutes, padding values, and warning messages.
+        max_allowed_input_size: Optional environment limit for training input
+            height and width, or a single limit for both dimensions.
+
+    Returns:
+        The validated inference configuration.
+
+    Raises:
+        CorruptedModelPackageError: If the file cannot be read, is malformed, or
+            declares an unsupported resize mode.
+        ModelPackageRestrictedError: If the package's declared input size cannot
+            be safely checked against the configured environment limit.
+    """
     try:
         decoded_config = read_json(path=config_path)
         if not isinstance(decoded_config, dict):
@@ -421,6 +434,15 @@ def parse_inference_config(
         if isinstance(max_allowed_input_size, int):
             max_allowed_input_size = (max_allowed_input_size, max_allowed_input_size)
         training_input_size = parsed_config.network_input.training_input_size
+        if training_input_size is None:
+            raise ModelPackageRestrictedError(
+                message="Configuration of runtime environment limits model input "
+                f"size to {max_allowed_input_size}, but the model package does not "
+                "declare a training input size that can be validated against that "
+                "limit.",
+                help_url="https://inference-models.roboflow.com/errors/model-loading/#modelpackagerestrictederror",
+            )
+
         if (
             training_input_size.height > max_allowed_input_size[0]
             or training_input_size.width > max_allowed_input_size[1]

--- a/inference_models/inference_models/models/common/roboflow/pre_processing.py
+++ b/inference_models/inference_models/models/common/roboflow/pre_processing.py
@@ -36,6 +36,26 @@ def pre_process_network_input(
     image_size_wh: Optional[Union[int, Tuple[int, int]]] = None,
     pre_processing_overrides: Optional[PreProcessingOverrides] = None,
 ) -> Tuple[torch.Tensor, List[PreProcessingMetadata]]:
+    """Pre-process model images into a dense tensor batch.
+
+    Args:
+        images: A single image, dense tensor batch, or list of images.
+        image_pre_processing: Roboflow preprocessing operations to apply.
+        network_input: Model input sizing and color configuration.
+        target_device: Device on which the processed tensor should reside.
+        input_color_format: Color format of the supplied images, when known.
+        image_size_wh: Optional requested output size as width and height.
+        pre_processing_overrides: Per-request preprocessing overrides.
+
+    Returns:
+        A dense ``B x C x H x W`` tensor and matching preprocessing metadata.
+
+    Raises:
+        ModelInputError: If the input is unsupported, empty, or produces images
+            with dimensions that cannot be represented in a dense tensor.
+        ModelRuntimeError: If the model's preprocessing configuration is not
+            supported.
+    """
     if network_input.input_channels != 3:
         raise ModelRuntimeError(
             message=f"`inference` currently does not support Roboflow pre-processing for model inputs with "
@@ -83,6 +103,29 @@ def pre_process_network_input(
             "all input batch elements arbitrarily - this type of model does not support input batches.",
             help_url="https://inference-models.roboflow.com/errors/models-runtime/#modelruntimeerror",
         )
+    if network_input.training_input_size is None:
+        processed_images, metadata = pre_process_network_input_to_image_list(
+            images=images,
+            image_pre_processing=image_pre_processing,
+            network_input=network_input,
+            target_device=target_device,
+            input_color_format=input_color_format,
+            image_size_wh=image_size_wh,
+            pre_processing_overrides=pre_processing_overrides,
+        )
+        image_shapes = {tuple(image.shape) for image in processed_images}
+        if len(image_shapes) != 1:
+            raise ModelInputError(
+                message="Pre-processing produced images with different spatial "
+                "dimensions, which cannot be represented as a dense tensor batch. "
+                "Use `pre_process_network_input_to_image_list` for models that "
+                "accept variable-size image lists.",
+                help_url="https://inference-models.roboflow.com/errors/input-validation/#modelinputerror",
+            )
+
+        dense_batch = torch.stack(processed_images, dim=0).contiguous()
+
+        return dense_batch, metadata
     if isinstance(images[0], np.ndarray):
         return pre_process_numpy_images_list(
             images=images,
@@ -109,19 +152,106 @@ def pre_process_network_input(
     )
 
 
+def pre_process_network_input_to_image_list(
+    images: Union[np.ndarray, torch.Tensor, List[np.ndarray], List[torch.Tensor]],
+    *,
+    image_pre_processing: ImagePreProcessing,
+    network_input: NetworkInputDefinition,
+    target_device: torch.device,
+    input_color_format: Optional[ColorFormat] = None,
+    image_size_wh: Optional[Union[int, Tuple[int, int]]] = None,
+    pre_processing_overrides: Optional[PreProcessingOverrides] = None,
+) -> Tuple[List[torch.Tensor], List[PreProcessingMetadata]]:
+    """Pre-process images for a model that accepts an image tensor list.
+
+    Fixed-size configurations use the established dense preprocessing path. An
+    any-size configuration without a training input size processes every input
+    separately so each image can retain its own post-processing dimensions.
+
+    Args:
+        images: A single image, dense tensor batch, or list of images.
+        image_pre_processing: Roboflow preprocessing operations to apply.
+        network_input: Model input sizing and color configuration.
+        target_device: Device on which the processed tensors should reside.
+        input_color_format: Color format of the supplied images, when known.
+        image_size_wh: Optional requested output size as width and height.
+        pre_processing_overrides: Per-request preprocessing overrides.
+
+    Returns:
+        Processed ``C x H x W`` tensors and matching preprocessing metadata.
+
+    Raises:
+        ModelInputError: If the input is an empty list or has an unsupported type.
+    """
+    if network_input.training_input_size is not None:
+        dense_batch, metadata = pre_process_network_input(
+            images=images,
+            image_pre_processing=image_pre_processing,
+            network_input=network_input,
+            target_device=target_device,
+            input_color_format=input_color_format,
+            image_size_wh=image_size_wh,
+            pre_processing_overrides=pre_processing_overrides,
+        )
+        processed_images = [image for image in dense_batch]
+
+        return processed_images, metadata
+
+    if isinstance(images, torch.Tensor) and images.ndim == 4:
+        individual_images = [image for image in images]
+    elif isinstance(images, list):
+        individual_images = images
+    else:
+        individual_images = [images]
+
+    if not individual_images:
+        raise ModelInputError(
+            message="Detected empty input to the model",
+            help_url="https://inference-models.roboflow.com/errors/input-validation/#modelinputerror",
+        )
+
+    processed_images, result_metadata = [], []
+    for image in individual_images:
+        dense_image, metadata = pre_process_network_input(
+            images=image,
+            image_pre_processing=image_pre_processing,
+            network_input=network_input,
+            target_device=target_device,
+            input_color_format=input_color_format,
+            image_size_wh=image_size_wh,
+            pre_processing_overrides=pre_processing_overrides,
+        )
+        processed_images.append(dense_image[0])
+        result_metadata.extend(metadata)
+
+    return processed_images, result_metadata
+
+
 def resolve_target_dimensions(
     network_input: NetworkInputDefinition,
     image_size_wh: Optional[Tuple[int, int]],
-    original_size_wh: Tuple[int, int],
+    fallback_size_wh: Tuple[int, int],
 ) -> Tuple[int, int]:
-    """The (width, height) the input is prepared at.
+    """Resolve the width and height at which an input is prepared.
 
     A model that accepts any input size may ship no training_input_size (a VLM
     fine-tuned on a version without a resize); its images keep their own size
     unless one is requested.
+
+    Args:
+        network_input: Model input sizing configuration.
+        image_size_wh: Explicitly requested width and height, when supplied.
+        fallback_size_wh: Post-preprocessing width and height to preserve for an
+            any-size model when no explicit size is requested.
+
+    Returns:
+        The target width and height for geometric input preparation.
+
+    Raises:
+        ModelRuntimeError: If a requested dynamic-size mode is unsupported.
     """
     if network_input.training_input_size is None:
-        return image_size_wh if image_size_wh is not None else original_size_wh
+        return image_size_wh if image_size_wh is not None else fallback_size_wh
     target_dimensions = (
         network_input.training_input_size.width,
         network_input.training_input_size.height,
@@ -180,14 +310,16 @@ def pre_process_images_tensor(
     ):
         images = images.permute(0, 3, 1, 2)
     original_size = ImageDimensions(width=images.shape[3], height=images.shape[2])
-    target_dimensions = resolve_target_dimensions(
-        network_input, image_size_wh, (original_size.width, original_size.height)
-    )
     image, static_crop_offset = apply_pre_processing_to_torch_image(
         image=images,
         image_pre_processing=image_pre_processing,
         network_input_channels=network_input.input_channels,
         pre_processing_overrides=pre_processing_overrides,
+    )
+    target_dimensions = resolve_target_dimensions(
+        network_input,
+        image_size_wh,
+        (image.shape[3], image.shape[2]),
     )
     if network_input.resize_mode not in NUMPY_IMAGES_PREPARATION_HANDLERS:
         raise ModelRuntimeError(
@@ -878,9 +1010,6 @@ def pre_process_numpy_image(
 ) -> Tuple[torch.Tensor, List[PreProcessingMetadata]]:
     if input_color_mode is None:
         input_color_mode = ColorMode.BGR
-    target_dimensions = resolve_target_dimensions(
-        network_input, image_size_wh, (image.shape[1], image.shape[0])
-    )
     original_size = ImageDimensions(width=image.shape[1], height=image.shape[0])
     image, static_crop_offset = apply_pre_processing_to_numpy_image(
         image=image,
@@ -888,6 +1017,11 @@ def pre_process_numpy_image(
         network_input_channels=network_input.input_channels,
         input_color_mode=input_color_mode,
         pre_processing_overrides=pre_processing_overrides,
+    )
+    target_dimensions = resolve_target_dimensions(
+        network_input,
+        image_size_wh,
+        (image.shape[1], image.shape[0]),
     )
     if network_input.resize_mode not in NUMPY_IMAGES_PREPARATION_HANDLERS:
         raise ModelRuntimeError(

--- a/inference_models/inference_models/models/common/roboflow/pre_processing.py
+++ b/inference_models/inference_models/models/common/roboflow/pre_processing.py
@@ -164,9 +164,10 @@ def pre_process_network_input_to_image_list(
 ) -> Tuple[List[torch.Tensor], List[PreProcessingMetadata]]:
     """Pre-process images for a model that accepts an image tensor list.
 
-    Fixed-size configurations use the established dense preprocessing path. An
-    any-size configuration without a training input size processes every input
-    separately so each image can retain its own post-processing dimensions.
+    Fixed-size configurations and uniform four-dimensional tensor batches use
+    the established dense preprocessing path. Ragged any-size inputs are
+    processed separately so each image can retain its own post-processing
+    dimensions.
 
     Args:
         images: A single image, dense tensor batch, or list of images.
@@ -183,7 +184,8 @@ def pre_process_network_input_to_image_list(
     Raises:
         ModelInputError: If the input is an empty list or has an unsupported type.
     """
-    if network_input.training_input_size is not None:
+    is_dense_tensor_batch = isinstance(images, torch.Tensor) and images.ndim == 4
+    if network_input.training_input_size is not None or is_dense_tensor_batch:
         dense_batch, metadata = pre_process_network_input(
             images=images,
             image_pre_processing=image_pre_processing,
@@ -193,7 +195,7 @@ def pre_process_network_input_to_image_list(
             image_size_wh=image_size_wh,
             pre_processing_overrides=pre_processing_overrides,
         )
-        processed_images = [image for image in dense_batch]
+        processed_images = list(dense_batch.unbind(dim=0))
 
         return processed_images, metadata
 

--- a/inference_models/inference_models/models/cosmos3/cosmos3_reasoner_hf.py
+++ b/inference_models/inference_models/models/cosmos3/cosmos3_reasoner_hf.py
@@ -24,15 +24,13 @@ from inference_models.configuration import (
     RUNNING_ON_JETSON,
 )
 from inference_models.entities import ColorFormat
-from inference_models.errors import CorruptedModelPackageError
-from inference_models.logger import LOGGER
 from inference_models.models.common.roboflow.model_packages import (
     InferenceConfig,
     ResizeMode,
     parse_inference_config,
 )
 from inference_models.models.common.roboflow.pre_processing import (
-    pre_process_network_input,
+    pre_process_network_input_to_image_list,
 )
 
 DEFAULT_PROMPT = "Describe what's in this image."
@@ -90,35 +88,23 @@ def _require_cosmos3_transformers() -> None:
 
 
 def _load_inference_config(package_dir: str) -> Optional[InferenceConfig]:
-    """The package's inference_config.json when it has one that parses.
-
-    The Cosmos processor sizes images itself, so the config only carries the
-    version's photometric steps (auto-orient, grayscale, contrast, static crop).
-    roboflow-train currently writes it with training_input_size: null for
-    versions without a resize, which the shared schema rejects; that config
-    could not drive preprocessing anyway, so it is skipped with a warning
-    rather than failing the load.
-    """
+    """Return the package's inference configuration when it is present."""
     config_path = os.path.join(package_dir, "inference_config.json")
     if not os.path.exists(config_path):
         return None
-    try:
-        return parse_inference_config(
-            config_path=config_path,
-            allowed_resize_modes={
-                ResizeMode.STRETCH_TO,
-                ResizeMode.LETTERBOX,
-                ResizeMode.CENTER_CROP,
-                ResizeMode.LETTERBOX_REFLECT_EDGES,
-                ResizeMode.FIT_LONGER_EDGE,
-            },
-        )
-    except CorruptedModelPackageError as error:
-        LOGGER.warning(
-            f"Ignoring {config_path}: {error.__cause__ or error}. Images reach the "
-            "Cosmos 3 Edge processor as-is."
-        )
-        return None
+
+    inference_config = parse_inference_config(
+        config_path=config_path,
+        allowed_resize_modes={
+            ResizeMode.STRETCH_TO,
+            ResizeMode.LETTERBOX,
+            ResizeMode.CENTER_CROP,
+            ResizeMode.LETTERBOX_REFLECT_EDGES,
+            ResizeMode.FIT_LONGER_EDGE,
+        },
+    )
+
+    return inference_config
 
 
 def _adapter_trains_new_tokens(adapter_config_path: str) -> bool:
@@ -308,14 +294,13 @@ class Cosmos3EdgeReasoner:
         if self._inference_config is not None and not as_video:
             # The version's preprocessing (photometric steps, any resize it baked)
             # applied the way the other fine-tuned VLMs do; the result is RGB.
-            images = pre_process_network_input(
+            images, _ = pre_process_network_input_to_image_list(
                 images=images,
                 image_pre_processing=self._inference_config.image_pre_processing,
                 network_input=self._inference_config.network_input,
                 target_device=self._device,
                 input_color_format=input_color_format,
-            )[0]
-            images = [frame[0] for frame in torch.split(images, 1, dim=0)]
+            )
         elif isinstance(images, np.ndarray):
             if input_color_format != "rgb":
                 images = images[:, :, ::-1]

--- a/inference_models/inference_models/models/florence2/florence2_hf.py
+++ b/inference_models/inference_models/models/florence2/florence2_hf.py
@@ -37,7 +37,7 @@ from inference_models.models.common.roboflow.model_packages import (
 )
 from inference_models.models.common.roboflow.pre_processing import (
     extract_input_images_dimensions,
-    pre_process_network_input,
+    pre_process_network_input_to_image_list,
 )
 
 GRANULARITY_2TASK = {
@@ -607,15 +607,16 @@ class Florence2HF:
             image_dimensions = extract_input_images_dimensions(images=image_list)
             pre_processing_metadata = None
         else:
-            images, pre_processing_metadata = pre_process_network_input(
-                images=images,
-                image_pre_processing=self._inference_config.image_pre_processing,
-                network_input=self._inference_config.network_input,
-                target_device=self._device,
-                input_color_format=input_color_format,
-                pre_processing_overrides=pre_processing_overrides,
+            image_list, pre_processing_metadata = (
+                pre_process_network_input_to_image_list(
+                    images=images,
+                    image_pre_processing=self._inference_config.image_pre_processing,
+                    network_input=self._inference_config.network_input,
+                    target_device=self._device,
+                    input_color_format=input_color_format,
+                    pre_processing_overrides=pre_processing_overrides,
+                )
             )
-            image_list = [e[0] for e in torch.split(images, 1, dim=0)]
             image_dimensions = [
                 e.size_after_pre_processing for e in pre_processing_metadata
             ]

--- a/inference_models/inference_models/models/gemma4/gemma4_hf.py
+++ b/inference_models/inference_models/models/gemma4/gemma4_hf.py
@@ -27,7 +27,7 @@ from inference_models.models.common.roboflow.model_packages import (
     parse_inference_config,
 )
 from inference_models.models.common.roboflow.pre_processing import (
-    pre_process_network_input,
+    pre_process_network_input_to_image_list,
 )
 
 # HF Supported budgets for tokens representing images.
@@ -289,15 +289,14 @@ class Gemma4HF:
 
             raw_list = _collect_list()
         else:
-            processed = pre_process_network_input(
+            raw_list, _ = pre_process_network_input_to_image_list(
                 images=images,
                 image_pre_processing=self._inference_config.image_pre_processing,
                 network_input=self._inference_config.network_input,
                 target_device=self._device,
                 input_color_format=input_color_format,
                 image_size_wh=image_size,
-            )[0]
-            raw_list = [t.squeeze(0) for t in torch.split(processed, 1, dim=0)]
+            )
 
         pil_images = [_to_pil_rgb(img, input_color_format) for img in raw_list]
 

--- a/inference_models/inference_models/models/paligemma/paligemma_hf.py
+++ b/inference_models/inference_models/models/paligemma/paligemma_hf.py
@@ -53,7 +53,7 @@ from inference_models.models.common.roboflow.model_packages import (
     parse_inference_config,
 )
 from inference_models.models.common.roboflow.pre_processing import (
-    pre_process_network_input,
+    pre_process_network_input_to_image_list,
 )
 
 
@@ -212,7 +212,7 @@ class PaliGemmaHF:
             else:
                 image_list = [_to_tensor(img) for img in images]
         else:
-            images = pre_process_network_input(
+            image_list, _ = pre_process_network_input_to_image_list(
                 images=images,
                 image_pre_processing=self._inference_config.image_pre_processing,
                 network_input=self._inference_config.network_input,
@@ -220,8 +220,7 @@ class PaliGemmaHF:
                 input_color_format=input_color_format,
                 image_size_wh=image_size,
                 pre_processing_overrides=pre_processing_overrides,
-            )[0]
-            image_list = [e[0] for e in torch.split(images, 1, dim=0)]
+            )
         num_images = len(image_list)
 
         if isinstance(prompt, str) and num_images > 1:

--- a/inference_models/inference_models/models/qwen25vl/qwen25vl_hf.py
+++ b/inference_models/inference_models/models/qwen25vl/qwen25vl_hf.py
@@ -27,7 +27,7 @@ from inference_models.models.common.roboflow.model_packages import (
     parse_inference_config,
 )
 from inference_models.models.common.roboflow.pre_processing import (
-    pre_process_network_input,
+    pre_process_network_input_to_image_list,
 )
 
 
@@ -215,7 +215,7 @@ class Qwen25VLHF:
             else:
                 image_list = [_to_tensor(img) for img in images]
         else:
-            images = pre_process_network_input(
+            image_list, _ = pre_process_network_input_to_image_list(
                 images=images,
                 image_pre_processing=self._inference_config.image_pre_processing,
                 network_input=self._inference_config.network_input,
@@ -223,8 +223,7 @@ class Qwen25VLHF:
                 input_color_format=input_color_format,
                 image_size_wh=image_size,
                 pre_processing_overrides=pre_processing_overrides,
-            )[0]
-            image_list = [e[0] for e in torch.split(images, 1, dim=0)]
+            )
         # Handle prompt and system prompt parsing logic from original implementation
         if prompt is None:
             prompt = "Describe what's in this image."

--- a/inference_models/inference_models/models/smolvlm/smolvlm_hf.py
+++ b/inference_models/inference_models/models/smolvlm/smolvlm_hf.py
@@ -22,7 +22,7 @@ from inference_models.models.common.roboflow.model_packages import (
     parse_inference_config,
 )
 from inference_models.models.common.roboflow.pre_processing import (
-    pre_process_network_input,
+    pre_process_network_input_to_image_list,
 )
 
 
@@ -219,7 +219,7 @@ class SmolVLMHF:
             else:
                 image_list = [_to_tensor(img) for img in images]
         else:
-            images = pre_process_network_input(
+            image_list, _ = pre_process_network_input_to_image_list(
                 images=images,
                 image_pre_processing=self._inference_config.image_pre_processing,
                 network_input=self._inference_config.network_input,
@@ -227,8 +227,7 @@ class SmolVLMHF:
                 input_color_format=input_color_format,
                 image_size_wh=image_size,
                 pre_processing_overrides=pre_processing_overrides,
-            )[0]
-            image_list = [e[0] for e in torch.split(images, 1, dim=0)]
+            )
         if images_to_single_prompt:
             content = [{"type": "image"}] * len(image_list)
             content.append({"type": "text", "text": prompt})

--- a/inference_models/tests/unit_tests/models/common/roboflow/test_model_packages.py
+++ b/inference_models/tests/unit_tests/models/common/roboflow/test_model_packages.py
@@ -569,3 +569,20 @@ def test_parse_inference_config_rejects_no_training_input_size_for_fixed_size_mo
         parse_inference_config(
             config_path=str(config_path), allowed_resize_modes={ResizeMode.STRETCH_TO}
         )
+
+
+def test_parse_inference_config_rejects_unbounded_input_when_size_limit_is_set(
+    tmp_path,
+) -> None:
+    config_path = tmp_path / "inference_config.json"
+    config_path.write_text(json.dumps(_any_size_config(None)))
+
+    with pytest.raises(
+        ModelPackageRestrictedError,
+        match="does not declare a training input size",
+    ):
+        parse_inference_config(
+            config_path=str(config_path),
+            allowed_resize_modes={ResizeMode.STRETCH_TO},
+            max_allowed_input_size=1024,
+        )

--- a/inference_models/tests/unit_tests/models/common/roboflow/test_pre_processing.py
+++ b/inference_models/tests/unit_tests/models/common/roboflow/test_pre_processing.py
@@ -25,6 +25,7 @@ from inference_models.models.common.roboflow.pre_processing import (
     images_to_pillow,
     make_the_value_divisible,
     pre_process_network_input,
+    pre_process_network_input_to_image_list,
 )
 
 
@@ -10141,3 +10142,180 @@ def test_pre_process_network_input_keeps_the_image_size_when_the_model_has_no_tr
     assert result_image.shape == (1, 3, 192, 168)
     assert requested_image.shape == (1, 3, 64, 96)
     assert batched_image.shape == (1, 3, 192, 168)
+
+
+def _any_size_network_input() -> NetworkInputDefinition:
+    return NetworkInputDefinition(
+        training_input_size=None,
+        dynamic_spatial_size_supported=True,
+        dynamic_spatial_size_mode=AnySizePadding(type="any-size"),
+        color_mode=ColorMode.RGB,
+        resize_mode=ResizeMode.STRETCH_TO,
+        input_channels=3,
+    )
+
+
+@pytest.mark.parametrize(
+    "images",
+    [
+        [
+            np.zeros((20, 30, 3), dtype=np.uint8),
+            np.zeros((40, 50, 3), dtype=np.uint8),
+        ],
+        [torch.zeros((3, 20, 30)), torch.zeros((3, 40, 50))],
+    ],
+)
+def test_pre_process_network_input_to_image_list_preserves_heterogeneous_sizes(
+    images,
+) -> None:
+    processed_images, metadata = pre_process_network_input_to_image_list(
+        images=images,
+        image_pre_processing=ImagePreProcessing(),
+        network_input=_any_size_network_input(),
+        target_device=torch.device("cpu"),
+    )
+
+    assert [tuple(image.shape) for image in processed_images] == [
+        (3, 20, 30),
+        (3, 40, 50),
+    ]
+    assert [item.inference_size for item in metadata] == [
+        ImageDimensions(height=20, width=30),
+        ImageDimensions(height=40, width=50),
+    ]
+
+
+@pytest.mark.parametrize(
+    "images",
+    [
+        [
+            np.zeros((20, 30, 3), dtype=np.uint8),
+            np.zeros((40, 50, 3), dtype=np.uint8),
+        ],
+        [torch.zeros((3, 20, 30)), torch.zeros((3, 40, 50))],
+    ],
+)
+def test_pre_process_network_input_rejects_heterogeneous_dense_batch(images) -> None:
+    with pytest.raises(ModelInputError, match="different spatial dimensions"):
+        pre_process_network_input(
+            images=images,
+            image_pre_processing=ImagePreProcessing(),
+            network_input=_any_size_network_input(),
+            target_device=torch.device("cpu"),
+        )
+
+
+@pytest.mark.parametrize(
+    "images",
+    [
+        [np.zeros((20, 30, 3), dtype=np.uint8) for _ in range(2)],
+        [torch.zeros((3, 20, 30)) for _ in range(2)],
+    ],
+)
+def test_pre_process_network_input_stacks_uniform_any_size_images(images) -> None:
+
+    dense_batch, metadata = pre_process_network_input(
+        images=images,
+        image_pre_processing=ImagePreProcessing(),
+        network_input=_any_size_network_input(),
+        target_device=torch.device("cpu"),
+    )
+
+    assert dense_batch.shape == (2, 3, 20, 30)
+    assert len(metadata) == 2
+
+
+@pytest.mark.parametrize(
+    "image",
+    [
+        np.zeros((20, 30, 3), dtype=np.uint8),
+        torch.zeros((3, 20, 30)),
+    ],
+)
+def test_any_size_preprocessing_preserves_dimensions_after_static_crop(image) -> None:
+    image_pre_processing = ImagePreProcessing(
+        **{
+            "static-crop": StaticCrop(
+                enabled=True,
+                x_min=0,
+                x_max=50,
+                y_min=0,
+                y_max=100,
+            )
+        }
+    )
+
+    processed_images, metadata = pre_process_network_input_to_image_list(
+        images=image,
+        image_pre_processing=image_pre_processing,
+        network_input=_any_size_network_input(),
+        target_device=torch.device("cpu"),
+    )
+
+    assert processed_images[0].shape == (3, 20, 15)
+    assert metadata[0].inference_size == ImageDimensions(height=20, width=15)
+
+
+@pytest.mark.parametrize(
+    "images",
+    [
+        [
+            np.zeros((20, 30, 3), dtype=np.uint8),
+            np.zeros((40, 50, 3), dtype=np.uint8),
+        ],
+        [torch.zeros((3, 20, 30)), torch.zeros((3, 40, 50))],
+    ],
+)
+def test_any_size_image_list_applies_explicit_requested_size(images) -> None:
+
+    processed_images, _ = pre_process_network_input_to_image_list(
+        images=images,
+        image_pre_processing=ImagePreProcessing(),
+        network_input=_any_size_network_input(),
+        target_device=torch.device("cpu"),
+        image_size_wh=(16, 12),
+    )
+
+    assert [tuple(image.shape) for image in processed_images] == [
+        (3, 12, 16),
+        (3, 12, 16),
+    ]
+
+
+@pytest.mark.parametrize(
+    "images",
+    [
+        [
+            np.zeros((20, 30, 3), dtype=np.uint8),
+            np.zeros((40, 50, 3), dtype=np.uint8),
+        ],
+        [torch.zeros((3, 20, 30)), torch.zeros((3, 40, 50))],
+    ],
+)
+def test_fixed_size_image_list_keeps_dense_preprocessing_behavior(images) -> None:
+    network_input = NetworkInputDefinition(
+        training_input_size=TrainingInputSize(height=64, width=64),
+        dynamic_spatial_size_supported=False,
+        color_mode=ColorMode.RGB,
+        resize_mode=ResizeMode.STRETCH_TO,
+        input_channels=3,
+    )
+    dense_batch, dense_metadata = pre_process_network_input(
+        images=images,
+        image_pre_processing=ImagePreProcessing(),
+        network_input=network_input,
+        target_device=torch.device("cpu"),
+    )
+    processed_images, list_metadata = pre_process_network_input_to_image_list(
+        images=images,
+        image_pre_processing=ImagePreProcessing(),
+        network_input=network_input,
+        target_device=torch.device("cpu"),
+    )
+
+    assert [tuple(image.shape) for image in processed_images] == [
+        (3, 64, 64),
+        (3, 64, 64),
+    ]
+    assert torch.equal(torch.stack(processed_images), dense_batch)
+    assert list_metadata == dense_metadata

--- a/inference_models/tests/unit_tests/models/common/roboflow/test_pre_processing.py
+++ b/inference_models/tests/unit_tests/models/common/roboflow/test_pre_processing.py
@@ -1,3 +1,5 @@
+from unittest.mock import MagicMock
+
 import numpy as np
 import pytest
 import torch
@@ -6,6 +8,9 @@ from PIL.Image import Image
 from inference_models import PreProcessingOverrides
 from inference_models.entities import ImageDimensions
 from inference_models.errors import ModelInputError, ModelRuntimeError
+from inference_models.models.common.roboflow import (
+    pre_processing as pre_processing_module,
+)
 from inference_models.models.common.roboflow.model_packages import (
     AnySizePadding,
     ColorMode,
@@ -10222,6 +10227,35 @@ def test_pre_process_network_input_stacks_uniform_any_size_images(images) -> Non
     )
 
     assert dense_batch.shape == (2, 3, 20, 30)
+    assert len(metadata) == 2
+
+
+def test_any_size_image_list_keeps_a_4d_tensor_batch_vectorized(
+    monkeypatch,
+) -> None:
+    images = torch.zeros((2, 3, 20, 30), dtype=torch.uint8)
+    batched_pre_processing = MagicMock(
+        wraps=pre_processing_module.pre_process_images_tensor
+    )
+    monkeypatch.setattr(
+        pre_processing_module,
+        "pre_process_images_tensor",
+        batched_pre_processing,
+    )
+
+    processed_images, metadata = pre_process_network_input_to_image_list(
+        images=images,
+        image_pre_processing=ImagePreProcessing(),
+        network_input=_any_size_network_input(),
+        target_device=torch.device("cpu"),
+    )
+
+    batched_pre_processing.assert_called_once()
+    assert batched_pre_processing.call_args.kwargs["images"] is images
+    assert [tuple(image.shape) for image in processed_images] == [
+        (3, 20, 30),
+        (3, 20, 30),
+    ]
     assert len(metadata) == 2
 
 

--- a/inference_models/tests/unit_tests/models/test_cosmos3_reasoner_hf.py
+++ b/inference_models/tests/unit_tests/models/test_cosmos3_reasoner_hf.py
@@ -8,6 +8,7 @@ import torch
 from inference_models.configuration import (
     INFERENCE_MODELS_COSMOS3_DEFAULT_MAX_NEW_TOKENS,
 )
+from inference_models.errors import CorruptedModelPackageError
 from inference_models.models.cosmos3 import cosmos3_reasoner_hf as reasoner_module
 from inference_models.models.cosmos3.cosmos3_reasoner_hf import Cosmos3EdgeReasoner
 
@@ -324,12 +325,13 @@ def test_load_inference_config_parses_the_trainers_any_size_config(tmp_path) -> 
     assert reasoner_module._load_inference_config(str(tmp_path / "missing")) is None
 
 
-def test_load_inference_config_skips_a_config_the_schema_rejects(tmp_path) -> None:
+def test_load_inference_config_rejects_a_config_the_schema_rejects(tmp_path) -> None:
     broken = json.loads(json.dumps(TRAINER_NULL_INFERENCE_CONFIG))
     broken["network_input"]["dynamic_spatial_size_supported"] = False
     (tmp_path / "inference_config.json").write_text(json.dumps(broken))
 
-    assert reasoner_module._load_inference_config(str(tmp_path)) is None
+    with pytest.raises(CorruptedModelPackageError):
+        reasoner_module._load_inference_config(str(tmp_path))
 
 
 def test_pre_process_generation_applies_the_packages_preprocessing(monkeypatch) -> None:
@@ -337,9 +339,13 @@ def test_pre_process_generation_applies_the_packages_preprocessing(monkeypatch) 
     reasoner._inference_config = reasoner_module.InferenceConfig.model_validate(
         VALID_INFERENCE_CONFIG
     )
-    prepared = torch.zeros((1, 3, 8, 8))
+    prepared = [torch.zeros((3, 8, 8))]
     pre_process = MagicMock(return_value=(prepared, [MagicMock()]))
-    monkeypatch.setattr(reasoner_module, "pre_process_network_input", pre_process)
+    monkeypatch.setattr(
+        reasoner_module,
+        "pre_process_network_input_to_image_list",
+        pre_process,
+    )
 
     reasoner.pre_process_generation(images=np.zeros((8, 8, 3), dtype=np.uint8))
 

--- a/inference_models/tests/unit_tests/models/test_vlm_any_size_preprocessing.py
+++ b/inference_models/tests/unit_tests/models/test_vlm_any_size_preprocessing.py
@@ -1,0 +1,178 @@
+from typing import List
+from unittest.mock import MagicMock
+
+import numpy as np
+import torch
+
+from inference_models.entities import ImageDimensions
+from inference_models.models.common.roboflow.model_packages import (
+    AnySizePadding,
+    ColorMode,
+    ImagePreProcessing,
+    InferenceConfig,
+    NetworkInputDefinition,
+    ResizeMode,
+)
+from inference_models.models.cosmos3.cosmos3_reasoner_hf import Cosmos3EdgeReasoner
+from inference_models.models.florence2.florence2_hf import Florence2HF
+from inference_models.models.gemma4.gemma4_hf import Gemma4HF
+from inference_models.models.paligemma.paligemma_hf import PaliGemmaHF
+from inference_models.models.qwen25vl.qwen25vl_hf import Qwen25VLHF
+from inference_models.models.smolvlm.smolvlm_hf import SmolVLMHF
+
+
+def _any_size_inference_config() -> InferenceConfig:
+    inference_config = InferenceConfig(
+        image_pre_processing=ImagePreProcessing(),
+        network_input=NetworkInputDefinition(
+            training_input_size=None,
+            dynamic_spatial_size_supported=True,
+            dynamic_spatial_size_mode=AnySizePadding(type="any-size"),
+            color_mode=ColorMode.RGB,
+            resize_mode=ResizeMode.STRETCH_TO,
+            input_channels=3,
+        ),
+    )
+
+    return inference_config
+
+
+def _heterogeneous_images() -> List[np.ndarray]:
+    images = [
+        np.zeros((20, 30, 3), dtype=np.uint8),
+        np.zeros((40, 50, 3), dtype=np.uint8),
+    ]
+
+    return images
+
+
+def _assert_tensor_image_shapes(images: List[torch.Tensor]) -> None:
+    assert [tuple(image.shape) for image in images] == [
+        (3, 20, 30),
+        (3, 40, 50),
+    ]
+
+
+def test_smolvlm_preserves_heterogeneous_images_for_the_processor() -> None:
+    processor = MagicMock()
+    processor.apply_chat_template.return_value = ["templated"]
+    model = SmolVLMHF(
+        model=MagicMock(),
+        processor=processor,
+        inference_config=_any_size_inference_config(),
+        device=torch.device("cpu"),
+        torch_dtype=torch.float32,
+    )
+
+    model.pre_process_generation(
+        images=_heterogeneous_images(),
+        prompt="Describe the images.",
+        input_color_format="rgb",
+    )
+
+    _assert_tensor_image_shapes(processor.call_args.kwargs["images"])
+
+
+def test_paligemma_preserves_heterogeneous_images_for_the_processor() -> None:
+    processor = MagicMock()
+    model = PaliGemmaHF(
+        model=MagicMock(),
+        processor=processor,
+        inference_config=_any_size_inference_config(),
+        device=torch.device("cpu"),
+        torch_dtype=torch.float32,
+    )
+
+    model.pre_process_generation(
+        images=_heterogeneous_images(),
+        prompt="Describe the images.",
+        input_color_format="rgb",
+    )
+
+    _assert_tensor_image_shapes(processor.call_args.kwargs["images"])
+
+
+def test_qwen25vl_preserves_heterogeneous_images_for_the_processor() -> None:
+    processor = MagicMock()
+    processor.apply_chat_template.return_value = "templated"
+    processor.return_value = {"pixel_values": torch.zeros((2, 3, 8, 8))}
+    model = Qwen25VLHF(
+        model=MagicMock(),
+        processor=processor,
+        inference_config=_any_size_inference_config(),
+        device=torch.device("cpu"),
+    )
+
+    model.pre_process_generation(
+        images=_heterogeneous_images(),
+        prompt="Describe the images.",
+        input_color_format="rgb",
+    )
+
+    _assert_tensor_image_shapes(processor.call_args.kwargs["images"])
+
+
+def test_gemma4_preserves_heterogeneous_images_for_the_processor() -> None:
+    processor = MagicMock()
+    model = Gemma4HF(
+        model=MagicMock(),
+        processor=processor,
+        inference_config=_any_size_inference_config(),
+        device=torch.device("cpu"),
+    )
+
+    model.pre_process_generation(
+        images=_heterogeneous_images(),
+        prompt="Describe the images.",
+        input_color_format="rgb",
+    )
+
+    conversation = processor.apply_chat_template.call_args.args[0]
+    image_content = conversation[1]["content"][:-1]
+    assert [entry["image"].size for entry in image_content] == [(30, 20), (50, 40)]
+
+
+def test_florence2_preserves_heterogeneous_images_for_the_processor() -> None:
+    processor = MagicMock()
+    model = Florence2HF(
+        model=MagicMock(),
+        processor=processor,
+        inference_config=_any_size_inference_config(),
+        device=torch.device("cpu"),
+        torch_dtype=torch.float32,
+    )
+
+    _, image_dimensions, metadata = model.pre_process_generation(
+        images=_heterogeneous_images(),
+        prompt="Describe the images.",
+        input_color_format="rgb",
+    )
+
+    _assert_tensor_image_shapes(processor.call_args.kwargs["images"])
+    assert image_dimensions == [
+        ImageDimensions(height=20, width=30),
+        ImageDimensions(height=40, width=50),
+    ]
+    assert metadata is not None
+
+
+def test_cosmos3_preserves_heterogeneous_images_for_the_processor() -> None:
+    model_weights = MagicMock()
+    model_weights.parameters.return_value = iter([torch.tensor(0.0)])
+    processor = MagicMock()
+    processor.apply_chat_template.return_value = "templated"
+    processor.return_value = {"input_ids": torch.tensor([[1, 2]])}
+    model = Cosmos3EdgeReasoner(
+        model=model_weights,
+        processor=processor,
+        inference_config=_any_size_inference_config(),
+        device=torch.device("cpu"),
+    )
+
+    model.pre_process_generation(
+        images=_heterogeneous_images(),
+        prompt="Describe the images.",
+        input_color_format="rgb",
+    )
+
+    _assert_tensor_image_shapes(processor.call_args.kwargs["images"])


### PR DESCRIPTION
## What does this PR do?

The Cosmos 3 fine-tuning change allows a model package to declare `training_input_size: null`. That means "do not force every image to a training resolution; let the VLM processor handle its natural size." The shared Roboflow preprocessing code accepted that configuration, but its batching and geometry logic still assumed that every processed image would have one common height and width.

Because this is shared preprocessing rather than Cosmos-specific code, the inconsistency could also affect SmolVLM, PaliGemma, Qwen2.5-VL, Gemma 4, and Florence 2.

### Problem 1: heterogeneous NumPy images crashed

For an any-size model, two NumPy images were correctly processed at their own dimensions, but the old API then tried to concatenate them into one dense tensor:

```text
image A: 20×30 -> tensor [1, C, 20, 30]
image B: 40×50 -> tensor [1, C, 40, 50]
                              |
                              v
                    torch.concat(...)
                              |
                              v
       RuntimeError: tensor sizes do not match
```

A dense tensor cannot represent different `H × W` values in the same batch. The failure therefore happened inside PyTorch instead of returning the independently sized images that these VLM processors support.

### Problem 2: heterogeneous tensor images could be silently distorted

The tensor-list path avoided the concatenation failure by resolving one target size from the **first** image and applying it to the entire list. With stretch resizing, the result looked like this:

```text
image A: [C, 20, 30] ----------------> [C, 20, 30]
image B: [C, 40, 50] -- stretched ---> [C, 20, 30]
                                              |
                                              v
                                  dense [2, C, 20, 30]
```

Inference completed, but image B's aspect ratio and spatial information were changed even though the package explicitly declared that arbitrary image sizes were supported. The behavior also depended on whether the same logical inputs arrived as NumPy arrays or tensors: one representation crashed, while the other silently changed the data.

### Problem 3: static crop could be resized back to the pre-crop dimensions

The fallback target dimensions were resolved before geometry-changing preprocessing. For a nullable any-size configuration, a crop could therefore reduce the image and then the resize step would expand the cropped result back to the original shape:

```text
original image                 20×30
target chosen before crop      20×30
crop right half                20×15
stretch to stale target        20×30
```

The crop removed the intended pixels, but the retained half was then stretched across the old width. This contradicted the expected any-size behavior, where the post-crop `20×15` dimensions should be retained unless the caller explicitly requests another supported size.

### Problem 4: invalid or restricted package configurations failed unclearly

Cosmos treated every `CorruptedModelPackageError` from an existing `inference_config.json` as if the file did not exist. A malformed or semantically invalid package could therefore load while silently skipping the preprocessing used during training. Separately, applying `max_allowed_input_size` to a nullable any-size package attempted to read `.height` and `.width` from `None`, producing an implementation-level exception instead of a package restriction error.

### Behavior after this change

This PR introduces `pre_process_network_input_to_image_list(...)` for model implementations whose processors accept image lists. For nullable any-size configurations, it preprocesses every image independently and returns one `C × H × W` tensor plus one metadata entry per image. The six affected VLM wrappers use this path, so heterogeneous dimensions reach their native processors without being forced into an artificial dense batch. Fixed-size configurations still delegate to the established dense path. Already-uniform inputs supplied as a dense 4D tensor also retain the previous vectorized preprocessing path; the processed batch is only unbound into inexpensive per-image tensor views afterward. The existing `pre_process_network_input(...)` contract also remains dense: it stacks uniform any-size results and raises a clear `ModelInputError` when heterogeneous results cannot be represented safely. Fallback dimensions are now resolved after static crop and other geometry-changing preprocessing, while fixed training sizes and explicit supported `image_size_wh` requests remain authoritative.

```mermaid
flowchart TD
    A[Input image or image list] --> B{Declared training size?}
    B -->|Yes| C[Existing fixed-size dense preprocessing]
    C --> D[List of C×H×W tensors]
    B -->|No: nullable any-size| E[Process each image independently]
    E --> F[Apply crop, color and photometric preprocessing]
    F --> G[Resolve fallback from post-processing dimensions]
    G --> D
    D --> H{Caller contract}
    H -->|VLM list API| I[Pass independently sized images to VLM processor]
    H -->|Dense API| J{All output shapes equal?}
    J -->|Yes| K[Stack into B×C×H×W]
    J -->|No| L[Raise ModelInputError]
```

Cosmos video handling, single-image HTTP behavior, fine-tune prompting, and thinking behavior are unchanged. An existing but invalid Cosmos configuration now raises `CorruptedModelPackageError`; only a genuinely missing file means there is no configuration. A maximum-size restriction applied without a declared training size now raises `ModelPackageRestrictedError` because the limit cannot be verified safely.

**Main elements:**
- Shared dense and image-list Roboflow preprocessing contracts, including post-processing dimension resolution
- Cosmos 3, SmolVLM, PaliGemma, Qwen2.5-VL, Gemma 4, and Florence 2 adoption
- Package validation and strict Cosmos inference configuration loading
- Unit coverage for NumPy/tensor inputs, all six VLM wrappers, configuration handling, and Cosmos behavior
- `inference-models` Unreleased changelog update

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other:

## Testing

### Unit tests

- 323 focused common preprocessing, package validation, Cosmos, Qwen2.5-VL, and six-wrapper tests passed.
- The complete `inference-models` unit suite reached 1,556 passed and 22 skipped, with 14 unrelated local-environment failures. After excluding exactly those failures, the remainder passed. Seven require the optional `sam3` package, two require `boto3`, and five compare macOS `/var` and `/private/var` aliases as unequal paths.

### Integration tests

- A real CUDA run on `orin-agx-jp62` with Transformers 5.15.0 and `nvidia/Cosmos3-Edge` passed. Two COCO images (`426 × 640` and `640 × 586`) retained their distinct sizes; Cosmos produced grids `[1, 26, 40]` and `[1, 40, 36]`, matching image-token counts `260` and `360`, and the model returned logits shaped `[2, 1, 131072]`. The normal single-image wrapper also completed successfully.
- 13 Cosmos workflow block and dependent-resource tests passed.
- The credential-gated Cosmos staging test was not run because `ROBOFLOW_API_KEY`, `COSMOS3_FINETUNE_MODEL_ID`, and CUDA were unavailable.

### Other

- A CPU timing sanity check for an eight-image `224 × 224` tensor measured the list API fast path at `0.0292 ms` versus `0.0267 ms` for direct dense preprocessing (`1.10×`), removing the clear per-image preprocessing overhead for this case.

- `UV_CACHE_DIR=/private/tmp/codex-uv-cache-pr2905 uv run make check_code_quality` passed.
- Black, isort, Flake8 undefined-name/syntax checks, and `git diff --check` passed for all changed Python files.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where necessary, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have updated the documentation accordingly (if applicable)
