### PR TITLE
Add ZDR configuration to OpenAI and Gemini workflow blocks

### DIFF
--- a/docs/workflows/zero_data_retention.md
+++ b/docs/workflows/zero_data_retention.md
@@ -1,0 +1,43 @@
+# Zero data retention in LLM blocks
+
+ZDR must already be enabled for the provider account/project associated with the
+API key, including Roboflow-managed keys. The OpenAI and Gemini block options do
+not provision or verify that account setting.
+
+| Block | Configuration | Request behavior |
+| --- | --- | --- |
+| OpenAI (`roboflow_core/open_ai@v6`) | `zero_data_retention: true` | Sends `store: false`, both directly and through the Roboflow passthrough. |
+| Gemini (`roboflow_core/google_gemini@v5`) | `zero_data_retention: true` | Uses the project's ZDR policy and rejects explicit context caching and Search/Maps grounding before sending a request. |
+| OpenRouter (`roboflow_core/openrouter@v2`) | `privacy_level: "zdr"` | Restricts routing to ZDR endpoints with `provider.zdr: true` and `data_collection: "deny"`. Works with managed and custom keys. |
+
+For example, an OpenAI step using a custom key supplied as a workflow input:
+
+```json
+{
+  "type": "roboflow_core/open_ai@v6",
+  "name": "caption",
+  "images": "$inputs.image",
+  "task_type": "caption",
+  "api_key": "$inputs.openai_api_key",
+  "zero_data_retention": true
+}
+```
+
+OpenAI and Gemini default to `zero_data_retention: false` to preserve existing
+workflow behavior. This does **not** disable ZDR already configured on the key.
+OpenRouter retains its existing `privacy_level: "deny"` default, which excludes
+training/data-collection providers but does not require zero retention.
+
+Gemini's `generateContent` API has no per-request ZDR switch; the block does not
+send an unsupported `store` or `zero_data_retention` parameter to Google. Its
+normal inline-image requests remain compatible with a ZDR-enabled project.
+
+OpenAI's `store: false` disables response storage; exclusion from abuse-monitoring
+logs still depends on the account/project's ZDR configuration. OpenRouter may
+reject requests when the selected model has no eligible ZDR endpoint.
+
+Provider documentation:
+
+- [OpenAI data controls](https://developers.openai.com/api/docs/guides/your-data)
+- [Gemini zero data retention](https://ai.google.dev/gemini-api/docs/zdr)
+- [OpenRouter zero data retention](https://openrouter.ai/docs/guides/features/zdr)

--- a/inference/core/workflows/core_steps/models/foundation/google_gemini/v5.py
+++ b/inference/core/workflows/core_steps/models/foundation/google_gemini/v5.py
@@ -308,6 +308,15 @@ class BlockManifest(WorkflowBlockManifest):
         examples=["rf_key:account", "xxx-xxx", "$inputs.google_api_key"],
         private=True,
     )
+    zero_data_retention: bool = Field(
+        default=False,
+        title="Zero Data Retention",
+        description=(
+            "Use a key whose Google project already has ZDR enabled. Rejects explicit "
+            "context caching and Search/Maps grounding. Gemini generateContent has no "
+            "per-request ZDR switch; retention is controlled by the key project."
+        ),
+    )
     model_version: Union[
         Selector(kind=[STRING_KIND]),
         Literal[tuple(MODEL_VERSION_IDS)],
@@ -476,6 +485,7 @@ class GoogleGeminiBlockV5(WorkflowBlock):
         google_code_execution: Optional[bool],
         max_concurrent_requests: Optional[int],
         api_key: str = "rf_key:account",
+        zero_data_retention: bool = False,
     ) -> BlockResult:
         inference_images = [i.to_inference_format() for i in images]
         raw_outputs = run_gemini_prompting(
@@ -492,6 +502,7 @@ class GoogleGeminiBlockV5(WorkflowBlock):
             thinking_level=thinking_level,
             google_code_execution=google_code_execution,
             max_concurrent_requests=max_concurrent_requests,
+            zero_data_retention=zero_data_retention,
         )
         return [
             {
@@ -518,6 +529,7 @@ def run_gemini_prompting(
     thinking_level: Optional[str],
     google_code_execution: Optional[bool],
     max_concurrent_requests: Optional[int],
+    zero_data_retention: bool = False,
 ) -> List[Tuple[str, Optional[int], Optional[int]]]:
     if task_type not in PROMPT_BUILDERS:
         raise ValueError(f"Task type: {task_type} not supported.")
@@ -551,6 +563,7 @@ def run_gemini_prompting(
         gemini_prompts=gemini_prompts,
         model_version=model_version,
         max_concurrent_requests=max_concurrent_requests,
+        zero_data_retention=zero_data_retention,
     )
 
 
@@ -560,6 +573,7 @@ def execute_gemini_requests(
     gemini_prompts: List[dict],
     model_version: str,
     max_concurrent_requests: Optional[int],
+    zero_data_retention: bool = False,
 ) -> List[Tuple[str, Optional[int], Optional[int]]]:
     tasks = [
         partial(
@@ -568,6 +582,7 @@ def execute_gemini_requests(
             google_api_key=google_api_key,
             prompt=prompt,
             model_version=model_version,
+            zero_data_retention=zero_data_retention,
         )
         for prompt in gemini_prompts
     ]
@@ -586,6 +601,7 @@ def execute_gemini_request(
     google_api_key: str,
     prompt: dict,
     model_version: str,
+    zero_data_retention: bool = False,
 ) -> Tuple[str, Optional[int], Optional[int]]:
     """Route to proxied or direct execution based on API key format."""
     if google_api_key.startswith(("rf_key:account", "rf_key:user:")):
@@ -594,12 +610,35 @@ def execute_gemini_request(
             google_api_key=google_api_key,
             prompt=prompt,
             model_version=model_version,
+            zero_data_retention=zero_data_retention,
         )
     else:
         return _execute_direct_gemini_request(
             google_api_key=google_api_key,
             prompt=prompt,
             model_version=model_version,
+            zero_data_retention=zero_data_retention,
+        )
+
+
+def validate_zdr_prompt(prompt: dict) -> None:
+    # generateContent has no per-request ZDR flag. The project must already
+    # have ZDR enabled; reject features that retain data despite that setting.
+    if prompt.get("cachedContent") or prompt.get("cached_content"):
+        raise ValueError(
+            "Explicit context caching is incompatible with zero data retention."
+        )
+    grounding_tools = {
+        "google_search",
+        "googleSearch",
+        "google_search_retrieval",
+        "googleSearchRetrieval",
+        "google_maps",
+        "googleMaps",
+    }
+    if any(grounding_tools.intersection(tool) for tool in prompt.get("tools", [])):
+        raise ValueError(
+            "Search/Maps grounding is incompatible with zero data retention."
         )
 
 
@@ -608,8 +647,12 @@ def _execute_proxied_gemini_request(
     google_api_key: str,
     prompt: dict,
     model_version: str,
+    zero_data_retention: bool = False,
 ) -> Tuple[str, Optional[int], Optional[int]]:
     """Execute Gemini request via Roboflow proxy."""
+    if zero_data_retention:
+        validate_zdr_prompt(prompt)
+
     payload = {
         "model": model_version,
         "google_api_key": google_api_key,
@@ -641,8 +684,12 @@ def _execute_direct_gemini_request(
     google_api_key: str,
     prompt: dict,
     model_version: str,
+    zero_data_retention: bool = False,
 ) -> Tuple[str, Optional[int], Optional[int]]:
     """Execute Gemini request directly to Google API."""
+    if zero_data_retention:
+        validate_zdr_prompt(prompt)
+
     response = requests.post(
         f"https://generativelanguage.googleapis.com/v1beta/models/{model_version}:generateContent",
         headers={

--- a/inference/core/workflows/core_steps/models/foundation/openai/v6.py
+++ b/inference/core/workflows/core_steps/models/foundation/openai/v6.py
@@ -438,6 +438,14 @@ class BlockManifest(WorkflowBlockManifest):
         examples=["xxx-xxx", "$inputs.openai_api_key"],
         private=True,
     )
+    zero_data_retention: bool = Field(
+        default=False,
+        title="Zero Data Retention",
+        description=(
+            "Use a key whose OpenAI organization/project already has ZDR enabled. "
+            "Disables response storage (store=false). This does not enable ZDR on the key."
+        ),
+    )
     model_version: Union[
         Selector(kind=[STRING_KIND]),
         Literal[tuple(MODEL_VERSION_IDS)],
@@ -585,6 +593,7 @@ class OpenAIBlockV6(WorkflowBlock):
         temperature: Optional[float],
         max_concurrent_requests: Optional[int],
         api_key: str = "rf_key:account",
+        zero_data_retention: bool = False,
     ) -> BlockResult:
         inference_images = [i.to_inference_format() for i in images]
         raw_outputs = run_openai_prompting(
@@ -601,6 +610,7 @@ class OpenAIBlockV6(WorkflowBlock):
             max_tokens=max_tokens,
             temperature=temperature,
             max_concurrent_requests=max_concurrent_requests,
+            zero_data_retention=zero_data_retention,
         )
         return [
             {
@@ -627,6 +637,7 @@ def run_openai_prompting(
     max_tokens: Optional[int],
     temperature: Optional[float],
     max_concurrent_requests: Optional[int],
+    zero_data_retention: bool = False,
 ) -> List[Tuple[str, Optional[int], Optional[int]]]:
     """Encode images, build per-task prompts and execute OpenAI requests.
 
@@ -686,6 +697,7 @@ def run_openai_prompting(
         max_tokens=max_tokens,
         temperature=temperature,
         max_concurrent_requests=max_concurrent_requests,
+        zero_data_retention=zero_data_retention,
     )
 
 
@@ -749,6 +761,7 @@ def execute_openai_requests(
     max_tokens: Optional[int],
     temperature: Optional[float],
     max_concurrent_requests: Optional[int],
+    zero_data_retention: bool = False,
 ) -> List[Tuple[str, Optional[int], Optional[int]]]:
     """Execute prepared OpenAI request payloads in parallel.
 
@@ -780,6 +793,7 @@ def execute_openai_requests(
             reasoning_effort=reasoning_effort,
             max_tokens=max_tokens,
             temperature=temperature,
+            zero_data_retention=zero_data_retention,
         )
         for prompt in openai_prompts
     ]
@@ -803,6 +817,7 @@ def _execute_proxied_openai_request(
     max_tokens: Optional[int],
     temperature: Optional[float],
     text_format: Optional[dict] = None,
+    zero_data_retention: bool = False,
 ) -> Tuple[str, Optional[int], Optional[int]]:
     """Executes OpenAI request via Roboflow proxy."""
     payload = {
@@ -810,6 +825,9 @@ def _execute_proxied_openai_request(
         "input": input_content,
         "openai_api_key": openai_api_key,
     }
+
+    if zero_data_retention:
+        payload["store"] = False
 
     if instructions is not None:
         payload["instructions"] = instructions
@@ -910,6 +928,7 @@ def _execute_direct_openai_request(
     max_tokens: Optional[int],
     temperature: Optional[float],
     text_format: Optional[dict] = None,
+    zero_data_retention: bool = False,
 ) -> Tuple[str, Optional[int], Optional[int]]:
     """Executes OpenAI request directly."""
     client = _get_openai_client(openai_api_key)
@@ -918,6 +937,9 @@ def _execute_direct_openai_request(
         "model": model_version,
         "input": input_content,
     }
+
+    if zero_data_retention:
+        request_params["store"] = False
 
     if instructions is not None:
         request_params["instructions"] = instructions
@@ -990,6 +1012,7 @@ def execute_openai_request(
     max_tokens: Optional[int],
     temperature: Optional[float],
     text_format: Optional[dict] = None,
+    zero_data_retention: bool = False,
 ) -> Tuple[str, Optional[int], Optional[int]]:
     """Execute a single OpenAI request, routing to direct or proxied mode.
 
@@ -1028,6 +1051,7 @@ def execute_openai_request(
             max_tokens=max_tokens,
             temperature=temperature,
             text_format=text_format,
+            zero_data_retention=zero_data_retention,
         )
     else:
         return _execute_direct_openai_request(
@@ -1039,6 +1063,7 @@ def execute_openai_request(
             max_tokens=max_tokens,
             temperature=temperature,
             text_format=text_format,
+            zero_data_retention=zero_data_retention,
         )
 
 

--- a/tests/workflows/unit_tests/core_steps/models/foundation/test_block_zdr.py
+++ b/tests/workflows/unit_tests/core_steps/models/foundation/test_block_zdr.py
@@ -1,0 +1,176 @@
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+from inference.core.workflows.core_steps.models.foundation.google_gemini import (
+    v5 as gemini,
+)
+from inference.core.workflows.core_steps.models.foundation.openai import v6 as openai
+from inference.core.workflows.core_steps.models.foundation.openrouter import (
+    v2 as openrouter,
+)
+from inference.core.workflows.execution_engine.entities.base import WorkflowImageData
+
+
+def image():
+    return WorkflowImageData(
+        parent_metadata=MagicMock(
+            parent_id="root", workflow_root_ancestor_metadata=None
+        ),
+        numpy_image=np.zeros((10, 10, 3), dtype=np.uint8),
+    )
+
+
+def manifest(module, block_type, **kwargs):
+    return module.BlockManifest.model_validate(
+        {
+            "type": block_type,
+            "name": "model",
+            "images": "$inputs.image",
+            "task_type": "caption",
+            **kwargs,
+        }
+    )
+
+
+def run(block, config):
+    return block.run(
+        images=[image()], **config.model_dump(exclude={"type", "name", "images"})
+    )
+
+
+@pytest.mark.parametrize("zdr", [False, True])
+@pytest.mark.parametrize("key", ["sk-test", "rf_key:account", "rf_key:user:test"])
+def test_openai_block_controls_response_storage_for_direct_and_proxy(zdr, key):
+    config = manifest(
+        openai, "roboflow_core/open_ai@v6", api_key=key, zero_data_retention=zdr
+    )
+    response = MagicMock(status="completed", output_text="ok", usage=None)
+    with patch.object(openai, "_get_openai_client") as client, patch.object(
+        openai, "post_to_roboflow_api"
+    ) as post:
+        client.return_value.responses.create.return_value = response
+        post.return_value = {
+            "status": "completed",
+            "output": [
+                {"type": "message", "content": [{"type": "output_text", "text": "ok"}]}
+            ],
+        }
+        result = run(
+            openai.OpenAIBlockV6(model_manager=MagicMock(), api_key="workspace-key"),
+            config,
+        )
+        assert result[0]["output"] == "ok"
+        if key.startswith("rf_key:"):
+            params = post.call_args.kwargs["payload"]
+            client.assert_not_called()
+        else:
+            params = client.return_value.responses.create.call_args.kwargs
+            post.assert_not_called()
+        if zdr:
+            assert params["store"] is False
+        else:
+            assert "store" not in params
+
+
+@pytest.mark.parametrize("zdr", [False, True])
+@pytest.mark.parametrize("key", ["google-key", "rf_key:account", "rf_key:user:test"])
+def test_gemini_zdr_uses_configured_key_without_unsupported_api_fields(zdr, key):
+    config = manifest(
+        gemini, "roboflow_core/google_gemini@v5", api_key=key, zero_data_retention=zdr
+    )
+    response = {
+        "candidates": [{"content": {"parts": [{"text": "ok"}]}, "finishReason": "STOP"}]
+    }
+    with patch.object(gemini.requests, "post") as direct, patch.object(
+        gemini, "post_to_roboflow_api"
+    ) as proxy, patch.object(
+        gemini, "validate_zdr_prompt", wraps=gemini.validate_zdr_prompt
+    ) as validate:
+        direct.return_value = MagicMock(status_code=200)
+        direct.return_value.json.return_value = response
+        proxy.return_value = response
+        result = run(
+            gemini.GoogleGeminiBlockV5(
+                model_manager=MagicMock(), api_key="workspace-key"
+            ),
+            config,
+        )
+        assert result[0]["output"] == "ok"
+        assert validate.call_count == int(zdr)
+        if key.startswith("rf_key:"):
+            payload = proxy.call_args.kwargs["payload"]
+            assert payload["google_api_key"] == key
+            direct.assert_not_called()
+        else:
+            payload = direct.call_args.kwargs["json"]
+            assert direct.call_args.kwargs["headers"]["x-goog-api-key"] == key
+            proxy.assert_not_called()
+        assert "zero_data_retention" not in payload
+        assert "store" not in payload
+
+
+@pytest.mark.parametrize("key", ["google-key", "rf_key:account"])
+@pytest.mark.parametrize(
+    "extra",
+    [
+        {"cachedContent": "cachedContents/test"},
+        {"cached_content": "cachedContents/test"},
+        *[
+            {"tools": [{name: {}}]}
+            for name in (
+                "google_search",
+                "googleSearch",
+                "google_search_retrieval",
+                "googleSearchRetrieval",
+                "google_maps",
+                "googleMaps",
+            )
+        ],
+    ],
+)
+def test_gemini_zdr_rejects_retaining_features_before_network(key, extra):
+    with patch.object(gemini.requests, "post") as direct, patch.object(
+        gemini, "post_to_roboflow_api"
+    ) as proxy:
+        with pytest.raises(ValueError, match="incompatible with zero data retention"):
+            gemini.execute_gemini_request(
+                roboflow_api_key="workspace-key",
+                google_api_key=key,
+                prompt={"contents": {"parts": [{"text": "hello"}]}, **extra},
+                model_version="gemini-2.5-pro",
+                zero_data_retention=True,
+            )
+        direct.assert_not_called()
+        proxy.assert_not_called()
+
+
+def test_native_blocks_keep_existing_default_and_expose_zdr_in_schema():
+    for module, block_type in [
+        (openai, "roboflow_core/open_ai@v6"),
+        (gemini, "roboflow_core/google_gemini@v5"),
+    ]:
+        assert manifest(module, block_type).zero_data_retention is False
+        field = module.BlockManifest.model_json_schema()["properties"][
+            "zero_data_retention"
+        ]
+        assert field["type"] == "boolean"
+        assert field["title"] == "Zero Data Retention"
+
+
+def test_openrouter_existing_zdr_option_reaches_shared_executor():
+    config = manifest(
+        openrouter,
+        "roboflow_core/openrouter@v2",
+        model_id="openai/gpt-4o",
+        privacy_level="zdr",
+    )
+    block = openrouter.OpenRouterBlockV2(
+        model_manager=MagicMock(), api_key="workspace-key"
+    )
+    with patch.object(
+        block, "execute_openrouter_batch_with_usage", return_value=[]
+    ) as execute:
+        run(block, config)
+        assert execute.call_args.kwargs["privacy_level"] == "zdr"


### PR DESCRIPTION
## Description

Add `zero_data_retention` (default false) to OpenAI v6 and Gemini v5. Provider keys are assumed to already belong to ZDR-enabled accounts/projects; the option does not provision or verify account-level ZDR.

- OpenAI sends `store: false` for direct and proxied requests.
- Gemini uses the project's ZDR policy and rejects explicit context caching and Search/Maps grounding before network access. No unsupported ZDR parameter is sent to `generateContent`.
- OpenRouter already supports `privacy_level: "zdr"`; preserve that setting and cover it with a block-level regression test.
- Document all three settings and preserve existing defaults and older block versions.

Companion passthrough change: https://github.com/roboflow/roboflow/pull/15459. Deploy it before relying on explicit `store: false` forwarding through the Roboflow proxy.

## Testing

213 tests passed:

```bash
python -m pytest \
  tests/workflows/unit_tests/core_steps/models/foundation/test_block_zdr.py \
  tests/workflows/unit_tests/core_steps/models/foundation/test_openai_v6.py \
  tests/workflows/unit_tests/core_steps/models/foundation/test_openai_v5.py \
  tests/workflows/unit_tests/core_steps/models/foundation/test_google_gemini_v5.py \
  tests/workflows/unit_tests/core_steps/models/foundation/test_google_gemini.py \
  tests/workflows/unit_tests/core_steps/models/foundation/test_openrouter_v2.py \
  tests/workflows/unit_tests/core_steps/common/test_openrouter.py -q
```

New tests run the real block/prompt/request chain with mocked provider transports, covering direct and managed/stored keys, both boolean values, schema defaults, and rejection before network access. Black, isort, and diff checks passed. No live provider calls.
