### PR TITLE
Restrict OpenAI-compatible workflow requests to approved endpoints

### DIFF
--- a/inference/core/env.py
+++ b/inference/core/env.py
@@ -1407,6 +1407,15 @@ if HTTP_API_THREADPOOL_WORKERS:
 else:
     HTTP_API_THREADPOOL_WORKERS = None
 
+# Exact operator-approved OpenAI-compatible base URLs, ignoring trailing slashes.
+# Empty by default: workflows cannot select arbitrary outbound destinations.
+OPENAI_COMPATIBLE_ALLOWED_BASE_URLS = {
+    url.rstrip("/")
+    for url in safe_split_value(
+        os.getenv("OPENAI_COMPATIBLE_ALLOWED_BASE_URLS", ""), strip=True
+    )
+}
+
 # Workflow block filtering configuration
 # Comma-separated list of block type categories to disable (e.g., "sink,model")
 WORKFLOW_DISABLED_BLOCK_TYPES = os.getenv("WORKFLOW_DISABLED_BLOCK_TYPES", "")

--- a/inference/core/env.py
+++ b/inference/core/env.py
@@ -1408,11 +1408,11 @@ else:
     HTTP_API_THREADPOOL_WORKERS = None
 
 # Exact operator-approved OpenAI-compatible base URLs, ignoring trailing slashes.
-# Empty by default: workflows cannot select arbitrary outbound destinations.
+# "*" allows any destination by default for compatibility; empty blocks all.
 OPENAI_COMPATIBLE_ALLOWED_BASE_URLS = {
     url.rstrip("/")
     for url in safe_split_value(
-        os.getenv("OPENAI_COMPATIBLE_ALLOWED_BASE_URLS", ""), strip=True
+        os.getenv("OPENAI_COMPATIBLE_ALLOWED_BASE_URLS", "*"), strip=True
     )
 }
 

--- a/inference/core/workflows/core_steps/models/foundation/openai_compatible/v1.py
+++ b/inference/core/workflows/core_steps/models/foundation/openai_compatible/v1.py
@@ -44,14 +44,16 @@ LM Studio, or any service that implements the OpenAI chat completions API).
 
 ## Server configuration
 
-The server operator must set `OPENAI_COMPATIBLE_ALLOWED_BASE_URLS` to a
-comma-separated list of trusted base URLs, for example:
+`OPENAI_COMPATIBLE_ALLOWED_BASE_URLS` defaults to `*`, allowing any destination
+for compatibility. Set it to an empty value to block all requests, or a
+comma-separated list of trusted base URLs to restrict destinations, for example:
 `http://localhost:8000/v1,https://llm.example.com/v1`.
-The default is empty, so requests are blocked until an endpoint is approved.
-Matching is exact (including scheme, port, and path), ignoring trailing slashes.
-Use HTTP(S) URLs without credentials, query strings, or fragments. Local/private
-servers and plain HTTP require explicit inclusion in this list. Only approve
-hosts whose DNS and service are trusted to receive workflow data and API keys.
+A `*` entry allows any destination even when other entries are present.
+Otherwise, matching is exact (including scheme, port, and path), ignoring
+trailing slashes. Use HTTP(S) URLs without credentials, query strings, or
+fragments. Local/private servers and plain HTTP are supported. When restricting
+destinations, only approve hosts whose DNS and service are trusted to receive
+workflow data and API keys.
 Redirects are not followed; configure the final API URL. Restart the server after
 changing this setting. Workflow inputs and selectors cannot modify the allowlist.
 
