### PR TITLE
Bound stream manager pipeline spawning

### DIFF
--- a/inference/core/env.py
+++ b/inference/core/env.py
@@ -1201,6 +1201,14 @@ try:
 except:
     STREAM_MANAGER_RAM_USAGE_QUEUE_SIZE = 10
 
+# Upper bound on managed pipeline processes. STREAM_MANAGER_MAX_RAM_MB is unset by default,
+# so without this the stream API can be made to spawn processes until the host runs out of
+# memory. Never lower than the number of processes the manager pre-loads on start.
+STREAM_MANAGER_MAX_ACTIVE_PIPELINES: int = max(
+    int(os.getenv("STREAM_MANAGER_MAX_ACTIVE_PIPELINES", "8")),
+    STREAM_API_PRELOADED_PROCESSES,
+)
+
 # Cache metadata lock timeout in seconds, default is 1.0
 CACHE_METADATA_LOCK_TIMEOUT = float(os.getenv("CACHE_METADATA_LOCK_TIMEOUT", 1.0))
 MODEL_LOCK_ACQUIRE_TIMEOUT = float(os.getenv("MODEL_LOCK_ACQUIRE_TIMEOUT", "60.0"))

--- a/inference/core/interfaces/stream_manager/manager_app/app.py
+++ b/inference/core/interfaces/stream_manager/manager_app/app.py
@@ -18,6 +18,7 @@ import psutil
 
 from inference.core import logger
 from inference.core.env import (
+    STREAM_MANAGER_MAX_ACTIVE_PIPELINES,
     STREAM_MANAGER_MAX_RAM_MB,
     STREAM_MANAGER_RAM_USAGE_QUEUE_SIZE,
 )
