### PR TITLE
fix(workflows): keep image dimensions on empty detections at both boundaries

### DIFF
--- a/inference/core/workflows/core_steps/common/deserializers.py
+++ b/inference/core/workflows/core_steps/common/deserializers.py
@@ -263,9 +263,18 @@ def deserialize_detections_kind(
             context="workflow_execution | runtime_input_validation",
         )
     parsed_detections = sv.Detections.from_inference(detections)
-    if len(parsed_detections) == 0:
-        return parsed_detections
     height, width = detections["image"]["height"], detections["image"]["width"]
+    if len(parsed_detections) == 0:
+        # Image dimensions describe the input image, not the rows: keep them on
+        # the empty result the same way empty_detections_with_image_metadata()
+        # does, so a serialize -> deserialize round trip and the tensor-native
+        # boundary still report them (#2974).
+        if height is not None and width is not None:
+            parsed_detections.metadata[IMAGE_DIMENSIONS_KEY] = [
+                int(height),
+                int(width),
+            ]
+        return parsed_detections
     image_metadata = np.array([[height, width]] * len(parsed_detections))
     parsed_detections.data[IMAGE_DIMENSIONS_KEY] = image_metadata
     raw_predictions = detections["predictions"]

--- a/inference/core/workflows/execution_engine/v1/dynamic_blocks/representation_boundary.py
+++ b/inference/core/workflows/execution_engine/v1/dynamic_blocks/representation_boundary.py
@@ -1108,7 +1108,7 @@ def sv_detections_to_native(
     detections_number = int(len(sv_detections))
     data = sv_detections.data or {}
     image_metadata = _rebuild_image_metadata_from_sv(
-        data=data, detections_number=detections_number
+        data=data, detections_number=detections_number, metadata=sv_detections.metadata
     )
     class_names_column = data.get(CLASS_NAME_DATA_COLUMN)
     class_id_values = (
@@ -1186,9 +1186,18 @@ def sv_detections_to_native(
 def _rebuild_image_metadata_from_sv(
     data: Dict[str, Any],
     detections_number: int,
+    metadata: Optional[Dict[str, Any]] = None,
 ) -> dict:
     image_metadata: dict = {}
     if detections_number == 0:
+        # No rows means no broadcast ``.data`` columns to read from, but the
+        # image dimensions are a property of the image and zero-row results
+        # carry them in ``sv.Detections.metadata`` (#2974).
+        image_dimensions = (metadata or {}).get(IMAGE_DIMENSIONS_KEY)
+        if image_dimensions is not None:
+            image_metadata[IMAGE_DIMENSIONS_KEY] = [
+                int(value) for value in np.asarray(image_dimensions).reshape(-1)[:2]
+            ]
         return image_metadata
     for key in _IMAGE_LEVEL_ID_KEYS + _IMAGE_LEVEL_SCALAR_KEYS:
         column = data.get(key)

--- a/tests/workflows/unit_tests/core_steps/common/test_deserializers.py
+++ b/tests/workflows/unit_tests/core_steps/common/test_deserializers.py
@@ -24,7 +24,11 @@ from inference.core.workflows.core_steps.common.deserializers import (
     deserialize_timestamp,
     deserialize_zone_kind,
 )
+from inference.core.workflows.core_steps.common.serializers import (
+    serialise_sv_detections,
+)
 from inference.core.workflows.errors import RuntimeInputError
+from inference.core.workflows.execution_engine.constants import IMAGE_DIMENSIONS_KEY
 from inference.core.workflows.execution_engine.entities.base import (
     ImageParentMetadata,
     OriginCoordinatesSystem,
@@ -84,6 +88,28 @@ def test_deserialize_detections_kind_when_serialized_empty_detections_given() ->
     # then
     assert isinstance(result, sv.Detections)
     assert len(result) == 0
+
+
+def test_deserialize_detections_kind_keeps_image_dimensions_for_empty_detections() -> (
+    None
+):
+    # given - the wire form of an empty result (issue #2974)
+    detections = {
+        "image": {"height": 480, "width": 640},
+        "predictions": [],
+    }
+
+    # when
+    result = deserialize_detections_kind(
+        parameter="my_param",
+        detections=detections,
+    )
+
+    # then - dimensions describe the image, not the rows, so an empty
+    # round trip must still report them instead of nulls
+    assert len(result) == 0
+    assert result.metadata[IMAGE_DIMENSIONS_KEY] == [480, 640]
+    assert serialise_sv_detections(result)["image"] == {"width": 640, "height": 480}
 
 
 def test_deserialize_detections_kind_when_serialized_non_empty_object_detections_given() -> (
@@ -1469,9 +1495,10 @@ def test_tensor_deserialize_detections_kind_round_trips_nearest_target_distance(
     )
 
     # then
-    assert [
-        entry["nearest_target_distance"] for entry in result.bboxes_metadata
-    ] == [12.5, None]
+    assert [entry["nearest_target_distance"] for entry in result.bboxes_metadata] == [
+        12.5,
+        None,
+    ]
     serialized = serializers_tensor.serialise_sv_detections(result)
     assert [
         prediction["nearest_target_distance"]

--- a/tests/workflows/unit_tests/execution_engine/dynamic_blocs/test_representation_boundary.py
+++ b/tests/workflows/unit_tests/execution_engine/dynamic_blocs/test_representation_boundary.py
@@ -378,6 +378,35 @@ def test_native_detections_to_sv_handles_plain_and_empty_detections() -> None:
     assert len(converted_empty) == 0
 
 
+def test_sv_detections_to_native_keeps_image_dimensions_for_empty_detections() -> None:
+    # given - a zero-row result carrying the image dimensions in metadata, the
+    # shape empty_detections_with_image_metadata() produces (issue #2974)
+    empty = sv.Detections.empty()
+    empty.metadata[IMAGE_DIMENSIONS_KEY] = [480, 640]
+
+    # when
+    result = sv_detections_to_native(sv_detections=empty)
+
+    # then
+    assert result.xyxy.shape[0] == 0
+    assert result.image_metadata[IMAGE_DIMENSIONS_KEY] == [480, 640]
+
+
+def test_sv_detections_to_native_reads_array_image_dimensions_for_empty_detections() -> (
+    None
+):
+    # given
+    empty = sv.Detections.empty()
+    empty.metadata[IMAGE_DIMENSIONS_KEY] = np.array([480, 640])
+
+    # when
+    result = sv_detections_to_native(sv_detections=empty)
+
+    # then - plain ints, like the row-based rebuild emits
+    assert result.image_metadata[IMAGE_DIMENSIONS_KEY] == [480, 640]
+    assert all(isinstance(v, int) for v in result.image_metadata[IMAGE_DIMENSIONS_KEY])
+
+
 def test_convert_kwargs_is_identity_when_tensor_representation_off() -> None:
     # given
     kwargs = {"predictions": _native_object_detections(), "threshold": 0.5}


### PR DESCRIPTION
Fixes #2974 (the follow-up promised in #2892).

## Description

Image dimensions describe the input image, not the detections, yet two supported boundaries still dropped them for zero-row results after #2892 made empty VLM-as-detector outputs carry them in `sv.Detections.metadata`:

- **Serialize → deserialize round trip.** `deserialize_detections_kind` returned early for zero rows, before the image dimensions were restored, so an empty payload such as `{"image": {"width": 640, "height": 480}, "predictions": []}` came back without them and re-serialised to `image.width` / `image.height` = `null`. Reachable from custom Python blocks, Modal, and anywhere the wire dict is rebuilt, regardless of the tensor representation flag.
- **numpy → tensor-native.** `_rebuild_image_metadata_from_sv` rebuilt image-level metadata only from per-row `.data` columns and returned `{}` for zero rows, so `sv_detections_to_native` on an empty `sv.Detections` lost the dimensions even when `metadata` carried them. Reachable with `ENABLE_TENSOR_DATA_REPRESENTATION`.

The fix keeps both producers consistent with `empty_detections_with_image_metadata()`: the deserializer stores `[height, width]` in `metadata[IMAGE_DIMENSIONS_KEY]` on the empty result (the serializer's existing metadata fallback then reports the real dimensions again), and the tensor-native rebuild takes an optional `metadata` argument and reads the dimensions from it when there are no rows, emitting plain ints as the row-based path does. Non-empty results are untouched.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested?

New unit tests:

- `test_deserialize_detections_kind_keeps_image_dimensions_for_empty_detections`: an empty wire payload deserialises with `metadata[IMAGE_DIMENSIONS_KEY] == [480, 640]` and `serialise_sv_detections` reports `{"width": 640, "height": 480}` instead of nulls.
- `test_sv_detections_to_native_keeps_image_dimensions_for_empty_detections` and `..._reads_array_image_dimensions_for_empty_detections`: an empty `sv.Detections` with the dimensions in `metadata` (list or numpy array) converts to a native `Detections` whose `image_metadata` carries `[480, 640]` as ints.

```
pytest tests/workflows/unit_tests/core_steps/common/test_deserializers.py tests/workflows/unit_tests/execution_engine/dynamic_blocs/test_representation_boundary.py
132 passed   (also with ENABLE_TENSOR_DATA_REPRESENTATION=True)
black / isort applied to the four changed files
```

## Any specific deployment considerations

None. Both changes only add data for zero-row results that previously carried none.

## Docs

No user-facing docs describe this behaviour; nothing to update.