### PR TITLE
Preserve usage report identity across collector retries

### DIFF
--- a/inference/usage_tracking/collector.py
+++ b/inference/usage_tracking/collector.py
@@ -8,6 +8,7 @@ import socket
 import sys
 import time
 from collections import defaultdict
+from copy import deepcopy
 from functools import wraps
 from queue import Queue
 from threading import Event, Lock, Thread
@@ -67,7 +68,10 @@ from .payload_helpers import (
     ResourceID,
     SystemDetails,
     UsagePayload,
+    get_usage_report_capability,
+    prepare_usage_reports,
     send_usage_payload,
+    send_usage_reports,
     sha256_hash,
     zip_usage_payloads,
 )
@@ -157,6 +161,7 @@ class UsageCollector:
             except Exception as exc:
                 logger.debug("Unable to create instance of SQLiteQueue, %s", exc)
         self._queue_lock = Lock()
+        self._delivery_lock = Lock()
 
         self._system_info_lock = Lock()
         self._system_info: Dict[str, Any] = {}
@@ -195,6 +200,7 @@ class UsageCollector:
             "hostname": "",
             "ip_address_hash": "",
             "processed_frames": 0,
+            "_usage_report_candidate": True,
             "fps": 0,
             "source_duration": 0,
             "category": "",
@@ -687,16 +693,137 @@ class UsageCollector:
 
     def _flush_queue(self):
         if OFFLINE_MODE:
-            # Leave any usage persisted by an earlier online run untouched.
-            # Draining before the sender-level guard would silently discard it.
             return
-        usage_payloads = self._dump_usage_queue_with_lock()
-        if not usage_payloads:
+        if not self._delivery_lock.acquire(blocking=False):
             return
