### PR TITLE
Carry model latency into inference usage rows

### DIFF
--- a/inference/core/registries/roboflow.py
+++ b/inference/core/registries/roboflow.py
@@ -62,7 +62,10 @@ from inference.core.roboflow_api import (
 from inference.core.utils.file_system import dump_json_atomic, read_json
 from inference.core.utils.roboflow import get_model_id_chunks
 from inference.models.aliases import resolve_roboflow_model_alias
-from inference.usage_tracking.model_types import record_model_descriptor
+from inference.usage_tracking.model_types import (
+    normalize_model_latency_ms,
+    record_model_descriptor,
+)
 from inference_models.models.auto_loaders import core as inference_models_auto_loaders
 from inference_models.models.auto_loaders.core import parse_model_config
 from inference_models.models.auto_loaders.entities import MODEL_CONFIG_FILE_NAME
@@ -450,7 +453,7 @@ def get_model_type(
         MissingDefaultModelError: If default model is not configured and API does not provide this info
         MalformedRoboflowAPIResponseError: Roboflow API responds in invalid format.
     """
-    task_type, model_type, model_variant = _resolve_model_type(
+    task_type, model_type, model_variant, model_latency_ms = _resolve_model_type(
         model_id=model_id,
         api_key=api_key,
         countinference=countinference,
@@ -465,12 +468,14 @@ def get_model_type(
         model_id=model_id,
         architecture=model_type,
         variant=model_variant,
+        latency_ms=model_latency_ms,
         task_type=task_type,
     )
     record_model_descriptor(
         model_id=resolve_roboflow_model_alias(model_id=model_id),
         architecture=model_type,
         variant=model_variant,
+        latency_ms=model_latency_ms,
         task_type=task_type,
     )
     return task_type, model_type
@@ -494,11 +499,11 @@ def _resolve_model_type(
     api_key: Optional[str] = None,
     countinference: Optional[bool] = None,
     service_secret: Optional[str] = None,
-) -> Tuple[TaskType, ModelType, Optional[str]]:
+) -> Tuple[TaskType, ModelType, Optional[str], Optional[float]]:
     model_id = resolve_roboflow_model_alias(model_id=model_id)
     local_model_type = _get_local_model_type(model_id=model_id)
     if local_model_type is not None:
-        return local_model_type[0], local_model_type[1], None
+        return local_model_type[0], local_model_type[1], None, None
     pipeline_definition = _get_model_pipeline_definition(model_id=model_id)
     if pipeline_definition is not None:
         logger.debug(f"Loading model pipeline: {model_id}.")
@@ -506,6 +511,7 @@ def _resolve_model_type(
             pipeline_definition.task_type,
             pipeline_definition.model_type,
             _coded_model_variant(model_id=model_id),
+            None,
         )
     validate_model_id_for_cache(model_id=model_id)
     dataset_id, version_id = get_model_id_chunks(model_id=model_id)
@@ -513,13 +519,13 @@ def _resolve_model_type(
     if model_id in GENERIC_MODELS:
         logger.debug(f"Loading generic model: {model_id}.")
         task_type, model_type = GENERIC_MODELS[model_id]
-        return task_type, model_type, _coded_model_variant(model_id=model_id)
+        return task_type, model_type, _coded_model_variant(model_id=model_id), None
 
     # then check if the dataset id is in the GENERIC_MODELS dictionary
     if dataset_id in GENERIC_MODELS:
         logger.debug(f"Loading generic model: {dataset_id}.")
         task_type, model_type = GENERIC_MODELS[dataset_id]
-        return task_type, model_type, _coded_model_variant(model_id=model_id)
+        return task_type, model_type, _coded_model_variant(model_id=model_id), None
 
     if MODELS_CACHE_AUTH_ENABLED and not OFFLINE_MODE:
         if not _check_if_api_key_has_access_to_model(
@@ -544,7 +550,12 @@ def _resolve_model_type(
             project_task_type=cached_metadata[0],
             model_type=cached_metadata[1],
         )
-        return cached_metadata[0], cached_metadata[1], cached_metadata[2]
+        return (
+            cached_metadata[0],
+            cached_metadata[1],
+            cached_metadata[2],
+            cached_metadata[3],
+        )
     if version_id == STUB_VERSION_ID:
         if api_key is None:
             raise MissingApiKeyError(
@@ -562,7 +573,7 @@ def _resolve_model_type(
             model_type=model_type,
             api_key=api_key,
         )
-        return project_task_type, model_type, None
+        return project_task_type, model_type, None, None
 
     if USE_INFERENCE_MODELS:
         api_data = get_model_metadata_from_inference_models_registry(
@@ -603,6 +614,7 @@ def _resolve_model_type(
     if model_type is None or project_task_type is None:
         raise ModelArtefactError("Error loading model artifacts from Roboflow API.")
     model_variant = api_data.get("modelVariant") or None
+    model_latency_ms = normalize_model_latency_ms(api_data.get("modelLatencyMs"))
     _ensure_model_supported_on_this_deployment(
         model_id=model_id,
         project_task_type=project_task_type,
@@ -614,10 +626,11 @@ def _resolve_model_type(
         project_task_type=project_task_type,
         model_type=model_type,
         model_variant=model_variant,
+        model_latency_ms=model_latency_ms,
         api_key=api_key,
     )
 
-    return project_task_type, model_type, model_variant
+    return project_task_type, model_type, model_variant, model_latency_ms
 
 
 def _ensure_model_supported_on_this_deployment(
@@ -655,7 +668,7 @@ def _get_cached_model_metadata(
     dataset_id: Union[DatasetID, ModelID],
     version_id: Optional[VersionID],
     api_key: Optional[str] = None,
-) -> Optional[Tuple[TaskType, ModelType, Optional[str]]]:
+) -> Optional[Tuple[TaskType, ModelType, Optional[str], Optional[float]]]:
     model_id = _combine_model_id(dataset_id=dataset_id, version_id=version_id)
     validate_model_id_for_cache(model_id=model_id)
     cache_key = _get_in_process_metadata_cache_key(
@@ -690,13 +703,18 @@ def _get_cached_model_metadata(
 
 def _normalize_cached_model_metadata(
     cached: Optional[Tuple[Any, ...]],
-) -> Optional[Tuple[TaskType, ModelType, Optional[str]]]:
+) -> Optional[Tuple[TaskType, ModelType, Optional[str], Optional[float]]]:
     if cached is None:
         return None
     if len(cached) >= 3:
-        return cached[0], cached[1], cached[2]
+        return (
+            cached[0],
+            cached[1],
+            cached[2],
+            normalize_model_latency_ms(cached[3]) if len(cached) >= 4 else None,
+        )
     if len(cached) == 2:
-        return cached[0], cached[1], None
+        return cached[0], cached[1], None, None
     return None
 
 
@@ -704,7 +722,7 @@ def _get_model_metadata_from_cache(
     dataset_id: Union[DatasetID, ModelID],
     version_id: Optional[VersionID],
     api_key: Optional[str] = None,
-) -> Optional[Tuple[TaskType, ModelType, Optional[str]]]:
+) -> Optional[Tuple[TaskType, ModelType, Optional[str], Optional[float]]]:
     model_id = _combine_model_id(dataset_id=dataset_id, version_id=version_id)
     # Layout 1: traditional model_type.json
     try:
@@ -770,7 +788,7 @@ def _load_model_metadata_from_path(
     path: str,
     required_model_id: Optional[str] = None,
     allow_ownerless: bool = False,
-) -> Optional[Tuple[TaskType, ModelType, Optional[str]]]:
+) -> Optional[Tuple[TaskType, ModelType, Optional[str], Optional[float]]]:
     try:
         model_metadata = _read_model_metadata_json(path=path)
     except FileNotFoundError:
@@ -807,13 +825,14 @@ def _load_model_metadata_from_path(
         model_metadata[PROJECT_TASK_TYPE_KEY],
         model_metadata[MODEL_TYPE_KEY],
         model_variant,
+        normalize_model_latency_ms(model_metadata.get("model_latency_ms")),
     )
 
 
 def _get_model_metadata_from_inference_models_cache(
     model_id: str,
     api_key: Optional[str] = None,
-) -> Optional[Tuple[TaskType, ModelType, Optional[str]]]:
+) -> Optional[Tuple[TaskType, ModelType, Optional[str], Optional[float]]]:
     """Check the `inference-models` cache layout for model metadata.
 
     Best-effort fallback used when the traditional ``model_type.json`` is
@@ -859,7 +878,7 @@ def _get_model_metadata_from_inference_models_cache(
             metadata.get("model_id"),
         ),
     )
-    return task_type, model_architecture, model_variant
+    return task_type, model_architecture, model_variant, None
 
 
 def _model_variant_from_offline_registry(
@@ -928,6 +947,7 @@ def save_model_metadata_in_cache(
     model_type: ModelType,
     api_key: Optional[str] = None,
     model_variant: Optional[str] = None,
+    model_latency_ms: Optional[float] = None,
 ) -> None:
     model_id = _combine_model_id(dataset_id=dataset_id, version_id=version_id)
     validate_model_id_for_cache(model_id=model_id)
@@ -938,6 +958,7 @@ def save_model_metadata_in_cache(
             project_task_type=project_task_type,
             model_type=model_type,
             model_variant=model_variant,
+            model_latency_ms=model_latency_ms,
         )
     else:
         with cache.lock(
@@ -950,6 +971,7 @@ def save_model_metadata_in_cache(
                 project_task_type=project_task_type,
                 model_type=model_type,
                 model_variant=model_variant,
+                model_latency_ms=model_latency_ms,
             )
     _in_process_metadata_cache.set(
         _get_in_process_metadata_cache_key(
@@ -957,7 +979,7 @@ def save_model_metadata_in_cache(
             version_id=version_id,
             api_key=api_key,
         ),
-        (project_task_type, model_type, model_variant),
+        (project_task_type, model_type, model_variant, model_latency_ms),
     )
 
 
@@ -967,6 +989,7 @@ def _save_model_metadata_in_cache(
     project_task_type: TaskType,
     model_type: ModelType,
     model_variant: Optional[str] = None,
+    model_latency_ms: Optional[float] = None,
 ) -> None:
     model_id = _combine_model_id(dataset_id=dataset_id, version_id=version_id)
     model_type_cache_path = construct_model_type_cache_path(
@@ -983,6 +1006,8 @@ def _save_model_metadata_in_cache(
     }
     if model_variant:
         metadata[MODEL_VARIANT_KEY] = model_variant
+    if model_latency_ms is not None:
+        metadata["model_latency_ms"] = model_latency_ms
     dump_json_atomic(
         path=model_type_cache_path, content=metadata, allow_override=True, indent=4
     )

--- a/inference/core/roboflow_api.py
+++ b/inference/core/roboflow_api.py
@@ -722,6 +722,7 @@ def get_model_metadata_from_inference_models_registry(
         "modelType": model_metadata["modelArchitecture"],
         "taskType": model_metadata["taskType"],
         "modelVariant": model_metadata.get("modelVariant"),
+        "modelLatencyMs": model_metadata.get("modelLatencyMs"),
     }
     cache.set(
         api_data_cache_key,

--- a/inference/usage_tracking/decorator_helpers.py
+++ b/inference/usage_tracking/decorator_helpers.py
@@ -361,6 +361,7 @@ def get_model_descriptor_from_kwargs(
                 architecture=str(architecture),
                 variant=str(variant) if variant else None,
                 task_type=str(task_type) if task_type else None,
+                latency_ms=getattr(model, "model_latency_ms", None),
             )
 
     return get_recorded_model_descriptor(get_model_id_from_kwargs(func_kwargs))
@@ -384,6 +385,8 @@ def get_model_resource_details_from_kwargs(
     model_descriptor = get_model_descriptor_from_kwargs(func_kwargs)
     if model_descriptor:
         resource_details["model_architecture"] = model_descriptor.architecture
+        if model_descriptor.latency_ms is not None:
+            resource_details["model_latency_ms"] = float(model_descriptor.latency_ms)
         if model_descriptor.variant:
             resource_details["model_variant"] = model_descriptor.variant
         if not task_type:

--- a/inference/usage_tracking/model_types.py
+++ b/inference/usage_tracking/model_types.py
@@ -11,6 +11,7 @@ pathological stream of distinct ids cannot grow the process forever, and newer
 ids still get a chance to be labeled.
 """
 
+import math
 from collections import OrderedDict
 from dataclasses import dataclass
 from typing import Any, Optional
@@ -35,6 +36,7 @@ class ModelDescriptor:
     architecture: str
     variant: Optional[str] = None
     task_type: Optional[str] = None
+    latency_ms: Optional[float] = None
 
 
 # Servers load a bounded number of models, but the map is keyed by caller-supplied
@@ -50,6 +52,7 @@ def record_model_descriptor(
     architecture: Optional[str],
     variant: Optional[str] = None,
     task_type: Optional[str] = None,
+    latency_ms: Optional[float] = None,
 ) -> None:
     """Remember the architecture / variant / task resolved for a model id.
 
@@ -67,6 +70,7 @@ def record_model_descriptor(
         architecture=str(architecture),
         variant=str(variant) if variant else None,
         task_type=str(task_type) if task_type else None,
+        latency_ms=normalize_model_latency_ms(latency_ms),
     )
     if model_id in _MODEL_DESCRIPTORS:
         _MODEL_DESCRIPTORS.move_to_end(model_id)
@@ -116,9 +120,16 @@ def bind_usage_model_descriptor(model: Any, *model_ids: Optional[str]) -> None:
     if recorded:
         model.model_architecture = recorded.architecture
         model.model_variant = recorded.variant
+        model.model_latency_ms = recorded.latency_ms
         if recorded.task_type and not getattr(model, "task_type", None):
             model.task_type = recorded.task_type
 
 
 def clear_recorded_model_descriptors() -> None:
     _MODEL_DESCRIPTORS.clear()
+
+
+def normalize_model_latency_ms(value: Any) -> Optional[float]:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return float(value) if math.isfinite(value) and value > 0 else None

--- a/tests/inference/unit_tests/core/registries/test_roboflow.py
+++ b/tests/inference/unit_tests/core/registries/test_roboflow.py
@@ -1605,6 +1605,7 @@ def test_get_model_type_records_registry_variant_for_usage_tracking(
         "modelType": "yolov8",
         "taskType": "instance-segmentation",
         "modelVariant": "yolov8-n",
+        "modelLatencyMs": 2.3,
     }
 
     try:
@@ -1615,12 +1616,13 @@ def test_get_model_type_records_registry_variant_for_usage_tracking(
 
         assert result == ("instance-segmentation", "yolov8")
         assert get_recorded_model_descriptor("yolov8n-seg-640") == ModelDescriptor(
-            "yolov8", "yolov8-n", task_type="instance-segmentation"
+            "yolov8", "yolov8-n", task_type="instance-segmentation", latency_ms=2.3
         )
         with open(metadata_path) as f:
             persisted_metadata = json.load(f)
         assert persisted_metadata["model_type"] == "yolov8"
         assert persisted_metadata["model_variant"] == "yolov8-n"
+        assert persisted_metadata["model_latency_ms"] == 2.3
 
         _in_process_metadata_cache.cache.clear()
         clear_recorded_model_descriptors()
@@ -1630,7 +1632,7 @@ def test_get_model_type_records_registry_variant_for_usage_tracking(
         )
         assert cached_result == ("instance-segmentation", "yolov8")
         assert get_recorded_model_descriptor("yolov8n-seg-640") == ModelDescriptor(
-            "yolov8", "yolov8-n", task_type="instance-segmentation"
+            "yolov8", "yolov8-n", task_type="instance-segmentation", latency_ms=2.3
         )
         get_model_metadata_from_inference_models_registry_mock.assert_called_once()
     finally:
@@ -2053,7 +2055,7 @@ def test_get_model_metadata_from_inference_models_cache_when_config_found(
         )
 
     # then
-    assert result == ("object-detection", "yolov8", None)
+    assert result == ("object-detection", "yolov8", None, None)
     find_cached_package.assert_called_once_with(
         model_id="coco/22",
         api_key="credential-a",
@@ -2095,7 +2097,7 @@ def test_get_model_metadata_from_inference_models_cache_reads_offline_registry_v
             api_key="credential-a",
         )
 
-    assert result == ("object-detection", "rfdetr", "rfdetr-nano")
+    assert result == ("object-detection", "rfdetr", "rfdetr-nano", None)
     load_record_raw_mock.assert_called_once_with(model_id="coco/38")
 
 
@@ -2133,7 +2135,7 @@ def test_get_model_metadata_from_inference_models_cache_reads_variant_by_canonic
             model_id="rfdetr-nano"
         )
 
-    assert result == ("object-detection", "rfdetr", "rfdetr-nano")
+    assert result == ("object-detection", "rfdetr", "rfdetr-nano", None)
     assert [
         call.kwargs["model_id"] for call in load_record_raw_mock.call_args_list
     ] == [
@@ -2174,7 +2176,7 @@ def test_get_model_metadata_from_inference_models_cache_survives_corrupt_id_fiel
         )
 
     # then - the unusable candidates are skipped, the requested id is still tried
-    assert result == ("object-detection", "rfdetr", None)
+    assert result == ("object-detection", "rfdetr", None, None)
     assert [
         call.kwargs["model_id"] for call in load_record_raw_mock.call_args_list
     ] == ["coco/38"]
@@ -2250,3 +2252,16 @@ def test_get_model_metadata_from_inference_models_cache_when_backend_disabled() 
 
     # then
     assert result is None
+
+
+@pytest.mark.parametrize(
+    "cached,expected",
+    [
+        (("object-detection", "rfdetr"), None),
+        (("object-detection", "rfdetr", "rfdetr-nas"), None),
+        (("object-detection", "rfdetr", "rfdetr-nas", 2.3), 2.3),
+        (("object-detection", "rfdetr", "rfdetr-nas", float("nan")), None),
+    ],
+)
+def test_cached_latency_backwards_compatibility(cached, expected):
+    assert roboflow._normalize_cached_model_metadata(cached)[3] == expected

--- a/tests/inference/unit_tests/core/test_roboflow_api.py
+++ b/tests/inference/unit_tests/core/test_roboflow_api.py
@@ -1367,6 +1367,7 @@ def test_get_model_metadata_from_inference_models_registry_when_valid_response_e
             "modelId": "coins_detection/1",
             "modelArchitecture": "rfdetr",
             "modelVariant": "rfdetr-nano",
+            "modelLatencyMs": 2.3,
             "taskType": "object-detection",
         },
     }
@@ -1388,6 +1389,7 @@ def test_get_model_metadata_from_inference_models_registry_when_valid_response_e
         "modelType": "rfdetr",
         "taskType": "object-detection",
         "modelVariant": "rfdetr-nano",
+        "modelLatencyMs": 2.3,
     }
 
 
@@ -1403,6 +1405,7 @@ def test_get_model_metadata_from_inference_models_registry_when_no_api_key_is_pr
             "modelId": "rfdetr-nano",
             "modelArchitecture": "rfdetr",
             "modelVariant": "rfdetr-nano",
+            "modelLatencyMs": None,
             "taskType": "object-detection",
         },
     }
@@ -1424,6 +1427,7 @@ def test_get_model_metadata_from_inference_models_registry_when_no_api_key_is_pr
         "modelType": "rfdetr",
         "taskType": "object-detection",
         "modelVariant": "rfdetr-nano",
+        "modelLatencyMs": None,
     }
 
 
@@ -1441,6 +1445,7 @@ def test_get_model_metadata_from_inference_models_registry_when_valid_response_e
             "modelId": "coins_detection/1",
             "modelArchitecture": "yolov8",
             "modelVariant": None,
+            "modelLatencyMs": None,
             "taskType": "object-detection",
         },
     }
