### PR TITLE
Fix custom Python blocks fed with semantic segmentation predictions

### DIFF
--- a/inference/core/workflows/core_steps/common/serializers.py
+++ b/inference/core/workflows/core_steps/common/serializers.py
@@ -403,6 +403,31 @@ def serialize_timestamp(timestamp: datetime) -> str:
     return timestamp.isoformat()
 
 
+def serialise_sv_detections_for_transport(detections: sv.Detections) -> dict:
+    """Serialise detections for the custom-Python-block remote executor.
+
+    Semantic segmentation blocks emit ``sv.Detections`` with ``mask=None``, the
+    class masks stored as COCO RLE in ``data["rle_mask"]`` and no
+    ``image_dimensions``. The plain serialiser drops the RLE and emits
+    ``image: {width: None, height: None}``, which makes
+    ``sv.Detections.from_inference`` raise on the receiving side. Keep the RLE
+    and fill the image size from it so the payload deserialises everywhere.
+    """
+    if detections.data.get(RLE_MASK_KEY_IN_SV_DETECTIONS) is not None:
+        serialised = serialise_rle_sv_detections(detections=detections)
+    else:
+        serialised = serialise_sv_detections(detections=detections)
+    image = serialised.get("image") or {}
+    if image.get("width") is None or image.get("height") is None:
+        for prediction in serialised.get("predictions", []):
+            rle = prediction.get(RLE_MASK_KEY_IN_INFERENCE_RESPONSE)
+            size = rle.get("size") if isinstance(rle, dict) else None
+            if size is not None and len(size) == 2:
+                serialised["image"] = {"width": int(size[1]), "height": int(size[0])}
+                break
+    return serialised
+
+
 def serialise_rle_sv_detections(detections: sv.Detections) -> dict:
     rle_masks = detections.data.get(RLE_MASK_KEY_IN_SV_DETECTIONS)
     if rle_masks is None:

--- a/inference/core/workflows/core_steps/models/roboflow/semantic_segmentation/v1.py
+++ b/inference/core/workflows/core_steps/models/roboflow/semantic_segmentation/v1.py
@@ -316,6 +316,14 @@ class RoboflowSemanticSegmentationModelBlockV1(WorkflowBlock):
         )
 
         if conf_array is not None:
-            result["confidence_mask"] = conf_array
+            # sv.Detections data fields must have one entry per detection:
+            # filtering indexes every field with a length-N boolean mask, and a
+            # bare (H, W) map here fails with "boolean index did not match
+            # indexed array along axis 0". Share the single map across an
+            # object array of length N instead of copying it per class.
+            confidence_maps = np.empty(len(class_id_list), dtype=object)
+            for idx in range(len(class_id_list)):
+                confidence_maps[idx] = conf_array
+            result["confidence_mask"] = confidence_maps
 
         return result

--- a/inference/core/workflows/core_steps/models/roboflow/semantic_segmentation/v1.py
+++ b/inference/core/workflows/core_steps/models/roboflow/semantic_segmentation/v1.py
@@ -23,6 +23,7 @@ from inference.core.managers.base import ModelManager
 from inference.core.workflows.core_steps.common.entities import StepExecutionMode
 from inference.core.workflows.execution_engine.constants import (
     DETECTION_ID_KEY,
+    IMAGE_DIMENSIONS_KEY,
     INFERENCE_ID_KEY,
     RLE_MASK_KEY_IN_SV_DETECTIONS,
 )
@@ -311,6 +312,9 @@ class RoboflowSemanticSegmentationModelBlockV1(WorkflowBlock):
             data={
                 "class_name": np.array(class_name_list),
                 DETECTION_ID_KEY: detection_ids,
+                IMAGE_DIMENSIONS_KEY: np.array(
+                    [list(mask_array.shape[:2])] * len(class_id_list)
+                ),
                 RLE_MASK_KEY_IN_SV_DETECTIONS: np.array(rle_list, dtype=object),
             },
         )

--- a/inference/core/workflows/core_steps/models/roboflow/semantic_segmentation/v1_tensor.py
+++ b/inference/core/workflows/core_steps/models/roboflow/semantic_segmentation/v1_tensor.py
@@ -148,7 +148,8 @@ BACKGROUND_CLASS_ID = 0
 
 # `image_metadata` key under which the dense per-pixel confidence map is carried
 # for numpy parity (numpy `v1.py` stores `conf_array` on the sv.Detections under
