### PR TITLE
Bound usage-flush at exit so unit-test process stops hanging

### DIFF
--- a/inference/core/managers/pingback.py
+++ b/inference/core/managers/pingback.py
@@ -1,3 +1,4 @@
+import atexit
 import time
 import traceback
 
@@ -94,12 +95,29 @@ class PingbackInfo:
                 replace_existing=True,
             )
             self.scheduler.start()
+            # The scheduler thread is a daemon, but the ThreadPoolExecutor it
+            # submits jobs to is torn down by the interpreter before atexit
+            # hooks run. Without an explicit shutdown the scheduler keeps
+            # ticking during interpreter finalisation and logs
+            # "cannot schedule new futures after shutdown" every interval.
+            atexit.register(self.stop, wait=False)
         except Exception as e:
             logger.debug(e)
 
-    def stop(self):
-        """Stops the scheduler."""
-        self.scheduler.shutdown()
+    def stop(self, wait: bool = True):
+        """Stops the scheduler.
+
+        Args:
+            wait (bool): Whether to wait for currently running pingback jobs to
+                finish before returning. Safe to call more than once.
+        """
+        scheduler = getattr(self, "scheduler", None)
+        if scheduler is None or not scheduler.running:
+            return
+        try:
+            scheduler.shutdown(wait=wait)
+        except Exception as e:
+            logger.debug(e)
 
     def post_data(self, model_manager):
         """Posts data to Roboflow about the models, container, device, and other relevant metrics.

--- a/inference/usage_tracking/collector.py
+++ b/inference/usage_tracking/collector.py
@@ -1246,10 +1246,21 @@ class UsageCollector:
         return decorator
 
     def _cleanup(self):
+        # Runs from atexit. Terminating the sender makes it flush everything
+        # still queued, and every payload that previously failed to send is
+        # re-queued - so with an unreachable or slow usage API this final flush
+        # can take minutes. Bound the wait: both threads are daemons and die
+        # with the process once we stop joining them.
+        deadline = time.monotonic() + self._settings.shutdown_flush_timeout_seconds
         self._terminate_collector_thread.set()
-        self._collector_thread.join()
+        self._collector_thread.join(timeout=max(0.0, deadline - time.monotonic()))
         self._terminate_sender_thread.set()
-        self._sender_thread.join()
+        self._sender_thread.join(timeout=max(0.0, deadline - time.monotonic()))
+        if self._collector_thread.is_alive() or self._sender_thread.is_alive():
+            logger.debug(
+                "Usage flush did not complete within %ss of shutdown - giving up",
+                self._settings.shutdown_flush_timeout_seconds,
+            )
 
 
 usage_collector = UsageCollector()

--- a/inference/usage_tracking/config.py
+++ b/inference/usage_tracking/config.py
@@ -20,11 +20,18 @@ class TelemetrySettings(BaseSettings):
     flush_interval: int = Field(default=10, ge=10, le=300)
     use_persistent_queue: Optional[bool] = True
     queue_size: int = Field(default=10, ge=10, le=10000)
+    # Upper bound on how long interpreter shutdown waits for the final usage
+    # flush; 0 disables the wait. The usage threads are daemons, so once the
+    # bound is hit they simply die with the process.
+    shutdown_flush_timeout_seconds: float = Field(default=30.0, ge=0, le=300)
 
     @model_validator(mode="after")
     def check_values(cls, inst: TelemetrySettings):
         inst.flush_interval = min(max(inst.flush_interval, 10), 300)
         inst.queue_size = min(max(inst.queue_size, 10), 10000)
+        inst.shutdown_flush_timeout_seconds = min(
+            max(inst.shutdown_flush_timeout_seconds, 0), 300
+        )
         # Wrap in the validator (not in the field defaults) so that
         # TELEMETRY_* env overrides are routed through the secure gateway too.
         inst.api_usage_endpoint_url = wrap_url(inst.api_usage_endpoint_url)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,12 @@ ASSETS_DIR = os.path.abspath(
 )
 
 os.environ["TELEMETRY_USE_PERSISTENT_QUEUE"] = "False"
+# Tests record usage under made-up API keys, so every payload is rejected and
+# re-queued. Without this, the usage collector's atexit hook re-sends all of
+# them to Roboflow when pytest exits (two 1s-timeout HTTP calls per key per
+# payload), which delays exit by ~15s normally and past the CI job timeout when
+# the API is slow. Nothing recorded here needs delivering.
+os.environ["TELEMETRY_SHUTDOWN_FLUSH_TIMEOUT_SECONDS"] = "0"
 os.environ["ONNXRUNTIME_EXECUTION_PROVIDERS"] = (
     "[CUDAExecutionProvider,CPUExecutionProvider]"
 )

--- a/tests/inference/unit_tests/core/managers/test_pingback_num_errors.py
+++ b/tests/inference/unit_tests/core/managers/test_pingback_num_errors.py
@@ -1,5 +1,6 @@
 from unittest import mock
 
+from inference.core.managers import base as base_module
 from inference.core.managers import pingback as pingback_module
 from inference.core.managers.base import ModelManager, ModelRegistry
 from inference.core.managers.decorators.base import ModelManagerDecorator
@@ -8,7 +9,11 @@ from inference.core.managers.decorators.base import ModelManagerDecorator
 def test_increment_num_errors():
     mm = ModelManager(ModelRegistry(dict()))
     mm_wrapper = ModelManagerDecorator(mm)
-    mm_wrapper.init_pingback()
+    # Do not start the real pingback scheduler: it would keep posting metrics
+    # to Roboflow from a background thread for the rest of the pytest session.
+    with mock.patch.object(base_module, "METRICS_ENABLED", False):
+        mm_wrapper.init_pingback()
+    assert mm.pingback is None
     mm_wrapper.num_errors += 1
     assert mm.num_errors == mm_wrapper.num_errors == 1
     mm.num_errors += 1
@@ -24,3 +29,25 @@ def test_pingback_post_is_noop_in_offline_mode():
         pingback.post_data(model_manager=mock.MagicMock())
 
     post.assert_not_called()
+
+
+def test_pingback_start_registers_atexit_shutdown_and_stop_is_idempotent():
+    pingback = pingback_module.PingbackInfo.__new__(pingback_module.PingbackInfo)
+    pingback.scheduler = mock.MagicMock()
+    pingback.scheduler.running = True
+    pingback.model_manager = mock.MagicMock()
+
+    with mock.patch.object(pingback_module, "METRICS_ENABLED", True), mock.patch.object(
+        pingback_module.atexit, "register"
+    ) as register:
+        pingback.start()
+
+    register.assert_called_once_with(pingback.stop, wait=False)
+
+    pingback.stop(wait=False)
+    pingback.scheduler.shutdown.assert_called_once_with(wait=False)
+
+    # a stopped (or never started) scheduler must be a no-op on later calls
+    pingback.scheduler.running = False
+    pingback.stop()
+    pingback.scheduler.shutdown.assert_called_once()

--- a/tests/inference/unit_tests/usage_tracking/test_collector.py
+++ b/tests/inference/unit_tests/usage_tracking/test_collector.py
@@ -3,6 +3,7 @@ import hashlib
 import json
 import sys
 import threading
+import time
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from queue import Queue
@@ -17,6 +18,7 @@ from inference.core.env import LAMBDA
 from inference.core.version import __version__ as inference_version
 from inference.core.workflows.errors import ClientCausedStepExecutionError
 from inference.usage_tracking import payload_helpers
+from inference.usage_tracking.collector import UsageCollector
 from inference.usage_tracking.decorator_helpers import (
     record_fixed_model_input_for_request,
     usage_billing_suppressed,
@@ -2822,3 +2824,32 @@ def test_source_tags_reach_nested_model_rows(usage_collector_with_mocked_threads
     assert request_details["source_info"] == "smart-polygon"
     assert model_details["source"] == "app"
     assert usage_source_tags.get() == {}
+
+
+def test_cleanup_gives_up_on_a_flush_that_outlives_the_shutdown_budget():
+    # given
+    release = threading.Event()
+    stuck_flush = threading.Thread(target=release.wait, daemon=True)
+    stuck_flush.start()
+    finished = threading.Thread(target=lambda: None)
+    finished.start()
+    finished.join()
+    collector_like = SimpleNamespace(
+        _settings=SimpleNamespace(shutdown_flush_timeout_seconds=0.5),
+        _terminate_collector_thread=threading.Event(),
+        _collector_thread=finished,
+        _terminate_sender_thread=threading.Event(),
+        _sender_thread=stuck_flush,
+    )
+
+    # when
+    started = time.monotonic()
+    try:
+        UsageCollector._cleanup(collector_like)
+    finally:
+        release.set()
+
+    # then
+    assert time.monotonic() - started < 5
+    assert collector_like._terminate_collector_thread.is_set()
+    assert collector_like._terminate_sender_thread.is_set()


### PR DESCRIPTION
## Problem

`UNIT TESTS - inference` intermittently hangs after the pytest summary line (e.g. `2923 passed ... in 215s`) until GitHub cancels the step at 20 minutes, logging once a minute:

```
Error submitting job "PingbackInfo.post_data (trigger: interval[0:01:00] ...)" to executor "default"
RuntimeError: cannot schedule new futures after shutdown
```

Seen on PR #2909 runs 34338294959, 34345546186, 34348381941 and on `main` runs 33889294453, 33883456737, 33880460232.

## Root cause

The scheduler error is only the visible symptom. Thread dumps taken every few seconds after `pytest_unconfigure` show the main thread stuck in `UsageCollector._cleanup` (the atexit hook in `inference/usage_tracking/collector.py`) joining the usage sender thread, which is inside `_offload_to_api` → `refresh_api_key_plan_cache` / `send_usage_payload`.

Why that takes so long:

- Unit tests record usage under made-up API keys, so every send is rejected and the payload is re-queued (`_offload_to_api` puts unsent payloads back). The queue is capped at 10 payloads but they are merged, so every fake key ever used stays in the backlog.
- `refresh_api_key_plan_cache` never updates the cache timestamp after a failure or 4xx, so `get_api_key_plan` refreshes on every call.
- The final flush therefore does one plan GET plus one usage POST, each with a 1s timeout, per key per payload, sequentially.

Even successful CI runs spend 13–19s between the summary line and the next step on this. When `api.roboflow.com` is slow enough that the calls hit their timeouts, the flush outlives the job.

Meanwhile `test_increment_num_errors` starts the real pingback `BackgroundScheduler`. Its daemon thread survives interpreter shutdown, and once `concurrent.futures` has torn down its executor every tick fails with the error above, which is what the log shows during the hang.

## Fix

- `UsageCollector._cleanup` now waits at most `TELEMETRY_SHUTDOWN_FLUSH_TIMEOUT_SECONDS` (new setting, default 30s, 0 disables the wait). Both usage threads are daemons, so once the bound is hit they die with the process. This also protects production shutdown from an unreachable usage API.
- `tests/conftest.py` sets that bound to 0: nothing recorded by unit tests needs delivering.
- `PingbackInfo.start()` registers an atexit shutdown of its scheduler, and `stop()` is idempotent and no longer raises when the scheduler was never started.
- `test_increment_num_errors` no longer starts a real scheduler.

## Verification

Full `pytest tests/inference/unit_tests tests/unit/core/cache/test_air_gapped.py` run locally (Python 3.11, CI requirement sets), measuring time from `pytest_unconfigure` to process exit:

| tree | exit time after summary | scheduler errors logged |
| --- | --- | --- |
| `main` @ 3092cbb13 | 16s (30s once the 1s timeouts bite) | yes |
| this branch | under 4s | 0 |

New tests cover the bounded cleanup and the pingback atexit/idempotent stop.

Note: `tests/inference/unit_tests/core/interfaces/http/test_builder.py::*_final_workflow_symlink` fail on any second local run because they leave symlinks in `/tmp/cache/workflow/local`. That is pre-existing and unrelated; CI runners are fresh so it passes there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