@@ -1469,6 +1474,7 @@ def test_get_model_metadata_from_inference_models_registry_when_valid_response_e
         "modelType": "yolov8",
         "taskType": "object-detection",
         "modelVariant": None,
+        "modelLatencyMs": None,
     }
 
 
@@ -1487,6 +1493,7 @@ def test_get_model_metadata_from_inference_models_registry_uses_request_workspac
             "modelId": "coins_detection/1",
             "modelArchitecture": "yolov8",
             "modelVariant": None,
+            "modelLatencyMs": None,
             "taskType": "object-detection",
         },
     }
@@ -1521,6 +1528,7 @@ def test_get_model_metadata_from_inference_models_registry_uses_request_workspac
         "modelType": "yolov8",
         "taskType": "object-detection",
         "modelVariant": None,
+        "modelLatencyMs": None,
     }
 
 
@@ -1539,6 +1547,7 @@ def test_get_model_metadata_from_inference_models_registry_does_not_send_token_w
             "modelId": "coins_detection/1",
             "modelArchitecture": "yolov8",
             "modelVariant": None,
+            "modelLatencyMs": None,
             "taskType": "object-detection",
         },
     }
@@ -1563,6 +1572,7 @@ def test_get_model_metadata_from_inference_models_registry_does_not_send_token_w
         "modelType": "yolov8",
         "taskType": "object-detection",
         "modelVariant": None,
