### PR TITLE
fix(tests): image-preprocessing resize assertions are always-true tuples and compare the wrong axes

### DIFF
--- a/tests/workflows/integration_tests/execution/test_workflow_with_image_preprocessing.py
+++ b/tests/workflows/integration_tests/execution/test_workflow_with_image_preprocessing.py
@@ -75,11 +75,8 @@ def test_resize_image_workflow_when_valid_input_provided(
         "resized_image",
     }, "Expected all declared outputs to be delivered"
     np_image = result[0]["resized_image"].numpy_image
-    assert (
-        np_image.shape[0] == 1000,
-        "Expected image to be resized to a width of 1000",
-    )
-    assert (np_image.shape[1] == 800, "Expected image to be resized to a height of 800")
+    assert np_image.shape[0] == 800, "Expected image to be resized to a height of 800"
+    assert np_image.shape[1] == 1000, "Expected image to be resized to a width of 1000"
 
 
 def test_upsize_image_workflow_when_valid_input_provided(
@@ -111,11 +108,8 @@ def test_upsize_image_workflow_when_valid_input_provided(
         "resized_image",
     }, "Expected all declared outputs to be delivered"
     np_image = result[0]["resized_image"].numpy_image
-    assert (
-        np_image.shape[0] == 1000,
-        "Expected image to be upsized to a width of 1000",
-    )
-    assert (np_image.shape[1] == 800, "Expected image to be upsized to a height of 800")
+    assert np_image.shape[0] == 800, "Expected image to be upsized to a height of 800"
+    assert np_image.shape[1] == 1000, "Expected image to be upsized to a width of 1000"
 
 
 def test_resize_image_workflow_when_missing_required_parameters() -> None:


### PR DESCRIPTION
## Description

Two bugs stacked on top of each other in
`tests/workflows/integration_tests/execution/test_workflow_with_image_preprocessing.py`.

### 1. The assertions are tuples, so they can never fail

```python
assert (
    np_image.shape[0] == 1000,
    "Expected image to be resized to a width of 1000",
)
assert (np_image.shape[1] == 800, "Expected image to be resized to a height of 800")
```

`assert (cond, "msg")` asserts a two-element tuple, which is always truthy. All
four occurrences (in `test_resize_image_workflow_when_valid_input_provided` and
`test_upsize_image_workflow_when_valid_input_provided`) are no-ops:

```
$ pyflakes tests/workflows/integration_tests/execution/test_workflow_with_image_preprocessing.py
:78:5: assertion is always true, perhaps remove parentheses?
:82:5: assertion is always true, perhaps remove parentheses?
:114:5: assertion is always true, perhaps remove parentheses?
:118:5: assertion is always true, perhaps remove parentheses?
```

Every other assertion in this same file already uses the correct
`assert (cond), "msg"` form (e.g. lines 189-194, 260-265, 375-377).

### 2. Once un-neutered, they are comparing the wrong axes

`RESIZE_IMAGE_WORKFLOW` sets `width: 1000, height: 800`, and the block does

```python
# inference/core/workflows/core_steps/classical_cv/image_preprocessing/v1.py:256
resized_image = cv2.resize(np_image, (width, height), interpolation=cv2.INTER_AREA)
```

`cv2.resize` takes `(width, height)` and returns an array of shape
`(height, width, channels)`, so the result is `(800, 1000, 3)` — `shape[0]` is
the **height** and `shape[1]` is the **width**. The assertions have them
swapped, and the messages confirm the intent (`shape[0] ... "a width of 1000"`).

The repo's own unit test states the same contract:

```python
# tests/workflows/unit_tests/core_steps/classical_cv/test_image_preprocessing.py:70
def test_image_preprocessing_resize_to_exact_dimensions() -> None:
    ...
    result = _run_v1(image, task_type="resize", width=32, height=24)
    assert result.numpy_image.shape == (24, 32, 3)
```

Verified directly:

```
>>> cv2.resize(np.zeros((1280,1920,3), np.uint8), (1000, 800), interpolation=cv2.INTER_AREA).shape
(800, 1000, 3)
>>> out.shape[0] == 1000, out.shape[1] == 800          # what the test asserts
(False, False)
>>> bool((out.shape[0] == 1000, "msg"))                # why it passes anyway
True
```

So simply removing the parentheses would turn both tests red — the axes have to
be swapped at the same time.

## Fix

```python
assert np_image.shape[0] == 800, "Expected image to be resized to a height of 800"
assert np_image.shape[1] == 1000, "Expected image to be resized to a width of 1000"
```

for both tests. Test-only change, `black` clean.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