-# `result["confidence_mask"]`). The serialiser never emits it into `predictions`,
+# `result["confidence_mask"]`, as a per-detection object array sharing one map).
+# The serialiser never emits it into `predictions`,
 # but it survives for consumers reading the prediction's `image_metadata`.
 CONFIDENCE_MASK_KEY = "confidence_mask"
 

--- a/inference/core/workflows/core_steps/models/roboflow/semantic_segmentation/v2.py
+++ b/inference/core/workflows/core_steps/models/roboflow/semantic_segmentation/v2.py
@@ -23,6 +23,7 @@ from inference.core.managers.base import ModelManager
 from inference.core.workflows.core_steps.common.entities import StepExecutionMode
 from inference.core.workflows.execution_engine.constants import (
     DETECTION_ID_KEY,
+    IMAGE_DIMENSIONS_KEY,
     INFERENCE_ID_KEY,
     RLE_MASK_KEY_IN_SV_DETECTIONS,
 )
@@ -372,11 +373,22 @@ class RoboflowSemanticSegmentationModelBlockV2(WorkflowBlock):
             data={
                 "class_name": np.array(class_name_list),
                 DETECTION_ID_KEY: detection_ids,
+                IMAGE_DIMENSIONS_KEY: np.array(
+                    [list(mask_array.shape[:2])] * len(class_id_list)
+                ),
                 RLE_MASK_KEY_IN_SV_DETECTIONS: np.array(rle_list, dtype=object),
             },
         )
 
         if conf_array is not None:
-            result["confidence_mask"] = conf_array
+            # sv.Detections data fields must have one entry per detection:
+            # filtering indexes every field with a length-N boolean mask, and a
+            # bare (H, W) map here fails with "boolean index did not match
+            # indexed array along axis 0". Share the single map across an
+            # object array of length N instead of copying it per class.
+            confidence_maps = np.empty(len(class_id_list), dtype=object)
+            for idx in range(len(class_id_list)):
+                confidence_maps[idx] = conf_array
+            result["confidence_mask"] = confidence_maps
 
         return result

--- a/inference/core/workflows/core_steps/models/roboflow/semantic_segmentation/v2_tensor.py
+++ b/inference/core/workflows/core_steps/models/roboflow/semantic_segmentation/v2_tensor.py
@@ -145,7 +145,8 @@ BACKGROUND_CLASS_ID = 0
 
 # `image_metadata` key under which the dense per-pixel confidence map is carried
 # for numpy parity (numpy `v2.py` stores `conf_array` on the sv.Detections under
-# `result["confidence_mask"]`). The serialiser never emits it into `predictions`,
+# `result["confidence_mask"]`, as a per-detection object array sharing one map).
+# The serialiser never emits it into `predictions`,
 # but it survives for consumers reading the prediction's `image_metadata`.
 CONFIDENCE_MASK_KEY = "confidence_mask"
 

--- a/inference/core/workflows/execution_engine/v1/dynamic_blocks/modal_executor.py
+++ b/inference/core/workflows/execution_engine/v1/dynamic_blocks/modal_executor.py
@@ -74,8 +74,8 @@ else:
 from datetime import datetime
 
 from inference.core.workflows.core_steps.common.deserializers import (
-    deserialize_detections_kind,
     deserialize_image_kind,
+    deserialize_rle_detections_kind,
     deserialize_video_metadata_kind,
 )
 
@@ -414,7 +414,7 @@ def serialize_for_modal_remote_execution(inputs: Dict[str, Any]) -> str:
         import supervision as sv
 
         from inference.core.workflows.core_steps.common.serializers import (
-            serialise_sv_detections,
+            serialise_sv_detections_for_transport,
             serialize_video_metadata_kind,
         )
         from inference.core.workflows.execution_engine.entities.base import (
@@ -424,7 +424,7 @@ def serialize_for_modal_remote_execution(inputs: Dict[str, Any]) -> str:
         )
 
         if isinstance(value, sv.Detections):
-            serialized = serialise_sv_detections(detections=value)
+            serialized = serialise_sv_detections_for_transport(detections=value)
             serialized["_type"] = "sv_detections"
         elif isinstance(value, Batch):
             # Batch is not a list/dict subclass, so without an explicit case it
@@ -487,7 +487,7 @@ def deserialize_for_modal_remote_execution(json_str: str) -> BlockResult:
                     decoded_obj = {
                         k: decode_inputs(v) for k, v in obj.items() if k != "_type"
                     }
