### PR TITLE
Expose per-source completed-frame telemetry for stream pipelines

### DIFF
--- a/inference/core/interfaces/stream/entities.py
+++ b/inference/core/interfaces/stream/entities.py
@@ -114,11 +114,27 @@ class LatencyMonitorReport:
 
 
 @dataclass(frozen=True)
+class SourceCompletionStatistics:
+    source_id: Optional[int]
+    completed_frames: int = 0
+    last_completed_at_monotonic: Optional[float] = None
+    last_frame_id: Optional[int] = None
+
+
+@dataclass(frozen=True)
+class CompletionStatistics:
+    # Process-local monotonic seconds; compare snapshots of the same pipeline only.
+    sampled_at_monotonic: float
+    sources: List[SourceCompletionStatistics]
+
+
+@dataclass(frozen=True)
 class PipelineStateReport:
     video_source_status_updates: List[StatusUpdate]
     latency_reports: List[LatencyMonitorReport]
     inference_throughput: float
     sources_metadata: List[SourceMetadata]
+    completion_statistics: Optional[CompletionStatistics] = None
 
 
 @dataclass(frozen=True)

--- a/inference/core/interfaces/stream/inference_pipeline.py
+++ b/inference/core/interfaces/stream/inference_pipeline.py
@@ -1143,6 +1143,12 @@ class InferencePipeline:
             predictions, video_frames = inference_results
             if _rfdetr_stream_pipeline_enabled():
                 predictions = _resolve_prediction_futures(predictions)
+            # Older duck-typed watchdogs need not implement completion telemetry.
+            on_completed = getattr(
+                self._watchdog, "on_model_prediction_completed", None
+            )
+            if on_completed is not None:
+                on_completed(frames=video_frames)
             if self._on_prediction is not None:
                 self._handle_predictions_dispatching(
                     predictions=predictions,

--- a/inference/core/interfaces/stream/watchdog.py
+++ b/inference/core/interfaces/stream/watchdog.py
@@ -6,6 +6,8 @@ observability. Please consider them internal details of implementation.
 from abc import ABC, abstractmethod
 from collections import deque
 from datetime import datetime
+from threading import Lock
+from time import monotonic
 from typing import Any, Deque, Dict, Iterable, List, Optional, TypeVar
 
 import supervision as sv
@@ -18,9 +20,11 @@ from inference.core.interfaces.camera.entities import (
 )
 from inference.core.interfaces.camera.video_source import VideoSource
 from inference.core.interfaces.stream.entities import (
+    CompletionStatistics,
     LatencyMonitorReport,
     ModelActivityEvent,
     PipelineStateReport,
+    SourceCompletionStatistics,
 )
 
 T = TypeVar("T")
@@ -53,6 +57,10 @@ class PipelineWatchDog(ABC):
         self,
         frames: List[VideoFrame],
     ) -> None:
+        pass
+
+    def on_model_prediction_completed(self, frames: List[VideoFrame]) -> None:
+        """Called by dispatch after prediction futures resolve, before sink delivery."""
         pass
 
     @abstractmethod
@@ -210,9 +218,18 @@ class BasePipelineWatchDog(PipelineWatchDog):
         self._inference_throughput_monitor = sv.FPSMonitor()
         self._latency_monitors: Dict[Optional[int], LatencyMonitor] = {}
         self._stream_updates = deque(maxlen=MAX_UPDATES_CONTEXT)
+        self._completion_lock = Lock()
+        self._completion_statistics: Dict[Optional[int], SourceCompletionStatistics] = (
+            {}
+        )
 
     def register_video_sources(self, video_sources: List[VideoSource]) -> None:
         self._video_sources = video_sources
+        with self._completion_lock:
+            self._completion_statistics = {
+                source.source_id: SourceCompletionStatistics(source_id=source.source_id)
+                for source in video_sources
+            }
         for source in video_sources:
             self._latency_monitors[source.source_id] = LatencyMonitor(
                 source_id=source.source_id
@@ -238,6 +255,21 @@ class BasePipelineWatchDog(PipelineWatchDog):
             )
             self._inference_throughput_monitor.tick()
 
