### PR TITLE
Add optional detection instructions to OpenAI v6

### DIFF
--- a/inference/core/workflows/core_steps/models/foundation/openai/v6.py
+++ b/inference/core/workflows/core_steps/models/foundation/openai/v6.py
@@ -404,6 +404,17 @@ class BlockManifest(WorkflowBlockManifest):
             "multiline": True,
         },
     )
+    detection_instructions: Optional[Union[Selector(kind=[STRING_KIND]), str]] = Field(
+        default=None,
+        description="Optional detection criteria, separate from the exact output class names.",
+        examples=["Only people wearing a helmet", "$inputs.detection_instructions"],
+        json_schema_extra={
+            "relevant_for": {
+                "task_type": {"values": ["object-detection"], "required": False}
+            },
+            "multiline": True,
+        },
+    )
     output_structure: Optional[Dict[str, str]] = Field(
         default=None,
         description="Dictionary with structure of expected JSON response",
@@ -585,6 +596,7 @@ class OpenAIBlockV6(WorkflowBlock):
         temperature: Optional[float],
         max_concurrent_requests: Optional[int],
         api_key: str = "rf_key:account",
+        detection_instructions: Optional[str] = None,
     ) -> BlockResult:
         inference_images = [i.to_inference_format() for i in images]
         raw_outputs = run_openai_prompting(
@@ -601,6 +613,7 @@ class OpenAIBlockV6(WorkflowBlock):
             max_tokens=max_tokens,
             temperature=temperature,
             max_concurrent_requests=max_concurrent_requests,
+            detection_instructions=detection_instructions,
         )
         return [
             {
@@ -627,6 +640,7 @@ def run_openai_prompting(
     max_tokens: Optional[int],
     temperature: Optional[float],
     max_concurrent_requests: Optional[int],
+    detection_instructions: Optional[str] = None,
 ) -> List[Tuple[str, Optional[int], Optional[int]]]:
     """Encode images, build per-task prompts and execute OpenAI requests.
 
@@ -643,6 +657,7 @@ def run_openai_prompting(
         prompt: Free-form text prompt for tasks that accept one.
         output_structure: Field descriptions for structured answering.
         classes: Class names for classification and detection tasks.
+        detection_instructions: Optional detection criteria, separate from class names.
         openai_api_key: OpenAI API key or Roboflow-proxied ``rf_key:`` key.
         model_version: OpenAI model identifier.
         reasoning_effort: Reasoning effort for models that support it.
@@ -676,6 +691,19 @@ def run_openai_prompting(
             image_height=image_height,
             model_version=model_version,
         )
+        if task_type == "object-detection" and detection_instructions:
+            generated_prompt["input"][0]["content"].append(
+                {
+                    "type": "input_text",
+                    "text": (
+                        "Apply these additional detection criteria. They describe which "
+                        "objects to include; they are not class names. Keep the exact "
+                        "allowed labels and coordinate/output format specified above. "
+                        "Return an empty detections list when no objects satisfy the criteria.\n"
+                        + detection_instructions
+                    ),
+                }
+            )
         openai_prompts.append(generated_prompt)
     return execute_openai_requests(
         roboflow_api_key=roboflow_api_key,

--- a/tests/workflows/unit_tests/core_steps/models/foundation/test_openai_v6.py
+++ b/tests/workflows/unit_tests/core_steps/models/foundation/test_openai_v6.py
@@ -1,15 +1,20 @@
 """Tests for the OpenAI v6 block (v5 + token-usage outputs).
 
 The v5 behavior suite lives in ``test_openai_v5.py``; this file covers the
-v6 delta: ``input_tokens`` / ``output_tokens`` outputs on both the proxied
-and direct execution paths.
+v6 additions: token-usage outputs on both execution paths and optional
+detection criteria that preserve the default Auto Label request.
 """
 
 from unittest.mock import MagicMock, Mock, patch
 
+import pytest
+
 from inference.core.workflows.core_steps.models.foundation.openai.v6 import (
+    BlockManifest,
     _execute_direct_openai_request,
     _execute_proxied_openai_request,
+    prepare_object_detection_prompt,
+    run_openai_prompting,
 )
 
 _OPENAI_OK = {
@@ -72,3 +77,83 @@ def test_direct_request_returns_usage(mock_get_client: Mock) -> None:
     )
 
     assert result == ("response", 14, 3)
+
+
+@pytest.mark.parametrize("model", ["gpt-6-astra", "gpt-5.1", "gpt-4.1"])
+@pytest.mark.parametrize(
+    "criteria", [None, "", "Only people wearing helmets, excluding cyclists"]
+)
+def test_detection_criteria_are_separate_from_labels(model, criteria):
+    with (
+        patch(
+            "inference.core.workflows.core_steps.models.foundation.openai.v6.load_image",
+            return_value=(object(), None),
+        ),
+        patch(
+            "inference.core.workflows.core_steps.models.foundation.openai.v6.encode_image_for_task",
+            return_value=("encoded", 640, 480),
+        ),
+        patch(
+            "inference.core.workflows.core_steps.models.foundation.openai.v6.execute_openai_requests",
+            return_value=[],
+        ) as execute,
+    ):
+        run_openai_prompting(
+            roboflow_api_key="test",
+            images=[{}],
+            task_type="object-detection",
+            prompt=None,
+            output_structure=None,
+            classes=["person"],
+            openai_api_key="rf_key:account",
+            model_version=model,
+            reasoning_effort=None,
+            image_detail="auto",
+            max_tokens=None,
+            temperature=None,
+            max_concurrent_requests=1,
+            detection_instructions=criteria,
+        )
+    content = execute.call_args.kwargs["openai_prompts"][0]["input"][0]["content"]
+    texts = [item["text"] for item in content if item["type"] == "input_text"]
+    assert "person" in texts[0]
+    if criteria:
+        assert criteria not in texts[0]
+        assert criteria in texts[1]
+        assert "not class names" in texts[1]
+        assert "empty detections list" in texts[1]
+    else:
+        assert len(texts) == 1
+        assert execute.call_args.kwargs["openai_prompts"][
+            0
+        ] == prepare_object_detection_prompt(
+            base64_image="encoded",
+            classes=["person"],
+            image_width=640,
+            image_height=480,
+            model_version=model,
+        )
+    assert any(item["type"] == "input_image" for item in content)
+
+
+def test_manifest_exposes_optional_detection_instructions():
+    manifest = BlockManifest(
+        type="roboflow_core/open_ai@v6",
+        name="detect",
+        images="$inputs.image",
+        task_type="object-detection",
+        classes="$inputs.classes",
+        detection_instructions="$inputs.detection_instructions",
+    )
+    assert manifest.detection_instructions == "$inputs.detection_instructions"
+
+
+def test_existing_detection_manifest_does_not_require_instructions():
+    manifest = BlockManifest(
+        type="roboflow_core/open_ai@v6",
+        name="detect",
+        images="$inputs.image",
+        task_type="object-detection",
+        classes=["person"],
+    )
+    assert manifest.detection_instructions is None


### PR DESCRIPTION
Find Objects needs to pass criteria such as “only people wearing a helmet” separately from the canonical `person` label. Putting the description into `classes` makes the GPT detection prompt treat the entire description as an allowed output label.

Add optional `detection_instructions` to `roboflow_core/open_ai@v6` and pass it through the existing executor. For object detection, non-empty criteria are appended as a separate text input while retaining the existing label, coordinate and output-format instructions. Absent, null and empty values preserve the standard Auto Label request. Regression tests cover the three detection prompt styles and optional manifest input.

Validation:
- Black and isort checks, Python compilation, and `git diff --check` passed.
- Nine isolated checks of the production prompt assembly passed with provider/image encoding mocked.
- Nine comparisons against the previous v6 produced identical complete provider request arguments for absent, null and empty instructions across all three detection prompt styles.
- The full Inference pytest suite was not run: the local environment lacks required Python dependencies (collection stopped at `filelock`). Live GPT execution remains to be validated after deployment.

Rollout: deploy the updated Inference service before syncing the companion Auto Label template that supplies `detection_instructions`. This PR contains only the Inference block and its tests; the application/template changes are separate.