-                    return deserialize_detections_kind("input", decoded_obj)
+                    return deserialize_rle_detections_kind("input", decoded_obj)
                 elif obj["_type"] == "video_metadata":
                     # First decode any nested special types
                     decoded_obj = {
@@ -903,7 +903,7 @@ def serialize_inputs_for_msgpack(inputs: Dict[str, Any]) -> Dict[str, Any]:
     import supervision as sv
 
     from inference.core.workflows.core_steps.common.serializers import (
-        serialise_sv_detections,
+        serialise_sv_detections_for_transport,
         serialize_video_metadata_kind,
     )
     from inference.core.workflows.execution_engine.entities.base import (
@@ -914,7 +914,7 @@ def serialize_inputs_for_msgpack(inputs: Dict[str, Any]) -> Dict[str, Any]:
 
     def _pack(value: Any) -> Any:
         if isinstance(value, sv.Detections):
-            d = serialise_sv_detections(detections=value)
+            d = serialise_sv_detections_for_transport(detections=value)
             d["_type"] = "sv_detections"
             return {k: _pack(v) for k, v in d.items()}
         if isinstance(value, Batch):
@@ -963,8 +963,8 @@ def _deserialize_msgpack_result(result: Any) -> Any:
     workflow_image, and video_metadata to mirror the HTTP path.
     """
     from inference.core.workflows.core_steps.common.deserializers import (
-        deserialize_detections_kind,
         deserialize_image_kind,
+        deserialize_rle_detections_kind,
         deserialize_video_metadata_kind,
     )
 
@@ -982,7 +982,7 @@ def _deserialize_msgpack_result(result: Any) -> Any:
                 for k, v in result.items()
                 if k != "_type"
             }
-            return deserialize_detections_kind("result", decoded)
+            return deserialize_rle_detections_kind("result", decoded)
         if _type == "workflow_image":
             decoded = {
                 k: _deserialize_msgpack_result(v)

--- a/modal/modal_app.py
+++ b/modal/modal_app.py
@@ -663,8 +663,8 @@ from datetime import datetime
         import numpy as np
 
         from inference.core.workflows.core_steps.common.deserializers import (
-            deserialize_detections_kind,
             deserialize_image_kind,
+            deserialize_rle_detections_kind,
             deserialize_video_metadata_kind,
         )
 
@@ -727,8 +727,8 @@ from datetime import datetime
             from datetime import datetime
 
             from inference.core.workflows.core_steps.common.deserializers import (
-                deserialize_detections_kind,
                 deserialize_image_kind,
+                deserialize_rle_detections_kind,
                 deserialize_video_metadata_kind,
             )
             from inference.core.workflows.execution_engine.entities.base import Batch
@@ -770,7 +770,7 @@ from datetime import datetime
 
                     from inference.core.workflows.core_steps.common.serializers import (
                         serialise_image,
-                        serialise_sv_detections,
+                        serialise_sv_detections_for_transport,
                         serialize_video_metadata_kind,
                     )
                     from inference.core.workflows.execution_engine.entities.base import (
@@ -780,7 +780,9 @@ from datetime import datetime
 
                     # Apply standard serialization and add type markers based on original type
                     if isinstance(value, sv.Detections):
-                        serialized = serialise_sv_detections(detections=value)
+                        serialized = serialise_sv_detections_for_transport(
+                            detections=value
+                        )
                         serialized["_type"] = "sv_detections"
                     elif isinstance(value, WorkflowImageData):
                         serialized = serialise_image(image=value)
@@ -861,7 +863,9 @@ from datetime import datetime
                                     for k, v in obj.items()
                                     if k != "_type"
                                 }
-                                return deserialize_detections_kind("input", decoded_obj)
+                                return deserialize_rle_detections_kind(
+                                    "input", decoded_obj
+                                )
                             elif obj["_type"] == "video_metadata":
                                 # First decode any nested special types
                                 decoded_obj = {
@@ -1117,8 +1121,8 @@ from datetime import datetime
         import numpy as np
 
         from inference.core.workflows.core_steps.common.deserializers import (
-            deserialize_detections_kind,
             deserialize_image_kind,
+            deserialize_rle_detections_kind,
             deserialize_video_metadata_kind,
         )
         from inference.core.workflows.execution_engine.entities.base import Batch
@@ -1182,7 +1186,7 @@ from datetime import datetime
 
                 if _type == "sv_detections":
                     decoded = {k: _decode(v) for k, v in obj.items() if k != "_type"}
-                    return deserialize_detections_kind("input", decoded)
+                    return deserialize_rle_detections_kind("input", decoded)
                 if _type == "video_metadata":
                     decoded = {k: _decode(v) for k, v in obj.items() if k != "_type"}
                     return deserialize_video_metadata_kind("input", decoded)
@@ -1234,7 +1238,7 @@ from datetime import datetime
 
         from inference.core.workflows.core_steps.common.serializers import (
             serialise_image,
-            serialise_sv_detections,
+            serialise_sv_detections_for_transport,
             serialize_video_metadata_kind,
         )
         from inference.core.workflows.execution_engine.entities.base import (
@@ -1248,7 +1252,7 @@ from datetime import datetime
             if isinstance(obj, datetime):
                 return {"_type": "datetime", "value": obj.isoformat()}
             if isinstance(obj, sv.Detections):
-                serialized = serialise_sv_detections(detections=obj)
+                serialized = serialise_sv_detections_for_transport(detections=obj)
                 serialized["_type"] = "sv_detections"
                 return _encode(serialized)
             if isinstance(obj, WorkflowImageData):

--- a/tests/workflows/unit_tests/core_steps/models/roboflow/semantic_segmentation/test_v1.py
+++ b/tests/workflows/unit_tests/core_steps/models/roboflow/semantic_segmentation/test_v1.py
@@ -469,3 +469,22 @@ def test_convert_to_sv_detections_output_survives_boolean_filtering() -> None:
     assert filtered.data["class_name"].tolist() == ["dog"]
     assert filtered.data["confidence_mask"][0].shape == (50, 50)
     assert filtered.data["confidence_mask"][0] is result.data["confidence_mask"][1]
+
+
+def test_convert_to_sv_detections_attaches_image_dimensions() -> None:
+    # Consumers such as the custom Python block transport and the detections
+    # serialisers read `image_dimensions` per detection, like every other
+    # model block provides it.
+    seg = np.zeros((40, 60), dtype=np.uint8)
+    seg[5:20, 5:20] = 1
+    seg[25:35, 30:55] = 2
+
+    result = BLOCK_CLS._convert_to_sv_detections(
+        {
+            "segmentation_mask": _encode_mask_as_base64_png(seg),
+            "class_map": {"1": "cat", "2": "dog"},
+        }
+    )
+
+    assert len(result) == 2
+    assert result.data["image_dimensions"].tolist() == [[40, 60], [40, 60]]

--- a/tests/workflows/unit_tests/core_steps/models/roboflow/semantic_segmentation/test_v1.py
+++ b/tests/workflows/unit_tests/core_steps/models/roboflow/semantic_segmentation/test_v1.py
@@ -156,7 +156,10 @@ def test_convert_to_sv_detections_derives_confidence_from_mask() -> None:
     )
 
     assert "confidence_mask" in result.data
-    assert result.data["confidence_mask"].shape == (50, 50)
+    # One entry per detection so boolean filtering keeps working; each entry
+    # is the shared full-frame confidence map.
+    assert result.data["confidence_mask"].shape == (len(result),)
+    assert result.data["confidence_mask"][0].shape == (50, 50)
     assert result.confidence is not None
     assert abs(float(result.confidence[0]) - 200 / 255.0) < 0.01
 
@@ -334,8 +337,11 @@ def test_convert_to_sv_detections_numpy_masks_match_base64_path() -> None:
     assert [r["counts"] for r in via_numpy.data["rle_mask"]] == [
         r["counts"] for r in via_b64.data["rle_mask"]
     ]
+    assert len(via_numpy.data["confidence_mask"]) == len(
+        via_b64.data["confidence_mask"]
+    )
     assert np.array_equal(
-        via_numpy.data["confidence_mask"], via_b64.data["confidence_mask"]
+        via_numpy.data["confidence_mask"][0], via_b64.data["confidence_mask"][0]
     )
 
 
@@ -360,7 +366,9 @@ _TENSOR_ONLY = pytest.mark.skipif(
 
 
 @_TENSOR_ONLY
-def test_tensor_native_response_conversion_carries_confidence_mask_on_image_metadata() -> None:
+def test_tensor_native_response_conversion_carries_confidence_mask_on_image_metadata() -> (
+    None
+):
     # numpy `v1.py` attaches the decoded confidence map under
     # `result["confidence_mask"]`; the tensor sibling carries the same map on
     # `InstanceDetections.image_metadata` (the serialiser emits neither).
@@ -434,3 +442,30 @@ def test_tensor_native_response_conversion_empty_mask_has_no_confidence_mask() -
 
     assert len(result) == 0
     assert CONFIDENCE_MASK_KEY not in result.image_metadata
+
+
+def test_convert_to_sv_detections_output_survives_boolean_filtering() -> None:
+    # Regression: the confidence map used to be stored as a bare (H, W) array
+    # in `data`, so filtering the detections (which indexes every data field
+    # with a length-N boolean mask) failed with "boolean index did not match
+    # indexed array along axis 0".
+    seg = np.zeros((50, 50), dtype=np.uint8)
+    seg[5:20, 5:20] = 1
+    seg[30:45, 30:45] = 2
+    conf = np.full((50, 50), 200, dtype=np.uint8)
+
+    result = BLOCK_CLS._convert_to_sv_detections(
+        {
+            "segmentation_mask": _encode_mask_as_base64_png(seg),
+            "confidence_mask": _encode_mask_as_base64_png(conf),
+            "class_map": {"1": "cat", "2": "dog"},
+        }
+    )
+    assert len(result) == 2
+
+    filtered = result[np.array([False, True])]
+
+    assert len(filtered) == 1
+    assert filtered.data["class_name"].tolist() == ["dog"]
+    assert filtered.data["confidence_mask"][0].shape == (50, 50)
+    assert filtered.data["confidence_mask"][0] is result.data["confidence_mask"][1]

--- a/tests/workflows/unit_tests/core_steps/models/roboflow/semantic_segmentation/test_v2.py
+++ b/tests/workflows/unit_tests/core_steps/models/roboflow/semantic_segmentation/test_v2.py
@@ -417,3 +417,22 @@ def test_convert_to_sv_detections_output_survives_boolean_filtering() -> None:
     assert filtered.data["class_name"].tolist() == ["dog"]
     assert filtered.data["confidence_mask"][0].shape == (50, 50)
     assert filtered.data["confidence_mask"][0] is result.data["confidence_mask"][1]
+
+
+def test_convert_to_sv_detections_attaches_image_dimensions() -> None:
+    # Consumers such as the custom Python block transport and the detections
+    # serialisers read `image_dimensions` per detection, like every other
+    # model block provides it.
+    seg = np.zeros((40, 60), dtype=np.uint8)
+    seg[5:20, 5:20] = 1
+    seg[25:35, 30:55] = 2
+
+    result = BLOCK_CLS._convert_to_sv_detections(
+        {
+            "segmentation_mask": _encode_mask_as_base64_png(seg),
+            "class_map": {"1": "cat", "2": "dog"},
+        }
+    )
+
+    assert len(result) == 2
+    assert result.data["image_dimensions"].tolist() == [[40, 60], [40, 60]]

--- a/tests/workflows/unit_tests/core_steps/models/roboflow/semantic_segmentation/test_v2.py
+++ b/tests/workflows/unit_tests/core_steps/models/roboflow/semantic_segmentation/test_v2.py
@@ -191,7 +191,10 @@ def test_convert_to_sv_detections_derives_confidence_from_mask() -> None:
     )
 
     assert "confidence_mask" in result.data
-    assert result.data["confidence_mask"].shape == (50, 50)
+    # One entry per detection so boolean filtering keeps working; each entry
+    # is the shared full-frame confidence map.
+    assert result.data["confidence_mask"].shape == (len(result),)
+    assert result.data["confidence_mask"][0].shape == (50, 50)
     assert result.confidence is not None
     assert abs(float(result.confidence[0]) - 200 / 255.0) < 0.01
 
@@ -369,8 +372,11 @@ def test_convert_to_sv_detections_numpy_masks_match_base64_path() -> None:
     assert [r["counts"] for r in via_numpy.data["rle_mask"]] == [
         r["counts"] for r in via_b64.data["rle_mask"]
     ]
+    assert len(via_numpy.data["confidence_mask"]) == len(
+        via_b64.data["confidence_mask"]
+    )
     assert np.array_equal(
-        via_numpy.data["confidence_mask"], via_b64.data["confidence_mask"]
+        via_numpy.data["confidence_mask"][0], via_b64.data["confidence_mask"][0]
     )
 
 
@@ -384,3 +390,30 @@ def test_convert_to_sv_detections_numpy_empty_mask_yields_empty_detections() -> 
     )
 
     assert len(result) == 0
+
+
+def test_convert_to_sv_detections_output_survives_boolean_filtering() -> None:
+    # Regression: the confidence map used to be stored as a bare (H, W) array
+    # in `data`, so filtering the detections (which indexes every data field
+    # with a length-N boolean mask) failed with "boolean index did not match
+    # indexed array along axis 0".
+    seg = np.zeros((50, 50), dtype=np.uint8)
+    seg[5:20, 5:20] = 1
+    seg[30:45, 30:45] = 2
+    conf = np.full((50, 50), 200, dtype=np.uint8)
+
+    result = RoboflowSemanticSegmentationModelBlockV2._convert_to_sv_detections(
+        {
+            "segmentation_mask": _encode_mask_as_base64_png(seg),
+            "confidence_mask": _encode_mask_as_base64_png(conf),
+            "class_map": {"1": "cat", "2": "dog"},
+        }
+    )
+    assert len(result) == 2
+
+    filtered = result[np.array([False, True])]
+
+    assert len(filtered) == 1
+    assert filtered.data["class_name"].tolist() == ["dog"]
+    assert filtered.data["confidence_mask"][0].shape == (50, 50)
+    assert filtered.data["confidence_mask"][0] is result.data["confidence_mask"][1]

--- a/tests/workflows/unit_tests/execution_engine/dynamic_blocs/test_modal_semantic_segmentation_transport.py
+++ b/tests/workflows/unit_tests/execution_engine/dynamic_blocs/test_modal_semantic_segmentation_transport.py
@@ -1,0 +1,265 @@
+"""Semantic-segmentation predictions across the Modal custom-block boundary.
+
+Semantic segmentation blocks emit ``sv.Detections`` with ``mask=None``, COCO RLE
+masks in ``data["rle_mask"]`` and (historically) no ``image_dimensions``. The
+generic serialiser dropped the RLE and produced ``image: {width: None,
+height: None}``; ``sv.Detections.from_inference`` then raised inside the
+websocket handler, outside the user-code guard, and the socket closed with no
+response ("WebSocket connection to Modal endpoint lost after the request was
+sent"). ``modal_app_with_fake_modal`` lives in conftest.
+"""
+
+import asyncio
+import json
+from uuid import uuid4
+
+import msgpack
+import numpy as np
+import supervision as sv
+from fastapi.testclient import TestClient
+from pycocotools import mask as mask_utils
+
+from inference.core.workflows.core_steps.common.serializers import (
+    serialise_sv_detections_for_transport,
+)
+from inference.core.workflows.execution_engine.constants import (
+    DETECTION_ID_KEY,
+    IMAGE_DIMENSIONS_KEY,
+    RLE_MASK_KEY_IN_SV_DETECTIONS,
+)
+from inference.core.workflows.execution_engine.v1.dynamic_blocks.modal_executor import (
+    _deserialize_msgpack_result,
+    serialize_for_modal_remote_execution,
+    serialize_inputs_for_msgpack,
+)
+
+from .conftest import build_ws_app
+
+H, W = 12, 16
+
+COVERAGE_CODE = """
+def run(self, predictions):
+    rles = predictions.data.get("rle_mask")
+    rle = rles[list(predictions.data["class_name"]).index("unharvested")]
+    total = int(rle["size"][0]) * int(rle["size"][1])
+    foreground = int(predictions.mask[1].sum()) if predictions.mask is not None else -1
+    return {"total": total, "foreground": foreground, "n": len(predictions)}
+"""
+
+
+def _semantic_segmentation_detections(with_image_dims: bool = False) -> sv.Detections:
+    label = np.zeros((H, W), dtype=np.uint8)
+    label[2:8, 3:11] = 1  # 48 px of class 1 ("unharvested")
+    xyxy, cids, names, rles = [], [], [], []
+    for cid, name in [(0, "harvested"), (1, "unharvested")]:
+        binary = label == cid
+        rows = np.where(np.any(binary, axis=1))[0]
+        cols = np.where(np.any(binary, axis=0))[0]
+        xyxy.append([cols[0], rows[0], cols[-1], rows[-1]])
+        cids.append(cid)
+        names.append(name)
+        rle = mask_utils.encode(np.asfortranarray(binary.astype(np.uint8)))
+        rle["counts"] = rle["counts"].decode("utf-8")
+        rles.append(rle)
+    data = {
+        "class_name": np.array(names),
+        DETECTION_ID_KEY: np.array([str(uuid4()) for _ in cids]),
+        RLE_MASK_KEY_IN_SV_DETECTIONS: np.array(rles, dtype=object),
+    }
+    if with_image_dims:
+        data[IMAGE_DIMENSIONS_KEY] = np.array([[H, W]] * len(cids))
+    return sv.Detections(
+        xyxy=np.array(xyxy, dtype=np.float64),
+        mask=None,
+        class_id=np.array(cids),
+        confidence=np.ones(len(cids), dtype=np.float32),
+        data=data,
+    )
+
+
+def _through_msgpack(payload: dict) -> dict:
+    return msgpack.unpackb(msgpack.packb(payload, use_bin_type=True), raw=False)
+
+
+def _ws_executor(module):
+    executor = module.Executor.__new__(module.Executor)
+    executor._code_namespaces = {}
+    executor._shared_globals = {}
+    return executor
+
+
+# --------------------------------------------------------------------------- #
+# serializer: RLE kept, image size recovered from it
+# --------------------------------------------------------------------------- #
+
+
+def test_transport_serializer_keeps_rle_and_recovers_image_size() -> None:
+    serialised = serialise_sv_detections_for_transport(
+        _semantic_segmentation_detections(with_image_dims=False)
+    )
+
+    assert serialised["image"] == {"width": W, "height": H}
+    assert [p["rle_mask"]["size"] for p in serialised["predictions"]] == [[H, W]] * 2
+    assert all("points" not in p for p in serialised["predictions"])
+
+
+def test_transport_serializer_falls_back_to_plain_detections() -> None:
+    detections = sv.Detections(
+        xyxy=np.array([[1.0, 2.0, 5.0, 6.0]]),
+        class_id=np.array([0]),
+        confidence=np.array([0.9], dtype=np.float32),
+        data={
+            "class_name": np.array(["a"]),
+            DETECTION_ID_KEY: np.array(["d1"]),
+            IMAGE_DIMENSIONS_KEY: np.array([[H, W]]),
+        },
+    )
+
+    serialised = serialise_sv_detections_for_transport(detections)
+
+    assert serialised["image"] == {"width": W, "height": H}
+    assert "rle_mask" not in serialised["predictions"][0]
+
+
+# --------------------------------------------------------------------------- #
+# websocket transport: inputs round trip with the RLE, and user code sees it
+# --------------------------------------------------------------------------- #
+
+
+def test_ws_inputs_round_trip_semantic_segmentation_without_image_dims(
+    modal_app_with_fake_modal,
+) -> None:
+    wire = _through_msgpack(
+        serialize_inputs_for_msgpack(
+            {"predictions": _semantic_segmentation_detections(with_image_dims=False)}
+        )
+    )
+
+    decoded = modal_app_with_fake_modal.Executor._deserialize_msgpack_inputs(wire)
+
+    rebuilt = decoded["predictions"]
+    assert isinstance(rebuilt, sv.Detections)
+    assert len(rebuilt) == 2
+    assert list(rebuilt.data["class_name"]) == ["harvested", "unharvested"]
+    assert rebuilt.data[RLE_MASK_KEY_IN_SV_DETECTIONS][1]["size"] == [H, W]
+    assert (rebuilt.data[IMAGE_DIMENSIONS_KEY] == [[H, W], [H, W]]).all()
+
+
+def test_ws_user_code_receives_rle_masks(modal_app_with_fake_modal) -> None:
+    module = modal_app_with_fake_modal
+    wire = _through_msgpack(
+        serialize_inputs_for_msgpack(
+            {"predictions": _semantic_segmentation_detections()}
+        )
+    )
+    inputs = module.Executor._deserialize_msgpack_inputs(wire)
+
+    response = module.Executor._run_user_code_ws(
+        _ws_executor(module), COVERAGE_CODE, [], "run", inputs
+    )
+
+    assert response["success"], response
+    assert response["result"] == {"total": H * W, "foreground": 48, "n": 2}
+
+
+def test_ws_result_round_trip_semantic_segmentation(
+    modal_app_with_fake_modal,
+) -> None:
+    encoded = modal_app_with_fake_modal.Executor._serialize_msgpack_result(
+        {"predictions": _semantic_segmentation_detections()}
+    )
+
+    decoded = _deserialize_msgpack_result(_through_msgpack(encoded))
+
+    rebuilt = decoded["predictions"]
+    assert len(rebuilt) == 2
+    assert rebuilt.data[RLE_MASK_KEY_IN_SV_DETECTIONS][1]["size"] == [H, W]
+
+
+# --------------------------------------------------------------------------- #
+# websocket handler: a deserialization failure is an error frame, not a hangup
+# --------------------------------------------------------------------------- #
+
+
+def test_ws_handler_reports_input_deserialization_failure_instead_of_closing(
+    modal_app_with_fake_modal,
+) -> None:
+    """The failure mode behind the original bug: detections the server cannot
+    rebuild must come back as an error frame, and the socket must survive."""
+    module = modal_app_with_fake_modal
+    _, ws_app = build_ws_app(module, module.Executor._run_user_code_ws)
+    # `predictions` is tagged as detections but lacks the required keys.
+    broken_frame = msgpack.packb(
+        {
+            "code_str": "def run(self, predictions):\n    return {'ok': True}\n",
+            "imports": [],
+            "run_function_name": "run",
+            "inputs": {"predictions": {"_type": "sv_detections", "image": None}},
+            "code_hash": "",
+            "workflow_context": {},
+        },
+        use_bin_type=True,
+    )
+
+    with TestClient(ws_app).websocket_connect("/ws") as websocket:
+        websocket.send_bytes(broken_frame)
+        first = msgpack.unpackb(websocket.receive_bytes(), raw=False)
+        # The socket must survive the failure: a good frame still gets served.
+        websocket.send_bytes(
+            msgpack.packb(
+                {
+                    "code_str": "def run(self, a):\n    return {'a': a}\n",
+                    "imports": [],
+                    "run_function_name": "run",
+                    "inputs": {"a": 1},
+                    "code_hash": "",
+                    "workflow_context": {},
+                },
+                use_bin_type=True,
+            )
+        )
+        second = msgpack.unpackb(websocket.receive_bytes(), raw=False)
+
+    assert first["success"] is False
+    assert first["server_error"] is True
+    assert "could not decode this request's inputs" in first["error"]
+    assert second["success"] is True
+    assert second["result"] == {"a": 1}
+
+
+# --------------------------------------------------------------------------- #
+# HTTP transport: same predictions must survive the JSON path too
+# --------------------------------------------------------------------------- #
+
+
+def test_http_inputs_round_trip_semantic_segmentation(
+    modal_app_with_fake_modal,
+) -> None:
+    module = modal_app_with_fake_modal
+    executor = _ws_executor(module)
+
+    class _FakeRequest:
+        def __init__(self, payload: dict):
+            self._body = json.dumps(payload).encode()
+            self.headers = {}
+
+        async def body(self) -> bytes:
+            return self._body
+
+    inputs_json = serialize_for_modal_remote_execution(
+        {"predictions": _semantic_segmentation_detections()}
+    )
+    request = _FakeRequest(
+        {
+            "code_str": COVERAGE_CODE,
+            "imports": [],
+            "run_function_name": "run",
+            "inputs_json": inputs_json,
+        }
+    )
+
+    response = asyncio.run(executor.execute_block(request))
+
+    assert response["success"], response
+    # The HTTP transport ships the result as a JSON string.
+    assert json.loads(response["result"]) == {"total": H * W, "foreground": 48, "n": 2}


### PR DESCRIPTION
## Problem

Passing `semantic_segmentation_prediction` output into a custom Python block failed every run with `WebSocket connection to Modal endpoint lost after the request was sent`, no traceback, `blockErrors: []`.

Root cause (reproduced offline): semantic segmentation emits `sv.Detections` with `mask=None`, RLE masks in `data["rle_mask"]`, and no `image_dimensions`. The custom-block transport used the plain serialiser, which drops the RLE and sends `image: {width: None, height: None}`. On Modal, `sv.Detections.from_inference` raised `TypeError` while decoding inputs, which the old handler turned into a bare disconnect. (#2879 already makes the server answer decode failures with an error frame; this PR fixes the payload so decoding succeeds.)

## Changes

- `serialise_sv_detections_for_transport`: keeps RLE masks and fills image size from them when dimensions are missing. Both Modal transports use it and decode with `deserialize_rle_detections_kind`.
- Semantic segmentation v1/v2 attach `image_dimensions`.
- Semantic segmentation v1/v2 stored the `(H, W)` confidence map as a bare `data` field, which broke any boolean filtering of the detections (`boolean index did not match indexed array along axis 0`). It is now a length-N object array sharing the single map.

## Tests

New `test_modal_semantic_segmentation_transport.py` (round trips on both transports, decode-failure error frame, socket survival) and boolean-filtering regressions for v1/v2. Affected suites: 815 passed, 47 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
