### PR TITLE
fix(tests): five rfdetr-seg static-crop tests shadow each other by name

### DIFF
--- a/inference_models/tests/integration_tests/models/test_rfdetr_seg_predictions_onnx.py
+++ b/inference_models/tests/integration_tests/models/test_rfdetr_seg_predictions_onnx.py
@@ -1085,7 +1085,7 @@ def test_package_with_static_crop_letterbox_against_torch_batch_input(
 
 @pytest.mark.slow
 @pytest.mark.onnx_extras
-def test_package_with_static_crop_letterbox_against_numpy_input(
+def test_package_with_static_crop_center_crop_against_numpy_input(
     snake_image_numpy: np.ndarray,
     snakes_rfdetr_seg_onnx_static_bs_static_crop_center_crop_package: str,
 ) -> None:
@@ -1118,7 +1118,7 @@ def test_package_with_static_crop_letterbox_against_numpy_input(
 
 @pytest.mark.slow
 @pytest.mark.onnx_extras
-def test_package_with_static_crop_letterbox_against_numpy_list_input(
+def test_package_with_static_crop_center_crop_against_numpy_list_input(
     snake_image_numpy: np.ndarray,
     snakes_rfdetr_seg_onnx_static_bs_static_crop_center_crop_package: str,
 ) -> None:
@@ -1161,7 +1161,7 @@ def test_package_with_static_crop_letterbox_against_numpy_list_input(
 
 @pytest.mark.slow
 @pytest.mark.onnx_extras
-def test_package_with_static_crop_letterbox_against_torch_input(
+def test_package_with_static_crop_center_crop_against_torch_input(
     snake_image_torch: torch.Tensor,
     snakes_rfdetr_seg_onnx_static_bs_static_crop_center_crop_package: str,
 ) -> None:
@@ -1194,7 +1194,7 @@ def test_package_with_static_crop_letterbox_against_torch_input(
 
 @pytest.mark.slow
 @pytest.mark.onnx_extras
-def test_package_with_static_crop_letterbox_against_torch_list_input(
+def test_package_with_static_crop_center_crop_against_torch_list_input(
     snake_image_torch: torch.Tensor,
     snakes_rfdetr_seg_onnx_static_bs_static_crop_center_crop_package: str,
 ) -> None:
@@ -1237,7 +1237,7 @@ def test_package_with_static_crop_letterbox_against_torch_list_input(
 
 @pytest.mark.slow
 @pytest.mark.onnx_extras
-def test_package_with_static_crop_letterbox_against_torch_batch_input(
+def test_package_with_static_crop_center_crop_against_torch_batch_input(
     snake_image_torch: torch.Tensor,
     snakes_rfdetr_seg_onnx_static_bs_static_crop_center_crop_package: str,
 ) -> None:


### PR DESCRIPTION
## What

`inference_models/tests/integration_tests/models/test_rfdetr_seg_predictions_onnx.py` has three blocks of static-crop package tests — **stretch**, **letterbox** and **center-crop** — each written by copying the previous one. The center-crop block kept the *letterbox* names:

| line | test name | fixture it actually uses |
|---|---|---|
| 938 | `test_package_with_static_crop_letterbox_against_numpy_input` | `..._static_crop_letterbox_package` |
| **1088** | `test_package_with_static_crop_letterbox_against_numpy_input` | `..._static_crop_**center_crop**_package` |

…and the same for `_numpy_list_input`, `_torch_input`, `_torch_list_input` and `_torch_batch_input` — five collisions in total.

pytest collects module attributes, so for each of those five names the **second** definition replaces the first. Net effect:

- the five **letterbox** tests have not been collected at all, so the letterbox static-crop package has no coverage;
- the five **center-crop** tests were being reported under a letterbox name.

Checkable without running the suite (it needs GPU/ONNX extras):

```console
$ python -c "
import ast, collections
p='inference_models/tests/integration_tests/models/test_rfdetr_seg_predictions_onnx.py'
n=[f.name for f in ast.parse(open(p).read()).body if isinstance(f, ast.FunctionDef)]
print([k for k,v in collections.Counter(n).items() if v>1])"
['test_package_with_static_crop_letterbox_against_numpy_input',
 'test_package_with_static_crop_letterbox_against_numpy_list_input',
 'test_package_with_static_crop_letterbox_against_torch_input',
 'test_package_with_static_crop_letterbox_against_torch_list_input',
 'test_package_with_static_crop_letterbox_against_torch_batch_input',
 'test_package_with_static_crop_stretch_against_numpy_input']
```

## Change

Rename the five center-crop definitions to `test_package_with_static_crop_center_crop_*`, matching the fixture each one requests. **Pure rename** — no fixture, marker, body or assertion is touched, and the new names do not collide with the existing (non-static-crop) `test_package_with_center_crop_*` tests.

These tests are `@pytest.mark.slow @pytest.mark.onnx_extras` and need a GPU/ONNX environment I do not have, so I could not execute them here. The five letterbox tests are being collected for the first time — if their expected boxes/mask areas need refreshing, I'm happy to update them in this PR.

## One thing I left alone

The same script also reports `test_package_with_static_crop_stretch_against_numpy_input` twice (lines 701 and 905). Those two use the *same* fixture and the same call but assert different boxes and mask bounds, so only a maintainer can say which one is current — I did not want to guess, and it is a separate concern from the letterbox/center-crop mix-up.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
