### PR TITLE
Prevent local model paths from bypassing model authorization

### DIFF
--- a/inference/core/env.py
+++ b/inference/core/env.py
@@ -614,6 +614,19 @@ if (
         "trusted single-tenant deployment, or disable one of these modes."
     )
 
+# Local paths have no Roboflow identity for per-model authorization. Offline
+# deployments already require an explicit authorization bypass above.
+if (
+    MODELS_CACHE_AUTH_ENABLED
+    and not OFFLINE_MODE
+    and ALLOW_INFERENCE_MODELS_DIRECTLY_ACCESS_LOCAL_PACKAGES
+):
+    raise ValueError(
+        "MODELS_CACHE_AUTH_ENABLED cannot authorize local model paths. "
+        "Disable ALLOW_INFERENCE_MODELS_DIRECTLY_ACCESS_LOCAL_PACKAGES "
+        "when per-model authorization is required."
+    )
+
 # Models cache auth cache ttl, default is 15 minutes
 MODELS_CACHE_AUTH_CACHE_TTL = int(os.getenv("MODELS_CACHE_AUTH_CACHE_TTL", 15 * 60))
 

--- a/inference_models/docs/how-to/local-packages.md
+++ b/inference_models/docs/how-to/local-packages.md
@@ -47,6 +47,20 @@ model = AutoModel.from_pretrained(
 !!! warning "Security Warning"
     Only enable `allow_local_code_packages` for trusted sources. This allows execution of arbitrary Python code from the model package.
 
+### Local Packages in Inference Server Workflows
+
+To load local packages through Inference Server workflows, enable
+`USE_INFERENCE_MODELS=True` and
+`ALLOW_INFERENCE_MODELS_DIRECTLY_ACCESS_LOCAL_PACKAGES=True`. This grants workflow
+callers access to local model packages readable by the server, including their
+Python code. Use this feature only with trusted callers and packages.
+
+Online servers reject this configuration when `MODELS_CACHE_AUTH_ENABLED=True`:
+a filesystem path cannot be authorized against a caller's Roboflow API key.
+Keep direct local loading disabled when per-model authorization is required.
+Offline deployments retain their explicit `ALLOW_OFFLINE_MODEL_CACHE_AUTH_BYPASS`
+opt-in for trusted single-tenant use.
+
 ### Creating Custom Model Packages
 
 #### Step 1: Create `model_config.json`

--- a/tests/inference/unit_tests/core/test_env.py
+++ b/tests/inference/unit_tests/core/test_env.py
@@ -1,5 +1,9 @@
 import importlib
 import os
+import subprocess
+import sys
+
+import pytest
 
 from inference.core import env as env_module
 
@@ -116,3 +120,34 @@ def test_workflows_remote_api_key_transport_rejects_invalid_value() -> None:
     # then
     assert result.returncode != 0
     assert "Invalid WORKFLOWS_REMOTE_API_KEY_TRANSPORT" in result.stderr
+
+
+@pytest.mark.parametrize("offline_mode", [False, True])
+@pytest.mark.parametrize("cache_auth", [False, True])
+@pytest.mark.parametrize("local_packages", [False, True])
+def test_local_packages_require_model_authorization_to_be_disabled(
+    offline_mode: bool, cache_auth: bool, local_packages: bool
+) -> None:
+    env = {
+        **os.environ,
+        "DISABLE_VERSION_CHECK": "True",
+        "USE_INFERENCE_MODELS": "True",
+        "OFFLINE_MODE": str(offline_mode),
+        "_ROBOFLOW_INFERENCE_OFFLINE_MODE_AT_PROCESS_START": str(offline_mode),
+        "ALLOW_OFFLINE_MODEL_CACHE_AUTH_BYPASS": "True",
+        "MODELS_CACHE_AUTH_ENABLED": str(cache_auth),
+        "ALLOW_INFERENCE_MODELS_DIRECTLY_ACCESS_LOCAL_PACKAGES": str(local_packages),
+    }
+    result = subprocess.run(
+        [sys.executable, "-c", "import inference.core.env"],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=60,
+    )
+
+    if cache_auth and local_packages and not offline_mode:
+        assert result.returncode != 0
+        assert "cannot authorize local model paths" in result.stderr
+    else:
+        assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## What does this PR do?

  Local model paths previously passed authorization without checking the caller’s
  API key when direct local loading was enabled, even with
  `MODELS_CACHE_AUTH_ENABLED=True`.

  Reject startup when online model authorization and direct local package loading
  are both enabled. Local filesystem paths have no Roboflow identity to authorize.
  Preserve trusted local loading and the existing explicit offline authorization
  bypass.

  Add coverage for eight configuration combinations and document the restriction.

  Local models still work by path without any API key if `ALLOW_INFERENCE_MODELS_DIRECTLY_ACCESS_LOCAL_PACKAGES=True`

## Type of Change

- Bug fix (non-breaking change that fixes an issue)

## Testing

17 focused tests passed

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)

## Additional Context

N/A