### PR TITLE
fix(workflows): recover more malformed VLM JSON shapes in vlm_as_* blocks

### DIFF
--- a/inference/core/workflows/core_steps/common/vlm_json.py
+++ b/inference/core/workflows/core_steps/common/vlm_json.py
@@ -5,7 +5,9 @@ from typing import List, Optional, Tuple, Union
 JSON_MARKDOWN_BLOCK_PATTERN = re.compile(r"```json([\s\S]*?)```", flags=re.IGNORECASE)
 ANY_MARKDOWN_BLOCK_PATTERN = re.compile(r"```[a-zA-Z0-9_+-]*[ \t]*\r?\n?([\s\S]*?)```")
 FENCE_LINE_PATTERN = re.compile(r"^[ \t]*```[a-zA-Z0-9_+-]*[ \t]*$", flags=re.MULTILINE)
-OBJECT_SEQUENCE_SEPARATOR_PATTERN = re.compile(r"^[\s,]*$")
+SEQUENCE_SEPARATOR_PATTERN = re.compile(r"^[\s,]*$")
+SEQUENCE_TAIL_PATTERN = re.compile(r"^[\s,]*\]?[\s,]*$")
+CLASS_ENTRY_LABEL_KEYS = ("class", "class_name", "label")
 
 JsonPayload = Union[dict, list]
 