+        "modelLatencyMs": None,
     }
 
 
@@ -1581,6 +1591,7 @@ def test_get_model_metadata_from_inference_models_registry_when_valid_response_e
             "modelId": "coins_detection/1",
             "modelArchitecture": "yolov8",
             "modelVariant": None,
+            "modelLatencyMs": None,
             "taskType": "object-detection",
         },
     }
@@ -1602,6 +1613,7 @@ def test_get_model_metadata_from_inference_models_registry_when_valid_response_e
         "modelType": "yolov8",
         "taskType": "object-detection",
         "modelVariant": None,
+        "modelLatencyMs": None,
     }
     assert "x-enforce-credits-verification" not in requests_mock.last_request.headers
 

--- a/tests/inference/unit_tests/usage_tracking/test_decorator_helpers.py
+++ b/tests/inference/unit_tests/usage_tracking/test_decorator_helpers.py
@@ -986,3 +986,28 @@ def test_source_info_falls_back_to_the_request_scope():
 
 def test_source_info_still_ignores_the_external_placeholder():
     assert get_source_info_from_kwargs({"source_info": "external"}) is None
+
+
+@pytest.mark.parametrize(
+    "latency", [2.3, None, 0, -1, float("inf"), float("nan"), True, "2.3"]
+)
+def test_nas_latency_survives_binding_and_map_eviction(latency):
+    clear_recorded_model_descriptors()
+    model = SimpleNamespace(model_id="workspace/nas-child")
+    record_model_descriptor(
+        model.model_id,
+        architecture="rfdetr",
+        variant="rfdetr-nas",
+        task_type="object-detection",
+        latency_ms=latency,
+    )
+    direct = get_model_resource_details_from_kwargs({"model_id": model.model_id})
+    bind_usage_model_descriptor(model, model.model_id)
+    clear_recorded_model_descriptors()
+    bound = get_model_resource_details_from_kwargs({"self": model})
+    assert bound == direct
+    if latency == 2.3:
+        assert bound["model_latency_ms"] == 2.3
+        assert isinstance(bound["model_latency_ms"], float)
+    else:
+        assert "model_latency_ms" not in bound


