### PR TITLE
fix(workflows): bound per-track class state in Track Class Lock block

### DIFF
--- a/inference/core/workflows/core_steps/transformations/track_class_lock/v1.py
+++ b/inference/core/workflows/core_steps/transformations/track_class_lock/v1.py
@@ -1,3 +1,4 @@
+import heapq
 from collections import OrderedDict, defaultdict
 from copy import deepcopy
 from typing import Annotated, Dict, List, Literal, Optional, Set, Tuple, Type, Union
@@ -51,6 +52,14 @@ MAX_STATE_TTL: int = 1_000_000
 # instead of O(new_ids * lost_tracks). The most-recently-lost tracks (the most
 # plausible re-attachment targets) are kept.
 MAX_REATTACH_CANDIDATES: int = 256
+# Upper bound on distinct classes for which a single track keeps voting state.
+# Class names come from the input detections, so without a cap one repeated
+# tracker id carrying a fresh class name per detection grows that track's
+# vote/confidence/class-id tables without limit (bypassing the per-video track
+# cap and TTL, which key on tracker id) and makes the per-detection ranking
+# cost grow with every detection. A real object flickers between a handful of
+# classes; once the cap is reached, votes for further NEW classes are ignored.
+MAX_CLASSES_PER_TRACK: int = 256
 LONG_DESCRIPTION = """
 Lock the class label of each tracked object by majority voting, eliminating class
 flicker in video workflows where a model alternates between similar classes for the
@@ -79,7 +88,8 @@ in the image's video metadata:
    Set reattach_window to 0 to disable re-attachment.
 5. State for tracks unseen for state_ttl frames is purged. Retained per-video
    track state is additionally capped, evicting least-recently-seen tracks, so
-   state stays bounded under high tracker-id turnover.
+   state stays bounded under high tracker-id turnover. Each track keeps voting
+   state for a bounded number of distinct classes.
 
 Each detection is annotated with a boolean `class_locked` flag in detections.data.
 
@@ -324,14 +334,15 @@ class TrackClassLockBlockV1(WorkflowBlock):
 
             if st["locked"] is None:
                 # pre-lock: cumulative voting (any order)
-                if qualifying:
+                if qualifying and _class_admissible(st, cname):
                     st["votes"][cname] += 1
                     st["conf_sum"][cname] += conf
                     if dets.class_id is not None:
-                        st["class_ids"][cname] = int(dets.class_id[i])
+                        _record_class_id(st, cname, int(dets.class_id[i]))
                 if st["votes"]:
-                    ranked = sorted(
-                        st["votes"].items(), key=lambda kv: kv[1], reverse=True
+                    # only the top two tallies matter; O(k) instead of a full sort
+                    ranked = heapq.nlargest(
+                        2, st["votes"].items(), key=lambda kv: kv[1]
                     )
                     top_c, top_v = ranked[0]
                     runner_v = ranked[1][1] if len(ranked) > 1 else 0
@@ -350,7 +361,7 @@ class TrackClassLockBlockV1(WorkflowBlock):
                         st["streak"] = 1
                         st["streak_conf"] = conf
                         if dets.class_id is not None:
-                            st["class_ids"][cname] = int(dets.class_id[i])
+                            _record_class_id(st, cname, int(dets.class_id[i]))
                     if st["streak"] >= switch_after:
                         new = st["challenger"]
                         st["locked"] = new
@@ -379,6 +390,32 @@ class TrackClassLockBlockV1(WorkflowBlock):
         _enforce_track_cap(tracks)
 
         return {OUTPUT_KEY: dets}
+
+
+def _class_admissible(st: dict, cname: str) -> bool:
+    """Whether a vote for ``cname`` may be counted for this track.
+
+    Votes for classes already tallied are always counted; a NEW class is only
+    admitted while the track holds fewer than ``MAX_CLASSES_PER_TRACK``
+    classes, bounding per-track state against inputs that carry a fresh class
+    name per detection.
+    """
+    return cname in st["votes"] or len(st["votes"]) < MAX_CLASSES_PER_TRACK
+
+
+def _record_class_id(st: dict, cname: str, class_id: int) -> None:
+    """Remember the numeric class id for ``cname`` with bounded table size.
+
+    ``class_ids`` is also written for post-lock challengers, so it can outgrow
+    the vote table; before admitting a new name at the cap, drop ids no longer
+    referenced by any vote, the lock or the current challenger.
+    """
+    class_ids = st["class_ids"]
+    if cname not in class_ids and len(class_ids) >= MAX_CLASSES_PER_TRACK:
+        referenced = set(st["votes"]) | {st["locked"], st["challenger"], cname}
+        for stale in [k for k in class_ids if k not in referenced]:
+            del class_ids[stale]
+    class_ids[cname] = class_id
 
 
 def _eligible_inheritance_candidates(

--- a/inference/core/workflows/core_steps/transformations/track_class_lock/v1_tensor.py
+++ b/inference/core/workflows/core_steps/transformations/track_class_lock/v1_tensor.py
@@ -15,6 +15,7 @@ component drives the voting and the relabelled tuple is returned so keypoints
 survive. Instance-segmentation masks are carried through unchanged.
 """
 