@@ -449,6 +450,13 @@ def get_or_spawn_pipeline_process(
             chosen_pipeline = processes_table[idle_pipelines[0]]
             chosen_pipeline.is_idle = False
             return chosen_pipeline
+
+        if len(processes_table) >= STREAM_MANAGER_MAX_ACTIVE_PIPELINES:
+            raise Exception(
+                "Cannot spawn new pipeline due to active pipelines limit,"
+                f" current number of pipelines: {len(processes_table)},"
+                f" max: {STREAM_MANAGER_MAX_ACTIVE_PIPELINES}"
+            )
 
         current_ram_usage = (
             sum(

--- a/inference/core/interfaces/stream_manager/manager_app/app.py
+++ b/inference/core/interfaces/stream_manager/manager_app/app.py
@@ -469,18 +469,15 @@ def get_or_spawn_pipeline_process(
             )
             + _get_current_process_ram_usage_mb()
         )
-        highest_pipeline_ram_usage = 0
-        if processes_table:
-            highest_pipeline_ram_usage = max(
-                max(
-                    (
-                        managed_pipeline.ram_usage_queue
-                        if managed_pipeline.ram_usage_queue
-                        else 0
-                    )
-                    for managed_pipeline in processes_table.values()
-                )
-            )
+        # pipelines spawned since the last check_process_health sweep have no RAM
+        # samples yet, hence the defaults
+        highest_pipeline_ram_usage = max(
+            (
+                max(managed_pipeline.ram_usage_queue, default=0)
+                for managed_pipeline in processes_table.values()
+            ),
+            default=0,
+        )
 
         if (
             STREAM_MANAGER_MAX_RAM_MB is not None

--- a/inference/core/interfaces/stream_manager/manager_app/app.py
+++ b/inference/core/interfaces/stream_manager/manager_app/app.py
@@ -501,7 +501,12 @@ def ensure_idle_pipelines_warmed_up(expected_warmed_up_pipelines: int) -> None:
     while True:
         with PROCESSES_TABLE_LOCK:
             idle_pipelines = len(get_idle_pipelines_id(processes_table=PROCESSES_TABLE))
-            if idle_pipelines < expected_warmed_up_pipelines:
+            # the warm pool must not push the manager past the limit that
+            # get_or_spawn_pipeline_process enforces - busy pipelines count against it too
+            if (
+                idle_pipelines < expected_warmed_up_pipelines
+                and len(PROCESSES_TABLE) < STREAM_MANAGER_MAX_ACTIVE_PIPELINES
+            ):
                 _ = spawn_managed_pipeline_process(processes_table=PROCESSES_TABLE)
         time.sleep(5)
 

--- a/tests/inference/unit_tests/core/interfaces/stream_manager/manager_app/test_app.py
+++ b/tests/inference/unit_tests/core/interfaces/stream_manager/manager_app/test_app.py
@@ -1,0 +1,85 @@
+from unittest import mock
+from unittest.mock import MagicMock
+
+import pytest
+
+from inference.core.interfaces.stream_manager.manager_app import app
+from inference.core.interfaces.stream_manager.manager_app.app import (
+    ManagedInferencePipeline,
+    get_or_spawn_pipeline_process,
+)
+
+
+def _managed_pipeline(pipeline_id: str, is_idle: bool) -> ManagedInferencePipeline:
+    managed_pipeline = ManagedInferencePipeline(
+        pipeline_id=pipeline_id,
+        pipeline_manager=MagicMock(),
+        command_queue=MagicMock(),
+        responses_queue=MagicMock(),
+        operation_lock=MagicMock(),
+        is_idle=is_idle,
+    )
+    # the RAM guard in get_or_spawn_pipeline_process cannot handle pipelines whose usage
+    # has not been sampled yet, so keep the queue populated here
+    managed_pipeline.ram_usage_queue.append(1)
+    return managed_pipeline
+
+
+@mock.patch.object(app, "STREAM_MANAGER_MAX_ACTIVE_PIPELINES", 2)
+@mock.patch.object(app, "spawn_managed_pipeline_process")
+def test_get_or_spawn_pipeline_process_spawns_when_below_limit(
+    spawn_managed_pipeline_process_mock: MagicMock,
+) -> None:
+    # given
+    processes_table = {"existing": _managed_pipeline("existing", is_idle=False)}
+
+    def _spawn(processes_table, mark_as_idle):
+        processes_table["new"] = _managed_pipeline("new", is_idle=mark_as_idle)
+        return "new"
+
+    spawn_managed_pipeline_process_mock.side_effect = _spawn
+
+    # when
+    result = get_or_spawn_pipeline_process(processes_table=processes_table)
+
+    # then
+    assert result.pipeline_id == "new"
+
+
+@mock.patch.object(app, "STREAM_MANAGER_MAX_ACTIVE_PIPELINES", 2)
+@mock.patch.object(app, "spawn_managed_pipeline_process")
+def test_get_or_spawn_pipeline_process_refuses_to_spawn_above_limit(
+    spawn_managed_pipeline_process_mock: MagicMock,
+) -> None:
+    # given
+    processes_table = {
+        "first": _managed_pipeline("first", is_idle=False),
+        "second": _managed_pipeline("second", is_idle=False),
+    }
+
+    # when
+    with pytest.raises(Exception):
+        _ = get_or_spawn_pipeline_process(processes_table=processes_table)
+
+    # then
+    spawn_managed_pipeline_process_mock.assert_not_called()
+
+
+@mock.patch.object(app, "STREAM_MANAGER_MAX_ACTIVE_PIPELINES", 2)
+@mock.patch.object(app, "spawn_managed_pipeline_process")
+def test_get_or_spawn_pipeline_process_reuses_idle_pipeline_at_limit(
+    spawn_managed_pipeline_process_mock: MagicMock,
+) -> None:
+    # given
+    processes_table = {
+        "busy": _managed_pipeline("busy", is_idle=False),
+        "idle": _managed_pipeline("idle", is_idle=True),
+    }
+
+    # when
+    result = get_or_spawn_pipeline_process(processes_table=processes_table)
+
+    # then
+    assert result.pipeline_id == "idle"
+    assert result.is_idle is False
+    spawn_managed_pipeline_process_mock.assert_not_called()

--- a/tests/inference/unit_tests/core/interfaces/stream_manager/manager_app/test_app.py
+++ b/tests/inference/unit_tests/core/interfaces/stream_manager/manager_app/test_app.py
@@ -7,8 +7,13 @@ import pytest
 from inference.core.interfaces.stream_manager.manager_app import app
 from inference.core.interfaces.stream_manager.manager_app.app import (
     ManagedInferencePipeline,
+    ensure_idle_pipelines_warmed_up,
     get_or_spawn_pipeline_process,
 )
+
+
+class _StopLoop(Exception):
+    """Breaks out of the infinite warm-up loop after a single sweep."""
 
 
 def _managed_pipeline(
@@ -128,6 +133,49 @@ def test_get_or_spawn_pipeline_process_refuses_to_spawn_above_ram_limit(
     # when
     with pytest.raises(Exception):
         _ = get_or_spawn_pipeline_process(processes_table=processes_table)
+
+    # then
+    spawn_managed_pipeline_process_mock.assert_not_called()
+
+
+@mock.patch.object(app, "STREAM_MANAGER_MAX_ACTIVE_PIPELINES", 2)
+@mock.patch.object(app, "spawn_managed_pipeline_process")
+@mock.patch.object(app, "time")
+def test_ensure_idle_pipelines_warmed_up_spawns_below_limit(
+    time_mock: MagicMock,
+    spawn_managed_pipeline_process_mock: MagicMock,
+) -> None:
+    # given
+    time_mock.sleep.side_effect = _StopLoop()
+    processes_table = {"busy": _managed_pipeline("busy", is_idle=False)}
+
+    # when
+    with mock.patch.object(app, "PROCESSES_TABLE", processes_table):
+        with pytest.raises(_StopLoop):
+            ensure_idle_pipelines_warmed_up(expected_warmed_up_pipelines=1)
+
+    # then
+    spawn_managed_pipeline_process_mock.assert_called_once()
+
+
+@mock.patch.object(app, "STREAM_MANAGER_MAX_ACTIVE_PIPELINES", 2)
+@mock.patch.object(app, "spawn_managed_pipeline_process")
+@mock.patch.object(app, "time")
+def test_ensure_idle_pipelines_warmed_up_respects_active_pipelines_limit(
+    time_mock: MagicMock,
+    spawn_managed_pipeline_process_mock: MagicMock,
+) -> None:
+    # given - warm pool is short, but every slot is taken by a busy pipeline
+    time_mock.sleep.side_effect = _StopLoop()
+    processes_table = {
+        "first": _managed_pipeline("first", is_idle=False),
+        "second": _managed_pipeline("second", is_idle=False),
+    }
+
+    # when
+    with mock.patch.object(app, "PROCESSES_TABLE", processes_table):
+        with pytest.raises(_StopLoop):
+            ensure_idle_pipelines_warmed_up(expected_warmed_up_pipelines=1)
 
     # then
     spawn_managed_pipeline_process_mock.assert_not_called()

--- a/tests/inference/unit_tests/core/interfaces/stream_manager/manager_app/test_app.py
+++ b/tests/inference/unit_tests/core/interfaces/stream_manager/manager_app/test_app.py
@@ -1,3 +1,4 @@
+from typing import List, Optional
 from unittest import mock
 from unittest.mock import MagicMock
 
@@ -10,7 +11,11 @@ from inference.core.interfaces.stream_manager.manager_app.app import (
 )
 
 
-def _managed_pipeline(pipeline_id: str, is_idle: bool) -> ManagedInferencePipeline:
+def _managed_pipeline(
+    pipeline_id: str,
+    is_idle: bool,
+    ram_usage_samples: Optional[List[int]] = None,
+) -> ManagedInferencePipeline:
     managed_pipeline = ManagedInferencePipeline(
         pipeline_id=pipeline_id,
         pipeline_manager=MagicMock(),
@@ -19,9 +24,7 @@ def _managed_pipeline(pipeline_id: str, is_idle: bool) -> ManagedInferencePipeli
         operation_lock=MagicMock(),
         is_idle=is_idle,
     )
-    # the RAM guard in get_or_spawn_pipeline_process cannot handle pipelines whose usage
-    # has not been sampled yet, so keep the queue populated here
-    managed_pipeline.ram_usage_queue.append(1)
+    managed_pipeline.ram_usage_queue.extend(ram_usage_samples or [])
     return managed_pipeline
 
 
@@ -82,4 +85,49 @@ def test_get_or_spawn_pipeline_process_reuses_idle_pipeline_at_limit(
     # then
     assert result.pipeline_id == "idle"
     assert result.is_idle is False
+    spawn_managed_pipeline_process_mock.assert_not_called()
+
+
+@mock.patch.object(app, "STREAM_MANAGER_MAX_ACTIVE_PIPELINES", 8)
+@mock.patch.object(app, "STREAM_MANAGER_MAX_RAM_MB", None)
+@mock.patch.object(app, "spawn_managed_pipeline_process")
+def test_get_or_spawn_pipeline_process_when_ram_usage_not_sampled_yet(
+    spawn_managed_pipeline_process_mock: MagicMock,
+) -> None:
+    # given - a pipeline spawned before check_process_health sampled its RAM usage
+    processes_table = {
+        "sampled": _managed_pipeline("sampled", is_idle=False, ram_usage_samples=[10]),
+        "not_sampled": _managed_pipeline("not_sampled", is_idle=False),
+    }
+
+    def _spawn(processes_table, mark_as_idle):
+        processes_table["new"] = _managed_pipeline("new", is_idle=mark_as_idle)
+        return "new"
+
+    spawn_managed_pipeline_process_mock.side_effect = _spawn
+
+    # when
+    result = get_or_spawn_pipeline_process(processes_table=processes_table)
+
+    # then
+    assert result.pipeline_id == "new"
+
+
+@mock.patch.object(app, "STREAM_MANAGER_MAX_ACTIVE_PIPELINES", 8)
+@mock.patch.object(app, "STREAM_MANAGER_MAX_RAM_MB", 100)
+@mock.patch.object(app, "_get_current_process_ram_usage_mb", MagicMock(return_value=10))
+@mock.patch.object(app, "spawn_managed_pipeline_process")
+def test_get_or_spawn_pipeline_process_refuses_to_spawn_above_ram_limit(
+    spawn_managed_pipeline_process_mock: MagicMock,
+) -> None:
+    # given - 10MB manager + 60MB last sample, peak 80MB predicted for the new pipeline
+    processes_table = {
+        "busy": _managed_pipeline("busy", is_idle=False, ram_usage_samples=[80, 60]),
+    }
+
+    # when
+    with pytest.raises(Exception):
+        _ = get_or_spawn_pipeline_process(processes_table=processes_table)
+
+    # then
     spawn_managed_pipeline_process_mock.assert_not_called()


### PR DESCRIPTION
## What does this PR do?

  BEFORE:
  `get_or_spawn_pipeline_process` spawned a new OS process for every
  `/inference_pipelines/initialise` that could not reuse an idle pipeline. The only
  ceiling was `STREAM_MANAGER_MAX_RAM_MB`, unset by default, so a caller could drive
  the stream manager until the host ran out of memory. Every published image ships
  `ENABLE_STREAM_API=True`, and self-hosted servers require no API key unless
  `WORKSPACES_WHITELISTED_FOR_LOCAL_DEPLOYMENT` is set.

  CHANGE:

  **`STREAM_MANAGER_MAX_ACTIVE_PIPELINES`, default 8.** Checked after the idle-reuse
  branch, so warm pipelines are still handed out at the limit. Raised to
  `STREAM_API_PRELOADED_PROCESSES` when that is higher — the manager cannot be capped
  below the number of processes it pre-loads.

  **Fixes a crash in the RAM guard.** The nested `max()` over `ram_usage_queue` raised
  `TypeError` whenever a pipeline had no samples yet (`'int' object is not iterable`,
  or `'>' not supported between int and deque` for a mixed table).
  `check_process_health`
  samples once per second, so a pipeline spawned in the last second has an empty queue
  and the next `initialise` failed with `INTERNAL_ERROR`. The expression runs before
  the
  `STREAM_MANAGER_MAX_RAM_MB` check, so this hit default deployments with no RAM limit
  configured. Now takes the peak sample per pipeline and across pipelines, with
  `default=0` — what the nested `max()` computed once every queue was populated.

  Not a replacement for authentication: `WORKSPACES_WHITELISTED_FOR_LOCAL_DEPLOYMENT`
  already covers `/inference_pipelines/*`. This bounds what one caller can cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Type of Change

- Bug fix (non-breaking change that fixes an issue)

## Testing

  New `tests/inference/unit_tests/core/interfaces/stream_manager/manager_app/test_app.py`
  covering spawn below limit, refusal at limit, idle reuse at limit, unsampled
  pipelines,
  and RAM-limit refusal. `tests/inference/unit_tests/core/interfaces/stream_manager/`:
  64 passed.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)

## Additional Context

N/A