@@ -107,7 +109,7 @@ class BlockManifest(WorkflowBlockManifest):
     base_url: Union[Selector(kind=[STRING_KIND]), str] = Field(
         title="Base URL",
         description="URL of the OpenAI-compatible server, including /v1. Must be listed "
-        "in the server's OPENAI_COMPATIBLE_ALLOWED_BASE_URLS setting.",
+        "in the server's OPENAI_COMPATIBLE_ALLOWED_BASE_URLS setting unless it contains *.",
         examples=["http://localhost:8000/v1", "$inputs.base_url"],
     )
     model_name: Union[Selector(kind=[STRING_KIND]), str] = Field(
@@ -251,7 +253,10 @@ class OpenAICompatibleBlockV1(WorkflowBlock):
 
     def _get_client(self, base_url: str, api_key: str) -> OpenAI:
         base_url = base_url.rstrip("/")
-        if base_url not in OPENAI_COMPATIBLE_ALLOWED_BASE_URLS:
+        if (
+            "*" not in OPENAI_COMPATIBLE_ALLOWED_BASE_URLS
+            and base_url not in OPENAI_COMPATIBLE_ALLOWED_BASE_URLS
+        ):
             raise ValueError(
                 "OpenAI-compatible endpoint is not approved by the server. Configure "
                 "OPENAI_COMPATIBLE_ALLOWED_BASE_URLS to allow this base URL."

--- a/inference/core/workflows/core_steps/models/foundation/openai_compatible/v1.py
+++ b/inference/core/workflows/core_steps/models/foundation/openai_compatible/v1.py
@@ -3,9 +3,11 @@ import re
 from collections import defaultdict
 from typing import Any, Dict, List, Literal, Optional, Set, Tuple, Type, Union
 
-from openai import OpenAI
+from httpx import URL
+from openai import DefaultHttpxClient, OpenAI
 from pydantic import ConfigDict, Field
 
+from inference.core.env import OPENAI_COMPATIBLE_ALLOWED_BASE_URLS
 from inference.core.logger import logger
 from inference.core.utils.image_utils import encode_image_to_jpeg_bytes
 from inference.core.workflows.core_steps.common.query_language.entities.operations import (
@@ -39,6 +41,19 @@ PARAMETER_REGEX = re.compile(r"({{\s*\$parameters\.(\w+)\s*}})")
 LONG_DESCRIPTION = """
 Send a prompt to any OpenAI-compatible API endpoint (e.g. local Qwen, vLLM, Ollama,
 LM Studio, or any service that implements the OpenAI chat completions API).
+
+## Server configuration
+
+The server operator must set `OPENAI_COMPATIBLE_ALLOWED_BASE_URLS` to a
+comma-separated list of trusted base URLs, for example:
+`http://localhost:8000/v1,https://llm.example.com/v1`.
+The default is empty, so requests are blocked until an endpoint is approved.
+Matching is exact (including scheme, port, and path), ignoring trailing slashes.
+Use HTTP(S) URLs without credentials, query strings, or fragments. Local/private
+servers and plain HTTP require explicit inclusion in this list. Only approve
+hosts whose DNS and service are trusted to receive workflow data and API keys.
+Redirects are not followed; configure the final API URL. Restart the server after
+changing this setting. Workflow inputs and selectors cannot modify the allowlist.
 
 ## How this block works
 
@@ -91,7 +106,8 @@ class BlockManifest(WorkflowBlockManifest):
     type: Literal["roboflow_core/openai_compatible@v1"]
     base_url: Union[Selector(kind=[STRING_KIND]), str] = Field(
         title="Base URL",
-        description="URL of the OpenAI-compatible server, including /v1.",
+        description="URL of the OpenAI-compatible server, including /v1. Must be listed "
+        "in the server's OPENAI_COMPATIBLE_ALLOWED_BASE_URLS setting.",
         examples=["http://localhost:8000/v1", "$inputs.base_url"],
     )
     model_name: Union[Selector(kind=[STRING_KIND]), str] = Field(
@@ -234,10 +250,33 @@ class OpenAICompatibleBlockV1(WorkflowBlock):
         return ">=1.4.0,<2.0.0"
 
     def _get_client(self, base_url: str, api_key: str) -> OpenAI:
+        base_url = base_url.rstrip("/")
+        if base_url not in OPENAI_COMPATIBLE_ALLOWED_BASE_URLS:
+            raise ValueError(
+                "OpenAI-compatible endpoint is not approved by the server. Configure "
+                "OPENAI_COMPATIBLE_ALLOWED_BASE_URLS to allow this base URL."
+            )
+        url = URL(base_url)
+        if (
+            url.scheme not in {"http", "https"}
+            or not url.host
+            or url.userinfo
+            or url.query
+            or url.fragment
+        ):
+            raise ValueError(
+                "OpenAI-compatible base URL must be an HTTP(S) URL without "
+                "credentials, query strings, or fragments."
+            )
         cache_key = (base_url, api_key)
         client = self._client_cache.get(cache_key)
         if client is None:
-            client = OpenAI(base_url=base_url, api_key=api_key, timeout=120.0)
+            client = OpenAI(
+                base_url=base_url,
+                api_key=api_key,
+                timeout=120.0,
+                http_client=DefaultHttpxClient(follow_redirects=False),
+            )
             self._client_cache[cache_key] = client
         return client
 

--- a/requirements/_requirements.txt
+++ b/requirements/_requirements.txt
@@ -25,7 +25,7 @@ setuptools>=83.0.0  # lack of upper-bound to ensure compatibility with Google Co
 networkx>=3.0.0,<4.0.0
 pydantic>=2.8.0,<2.12.0
 pydantic-settings<2.8
-openai>=1.12.0,<2.0.0
+openai>=1.17.0,<2.0.0
 structlog>=24.1.0,<25.0.0
 zxing-cpp~=2.2.0
 boto3>=1.40.0,<=1.41.5

--- a/tests/inference/unit_tests/core/test_env.py
+++ b/tests/inference/unit_tests/core/test_env.py
@@ -1,6 +1,8 @@
 import importlib
 import os
 
+import pytest
+
 from inference.core import env as env_module
 
 
@@ -116,3 +118,31 @@ def test_workflows_remote_api_key_transport_rejects_invalid_value() -> None:
     # then
     assert result.returncode != 0
     assert "Invalid WORKFLOWS_REMOTE_API_KEY_TRANSPORT" in result.stderr
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (None, {"*"}),
+        (" * ", {"*"}),
+        ("", set()),
+        (" , ", set()),
+        (
+            " https://approved.example/v1/, http://localhost:8000/v1/ ",
+            {"https://approved.example/v1", "http://localhost:8000/v1"},
+        ),
+    ],
+)
+def test_openai_compatible_allowed_base_urls_configuration(
+    monkeypatch, value, expected
+) -> None:
+    try:
+        with monkeypatch.context() as env_context:
+            if value is None:
+                env_context.delenv("OPENAI_COMPATIBLE_ALLOWED_BASE_URLS", raising=False)
+            else:
+                env_context.setenv("OPENAI_COMPATIBLE_ALLOWED_BASE_URLS", value)
+            importlib.reload(env_module)
+            assert env_module.OPENAI_COMPATIBLE_ALLOWED_BASE_URLS == expected
+    finally:
+        importlib.reload(env_module)

--- a/tests/workflows/unit_tests/core_steps/models/foundation/test_openai_compatible_v1.py
+++ b/tests/workflows/unit_tests/core_steps/models/foundation/test_openai_compatible_v1.py
@@ -1,10 +1,15 @@
+import json
 from typing import Any
 from unittest.mock import MagicMock, patch
 
+import httpx
 import numpy as np
 import pytest
 from pydantic import ValidationError
 
+from inference.core.workflows.core_steps.models.foundation.openai_compatible import (
+    v1 as openai_compatible,
+)
 from inference.core.workflows.core_steps.models.foundation.openai_compatible.v1 import (
     BlockManifest,
     OpenAICompatibleBlockV1,
@@ -203,6 +208,11 @@ def test_resolve_parameters_no_ops() -> None:
 @patch(
     "inference.core.workflows.core_steps.models.foundation.openai_compatible.v1._execute_request"
 )
+@patch.object(
+    openai_compatible,
+    "OPENAI_COMPATIBLE_ALLOWED_BASE_URLS",
+    {"http://localhost:8000/v1"},
+)
 def test_block_run_success(mock_execute: MagicMock) -> None:
     mock_execute.return_value = "The model response"
     block = OpenAICompatibleBlockV1()
@@ -225,6 +235,11 @@ def test_block_run_success(mock_execute: MagicMock) -> None:
 @patch(
     "inference.core.workflows.core_steps.models.foundation.openai_compatible.v1._execute_request"
 )
+@patch.object(
+    openai_compatible,
+    "OPENAI_COMPATIBLE_ALLOWED_BASE_URLS",
+    {"http://localhost:8000/v1"},
+)
 def test_block_run_error(mock_execute: MagicMock) -> None:
     mock_execute.side_effect = RuntimeError("Connection refused")
     block = OpenAICompatibleBlockV1()
@@ -246,6 +261,11 @@ def test_block_run_error(mock_execute: MagicMock) -> None:
 
 @patch(
     "inference.core.workflows.core_steps.models.foundation.openai_compatible.v1._execute_request"
+)
+@patch.object(
+    openai_compatible,
+    "OPENAI_COMPATIBLE_ALLOWED_BASE_URLS",
+    {"http://localhost:8000/v1"},
 )
 def test_block_run_forwards_extra_body(mock_execute: MagicMock) -> None:
     mock_execute.return_value = "A"
@@ -300,6 +320,11 @@ def test_manifest_extra_body_defaults_to_none() -> None:
 
 @patch(
     "inference.core.workflows.core_steps.models.foundation.openai_compatible.v1._execute_request"
+)
+@patch.object(
+    openai_compatible,
+    "OPENAI_COMPATIBLE_ALLOWED_BASE_URLS",
+    {"http://localhost:8000/v1"},
 )
 def test_block_run_without_extra_body_kwarg_is_backwards_compatible(
     mock_execute: MagicMock,
@@ -394,3 +419,133 @@ def test_execute_request_forwards_empty_extra_body(mock_openai: MagicMock) -> No
         extra_body={},
     )
     assert mock_client.chat.completions.create.call_args.kwargs["extra_body"] == {}
+
+
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        "http://127.0.0.1/v1",
+        "http://10.0.0.1/v1",
+        "http://169.254.169.254/latest",
+        "http://[::1]/v1",
+        "https://attacker.example/v1",
+        "https://approved.example.attacker.example/v1",
+        "https://approved.example@attacker.example/v1",
+        "https://approved.example:8443/v1",
+        "https://approved.example/v1/other",
+        "http://approved.example/v1",
+    ],
+)
+def test_unapproved_endpoints_never_create_client(monkeypatch, base_url) -> None:
+    monkeypatch.setattr(
+        openai_compatible,
+        "OPENAI_COMPATIBLE_ALLOWED_BASE_URLS",
+        {"https://approved.example/v1"},
+    )
+    with patch.object(openai_compatible, "OpenAI") as create_client:
+        with pytest.raises(ValueError, match="not approved"):
+            OpenAICompatibleBlockV1()._get_client(base_url, "test-key")
+    create_client.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        "file:///tmp/v1",
+        "ftp://approved.example/v1",
+        "//approved.example/v1",
+        "https://user:password@approved.example/v1",
+        "https://approved.example/v1?path=other",
+        "https://approved.example/v1#fragment",
+    ],
+)
+def test_invalid_approved_url_never_creates_client(monkeypatch, base_url) -> None:
+    monkeypatch.setattr(
+        openai_compatible, "OPENAI_COMPATIBLE_ALLOWED_BASE_URLS", {base_url}
+    )
+    with patch.object(openai_compatible, "OpenAI") as create_client:
+        with pytest.raises(ValueError, match=r"HTTP\(S\) URL"):
+            OpenAICompatibleBlockV1()._get_client(base_url, "test-key")
+    create_client.assert_not_called()
+
+
+def test_empty_allowlist_blocks_run_before_network_access(monkeypatch) -> None:
+    monkeypatch.setattr(openai_compatible, "OPENAI_COMPATIBLE_ALLOWED_BASE_URLS", set())
+    with patch.object(openai_compatible, "OpenAI") as create_client:
+        result = OpenAICompatibleBlockV1().run(
+            base_url="http://localhost:8000/v1",
+            model_name="test-model",
+            api_key="test-key",
+            system_prompt=None,
+            prompt="Hello",
+            prompt_parameters={},
+            prompt_parameters_operations={},
+            max_tokens=10,
+            temperature=None,
+        )
+    assert result["output"] == ""
+    assert "not approved" in result["error_status"]
+    create_client.assert_not_called()
+
+
+def test_cached_client_still_requires_approved_endpoint(monkeypatch) -> None:
+    base_url = "http://localhost:8000/v1"
+    allowed = {base_url}
+    monkeypatch.setattr(
+        openai_compatible, "OPENAI_COMPATIBLE_ALLOWED_BASE_URLS", allowed
+    )
+    block = OpenAICompatibleBlockV1()
+    with block._get_client(base_url, "test-key") as client:
+        assert block._get_client(base_url + "/", "test-key") is client
+        allowed.clear()
+        with pytest.raises(ValueError, match="not approved"):
+            block._get_client(base_url, "test-key")
+
+
+@pytest.mark.parametrize("status_code", [200, 301, 302, 303, 307, 308])
+def test_approved_endpoint_uses_real_sdk_without_following_redirects(
+    monkeypatch, status_code
+) -> None:
+    base_url = "http://localhost:8000/v1"
+    monkeypatch.setattr(
+        openai_compatible, "OPENAI_COMPATIBLE_ALLOWED_BASE_URLS", {base_url}
+    )
+    requests = []
+
+    def respond(request):
+        requests.append(request)
+        if len(requests) == 1 and status_code != 200:
+            return httpx.Response(
+                status_code,
+                headers={"Location": "http://169.254.169.254/redirect-target"},
+            )
+        return httpx.Response(
+            200,
+            json={"choices": [{"message": {"content": "ok"}}]},
+        )
+
+    block = OpenAICompatibleBlockV1()
+    with patch.object(httpx.HTTPTransport, "handle_request", side_effect=respond):
+        with block._get_client(base_url, "synthetic-secret"):
+            result = block.run(
+                base_url=base_url + "/",
+                model_name="test-model",
+                api_key="synthetic-secret",
+                system_prompt=None,
+                prompt="Value: {{ $parameters.secret }}",
+                prompt_parameters={"secret": "private-text", "image": b"image"},
+                prompt_parameters_operations={},
+                max_tokens=10,
+                temperature=None,
+            )
+    assert len(requests) == 1
+    assert str(requests[0].url) == base_url + "/chat/completions"
+    assert requests[0].headers["Authorization"] == "Bearer synthetic-secret"
+    content = json.loads(requests[0].content)["messages"][0]["content"]
+    assert content[0] == {"type": "text", "text": "Value: private-text"}
+    assert content[1]["image_url"]["url"] == "data:image/jpeg;base64,aW1hZ2U="
+    if status_code == 200:
+        assert result == {"output": "ok", "error_status": ""}
+    else:
+        assert result["output"] == ""
+        assert result["error_status"]

--- a/tests/workflows/unit_tests/core_steps/models/foundation/test_openai_compatible_v1.py
+++ b/tests/workflows/unit_tests/core_steps/models/foundation/test_openai_compatible_v1.py
@@ -502,13 +502,14 @@ def test_cached_client_still_requires_approved_endpoint(monkeypatch) -> None:
             block._get_client(base_url, "test-key")
 
 
+@pytest.mark.parametrize("allowed_url", ["*", "http://localhost:8000/v1"])
 @pytest.mark.parametrize("status_code", [200, 301, 302, 303, 307, 308])
 def test_approved_endpoint_uses_real_sdk_without_following_redirects(
-    monkeypatch, status_code
+    monkeypatch, status_code, allowed_url
 ) -> None:
     base_url = "http://localhost:8000/v1"
     monkeypatch.setattr(
-        openai_compatible, "OPENAI_COMPATIBLE_ALLOWED_BASE_URLS", {base_url}
+        openai_compatible, "OPENAI_COMPATIBLE_ALLOWED_BASE_URLS", {allowed_url}
     )
     requests = []
 
@@ -549,3 +550,15 @@ def test_approved_endpoint_uses_real_sdk_without_following_redirects(
     else:
         assert result["output"] == ""
         assert result["error_status"]
+
+
+@pytest.mark.parametrize("allowed", [{"*"}, {"*", "https://approved.example/v1"}])
+@pytest.mark.parametrize(
+    "base_url", ["http://127.0.0.1/v1", "https://other.example/v1"]
+)
+def test_wildcard_allows_any_destination(monkeypatch, allowed, base_url) -> None:
+    monkeypatch.setattr(
+        openai_compatible, "OPENAI_COMPATIBLE_ALLOWED_BASE_URLS", allowed
+    )
+    with OpenAICompatibleBlockV1()._get_client(base_url, "test-key") as client:
+        assert str(client.base_url) == base_url + "/"


### PR DESCRIPTION
## What does this PR do?

  Workflow-controlled base URLs allowed server-side requests to arbitrary
  destinations carrying credentials and workflow data.

  Require an exact operator-configured OPENAI_COMPATIBLE_ALLOWED_BASE_URLS
  allowlist, validate URL structure, and disable redirects. Check approval before
  using cached clients.

  Migration required: The allowlist defaults to empty. Operators must explicitly
  approve endpoints, including local servers, and restart the server. Configuration
  instructions are included in the block documentation.

## Type of Change

- Bug fix (non-breaking change that fixes an issue)

## Testing

60 tests passed; 16 regression cases fail against the original

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)

## Additional Context

N/A