+    def on_model_prediction_completed(self, frames: List[VideoFrame]) -> None:
+        # The dispatch and manager status threads share only these new counters.
+        with self._completion_lock:
+            completed_at = monotonic()
+            for frame in frames:
+                previous = self._completion_statistics[frame.source_id]
+                self._completion_statistics[frame.source_id] = (
+                    SourceCompletionStatistics(
+                        source_id=frame.source_id,
+                        completed_frames=previous.completed_frames + 1,
+                        last_completed_at_monotonic=completed_at,
+                        last_frame_id=frame.frame_id,
+                    )
+                )
+
     def get_report(self) -> PipelineStateReport:
         sources_metadata = []
         if self._video_sources is not None:
@@ -249,11 +281,17 @@ class BasePipelineWatchDog(PipelineWatchDog):
             _inference_throughput_fps = self._inference_throughput_monitor.fps
         else:
             _inference_throughput_fps = self._inference_throughput_monitor()
+        with self._completion_lock:
+            completion_statistics = CompletionStatistics(
+                sampled_at_monotonic=monotonic(),
+                sources=list(self._completion_statistics.values()),
+            )
         return PipelineStateReport(
             video_source_status_updates=list(self._stream_updates),
             latency_reports=latency_reports,
             inference_throughput=_inference_throughput_fps,
             sources_metadata=sources_metadata,
+            completion_statistics=completion_statistics,
         )
 
 

--- a/inference/core/interfaces/stream_manager/api/entities.py
+++ b/inference/core/interfaces/stream_manager/api/entities.py
@@ -33,8 +33,8 @@ class FrameMetadata(BaseModel):
 
 
 class ConsumePipelineResponse(CommandResponse):
-    outputs: List[dict]
-    frames_metadata: List[FrameMetadata]
+    outputs: List[Optional[dict]]
+    frames_metadata: List[Optional[FrameMetadata]]
 
 
 class InitializeWebRTCPipelineResponse(CommandResponse):

--- a/inference/core/interfaces/stream_manager/api/stream_manager_client.py
+++ b/inference/core/interfaces/stream_manager/api/stream_manager_client.py
@@ -195,7 +195,7 @@ class StreamManagerClient:
             context=context,
             outputs=response[RESPONSE_KEY]["outputs"],
             frames_metadata=[
-                FrameMetadata.model_validate(f)
+                FrameMetadata.model_validate(f) if f is not None else None
                 for f in response[RESPONSE_KEY]["frames_metadata"]
             ],
         )

--- a/tests/inference/unit_tests/core/interfaces/stream/test_interface_pipeline.py
+++ b/tests/inference/unit_tests/core/interfaces/stream/test_interface_pipeline.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from functools import partial
 from inspect import signature
 from queue import Queue
-from threading import Lock
+from threading import Event, Lock, Thread
 from typing import Any, List, Optional, Tuple, Union
 from unittest.mock import MagicMock
 
@@ -981,3 +981,118 @@ def test_execute_inference_tags_thread_with_pipeline_stream_session_id() -> None
     assert ids_seen_by_inference["pipeline_1"] == pipeline_1._stream_session_id
     assert ids_seen_by_inference["pipeline_2"] == pipeline_2._stream_session_id
     assert stream_session_id.get() is None
