### PR TITLE
Publish inference server on localhost by default

### DIFF
--- a/app_bundles/osx/run_inference.py
+++ b/app_bundles/osx/run_inference.py
@@ -107,7 +107,7 @@ os.environ["SSL_CERT_FILE"] = certifi.where()
 os.environ.setdefault("VERSION_CHECK_MODE", "continuous")
 os.environ.setdefault("PROJECT", "roboflow-platform")
 os.environ.setdefault("NUM_WORKERS", "1")
-os.environ.setdefault("HOST", "0.0.0.0")
+os.environ.setdefault("HOST", "127.0.0.1")
 os.environ.setdefault("PORT", "9001")
 os.environ.setdefault("WORKFLOWS_STEP_EXECUTION_MODE", "local")
 os.environ.setdefault("WORKFLOWS_MAX_CONCURRENT_STEPS", "4")
@@ -182,7 +182,7 @@ if __name__ == "__main__":
 
         config = uvicorn.Config(
             app,
-            host="0.0.0.0",
+            host=os.environ["HOST"],
             port=port,
             log_level="info",
             access_log=True,

--- a/app_bundles/windows/run_inference.py
+++ b/app_bundles/windows/run_inference.py
@@ -98,7 +98,7 @@ os.environ["SSL_CERT_FILE"] = certifi.where()
 os.environ.setdefault("VERSION_CHECK_MODE", "continuous")
 os.environ.setdefault("PROJECT", "roboflow-platform")
 os.environ.setdefault("NUM_WORKERS", "1")
-os.environ.setdefault("HOST", "0.0.0.0")
+os.environ.setdefault("HOST", "127.0.0.1")
 os.environ.setdefault("PORT", "9001")
 os.environ.setdefault("WORKFLOWS_STEP_EXECUTION_MODE", "local")
 os.environ.setdefault("WORKFLOWS_MAX_CONCURRENT_STEPS", "4")
@@ -172,7 +172,7 @@ if __name__ == "__main__":
         
         config = uvicorn.Config(
             app,
-            host="0.0.0.0",
+            host=os.environ["HOST"],
             port=port,
             log_level="info",
             access_log=True,

--- a/inference/core/interfaces/http/http_api.py
+++ b/inference/core/interfaces/http/http_api.py
@@ -3,7 +3,6 @@ import concurrent
 import logging
 import os
 import re
-import warnings
 from concurrent.futures import CancelledError, Future, ThreadPoolExecutor
 from contextlib import nullcontext
 from dataclasses import dataclass
@@ -216,6 +215,7 @@ from inference.core.env import (
     STRUCTURED_API_LOGGING,
     USE_INFERENCE_MODELS,
     WEBRTC_WORKER_ENABLED,
+    WORKFLOWS_CUSTOM_PYTHON_EXECUTION_MODE,
     WORKFLOWS_MAX_CONCURRENT_STEPS,
     WORKFLOWS_PROFILER_BUFFER_SIZE,
     WORKFLOWS_STEP_EXECUTION_MODE,
@@ -344,7 +344,6 @@ from inference.core.utils.requests import (
     deduct_api_key_from_string,
 )
 from inference.core.utils.url_utils import get_secure_gateway_base_url, wrap_url
-from inference.core.warnings import InferenceDeprecationWarning
 from inference.core.workflows.core_steps.common.entities import StepExecutionMode
 from inference.core.workflows.errors import (
     WorkflowBlockError,
@@ -424,13 +423,24 @@ HEALTH_CHECK_LOG_PATHS = frozenset(
 )
 
 
-if ALLOW_CUSTOM_PYTHON_EXECUTION_IN_WORKFLOWS:
-    warnings.warn(
-        "Your `inference` configuration specifies `ALLOW_CUSTOM_PYTHON_EXECUTION_IN_WORKFLOWS=True`. "
-        "Currently, Workflows Custom Python blocks are allowed by default - but this is going to change 19.06.2026. "
-        "If your workload relies on that setting, please make adjustment to your configuration before the inference "
-        "release following mentioned date. Otherwise - you may ignore this warning.",
-        category=InferenceDeprecationWarning,
+if (
+    ALLOW_CUSTOM_PYTHON_EXECUTION_IN_WORKFLOWS
+    and WORKFLOWS_CUSTOM_PYTHON_EXECUTION_MODE == "local"
+    and not (
+        WORKSPACES_WHITELISTED_FOR_LOCAL_DEPLOYMENT
+        or DEDICATED_DEPLOYMENT_WORKSPACE_URL
+    )
+):
+    # Logged rather than raised as a warning, because INFERENCE_WARNINGS_DISABLED must not
+    # be able to silence a security notice.
+    logger.warning(
+        "SECURITY: this server accepts requests without authentication and runs Workflows Custom Python "
+        "blocks in its own process (ALLOW_CUSTOM_PYTHON_EXECUTION_IN_WORKFLOWS=True), so any client that can "
+        "reach it can execute arbitrary code on this host. This is safe only while the server is reachable "
+        "from trusted clients alone. Set ALLOW_CUSTOM_PYTHON_EXECUTION_IN_WORKFLOWS=False if you do not need "
+        "custom Python, and set WORKSPACES_WHITELISTED_FOR_LOCAL_DEPLOYMENT (or put your own authentication "
+        "in front of the server) if it is reachable from other machines. See "
+        "https://docs.roboflow.com/deployment/self-hosted/inference-server/configuration/security"
     )
 
 

--- a/inference_cli/lib/container_adapter.py
+++ b/inference_cli/lib/container_adapter.py
@@ -13,6 +13,13 @@ from inference_cli.lib.exceptions import DockerConnectionErrorException
 from inference_cli.lib.logger import CLI_LOGGER
 from inference_cli.lib.utils import read_env_file
 
+DEFAULT_BIND_ADDRESS = "127.0.0.1"
+LOOPBACK_BIND_ADDRESSES = {"127.0.0.1", "::1", "localhost"}
+SECURITY_DOCS_URL = (
+    "https://docs.roboflow.com/deployment/self-hosted/inference-server/"
+    "configuration/security"
+)
+
 
 def ensure_docker_is_running() -> None:
     try:
@@ -218,6 +225,7 @@ def start_inference_container(
     development: bool = False,
     use_local_images: bool = False,
     volumes: Optional[Dict[str, dict]] = None,
+    bind_address: Optional[str] = None,
 ) -> None:
     containers = find_running_inference_containers()
     if len(containers) > 0:
@@ -243,6 +251,8 @@ def start_inference_container(
         privileged = True
         docker_run_kwargs = {"runtime": "nvidia"}
 
+    bind_address = resolve_bind_address(bind_address=bind_address, is_jetson=is_jetson)
+
     environment = prepare_container_environment(
         port=port,
         project=project,
@@ -255,9 +265,10 @@ def start_inference_container(
     )
     pull_image(image, use_local_images=use_local_images)
     print(f"Starting inference server container...")
-    ports = {str(port): port}
+    announce_bind_address(bind_address=bind_address, port=port)
+    ports = {str(port): (bind_address, port)}
     if development:
-        ports["9002"] = 9002
+        ports["9002"] = (bind_address, 9002)
     docker_client = docker.from_env()
     docker_client.containers.run(
         image=image,
@@ -289,6 +300,31 @@ def start_inference_container(
         network_mode="bridge",
         ipc_mode="private" if not is_jetson else None,
         **docker_run_kwargs,
+    )
+
+
+def resolve_bind_address(bind_address: Optional[str], is_jetson: bool) -> str:
+    if bind_address is not None:
+        return bind_address
+    # Jetson images run on headless edge devices that are almost always driven from another
+    # machine on the LAN, so loopback-only would break their default use case.
+    return "0.0.0.0" if is_jetson else DEFAULT_BIND_ADDRESS
+
+
+def announce_bind_address(bind_address: str, port: int) -> None:
+    if bind_address in LOOPBACK_BIND_ADDRESSES:
+        print(
+            f"Inference server will only accept connections from this machine "
+            f"({bind_address}:{port}). Use --bind-address 0.0.0.0 to expose it to your "
+            f"network - see {SECURITY_DOCS_URL} first."
+        )
+        return None
+    print(
+        f"WARNING: the inference server is being published on {bind_address}:{port}, so it will accept "
+        f"connections from other machines. The server requires no authentication by default and executes "
+        f"Workflows Custom Python blocks, which is remote code execution for anyone who can reach the port. "
+        f"Set WORKSPACES_WHITELISTED_FOR_LOCAL_DEPLOYMENT (or put your own auth in front of the server) and "
+        f"set ALLOW_CUSTOM_PYTHON_EXECUTION_IN_WORKFLOWS=False unless you need it. See {SECURITY_DOCS_URL}"
     )
 
 

--- a/inference_cli/server.py
+++ b/inference_cli/server.py
@@ -24,6 +24,17 @@ def start(
             help="Port to run the inference server on (default is 9001).",
         ),
     ] = 9001,
+    bind_address: Annotated[
+        Optional[str],
+        typer.Option(
+            "--bind-address",
+            "-b",
+            help="Host address the server port is published on. Defaults to 127.0.0.1 (connections only from this "
+            "machine), except for Jetson images, which default to 0.0.0.0 because they are usually driven from "
+            "another machine. Binding to 0.0.0.0 exposes a server that has no authentication by default and runs "
+            "Workflows Custom Python blocks, so secure it first.",
+        ),
+    ] = None,
     rf_env: Annotated[
         str,
         typer.Option(
@@ -103,6 +114,13 @@ def start(
         typer.echo(docker_error)
         raise typer.Exit(code=1) from docker_error
 
+    if tunnel and bind_address != "0.0.0.0":
+        typer.echo(
+            "The tunnel runs in a separate container and reaches the server through the host gateway, which a "
+            "loopback-only binding rejects. Publishing the server on 0.0.0.0 so the tunnel can connect."
+        )
+        bind_address = "0.0.0.0"
+
     parsed_volumes = {}
     for v in volumes or []:
         parts = v.split(":")
@@ -119,6 +137,7 @@ def start(
         start_inference_container(
             image=image,
             port=port,
+            bind_address=bind_address,
             project=rf_env,
             env_file_path=env_file_path,
             development=development,

--- a/tests/inference_cli/unit_tests/test_container_adapter.py
+++ b/tests/inference_cli/unit_tests/test_container_adapter.py
@@ -114,3 +114,90 @@ def test_prepare_container_environment_when_env_file_not_defined() -> None:
             "NUM_WORKERS=3",
         ]
     )
+
+
+@mock.patch.object(container_adapter, "pull_image")
+@mock.patch.object(
+    container_adapter, "find_running_inference_containers", return_value=[]
+)
+@mock.patch.object(container_adapter, "docker")
+def test_start_inference_container_publishes_ports_on_loopback_by_default(
+    docker_mock: MagicMock,
+    _find_containers_mock: MagicMock,
+    _pull_image_mock: MagicMock,
+) -> None:
+    # when
+    start_inference_container(
+        image="roboflow/roboflow-inference-server-cpu:latest",
+        port=9001,
+        development=True,
+    )
+
+    # then
+    _, kwargs = docker_mock.from_env.return_value.containers.run.call_args
+    assert kwargs["ports"] == {"9001": ("127.0.0.1", 9001), "9002": ("127.0.0.1", 9002)}
+
+
+@mock.patch.object(container_adapter, "pull_image")
+@mock.patch.object(
+    container_adapter, "find_running_inference_containers", return_value=[]
+)
+@mock.patch.object(container_adapter, "docker")
+def test_start_inference_container_publishes_ports_on_all_interfaces_for_jetson(
+    docker_mock: MagicMock,
+    _find_containers_mock: MagicMock,
+    _pull_image_mock: MagicMock,
+) -> None:
+    # when
+    start_inference_container(
+        image="roboflow/roboflow-inference-server-jetson-6.2.0:latest",
+        port=9001,
+    )
+
+    # then
+    _, kwargs = docker_mock.from_env.return_value.containers.run.call_args
+    assert kwargs["ports"] == {"9001": ("0.0.0.0", 9001)}
+
+
+@mock.patch.object(container_adapter, "pull_image")
+@mock.patch.object(
+    container_adapter, "find_running_inference_containers", return_value=[]
+)
+@mock.patch.object(container_adapter, "docker")
+def test_start_inference_container_bind_address_overrides_jetson_default(
+    docker_mock: MagicMock,
+    _find_containers_mock: MagicMock,
+    _pull_image_mock: MagicMock,
+) -> None:
+    # when
+    start_inference_container(
+        image="roboflow/roboflow-inference-server-jetson-6.2.0:latest",
+        port=9001,
+        bind_address="127.0.0.1",
+    )
+
+    # then
+    _, kwargs = docker_mock.from_env.return_value.containers.run.call_args
+    assert kwargs["ports"] == {"9001": ("127.0.0.1", 9001)}
+
+
+@mock.patch.object(container_adapter, "pull_image")
+@mock.patch.object(
+    container_adapter, "find_running_inference_containers", return_value=[]
+)
+@mock.patch.object(container_adapter, "docker")
+def test_start_inference_container_publishes_ports_on_requested_bind_address(
+    docker_mock: MagicMock,
+    _find_containers_mock: MagicMock,
+    _pull_image_mock: MagicMock,
+) -> None:
+    # when
+    start_inference_container(
+        image="roboflow/roboflow-inference-server-cpu:latest",
+        port=9001,
+        bind_address="0.0.0.0",
+    )
+
+    # then
+    _, kwargs = docker_mock.from_env.return_value.containers.run.call_args
+    assert kwargs["ports"] == {"9001": ("0.0.0.0", 9001)}


### PR DESCRIPTION
## What does this PR do?

BEFORE:
`inference server start` published port 9001 on every host interface. A self-hosted server requires no authentication by default and executes Workflows Custom Python blocks in its own process, so any machine that could route to the host had remote code execution on it — a laptop on shared Wi-Fi was enough.

CHANGE:
**`inference server start` publishes on `127.0.0.1`.** `--bind-address` / `-b` opts out. Binding to a non-loopback address prints a warning naming the two controls that matter (`WORKSPACES_WHITELISTED_FOR_LOCAL_DEPLOYMENT`,  `ALLOW_CUSTOM_PYTHON_EXECUTION_IN_WORKFLOWS`).

**Jetson images keep `0.0.0.0`.** They are headless devices almost always driven from another machine, so loopback would break their default use case. They still get the exposure warning on every start.

**macOS and Windows app bundles bind `127.0.0.1`.** They were setting `HOST` and then passing a hardcoded `0.0.0.0` to uvicorn regardless; `HOST` is now honoured.

**Startup security notice** in `http_api.py`, replacing the deprecation warning that announced the `ALLOW_CUSTOM_PYTHON_EXECUTION_IN_WORKFLOWS` default flip on 19.06.2026 (removed). It fires only on the combination that is actually dangerous — custom Python enabled, local in-process execution mode, and no auth configured — so Modal-mode and authenticated servers stay quiet. It uses `logger.warning` rather than `warnings.warn`, because `INFERENCE_WARNINGS_DISABLED` should not be able to silence a security notice.

`HOST` selects the interface *inside* the container, which is a separate network namespace. An image shipping `HOST=127.0.0.1` would bind the container's own loopback, which published ports cannot reach — the server would be unreachable even from the host, breaking every bridge deployment, k8s probes, and the Helm chart. The restriction has to be applied on the host side of the port mapping (`-p 127.0.0.1:9001:9001`), so the CLI is the only place we control it. The startup notice is the in-image half.

THIS IS BREAKING CHANGE

Anyone reaching a CLI-started server from another machine — a camera host calling a shared GPU box, a CI runner, a phone on the same Wi-Fi — gets connection refused until they pass `--bind-address 0.0.0.0`. Jetson and `--tunnel` are unaffected.

## Type of Change

- Bug fix (non-breaking change that fixes an issue)

## Testing

Test CLI on AMD64+ARM and on Jetson, test installers

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)

## Additional Context

N/A