-        merged_payloads: APIKeyUsage = zip_usage_payloads(
-            usage_payloads=usage_payloads,
+        try:
+            self._flush_report_delivery()
+        except Exception as exc:
+            logger.warning("Usage delivery remains pending: %s", exc)
+        finally:
+            self._delivery_lock.release()
+
+    def _flush_report_delivery(self):
+        persistent = isinstance(self._queue, SQLiteQueue)
+        delivery = (
+            self._queue.read_report_delivery()
+            if persistent
+            else getattr(self, "_report_delivery", {})
         )
-        self._offload_to_api(payloads=merged_payloads)
+        if delivery:
+            self._send_prepared_reports(delivery, persistent)
+        raw = (
+            self._queue.peek_payloads()
+            if persistent
+            else self._dump_usage_queue_with_lock()
+        )
+        if not raw:
+            return
+        keys = dict(a[::-1] for a in self._hashed_api_keys.items())
+        capabilities = {}
+        enterprises = {}
+        for key in {key for payload in raw for key in payload if key}:
+            api_key = keys.get(key)
+            if not api_key:
+                continue
+            try:
+                capabilities[key] = get_usage_report_capability(
+                    api_key,
+                    self._settings.api_plan_endpoint_url,
+                    ssl_verify=ssl_verify_for_endpoint(
+                        self._settings.api_plan_endpoint_url
+                    ),
+                    extra_headers=build_roboflow_api_headers(),
+                )
+                if capabilities[key] is not None:
+                    plan = self._plan_details.get_api_key_plan(api_key=api_key)
+                    enterprises[key] = plan[self._plan_details._is_enterprise_col_name]
+            except Exception as exc:
+                capabilities.pop(key, None)
+                logger.debug("Usage capability remains unknown: %s", exc)
+
+        def partition(payloads, retained):
+            prepared, legacy, deferred = {}, [], []
+            for payload in zip_usage_payloads(payloads):
+                for key, resources in payload.items():
+                    if any(
+                        resource.get("_legacy_delivery")
+                        or resource.get("_usage_report_candidate") is not True
+                        for resource in resources.values()
+                    ):
+                        legacy.append({key: resources})
+                    elif key not in capabilities:
+                        deferred.append({key: resources})
+                    elif capabilities[key] is None:
+                        legacy.append({key: resources})
+                    elif any(
+                        report["report_ownership_fingerprint"]
+                        == capabilities[key]["ownership_fingerprint"]
+                        for report in retained.get(key, {}).values()
+                    ):
+                        deferred.append({key: resources})
+                    else:
+                        resources = deepcopy(resources)
+                        for resource in resources.values():
+                            resource["enterprise"] = enterprises[key]
+                        prepared.setdefault(key, {}).update(
+                            prepare_usage_reports(resources, capabilities[key])
+                        )
+            return prepared, legacy, deferred
+
+        if persistent:
+            delivery, legacy = self._queue.prepare_report_delivery(partition)
+        else:
+            try:
+                delivery, legacy, deferred = partition(
+                    raw, getattr(self, "_report_delivery", {})
+                )
+            except Exception:
+                for payload in raw:
+                    self._enqueue_payload(payload)
+                raise
+            retained = getattr(self, "_report_delivery", {})
+            for key, reports in delivery.items():
+                retained.setdefault(key, {}).update(reports)
+            self._report_delivery = retained
+            for payload in deferred:
+                self._enqueue_payload(payload)
+        self._offload_to_api(legacy)
+        if delivery:
+            self._send_prepared_reports(delivery, persistent)
+
+    def _send_prepared_reports(self, delivery, persistent):
+        keys = dict(a[::-1] for a in self._hashed_api_keys.items())
+        acknowledged = set()
+        for key, reports in delivery.items():
+            api_key = keys.get(key)
+            if not api_key:
+                continue
+            outcomes = send_usage_reports(
+                reports,
+                api_key,
+                self._settings.api_usage_endpoint_url,
+                ssl_verify=ssl_verify_for_endpoint(
+                    self._settings.api_usage_endpoint_url
+                ),
+                extra_headers=build_roboflow_api_headers(),
+            )
+            for report_id, outcome in outcomes.items():
+                if outcome != "accepted":
+                    logger.warning("Usage report %s rejected: %s", report_id, outcome)
+            acknowledged.update(outcomes)
+        if persistent:
+            self._queue.acknowledge_reports(acknowledged)
+        else:
+            self._report_delivery = {
+                key: {
+                    report_id: report
+                    for report_id, report in reports.items()
+                    if report_id not in acknowledged
+                }
+                for key, reports in getattr(self, "_report_delivery", {}).items()
+                if any(report_id not in acknowledged for report_id in reports)
+            }
 
     def _offload_to_api(self, payloads: List[APIKeyUsage]):
         if OFFLINE_MODE:
@@ -738,6 +865,9 @@ class UsageCollector:
                 if api_key_hash not in api_keys_hashes_failed:
                     del payload[api_key_hash]
             if payload:
+                for resources in payload.values():
+                    for resource in resources.values():
+                        resource["_legacy_delivery"] = True
                 logger.debug("Enqueuing back unsent payload")
                 self._enqueue_payload(payload=payload)
 

--- a/inference/usage_tracking/collector.py
+++ b/inference/usage_tracking/collector.py
@@ -803,7 +803,7 @@ class UsageCollector:
                 api_key = original_key
                 for candidate in reversed(supplied_keys):
                     if candidate == original_key:
-                        break
+                        continue
                     if candidate not in replacement_workspaces:
                         try:
                             capability = get_usage_report_capability(

--- a/inference/usage_tracking/collector.py
+++ b/inference/usage_tracking/collector.py
@@ -793,12 +793,42 @@ class UsageCollector:
             self._send_prepared_reports(delivery, persistent)
 
     def _send_prepared_reports(self, delivery, persistent):
-        keys = dict(a[::-1] for a in self._hashed_api_keys.items())
-        acknowledged = set()
+        supplied_keys = dict(self._hashed_api_keys)
+        keys = {key_hash: api_key for api_key, key_hash in supplied_keys.items()}
+        replacement_workspaces = {}
+        transports = {}
         for key, reports in delivery.items():
-            api_key = keys.get(key)
-            if not api_key:
-                continue
+            original_key = keys.get(key)
+            for report_id, report in reports.items():
+                api_key = original_key
+                for candidate in reversed(supplied_keys):
+                    if candidate == original_key:
+                        break
+                    if candidate not in replacement_workspaces:
+                        try:
+                            capability = get_usage_report_capability(
+                                candidate,
+                                self._settings.api_plan_endpoint_url,
+                                ssl_verify=ssl_verify_for_endpoint(
+                                    self._settings.api_plan_endpoint_url
+                                ),
+                                extra_headers=build_roboflow_api_headers(),
+                            )
+                            replacement_workspaces[candidate] = (
+                                capability["workspace_id"] if capability else None
+                            )
+                        except Exception:
+                            replacement_workspaces[candidate] = None
+                    if (
+                        replacement_workspaces[candidate]
+                        == report["report_workspace_id"]
+                    ):
+                        api_key = candidate
+                        break
+                if api_key:
+                    transports.setdefault(api_key, {})[report_id] = report
+        acknowledged = set()
+        for api_key, reports in transports.items():
             outcomes = send_usage_reports(
                 reports,
                 api_key,

--- a/inference/usage_tracking/payload_helpers.py
+++ b/inference/usage_tracking/payload_helpers.py
@@ -1,7 +1,9 @@
 import hashlib
 import os
 import sys
+from copy import deepcopy
 from typing import Any, DefaultDict, Dict, List, Optional, Set, Union
+from uuid import uuid4
 
 import requests
 
@@ -74,6 +76,10 @@ def merge_usage_dicts(d1: UsagePayload, d2: UsagePayload):
     merged["execution_duration"] = d1.get("execution_duration", 0) + d2.get(
         "execution_duration", 0
     )
+    if "_usage_report_candidate" in d1 or "_usage_report_candidate" in d2:
+        merged["_usage_report_candidate"] = (
+            not d1 or d1.get("_usage_report_candidate") is True
+        ) and (not d2 or d2.get("_usage_report_candidate") is True)
     return {**d1, **d2, **merged}
 
 
@@ -209,10 +215,12 @@ def send_usage_payload(
             api_keys_hashes_failed.add(api_key_hash)
             continue
         complete_workflow_payloads = [
-            w for w in workflow_payloads.values() if "processed_frames" in w
+            dict(w) for w in workflow_payloads.values() if "processed_frames" in w
         ]
         try:
             for workflow_payload in complete_workflow_payloads:
+                workflow_payload.pop("_legacy_delivery", None)
+                workflow_payload.pop("_usage_report_candidate", None)
                 if "api_key_hash" in workflow_payload:
                     del workflow_payload["api_key_hash"]
                 stream_session_id = workflow_payload.pop("stream_session_id", None)
@@ -240,3 +248,120 @@ def send_usage_payload(
 def sha256_hash(payload: str, length=5):
     payload_hash = hashlib.sha256(payload.encode())
     return payload_hash.hexdigest()[:length]
+
+
+def get_usage_report_capability(
+    api_key: str,
+    api_plan_endpoint_url: str,
+    ssl_verify: bool = True,
+    extra_headers: Optional[Dict[str, str]] = None,
+) -> Optional[Dict[str, Any]]:
+    """A failed lookup is unknown, never permission to downgrade a report."""
+    if OFFLINE_MODE:
+        raise ConnectionError("Offline usage capability lookup")
+    response = requests.get(
+        api_plan_endpoint_url,
+        headers={"Authorization": f"Bearer {api_key}", **(extra_headers or {})},
+        verify=ssl_verify,
+        timeout=1,
+    )
+    response.raise_for_status()
+    body = response.json()
+    if not isinstance(body, dict):
+        raise ValueError("Invalid usage capability response")
+    capability = body.get("usage_report_protocol")
+    if capability is None:
+        return None
+    if (
+        not isinstance(capability, dict)
+        or type(capability.get("version")) is not int
+        or capability.get("version") != 1
+        or not isinstance(capability.get("workspace_id"), str)
+        or not capability["workspace_id"]
+        or not isinstance(capability.get("ownership_fingerprint"), str)
+        or len(capability["ownership_fingerprint"]) != 64
+        or any(c not in "0123456789abcdef" for c in capability["ownership_fingerprint"])
+    ):
+        raise ValueError("Invalid usage report capability")
+    return capability
+
+
+def prepare_usage_reports(
+    resource_payloads: ResourceUsage, capability: Dict[str, Any]
+) -> ResourceUsage:
+    reports = {}
+    for payload in resource_payloads.values():
+        if "processed_frames" not in payload:
+            continue
+        report = deepcopy(payload)
+        report.pop("api_key_hash", None)
+        report.pop("api_key", None)
+        report.pop("_usage_report_candidate", None)
+        report.pop("_legacy_delivery", None)
+        stream_session = report.pop("stream_session_id", None)
+        if stream_session:
+            report["exec_session_id"] = stream_session
+        report_id = str(uuid4())
+        report.update(
+            report_version=1,
+            report_id=report_id,
+            report_workspace_id=capability["workspace_id"],
+            report_ownership_fingerprint=capability["ownership_fingerprint"],
+        )
+        reports[report_id] = report
+    return reports
+
+
+def send_usage_reports(
+    reports: ResourceUsage,
+    api_key: str,
+    api_usage_endpoint_url: str,
+    ssl_verify: bool = True,
+    extra_headers: Optional[Dict[str, str]] = None,
+) -> Dict[str, str]:
+    if OFFLINE_MODE or not reports:
+        return {}
+    body = [dict(deepcopy(report), api_key=api_key) for report in reports.values()]
+    try:
+        response = requests.post(
+            api_usage_endpoint_url,
+            json=body,
+            verify=ssl_verify,
+            headers={"Authorization": f"Bearer {api_key}", **(extra_headers or {})},
+            timeout=1,
+        )
+        if response.status_code != 200:
+            return {}
+        return usage_report_outcomes(response.json(), set(reports))
+    except Exception:
+        return {}
+
+
+def usage_report_outcomes(body: Any, sent_ids: Set[str]) -> Dict[str, str]:
+    """Only explicit terminal outcomes retire a prepared report."""
+    if not isinstance(body, dict) or not isinstance(
+        body.get("usage_report_results"), list
+    ):
+        return {}
+    outcomes = {}
+    seen = set()
+    for result in body["usage_report_results"]:
+        if not isinstance(result, dict):
+            return {}
+        report_id = result.get("report_id")
+        if (
+            not isinstance(report_id, str)
+            or report_id not in sent_ids
+            or report_id in seen
+        ):
+            return {}
+        seen.add(report_id)
+        if result.get("status") == "accepted":
+            outcomes[report_id] = "accepted"
+        elif (
+            result.get("status") == "rejected"
+            and isinstance(result.get("reason"), str)
+            and result["reason"]
+        ):
+            outcomes[report_id] = result["reason"]
+    return outcomes

--- a/inference/usage_tracking/sqlite_queue.py
+++ b/inference/usage_tracking/sqlite_queue.py
@@ -60,3 +60,82 @@ class SQLiteQueue(SQLiteWrapper):
             except Exception as exc:
                 logger.debug("Failed to process sqlite payload %s - %s", p, exc)
         return usage_payloads
+
+    def peek_payloads(self):
+        with sqlite3.connect(self._db_file_path, timeout=1) as connection:
+            rows = connection.execute(
+                f"SELECT payload FROM {self._tbl_name} ORDER BY id LIMIT 100"
+            ).fetchall()
+        return [json.loads(row[0]) for row in rows]
+
+    def read_report_delivery(self):
+        with sqlite3.connect(self._db_file_path, timeout=1) as connection:
+            connection.execute(
+                "CREATE TABLE IF NOT EXISTS usage_report_delivery "
+                "(id INTEGER PRIMARY KEY CHECK (id = 1), payload TEXT NOT NULL)"
+            )
+            row = connection.execute(
+                "SELECT payload FROM usage_report_delivery WHERE id = 1"
+            ).fetchone()
+        return json.loads(row[0]) if row else {}
+
+    def prepare_report_delivery(self, partition):
+        """Replace raw rows and retain frozen reports in the same local commit."""
+        with sqlite3.connect(self._db_file_path, timeout=1) as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            connection.execute(
+                "CREATE TABLE IF NOT EXISTS usage_report_delivery "
+                "(id INTEGER PRIMARY KEY CHECK (id = 1), payload TEXT NOT NULL)"
+            )
+            current = connection.execute(
+                "SELECT payload FROM usage_report_delivery WHERE id = 1"
+            ).fetchone()
+            retained = json.loads(current[0]) if current else {}
+            rows = connection.execute(
+                f"SELECT id, payload FROM {self._tbl_name} ORDER BY id LIMIT 100"
+            ).fetchall()
+            prepared, legacy, deferred = partition(
+                [json.loads(row[1]) for row in rows], retained
+            )
+            connection.executemany(
+                f"DELETE FROM {self._tbl_name} WHERE id = ?",
+                [(row[0],) for row in rows],
+            )
+            connection.executemany(
+                f"INSERT INTO {self._tbl_name} (payload) VALUES (?)",
+                [(json.dumps(payload),) for payload in deferred],
+            )
+            if prepared:
+                for key, reports in prepared.items():
+                    retained.setdefault(key, {}).update(reports)
+                connection.execute(
+                    "INSERT OR REPLACE INTO usage_report_delivery (id, payload) VALUES (1, ?)",
+                    (json.dumps(retained),),
+                )
+        return prepared, legacy
+
+    def acknowledge_reports(self, report_ids):
+        with sqlite3.connect(self._db_file_path, timeout=1) as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            current = connection.execute(
+                "SELECT payload FROM usage_report_delivery WHERE id = 1"
+            ).fetchone()
+            if not current:
+                return
+            delivery = json.loads(current[0])
+            remaining = {
+                key: {
+                    report_id: report
+                    for report_id, report in reports.items()
+                    if report_id not in report_ids
+                }
+                for key, reports in delivery.items()
+            }
+            remaining = {key: reports for key, reports in remaining.items() if reports}
+            if remaining:
+                connection.execute(
+                    "UPDATE usage_report_delivery SET payload = ? WHERE id = 1",
+                    (json.dumps(remaining),),
+                )
+            else:
+                connection.execute("DELETE FROM usage_report_delivery WHERE id = 1")

--- a/tests/inference/unit_tests/usage_tracking/test_collector.py
+++ b/tests/inference/unit_tests/usage_tracking/test_collector.py
@@ -63,6 +63,7 @@ def test_create_empty_usage_dict(usage_collector_with_mocked_threads):
                     "hostname": "",
                     "ip_address_hash": "",
                     "processed_frames": 0,
+                    "_usage_report_candidate": True,
                     "fps": 0,
                     "source_duration": 0,
                     "category": "",

--- a/tests/inference/unit_tests/usage_tracking/test_usage_report_delivery.py
+++ b/tests/inference/unit_tests/usage_tracking/test_usage_report_delivery.py
@@ -379,3 +379,104 @@ def test_sqlite_failed_prepare_rolls_back_raw_deletion(tmp_path):
         )
     assert queue.peek_payloads() == [payload]
     assert queue.read_report_delivery() == {}
+
+
+@pytest.mark.parametrize("persistent", [False, True])
+@pytest.mark.parametrize("keep_original", [False, True])
+def test_supplied_rotated_credential_replays_original_workspace_report(
+    usage_collector_with_mocked_threads,
+    monkeypatch,
+    tmp_path,
+    persistent,
+    keep_original,
+):
+    from inference.usage_tracking.sqlite_queue import SQLiteQueue
+
+    collector = usage_collector_with_mocked_threads
+    queue = (
+        SQLiteQueue(db_file_path=str(tmp_path / "rotation.db")) if persistent else None
+    )
+    module = configure_collector(collector, monkeypatch, queue)
+    sent = []
+    monkeypatch.setattr(
+        helpers.requests,
+        "post",
+        lambda *a, json, **kw: sent.append(deepcopy(json))
+        or SimpleNamespace(status_code=503),
+    )
+    collector._enqueue_payload({"hash": raw_usage(7)})
+    collector._flush_queue()
+    original = deepcopy(sent[0][0])
+    if not keep_original:
+        collector._hashed_api_keys.clear()
+    collector._hashed_api_keys.update(
+        {"replacement-key": "replacement-hash", "unrelated-key": "unrelated-hash"}
+    )
+    monkeypatch.setattr(
+        module,
+        "get_usage_report_capability",
+        lambda key, *a, **kw: dict(
+            CAPABILITY,
+            workspace_id="other" if key == "unrelated-key" else "workspace",
+            ownership_fingerprint="b" * 64,
+        ),
+    )
+    accepted = {}
+
+    def send(*a, json, **kw):
+        assert kw["headers"]["Authorization"] == "Bearer replacement-key"
+        for report in json:
+            accepted[report["report_id"]] = deepcopy(report)
+        return SimpleNamespace(
+            status_code=200,
+            json=lambda: {
+                "usage_report_results": [
+                    {"report_id": report["report_id"], "status": "accepted"}
+                    for report in json
+                ]
+            },
+        )
+
+    monkeypatch.setattr(helpers.requests, "post", send)
+    collector._enqueue_payload({"replacement-hash": raw_usage(3)})
+    collector._flush_queue()
+    replay = accepted[original["report_id"]]
+    assert replay == dict(original, api_key="replacement-key")
+    assert sum(report["processed_frames"] for report in accepted.values()) == 10
+    assert (
+        queue.read_report_delivery() if persistent else collector._report_delivery
+    ) == {}
+
+
+@pytest.mark.parametrize("persistent", [False, True])
+def test_unrelated_replacement_credential_cannot_send_retained_report(
+    usage_collector_with_mocked_threads, monkeypatch, tmp_path, persistent
+):
+    from inference.usage_tracking.sqlite_queue import SQLiteQueue
+
+    collector = usage_collector_with_mocked_threads
+    queue = (
+        SQLiteQueue(db_file_path=str(tmp_path / "unrelated.db")) if persistent else None
+    )
+    module = configure_collector(collector, monkeypatch, queue)
+    monkeypatch.setattr(
+        helpers.requests, "post", lambda *a, **kw: SimpleNamespace(status_code=503)
+    )
+    collector._enqueue_payload({"hash": raw_usage(7)})
+    collector._flush_queue()
+    before = deepcopy(
+        queue.read_report_delivery() if persistent else collector._report_delivery
+    )
+    collector._hashed_api_keys = {"unrelated-key": "unrelated-hash"}
+    monkeypatch.setattr(
+        module,
+        "get_usage_report_capability",
+        lambda *a, **kw: dict(CAPABILITY, workspace_id="other"),
+    )
+    sent = []
+    monkeypatch.setattr(helpers.requests, "post", lambda *a, **kw: sent.append(kw))
+    collector._flush_queue()
+    assert not sent
+    assert (
+        queue.read_report_delivery() if persistent else collector._report_delivery
+    ) == before

--- a/tests/inference/unit_tests/usage_tracking/test_usage_report_delivery.py
+++ b/tests/inference/unit_tests/usage_tracking/test_usage_report_delivery.py
@@ -412,15 +412,17 @@ def test_supplied_rotated_credential_replays_original_workspace_report(
     collector._hashed_api_keys.update(
         {"replacement-key": "replacement-hash", "unrelated-key": "unrelated-hash"}
     )
-    monkeypatch.setattr(
-        module,
-        "get_usage_report_capability",
-        lambda key, *a, **kw: dict(
+
+    def capability_for_key(key, *a, **kw):
+        if key == "api-key":
+            raise ConnectionError("revoked original credential")
+        return dict(
             CAPABILITY,
             workspace_id="other" if key == "unrelated-key" else "workspace",
             ownership_fingerprint="b" * 64,
-        ),
-    )
+        )
+
+    monkeypatch.setattr(module, "get_usage_report_capability", capability_for_key)
     accepted = {}
 
     def send(*a, json, **kw):
@@ -480,3 +482,73 @@ def test_unrelated_replacement_credential_cannot_send_retained_report(
     assert (
         queue.read_report_delivery() if persistent else collector._report_delivery
     ) == before
+
+
+@pytest.mark.parametrize("persistent", [False, True])
+def test_known_earlier_credential_can_replay_after_original_is_revoked(
+    usage_collector_with_mocked_threads, monkeypatch, tmp_path, persistent
+):
+    from inference.usage_tracking.sqlite_queue import SQLiteQueue
+
+    collector = usage_collector_with_mocked_threads
+    queue = (
+        SQLiteQueue(db_file_path=str(tmp_path / "earlier-key.db"))
+        if persistent
+        else None
+    )
+    module = configure_collector(collector, monkeypatch, queue)
+    collector._hashed_api_keys = {
+        "replacement-key": "replacement-hash",
+        "api-key": "hash",
+    }
+
+    def initial_capability(key, *a, **kw):
+        if key == "replacement-key":
+            raise ConnectionError("replacement temporarily unavailable")
+        return CAPABILITY
+
+    monkeypatch.setattr(module, "get_usage_report_capability", initial_capability)
+    sent = []
+    monkeypatch.setattr(
+        helpers.requests,
+        "post",
+        lambda *a, json, **kw: sent.append(deepcopy(json))
+        or SimpleNamespace(status_code=503),
+    )
+    collector._enqueue_payload({"hash": raw_usage(7)})
+    collector._flush_queue()
+    original = deepcopy(sent[0][0])
+
+    def rotated_capability(key, *a, **kw):
+        if key == "api-key":
+            raise ConnectionError("original revoked")
+        return dict(CAPABILITY, ownership_fingerprint="b" * 64)
+
+    monkeypatch.setattr(module, "get_usage_report_capability", rotated_capability)
+    collector._hashed_api_keys["replacement-key"] = "replacement-hash"
+    assert list(collector._hashed_api_keys) == ["replacement-key", "api-key"]
+    accepted = {}
+
+    def send(*a, json, **kw):
+        if kw["headers"]["Authorization"] != "Bearer replacement-key":
+            return SimpleNamespace(status_code=401)
+        for report in json:
+            accepted[report["report_id"]] = deepcopy(report)
+        return SimpleNamespace(
+            status_code=200,
+            json=lambda: {
+                "usage_report_results": [
+                    {"report_id": report["report_id"], "status": "accepted"}
+                    for report in json
+                ]
+            },
+        )
+
+    monkeypatch.setattr(helpers.requests, "post", send)
+    collector._enqueue_payload({"replacement-hash": raw_usage(3)})
+    collector._flush_queue()
+    assert accepted[original["report_id"]] == dict(original, api_key="replacement-key")
+    assert sum(report["processed_frames"] for report in accepted.values()) == 10
+    assert (
+        queue.read_report_delivery() if persistent else collector._report_delivery
+    ) == {}

--- a/tests/inference/unit_tests/usage_tracking/test_usage_report_delivery.py
+++ b/tests/inference/unit_tests/usage_tracking/test_usage_report_delivery.py
@@ -1,0 +1,381 @@
+from copy import deepcopy
+from types import SimpleNamespace
+
+import pytest
+
+from inference.usage_tracking import payload_helpers as helpers
+
+CAPABILITY = {
+    "version": 1,
+    "workspace_id": "workspace",
+    "ownership_fingerprint": "a" * 64,
+}
+
+
+def raw_usage(frames=10):
+    return {
+        "resource": {
+            "_usage_report_candidate": True,
+            "resource_id": "resource",
+            "category": "model",
+            "processed_frames": frames,
+            "timestamp_start": 1000000000000000000,
+            "timestamp_stop": 1000000010000000000,
+            "execution_duration": 10,
+            "exec_session_id": "process",
+            "stream_session_id": "stream",
+            "api_key_hash": "hash",
+            "source_duration": 0,
+            "resource_details": '{"source":"test"}',
+        }
+    }
+
+
+def test_prepare_and_timeout_retry_preserve_original_report(monkeypatch):
+    raw = raw_usage()
+    original = deepcopy(raw)
+    reports = helpers.prepare_usage_reports(raw, CAPABILITY)
+    report_id = next(iter(reports))
+    observed = {}
+    calls = []
+
+    def send(*args, json, **kwargs):
+        calls.append(deepcopy(json))
+        for report in json:
+            observed.setdefault(report["report_id"], report["processed_frames"])
+        if len(calls) == 1:
+            raise TimeoutError("accepted, response lost")
+        return SimpleNamespace(
+            status_code=200,
+            json=lambda: {
+                "usage_report_results": [
+                    {"report_id": report["report_id"], "status": "accepted"}
+                    for report in json
+                ]
+            },
+        )
+
+    monkeypatch.setattr(helpers.requests, "post", send)
+    assert (
+        helpers.send_usage_reports(reports, "api-key", "https://example.invalid") == {}
+    )
+    newer = helpers.prepare_usage_reports(raw_usage(5), CAPABILITY)
+    assert helpers.send_usage_reports(
+        reports, "api-key", "https://example.invalid"
+    ) == {report_id: "accepted"}
+    helpers.send_usage_reports(newer, "api-key", "https://example.invalid")
+    assert sum(observed.values()) == 15
+    assert calls[0] == calls[1]
+    assert raw == original
+    assert "api_key" not in reports[report_id]
+    assert reports[report_id]["exec_session_id"] == "stream"
+
+
+def test_partial_report_outcomes_only_retire_terminal_ids():
+    result = helpers.usage_report_outcomes(
+        {
+            "usage_report_results": [
+                {"report_id": "one", "status": "accepted"},
+                {
+                    "report_id": "two",
+                    "status": "retryable",
+                    "reason": "ownership_conflict",
+                },
+                {"report_id": "three", "status": "rejected", "reason": "invalid_input"},
+            ]
+        },
+        {"one", "two", "three", "four"},
+    )
+    assert result == {"one": "accepted", "three": "invalid_input"}
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        None,
+        {"status": "OK"},
+        {"usage_report_results": None},
+        {"usage_report_results": [{"report_id": "other", "status": "accepted"}]},
+        {"usage_report_results": [{"report_id": "one", "status": "accepted"}] * 2},
+        {"usage_report_results": [{"report_id": "one", "status": "rejected"}]},
+    ],
+)
+def test_missing_or_malformed_acknowledgements_retain_reports(body):
+    assert helpers.usage_report_outcomes(body, {"one"}) == {}
+
+
+@pytest.mark.parametrize("capability", [None, CAPABILITY])
+def test_successful_capability_negotiation(monkeypatch, capability):
+    monkeypatch.setattr(
+        helpers.requests,
+        "get",
+        lambda *a, **k: SimpleNamespace(
+            raise_for_status=lambda: None,
+            json=lambda: {"usage_report_protocol": capability},
+        ),
+    )
+    assert (
+        helpers.get_usage_report_capability("key", "https://example.invalid")
+        == capability
+    )
+
+
+def test_failed_negotiation_does_not_imply_legacy(monkeypatch):
+    def fail(*a, **k):
+        raise TimeoutError("unavailable")
+
+    monkeypatch.setattr(helpers.requests, "get", fail)
+    with pytest.raises(TimeoutError):
+        helpers.get_usage_report_capability("key", "https://example.invalid")
+
+
+def test_legacy_transport_does_not_emit_attempt_marker_or_mutate_retry(monkeypatch):
+    raw = raw_usage()
+    raw["resource"]["_legacy_delivery"] = True
+    original = deepcopy(raw)
+    calls = []
+    monkeypatch.setattr(
+        helpers.requests,
+        "post",
+        lambda *a, json, **k: calls.append(json) or SimpleNamespace(status_code=200),
+    )
+    assert helpers.send_usage_payload({"key": raw}, "https://example.invalid") == set()
+    assert "_legacy_delivery" not in calls[0][0]
+    assert raw == original
+
+
+def configure_collector(collector, monkeypatch, persistent_queue=None):
+    from queue import Queue
+    from inference.usage_tracking import collector as module
+
+    collector._queue = persistent_queue or Queue(maxsize=1)
+    collector._report_delivery = {}
+    collector._hashed_api_keys = {"api-key": "hash"}
+    collector._settings = SimpleNamespace(
+        api_usage_endpoint_url="https://example.invalid/usage/inference",
+        api_plan_endpoint_url="https://example.invalid/usage/plan",
+    )
+    collector._plan_details = SimpleNamespace(
+        _is_enterprise_col_name="enterprise",
+        get_api_key_plan=lambda **kw: {"enterprise": False},
+    )
+    monkeypatch.setattr(module, "OFFLINE_MODE", False)
+    monkeypatch.setattr(helpers, "OFFLINE_MODE", False)
+    monkeypatch.setattr(
+        module, "get_usage_report_capability", lambda *a, **kw: CAPABILITY
+    )
+    return module
+
+
+def test_actual_collector_timeout_new_usage_and_queue_compaction(
+    usage_collector_with_mocked_threads, monkeypatch
+):
+    collector = usage_collector_with_mocked_threads
+    configure_collector(collector, monkeypatch)
+    received, bodies = {}, []
+
+    def send(*a, json, **kw):
+        bodies.append(deepcopy(json))
+        for report in json:
+            received.setdefault(report["report_id"], report["processed_frames"])
+        if len(bodies) == 1:
+            raise TimeoutError("accepted, response lost")
+        return SimpleNamespace(
+            status_code=200,
+            json=lambda: {
+                "usage_report_results": [
+                    {"report_id": report["report_id"], "status": "accepted"}
+                    for report in json
+                ]
+            },
+        )
+
+    monkeypatch.setattr(helpers.requests, "post", send)
+    collector._enqueue_payload({"hash": raw_usage(10)})
+    collector._flush_queue()
+    retained = deepcopy(collector._report_delivery)
+    collector._enqueue_payload({"hash": raw_usage(2)})
+    collector._enqueue_payload({"hash": raw_usage(3)})
+    assert collector._report_delivery == retained
+    assert collector._queue.qsize() == 1
+    collector._flush_queue()
+    collector._flush_queue()
+    assert bodies[0] == bodies[1]
+    assert sum(received.values()) == 15
+    assert collector._report_delivery == {}
+
+
+def test_actual_collector_legacy_attempt_cannot_upgrade(
+    usage_collector_with_mocked_threads, monkeypatch
+):
+    collector = usage_collector_with_mocked_threads
+    module = configure_collector(collector, monkeypatch)
+    monkeypatch.setattr(module, "get_usage_report_capability", lambda *a, **kw: None)
+    sent = []
+
+    def send(*a, json, **kw):
+        sent.append(deepcopy(json))
+        if len(sent) == 1:
+            raise TimeoutError("legacy accepted, response lost")
+        return SimpleNamespace(status_code=200)
+
+    monkeypatch.setattr(helpers.requests, "post", send)
+    collector._enqueue_payload({"hash": raw_usage(10)})
+    collector._flush_queue()
+    monkeypatch.setattr(
+        module, "get_usage_report_capability", lambda *a, **kw: CAPABILITY
+    )
+    collector._enqueue_payload({"hash": raw_usage(5)})
+    collector._flush_queue()
+    assert [report[0]["processed_frames"] for report in sent] == [10, 15]
+    assert all("report_version" not in report for batch in sent for report in batch)
+    assert all("_legacy_delivery" not in report for batch in sent for report in batch)
+
+
+def test_sqlite_prepared_report_survives_restart_and_customer_change(
+    usage_collector_with_mocked_threads, monkeypatch, tmp_path
+):
+    from inference.usage_tracking.sqlite_queue import SQLiteQueue
+
+    collector = usage_collector_with_mocked_threads
+    queue = SQLiteQueue(db_file_path=str(tmp_path / "usage.db"))
+    module = configure_collector(collector, monkeypatch, queue)
+    sent = []
+
+    def send(*a, json, **kw):
+        sent.append(deepcopy(json))
+        if len(sent) == 1:
+            raise TimeoutError("accepted, response lost")
+        return SimpleNamespace(
+            status_code=200,
+            json=lambda: {
+                "usage_report_results": [
+                    {"report_id": report["report_id"], "status": "accepted"}
+                    for report in json
+                ]
+            },
+        )
+
+    monkeypatch.setattr(helpers.requests, "post", send)
+    collector._enqueue_payload({"hash": raw_usage()})
+    collector._flush_queue()
+    before = queue.read_report_delivery()
+    assert before
+    collector._queue = SQLiteQueue(db_file_path=str(tmp_path / "usage.db"))
+
+    def should_not_renegotiate(*a, **kw):
+        raise AssertionError("Attempted report renegotiated ownership")
+
+    monkeypatch.setattr(module, "get_usage_report_capability", should_not_renegotiate)
+    collector._flush_queue()
+    assert sent[0] == sent[1]
+    assert collector._queue.read_report_delivery() == {}
+    assert collector._queue.empty()
+
+
+@pytest.mark.parametrize("persistent", [False, True])
+def test_collector_conflicted_owner_does_not_block_new_owner(
+    usage_collector_with_mocked_threads, monkeypatch, tmp_path, persistent
+):
+    from inference.usage_tracking.sqlite_queue import SQLiteQueue
+
+    collector = usage_collector_with_mocked_threads
+    queue = (
+        SQLiteQueue(db_file_path=str(tmp_path / "fairness.db")) if persistent else None
+    )
+    module = configure_collector(collector, monkeypatch, queue)
+    collector._hashed_api_keys["healthy-key"] = "healthy-hash"
+    accepted, conflicted = {}, []
+
+    def send(*a, json, **kw):
+        outcomes = []
+        for report in json:
+            if report["report_ownership_fingerprint"] == "a" * 64:
+                conflicted.append(deepcopy(report))
+                outcomes.append(
+                    {
+                        "report_id": report["report_id"],
+                        "status": "retryable",
+                        "reason": "ownership_conflict",
+                    }
+                )
+            else:
+                accepted.setdefault(report["report_id"], report["processed_frames"])
+                outcomes.append(
+                    {"report_id": report["report_id"], "status": "accepted"}
+                )
+        return SimpleNamespace(
+            status_code=200, json=lambda: {"usage_report_results": outcomes}
+        )
+
+    monkeypatch.setattr(helpers.requests, "post", send)
+    collector._enqueue_payload({"hash": raw_usage(10)})
+    collector._flush_queue()
+    original = deepcopy(conflicted[0])
+    monkeypatch.setattr(
+        module,
+        "get_usage_report_capability",
+        lambda key, *a, **kw: (
+            CAPABILITY
+            if key == "api-key"
+            else dict(CAPABILITY, ownership_fingerprint="b" * 64)
+        ),
+    )
+    for _ in range(3):
+        collector._enqueue_payload({"hash": raw_usage(1), "healthy-hash": raw_usage(2)})
+        collector._flush_queue()
+    retained = (
+        queue.read_report_delivery() if persistent else collector._report_delivery
+    )
+    assert list(retained) == ["hash"]
+    assert len(retained["hash"]) == 1
+    assert all(report == original for report in conflicted)
+    assert sum(accepted.values()) == 6
+    # A new ownership basis may prepare new usage while the old report stays frozen.
+    monkeypatch.setattr(
+        module,
+        "get_usage_report_capability",
+        lambda *a, **kw: dict(CAPABILITY, ownership_fingerprint="c" * 64),
+    )
+    collector._flush_queue()
+    assert sum(accepted.values()) == 9
+    retained = (
+        queue.read_report_delivery() if persistent else collector._report_delivery
+    )
+    assert len(retained["hash"]) == 1
+
+
+def test_unmarked_legacy_usage_keeps_compacted_new_usage_legacy():
+    legacy = raw_usage(10)
+    legacy["resource"].pop("_usage_report_candidate")
+    merged = helpers.zip_usage_payloads([{"key": legacy}, {"key": raw_usage(5)}])
+    assert merged[0]["key"]["resource"]["processed_frames"] == 15
+    assert merged[0]["key"]["resource"]["_usage_report_candidate"] is False
+
+
+def test_sqlite_failed_prepare_rolls_back_raw_deletion(tmp_path):
+    import sqlite3
+    from inference.usage_tracking.sqlite_queue import SQLiteQueue
+
+    queue = SQLiteQueue(db_file_path=str(tmp_path / "rollback.db"))
+    payload = {"hash": raw_usage(10)}
+    queue.put(payload)
+    queue.read_report_delivery()
+    with sqlite3.connect(queue._db_file_path) as connection:
+        connection.execute(
+            "CREATE TRIGGER fail_prepare BEFORE INSERT ON usage_report_delivery BEGIN SELECT RAISE(ABORT, 'disk failure'); END"
+        )
+    with pytest.raises(sqlite3.IntegrityError, match="disk failure"):
+        queue.prepare_report_delivery(
+            lambda payloads, retained: (
+                {
+                    "hash": helpers.prepare_usage_reports(
+                        payloads[0]["hash"], CAPABILITY
+                    )
+                },
+                [],
+                [],
+            )
+        )
+    assert queue.peek_payloads() == [payload]
+    assert queue.read_report_delivery() == {}


### PR DESCRIPTION
## Problem and change

When an accepted usage request times out, the collector currently merges its retry with newly recorded usage. An accepted 10 frames followed by 5 new frames can therefore submit 15 again and count 25. For workspaces that explicitly advertise usage report v1, freeze the final resource payload and report ID before sending, retain the original through partial acknowledgments and retries, and atomically prepare/acknowledge persistent reports in the existing SQLite queue.

A supplied replacement credential can replay a retained report after live capability confirms its workspace, without changing its original body or ownership fingerprint. Memory and SQLite tests cover removal or retention of the old credential, an already-known replacement inserted earlier in the credential map, and unrelated-workspace isolation. A conflicted ownership basis keeps its original report while other owners continue; new usage for that same basis remains in the existing compacting raw queue. Unmarked persisted records and previously attempted legacy payloads keep legacy semantics, including when compacted with new usage. Transport markers are stripped, and the shared dependency-free helpers also serve the Redis offloader.

## Validation

30 passing focused cases: 27 new helper/actual collector/SQLite cases plus 3 existing SQLite cases. These cover accepted timeout + new usage = 15, partial/malformed acknowledgments, immutable ownership across restart, memory/SQLite multi-owner progress, conservative legacy compaction, and SQLite transaction rollback after a failed prepared-report insert. The local runner substitutes unrelated model-startup modules because the full inference model runtime is unavailable; actual collector methods, helpers, SQLiteQueue, and SQLiteWrapper execute. HTTP is intercepted. Black and `git diff --check` pass. Full-target CI is not established by this local run.

## Dependencies and rollout

Requires the receiver contract in https://github.com/roboflow/roboflow/pull/15282 and the matching Redis offloader change before collector activation. Deploy receiver first, then the compatible offloader pinned to this exact helper source, drain incompatible workers, then release/update inference producers. Old offloaders must not consume new marked raw records during rollout. Failed capability lookup retains unattempted usage; a report that has been attempted never downgrades or changes ownership.

This PR does not publish a package, deploy images, activate financial rollout, or decide PRO-402 funding-boundary policy. Durable raw storage retains its existing capacity behavior; prepared contents do not grow on retry, but no fixed-byte memory guarantee is claimed.

## Review and project scope

Part of PRO-147
Part of PRO-98

This is the immutable producer/offloader delivery portion of the pricing revamp: retries must not double-count usage before canonical prepaid settlement can be safely used. It does not complete either issue’s full accounting or release scope.

Two dedicated context-isolated reviews approve the current head under the authorized Jarbas-outage substitute: [correctness](https://github.com/roboflow/inference/pull/2946#pullrequestreview-5136569256) and [simplicity](https://github.com/roboflow/inference/pull/2946#pullrequestreview-5136569779). These are recorded approval verdicts in GitHub comments, not native or Jarbas approvals.

CodeQL alert [477](https://github.com/roboflow/inference/security/code-scanning/477) was independently traced to the existing deterministic API-key cache index and dismissed as a documented false positive; no source suppression or hash change was made.