+
+
+@pytest.mark.parametrize("failed", [False, True])
+def test_completion_statistics_wait_for_prediction_futures(monkeypatch, failed) -> None:
+    monkeypatch.setenv("RFDETR_PIPELINE_DEPTH", "2")
+    resolving = Event()
+
+    class PendingPrediction(Future):
+        def result(self, timeout=None):
+            resolving.set()
+            return super().result(timeout=2)
+
+    pending = PendingPrediction()
+    sources = [VideoSourceStub(1, False, source_id=i) for i in range(2)]
+    frames = [source.read_frame() for source in sources]
+    watchdog = BasePipelineWatchDog()
+    watchdog.register_video_sources(sources)
+    queue = Queue()
+    errors = []
+    pipeline = InferencePipeline(
+        on_video_frame=lambda frames: [],
+        video_sources=sources,
+        predictions_queue=queue,
+        watchdog=watchdog,
+        status_update_handlers=[],
+    )
+    # The existing ready callback measures submission; completion must stay zero.
+    pipeline._queue_inference_result([{"output": pending}, {}], frames)
+    queue.put(None)
+
+    def dispatch():
+        try:
+            pipeline._dispatch_inference_results()
+        except Exception as error:
+            errors.append(error)
+
+    thread = Thread(target=dispatch)
+    thread.start()
+    try:
+        assert resolving.wait(timeout=2)
+        before = watchdog.get_report().completion_statistics
+        assert [s.completed_frames for s in before.sources] == [0, 0]
+        assert all(s.last_completed_at_monotonic is None for s in before.sources)
+        if failed:
+            pending.set_exception(ValueError("prediction failed"))
+        else:
+            pending.set_result("prediction")
+    finally:
+        if not pending.done():
+            pending.set_result(None)
+        thread.join(timeout=3)
+    assert not thread.is_alive()
+    after = watchdog.get_report().completion_statistics
+    assert [s.completed_frames for s in after.sources] == ([0, 0] if failed else [1, 1])
+    assert bool(errors) == failed
+    assert [s.completed_frames for s in before.sources] == [0, 0]
+    if not failed:
+        assert all(s.last_frame_id == 1 for s in after.sources)
+        assert all(
+            before.sampled_at_monotonic
+            <= s.last_completed_at_monotonic
+            <= after.sampled_at_monotonic
+            for s in after.sources
+        )
+
+
+def test_dispatch_preserves_legacy_duck_typed_watchdog(monkeypatch) -> None:
+    monkeypatch.setenv("RFDETR_PIPELINE_DEPTH", "1")
+    queue = Queue()
+    queue.put(([{}], []))
+    queue.put(None)
+    pipeline = InferencePipeline(
+        on_video_frame=lambda frames: [],
+        video_sources=[],
+        predictions_queue=queue,
+        watchdog=_PredictionReadyWatchdog(),
+        status_update_handlers=[],
+    )
+    pipeline._dispatch_inference_results()
+    assert queue.unfinished_tasks == 0
+
+
+def test_completion_counts_null_predictions_before_sink_failure(monkeypatch) -> None:
+    monkeypatch.setenv("RFDETR_PIPELINE_DEPTH", "1")
+    sources = [VideoSourceStub(1, False, source_id=i) for i in range(2)]
+    watchdog = BasePipelineWatchDog()
+    watchdog.register_video_sources(sources)
+    queue = Queue()
+    queue.put(([None], [sources[0].read_frame()]))
+    queue.put(None)
+    observed = []
+
+    def failing_sink(predictions, frames):
+        observed.append(
+            [
+                s.completed_frames
+                for s in watchdog.get_report().completion_statistics.sources
+            ]
+        )
+        assert predictions == [None, None]
+        assert frames[0].source_id == 0
+        assert frames[1] is None
+        raise RuntimeError("sink unavailable")
+
+    pipeline = InferencePipeline(
+        on_video_frame=lambda frames: [],
+        video_sources=sources,
+        predictions_queue=queue,
+        watchdog=watchdog,
+        status_update_handlers=[],
+        on_prediction=failing_sink,
+    )
+    pipeline._dispatch_inference_results()
+    assert observed == [[1, 0]]
+    assert queue.unfinished_tasks == 0

--- a/tests/inference/unit_tests/core/interfaces/stream/test_watchdog.py
+++ b/tests/inference/unit_tests/core/interfaces/stream/test_watchdog.py
@@ -1,4 +1,6 @@
+from dataclasses import asdict
 from datetime import datetime, timedelta