@@ -15,8 +17,8 @@ def extract_json_payload(raw: Optional[str]) -> Tuple[bool, JsonPayload]:
 
     Tries, in order: the first ```json block, the first fenced block with any
     tag, the text with stray fence lines removed, a sequence of top-level
-    objects (JSON Lines / `{...}, {...}`), and the outermost [...] or {...}
-    substring.
+    values (JSON Lines / `{...}, {...}` / `[...]\\n[...]`, tolerating one
+    stray trailing `]`), and the outermost [...] or {...} substring.
     """
     if not isinstance(raw, str):
         return True, {}
@@ -25,7 +27,7 @@ def extract_json_payload(raw: Optional[str]) -> Tuple[bool, JsonPayload]:
         if payload is not None:
             return False, payload
     stripped = FENCE_LINE_PATTERN.sub("", raw)
-    sequence = _parse_object_sequence(stripped)
+    sequence = _parse_value_sequence(stripped)
     if sequence is not None:
         return False, sequence
     for opening, closing in (("[", "]"), ("{", "}")):
@@ -33,6 +35,35 @@ def extract_json_payload(raw: Optional[str]) -> Tuple[bool, JsonPayload]:
         if payload is not None:
             return False, payload
     return True, {}
+
+
+def coerce_classification_payload(payload: JsonPayload) -> Optional[dict]:
+    """Return a dict payload for the classifier, or None when the shape is unusable.
+
+    A bare list of ``{"class": ..., "confidence": ...}`` entries (the
+    ``predicted_classes`` array emitted without its wrapper) is wrapped into
+    the multi-label shape; ``class_name`` / ``label`` are accepted as aliases.
+    """
+    if isinstance(payload, dict):
+        return payload
+    if not isinstance(payload, list) or not payload:
+        return None
+    entries = []
+    for entry in payload:
+        label = _get_class_entry_label(entry)
+        if label is None:
+            return None
+        entries.append({"class": label, "confidence": entry.get("confidence", 1.0)})
+    return {"predicted_classes": entries}
+
+
+def _get_class_entry_label(entry: object) -> Optional[str]:
+    if not isinstance(entry, dict):
+        return None
+    for key in CLASS_ENTRY_LABEL_KEYS:
+        if entry.get(key) is not None:
+            return str(entry[key])
+    return None
 
 
 def _candidate_texts(raw: str) -> List[str]:
@@ -58,29 +89,42 @@ def _try_parse_json(content: str) -> Optional[JsonPayload]:
     return None
 
 
-def _parse_object_sequence(content: str) -> Optional[list]:
-    # Only succeeds when the whole text is objects separated by whitespace or
-    # commas, so garbage around fragments never becomes an empty success.
+def _parse_value_sequence(content: str) -> Optional[list]:
+    # Only succeeds when the whole text is objects / arrays separated by
+    # whitespace or commas (plus at most one stray closing bracket at the
+    # end), so garbage around fragments never becomes an empty success.
     decoder = json.JSONDecoder()
-    entries: List[dict] = []
+    entries: list = []
+    values_found = 0
     index = 0
     while index < len(content):
-        start = content.find("{", index)
+        start = _find_value_start(content, index)
         if start == -1:
             break
-        if not OBJECT_SEQUENCE_SEPARATOR_PATTERN.match(content[index:start]):
+        if not SEQUENCE_SEPARATOR_PATTERN.match(content[index:start]):
             return None
         try:
-            entry, end = decoder.raw_decode(content, start)
+            value, end = decoder.raw_decode(content, start)
         except json.JSONDecodeError:
             return None
-        if not isinstance(entry, dict):
+        if isinstance(value, dict):
+            entries.append(value)
+        elif isinstance(value, list):
+            entries.extend(value)
+        else:
             return None
-        entries.append(entry)
+        values_found += 1
         index = end
-    if not entries or not OBJECT_SEQUENCE_SEPARATOR_PATTERN.match(content[index:]):
+    if not values_found or not SEQUENCE_TAIL_PATTERN.match(content[index:]):
         return None
     return entries
+
+
+def _find_value_start(content: str, index: int) -> int:
+    positions = [
+        p for p in (content.find("{", index), content.find("[", index)) if p != -1
+    ]
+    return min(positions) if positions else -1
 
 
 def _parse_outermost(content: str, opening: str, closing: str) -> Optional[JsonPayload]:

--- a/inference/core/workflows/core_steps/formatters/vlm_as_classifier/v1.py
+++ b/inference/core/workflows/core_steps/formatters/vlm_as_classifier/v1.py
@@ -4,7 +4,10 @@ from uuid import uuid4
 
 from pydantic import ConfigDict, Field
 
-from inference.core.workflows.core_steps.common.vlm_json import extract_json_payload
+from inference.core.workflows.core_steps.common.vlm_json import (
+    coerce_classification_payload,
+    extract_json_payload,
+)
 from inference.core.workflows.execution_engine.entities.base import (
     OutputDefinition,
     WorkflowImageData,
@@ -211,9 +214,12 @@ def string2json(
     raw_json: str,
 ) -> Tuple[bool, dict]:
     error_status, payload = extract_json_payload(raw_json)
-    if error_status or not isinstance(payload, dict):
+    if error_status:
         return True, {}
-    return False, payload
+    coerced = coerce_classification_payload(payload)
+    if coerced is None:
+        return True, {}
+    return False, coerced
 
 
 def parse_multi_class_classification_results(

--- a/inference/core/workflows/core_steps/formatters/vlm_as_classifier/v1_tensor.py
+++ b/inference/core/workflows/core_steps/formatters/vlm_as_classifier/v1_tensor.py
@@ -6,7 +6,10 @@ import torch
 from pydantic import ConfigDict, Field
 
 from inference.core.env import WORKFLOWS_IMAGE_TENSOR_DEVICE
-from inference.core.workflows.core_steps.common.vlm_json import extract_json_payload
+from inference.core.workflows.core_steps.common.vlm_json import (
+    coerce_classification_payload,
+    extract_json_payload,
+)
 from inference.core.workflows.execution_engine.constants import (
     CLASS_NAMES_KEY,
     CLASSIFICATION_STYLE_FORMATTER,
@@ -231,9 +234,12 @@ def string2json(
     raw_json: str,
 ) -> Tuple[bool, dict]:
     error_status, payload = extract_json_payload(raw_json)
-    if error_status or not isinstance(payload, dict):
+    if error_status:
         return True, {}
-    return False, payload
+    coerced = coerce_classification_payload(payload)
+    if coerced is None:
+        return True, {}
+    return False, coerced
 
 
 def parse_multi_class_classification_results(

--- a/inference/core/workflows/core_steps/formatters/vlm_as_classifier/v2.py
+++ b/inference/core/workflows/core_steps/formatters/vlm_as_classifier/v2.py
@@ -4,7 +4,10 @@ from uuid import uuid4
 
 from pydantic import ConfigDict, Field
 
-from inference.core.workflows.core_steps.common.vlm_json import extract_json_payload
+from inference.core.workflows.core_steps.common.vlm_json import (
+    coerce_classification_payload,
+    extract_json_payload,
+)
 from inference.core.workflows.execution_engine.entities.base import (
     OutputDefinition,
     WorkflowImageData,
@@ -217,9 +220,12 @@ def string2json(
     raw_json: str,
 ) -> Tuple[bool, dict]:
     error_status, payload = extract_json_payload(raw_json)
-    if error_status or not isinstance(payload, dict):
+    if error_status:
         return True, {}
-    return False, payload
+    coerced = coerce_classification_payload(payload)
+    if coerced is None:
+        return True, {}
+    return False, coerced
 
 
 def parse_multi_class_classification_results(

--- a/inference/core/workflows/core_steps/formatters/vlm_as_classifier/v2_tensor.py
+++ b/inference/core/workflows/core_steps/formatters/vlm_as_classifier/v2_tensor.py
@@ -6,7 +6,10 @@ import torch
 from pydantic import ConfigDict, Field
 
 from inference.core.env import WORKFLOWS_IMAGE_TENSOR_DEVICE
-from inference.core.workflows.core_steps.common.vlm_json import extract_json_payload
+from inference.core.workflows.core_steps.common.vlm_json import (
+    coerce_classification_payload,
+    extract_json_payload,
+)
 from inference.core.workflows.execution_engine.constants import (
     CLASS_NAMES_KEY,
     CLASSIFICATION_STYLE_FORMATTER,
@@ -237,9 +240,12 @@ def string2json(
     raw_json: str,
 ) -> Tuple[bool, dict]:
     error_status, payload = extract_json_payload(raw_json)
-    if error_status or not isinstance(payload, dict):
+    if error_status:
         return True, {}
-    return False, payload
+    coerced = coerce_classification_payload(payload)
+    if coerced is None:
+        return True, {}
+    return False, coerced
 
 
 def parse_multi_class_classification_results(

--- a/inference/core/workflows/core_steps/formatters/vlm_as_detector/qwen_detection_parsing.py
+++ b/inference/core/workflows/core_steps/formatters/vlm_as_detector/qwen_detection_parsing.py
@@ -34,7 +34,8 @@ def extract_qwen_detection_entries(
     """Extract the list of detection entries from parsed Qwen JSON output.
 
     The Qwen prompt asks for a bare JSON list, but some responses wrap the
-    entries in a ``{"detections": [...]}`` object; both shapes are accepted.
+    entries in a ``{"detections": [...]}`` object or emit a single detection
+    object on its own; all three shapes are accepted.
 
     Args:
         parsed_data: JSON payload extracted from the VLM output.
@@ -51,6 +52,8 @@ def extract_qwen_detection_entries(
         parsed_data.get("detections"), list
     ):
         return parsed_data["detections"]
+    if isinstance(parsed_data, dict) and any(key in parsed_data for key in _BOX_KEYS):
+        return [parsed_data]
     raise ValueError("Unexpected Qwen object detection response format")
 
 
@@ -150,8 +153,8 @@ def parse_qwen_object_detection_response(
         Parsed detections in the original image's coordinate space.
 
     Raises:
-        ValueError: If the response is neither a JSON list nor a
-            ``{"detections": [...]}`` object.
+        ValueError: If the response is not a JSON list, a
+            ``{"detections": [...]}`` object, or a single detection object.
     """
     entries = extract_qwen_detection_entries(parsed_data=parsed_data)
     class_name2id = create_classes_index(classes=classes)

--- a/tests/workflows/unit_tests/core_steps/common/test_vlm_json.py
+++ b/tests/workflows/unit_tests/core_steps/common/test_vlm_json.py
@@ -1,6 +1,9 @@
 import pytest
 
-from inference.core.workflows.core_steps.common.vlm_json import extract_json_payload
+from inference.core.workflows.core_steps.common.vlm_json import (
+    coerce_classification_payload,
+    extract_json_payload,
+)
 
 
 def test_extract_json_payload_when_plain_json_object_given() -> None:
@@ -190,3 +193,74 @@ def test_extract_json_payload_when_non_string_given() -> None:
     # then
     assert error_status is True
     assert payload == {}
+
+
+def test_extract_json_payload_when_sequence_of_arrays_given() -> None:
+    # when
+    error_status, payload = extract_json_payload('[{"a": 1}]\n[]\n[{"a": 2}]')
+
+    # then
+    assert error_status is False
+    assert payload == [{"a": 1}, {"a": 2}]
+
+
+def test_extract_json_payload_when_only_empty_arrays_given() -> None:
+    # when
+    error_status, payload = extract_json_payload("[]\n[]")
+
+    # then
+    assert error_status is False
+    assert payload == []
+
+
+def test_extract_json_payload_when_objects_end_with_stray_closing_bracket() -> None:
+    # given - list body emitted without its opening bracket
+    raw = '{"a": 1}, {"a": 2}]'
+
+    # when
+    error_status, payload = extract_json_payload(raw)
+
+    # then
+    assert error_status is False
+    assert payload == [{"a": 1}, {"a": 2}]
+
+
+def test_coerce_classification_payload_when_dict_given() -> None:
+    # when
+    result = coerce_classification_payload({"class_name": "cat", "confidence": 0.9})
+
+    # then
+    assert result == {"class_name": "cat", "confidence": 0.9}
+
+
+def test_coerce_classification_payload_when_bare_class_list_given() -> None:
+    # when
+    result = coerce_classification_payload(
+        [
+            {"class": "cat", "confidence": 0.9},
+            {"class_name": "dog"},
+            {"label": "cow", "confidence": 0.2},
+        ]
+    )
+
+    # then
+    assert result == {
+        "predicted_classes": [
+            {"class": "cat", "confidence": 0.9},
+            {"class": "dog", "confidence": 1.0},
+            {"class": "cow", "confidence": 0.2},
+        ]
+    }
+
+
+@pytest.mark.parametrize(
+    "payload", [[], [{"confidence": 0.9}], ["cat"], [{"class": "cat"}, 3]]
+)
+def test_coerce_classification_payload_when_list_is_not_class_entries(
+    payload: list,
+) -> None:
+    # when
+    result = coerce_classification_payload(payload)
+
+    # then
+    assert result is None

--- a/tests/workflows/unit_tests/core_steps/formatters/vlm_as_classifier/test_v2.py
+++ b/tests/workflows/unit_tests/core_steps/formatters/vlm_as_classifier/test_v2.py
@@ -377,8 +377,34 @@ def test_run_when_json_wrapped_in_prose_given() -> None:
     assert result["predictions"]["top"] == "cat"
 
 
-def test_run_when_json_list_given() -> None:
-    # given - a list is never a valid classification payload
+def test_run_when_bare_class_list_given() -> None:
+    # given - Qwen3.6: the multi-label `predicted_classes` array without its wrapper
+    image = WorkflowImageData(
+        numpy_image=np.zeros((192, 168, 3), dtype=np.uint8),
+        parent_metadata=ImageParentMetadata(parent_id="parent"),
+    )
+    block = VLMAsClassifierBlockV2()
+    vlm_output = (
+        '```json\n[\n  {"class": "Vehicle", "confidence": 0.95},\n'
+        '  {"class": "fire", "confidence": 0.8}\n]\n```'
+    )
+
+    # when
+    result = block.run(
+        image=image,
+        vlm_output=vlm_output,
+        classes=["Vehicle", "tank", "fire"],
+    )
+
+    # then
+    assert result["error_status"] is False
+    assert result["predictions"]["predicted_classes"] == ["Vehicle", "fire"]
+    assert result["predictions"]["predictions"]["Vehicle"]["confidence"] == 0.95
+    assert result["predictions"]["predictions"]["tank"]["confidence"] == 0.0
+
+
+def test_run_when_json_list_of_non_class_entries_given() -> None:
+    # given - a list that is not class entries is not a classification payload
     image = WorkflowImageData(
         numpy_image=np.zeros((192, 168, 3), dtype=np.uint8),
         parent_metadata=ImageParentMetadata(parent_id="parent"),
@@ -388,7 +414,7 @@ def test_run_when_json_list_given() -> None:
     # when
     result = block.run(
         image=image,
-        vlm_output='[{"class_name": "cat", "confidence": 0.9}]',
+        vlm_output='[{"box_2d": [1, 2, 3, 4]}]',
         classes=["car", "cat"],
     )
 

--- a/tests/workflows/unit_tests/core_steps/formatters/vlm_as_detector/test_v2.py
+++ b/tests/workflows/unit_tests/core_steps/formatters/vlm_as_detector/test_v2.py
@@ -984,3 +984,76 @@ def test_run_method_for_truncated_output_sets_error_status() -> None:
     # then
     assert result["error_status"] is True
     assert result["predictions"] is None
+
+
+def test_run_method_for_zai_flash_single_detection_object() -> None:
+    # given - GLM 5.3 Flash: one detection emitted without the enclosing list
+    block = VLMAsDetectorBlockV2()
+    image = WorkflowImageData(
+        numpy_image=np.zeros((1000, 1000, 3), dtype=np.uint8),
+        parent_metadata=ImageParentMetadata(parent_id="parent"),
+    )
+
+    # when
+    result = block.run(
+        image=image,
+        vlm_output='{"bbox_2d": [147, 0, 432, 690], "label": "gun"}',
+        classes=["gun"],
+        model_type="zai-flash",
+        task_type="object-detection",
+    )
+
+    # then
+    assert result["error_status"] is False
+    assert result["predictions"].data["class_name"].tolist() == ["gun"]
+    assert np.allclose(
+        result["predictions"].xyxy, np.array([[147, 0, 432, 690]]), atol=1.0
+    )
+
+
+def test_run_method_for_zai_flash_list_missing_opening_bracket() -> None:
+    # given - GLM 5.3 Flash: `{...}, {...}]` with the opening bracket dropped
+    block = VLMAsDetectorBlockV2()
+    image = WorkflowImageData(
+        numpy_image=np.zeros((1000, 1000, 3), dtype=np.uint8),
+        parent_metadata=ImageParentMetadata(parent_id="parent"),
+    )
+    vlm_output = (
+        '{"bbox_2d": [419, 587, 459, 856], "label": "blue player"}, '
+        '{"bbox_2d": [607, 104, 681, 326], "label": "basket"}]'
+    )
+
+    # when
+    result = block.run(
+        image=image,
+        vlm_output=vlm_output,
+        classes=["blue player", "basket"],
+        model_type="zai-flash",
+        task_type="object-detection",
+    )
+
+    # then
+    assert result["error_status"] is False
+    assert result["predictions"].class_id.tolist() == [0, 1]
+
+
+def test_run_method_for_zai_flash_repeated_empty_arrays() -> None:
+    # given - GLM 5.3 Flash: "[]\n[]" for an image with no matches
+    block = VLMAsDetectorBlockV2()
+    image = WorkflowImageData(
+        numpy_image=np.zeros((1000, 1000, 3), dtype=np.uint8),
+        parent_metadata=ImageParentMetadata(parent_id="parent"),
+    )
+
+    # when
+    result = block.run(
+        image=image,
+        vlm_output="[]\n[]",
+        classes=["car"],
+        model_type="zai-flash",
+        task_type="object-detection",
+    )
+
+    # then
+    assert result["error_status"] is False
+    assert len(result["predictions"]) == 0


### PR DESCRIPTION
Follow-up to #2921 (now on `main` via #2926). Replaces #2928, whose branch was cut from the fast-track branch before it was squash-merged and therefore showed all of its commits. This is the same single commit, cherry-picked onto `main`.

## Why
Replaying the last 14 days of playground parse failures (191) through #2921 leaves 13 unrecovered. 6 of those are complete, well-formed detections in a container shape the extractor still rejected. This recovers them; the other 7 are truncated / corrupted output or prose with no JSON at all.

## Changes
- `extract_json_payload`: the top-level sequence parser accepts arrays as well as objects (`[]\n[]`, `[...]\n[...]` are merged) and tolerates one stray trailing `]` after a comma-separated list body whose opening bracket was dropped. Truncated output still fails.
- Qwen-family detector parsing (`qwen`, `zai`, `zai-flash`): a single detection object emitted without its enclosing list is treated as a one-entry list.
- `vlm_as_classifier` (v1/v2 + tensor): a bare list of `{"class"|"class_name"|"label", "confidence"}` entries (the multi-label `predicted_classes` array without its wrapper) is accepted as multi-label output.

## Real samples recovered (GLM 5.3 Flash, Qwen3.6 35B)
Each is a complete, well-formed answer whose only defect is the container around the entries. All four still failed after #2921.

**1. Single detection object, no list around it**
```
{"bbox_2d": [147, 0, 432, 690], "label": "gun"}
```
Problem: parses as a dict, and the Qwen-family parser only accepted a list or `{"detections": [...]}`, so it raised "Unexpected Qwen object detection response format". Fix: a dict carrying a box key becomes a one-entry list.

**2. List body with the opening `[` dropped, closing `]` kept**
```
{"bbox_2d": [419, 587, 459, 856], "label": "blue player"}, {"bbox_2d": [607, 104, 681, 326], "label": "basket"}]
```
Problem: `json.loads` fails on the whole text; the #2921 sequence parser rejected the stray `]` after the last object; the outermost-`[...]` fallback grabs the `[` inside the first box and produces garbage. Fix: one trailing `]` is tolerated after the last value.

**3. One empty array per line**
```
[]
[]
```
Problem: `json.loads` stops after the first `[]` and fails on the extra data; the sequence parser only scanned for `{` objects. Fix: arrays are accepted as sequence values and concatenated.

**4. Classifier: the `predicted_classes` array without its wrapper**
```
[{"class": "Vehicle", "confidence": 0.95}, {"class": "fire", "confidence": 0.8}]
```
Problem: the multi-label prompt asks for `{"predicted_classes": [...]}`; the model returned only the inner array, and the classifier only accepted a dict. Fix: a list of class entries is wrapped into `{"predicted_classes": [...]}`.

## Verification
- **Stored outputs (14d, 191 parse failures from the playground DB)** replayed through a real `ExecutionEngine` workflow (relay step → `vlm_as_detector@v2` / `vlm_as_classifier@v2`): fast-track after #2921 → 13 still failing; this branch → 7. The 7 are unrecoverable: 2 truncated / corrupted-token outputs (GLM 5.3 Flash), 2 corrupted tokens mid-JSON (Gemma 4 31B), 3 prose-only "nothing found" replies with no JSON (Muse Glimmer, Qwen3.8 Flash).
- **Live repro, GLM 5.3 Flash** (`zai_vlm@v1` → `vlm_as_detector@v2 zai-flash`, 100 runs over 82 COCO images × 6 class sets): 99 parsed. Shapes seen: 75 plain arrays, 17 without an enclosing array (10 single objects, 7 JSON Lines), 7 fenced. The 1 failure is a 2.7k-char output cut at `max_tokens` (2048) on a crowd image, not a parser gap.
- **Live repro, Qwen 3.8 Max** (`qwen_vlm@v3` → `qwen`, 50 runs): 49 parsed, 13 of them with the bare-array + lone trailing `` ``` `` shape from #2921. The 1 failure was an OpenRouter 400 "Provider returned error" from the model step.
- `pytest tests/workflows/unit_tests/core_steps/common/test_vlm_json.py tests/workflows/unit_tests/core_steps/formatters/vlm_as_detector tests/workflows/unit_tests/core_steps/formatters/vlm_as_classifier`: 127 passed.
- black / isort clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)