### PR TITLE
Add GPT-6 Astra to OpenAI workflow block

### DIFF
--- a/inference/core/workflows/core_steps/models/foundation/openai/v6.py
+++ b/inference/core/workflows/core_steps/models/foundation/openai/v6.py
@@ -70,6 +70,12 @@ PLAIN_ABSOLUTE_STYLE = "plain-absolute"
 # GPT-5.6 Terra/Luna assumed to match Sol's `max` (docs describe the set family-wide).
 OPENAI_MODELS = [
     {
+        "id": "gpt-6-astra",
+        "name": "GPT-6 Astra",
+        "reasoning_effort_values": ["low", "medium", "high", "xhigh", "max"],
+        "detection_prompt_style": STRUCTURED_ABSOLUTE_STYLE,
+    },
+    {
         "id": "gpt-5.6-sol",
         "name": "GPT-5.6 Sol",
         "reasoning_effort_values": ["none", "low", "medium", "high", "xhigh", "max"],


### PR DESCRIPTION
## What does this PR do?

OpenAI released GPT-6 Astra (API id `gpt-6-astra`) on 2026-09-03. It was not selectable in the `open_ai` workflow block, so users could only reach it via a selector-supplied model id with no reasoning-effort validation and no entry in the block metadata.

This PR registers `gpt-6-astra` in the latest OpenAI block version, `open_ai@v6`. The single `OPENAI_MODELS` entry drives `MODEL_VERSION_IDS`, `MODEL_VERSION_METADATA`, reasoning-effort validation and the object-detection prompt style. Reasoning levels follow the [official model page](https://developers.openai.com/api/docs/models/gpt-6-astra): `low`, `medium`, `high`, `xhigh`, `max`. Detection uses the `structured-absolute` prompt style, matching the newest generations and the documented default for future models. Older block versions are left untouched.

**Main elements:**
- `inference/core/workflows/core_steps/models/foundation/openai/v6.py` — new `OPENAI_MODELS` entry

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other:

## Testing

### Unit tests

- No new tests; the entry is data-only and covered by the existing `OPENAI_MODELS`-derived validation paths.

### Integration tests

- None for this PR.

### Other

- `uv run pytest tests/workflows/unit_tests/core_steps/models/foundation/test_openai_v6.py` — passes
- `black --check` on the touched file

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [ ] I have updated the documentation accordingly (if applicable)

## Additional Context

- Roboflow-managed key (`rf_key:*`) proxy allowlisting is server-side and not part of this repo.
- No Linear issue linked; add one if applicable.