### PR TITLE
Prevent SSRF and stalled opens in WebRTC MJPEG input

### DIFF
--- a/examples/webrtc_sdk/mjpeg_basic.py
+++ b/examples/webrtc_sdk/mjpeg_basic.py
@@ -12,8 +12,18 @@ Usage:
       [--stream-output <output_name>] \\
       [--data-output <output_name>]
 
+The server accepts HTTP(S) MJPEG streams from public addresses by default.
+For a private camera such as camera.local, set
+WEBRTC_MJPEG_ALLOW_NON_GLOBAL_ADDRESSES=True on a trusted inference server.
+This permits callers to reach private, loopback and link-local HTTP services;
+keep it disabled on servers accepting untrusted requests. File paths and other
+protocols remain prohibited. Destinations are checked on every redirect
+(at most five), connections/read operations time out after five seconds,
+and environment HTTP proxies are not used for MJPEG input.
+
 Press 'q' in the preview window to exit.
 """
+
 import argparse
 
 import av

--- a/inference/core/env.py
+++ b/inference/core/env.py
@@ -826,6 +826,10 @@ DEBUG_WEBRTC_PROCESSING_LATENCY = str2bool(
     os.getenv("DEBUG_WEBRTC_PROCESSING_LATENCY", "False")
 )
 WEBRTC_REALTIME_PROCESSING = str2bool(os.getenv("WEBRTC_REALTIME_PROCESSING", "True"))
+# Enable only on trusted deployments that need MJPEG cameras on private networks.
+WEBRTC_MJPEG_ALLOW_NON_GLOBAL_ADDRESSES = str2bool(
+    os.getenv("WEBRTC_MJPEG_ALLOW_NON_GLOBAL_ADDRESSES", "False")
+)
 
 NUM_CELERY_WORKERS = os.getenv("NUM_CELERY_WORKERS", 4)
 CELERY_LOG_LEVEL = os.getenv("CELERY_LOG_LEVEL", "WARNING")

--- a/inference/core/interfaces/webrtc_worker/webrtc.py
+++ b/inference/core/interfaces/webrtc_worker/webrtc.py
@@ -33,6 +33,7 @@ from inference.core.env import (
     WEBRTC_DATA_CHANNEL_BUFFER_DRAINING_DELAY,
     WEBRTC_DATA_CHANNEL_BUFFER_SIZE_LIMIT,
     WEBRTC_GZIP_PREVIEW_FRAME_COMPRESSION,
+    WEBRTC_MJPEG_ALLOW_NON_GLOBAL_ADDRESSES,
     WEBRTC_MODAL_PUBLIC_STUN_SERVERS,
     WEBRTC_MODAL_RTSP_PLACEHOLDER,
     WEBRTC_MODAL_RTSP_PLACEHOLDER_URL,
@@ -78,6 +79,7 @@ from inference.core.interfaces.webrtc_worker.utils import (
 )
 from inference.core.managers.base import ModelManager
 from inference.core.roboflow_api import get_workflow_specification
+from inference.core.utils.mjpeg import open_mjpeg_player
 from inference.core.workflows.errors import WorkflowError, WorkflowSyntaxError
 from inference.core.workflows.execution_engine.entities.base import WorkflowImageData
 from inference.usage_tracking.collector import usage_collector
@@ -1130,7 +1132,10 @@ async def init_rtc_peer_connection_with_loop(
             "Processing MJPEG URL: %s",
             sanitize_source_reference(webrtc_request.mjpeg_url),
         )
-        player = _open_media_player(webrtc_request.mjpeg_url)
+        player = open_mjpeg_player(
+            webrtc_request.mjpeg_url,
+            allow_non_global_addresses=WEBRTC_MJPEG_ALLOW_NON_GLOBAL_ADDRESSES,
+        )
         video_processor.set_track(track=player.video)
 
         if not should_send_video:

--- a/inference/core/utils/mjpeg.py
+++ b/inference/core/utils/mjpeg.py
@@ -1,0 +1,97 @@
+"""Open MJPEG over validated HTTP connections, never through FFmpeg networking."""
+
+import time
+from contextlib import ExitStack
+from urllib.parse import urljoin, urlsplit
+
+import requests
+from aiortc.contrib.media import MediaPlayer
+
+from inference.core.interfaces.camera.source_reference_sanitizer import (
+    sanitize_source_reference,
+)
+from inference.core.utils.url_input import SSRFProtectedHTTPAdapter
+
+MJPEG_TIMEOUT_SECONDS = 5.0
+MJPEG_MAX_REDIRECTS = 5
+
+
+class _MJPEGReader:
+    def __init__(self, response: requests.Response):
+        self.response = response
+        self.open_deadline = time.monotonic() + MJPEG_TIMEOUT_SECONDS
+
+    def read(self, size: int) -> bytes:
+        try:
+            if self.open_deadline and time.monotonic() >= self.open_deadline:
+                raise TimeoutError("MJPEG opening timed out")
+            # Return available bytes so PyAV can check its timeout between reads.
+            # Filling an entire buffer lets a trickling peer evade read timeouts.
+            read1 = getattr(self.response.raw, "read1", None)
+            if read1 is not None:
+                return read1(size)
+            # ponytail: urllib3 1.x reads one byte; upgrade to 2.x for buffered read1.
+            return self.response.raw.read(min(size, 1))
+        except Exception:
+            # HTTP errors can embed credentials, including during playback.
+            raise RuntimeError(
+                "Could not read MJPEG stream (failed or timed out)"
+            ) from None
+
+
+def open_mjpeg_player(
+    url: str, *, allow_non_global_addresses: bool = False
+) -> MediaPlayer:
+    """Validate/pin each HTTP hop and keep its response alive until the track ends."""
+    try:
+        with ExitStack() as resources:
+            adapter = SSRFProtectedHTTPAdapter(
+                allow_non_global_addresses=allow_non_global_addresses
+            )
+            resources.callback(adapter.close)
+            for redirect in range(MJPEG_MAX_REDIRECTS + 1):
+                parsed = urlsplit(url)
+                if (
+                    parsed.scheme not in {"http", "https"}
+                    or not parsed.hostname
+                    or "\\" in parsed.netloc
+                ):
+                    raise ValueError("MJPEG requires an HTTP(S) URL with a valid host")
+                request = requests.Request("GET", url).prepare()
+                # Send through the adapter directly: no environment proxies/netrc
+                # and no automatic redirects that drain unbounded response bodies.
+                response = adapter.send(
+                    request, stream=True, timeout=MJPEG_TIMEOUT_SECONDS, proxies={}
+                )
+                if response.is_redirect:
+                    response.close()
+                    if redirect == MJPEG_MAX_REDIRECTS:
+                        raise ValueError("Too many MJPEG redirects")
+                    url = urljoin(request.url, response.headers["Location"])
+                    continue
+                resources.callback(response.close)
+                response.raise_for_status()
+                reader = _MJPEGReader(response)
+                content_type = response.headers.get("Content-Type", "").lower()
+                player = MediaPlayer(
+                    reader,
+                    format=(
+                        "mpjpeg"
+                        if content_type.startswith("multipart/x-mixed-replace")
+                        else "mjpeg"
+                    ),
+                    options={"protocol_whitelist": ""},
+                    timeout=MJPEG_TIMEOUT_SECONDS,
+                )
+                if player.video is None:
+                    raise ValueError("MJPEG stream has no video track")
+                reader.open_deadline = None
+                # PlayerStreamTrack.stop emits ended on both shutdown and EOF.
+                player.video.on("ended", resources.pop_all().close)
+                return player
+    except Exception as error:
+        # Transport errors can include a credentialed relative request target.
+        raise RuntimeError(
+            f"Failed to open MJPEG stream {sanitize_source_reference(url)}: "
+            f"{type(error).__name__}"
+        ) from None

--- a/inference/core/utils/url_input.py
+++ b/inference/core/utils/url_input.py
@@ -86,7 +86,7 @@ def address_is_global(address: str) -> bool:
         return False
     if isinstance(parsed, ipaddress.IPv6Address) and parsed.ipv4_mapped is not None:
         parsed = parsed.ipv4_mapped
-    return parsed.is_global
+    return parsed.is_global and not parsed.is_multicast
 
 
 def _strip_ipv6_brackets(host: str) -> str:

--- a/tests/inference/unit_tests/core/utils/test_mjpeg.py
+++ b/tests/inference/unit_tests/core/utils/test_mjpeg.py
@@ -1,0 +1,306 @@
+import asyncio
+import io
+import socket
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from unittest.mock import Mock
+
+import av
+import pytest
+from aiortc.mediastreams import MediaStreamError
+from urllib3.connection import HTTPConnection
+from urllib3.response import HTTPResponse
+
+from inference.core.utils import mjpeg
+
+
+@pytest.fixture
+def mjpeg_server():
+    frame = av.VideoFrame(16, 16, "yuvj420p")
+    for plane in frame.planes:
+        plane.update(bytes([128]) * plane.buffer_size)
+    buffer = io.BytesIO()
+    with av.open(buffer, "w", format="mjpeg") as output:
+        stream = output.add_stream("mjpeg", rate=25)
+        stream.width = stream.height = 16
+        stream.pix_fmt = "yuvj420p"
+        for packet in stream.encode(frame):
+            output.mux(packet)
+        for packet in stream.encode():
+            output.mux(packet)
+    jpeg = buffer.getvalue()
+    stopped = threading.Event()
+    calls = []
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            calls.append((self.path, self.headers["Host"]))
+            redirects = {
+                "/redirect": "/stream",
+                "/private": "http://127.0.0.1:9/private",
+                "/file": "file:///tmp/secret.jpg",
+                "/loop": "/loop",
+            }
+            if self.path in redirects:
+                self.send_response(302)
+                self.send_header("Location", redirects[self.path])
+                self.end_headers()
+                # The redirect body must never be drained before validation.
+                stopped.wait(3)
+                return
+            if self.path == "/stall-headers":
+                stopped.wait(3)
+                return
+            multipart = self.path == "/multipart"
+            self.send_response(200)
+            self.send_header(
+                "Content-Type",
+                (
+                    "multipart/x-mixed-replace; boundary=frame"
+                    if multipart
+                    else "image/jpeg"
+                ),
+            )
+            self.end_headers()
+            if self.path == "/stall-body":
+                stopped.wait(3)
+                return
+            if self.path == "/trickle":
+                try:
+                    while not stopped.wait(0.01):
+                        self.wfile.write(b"x")
+                        self.wfile.flush()
+                except (BrokenPipeError, ConnectionResetError):
+                    pass
+                return
+            if self.path == "/playlist":
+                self.wfile.write(b"#EXTM3U\n#EXTINF:1,\nhttp://127.0.0.1:9/secret\n")
+                return
+            if multipart:
+                part = (
+                    b"--frame\r\nContent-Type: image/jpeg\r\nContent-Length: "
+                    + str(len(jpeg)).encode()
+                    + b"\r\n\r\n"
+                    + jpeg
+                    + b"\r\n"
+                )
+                self.wfile.write(part * 30 + b"--frame--\r\n")
+            else:
+                self.wfile.write(jpeg * 30)
+
+        def log_message(self, *args):
+            pass
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server.server_port, calls
+    finally:
+        stopped.set()
+        server.shutdown()
+        server.server_close()
+        thread.join()
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "/tmp/secret.jpg",
+        "file:///tmp/secret.jpg",
+        "tcp://127.0.0.1:9",
+        "concat:http://example.com/a|file:/tmp/secret.jpg",
+        "http:///stream",
+        "http://user:pass@camera.example:bad/stream",
+        "http://camera.example\\@127.0.0.1/stream",
+        "http://[::1",
+    ],
+)
+def test_mjpeg_rejects_invalid_urls_before_connecting(url, monkeypatch):
+    connect = Mock(side_effect=AssertionError("Must not connect"))
+    monkeypatch.setattr(HTTPConnection, "connect", connect)
+    with pytest.raises(RuntimeError, match="Failed to open MJPEG"):
+        mjpeg.open_mjpeg_player(url)
+    connect.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "host",
+    [
+        "127.0.0.1",
+        "10.0.0.1",
+        "169.254.169.254",
+        "100.64.0.1",
+        "[::1]",
+        "[::ffff:127.0.0.1]",
+        "224.0.0.1",
+        "[ff02::1]",
+        "localhost",
+        "metadata.internal",
+        "2130706433",
+        "0x7f000001",
+        "017700000001",
+    ],
+)
+def test_mjpeg_blocks_non_public_destinations(host, monkeypatch):
+    monkeypatch.setattr(
+        socket,
+        "getaddrinfo",
+        lambda *a, **k: [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.1", 80))
+        ],
+    )
+    connect = Mock(side_effect=AssertionError("Must not connect"))
+    monkeypatch.setattr(HTTPConnection, "connect", connect)
+    with pytest.raises(RuntimeError, match="URLAddressNotAllowedError"):
+        mjpeg.open_mjpeg_player(f"http://{host}/stream")
+    connect.assert_not_called()
+
+
+def _route_public_camera_to_test_server(monkeypatch, port):
+    original_resolve = socket.getaddrinfo
+    resolutions = []
+
+    def resolve(host, *args, **kwargs):
+        if host == "camera.example":
+            resolutions.append(host)
+            ip = "8.8.8.8" if len(resolutions) == 1 else "127.0.0.1"
+            return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", (ip, port))]
+        return original_resolve(host, *args, **kwargs)
+
+    def connect_to_test_server(connection):
+        # A hostname here would let a second DNS lookup change the target.
+        assert connection.host == "8.8.8.8"
+        return socket.create_connection(("127.0.0.1", port))
+
+    monkeypatch.setattr(socket, "getaddrinfo", resolve)
+    monkeypatch.setattr(HTTPConnection, "_new_conn", connect_to_test_server)
+    return resolutions
+
+
+@pytest.mark.parametrize("legacy_reader", [False, True])
+@pytest.mark.parametrize("path", ["/stream", "/multipart"])
+def test_mjpeg_decodes_public_stream_pins_dns_and_closes_resources(
+    path, legacy_reader, mjpeg_server, monkeypatch
+):
+    if legacy_reader:
+        monkeypatch.setattr(HTTPResponse, "read1", None)
+    port, calls = mjpeg_server
+    resolutions = _route_public_camera_to_test_server(monkeypatch, port)
+    monkeypatch.setenv("HTTP_PROXY", "http://127.0.0.1:9")
+    closed = Mock()
+    original_close = mjpeg.SSRFProtectedHTTPAdapter.close
+
+    def close(adapter):
+        closed()
+        original_close(adapter)
+
+    monkeypatch.setattr(mjpeg.SSRFProtectedHTTPAdapter, "close", close)
+    player = mjpeg.open_mjpeg_player(f"http://camera.example{path}")
+
+    async def receive():
+        try:
+            frame = await asyncio.wait_for(player.video.recv(), timeout=2)
+            assert (frame.width, frame.height) == (16, 16)
+        finally:
+            player.video.stop()
+
+    asyncio.run(receive())
+    assert resolutions == ["camera.example"]
+    assert calls == [(path, "camera.example")]
+    closed.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "path, message",
+    [("/private", "URLAddressNotAllowedError"), ("/file", "ValueError")],
+)
+def test_mjpeg_revalidates_redirect_destinations(
+    path, message, mjpeg_server, monkeypatch
+):
+    port, calls = mjpeg_server
+    _route_public_camera_to_test_server(monkeypatch, port)
+    started = time.monotonic()
+    with pytest.raises(RuntimeError, match=message):
+        mjpeg.open_mjpeg_player(f"http://camera.example{path}")
+    assert time.monotonic() - started < 1
+    assert calls == [(path, "camera.example")]
+
+
+def test_mjpeg_allows_explicit_private_camera_opt_in_and_relative_redirect(
+    mjpeg_server,
+):
+    port, calls = mjpeg_server
+    player = mjpeg.open_mjpeg_player(
+        f"http://127.0.0.1:{port}/redirect", allow_non_global_addresses=True
+    )
+    player.video.stop()
+    assert [path for path, _ in calls] == ["/redirect", "/stream"]
+
+
+def test_mjpeg_caps_redirects(mjpeg_server):
+    port, calls = mjpeg_server
+    with pytest.raises(RuntimeError, match="ValueError"):
+        mjpeg.open_mjpeg_player(
+            f"http://127.0.0.1:{port}/loop", allow_non_global_addresses=True
+        )
+    assert len(calls) == mjpeg.MJPEG_MAX_REDIRECTS + 1
+
+
+@pytest.mark.parametrize("path", ["/stall-headers", "/stall-body", "/trickle"])
+def test_mjpeg_times_out_stalled_and_trickling_streams(path, mjpeg_server, monkeypatch):
+    port, _ = mjpeg_server
+    monkeypatch.setattr(mjpeg, "MJPEG_TIMEOUT_SECONDS", 0.15)
+    started = time.monotonic()
+    with pytest.raises(RuntimeError):
+        mjpeg.open_mjpeg_player(
+            f"http://127.0.0.1:{port}{path}", allow_non_global_addresses=True
+        )
+    assert time.monotonic() - started < 1
+
+
+def test_mjpeg_does_not_autodetect_network_playlists(mjpeg_server, monkeypatch):
+    port, calls = mjpeg_server
+    connections = []
+    original_connect = HTTPConnection._new_conn
+
+    def connect(connection):
+        connections.append(connection.port)
+        assert connection.port == port
+        return original_connect(connection)
+
+    monkeypatch.setattr(HTTPConnection, "_new_conn", connect)
+    player = mjpeg.open_mjpeg_player(
+        f"http://127.0.0.1:{port}/playlist", allow_non_global_addresses=True
+    )
+
+    async def receive():
+        try:
+            with pytest.raises(MediaStreamError):
+                await asyncio.wait_for(player.video.recv(), timeout=2)
+        finally:
+            player.video.stop()
+
+    asyncio.run(receive())
+    assert len(connections) == 1
+    assert len(calls) == 1
+
+
+def test_mjpeg_errors_do_not_expose_relative_url_credentials(monkeypatch):
+    monkeypatch.setattr(
+        mjpeg.SSRFProtectedHTTPAdapter,
+        "send",
+        Mock(
+            side_effect=mjpeg.requests.ConnectionError(
+                "Max retries: /camera?token=secret"
+            )
+        ),
+    )
+    with pytest.raises(RuntimeError) as error:
+        mjpeg.open_mjpeg_player(
+            "http://user:password@camera.example/camera?token=secret"
+        )
+    assert "secret" not in str(error.value)
+    assert "password" not in str(error.value)
+    assert "ConnectionError" in str(error.value)

--- a/tests/inference/unit_tests/core/utils/test_url_input.py
+++ b/tests/inference/unit_tests/core/utils/test_url_input.py
@@ -49,6 +49,8 @@ def _fake_getaddrinfo(ip: str):
         ("fc00::1", False),  # IPv6 ULA
         ("::ffff:127.0.0.1", False),  # IPv4-mapped loopback must not slip through
         ("2001:4860:4860::8888", True),  # public IPv6 (Google DNS)
+        ("224.0.0.1", False),  # multicast is not a public unicast destination
+        ("ff02::1", False),
         ("not-an-ip", False),
     ],
 )


### PR DESCRIPTION
## What does this PR do?

  Caller-controlled mjpeg_url values could access local files and internal services
  or block worker initialization.

  Route MJPEG through the existing protected HTTP transport, validate and pin
  destination IPs on every redirect, restrict decoding to MJPEG, and add timeouts
  and connection cleanup.

  Private cameras now require WEBRTC_MJPEG_ALLOW_NON_GLOBAL_ADDRESSES=True on the
  server.

## Type of Change

- Bug fix (non-breaking change that fixes an issue)

## Testing

106 tests passed using an isolated transport harness

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)

## Additional Context

N/A