+import heapq
 from collections import OrderedDict, defaultdict
 from copy import deepcopy
 from typing import List, Optional, Set, Tuple, Type, Union
@@ -30,9 +31,11 @@ from inference.core.workflows.core_steps.transformations.track_class_lock.v1 imp
     MAX_STATE_TTL,
     MAX_TRACKED_VIDEOS,
     BlockManifest,
+    _class_admissible,
     _eligible_inheritance_candidates,
     _enforce_track_cap,
     _find_lock_to_inherit,
+    _record_class_id,
 )
 from inference.core.workflows.execution_engine.constants import (
     CLASS_NAME_KEY,
@@ -206,13 +209,13 @@ def _vote_and_lock(
         qualifying = conf >= vote_confidence
 
         if st["locked"] is None:
-            if qualifying:
+            if qualifying and _class_admissible(st, cname):
                 st["votes"][cname] += 1
                 st["conf_sum"][cname] += conf
                 if dets.class_id is not None:
-                    st["class_ids"][cname] = int(dets.class_id[i])
+                    _record_class_id(st, cname, int(dets.class_id[i]))
             if st["votes"]:
-                ranked = sorted(st["votes"].items(), key=lambda kv: kv[1], reverse=True)
+                ranked = heapq.nlargest(2, st["votes"].items(), key=lambda kv: kv[1])
                 top_c, top_v = ranked[0]
                 runner_v = ranked[1][1] if len(ranked) > 1 else 0
                 if top_v >= min_votes and top_v - runner_v >= lead_margin:
@@ -227,7 +230,7 @@ def _vote_and_lock(
                     st["streak"] = 1
                     st["streak_conf"] = conf
                     if dets.class_id is not None:
-                        st["class_ids"][cname] = int(dets.class_id[i])
+                        _record_class_id(st, cname, int(dets.class_id[i]))
                 if st["streak"] >= switch_after:
                     new = st["challenger"]
                     st["locked"] = new

--- a/tests/workflows/unit_tests/core_steps/transformations/test_track_class_lock.py
+++ b/tests/workflows/unit_tests/core_steps/transformations/test_track_class_lock.py
@@ -7,6 +7,7 @@ import supervision as sv
 from pydantic import ValidationError
 
 from inference.core.workflows.core_steps.transformations.track_class_lock.v1 import (
+    MAX_CLASSES_PER_TRACK,
     MAX_REATTACH_CANDIDATES,
     MAX_STATE_TTL,
     MAX_TRACKED_VIDEOS,
@@ -608,3 +609,109 @@ def test_track_class_lock_manifest_rejects_state_ttl_over_max() -> None:
     # when / then
     with pytest.raises(ValidationError):
         BlockManifest.model_validate(data)
+
+
+def _one_track_many_classes(n: int, tracker_id: int = 7) -> sv.Detections:
+    # one tracker id repeated n times, a never-before-seen class per detection
+    return sv.Detections(
+        xyxy=np.tile(np.array([[10.0, 10.0, 50.0, 50.0]]), (n, 1)),
+        confidence=np.full(n, 0.9),
+        class_id=np.arange(n),
+        tracker_id=np.full(n, tracker_id),
+        data={"class_name": np.array([f"class_{i}" for i in range(n)], dtype=object)},
+    )
+
+
+def test_track_class_lock_bounds_per_track_class_state() -> None:
+    # given - a single track fed a fresh class name on every detection; the
+    # track cap and TTL key on tracker id, so only a per-track class cap helps
+    block = TrackClassLockBlockV1()
+    n = MAX_CLASSES_PER_TRACK * 4
+
+    # when - spread over frames so TTL never expires the track either
+    for _ in range(3):
+        block.run(image=_image(), detections=_one_track_many_classes(n), **KNOBS)
+
+    # then - vote/confidence/class-id tables stay bounded, no spurious lock
+    st = block._per_video_state["vid_1"]["tracks"][7]
+    assert len(st["votes"]) <= MAX_CLASSES_PER_TRACK
+    assert len(st["conf_sum"]) <= MAX_CLASSES_PER_TRACK
+    assert len(st["class_ids"]) <= MAX_CLASSES_PER_TRACK + 3
+    assert st["locked"] is None
+
+
+def test_track_class_lock_bounds_class_ids_for_post_lock_challengers() -> None:
+    # given - a locked track that then sees a different challenger class on
+    # every frame (each challenger records its class id)
+    block = TrackClassLockBlockV1()
+    for _ in range(10):
+        block.run(image=_image(), detections=_frame("cat", 0.9), **KNOBS)
+    assert block._per_video_state["vid_1"]["tracks"][7]["locked"] == "cat"
+
+    # when
+    for i in range(MAX_CLASSES_PER_TRACK * 2):
+        challenger = sv.Detections(
+            xyxy=np.array([[10.0, 10.0, 50.0, 50.0]]),
+            confidence=np.array([0.95]),
+            class_id=np.array([100 + i]),
+            tracker_id=np.array([7]),
+            data={"class_name": np.array([f"challenger_{i}"], dtype=object)},
+        )
+        result = block.run(image=_image(), detections=challenger, **KNOBS)
+
+    # then - still locked on cat, class-id table bounded, lock id preserved
+    st = block._per_video_state["vid_1"]["tracks"][7]
+    assert st["locked"] == "cat"
+    assert len(st["class_ids"]) <= MAX_CLASSES_PER_TRACK + 3
+    assert st["class_ids"]["cat"] == CLASS_IDS["cat"]
+    out = result["tracked_detections"]
+    assert out.data["class_name"][0] == "cat"
+    assert out.class_id[0] == CLASS_IDS["cat"]
+
+
+def test_track_class_lock_still_locks_when_true_class_is_among_many() -> None:
+    # given - junk classes fill the per-track table, but the real class keeps
+    # being observed; admitted classes must keep collecting votes and lock
+    block = TrackClassLockBlockV1()
+    block.run(
+        image=_image(),
+        detections=_one_track_many_classes(MAX_CLASSES_PER_TRACK),
+        **KNOBS,
+    )
+    # class_0 is already admitted; vote for it repeatedly
+    for _ in range(12):
+        frame = sv.Detections(
+            xyxy=np.array([[10.0, 10.0, 50.0, 50.0]]),
+            confidence=np.array([0.9]),
+            class_id=np.array([0]),
+            tracker_id=np.array([7]),
+            data={"class_name": np.array(["class_0"], dtype=object)},
+        )
+        result = block.run(image=_image(), detections=frame, **KNOBS)
+
+    # then
+    out = result["tracked_detections"]
+    assert out.data["class_locked"][0]
+    assert out.data["class_name"][0] == "class_0"
+
+
+def test_track_class_lock_tensor_variant_bounds_per_track_class_state() -> None:
+    # given - the tensor-native sibling duplicates the voting loop; it must
+    # apply the same per-track class cap (skipped where torch is unavailable)
+    pytest.importorskip("torch")
+    from inference.core.workflows.core_steps.transformations.track_class_lock import (
+        v1_tensor,
+    )
+
+    block = v1_tensor.TrackClassLockBlockV1()
+    n = MAX_CLASSES_PER_TRACK * 4
+
+    # when - drive the shared voting state machine on a boundary sv.Detections
+    for _ in range(3):
+        v1_tensor._vote_and_lock(block, _image(), _one_track_many_classes(n), **KNOBS)
+
+    # then
+    st = block._per_video_state["vid_1"]["tracks"][7]
+    assert len(st["votes"]) <= MAX_CLASSES_PER_TRACK
+    assert len(st["class_ids"]) <= MAX_CLASSES_PER_TRACK + 3
+    assert st["locked"] is None


### PR DESCRIPTION
## Summary

Follow-up to #2937, addressing the review point that the caps added there leave an attacker-controlled path open. Those caps key on **tracker id**. A single repeated tracker id carrying a never-before-seen class name on every detection still grew that one track's vote, confidence and class-id tables without limit, and re-sorted the whole vote table for every detection. With default parameters no class ever locks, the 4,096-track cap never applies to a single track, and continued observations keep it from expiring by TTL.

Reproduced on `main` (one tracker id, unique class per detection):

| detections | retained classes | time |
|---:|---:|---:|
| 1,000 | 1,000 | 0.017 s |
| 2,000 | 2,000 | 0.066 s |
| 4,000 | 4,000 | 0.299 s |

This is pre-existing behaviour rather than something #2937 introduced, but it is the same attacker-controlled shape.

## Fix

- **`MAX_CLASSES_PER_TRACK = 256`.** Votes for classes already tallied are always counted; a *new* class is admitted only while the track holds fewer than the cap. A real object flickers between a handful of classes, so legitimate use is unaffected.
- **Class-id table bounded too.** It is also written for post-lock challengers, so before admitting a new name at the cap, ids no longer referenced by any vote, the lock or the current challenger are dropped.
- **Top-two ranking instead of a full sort** per detection (`heapq.nlargest(2)`). Only the top two tallies are used; ordering semantics are identical, cost is O(k) rather than O(k log k).
- Applied to both the numpy variant and the tensor-native sibling, which share the new helpers.

After the change, 16,000 such detections on one track leave 256 retained classes and take 0.17 s, linear in the number of detections.

## Tests

Four regression tests added (42 total in the file, all passing):
- per-track class state stays bounded across frames for a repeated tracker id;
- the class-id table stays bounded across hundreds of distinct post-lock challengers while the lock and its class id are preserved;
- an admitted class still locks normally when junk classes fill the table;
- the tensor-native variant applies the same bound (skipped where torch is unavailable).

## Not changed, deliberately

- The per-video track cap is still enforced after each frame, so a frame with N brand-new tracker ids briefly creates N states before trimming. That transient is proportional to the detections already held in memory for the request, and trimming mid-frame would mean evicting tracks from the very frame being processed.
- Scope is the class-state bound only; no changes to the caps or re-attachment logic from #2937.

🤖 Generated with [Claude Code](https://claude.com/claude-code)