### PR DESCRIPTION
# Description

Carry the registry's optional `modelLatencyMs` from model load through metadata caches and bound model descriptors into `resource_details.model_latency_ms`. This lets Serverless price NAS images without billing-time registry lookups and preserves metadata when the descriptor map evicts entries.

## Type of change

- [x] New feature (non-breaking)

## How has this change been tested?

- 505 registry, API mapping, and usage-tracking tests pass; 10 existing skips. `QWEN_3_5_ENABLED=false` avoids an unavailable optional local dependency.
- Added latency persistence, old-cache compatibility, invalid values, and bound-instance/map eviction coverage. Changed-code syntax/undefined-name lint passes.

- Current-head `build-dev-test (3.10)` was cancelled; it is not a passing build. No Jarbas review is recorded.

## Any specific deployment considerations

Requires models-service metadata and trainer publication first. Refresh preexisting NAS metadata caches as needed; old entries remain readable but have no latency and therefore require the billing cap. Keep per-image billing disabled until fleet-wide usage rows and backfill coverage are verified.

Related PRs: [UI estimates](https://github.com/roboflow/roboflow/pull/15165), [stock tiers](https://github.com/roboflow/roboflow/pull/15415), [models service](https://github.com/roboflow/roboflow/pull/15439), [NAS pricing and hover UI](https://github.com/roboflow/roboflow/pull/15440), [trainer](https://github.com/roboflow/roboflow-train/pull/909).

Implemented with Codex.
