### PR TITLE
CI improvement - terminate stale in-flight CI actions.

### DIFF
--- a/.github/scripts/check_workflow_concurrency.py
+++ b/.github/scripts/check_workflow_concurrency.py
@@ -1,0 +1,89 @@
+"""Guard for the shared CI concurrency policy.
+
+Every workflow triggered by ``pull_request`` or ``push`` must declare a
+top-level ``concurrency`` block whose ``group`` is keyed by
+``github.workflow`` and which sets ``cancel-in-progress``. Because
+``github.workflow`` resolves to the workflow ``name:``, names must also be
+unique, otherwise two workflows would share a concurrency group and cancel
+each other.
+
+Usage: ``python3 .github/scripts/check_workflow_concurrency.py [workflows_dir]``
+Exit code 0 when every workflow complies, 1 otherwise (offenders are listed).
+"""
+
+from __future__ import annotations
+
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+import yaml
+
+GUARDED_TRIGGERS = {"pull_request", "push"}
+DEFAULT_WORKFLOWS_DIR = Path(__file__).resolve().parents[1] / "workflows"
+
+
+def _triggers(document: dict) -> set[str]:
+    # PyYAML parses a bare ``on`` key as boolean True.
+    on = document.get(True, document.get("on"))
+    if isinstance(on, dict):
+        return set(on)
+    if isinstance(on, list):
+        return set(on)
+    if isinstance(on, str):
+        return {on}
+    return set()
+
+
+def find_offenders(workflows_dir: Path) -> list[str]:
+    offenders: list[str] = []
+    names: dict[str, list[str]] = defaultdict(list)
+    for path in sorted(workflows_dir.glob("*.yml")) + sorted(workflows_dir.glob("*.yaml")):
+        with path.open() as handle:
+            document = yaml.safe_load(handle)
+        if not isinstance(document, dict):
+            offenders.append(f"{path.name}: not a mapping at top level")
+            continue
+        name = document.get("name")
+        if name:
+            names[str(name)].append(path.name)
+        if not _triggers(document) & GUARDED_TRIGGERS:
+            continue
+        concurrency = document.get("concurrency")
+        if not isinstance(concurrency, dict):
+            offenders.append(
+                f"{path.name}: triggered by pull_request/push but has no top-level concurrency block"
+            )
+            continue
+        group = str(concurrency.get("group", ""))
+        if "github.workflow" not in group:
+            offenders.append(f"{path.name}: concurrency.group must be keyed by github.workflow")
+        if "cancel-in-progress" not in concurrency:
+            offenders.append(f"{path.name}: concurrency block must set cancel-in-progress")
+    for name, files in sorted(names.items()):
+        if len(files) > 1:
+            offenders.append(
+                f"duplicate workflow name {name!r} in {', '.join(files)}: "
+                "github.workflow is the concurrency-group key, names must be unique"
+            )
+    return offenders
+
+
+def main(argv: list[str]) -> int:
+    workflows_dir = Path(argv[1]) if len(argv) > 1 else DEFAULT_WORKFLOWS_DIR
+    offenders = find_offenders(workflows_dir)
+    if offenders:
+        print("Concurrency policy violations:")
+        for offender in offenders:
+            print(f"  - {offender}")
+        print(
+            "\nAdd the shared concurrency block (copy it from any workflow under "
+            ".github/workflows) or fix the duplicate name."
+        )
+        return 1
+    print(f"OK: concurrency policy holds for every workflow in {workflows_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/.github/workflows/check_model_licenses.yml
+++ b/.github/workflows/check_model_licenses.yml
@@ -9,8 +9,12 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  # One live run per workflow per ref. A newer push to the same PR, or a newer
+  # merge to main, cancels the older run. Manual dispatches get their own group
+  # (keyed by run id) so they never cancel, or get cancelled by, push-triggered
+  # runs. Release runs are keyed by the tag ref and are never cancelled.
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
 
 jobs:
   validate-models:

--- a/.github/workflows/codeflash.yml
+++ b/.github/workflows/codeflash.yml
@@ -8,8 +8,12 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # One live run per workflow per ref. A newer push to the same PR, or a newer
+  # merge to main, cancels the older run. Manual dispatches get their own group
+  # (keyed by run id) so they never cancel, or get cancelled by, push-triggered
+  # runs. Release runs are keyed by the tag ref and are never cancelled.
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
 
 jobs:
   optimize:

--- a/.github/workflows/docker.cpu.parallel.yml
+++ b/.github/workflows/docker.cpu.parallel.yml
@@ -13,6 +13,14 @@ on:
         description: "Do you want to push image after build?"
         default: false
 
+concurrency:
+  # One live run per workflow per ref. A newer push to the same PR, or a newer
+  # merge to main, cancels the older run. Manual dispatches get their own group
+  # (keyed by run id) so they never cancel, or get cancelled by, push-triggered
+  # runs. Release runs are keyed by the tag ref and are never cancelled.
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
+
 env:
   VERSION: "0.0.0" # Default version, will be overwritten
 

--- a/.github/workflows/docker.cpu.slim.yml
+++ b/.github/workflows/docker.cpu.slim.yml
@@ -13,6 +13,14 @@ on:
         description: "Do you want to push image after build?"
         default: false
 
+concurrency:
+  # One live run per workflow per ref. A newer push to the same PR, or a newer
+  # merge to main, cancels the older run. Manual dispatches get their own group
+  # (keyed by run id) so they never cancel, or get cancelled by, push-triggered
+  # runs. Release runs are keyed by the tag ref and are never cancelled.
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
+
 env:
   VERSION: "0.0.0" # Default version, will be overwritten
 

--- a/.github/workflows/docker.cpu.yml
+++ b/.github/workflows/docker.cpu.yml
@@ -17,6 +17,14 @@ on:
         description: "Custom tag to use for the image (overrides VERSION)"
         default: ""
 
+concurrency:
+  # One live run per workflow per ref. A newer push to the same PR, or a newer
+  # merge to main, cancels the older run. Manual dispatches get their own group
+  # (keyed by run id) so they never cancel, or get cancelled by, push-triggered
+  # runs. Release runs are keyed by the tag ref and are never cancelled.
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
+
 env:
   VERSION: "0.0.0" # Default version, will be overwritten
   BASE_IMAGE: "roboflow/roboflow-inference-server-cpu"

--- a/.github/workflows/docker.gpu.cu13.yml
+++ b/.github/workflows/docker.gpu.cu13.yml
@@ -17,6 +17,14 @@ on:
         description: "Custom tag to use for the image (overrides VERSION)"
         default: ""
 
+concurrency:
+  # One live run per workflow per ref. A newer push to the same PR, or a newer
+  # merge to main, cancels the older run. Manual dispatches get their own group
+  # (keyed by run id) so they never cancel, or get cancelled by, push-triggered
+  # runs. Release runs are keyed by the tag ref and are never cancelled.
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
+
 env:
   VERSION: "0.0.0" # Default version, will be overwritten
   BASE_IMAGE: "roboflow/roboflow-inference-server-gpu-cu13"

--- a/.github/workflows/docker.gpu.parallel.yml
+++ b/.github/workflows/docker.gpu.parallel.yml
@@ -13,6 +13,14 @@ on:
         description: "Do you want to push image after build?"
         default: false
 
+concurrency:
+  # One live run per workflow per ref. A newer push to the same PR, or a newer
+  # merge to main, cancels the older run. Manual dispatches get their own group
+  # (keyed by run id) so they never cancel, or get cancelled by, push-triggered
+  # runs. Release runs are keyed by the tag ref and are never cancelled.
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
+
 env:
   VERSION: "0.0.0" # Default version, will be overwritten
 

--- a/.github/workflows/docker.gpu.slim.yml
+++ b/.github/workflows/docker.gpu.slim.yml
@@ -13,6 +13,14 @@ on:
         description: "Do you want to push image after build?"
         default: false
 
+concurrency:
+  # One live run per workflow per ref. A newer push to the same PR, or a newer
+  # merge to main, cancels the older run. Manual dispatches get their own group
+  # (keyed by run id) so they never cancel, or get cancelled by, push-triggered
+  # runs. Release runs are keyed by the tag ref and are never cancelled.
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
+
 env:
   VERSION: "0.0.0" # Default version, will be overwritten
 

--- a/.github/workflows/docker.gpu.udp.yml
+++ b/.github/workflows/docker.gpu.udp.yml
@@ -13,6 +13,14 @@ on:
         description: "Do you want to push image after build?"
         default: false
 
+concurrency:
+  # One live run per workflow per ref. A newer push to the same PR, or a newer
+  # merge to main, cancels the older run. Manual dispatches get their own group
+  # (keyed by run id) so they never cancel, or get cancelled by, push-triggered
+  # runs. Release runs are keyed by the tag ref and are never cancelled.
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
+
 env:
   VERSION: "0.0.0" # Default version, will be overwritten
 

--- a/.github/workflows/docker.gpu.yml
+++ b/.github/workflows/docker.gpu.yml
@@ -17,6 +17,14 @@ on:
         description: "Custom tag to use for the image (overrides VERSION)"
         default: ""
 
+concurrency:
+  # One live run per workflow per ref. A newer push to the same PR, or a newer
+  # merge to main, cancels the older run. Manual dispatches get their own group
+  # (keyed by run id) so they never cancel, or get cancelled by, push-triggered
+  # runs. Release runs are keyed by the tag ref and are never cancelled.
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
+
 env:
   VERSION: "0.0.0" # Default version, will be overwritten
   BASE_IMAGE: "roboflow/roboflow-inference-server-gpu"

--- a/.github/workflows/docker.inference-exp.yml
+++ b/.github/workflows/docker.inference-exp.yml
@@ -22,6 +22,14 @@ on:
     branches:
       - main
 
+concurrency:
+  # One live run per workflow per ref. A newer push to the same PR, or a newer
+  # merge to main, cancels the older run. Manual dispatches get their own group
+  # (keyed by run id) so they never cancel, or get cancelled by, push-triggered
+  # runs. Release runs are keyed by the tag ref and are never cancelled.
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
+
 env:
   DEPOT_PROJECT_ID: grl7ffzxd7
 

--- a/.github/workflows/docker.jetson.5.1.1.yml
+++ b/.github/workflows/docker.jetson.5.1.1.yml
@@ -17,6 +17,14 @@ on:
         description: "Custom tag to use for the image (overrides VERSION)"
         default: ""
 
+concurrency:
+  # One live run per workflow per ref. A newer push to the same PR, or a newer
+  # merge to main, cancels the older run. Manual dispatches get their own group
+  # (keyed by run id) so they never cancel, or get cancelled by, push-triggered
+  # runs. Release runs are keyed by the tag ref and are never cancelled.
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
+
 env:
   VERSION: "0.0.0" # Default version, will be overwritten
   BASE_IMAGE: "roboflow/roboflow-inference-server-jetson-5.1.1"

--- a/.github/workflows/docker.jetson.6.2.0.yml
+++ b/.github/workflows/docker.jetson.6.2.0.yml
@@ -17,6 +17,14 @@ on:
         description: "Custom tag to use for the image (overrides VERSION)"
         default: ""
 
+concurrency:
+  # One live run per workflow per ref. A newer push to the same PR, or a newer
+  # merge to main, cancels the older run. Manual dispatches get their own group
+  # (keyed by run id) so they never cancel, or get cancelled by, push-triggered
+  # runs. Release runs are keyed by the tag ref and are never cancelled.
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
+
 env:
   VERSION: "0.0.0" # Default version, will be overwritten
   BASE_IMAGE: "roboflow/roboflow-inference-server-jetson-6.2.0"

--- a/.github/workflows/docker.jetson.7.2.0.yml
+++ b/.github/workflows/docker.jetson.7.2.0.yml
@@ -21,6 +21,14 @@ on:
         description: "Build the media image from this ref before the server image"
         default: false
 
+concurrency:
+  # One live run per workflow per ref. A newer push to the same PR, or a newer
+  # merge to main, cancels the older run. Manual dispatches get their own group
+  # (keyed by run id) so they never cancel, or get cancelled by, push-triggered
+  # runs. Release runs are keyed by the tag ref and are never cancelled.
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
+
 env:
   VERSION: "0.0.0"
   BASE_IMAGE: "roboflow/roboflow-inference-server-jetson-7.2.0"

--- a/.github/workflows/docker.media.jetson.7.2.0.yml
+++ b/.github/workflows/docker.media.jetson.7.2.0.yml
@@ -24,6 +24,14 @@ on:
         description: "Custom tag to use for the image"
         default: ""
 
+concurrency:
+  # One live run per workflow per ref. A newer push to the same PR, or a newer
+  # merge to main, cancels the older run. Manual dispatches get their own group
+  # (keyed by run id) so they never cancel, or get cancelled by, push-triggered
+  # runs. Release runs are keyed by the tag ref and are never cancelled.
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
+
 env:
   VERSION: "0.0.0"
   BASE_IMAGE: "roboflow/roboflow-inference-media-jetson-7.2.0"

--- a/.github/workflows/docker.trt.yml
+++ b/.github/workflows/docker.trt.yml
@@ -13,6 +13,14 @@ on:
         description: "Do you want to push image after build?"
         default: false
 
+concurrency:
+  # One live run per workflow per ref. A newer push to the same PR, or a newer
+  # merge to main, cancels the older run. Manual dispatches get their own group
+  # (keyed by run id) so they never cancel, or get cancelled by, push-triggered
+  # runs. Release runs are keyed by the tag ref and are never cancelled.
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
+
 env:
   VERSION: "0.0.0" # Default version, will be overwritten
 

--- a/.github/workflows/docker.wheels.jetson.7.2.0.yml
+++ b/.github/workflows/docker.wheels.jetson.7.2.0.yml
@@ -23,6 +23,14 @@ on:
         description: "Custom tag to use for the image"
         default: ""
 
+concurrency:
+  # One live run per workflow per ref. A newer push to the same PR, or a newer
+  # merge to main, cancels the older run. Manual dispatches get their own group
+  # (keyed by run id) so they never cancel, or get cancelled by, push-triggered
+  # runs. Release runs are keyed by the tag ref and are never cancelled.
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
+
 env:
   VERSION: "0.0.0"
   BASE_IMAGE: "roboflow/roboflow-inference-wheels-jetson-7.2.0"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,6 +21,14 @@ on:
         required: false
         default: false
 
+concurrency:
+  # One live run per workflow per ref. A newer push to the same PR, or a newer
+  # merge to main, cancels the older run. Manual dispatches get their own group
+  # (keyed by run id) so they never cancel, or get cancelled by, push-triggered
+  # runs. Release runs are keyed by the tag ref and are never cancelled.
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
+
 jobs:
   build:
     runs-on: depot-ubuntu-22.04-32

--- a/.github/workflows/e2e_tests_inference_experimental_cpu.yml
+++ b/.github/workflows/e2e_tests_inference_experimental_cpu.yml
@@ -6,6 +6,14 @@ on:
     branches: [main]
   workflow_dispatch:
 
+concurrency:
+  # One live run per workflow per ref. A newer push to the same PR, or a newer
+  # merge to main, cancels the older run. Manual dispatches get their own group
+  # (keyed by run id) so they never cancel, or get cancelled by, push-triggered
+  # runs. Release runs are keyed by the tag ref and are never cancelled.
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
+
 jobs:
   e2e-tests-inference-models-gpu:
     runs-on:

--- a/.github/workflows/e2e_tests_inference_experimental_gpu.yml
+++ b/.github/workflows/e2e_tests_inference_experimental_gpu.yml
@@ -6,6 +6,14 @@ on:
     branches: [main]
   workflow_dispatch:
 
+concurrency:
+  # One live run per workflow per ref. A newer push to the same PR, or a newer
+  # merge to main, cancels the older run. Manual dispatches get their own group
+  # (keyed by run id) so they never cancel, or get cancelled by, push-triggered
+  # runs. Release runs are keyed by the tag ref and are never cancelled.
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
+
 jobs:
   e2e-tests-inference-models-gpu:
     runs-on: Roboflow-GPU-VM-Runner

--- a/.github/workflows/integration_e2e_tests_inference_sdk_x86.yml
+++ b/.github/workflows/integration_e2e_tests_inference_sdk_x86.yml
@@ -9,8 +9,12 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  # One live run per workflow per ref. A newer push to the same PR, or a newer
+  # merge to main, cancels the older run. Manual dispatches get their own group
+  # (keyed by run id) so they never cancel, or get cancelled by, push-triggered
+  # runs. Release runs are keyed by the tag ref and are never cancelled.
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
 
 jobs:
   call_is_mergeable:

--- a/.github/workflows/integration_tests_inference_cli_depending_on_inference_x86.yml
+++ b/.github/workflows/integration_tests_inference_cli_depending_on_inference_x86.yml
@@ -6,6 +6,14 @@ on:
     branches: [main]
   workflow_dispatch:
 
+concurrency:
+  # One live run per workflow per ref. A newer push to the same PR, or a newer
+  # merge to main, cancels the older run. Manual dispatches get their own group
+  # (keyed by run id) so they never cancel, or get cancelled by, push-triggered
+  # runs. Release runs are keyed by the tag ref and are never cancelled.
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
+
 jobs:
   call_is_mergeable:
     uses: ./.github/workflows/check_if_branch_is_mergeable.yml

--- a/.github/workflows/integration_tests_inference_cli_x86.yml
+++ b/.github/workflows/integration_tests_inference_cli_x86.yml
@@ -6,6 +6,14 @@ on:
     branches: [main]
   workflow_dispatch:
 
+concurrency:
+  # One live run per workflow per ref. A newer push to the same PR, or a newer
+  # merge to main, cancels the older run. Manual dispatches get their own group
+  # (keyed by run id) so they never cancel, or get cancelled by, push-triggered
+  # runs. Release runs are keyed by the tag ref and are never cancelled.
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
+
 jobs:
   call_is_mergeable:
     uses: ./.github/workflows/check_if_branch_is_mergeable.yml

--- a/.github/workflows/integration_tests_inference_experimental_cpu.yml
+++ b/.github/workflows/integration_tests_inference_experimental_cpu.yml
@@ -29,8 +29,12 @@ on:
           - '3.12'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  # One live run per workflow per ref. A newer push to the same PR, or a newer
+  # merge to main, cancels the older run. Manual dispatches get their own group
+  # (keyed by run id) so they never cancel, or get cancelled by, push-triggered
+  # runs. Release runs are keyed by the tag ref and are never cancelled.
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
 
 jobs:
   integration-tests-inference-models-cpu:

--- a/.github/workflows/integration_tests_inference_experimental_gpu.yml
+++ b/.github/workflows/integration_tests_inference_experimental_gpu.yml
@@ -25,6 +25,14 @@ on:
         options:
           - '3.12'
 
+concurrency:
+  # One live run per workflow per ref. A newer push to the same PR, or a newer
+  # merge to main, cancels the older run. Manual dispatches get their own group
+  # (keyed by run id) so they never cancel, or get cancelled by, push-triggered
+  # runs. Release runs are keyed by the tag ref and are never cancelled.
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
+
 jobs:
   integration-tests-inference-models-gpu:
     name: ${{ matrix.extras.marker }}:${{ matrix.python-version }}:cuda-graphs:${{ matrix.extras.enable_auto_cuda_graphs_for_trt }}

--- a/.github/workflows/integration_tests_inference_models.yml
+++ b/.github/workflows/integration_tests_inference_models.yml
@@ -6,6 +6,14 @@ on:
     branches: [main]
   workflow_dispatch:
 
+concurrency:
+  # One live run per workflow per ref. A newer push to the same PR, or a newer
+  # merge to main, cancels the older run. Manual dispatches get their own group
+  # (keyed by run id) so they never cancel, or get cancelled by, push-triggered
+  # runs. Release runs are keyed by the tag ref and are never cancelled.
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
+
 jobs:
   call_is_mergeable:
     uses: ./.github/workflows/check_if_branch_is_mergeable.yml

--- a/.github/workflows/integration_tests_inference_server_x86.yml
+++ b/.github/workflows/integration_tests_inference_server_x86.yml
@@ -14,6 +14,15 @@ on:
           - all
           - "true"
           - "false"
+
+concurrency:
+  # One live run per workflow per ref. A newer push to the same PR, or a newer
+  # merge to main, cancels the older run. Manual dispatches get their own group
+  # (keyed by run id) so they never cancel, or get cancelled by, push-triggered
+  # runs. Release runs are keyed by the tag ref and are never cancelled.
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
+
 jobs:
   build:
     if: ${{ !github.event.act }}

--- a/.github/workflows/integration_tests_workflows_tensor_native_x86.yml
+++ b/.github/workflows/integration_tests_workflows_tensor_native_x86.yml
@@ -19,8 +19,12 @@ on:
           - "3.12"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  # One live run per workflow per ref. A newer push to the same PR, or a newer
+  # merge to main, cancels the older run. Manual dispatches get their own group
+  # (keyed by run id) so they never cancel, or get cancelled by, push-triggered
+  # runs. Release runs are keyed by the tag ref and are never cancelled.
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
 
 jobs:
   call_is_mergeable:

--- a/.github/workflows/integration_tests_workflows_x86.yml
+++ b/.github/workflows/integration_tests_workflows_x86.yml
@@ -27,8 +27,12 @@ on:
           - "false"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  # One live run per workflow per ref. A newer push to the same PR, or a newer
+  # merge to main, cancels the older run. Manual dispatches get their own group
+  # (keyed by run id) so they never cancel, or get cancelled by, push-triggered
+  # runs. Release runs are keyed by the tag ref and are never cancelled.
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
 
 jobs:
   call_is_mergeable:

--- a/.github/workflows/static_code_analysis.yml
+++ b/.github/workflows/static_code_analysis.yml
@@ -8,8 +8,12 @@ on:
     branches: [main]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  # One live run per workflow per ref. A newer push to the same PR, or a newer
+  # merge to main, cancels the older run. Manual dispatches get their own group
+  # (keyed by run id) so they never cancel, or get cancelled by, push-triggered
+  # runs. Release runs are keyed by the tag ref and are never cancelled.
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
 
 jobs:
   build-dev-test:

--- a/.github/workflows/test.colab.cpu.yml
+++ b/.github/workflows/test.colab.cpu.yml
@@ -6,6 +6,13 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+concurrency:
+  # One live run per workflow per ref. A newer push to the same PR, or a newer
+  # merge to main, cancels the older run. Manual dispatches get their own group
+  # (keyed by run id) so they never cancel, or get cancelled by, push-triggered
+  # runs. Release runs are keyed by the tag ref and are never cancelled.
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
 
 jobs:
   build:

--- a/.github/workflows/test.colab.gpu.yml
+++ b/.github/workflows/test.colab.gpu.yml
@@ -6,6 +6,13 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+concurrency:
+  # One live run per workflow per ref. A newer push to the same PR, or a newer
+  # merge to main, cancels the older run. Manual dispatches get their own group
+  # (keyed by run id) so they never cancel, or get cancelled by, push-triggered
+  # runs. Release runs are keyed by the tag ref and are never cancelled.
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
 
 jobs:
   build:

--- a/.github/workflows/test.nvidia_t4.yml
+++ b/.github/workflows/test.nvidia_t4.yml
@@ -29,6 +29,14 @@ on:
           - "true"
           - "false"
 
+concurrency:
+  # One live run per workflow per ref. A newer push to the same PR, or a newer
+  # merge to main, cancels the older run. Manual dispatches get their own group
+  # (keyed by run id) so they never cancel, or get cancelled by, push-triggered
+  # runs. Release runs are keyed by the tag ref and are never cancelled.
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
+
 jobs:
   build:
     if: ${{ !github.event.act }}

--- a/.github/workflows/test.nvidia_t4_parallel_server.yml
+++ b/.github/workflows/test.nvidia_t4_parallel_server.yml
@@ -16,6 +16,14 @@ on:
           - regression_without_torch
           - regression_with_torch
 
+concurrency:
+  # One live run per workflow per ref. A newer push to the same PR, or a newer
+  # merge to main, cancels the older run. Manual dispatches get their own group
+  # (keyed by run id) so they never cancel, or get cancelled by, push-triggered
+  # runs. Release runs are keyed by the tag ref and are never cancelled.
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
+
 jobs:
   build:
     if: ${{ !github.event.act }}

--- a/.github/workflows/test_package_install_inference.yml
+++ b/.github/workflows/test_package_install_inference.yml
@@ -9,6 +9,14 @@ permissions:
   id-token: write
   contents: read
 
+concurrency:
+  # One live run per workflow per ref. A newer push to the same PR, or a newer
+  # merge to main, cancels the older run. Manual dispatches get their own group
+  # (keyed by run id) so they never cancel, or get cancelled by, push-triggered
+  # runs. Release runs are keyed by the tag ref and are never cancelled.
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
+
 jobs:
   call_is_mergeable:
     uses: ./.github/workflows/check_if_branch_is_mergeable.yml

--- a/.github/workflows/test_package_install_inference_cli.yml
+++ b/.github/workflows/test_package_install_inference_cli.yml
@@ -9,6 +9,14 @@ permissions:
   id-token: write
   contents: read
 
+concurrency:
+  # One live run per workflow per ref. A newer push to the same PR, or a newer
+  # merge to main, cancels the older run. Manual dispatches get their own group
+  # (keyed by run id) so they never cancel, or get cancelled by, push-triggered
+  # runs. Release runs are keyed by the tag ref and are never cancelled.
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
+
 jobs:
   call_is_mergeable:
     uses: ./.github/workflows/check_if_branch_is_mergeable.yml

--- a/.github/workflows/test_package_install_inference_gpu.yml
+++ b/.github/workflows/test_package_install_inference_gpu.yml
@@ -9,6 +9,14 @@ permissions:
   id-token: write
   contents: read
 
+concurrency:
+  # One live run per workflow per ref. A newer push to the same PR, or a newer
+  # merge to main, cancels the older run. Manual dispatches get their own group
+  # (keyed by run id) so they never cancel, or get cancelled by, push-triggered
+  # runs. Release runs are keyed by the tag ref and are never cancelled.
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
+
 jobs:
   call_is_mergeable:
     uses: ./.github/workflows/check_if_branch_is_mergeable.yml

--- a/.github/workflows/test_package_install_inference_gpu_with_extras.yml
+++ b/.github/workflows/test_package_install_inference_gpu_with_extras.yml
@@ -9,6 +9,14 @@ permissions:
   id-token: write
   contents: read
 
+concurrency:
+  # One live run per workflow per ref. A newer push to the same PR, or a newer
+  # merge to main, cancels the older run. Manual dispatches get their own group
+  # (keyed by run id) so they never cancel, or get cancelled by, push-triggered
+  # runs. Release runs are keyed by the tag ref and are never cancelled.
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
+
 jobs:
   call_is_mergeable:
     uses: ./.github/workflows/check_if_branch_is_mergeable.yml

--- a/.github/workflows/test_package_install_inference_sdk.yml
+++ b/.github/workflows/test_package_install_inference_sdk.yml
@@ -9,6 +9,14 @@ permissions:
   id-token: write
   contents: read
 
+concurrency:
+  # One live run per workflow per ref. A newer push to the same PR, or a newer
+  # merge to main, cancels the older run. Manual dispatches get their own group
+  # (keyed by run id) so they never cancel, or get cancelled by, push-triggered
+  # runs. Release runs are keyed by the tag ref and are never cancelled.
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
+
 jobs:
   call_is_mergeable:
     uses: ./.github/workflows/check_if_branch_is_mergeable.yml

--- a/.github/workflows/test_package_install_inference_with_extras.yml
+++ b/.github/workflows/test_package_install_inference_with_extras.yml
@@ -9,6 +9,14 @@ permissions:
   id-token: write
   contents: read
 
+concurrency:
+  # One live run per workflow per ref. A newer push to the same PR, or a newer
+  # merge to main, cancels the older run. Manual dispatches get their own group
+  # (keyed by run id) so they never cancel, or get cancelled by, push-triggered
+  # runs. Release runs are keyed by the tag ref and are never cancelled.
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
+
 jobs:
   call_is_mergeable:
     uses: ./.github/workflows/check_if_branch_is_mergeable.yml

--- a/.github/workflows/unit_tests_inference_cli_x86.yml
+++ b/.github/workflows/unit_tests_inference_cli_x86.yml
@@ -9,8 +9,12 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  # One live run per workflow per ref. A newer push to the same PR, or a newer
+  # merge to main, cancels the older run. Manual dispatches get their own group
+  # (keyed by run id) so they never cancel, or get cancelled by, push-triggered
+  # runs. Release runs are keyed by the tag ref and are never cancelled.
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
 
 jobs:
   call_is_mergeable:

--- a/.github/workflows/unit_tests_inference_experimental.yml
+++ b/.github/workflows/unit_tests_inference_experimental.yml
@@ -9,8 +9,12 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  # One live run per workflow per ref. A newer push to the same PR, or a newer
+  # merge to main, cancels the older run. Manual dispatches get their own group
+  # (keyed by run id) so they never cancel, or get cancelled by, push-triggered
+  # runs. Release runs are keyed by the tag ref and are never cancelled.
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
 
 jobs:
   unit-tests-inference-models:

--- a/.github/workflows/unit_tests_inference_experimental_gpu.yml
+++ b/.github/workflows/unit_tests_inference_experimental_gpu.yml
@@ -8,6 +8,14 @@ on:
     branches: [main]
   workflow_dispatch:
 
+concurrency:
+  # One live run per workflow per ref. A newer push to the same PR, or a newer
+  # merge to main, cancels the older run. Manual dispatches get their own group
+  # (keyed by run id) so they never cancel, or get cancelled by, push-triggered
+  # runs. Release runs are keyed by the tag ref and are never cancelled.
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
+
 jobs:
   unit-tests-inference-models-gpu:
     name: trt_extras:3.12

--- a/.github/workflows/unit_tests_inference_model_manager_and_server.yml
+++ b/.github/workflows/unit_tests_inference_model_manager_and_server.yml
@@ -16,8 +16,12 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  # One live run per workflow per ref. A newer push to the same PR, or a newer
+  # merge to main, cancels the older run. Manual dispatches get their own group
+  # (keyed by run id) so they never cancel, or get cancelled by, push-triggered
+  # runs. Release runs are keyed by the tag ref and are never cancelled.
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
 
 jobs:
   call_is_mergeable:

--- a/.github/workflows/unit_tests_inference_sdk_x86.yml
+++ b/.github/workflows/unit_tests_inference_sdk_x86.yml
@@ -9,8 +9,12 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  # One live run per workflow per ref. A newer push to the same PR, or a newer
+  # merge to main, cancels the older run. Manual dispatches get their own group
+  # (keyed by run id) so they never cancel, or get cancelled by, push-triggered
+  # runs. Release runs are keyed by the tag ref and are never cancelled.
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
 
 jobs:
   call_is_mergeable:

--- a/.github/workflows/unit_tests_inference_x86.yml
+++ b/.github/workflows/unit_tests_inference_x86.yml
@@ -10,8 +10,12 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  # One live run per workflow per ref. A newer push to the same PR, or a newer
+  # merge to main, cancels the older run. Manual dispatches get their own group
+  # (keyed by run id) so they never cancel, or get cancelled by, push-triggered
+  # runs. Release runs are keyed by the tag ref and are never cancelled.
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
 
 jobs:
   call_is_mergeable:

--- a/.github/workflows/unit_tests_workflows_tensor_native_x86.yml
+++ b/.github/workflows/unit_tests_workflows_tensor_native_x86.yml
@@ -10,8 +10,12 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  # One live run per workflow per ref. A newer push to the same PR, or a newer
+  # merge to main, cancels the older run. Manual dispatches get their own group
+  # (keyed by run id) so they never cancel, or get cancelled by, push-triggered
+  # runs. Release runs are keyed by the tag ref and are never cancelled.
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
 
 jobs:
   call_is_mergeable:

--- a/.github/workflows/unit_tests_workflows_x86.yml
+++ b/.github/workflows/unit_tests_workflows_x86.yml
@@ -10,8 +10,12 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  # One live run per workflow per ref. A newer push to the same PR, or a newer
+  # merge to main, cancels the older run. Manual dispatches get their own group
+  # (keyed by run id) so they never cancel, or get cancelled by, push-triggered
+  # runs. Release runs are keyed by the tag ref and are never cancelled.
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
 
 jobs:
   call_is_mergeable:

--- a/.github/workflows/validate.github-actions.yml
+++ b/.github/workflows/validate.github-actions.yml
@@ -18,6 +18,14 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  # One live run per workflow per ref. A newer push to the same PR, or a newer
+  # merge to main, cancels the older run. Manual dispatches get their own group
+  # (keyed by run id) so they never cancel, or get cancelled by, push-triggered
+  # runs. Release runs are keyed by the tag ref and are never cancelled.
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
+
 jobs:
   actionlint:
     name: Lint every workflow

--- a/.github/workflows/validate.github-actions.yml
+++ b/.github/workflows/validate.github-actions.yml
@@ -6,6 +6,7 @@ on:
       - ".github/workflows/**"
       - ".github/actions/**"
       - ".github/actionlint.y*"
+      - ".github/scripts/**"
   push:
     branches:
       - main
@@ -13,6 +14,7 @@ on:
       - ".github/workflows/**"
       - ".github/actions/**"
       - ".github/actionlint.y*"
+      - ".github/scripts/**"
   workflow_dispatch:
 
 permissions:
@@ -41,3 +43,14 @@ jobs:
           # Shell/Python static analysis belongs to their dedicated checks;
           # this gate is strictly for Actions YAML, expressions, and actions.
           args: -no-color -shellcheck= -pyflakes=
+
+      # Every pull_request/push-triggered workflow must carry the shared
+      # concurrency block (see the `concurrency:` comment in any workflow), and
+      # workflow names must be unique because github.workflow is the group key.
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Check concurrency blocks and unique workflow names
+        run: |
+          python -m pip install --quiet pyyaml
+          python .github/scripts/check_workflow_concurrency.py


### PR DESCRIPTION
## What does this PR do?

We usually run plenty of CI actions due to them being in-flight after consecutive commit got applied - this PR attempts to fix the waste.

## Type of Change

<!-- Please select one and delete the others, or describe if Other -->

- Bug fix (non-breaking change that fixes an issue)
- New feature (non-breaking change that adds functionality)

## Testing

<!-- Describe how you tested your changes -->
- CI change to be tested empirically
- [ ] I have tested this change locally
- [ ] I have added/updated tests for this change

**Test details:**
<!-- Describe what tests were added/updated and what they cover -->

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)

## Additional Context

<!-- Add any other context, screenshots, or notes about the PR here -->
