### PR TITLE
Fix root-image dimensions for empty VLM detections

### DIFF
--- a/inference/core/workflows/core_steps/common/utils.py
+++ b/inference/core/workflows/core_steps/common/utils.py
@@ -230,28 +230,14 @@ def attach_parents_coordinates_to_batch_of_sv_detections(
     return result
 
 
-def empty_detections_with_image_metadata(
-    image_height: int,
-    image_width: int,
-) -> sv.Detections:
-    """Create a zero-row ``sv.Detections`` that carries image dimensions in
-    ``metadata`` so the numpy serialiser can emit real ``image.width`` /
-    ``image.height`` for empty VLM results — matching the tensor-native path.
-
-    ``sv.Detections.data`` is per-row, so zero rows means the serialiser's
-    per-row loop never executes and any keys stored there are invisible.
-    ``metadata`` is a free-form dict on ``sv.Detections`` that survives zero
-    rows and is read by the serialiser as a fallback when no per-row
-    ``IMAGE_DIMENSIONS_KEY`` is found.
-
-    Built on ``sv.Detections.empty()`` so the returned object keeps the empty
-    ``confidence`` / ``class_id`` arrays downstream consumers rely on (a bare
-    ``sv.Detections(xyxy=...)`` leaves them ``None``, which breaks e.g.
-    ``DetectionsPropertyExtract``).
+def empty_detections_with_image_metadata(image: WorkflowImageData) -> sv.Detections:
+    """Keep image/parent metadata for zero-row results and retain the empty
+    confidence/class_id arrays expected by downstream blocks.
     """
+    image_height, image_width = image.numpy_image.shape[:2]
     detections = sv.Detections.empty()
     detections.metadata[IMAGE_DIMENSIONS_KEY] = [image_height, image_width]
-    return detections
+    return attach_parents_coordinates_to_sv_detections(detections, image)
 
 
 def attach_parents_coordinates_to_sv_detections(
@@ -282,6 +268,21 @@ def attach_parent_coordinates_to_detections(
     dimensions_key: str,
 ) -> sv.Detections:
     parent_coordinates_system = parent_metadata.origin_coordinates
+    if len(detections) == 0:
+        # Per-row data cannot retain lineage when there are no rows.
+        detections.metadata.update(
+            {
+                parent_id_key: parent_metadata.parent_id,
+                coordinates_key: [
+                    parent_coordinates_system.left_top_x,
+                    parent_coordinates_system.left_top_y,
+                ],
+                dimensions_key: [
+                    parent_coordinates_system.origin_height,
+                    parent_coordinates_system.origin_width,
+                ],
+            }
+        )
     detections[parent_id_key] = np.array([parent_metadata.parent_id] * len(detections))
     coordinates = np.array(
         [[parent_coordinates_system.left_top_x, parent_coordinates_system.left_top_y]]
@@ -313,6 +314,22 @@ def sv_detections_to_root_coordinates(
 ) -> sv.Detections:
     detections_copy = deepcopy(detections)
     if len(detections_copy) == 0:
+        root_dimensions = detections_copy.metadata.get(ROOT_PARENT_DIMENSIONS_KEY)
+        if root_dimensions is not None:
+            detections_copy.metadata.update(
+                {
+                    IMAGE_DIMENSIONS_KEY: list(root_dimensions),
+                    PARENT_DIMENSIONS_KEY: list(root_dimensions),
+                    PARENT_COORDINATES_KEY: [0, 0],
+                    ROOT_PARENT_COORDINATES_KEY: [0, 0],
+                    SCALING_RELATIVE_TO_PARENT_KEY: 1.0,
+                    SCALING_RELATIVE_TO_ROOT_PARENT_KEY: 1.0,
+                }
+            )
+            if ROOT_PARENT_ID_KEY in detections_copy.metadata:
+                detections_copy.metadata[PARENT_ID_KEY] = detections_copy.metadata[
+                    ROOT_PARENT_ID_KEY
+                ]
         return detections_copy
 
     if any(

--- a/inference/core/workflows/core_steps/formatters/vlm_as_detector/anthropic_detection_parsing.py
+++ b/inference/core/workflows/core_steps/formatters/vlm_as_detector/anthropic_detection_parsing.py
@@ -89,11 +89,7 @@ def parse_anthropic_object_detection_response(
     if not isinstance(parsed_data, list):
         raise ValueError("Unexpected Anthropic Claude object detection response format")
     if len(parsed_data) == 0:
-        image_height, image_width = image.numpy_image.shape[:2]
-        return empty_detections_with_image_metadata(
-            image_height=image_height,
-            image_width=image_width,
-        )
+        return empty_detections_with_image_metadata(image=image)
 
     class_name2id = create_classes_index(classes=classes)
     image_height, image_width = image.numpy_image.shape[:2]

--- a/inference/core/workflows/core_steps/formatters/vlm_as_detector/gemini_detection_parsing.py
+++ b/inference/core/workflows/core_steps/formatters/vlm_as_detector/gemini_detection_parsing.py
@@ -78,10 +78,7 @@ def parse_gemini_object_detection_response(
     image_height, image_width = image.numpy_image.shape[:2]
     detections = extract_gemini_detection_entries(parsed_data=parsed_data)
     if len(detections) == 0:
-        return empty_detections_with_image_metadata(
-            image_height=image_height,
-            image_width=image_width,
-        )
+        return empty_detections_with_image_metadata(image=image)
 
     xyxy, class_id, class_name, confidence = [], [], [], []
     for detection in detections:

--- a/inference/core/workflows/core_steps/formatters/vlm_as_detector/muse_detection_parsing.py
+++ b/inference/core/workflows/core_steps/formatters/vlm_as_detector/muse_detection_parsing.py
@@ -164,10 +164,7 @@ def parse_muse_object_detection_response(
         confidence.append(1.0)
 
     if not xyxy:
-        return empty_detections_with_image_metadata(
-            image_height=image_height,
-            image_width=image_width,
-        )
+        return empty_detections_with_image_metadata(image=image)
 
     xyxy = np.array(xyxy).round(0)
     detection_ids = np.array([str(uuid4()) for _ in range(len(xyxy))])

--- a/inference/core/workflows/core_steps/formatters/vlm_as_detector/openai_detection_parsing.py
+++ b/inference/core/workflows/core_steps/formatters/vlm_as_detector/openai_detection_parsing.py
@@ -90,11 +90,7 @@ def parse_openai_object_detection_response(
     if not isinstance(parsed_data, list):
         raise ValueError("Unexpected OpenAI object detection response format")
     if len(parsed_data) == 0:
-        image_height, image_width = image.numpy_image.shape[:2]
-        return empty_detections_with_image_metadata(
-            image_height=image_height,
-            image_width=image_width,
-        )
+        return empty_detections_with_image_metadata(image=image)
 
     class_name2id = create_classes_index(classes=classes)
     image_height, image_width = image.numpy_image.shape[:2]

--- a/inference/core/workflows/core_steps/formatters/vlm_as_detector/qwen_detection_parsing.py
+++ b/inference/core/workflows/core_steps/formatters/vlm_as_detector/qwen_detection_parsing.py
@@ -187,10 +187,7 @@ def parse_qwen_object_detection_response(
         confidence.append(1.0)
 
     if not xyxy:
-        return empty_detections_with_image_metadata(
-            image_height=image_height,
-            image_width=image_width,
-        )
+        return empty_detections_with_image_metadata(image=image)
 
     xyxy = np.array(xyxy).round(0)
     confidence = np.array(confidence)

--- a/inference/core/workflows/core_steps/formatters/vlm_as_detector/spacexai_detection_parsing.py
+++ b/inference/core/workflows/core_steps/formatters/vlm_as_detector/spacexai_detection_parsing.py
@@ -100,11 +100,7 @@ def parse_spacexai_object_detection_response(
     """
     detections = extract_spacexai_detection_entries(parsed_data=parsed_data)
     if len(detections) == 0:
-        image_height, image_width = image.numpy_image.shape[:2]
-        return empty_detections_with_image_metadata(
-            image_height=image_height,
-            image_width=image_width,
-        )
+        return empty_detections_with_image_metadata(image=image)
 
     class_name2id = create_classes_index(classes=classes)
     image_height, image_width = image.numpy_image.shape[:2]

--- a/inference/core/workflows/core_steps/formatters/vlm_as_detector/v2.py
+++ b/inference/core/workflows/core_steps/formatters/vlm_as_detector/v2.py
@@ -371,10 +371,7 @@ def parse_llm_object_detection_response(
     class_name2id = create_classes_index(classes=classes)
     image_height, image_width = image.numpy_image.shape[:2]
     if len(parsed_data["detections"]) == 0:
-        return empty_detections_with_image_metadata(
-            image_height=image_height,
-            image_width=image_width,
-        )
+        return empty_detections_with_image_metadata(image=image)
     xyxy, class_id, class_name, confidence = [], [], [], []
     for detection in parsed_data["detections"]:
         xyxy.append(

--- a/inference/core/workflows/execution_engine/v1/executor/output_constructor.py
+++ b/inference/core/workflows/execution_engine/v1/executor/output_constructor.py
@@ -412,7 +412,7 @@ def data_needs_sv_detections_coordinate_conversion(data: Any) -> bool:
 
 def _sv_detections_need_root_coordinate_conversion(detections: sv.Detections) -> bool:
     if len(detections) == 0:
-        return False
+        return ROOT_PARENT_DIMENSIONS_KEY in detections.metadata
     root_coordinates = detections.data.get(ROOT_PARENT_COORDINATES_KEY)
     if root_coordinates is None:
         return False

--- a/tests/workflows/unit_tests/core_steps/common/test_utils.py
+++ b/tests/workflows/unit_tests/core_steps/common/test_utils.py
@@ -5,8 +5,8 @@ import cv2
 import numpy as np
 import pytest
 import supervision as sv
-from supervision.config import ORIENTED_BOX_COORDINATES
 from pycocotools import mask as mask_utils
+from supervision.config import ORIENTED_BOX_COORDINATES
 
 from inference.core.workflows.core_steps.common.serializers import (
     serialise_rle_sv_detections,
@@ -48,7 +48,11 @@ from inference.core.workflows.execution_engine.entities.base import (
 
 def test_empty_detections_with_image_metadata_keeps_empty_field_contract() -> None:
     # given / when
-    result = empty_detections_with_image_metadata(image_height=480, image_width=640)
+    image = WorkflowImageData(
+        parent_metadata=ImageParentMetadata(parent_id="image"),
+        numpy_image=np.zeros((480, 640, 3), dtype=np.uint8),
+    )
+    result = empty_detections_with_image_metadata(image=image)
 
     # then - image dimensions travel in metadata (zero rows means `data` is
     # invisible to the serialiser), while the fields `sv.Detections.empty()`

--- a/tests/workflows/unit_tests/core_steps/formatters/test_empty_vlm_root_coordinates.py
+++ b/tests/workflows/unit_tests/core_steps/formatters/test_empty_vlm_root_coordinates.py
@@ -1,0 +1,103 @@
+import numpy as np
+import pytest
+
+from inference.core.workflows.core_steps.common.serializers import (
+    serialise_sv_detections,
+)
+from inference.core.workflows.core_steps.formatters.vlm_as_detector.anthropic_detection_parsing import (
+    parse_anthropic_object_detection_response,
+)
+from inference.core.workflows.core_steps.formatters.vlm_as_detector.gemini_detection_parsing import (
+    parse_gemini_object_detection_response,
+)
+from inference.core.workflows.core_steps.formatters.vlm_as_detector.muse_detection_parsing import (
+    parse_muse_object_detection_response,
+)
+from inference.core.workflows.core_steps.formatters.vlm_as_detector.openai_detection_parsing import (
+    parse_openai_object_detection_response,
+)
+from inference.core.workflows.core_steps.formatters.vlm_as_detector.qwen_detection_parsing import (
+    parse_qwen_object_detection_response,
+)
+from inference.core.workflows.core_steps.formatters.vlm_as_detector.spacexai_detection_parsing import (
+    parse_spacexai_object_detection_response,
+)
+from inference.core.workflows.core_steps.formatters.vlm_as_detector.v2 import (
+    parse_llm_object_detection_response,
+)
+from inference.core.workflows.execution_engine.constants import (
+    IMAGE_DIMENSIONS_KEY,
+    ROOT_PARENT_COORDINATES_KEY,
+    ROOT_PARENT_DIMENSIONS_KEY,
+    ROOT_PARENT_ID_KEY,
+)
+from inference.core.workflows.execution_engine.entities.base import (
+    ImageParentMetadata,
+    OriginCoordinatesSystem,
+    WorkflowImageData,
+)
+from inference.core.workflows.execution_engine.v1.executor.output_constructor import (
+    _prepare_data_piece_for_output,
+)
+
+
+@pytest.mark.parametrize(
+    "parser,response",
+    [
+        (parse_anthropic_object_detection_response, []),
+        (parse_gemini_object_detection_response, []),
+        (parse_muse_object_detection_response, []),
+        (parse_openai_object_detection_response, []),
+        (parse_qwen_object_detection_response, []),
+        (parse_spacexai_object_detection_response, []),
+        (parse_llm_object_detection_response, {"detections": []}),
+    ],
+)
+@pytest.mark.parametrize(
+    "size,offset",
+    [((60, 80), (50, 100)), ((60, 80), (0, 0)), ((480, 640), (0, 0))],
+)
+def test_empty_vlm_output_honors_coordinate_system(parser, response, size, offset):
+    height, width = size
+    image = WorkflowImageData(
+        numpy_image=np.zeros((height, width, 3), dtype=np.uint8),
+        parent_metadata=ImageParentMetadata(parent_id="crop"),
+        workflow_root_ancestor_metadata=ImageParentMetadata(
+            parent_id="root",
+            origin_coordinates=OriginCoordinatesSystem(
+                left_top_x=offset[0],
+                left_top_y=offset[1],
+                origin_width=640,
+                origin_height=480,
+            ),
+        ),
+    )
+    detections = parser(
+        image=image, parsed_data=response, classes=["cat"], inference_id="test"
+    )
+    own = _prepare_data_piece_for_output(
+        data_piece=detections,
+        resolve_output_futures=False,
+        convert_to_parent_coordinates=False,
+    )
+    parent = _prepare_data_piece_for_output(
+        data_piece=detections,
+        resolve_output_futures=False,
+        convert_to_parent_coordinates=True,
+    )
+
+    assert serialise_sv_detections(parent) == {
+        "image": {"width": 640, "height": 480},
+        "predictions": [],
+    }
+    assert serialise_sv_detections(own) == {
+        "image": {"width": width, "height": height},
+        "predictions": [],
+    }
+    assert detections.metadata[IMAGE_DIMENSIONS_KEY] == [height, width]
+    assert detections.metadata[ROOT_PARENT_COORDINATES_KEY] == list(offset)
+    assert parent.metadata[ROOT_PARENT_COORDINATES_KEY] == [0, 0]
+    assert parent.metadata[ROOT_PARENT_DIMENSIONS_KEY] == [480, 640]
+    assert parent.metadata[ROOT_PARENT_ID_KEY] == "root"
+    assert parent.confidence.tolist() == []
+    assert parent.class_id.tolist() == []


### PR DESCRIPTION
## What does this PR do?

  Empty VLM detections from cropped images lose parent lineage, causing PARENT
  outputs to report crop dimensions instead of root-image dimensions.

  Preserve parent metadata for zero-row detections and apply it during output
  conversion. OWN outputs retain crop dimensions, and conversion leaves the
  original detections unchanged.

  Validation:

  - Added regression coverage for all seven VLM parsers, including offset and top-
    left crops.

  - Passed 21 new cases and four existing checks using source-loaded code with
    actual Supervision.

  - Formatting and whitespace checks passed.
  - Full project tests were unavailable locally due to missing dependencies.

## Type of Change

- Bug fix (non-breaking change that fixes an issue)

## Testing

New test added, CI passing

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)

## Additional Context

N/A