### PR TITLE
Include PostgreSQL binary driver in inference runtime

### DIFF
--- a/.github/workflows/test_package_install_inference.yml
+++ b/.github/workflows/test_package_install_inference.yml
@@ -49,4 +49,4 @@ jobs:
       - name: 🧪 Testing package installation
         working-directory: "/"
         run: |
-          python -c "import os; import platform; print(f'Python version: {platform.python_version()}'); print(f'CWD: {os.getcwd()}'); from inference import get_model"
+          python -c "import os; import platform; print(f'Python version: {platform.python_version()}'); print(f'CWD: {os.getcwd()}'); from inference import get_model; import psycopg; assert psycopg.pq.__impl__ == 'binary'"

--- a/.github/workflows/test_package_install_inference_gpu.yml
+++ b/.github/workflows/test_package_install_inference_gpu.yml
@@ -71,4 +71,4 @@ jobs:
       - name: 🧪 Testing package installation
         working-directory: "/"
         run: |
-          python -c "import os; import platform; print(f'Python version: {platform.python_version()}'); print(f'CWD: {os.getcwd()}'); from inference import get_model"
+          python -c "import os; import platform; print(f'Python version: {platform.python_version()}'); print(f'CWD: {os.getcwd()}'); from inference import get_model; import psycopg; assert psycopg.pq.__impl__ == 'binary'"

--- a/requirements/_requirements.txt
+++ b/requirements/_requirements.txt
@@ -13,6 +13,7 @@ opencv-contrib-python>=4.8.1.78,<4.13.0  # Note: opencv-python considers this as
 pillow>=12.3.0,<13.0.0
 prometheus-fastapi-instrumentator<=6.0.0
 psutil>=7.0.0
+psycopg[binary]>=3.2,<4
 redis~=5.0.0
 requests>=2.33.0,<3.0.0
 rich>=13.0.0,<15.0.0


### PR DESCRIPTION
# Description

Customers currently install a PostgreSQL driver inside Custom Python blocks; include the binary Psycopg dependency in the shared Inference runtime requirements so they can import it directly, with pip selecting a compatible version within `>=3.2,<4`.

## Type of change

- [x] New feature (non-breaking)

## How has this change been tested?

- Binary install/import on Python 3.10 and 3.12 (macOS ARM64), and Python 3.11 (Linux ARM64).
- Parameterized insert/read against disposable PostgreSQL 16.
- Extended existing CPU/GPU package-install CI checks to assert the binary driver is available.

## Any specific deployment considerations

- Rebuild Inference images; consuming cloud workers and remote Custom Python images must adopt the release.
- Native PostgreSQL workflow block follows in a stacked PR.
