### PR TITLE
Bound workflow keypoint padding to prevent memory exhaustion

### DIFF
--- a/inference/core/workflows/core_steps/common/keypoints.py
+++ b/inference/core/workflows/core_steps/common/keypoints.py
@@ -22,6 +22,20 @@ from typing import Optional, Sequence
 # ``add_inference_keypoints_to_sv_detections``. Real keypoints never carry it.
 KEYPOINT_PADDING_CLASS_NAME = ""
 
+# Bounds the dense keypoint arrays to about 28 MB on 64-bit NumPy (12 MB for
+# torch). A limit on real keypoints alone would not bound ragged padding.
+MAX_KEYPOINTS_PADDING_CELLS = 1_000_000
+
+
+def validate_keypoints_padding(detections_count: int, max_keypoints: int) -> None:
+    padding_cells = detections_count * max_keypoints
+    if padding_cells > MAX_KEYPOINTS_PADDING_CELLS:
+        raise ValueError(
+            f"Keypoint padding requires {padding_cells} slots, exceeding the limit "
+            f"of {MAX_KEYPOINTS_PADDING_CELLS}. Reduce the number of detections "
+            "or keypoints per detection."
+        )
+
 
 def real_keypoints_count(keypoint_class_names: Optional[Sequence], total: int) -> int:
     """Return how many of a detection's keypoint slots are real (not padding).

--- a/inference/core/workflows/core_steps/common/tensor_native.py
+++ b/inference/core/workflows/core_steps/common/tensor_native.py
@@ -21,6 +21,9 @@ from pycocotools import mask as mask_utils
 from supervision.config import ORIENTED_BOX_COORDINATES
 
 from inference.core.env import WORKFLOWS_IMAGE_TENSOR_DEVICE
+from inference.core.workflows.core_steps.common.keypoints import (
+    validate_keypoints_padding,
+)
 from inference.core.workflows.execution_engine.constants import (
     CLASS_ID_KEY,
     CLASS_NAME_KEY,
@@ -1030,6 +1033,7 @@ def build_native_key_points(
         list(conf) if conf else [] for conf in per_instance_confidence
     ]
     max_key_points = max((len(xy) for xy in normalised_xy), default=0)
+    validate_keypoints_padding(number_of_instances, max_key_points)
     xy_tensor = torch.zeros(
         (number_of_instances, max_key_points, 2), dtype=torch.float32
     )

--- a/inference/core/workflows/core_steps/common/utils.py
+++ b/inference/core/workflows/core_steps/common/utils.py
@@ -30,6 +30,7 @@ from inference.core.managers.base import ModelManager
 from inference.core.roboflow_api import ModelEndpointType
 from inference.core.workflows.core_steps.common.keypoints import (
     KEYPOINT_PADDING_CLASS_NAME,
+    validate_keypoints_padding,
 )
 from inference.core.workflows.execution_engine.constants import (
     DETECTION_ID_KEY,
@@ -193,6 +194,7 @@ def add_inference_keypoints_to_sv_detections(
     # is_data_equal (used in Detections indexing/comparison).
     max_kps = max((len(kp) for kp in keypoints_xy), default=0)
     n = len(inference_prediction)
+    validate_keypoints_padding(n, max_kps)
     padded_xy = np.zeros((n, max_kps, 2), dtype=np.float32)
     padded_conf = np.zeros((n, max_kps), dtype=np.float32)
     padded_class_id = np.zeros((n, max_kps), dtype=int)

--- a/inference/core/workflows/core_steps/models/roboflow/keypoint_detection/v1_tensor.py
+++ b/inference/core/workflows/core_steps/models/roboflow/keypoint_detection/v1_tensor.py
@@ -54,6 +54,9 @@ from inference.core.env import (
 )
 from inference.core.managers.base import ModelManager
 from inference.core.workflows.core_steps.common.entities import StepExecutionMode
+from inference.core.workflows.core_steps.common.keypoints import (
+    validate_keypoints_padding,
+)
 from inference.core.workflows.core_steps.common.tensor_native import (
     attach_native_detection_metadata,
     native_detections_from_inference_predictions,
@@ -611,6 +614,7 @@ def _native_key_points_from_inference_predictions(
         object_class_ids.append(int(detection_dict.get("class_id", 0)))
     number_of_instances = len(detection_dicts)
     max_key_points = max((len(xy) for xy in per_instance_xy), default=0)
+    validate_keypoints_padding(number_of_instances, max_key_points)
     xy_tensor = torch.zeros(
         (number_of_instances, max_key_points, 2), dtype=torch.float32, device=device
     )

--- a/inference/core/workflows/core_steps/models/roboflow/keypoint_detection/v2_tensor.py
+++ b/inference/core/workflows/core_steps/models/roboflow/keypoint_detection/v2_tensor.py
@@ -55,6 +55,9 @@ from inference.core.env import (
 )
 from inference.core.managers.base import ModelManager
 from inference.core.workflows.core_steps.common.entities import StepExecutionMode
+from inference.core.workflows.core_steps.common.keypoints import (
+    validate_keypoints_padding,
+)
 from inference.core.workflows.core_steps.common.tensor_native import (
     attach_native_detection_metadata,
     native_detections_from_inference_predictions,
@@ -613,6 +616,7 @@ def _native_key_points_from_inference_predictions(
         object_class_ids.append(int(detection_dict.get("class_id", 0)))
     number_of_instances = len(detection_dicts)
     max_key_points = max((len(xy) for xy in per_instance_xy), default=0)
+    validate_keypoints_padding(number_of_instances, max_key_points)
     xy_tensor = torch.zeros(
         (number_of_instances, max_key_points, 2), dtype=torch.float32, device=device
     )

--- a/inference/core/workflows/core_steps/models/roboflow/keypoint_detection/v3_tensor.py
+++ b/inference/core/workflows/core_steps/models/roboflow/keypoint_detection/v3_tensor.py
@@ -49,6 +49,9 @@ from inference.core.env import (
 )
 from inference.core.managers.base import ModelManager
 from inference.core.workflows.core_steps.common.entities import StepExecutionMode
+from inference.core.workflows.core_steps.common.keypoints import (
+    validate_keypoints_padding,
+)
 from inference.core.workflows.core_steps.common.tensor_native import (
     attach_native_detection_metadata,
     native_detections_from_inference_predictions,
@@ -646,6 +649,7 @@ def _native_key_points_from_inference_predictions(
         object_class_ids.append(int(detection_dict.get("class_id", 0)))
     number_of_instances = len(detection_dicts)
     max_key_points = max((len(xy) for xy in per_instance_xy), default=0)
+    validate_keypoints_padding(number_of_instances, max_key_points)
     xy_tensor = torch.zeros(
         (number_of_instances, max_key_points, 2), dtype=torch.float32, device=device
     )

--- a/inference/core/workflows/execution_engine/v1/dynamic_blocks/representation_boundary.py
+++ b/inference/core/workflows/execution_engine/v1/dynamic_blocks/representation_boundary.py
@@ -33,6 +33,9 @@ from inference.core.env import (
     ENABLE_TENSOR_DATA_REPRESENTATION,
     WORKFLOWS_IMAGE_TENSOR_DEVICE,
 )
+from inference.core.workflows.core_steps.common.keypoints import (
+    validate_keypoints_padding,
+)
 from inference.core.workflows.core_steps.common.serializers_tensor import (
     serialise_native_classification,
 )
@@ -704,6 +707,7 @@ def _attach_padded_keypoint_columns(
         for per_box in bboxes_metadata
     ]
     max_kps = max((len(kp) for kp in keypoints_xy), default=0)
+    validate_keypoints_padding(detections_number, max_kps)
     padded_xy = np.zeros((detections_number, max_kps, 2), dtype=np.float32)
     padded_conf = np.zeros((detections_number, max_kps), dtype=np.float32)
     padded_class_id = np.zeros((detections_number, max_kps), dtype=int)

--- a/tests/workflows/unit_tests/core_steps/common/test_keypoints.py
+++ b/tests/workflows/unit_tests/core_steps/common/test_keypoints.py
@@ -1,5 +1,12 @@
-import numpy as np
+from functools import partial
+from importlib import import_module
+from unittest.mock import patch
 
+import numpy as np
+import pytest
+import supervision as sv
+
+from inference.core.workflows.core_steps.common import keypoints
 from inference.core.workflows.core_steps.common.keypoints import (
     KEYPOINT_PADDING_CLASS_NAME,
     real_keypoints_count,
@@ -30,3 +37,156 @@ def test_real_keypoints_count_when_all_padding() -> None:
 def test_real_keypoints_count_falls_back_to_total_without_names() -> None:
     # No class-name metadata -> keypoints are emitted unchanged (fallback to total).
     assert real_keypoints_count(None, total=4) == 4
+
+
+@pytest.mark.parametrize(
+    "detections_count,max_keypoints",
+    [(0, 0), (10, 0), (1, 1_000_000), (1000, 1000)],
+)
+def test_validate_keypoints_padding_accepts_bounded_shapes(
+    detections_count: int, max_keypoints: int
+) -> None:
+    keypoints.validate_keypoints_padding(detections_count, max_keypoints)
+
+
+def test_validate_keypoints_padding_rejects_above_limit() -> None:
+    with pytest.raises(ValueError, match="exceeding the limit"):
+        keypoints.validate_keypoints_padding(1, 1_000_001)
+
+
+@pytest.mark.parametrize(
+    "padding_path", ["numpy", "boundary", "native", "v1", "v2", "v3"]
+)
+@pytest.mark.parametrize("large_index", [0, 2])
+def test_keypoint_padding_rejects_before_allocation(
+    monkeypatch: pytest.MonkeyPatch, padding_path: str, large_index: int
+) -> None:
+    from inference.core.workflows.core_steps.common.tensor_native import (
+        build_native_key_points,
+    )
+    from inference.core.workflows.core_steps.common.utils import (
+        add_inference_keypoints_to_sv_detections,
+    )
+    from inference.core.workflows.execution_engine.v1.dynamic_blocks.representation_boundary import (
+        _attach_padded_keypoint_columns,
+    )
+
+    # Only two real keypoints, but padding would require six slots.
+    monkeypatch.setattr(keypoints, "MAX_KEYPOINTS_PADDING_CELLS", 4)
+    predictions = [{"keypoints": []} for _ in range(3)]
+    predictions[large_index]["keypoints"] = [
+        {"x": 1, "y": 2, "class": "nose", "class_id": 0, "confidence": 0.9}
+    ] * 2
+    metadata = [
+        {
+            "keypoints_xy": [[k["x"], k["y"]] for k in p["keypoints"]],
+            "keypoints_confidence": [k["confidence"] for k in p["keypoints"]],
+            "keypoints_class_id": [k["class_id"] for k in p["keypoints"]],
+            "keypoints_class_name": [k["class"] for k in p["keypoints"]],
+        }
+        for p in predictions
+    ]
+    if padding_path == "numpy":
+        pad = partial(
+            add_inference_keypoints_to_sv_detections,
+            inference_prediction=predictions,
+            detections=sv.Detections(xyxy=np.zeros((3, 4))),
+        )
+    elif padding_path == "boundary":
+        pad = partial(
+            _attach_padded_keypoint_columns,
+            data={},
+            bboxes_metadata=metadata,
+            detections_number=3,
+        )
+    elif padding_path == "native":
+        pad = partial(
+            build_native_key_points,
+            per_instance_xy=[m["keypoints_xy"] for m in metadata],
+            per_instance_confidence=[m["keypoints_confidence"] for m in metadata],
+            object_class_ids=[0] * 3,
+            image_metadata={},
+        )
+    else:
+        module = import_module(
+            "inference.core.workflows.core_steps.models.roboflow."
+            f"keypoint_detection.{padding_path}_tensor"
+        )
+        pad = partial(
+            module._native_key_points_from_inference_predictions,
+            detection_dicts=predictions,
+            image_metadata={},
+        )
+
+    with (
+        patch("numpy.zeros") as numpy_zeros,
+        patch("numpy.full") as numpy_full,
+        patch("torch.zeros") as torch_zeros,
+        pytest.raises(ValueError, match="Keypoint padding requires 6 slots"),
+    ):
+        pad()
+    numpy_zeros.assert_not_called()
+    numpy_full.assert_not_called()
+    torch_zeros.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "kind",
+    [
+        "object_detection_prediction",
+        "instance_segmentation_prediction",
+        "keypoint_detection_prediction",
+    ],
+)
+def test_workflow_rejects_excessive_keypoint_padding(
+    monkeypatch: pytest.MonkeyPatch, kind: str
+) -> None:
+    from inference.core.workflows.core_steps import loader
+    from inference.core.workflows.core_steps.common.deserializers import (
+        deserialize_detections_kind,
+    )
+    from inference.core.workflows.errors import RuntimeInputError
+    from inference.core.workflows.execution_engine.core import ExecutionEngine
+
+    monkeypatch.setattr(keypoints, "MAX_KEYPOINTS_PADDING_CELLS", 4)
+    # Exercise the affected NumPy input route regardless of the suite's tensor flag.
+    monkeypatch.setitem(loader.KINDS_DESERIALIZERS, kind, deserialize_detections_kind)
+    engine = ExecutionEngine.init(
+        workflow_definition={
+            "version": "1.3.0",
+            "inputs": [
+                {"type": "WorkflowBatchInput", "name": "detections", "kind": [kind]}
+            ],
+            "steps": [],
+            "outputs": [
+                {
+                    "type": "JsonField",
+                    "name": "detections",
+                    "selector": "$inputs.detections",
+                }
+            ],
+        },
+        init_parameters={},
+    )
+    prediction = {
+        "x": 10,
+        "y": 10,
+        "width": 2,
+        "height": 2,
+        "confidence": 0.9,
+        "class_id": 0,
+        "class": "object",
+    }
+    predictions = [dict(prediction) for _ in range(3)]
+    predictions[0]["keypoints"] = [
+        {"x": 1, "y": 2, "class": "nose", "class_id": 0, "confidence": 0.9}
+    ] * 2
+    payload = {"image": {"width": 20, "height": 20}, "predictions": predictions}
+
+    with pytest.raises(RuntimeInputError, match="Keypoint padding requires 6 slots"):
+        engine.run(runtime_parameters={"detections": payload})
+
+    # The exact limit still accepts a legitimate ragged prediction.
+    payload["predictions"] = predictions[:2]
+    result = engine.run(runtime_parameters={"detections": payload})
+    assert result[0]["detections"].data["keypoints_xy"].shape == (2, 2, 2)


### PR DESCRIPTION
## What does this PR do?

  Workflow inputs can supply ragged keypoints that trigger allocations proportional
  to detections × max_keypoints. A safe reproduction through the workflow engine
  showed an 840 KB payload requesting 700 MB of arrays.

  Add a shared limit of 1,000,000 padded keypoint slots across all six NumPy and
  Torch padding paths. Oversized inputs fail before dense allocation. Regression
  coverage verifies allocation prevention, workflow input errors, and acceptance at
  the limit.

## Type of Change

- Bug fix (non-breaking change that fixes an issue)

## Testing

255 tests passed, including 20 new regression cases

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)

## Additional Context

N/A