+from threading import Event, Thread
 from typing import Optional
 from unittest.mock import MagicMock
 
@@ -293,3 +295,51 @@ def test_base_watchdog_gives_correct_report_when_all_events_are_in_series_relate
     assert (
         result.sources_metadata[0] == "METADATA"
     ), "Metadata must match mocked video source response"
+
+
+def test_completion_statistics_are_atomic_detached_snapshots() -> None:
+    watchdog = BasePipelineWatchDog()
+    sources = [MagicMock(source_id=i) for i in range(3)]
+    watchdog.register_video_sources(sources)
+    initial = watchdog.get_report().completion_statistics
+    frames = [
+        VideoFrame(
+            image=np.zeros((1, 1, 3)),
+            source_id=i,
+            frame_id=12 + i,
+            frame_timestamp=datetime.now(),
+        )
+        for i in range(2)
+    ]
+    start = Event()
+
+    def complete_batches():
+        start.wait()
+        for _ in range(1000):
+            watchdog.on_model_prediction_completed(frames)
+
+    writer = Thread(target=complete_batches)
+    writer.start()
+    start.set()
+    try:
+        for _ in range(100):
+            snapshot = watchdog.get_report().completion_statistics
+            first, second, idle = snapshot.sources
+            assert first.completed_frames == second.completed_frames
+            assert (
+                first.last_completed_at_monotonic == second.last_completed_at_monotonic
+            )
+            if first.completed_frames:
+                assert (
+                    first.last_completed_at_monotonic <= snapshot.sampled_at_monotonic
+                )
+            assert idle.completed_frames == 0
+            assert idle.last_frame_id is None
+    finally:
+        writer.join(timeout=3)
+    assert not writer.is_alive()
+    final = watchdog.get_report().completion_statistics
+    assert [s.completed_frames for s in final.sources] == [1000, 1000, 0]
+    assert [s.last_frame_id for s in final.sources] == [12, 13, None]
+    assert [s.completed_frames for s in initial.sources] == [0, 0, 0]
+    assert asdict(final)["sources"][0]["completed_frames"] == 1000

--- a/tests/inference/unit_tests/core/interfaces/stream_manager/api/test_stream_manager_client.py
+++ b/tests/inference/unit_tests/core/interfaces/stream_manager/api/test_stream_manager_client.py
@@ -730,3 +730,28 @@ def assert_correct_command_sent(
         + serialised_command
     )
     assert writer.get_content() == payload, message
+
+
+@pytest.mark.asyncio
+async def test_consume_result_preserves_missing_camera_placeholders() -> None:
+    client = StreamManagerClient.init(host="127.0.0.1", port=7070)
+    client._handle_command = AsyncMock(
+        return_value={
+            "response": {
+                "status": "success",
+                "outputs": [{"prediction": 1}, None],
+                "frames_metadata": [
+                    {
+                        "frame_timestamp": "2026-01-01T00:00:00",
+                        "frame_id": 2,
+                        "source_id": 0,
+                    },
+                    None,
+                ],
+            },
+        }
+    )
+    result = await client.consume_pipeline_result("pipeline", excluded_fields=[])
+    assert result.outputs == [{"prediction": 1}, None]
+    assert result.frames_metadata[0].source_id == 0
+    assert result.frames_metadata[1] is None


### PR DESCRIPTION
## What does this PR do?

  Add cumulative completed-frame counters and monotonic timestamps to pipeline
  status reports, allowing clients to measure per-camera FPS and detect stalled
  sources. Existing rolling throughput can reflect submitted work before
  asynchronous predictions finish.

  Counters advance after successful prediction completion, before sink delivery,
  and are returned as atomic snapshots. The change also preserves None placeholders
  in consumed multi-camera outputs.

  Includes tests for asynchronous success/failure, snapshot consistency, missing-
  frame placeholders, and stream-manager response compatibility.

## Type of Change

- New feature (non-breaking change that adds functionality)

## Testing

CI passing
Tested manually

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)

## Additional Context

N/A